### PR TITLE
[sparkle] - fix(Sheet): closing transition

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.354",
+  "version": "0.2.355",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.354",
+      "version": "0.2.355",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.354",
+  "version": "0.2.355",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -64,7 +64,7 @@ const SheetContent = React.forwardRef<
 >(({ className, children, size, trapFocusScope, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
-    <FocusScope trapped={trapFocusScope}>
+    <FocusScope trapped={trapFocusScope} asChild>
       <SheetPrimitive.Content
         ref={ref}
         className={cn(sheetVariants({ size }), className)}


### PR DESCRIPTION
## Description

This PR adds a "asChild" property to the `FocusScope` wrapping the `SheetContent`. It ensures that we do not create a new DOM element hence maintaining the expected Radix transition.

## Risk

Low

## Deploy Plan

Publish sparkle
