### PR TITLE
fix(Zendesk) - use the new internal IDs in content nodes

### DIFF
--- a/connectors/migrations/20250102_clean_zendesk_tickets_articles.ts
+++ b/connectors/migrations/20250102_clean_zendesk_tickets_articles.ts
@@ -1,10 +1,6 @@
 import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 
-import {
-  getArticleInternalId,
-  getTicketInternalId,
-} from "@connectors/connectors/zendesk/lib/id_conversions";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { deleteDataSourceDocument } from "@connectors/lib/data_sources";
@@ -39,10 +35,7 @@ async function cleanTickets(
           return deleteDataSourceDocument(
             dataSourceConfigFromConnector(connector),
             // this is the old internal ID
-            getTicketInternalId({
-              connectorId: connector.id,
-              ticketId: ticket.ticketId,
-            })
+            `zendesk-ticket-${connector.id}-${ticket.ticketId}`
           );
         },
         { concurrency: DOCUMENT_CONCURRENCY }
@@ -89,10 +82,7 @@ async function cleanArticles(
           return deleteDataSourceDocument(
             dataSourceConfigFromConnector(connector),
             // this is the old internal ID
-            getArticleInternalId({
-              connectorId: connector.id,
-              articleId: article.articleId,
-            })
+            `zendesk-article-${connector.id}-${article.articleId}`
           );
         },
         { concurrency: DOCUMENT_CONCURRENCY }

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -6,10 +6,7 @@ import type {
   ZendeskFetchedSection,
   ZendeskFetchedUser,
 } from "@connectors/@types/node-zendesk";
