### PR TITLE
Upg: only list conversations space if requested, limit to default selected as early as possible.

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -34,7 +34,6 @@ import {
   O1_MINI_MODEL_CONFIG,
   O1_MODEL_CONFIG,
 } from "@dust-tt/types";
-import assert from "assert";
 
 import {
   DEFAULT_BROWSE_ACTION_DESCRIPTION,
@@ -52,8 +51,6 @@ import {
   PRODUCTION_DUST_APPS_WORKSPACE_ID,
 } from "@app/lib/registry";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 
 // Used when returning an agent with status 'disabled_by_admin'
@@ -102,24 +99,12 @@ async function getDataSourcesAndWorkspaceIdForGlobalAgents(
   auth: Authenticator
 ): Promise<PrefetchedDataSourcesType> {
   const owner = auth.getNonNullableWorkspace();
-
-  const globalGroup = await GroupResource.fetchWorkspaceGlobalGroup(auth);
-  assert(globalGroup.isOk(), "Failed to fetch global group");
-
-  const globalGroupSpaces = await SpaceResource.listForGroups(auth, [
-    globalGroup.value,
-  ]);
-
-  const dataSourceViews = await DataSourceViewResource.listBySpaces(
-    auth,
-    globalGroupSpaces
-  );
+  const dsvs = await DataSourceViewResource.listAssistantDefaultSelected(auth);
 
   return {
-    dataSourceViews: dataSourceViews.map((dsv) => {
+    dataSourceViews: dsvs.map((dsv) => {
       return {
         ...dsv.toJSON(),
-        assistantDefaultSelected: dsv.dataSource.assistantDefaultSelected,
         isInGlobalSpace: dsv.space.isGlobal(),
       };
     }),

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -110,13 +110,9 @@ async function getDataSourcesAndWorkspaceIdForGlobalAgents(
     globalGroup.value,
   ]);
 
-  const nonConversationSpaces = globalGroupSpaces.filter(
-    (space) => !space.isConversations()
-  );
-
   const dataSourceViews = await DataSourceViewResource.listBySpaces(
     auth,
-    nonConversationSpaces
+    globalGroupSpaces
   );
 
   return {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -294,10 +294,12 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
           model: DataSourceModel,
           as: "dataSourceForView",
           required: true,
+          where: {
+            assistantDefaultSelected: true,
+          },
         },
       ],
       where: {
-        "$dataSourceForView.assistantDefaultSelected$": true,
         vaultId: spaces.map((s) => s.id),
       },
     });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -9,6 +9,7 @@ import type {
   Result,
 } from "@dust-tt/types";
 import { formatUserFullName, Ok, removeNulls } from "@dust-tt/types";
+import assert from "assert";
 import type {
   Attributes,
   CreationAttributes,
@@ -24,10 +25,11 @@ import { isFolder, isWebsite } from "@app/lib/data_sources";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import type { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -275,6 +277,27 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
+        vaultId: spaces.map((s) => s.id),
+      },
+    });
+  }
+
+  static async listAssistantDefaultSelected(auth: Authenticator) {
+    const globalGroup = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    assert(globalGroup.isOk(), "Failed to fetch global group");
+
+    const spaces = await SpaceResource.listForGroups(auth, [globalGroup.value]);
+
+    return this.baseFetch(auth, undefined, {
+      includes: [
+        {
+          model: DataSourceModel,
+          as: "dataSourceForView",
+          required: true,
+        },
+      ],
+      where: {
+        "$dataSourceForView.assistantDefaultSelected$": true,
         vaultId: spaces.map((s) => s.id),
       },
     });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -221,7 +221,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
-  static async listForGroups(auth: Authenticator, groups: GroupResource[]) {
+  static async listForGroups(
+    auth: Authenticator,
+    groups: GroupResource[],
+    options?: { includeConversationsSpace?: boolean }
+  ) {
     const groupSpaces = await GroupSpaceModel.findAll({
       where: {
         groupId: groups.map((g) => g.id),
@@ -231,6 +235,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const spaces = await this.baseFetch(auth, {
       where: {
         id: groupSpaces.map((v) => v.vaultId),
+        kind: {
+          [Op.in]: [
+            "system",
+            "global",
+            "regular",
+            "public",
+            ...(options?.includeConversationsSpace ? ["conversations"] : []),
+          ],
+        },
       },
     });
 

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -411,9 +411,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
       },
       includes: [
         {
-          // @ts-expect-error @todo(DOC_TRACKER) Fix to remove the ts-expect-error.
           model: TrackerGenerationModel,
-          // @ts-expect-error @todo(DOC_TRACKER) Fix to remove the ts-expect-error.
           as: "generations",
           where: {
             consumedAt: null,

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
+    "noErrorTruncation": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Description

Simple refactor to follow the pattern of the other functions, default to not fetching the conversation space.
Optimize the query to only fetch the datasource that are set as valid for the default assistants.

## Risk

Low, tested locally.

## Deploy Plan

Deploy `prod`