### PR TITLE
Conversation: Add column lastUserMessageAt to then sort convo by last used

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -126,6 +126,7 @@ export async function createConversation(
     // TODO(2024-11-04 flav) `group-id` clean-up.
     groupIds: [],
     requestedGroupIds: [],
+    lastUserMessageAt: null,
   });
 
   return {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -28,6 +28,8 @@ export class Conversation extends BaseModel<Conversation> {
   declare groupIds: number[];
   declare requestedGroupIds: number[][];
 
+  declare lastUserMessageAt: Date | null;
+
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 
@@ -66,6 +68,10 @@ Conversation.init(
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INTEGER)),
       allowNull: false,
       defaultValue: [],
+    },
+    lastUserMessageAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
   },
   {

--- a/front/migrations/db/migration_139.sql
+++ b/front/migrations/db/migration_139.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jan 07, 2025
+ALTER TABLE "public"."conversations" ADD COLUMN "lastUserMessageAt" TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
## Description

Context: https://github.com/dust-tt/tasks/issues/1882

This is the first PR to create the new nullable column. 
Once deployed I'll add the code to fill this one + use it to sort conversations. 

## Risk

Column is nullable so should be non-blocking, even it the table is large.


## Deploy Plan

Merge
Run migration
Deploy front. 
