### PR TITLE
[front] Fix markdown file uploads

### DIFF
--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -40,9 +40,14 @@ export const parseUploadRequest = async (
 
       // Ensure the file is of the correct type.
       filter: function (part) {
-        // formidable returns markdown file parts as application/octet-stream
         if (file.contentType === "text/markdown") {
-          return part.mimetype === "application/octet-stream";
+          // some setups do not detect the markdown type and return a content type of application/octet-stream
+          return (
+            part.mimetype !== null &&
+            ["text/markdown", "application/octet-stream"].includes(
+              part.mimetype
+            )
+          );
         }
         return part.mimetype === file.contentType;
       },

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -40,6 +40,9 @@ export const parseUploadRequest = async (
 
       // Ensure the file is of the correct type.
       filter: function (part) {
+        if (file.contentType === "text/markdown") {
+          return part.mimetype === "application/octet-stream";
+        }
         return part.mimetype === file.contentType;
       },
     });

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -40,6 +40,7 @@ export const parseUploadRequest = async (
 
       // Ensure the file is of the correct type.
       filter: function (part) {
+        // formidable returns markdown file parts as application/octet-stream
         if (file.contentType === "text/markdown") {
           return part.mimetype === "application/octet-stream";
         }


### PR DESCRIPTION
## Description

- Closes [#1902](https://github.com/dust-tt/tasks/issues/1902)
- Fixes the file upload for markdown files: `formidable` receives parts of type `application/octet-stream` whereas we already identified the file content as being `text/markdown`.

## Risk

- Low.

## Deploy Plan

- Deploy front.
