### PR TITLE
Ext: Remove nodeEnv from DustAPI constructor

### DIFF
--- a/extension/app/src/lib/dust_api.ts
+++ b/extension/app/src/lib/dust_api.ts
@@ -16,7 +16,6 @@ export const useDustAPI = () => {
   return new DustAPI(
     {
       url: process.env.DUST_DOMAIN,
-      nodeEnv: process.env.NODE_ENV,
     },
     {
       apiKey: () => getAccessToken(),


### PR DESCRIPTION
## Description

NodeEnv was removed from the sdk here: https://github.com/dust-tt/dust/pull/9508

## Risk

/ 

## Deploy Plan

/ 