### PR TITLE
Revert "fix(Zendesk) - use the new internal IDs in content nodes"

### DIFF
--- a/connectors/migrations/20250102_clean_zendesk_tickets_articles.ts
+++ b/connectors/migrations/20250102_clean_zendesk_tickets_articles.ts
@@ -1,6 +1,10 @@
 import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 
+import {
+  getArticleInternalId,
+  getTicketInternalId,
+} from "@connectors/connectors/zendesk/lib/id_conversions";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { deleteDataSourceDocument } from "@connectors/lib/data_sources";
@@ -35,7 +39,10 @@ async function cleanTickets(
           return deleteDataSourceDocument(
             dataSourceConfigFromConnector(connector),
             // this is the old internal ID
-            `zendesk-ticket-${connector.id}-${ticket.ticketId}`
+            getTicketInternalId({
+              connectorId: connector.id,
+              ticketId: ticket.ticketId,
+            })
           );
         },
         { concurrency: DOCUMENT_CONCURRENCY }
@@ -82,7 +89,10 @@ async function cleanArticles(
           return deleteDataSourceDocument(
             dataSourceConfigFromConnector(connector),
             // this is the old internal ID
-            `zendesk-article-${connector.id}-${article.articleId}`
+            getArticleInternalId({
+              connectorId: connector.id,
+              articleId: article.articleId,
+            })
           );
         },
         { concurrency: DOCUMENT_CONCURRENCY }