-import {
-  getArticleInternalId,
-  getArticleNewInternalId,
-} from "@connectors/connectors/zendesk/lib/id_conversions";
+import { getArticleInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import {
   deleteDataSourceDocument,
   renderDocumentTitleAndContent,
@@ -28,6 +25,7 @@ const turndownService = new TurndownService();
  */
 export async function deleteArticle(
   connectorId: ModelId,
+  brandId: number,
   articleId: number,
   dataSourceConfig: DataSourceConfig,
   loggerArgs: Record<string, string | number | null>
@@ -38,7 +36,7 @@ export async function deleteArticle(
   );
   await deleteDataSourceDocument(
     dataSourceConfig,
-    getArticleInternalId({ connectorId, articleId })
+    getArticleInternalId({ connectorId, brandId, articleId })
   );
   await ZendeskArticleResource.deleteByArticleId({ connectorId, articleId });
 }
@@ -149,27 +147,16 @@ export async function syncArticle({
       updatedAt,
     });
 
-    const oldDocumentId = getArticleInternalId({
-      connectorId,
-      articleId: article.id,
-    });
-
-    // TODO(2025-01-02 aubin): stop deleting old documents once the migration of internal IDs is done.
-    await deleteDataSourceDocument(dataSourceConfig, oldDocumentId, {
-      ...loggerArgs,
-      articleId: article.id,
-    });
-
-    const parents = articleInDb.getParentInternalIds(connectorId);
-    const newDocumentId = getArticleNewInternalId({
+    const documentId = getArticleInternalId({
       connectorId,
       brandId: category.brandId,
       articleId: article.id,
     });
 
+    const parents = articleInDb.getParentInternalIds(connectorId);
     await upsertDataSourceDocument({
       dataSourceConfig,
-      documentId: newDocumentId,
+      documentId,
       documentContent,
       documentUrl: article.html_url,
       timestampMs: updatedAt.getTime(),
@@ -178,7 +165,7 @@ export async function syncArticle({
         `createdAt:${createdAt.getTime()}`,
         `updatedAt:${updatedAt.getTime()}`,
       ],
-      parents: [newDocumentId, ...parents.slice(1)],
+      parents,
       parentId: parents[1],
       loggerArgs: { ...loggerArgs, articleId: article.id },
       upsertContext: { sync_type: "batch" },
@@ -186,7 +173,6 @@ export async function syncArticle({
       mimeType: "application/vnd.dust.zendesk.article",
       async: true,
     });
-
     await articleInDb.update({ lastUpsertedTs: new Date(currentSyncDateMs) });
   } else {
     logger.warn(

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -41,7 +41,11 @@ export async function deleteCategory({
     (article) =>
       deleteDataSourceDocument(
         dataSourceConfig,
-        getArticleInternalId({ connectorId, articleId: article.articleId })
+        getArticleInternalId({
+          connectorId,
+          brandId,
+          articleId: article.articleId,
+        })
       ),
     { concurrency: 10 }
   );

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -229,6 +229,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
       if (ticket.status === "deleted") {
         return deleteTicket({
           connectorId,
+          brandId,
           ticketId: ticket.id,
           dataSourceConfig,
           loggerArgs,

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -392,6 +392,7 @@ export async function zendeskCategorySyncWorkflow({
     await runZendeskActivityWithPagination((url) =>
       syncZendeskArticleBatchActivity({
         connectorId,
+        brandId,
         categoryId,
         currentSyncDateMs,
         forceResync,
@@ -527,6 +528,7 @@ async function runZendeskBrandHelpCenterSyncActivities({
     await runZendeskActivityWithPagination((url) =>
       syncZendeskArticleBatchActivity({
         connectorId,
+        brandId,
         categoryId,
         currentSyncDateMs,
         forceResync,

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -392,7 +392,6 @@ export async function zendeskCategorySyncWorkflow({
     await runZendeskActivityWithPagination((url) =>
       syncZendeskArticleBatchActivity({
         connectorId,
-        brandId,
         categoryId,
         currentSyncDateMs,
         forceResync,
@@ -528,7 +527,6 @@ async function runZendeskBrandHelpCenterSyncActivities({
     await runZendeskActivityWithPagination((url) =>
       syncZendeskArticleBatchActivity({
         connectorId,
-        brandId,
         categoryId,
         currentSyncDateMs,
         forceResync,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -722,7 +722,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     const { brandId, ticketId } = this;
     return {
       provider: "zendesk",
-      internalId: getTicketInternalId({ connectorId, ticketId }),
+      internalId: getTicketInternalId({ connectorId, brandId, ticketId }),
       parentInternalId: getTicketsInternalId({ connectorId, brandId }),
       type: "file",
       title: this.subject,
@@ -738,7 +738,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     const { brandId, ticketId } = this;
     /// Tickets have two parents: the Tickets and the Brand.
     return [
-      getTicketInternalId({ connectorId, ticketId }),
+      getTicketInternalId({ connectorId, brandId, ticketId }),
       getTicketsInternalId({ connectorId, brandId }),
       getBrandInternalId({ connectorId, brandId }),
     ];
@@ -752,13 +752,16 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     connectorId: number;
     expirationDate: Date;
     batchSize: number;
-  }): Promise<number[]> {
+  }): Promise<{ brandId: number; ticketId: number }[]> {
     const tickets = await ZendeskTicket.findAll({
-      attributes: ["ticketId"],
+      attributes: ["brandId", "ticketId"],
       where: { connectorId, ticketUpdatedAt: { [Op.lt]: expirationDate } },
       limit: batchSize,
     });
-    return tickets.map((ticket) => Number(ticket.get().ticketId));
+    return tickets.map((ticket) => {
+      const { ticketId, brandId } = ticket.get();
+      return { ticketId, brandId };
+    });
   }
 
   static async fetchByTicketId({
@@ -923,7 +926,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     const { brandId, categoryId, articleId } = this;
     return {
       provider: "zendesk",
-      internalId: getArticleInternalId({ connectorId, articleId }),
+      internalId: getArticleInternalId({ connectorId, brandId, articleId }),
       parentInternalId: getCategoryInternalId({
         connectorId,
         brandId,
@@ -943,7 +946,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     const { brandId, categoryId, articleId } = this;
     /// Articles have three parents: the Category, the Help Center and the Brand.
     return [
-      getArticleInternalId({ connectorId, articleId }),
+      getArticleInternalId({ connectorId, brandId, articleId }),
       getCategoryInternalId({ connectorId, brandId, categoryId }),
       getHelpCenterInternalId({ connectorId, brandId }),
       getBrandInternalId({ connectorId, brandId }),


### PR DESCRIPTION
## Description

- Follows up on #9704
- Part of #9691
- This PR aims at using the new internal IDs in the content nodes (the ones with the brand ID).

## Risk

- theoretically could break the assistant builder and space configuration since it changes the content nodes but in practice internal IDs are always read using the generic function `getIdsFromInternalId` so every call site is covered at once

## Deploy Plan

- Deploy connectors.
