### PR TITLE
Add Zendesk workflows to the production check `checkActiveWorkflows`

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -1,5 +1,10 @@
-import type { ModelId, Result } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import {
+  Err,
+  getZendeskGarbageCollectionWorkflowId,
+  getZendeskSyncWorkflowId,
+  Ok,
+} from "@dust-tt/types";
 import type { WorkflowHandle } from "@temporalio/client";
 import {
   WorkflowExecutionAlreadyStartedError,
@@ -24,16 +29,6 @@ import {
   ZendeskBrandResource,
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
-
-export function getZendeskSyncWorkflowId(connectorId: ModelId): string {
-  return `zendesk-sync-${connectorId}`;
-}
-
-export function getZendeskGarbageCollectionWorkflowId(
-  connectorId: ModelId
-): string {
-  return `zendesk-gc-${connectorId}`;
-}
 
 export async function launchZendeskSyncWorkflow(
   connector: ConnectorResource,

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -1,4 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
+import { getZendeskGarbageCollectionWorkflowId } from "@dust-tt/types";
 
 import {
   getArticleInternalId,
@@ -15,7 +16,6 @@ import {
   fetchZendeskArticle,
   getZendeskBrandSubdomain,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
-import { getZendeskGarbageCollectionWorkflowId } from "@connectors/connectors/zendesk/temporal/client";
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -1,12 +1,12 @@
 import type { ConnectorProvider } from "@dust-tt/types";
 import {
-  microsoftGarbageCollectionWorkflowId,
-  microsoftIncrementalSyncWorkflowId,
-} from "@dust-tt/types";
-import {
   getIntercomSyncWorkflowId,
+  getZendeskGarbageCollectionWorkflowId,
+  getZendeskSyncWorkflowId,
   googleDriveIncrementalSyncWorkflowId,
   makeConfluenceSyncWorkflowId,
+  microsoftGarbageCollectionWorkflowId,
+  microsoftIncrementalSyncWorkflowId,
 } from "@dust-tt/types";
 import type { Client, WorkflowHandle } from "@temporalio/client";
 import { QueryTypes } from "sequelize";
@@ -48,6 +48,12 @@ const providersToCheck: Partial<Record<ConnectorProvider, ProviderCheck>> = {
     makeIdsFn: (connector: ConnectorBlob) => [
       microsoftIncrementalSyncWorkflowId(connector.id),
       microsoftGarbageCollectionWorkflowId(connector.id),
+    ],
+  },
+  zendesk: {
+    makeIdsFn: (connector: ConnectorBlob) => [
+      getZendeskSyncWorkflowId(connector.id),
+      getZendeskGarbageCollectionWorkflowId(connector.id),
     ],
   },
 };

--- a/types/src/connectors/zendesk.ts
+++ b/types/src/connectors/zendesk.ts
@@ -1,0 +1,11 @@
+import { ModelId } from "../shared/model_id";
+
+export function getZendeskSyncWorkflowId(connectorId: ModelId): string {
+  return `zendesk-sync-${connectorId}`;
+}
+
+export function getZendeskGarbageCollectionWorkflowId(
+  connectorId: ModelId
+): string {
+  return `zendesk-gc-${connectorId}`;
+}

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -13,6 +13,7 @@ export * from "./connectors/notion";
 export * from "./connectors/slack";
 export * from "./connectors/snowflake";
 export * from "./connectors/webcrawler";
+export * from "./connectors/zendesk";
 export * from "./core/content_node";
 export * from "./core/data_source";
 export * from "./front/api_handlers/internal/agent_configuration";


### PR DESCRIPTION
## Description

- Every Zendesk connector should have 2 workflows running at all time: sync and gc.
- These were not tracked by the production check `checkActiveWorkflows`.
- This PR fixes that.
- Code in the zendesk connector changes but no need to stop and resume Zendesk connectors, only the client and certain activities (they import the function that gets the workflow name for logging) are affected: no workflow code change.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Deploy connectors.
