### PR TITLE
enh(Zendesk) - rethrow 404 on the articles as 403 if user is not an admin

### DIFF
--- a/connectors/src/connectors/zendesk/lib/errors.ts
+++ b/connectors/src/connectors/zendesk/lib/errors.ts
@@ -51,7 +51,9 @@ export function isZendeskExpiredCursorError(
  * The idea is that we only try/catch the part where we call the API, without wrapping any of our code and from then
  * only certain functions can actually handle 404 by returning a null.
  */
-export function isZendeskNotFoundError(err: unknown): boolean {
+export function isZendeskNotFoundError(
+  err: unknown
+): err is ZendeskApiError & boolean {
   return err instanceof ZendeskApiError && err.status === 404;
 }
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -290,7 +290,8 @@ export async function fetchRecentlyUpdatedArticles({
         subdomain: brandSubdomain,
         accessToken,
       });
-      if (user && user.role !== "admin") {
+      // only admins and agents can fetch this endpoint: https://developer.zendesk.com/documentation/help_center/help-center-api/understanding-incremental-article-exports/#authenticating-the-requests
+      if (user && user.role !== "admin" && user.role !== "agent") {
         throw new ZendeskApiError(
           "Error fetching the incremental articles endpoint, user is not admin.",
           403,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -277,12 +277,29 @@ export async function fetchRecentlyUpdatedArticles({
 }> {
   // this endpoint retrieves changes in content, not only in metadata despite what is mentioned in the documentation.
   const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`;
-  const response = await fetchFromZendeskWithRetries({ url, accessToken });
-  return {
-    articles: response.articles,
-    hasMore: response.next_page !== null && response.articles.length !== 0,
-    endTime: response.end_time,
-  };
+  try {
+    const response = await fetchFromZendeskWithRetries({ url, accessToken });
+    return {
+      articles: response.articles,
+      hasMore: response.next_page !== null && response.articles.length !== 0,
+      endTime: response.end_time,
+    };
+  } catch (e) {
+    if (isZendeskNotFoundError(e)) {
+      const user = await fetchZendeskCurrentUser({
+        subdomain: brandSubdomain,
+        accessToken,
+      });
+      if (user && user.role !== "admin") {
+        throw new ZendeskApiError(
+          "Error fetching the incremental articles endpoint, user is not admin.",
+          403,
+          e.data
+        );
+      }
+    }
+    throw e;
+  }
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -292,10 +292,11 @@ export async function fetchRecentlyUpdatedArticles({
       });
       // only admins and agents can fetch this endpoint: https://developer.zendesk.com/documentation/help_center/help-center-api/understanding-incremental-article-exports/#authenticating-the-requests
       if (user && user.role !== "admin" && user.role !== "agent") {
+        const { role, suspended, active } = user;
         throw new ZendeskApiError(
-          "Error fetching the incremental articles endpoint, user is not admin.",
+          "Error fetching the incremental articles endpoint, user must be admin/agent.",
           403,
-          e.data
+          { ...e.data, role, suspended, active }
         );
       }
     }


### PR DESCRIPTION
## Description

- The articles incremental endpoint requires the authenticated user to be either an admin or an agent: https://developer.zendesk.com/documentation/help_center/help-center-api/understanding-incremental-article-exports/#authenticating-the-requests
- For some reason, we get 404 instead of 403 otherwise.
- This PR aims at recasting these 404 errors to catch them in `cast_known_errors`, which then rethrows as `ExternalOAuthError`.
- Tooling that was used: `./admin/cli.sh zendesk check-is-admin`

## Risk

- Low

## Deploy Plan

- Deploy connectors.
