### PR TITLE
Don't use redis for getAgentUsage

### DIFF
--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -16,6 +16,7 @@ import {
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import { getAssistantsUsageData } from "@app/lib/workspace_usage";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { PostAgentScopeRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
@@ -290,6 +291,9 @@ export function useAgentUsage({
   agentConfigurationId: string | null;
   disabled?: boolean;
 }) {
+  const workspace = getWorkspace(workspaceId);
+  const agentUsage = getAssistantsUsageData(start, end, workspace);
+
   const agentUsageFetcher: Fetcher<GetAgentUsageResponseBody> = fetcher;
   const fetchUrl = agentConfigurationId
     ? `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/usage`

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -16,7 +16,6 @@ import {
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import { getAssistantsUsageData } from "@app/lib/workspace_usage";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { PostAgentScopeRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
@@ -291,9 +290,6 @@ export function useAgentUsage({
   agentConfigurationId: string | null;
   disabled?: boolean;
 }) {
-  const workspace = getWorkspace(workspaceId);
-  const agentUsage = getAssistantsUsageData(start, end, workspace);
-
   const agentUsageFetcher: Fetcher<GetAgentUsageResponseBody> = fetcher;
   const fetchUrl = agentConfigurationId
     ? `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/usage`

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -416,7 +416,7 @@ export async function getAssistantUsageData(
       JOIN "users" aut ON ac."authorId" = aut."id"
     WHERE
       a."createdAt" BETWEEN :startDate AND :endDate
-      AND ac."workspaceId" = ${wId}
+      AND ac."workspaceId" = :wId
       AND ac."status" = 'active'
       AND ac."sId" = :agentConfigurationId
     GROUP BY
@@ -432,6 +432,7 @@ export async function getAssistantUsageData(
         startDate: format(startDate, "yyyy-MM-dd'T'00:00:00"),
         endDate: format(endDate, "yyyy-MM-dd'T'23:59:59"),
         agentConfigurationId: agentConfiguration.sId,
+        wId,
       },
     }
   );
@@ -473,7 +474,7 @@ export async function getAssistantsUsageData(
       JOIN "users" aut ON ac."authorId" = aut."id"
     WHERE
       a."createdAt" BETWEEN :startDate AND :endDate
-      AND ac."workspaceId" = ${wId}
+      AND ac."workspaceId" = :wId
       AND ac."status" = 'active'
       AND ac."scope" != 'private'
     GROUP BY
@@ -488,6 +489,7 @@ export async function getAssistantsUsageData(
       replacements: {
         startDate: format(startDate, "yyyy-MM-dd'T'00:00:00"), // Use first day of start month
         endDate: format(endDate, "yyyy-MM-dd'T'23:59:59"), // Use last day of end month
+        wId,
       },
     }
   );

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -418,7 +418,7 @@ export async function getAssistantUsageData(
       a."createdAt" BETWEEN :startDate AND :endDate
       AND ac."workspaceId" = ${wId}
       AND ac."status" = 'active'
-      AND ac."sId" = :assistantSid
+      AND ac."sId" = :agentConfigurationId
     GROUP BY
       ac."name",
       ac."description",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1824
We used to have redis because we were displaying the number of agent messages on the homepage for each agent - this is not the case anymore - we only calculate when opening the assistant manager modal.

The discrepancy between the redis count and the actual count has been bugging some customers that need exact data to decide to automatically retire some agents.

## Risk

High load on DB if I missed a spot with a list.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
