### PR TITLE
fix(Zendesk) - fix `users.showMany` failing due to URI too long

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -192,7 +192,7 @@ ${comments
       );
       author = null;
     }
-    return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${comment.body}`;
+    return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${comment.body.replace(/[\u2028\u2029]/g, "")}`; // removing line and paragraph separators
   })
   .join("\n")}
 `.trim();

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -8,6 +8,7 @@ import type {
   ZendeskFetchedBrand,
   ZendeskFetchedCategory,
   ZendeskFetchedTicket,
+  ZendeskFetchedTicketComment,
   ZendeskFetchedUser,
 } from "@connectors/@types/node-zendesk";
 import {
@@ -391,6 +392,31 @@ export async function fetchZendeskTicket({
     }
     throw e;
   }
+}
+
+/**
+ * Fetches a single ticket from the Zendesk API.
+ */
+export async function fetchZendeskTicketComments({
+  accessToken,
+  brandSubdomain,
+  ticketId,
+}: {
+  accessToken: string;
+  brandSubdomain: string;
+  ticketId: number;
+}): Promise<ZendeskFetchedTicketComment[]> {
+  const comments = [];
+  let url: string = `https://${brandSubdomain}.zendesk.com/api/v2/tickets/${ticketId}/comments`;
+  let hasMore = true;
+
+  while (hasMore) {
+    const response = await fetchFromZendeskWithRetries({ url, accessToken });
+    comments.push(...response.comments);
+    hasMore = response.hasMore || false;
+    url = response.nextLink;
+  }
+  return comments;
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -407,7 +407,7 @@ export async function fetchZendeskTicketComments({
   ticketId: number;
 }): Promise<ZendeskFetchedTicketComment[]> {
   const comments = [];
-  let url: string = `https://${brandSubdomain}.zendesk.com/api/v2/tickets/${ticketId}/comments`;
+  let url: string = `https://${brandSubdomain}.zendesk.com/api/v2/tickets/${ticketId}/comments?page[size]=100`;
   let hasMore = true;
 
   while (hasMore) {

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -10,6 +10,7 @@ import {
   changeZendeskClientSubdomain,
   createZendeskClient,
   fetchRecentlyUpdatedArticles,
+  fetchZendeskManyUsers,
   fetchZendeskTickets,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -235,9 +236,11 @@ export async function syncZendeskTicketUpdateBatchActivity({
         });
       } else if (["solved", "closed"].includes(ticket.status)) {
         const comments = await zendeskApiClient.tickets.getComments(ticket.id);
-        const { result: users } = await zendeskApiClient.users.showMany(
-          comments.map((c) => c.author_id)
-        );
+        const users = await fetchZendeskManyUsers({
+          accessToken,
+          brandSubdomain,
+          userIds: comments.map((c) => c.author_id),
+        });
         return syncTicket({
           connectorId,
           ticket,


### PR DESCRIPTION
## Description

- We fetching users when syncing tickets in order to relate comment's authors with their metadata (email, name).
- This fetch fails silently (hidden) but can be traced back to a 414 in https://app.datadoghq.eu/apm/trace/3092519496025536636?graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=6202661528749580084&timeHint=1735899816656.0054&traceQuery=
- The error is due to an URI too long, very likely due to having too many users at once (the API supports at most 100 users at once).
- This PR fixes that by replacing the use of the library `node-zendesk` (SDK that wraps the API), which does not split the IDs by chunks of 100, by a function that wraps the endpoint with this splitting.
- This PR also removes a reliance on `node-zendesk` for fetching comments, in an effort to remove this dependency.
- This PR also removes line separators and paragraph separators from comment bodies, in an effort to make the connector more robust.

## Risk

- Low

## Deploy Plan

- Deploy connectors
