### PR TITLE
[Elasticsearch] Fail on node indexation error

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -144,7 +144,6 @@ impl SearchStore for ElasticsearchSearchStore {
     }
 
     async fn index_node(&self, node: Node) -> Result<()> {
-        // todo(kw-search): fail on error
         let now = utils::now();
         // Note: in elasticsearch, the index API updates the document if it
         // already exists.
@@ -175,7 +174,7 @@ impl SearchStore for ElasticsearchSearchStore {
                     "[ElasticsearchSearchStore] Failed to index {}",
                     node.node_type.to_string()
                 );
-                Ok(())
+                Err(anyhow::anyhow!("Failed to index node {}", error))
             }
         }
     }
@@ -186,7 +185,6 @@ impl SearchStore for ElasticsearchSearchStore {
             .delete(DeleteParts::IndexId(NODES_INDEX_NAME, &node.unique_id()))
             .send()
             .await?;
-        // todo(kw-search): fail on error
         match response.status_code().is_success() {
             true => Ok(()),
             false => {
@@ -215,7 +213,6 @@ impl SearchStore for ElasticsearchSearchStore {
             }))
             .send()
             .await?;
-        // todo(kw-search): fail on error
         match response.status_code().is_success() {
             true => Ok(()),
             false => {


### PR DESCRIPTION
Description
---
Previously, when indexing a node in elasticsearch, we didn't fail, but just logged an error. This was to test the newly-introduced infrastructure.

This PR switches to erring, which is the correct behaviour now that the infra is confirmed stable enough.

Risks
---
Very low, no errors have been witnessed last week
https://app.datadoghq.eu/dashboard/ss3-x6k-9kr/elasticsearch?fromUser=true&refresh_mode=sliding&from_ts=1735572313097&to_ts=1736177113097&live=true

Deploy
---
core
