### PR TITLE
enh(Zendesk) - prevent resuming paused zendesk connectors

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -212,6 +212,13 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
       return new Err(new Error("Connector not found"));
     }
+    if (connector.isPaused()) {
+      logger.error(
+        { connectorId },
+        "[Zendesk] Cannot resume a paused connector."
+      );
+      return new Err(new Error("Cannot resume a paused connector"));
+    }
 
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     const loggerArgs = {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -213,11 +213,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
     if (connector.isPaused()) {
-      logger.error(
+      logger.warn(
         { connectorId },
         "[Zendesk] Cannot resume a paused connector."
       );
-      return new Err(new Error("Cannot resume a paused connector"));
+      return new Ok(undefined);
     }
 
     const dataSourceConfig = dataSourceConfigFromConnector(connector);

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -217,6 +217,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         { connectorId },
         "[Zendesk] Cannot resume a paused connector."
       );
+      // we don't return an error since this could be used within a batch-resume, only need to be informed
       return new Ok(undefined);
     }
 


### PR DESCRIPTION
## Description

- This PR skips the launch of the workflows on `ZendeskConnectorManager.resume` if the connector is paused.
- This change is long overdue, paused connectors were previously tracked manually and paused again after launching a resume-all (which launches workflows even when paused).
- Summary:
  - Stop: stops the workflows for the connector (sync + GC)
  - Resume: resumes the 2 workflows
  - Pause: marks the connector as paused and stops (calls stop)
  - Unpause: marks the connector as unpaused and resumes (calls resume)

## Risk

- Low, only admin actions affected.

## Deploy Plan

- Deploy connectors.
