### PR TITLE
Filter Out Conversation Spaces from Global Agent Data Sources

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -104,11 +104,11 @@ async function getDataSourcesAndWorkspaceIdForGlobalAgents(
   const globalGroup = await GroupResource.fetchWorkspaceGlobalGroup(auth);
   assert(globalGroup.isOk(), "Failed to fetch global group");
 
-  const allSpaces = await SpaceResource.listForGroups(auth, [
+  const globalGroupSpaces = await SpaceResource.listForGroups(auth, [
     globalGroup.value,
   ]);
 
-  const nonConversationSpaces = allSpaces.filter(
+  const nonConversationSpaces = globalGroupSpaces.filter(
     (space) => !space.isConversations()
   );
 

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -104,13 +104,17 @@ async function getDataSourcesAndWorkspaceIdForGlobalAgents(
   const globalGroup = await GroupResource.fetchWorkspaceGlobalGroup(auth);
   assert(globalGroup.isOk(), "Failed to fetch global group");
 
-  const defaultSpaces = await SpaceResource.listForGroups(auth, [
+  const allSpaces = await SpaceResource.listForGroups(auth, [
     globalGroup.value,
   ]);
 
+  const nonConversationSpaces = allSpaces.filter(
+    (space) => !space.isConversations()
+  );
+
   const dataSourceViews = await DataSourceViewResource.listBySpaces(
     auth,
-    defaultSpaces
+    nonConversationSpaces
   );
 
   return {


### PR DESCRIPTION
## Description

See context [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1736175325301009).

Problem:
- Through Node debugger profiling, we identified a performance bottleneck in `getDataSourcesAndWorkspaceIdForGlobalAgents`
- The function was unnecessarily loading data source views from conversation spaces
- For example, in the Dust workspace alone, this resulted in 1,091 redundant data source views being frequently loaded

Solution:
- Added filtering to exclude conversation spaces when fetching data source views
- Global assistants don't need access to conversation space resources
- This significantly reduces the number of data source views being loaded and processed

<img width="665" alt="image" src="https://github.com/user-attachments/assets/346ac4ac-0884-4dc1-b8e1-3c0ccd8c835c" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
