### PR TITLE
fix(Zendesk) - render the plain body in tickets instead of the body

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -192,7 +192,7 @@ ${comments
       );
       author = null;
     }
-    return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${comment.body.replace(/[\u2028\u2029]/g, "")}`; // removing line and paragraph separators
+    return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${comment.plain_body.replace(/[\u2028\u2029]/g, "")}`; // removing line and paragraph separators
   })
   .join("\n")}
 `.trim();


### PR DESCRIPTION
## Description

- We got [RangeError: Maximum call stack size exceeded](https://app.datadoghq.eu/logs?query=%22RangeError%3A%20Maximum%20call%20stack%20size%20exceeded%22%20%40activityName%3AsyncZendeskTicketBatchActivity&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1735908313902&to_ts=1735922713902&live=true) when converting the body of ticket comments from HTML to markdown.
- The content of the ticket comments turned out to contain html elements that cause an infinite recursion.
- Instead of relying on the `body` field of the comments, which contain some html content, this PR proposes to use the `plain_body`, which is an HTML-free version.
- On the examples studied, the extra HTML content did not bring significant semantic information, the `plain_body` is mostly a restructuration of the same information.

## Risk

- Low

## Deploy Plan

- Deploy connectors.
