### PR TITLE
Grant admin role to system key + fix patch data source view endpoint

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -388,7 +388,12 @@ export class Authenticator {
     let role = "none" as RoleType;
     const isKeyWorkspace = keyWorkspace.id === workspace?.id;
     if (isKeyWorkspace) {
-      role = "builder";
+      // System keys have admin role on their workspace.
+      if (key.isSystem) {
+        role = "admin";
+      } else {
+        role = "builder";
+      }
     }
 
     const getSubscriptionForWorkspace = (workspace: Workspace) =>

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -178,7 +178,7 @@ async function handler(
 
   if (
     !dataSourceView ||
-    req.query.vId !== dataSourceView.space.sId ||
+    req.query.spaceId !== dataSourceView.space.sId ||
     !dataSourceView.canList(auth)
   ) {
     return apiError(req, res, {

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "ISC",
       "dependencies": {
         "eventsource-parser": "^1.1.1",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -985,7 +985,7 @@ export class DustAPI {
   ) {
     const res = await this.request({
       method: "PATCH",
-      path: `data_source_views/${dataSourceView.sId}`,
+      path: `spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}`,
       body: patchData,
     });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Getting there... most of those endpoints never really worked....

This PR:
- fixes the patch on data source views (used to auto-join a slack channel)
- updates the endpoint used in the SDK JS. Somehow it targets an endpoint that does not exist anymore 🙄 (public documentation is already up-to-date).
- ⚠️ grant `admin` role to all system key on their own workspace. This is required to pass the `canAdministrate` role when updating parents of a data source view and it seems pretty legit as we use this key for several admin operations.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
⚠️ Role change for system API key.

Tested locally. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
