### PR TITLE
Bump keep-alive above default LBs

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -3,7 +3,7 @@
     "dev:all": "concurrently --kill-others \"cd ../types/ && npm run start\" \"sleep 20 && cd ../sdks/js/ && npm run start\" \"sleep 22 && next dev\" \"sleep 22 && tsx ./start_worker.ts\"",
     "dev": "next dev",
     "build": "next build",
-    "start": "next start --keepAliveTimeout 6000",
+    "start": "next start --keepAliveTimeout 610000",
     "start:worker": "tsx ./start_worker.ts",
     "lint": "next lint",
     "docs": "npx next-swagger-doc-cli swagger.json 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || { npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json && npm run format; }",


### PR DESCRIPTION
## Description

Bump keep-alive to very high value as inspired by https://github.com/vercel/next.js/pull/35827/files + above known ALB values.

## Risk

Will deploy on front-edge first to test and give it a try. Many potential risks of resource exhaustion. Will monitor and revert accordingly.

## Deploy Plan

- deploy `front` and monitor