### PR TITLE
Whitelist `.mdx` files in GitHub connector

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -636,6 +636,7 @@ const EXTENSION_WHITELIST = [
 
   // Documentation
   ".md", // Markdown
+  ".mdx", // Markdown with JSX
   ".rst", // ReStructured Text
   ".adoc", // AsciiDoc
   ".tex", // LaTeX


### PR DESCRIPTION
## Description

- Add `.mdx` to the extension whitelist in the GitHub connector.
- `.mdx` files are Markdown files with JSX: https://mdxjs.com/

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Resync code for one connector that is known to have `.mdx` files and was subject to an inquiry by a customer.
