### PR TITLE
Bump nextJS keep-alive to 6s

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -3,7 +3,7 @@
     "dev:all": "concurrently --kill-others \"cd ../types/ && npm run start\" \"sleep 20 && cd ../sdks/js/ && npm run start\" \"sleep 22 && next dev\" \"sleep 22 && tsx ./start_worker.ts\"",
     "dev": "next dev",
     "build": "next build",
-    "start": "next start --keepAliveTimeout 5000",
+    "start": "next start --keepAliveTimeout 6000",
     "start:worker": "tsx ./start_worker.ts",
     "lint": "next lint",
     "docs": "npx next-swagger-doc-cli swagger.json 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || { npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json && npm run format; }",


### PR DESCRIPTION
## Description

Assuming the ECONNRESET we see here: https://app.datadoghq.eu/logs?query=%22DustAPI%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=3148154741905360483&storage=hot&stream_sort=desc&viz=stream&from_ts=1735902211829&to_ts=1735916611829&live=true

Are due to having the same value. But it's possible the load balancer in front of front is keep-alive aware in which case we may want to bump it to a much larger value.

See: https://github.com/vercel/next.js/pull/35827/files

## Risk

N/A

## Deploy Plan

- deploy `front`