### PR TITLE
Ext: disable quick action ask dust

### DIFF
--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -51,11 +51,6 @@ chrome.runtime.onInstalled.addListener(() => {
   void chrome.storage.local.set({ extensionReady: false });
   void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
   chrome.contextMenus.create({
-    id: "ask_dust",
-    title: "Ask @dust to summarize this page",
-    contexts: ["all"],
-  });
-  chrome.contextMenus.create({
     id: "add_tab_content",
     title: "Add tab content to conversation",
     contexts: ["all"],
@@ -96,14 +91,11 @@ const shouldDisableContextMenuForDomain = async (
 };
 
 const toggleContextMenus = (isDisabled: boolean) => {
-  [
-    "ask_dust",
-    "add_tab_content",
-    "add_tab_screenshot",
-    "add_selection",
-  ].forEach((menuId) => {
-    chrome.contextMenus.update(menuId, { enabled: !isDisabled });
-  });
+  ["add_tab_content", "add_tab_screenshot", "add_selection"].forEach(
+    (menuId) => {
+      chrome.contextMenus.update(menuId, { enabled: !isDisabled });
+    }
+  );
 };
 
 // Add URL change listener to update context menu state.
@@ -140,20 +132,24 @@ chrome.runtime.onConnect.addListener((port) => {
 
 const getActionHandler = (menuItemId: string | number) => {
   switch (menuItemId) {
-    case "ask_dust":
-      return () => {
-        const params = JSON.stringify({
-          includeContent: true,
-          includeCapture: false,
-          text: ":mention[dust]{sId=dust} summarize this page.",
-          configurationId: "dust",
-        });
-        void chrome.runtime.sendMessage({
-          type: "EXT_ROUTE_CHANGE",
-          pathname: "/run",
-          search: `?${params}`,
-        });
-      };
+    /**
+     * We have the logic to add an action that will open a convo a pre-post a message.
+     * We're not using it anymore at the moment but keeping ref here for future iteration
+     * if we want to experiment again with quick actions.
+     *
+     * const params = JSON.stringify({
+     *    includeContent: true,
+     *    includeCapture: false,
+     *    text: ":mention[dust]{sId=dust} summarize this page.",
+     *    configurationId: "dust",
+     *  });
+     *  void chrome.runtime.sendMessage({
+     *    type: "EXT_ROUTE_CHANGE",
+     *    pathname: "/run",
+     *    search: `?${params}`,
+     *  });
+     *
+     */
     case "add_tab_content":
       return () => {
         void chrome.runtime.sendMessage({

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -133,7 +133,7 @@ chrome.runtime.onConnect.addListener((port) => {
 const getActionHandler = (menuItemId: string | number) => {
   switch (menuItemId) {
     /**
-     * We have the logic to add an action that will open a convo a pre-post a message.
+     * We have the logic to add an action that will open a convo and pre-post a message.
      * We're not using it anymore at the moment but keeping ref here for future iteration
      * if we want to experiment again with quick actions.
      *


### PR DESCRIPTION
## Description

Context: https://github.com/dust-tt/tasks/issues/1884

We will re-explore quick actions but probably not as is with an assistant handle and a prompt, since we've got some concerns it goes against the concept of custom assistants. 

I do not want to remove all the run code because I'm convinced we will reuse it soon. I kept the example as comment.

## Risk

/ 

## Deploy Plan

/ 
