### PR TITLE
fix(Zendesk) - add a default value for tickets' subject

### DIFF
--- a/connectors/src/@types/node-zendesk.d.ts
+++ b/connectors/src/@types/node-zendesk.d.ts
@@ -117,7 +117,7 @@ interface ZendeskFetchedTicket {
   };
   sharing_agreement_ids: number[];
   status: "new" | "open" | "pending" | "hold" | "solved" | "closed" | "deleted";
-  subject: string;
+  subject: string | null;
   submitter_id: number;
   tags: string[];
   type: "problem" | "incident" | "question" | "task";

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -88,6 +88,10 @@ export async function syncTicket({
     !ticketInDb.lastUpsertedTs ||
     ticketInDb.lastUpsertedTs < updatedAtDate;
 
+  // Tickets can be created without a subject using the API or by email,
+  // if they were never attended in the Agent Workspace their subject is not populated.
+  ticket.subject ||= "No subject";
+
   if (!ticketInDb) {
     ticketInDb = await ZendeskTicketResource.makeNew({
       blob: {


### PR DESCRIPTION
## Description

- Fix [validation errors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40dd.service%3Aconnectors-worker%20%40error.aggregateErrors.message%3A%22zendesk_tickets.subject%20cannot%20be%20null%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1735883874932&to_ts=1735887474932&live=true) on the subject not being nullable in the db.
- This PR adds a default value for ticket that have no subject.
- Such ticket can exist when created using the API or by email and if they were never attended in the Agent Workspace (if attended their subject is automatically populated using the first comment).

## Risk

- Low

## Deploy Plan

- Deploy connectors.