--- a/connectors/src/connectors/zendesk/lib/id_conversions.ts
+++ b/connectors/src/connectors/zendesk/lib/id_conversions.ts
@@ -39,6 +39,16 @@ export function getCategoryInternalId({
 
 export function getArticleInternalId({
   connectorId,
+  articleId,
+}: {
+  connectorId: ModelId;
+  articleId: number;
+}): string {
+  return `zendesk-article-${connectorId}-${articleId}`;
+}
+
+export function getArticleNewInternalId({
+  connectorId,
   brandId,
   articleId,
 }: {
@@ -61,6 +71,16 @@ export function getTicketsInternalId({
 
 export function getTicketInternalId({
   connectorId,
+  ticketId,
+}: {
+  connectorId: ModelId;
+  ticketId: number;
+}): string {
+  return `zendesk-ticket-${connectorId}-${ticketId}`;
+}
+
+export function getTicketNewInternalId({
+  connectorId,
   brandId,
   ticketId,
 }: {
@@ -80,63 +100,51 @@ function _getIdFromInternal(internalId: string, prefix: string): number | null {
     : null;
 }
 
-/**
- * Conversion from an internalId to a pair of IDs.
- */
-function _getIdsFromInternal(
-  internalId: string,
-  prefix: string
-): [number, number] | null {
-  if (!internalId.startsWith(prefix)) {
-    return null;
-  }
-  const ids = internalId
-    .replace(prefix, "")
-    .split("-")
-    .map((id) => parseInt(id, 10));
-  if (ids.length !== 2) {
-    return null;
-  }
-  return ids as [number, number];
-}
+export type InternalIdType =
+  | "brand"
+  | "help-center"
+  | "tickets"
+  | "article"
+  | "ticket";
 
-export function getIdsFromInternalId(
+export function getIdFromInternalId(
   connectorId: ModelId,
   internalId: string
 ):
+  | { type: InternalIdType; objectId: number }
   | {
-      type: "brand" | "help-center" | "tickets";
-      objectIds: { brandId: number };
-    }
-  | { type: "category"; objectIds: { brandId: number; categoryId: number } }
-  | { type: "article"; objectIds: { brandId: number; articleId: number } }
-  | { type: "ticket"; objectIds: { brandId: number; ticketId: number } } {
+      type: "category";
+      objectId: {
+        categoryId: number;
+        brandId: number;
+      };
+    } {
   let objectId = getBrandIdFromInternalId(connectorId, internalId);
   if (objectId) {
-    return { type: "brand", objectIds: { brandId: objectId } };
+    return { type: "brand", objectId };
   }
   objectId = getBrandIdFromHelpCenterId(connectorId, internalId);
   if (objectId) {
-    return { type: "help-center", objectIds: { brandId: objectId } };
+    return { type: "help-center", objectId };
   }
   objectId = getBrandIdFromTicketsId(connectorId, internalId);
   if (objectId) {
-    return { type: "tickets", objectIds: { brandId: objectId } };
+    return { type: "tickets", objectId };
   }
-  const categoryObjectIds = getCategoryIdFromInternalId(
+  const { categoryId, brandId } = getCategoryIdFromInternalId(
     connectorId,
     internalId
   );
-  if (categoryObjectIds) {
-    return { type: "category", objectIds: categoryObjectIds };
+  if (categoryId && brandId) {
+    return { type: "category", objectId: { categoryId, brandId } };
   }
-  const articleObjectIds = getArticleIdFromInternalId(connectorId, internalId);
-  if (articleObjectIds) {
-    return { type: "article", objectIds: articleObjectIds };
+  objectId = getArticleIdFromInternalId(connectorId, internalId);
+  if (objectId) {
+    return { type: "article", objectId };
   }
-  const ticketObjectIds = getTicketIdFromInternalId(connectorId, internalId);
-  if (ticketObjectIds) {
-    return { type: "ticket", objectIds: ticketObjectIds };
+  objectId = getTicketIdFromInternalId(connectorId, internalId);
+  if (objectId) {
+    return { type: "ticket", objectId };
   }
   logger.error(
     { connectorId, internalId },
@@ -165,19 +173,23 @@ function getBrandIdFromHelpCenterId(
 function getCategoryIdFromInternalId(
   connectorId: ModelId,
   internalId: string
-): { brandId: number; categoryId: number } | null {
+): { categoryId: number | null; brandId: number | null } {
   const prefix = `zendesk-category-${connectorId}-`;
-  const ids = _getIdsFromInternal(internalId, prefix);
-  return ids && { brandId: ids[0], categoryId: ids[1] };
+  if (!internalId.startsWith(prefix)) {
+    return { categoryId: null, brandId: null };
+  }
+  const [firstId, secondId] = internalId.replace(prefix, "").split("-");
+  if (firstId === undefined || secondId === undefined) {
+    return { categoryId: null, brandId: null };
+  }
+  return { brandId: parseInt(firstId), categoryId: parseInt(secondId) };
 }
 
 function getArticleIdFromInternalId(
   connectorId: ModelId,
   internalId: string
-): { brandId: number; articleId: number } | null {
-  const prefix = `zendesk-article-${connectorId}-`;
-  const ids = _getIdsFromInternal(internalId, prefix);
-  return ids && { brandId: ids[0], articleId: ids[1] };
+): number | null {
+  return _getIdFromInternal(internalId, `zendesk-article-${connectorId}-`);
 }
 
 function getBrandIdFromTicketsId(
@@ -193,8 +205,6 @@ function getBrandIdFromTicketsId(
 function getTicketIdFromInternalId(
   connectorId: ModelId,
   internalId: string
-): { brandId: number; ticketId: number } | null {
-  const prefix = `zendesk-ticket-${connectorId}-`;
-  const ids = _getIdsFromInternal(internalId, prefix);
-  return ids && { brandId: ids[0], ticketId: ids[1] };
+): number | null {
+  return _getIdFromInternal(internalId, `zendesk-ticket-${connectorId}-`);
 }

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -41,11 +41,7 @@ export async function deleteCategory({
     (article) =>
       deleteDataSourceDocument(
         dataSourceConfig,
-        getArticleInternalId({
-          connectorId,
-          brandId,
-          articleId: article.articleId,
-        })
+        getArticleInternalId({ connectorId, articleId: article.articleId })
       ),
     { concurrency: 10 }
   );

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -229,7 +229,6 @@ export async function syncZendeskTicketUpdateBatchActivity({
       if (ticket.status === "deleted") {
         return deleteTicket({
           connectorId,
-          brandId,
           ticketId: ticket.id,
           dataSourceConfig,
           loggerArgs,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -722,7 +722,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     const { brandId, ticketId } = this;
     return {
       provider: "zendesk",
-      internalId: getTicketInternalId({ connectorId, brandId, ticketId }),
+      internalId: getTicketInternalId({ connectorId, ticketId }),
       parentInternalId: getTicketsInternalId({ connectorId, brandId }),
       type: "file",
       title: this.subject,
@@ -738,7 +738,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     const { brandId, ticketId } = this;
     /// Tickets have two parents: the Tickets and the Brand.
     return [
-      getTicketInternalId({ connectorId, brandId, ticketId }),
+      getTicketInternalId({ connectorId, ticketId }),
       getTicketsInternalId({ connectorId, brandId }),
       getBrandInternalId({ connectorId, brandId }),
     ];
@@ -752,16 +752,13 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     connectorId: number;
     expirationDate: Date;
     batchSize: number;
-  }): Promise<{ brandId: number; ticketId: number }[]> {
+  }): Promise<number[]> {
     const tickets = await ZendeskTicket.findAll({
-      attributes: ["brandId", "ticketId"],
+      attributes: ["ticketId"],
       where: { connectorId, ticketUpdatedAt: { [Op.lt]: expirationDate } },
       limit: batchSize,
     });
-    return tickets.map((ticket) => {
-      const { ticketId, brandId } = ticket.get();
-      return { ticketId, brandId };
-    });
+    return tickets.map((ticket) => Number(ticket.get().ticketId));
   }
 
   static async fetchByTicketId({
@@ -926,7 +923,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     const { brandId, categoryId, articleId } = this;
     return {
       provider: "zendesk",
-      internalId: getArticleInternalId({ connectorId, brandId, articleId }),
+      internalId: getArticleInternalId({ connectorId, articleId }),
       parentInternalId: getCategoryInternalId({
         connectorId,
         brandId,
@@ -946,7 +943,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     const { brandId, categoryId, articleId } = this;
     /// Articles have three parents: the Category, the Help Center and the Brand.
     return [
-      getArticleInternalId({ connectorId, brandId, articleId }),
+      getArticleInternalId({ connectorId, articleId }),
       getCategoryInternalId({ connectorId, brandId, categoryId }),
       getHelpCenterInternalId({ connectorId, brandId }),
       getBrandInternalId({ connectorId, brandId }),


### PR DESCRIPTION
Reverts dust-tt/dust#9711, which was merged too fast (has to be merged after the full syncs to properly delete the old documents)