### PR TITLE
Move sdk/js to Axios

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -84,7 +84,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.22-rc.0",
+      "version": "1.0.22",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -84,9 +84,10 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.15",
+      "version": "1.0.22-rc.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
         "zod": "^3.23.8"

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -142,15 +142,14 @@ export async function autoReadChannel(
           );
         }
 
-        const patchData = {
-          parentsToAdd: [
-            slackChannelInternalIdFromSlackChannelId(channel.slackChannelId),
-          ],
-          parentsToRemove: undefined,
-        };
         const updateDataSourceViewRes = await dustAPI.patchDataSourceView(
           dataSourceView,
-          patchData
+          {
+            parentsToAdd: [
+              slackChannelInternalIdFromSlackChannelId(channel.slackChannelId),
+            ],
+            parentsToRemove: undefined,
+          }
         );
 
         if (updateDataSourceViewRes.isErr()) {

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -383,7 +383,7 @@ async function answerMessage(
     lastSlackChatBotMessage?.conversationId || null
   );
 
-  const agentConfigurationsRes = await dustAPI.getAgentConfigurations();
+  const agentConfigurationsRes = await dustAPI.getAgentConfigurations({});
   if (agentConfigurationsRes.isErr()) {
     return new Err(new Error(agentConfigurationsRes.error.message));
   }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1251,15 +1251,15 @@ export async function _upsertDataSourceFolder({
 }) {
   const now = new Date();
 
-  const r = await getDustAPI(dataSourceConfig).upsertFolder(
-    dataSourceConfig.dataSourceId,
+  const r = await getDustAPI(dataSourceConfig).upsertFolder({
+    dataSourceId: dataSourceConfig.dataSourceId,
     folderId,
-    timestampMs ? timestampMs : now.getTime(),
+    timestamp: timestampMs ? timestampMs : now.getTime(),
     title,
     parentId,
     parents,
-    mimeType
-  );
+    mimeType,
+  });
 
   if (r.isErr()) {
     throw r.error;

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -51,7 +51,6 @@ export const MAX_DOCUMENT_TXT_LEN = 750000;
 export const MAX_SMALL_DOCUMENT_TXT_LEN = 500000;
 // For some data sources we allow large documents (5mb) to be processed (behind flag).
 export const MAX_LARGE_DOCUMENT_TXT_LEN = 5000000;
-
 export const MAX_FILE_SIZE_TO_DOWNLOAD = 128 * 1024 * 1024;
 
 type UpsertContext = {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1274,10 +1274,10 @@ export async function deleteDataSourceFolder({
   folderId: string;
   loggerArgs?: Record<string, string | number>;
 }) {
-  const r = await getDustAPI(dataSourceConfig).deleteFolder(
-    dataSourceConfig.dataSourceId,
-    folderId
-  );
+  const r = await getDustAPI(dataSourceConfig).deleteFolder({
+    dataSourceId: dataSourceConfig.dataSourceId,
+    folderId,
+  });
 
   if (r.isErr()) {
     throw r.error;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -143,9 +143,10 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
         "zod": "^3.23.8"

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.21",
+  "version": "1.0.22-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.21",
+      "version": "1.0.22-rc.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.21",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
         "zod": "^3.23.8"
@@ -3444,8 +3445,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/asyncro": {
       "version": "3.0.0",
@@ -3475,6 +3475,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4049,7 +4059,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4442,7 +4451,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5738,6 +5746,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -5751,7 +5778,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8096,7 +8122,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8105,7 +8130,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -8850,6 +8874,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -8198,9 +8198,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.22-rc.0",
+  "version": "1.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.22-rc.0",
+      "version": "1.0.22",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.21",
+  "version": "1.0.22-rc.0",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.22-rc.0",
+  "version": "1.0.22",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -40,6 +40,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "axios": "^1.7.9",
     "eventsource-parser": "^1.1.1",
     "moment-timezone": "^0.5.46",
     "zod": "^3.23.8"

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -137,15 +137,16 @@ export class DustAPI {
   /**
    * Fetches the current user's information from the API.
    *
-   * This method sends a GET request to the `/api/v1/me` endpoint with the necessary
-   * authorization headers. It then processes the response to extract the user information.
-   * Note that this will only work if you are using an OAuth2 token. It will always fail with a workspace API key.
+   * This method sends a GET request to the `/api/v1/me` endpoint with the necessary authorization
+   * headers. It then processes the response to extract the user information.  Note that this will
+   * only work if you are using an OAuth2 token. It will always fail with a workspace API key.
    *
    * @returns {Promise<Result<User, Error>>} A promise that resolves to a Result object containing
    * either the user information or an error.
    */
   async me() {
-    // This method call directly _fetchWithError and _resultFromResponse as it's a little special : it doesn't live under the workspace resource.
+    // This method call directly _fetchWithError and _resultFromResponse as it's a little special:
+    // it doesn't live under the workspace resource.
     const headers: RequestInit["headers"] = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${await this.getApiKey()}`,
@@ -415,7 +416,8 @@ export class DustAPI {
             pendingEvents = [];
           }
           if (!hasRunId) {
-            // once the stream is entirely consumed, if we haven't received a run id, reject the promise
+            // Once the stream is entirely consumed, if we haven't received a run id, reject the
+            // promise.
             setImmediate(() => {
               logger.error({}, "No run id received.");
               rejectDustRunIdPromise(new Error("No run id received"));
@@ -458,7 +460,8 @@ export class DustAPI {
    * @param workspaceId string the workspace id to fetch data sources for
    */
   async getDataSources(workspaceId: string) {
-    // Note for henry: do we need to override the workspace id here? (isn't it already derived from the credentials?)
+    // Note for henry: do we need to override the workspace id here? (isn't it already derived from
+    // the credentials?)
     const res = await this.request({
       overrideWorkspaceId: workspaceId,
       method: "GET",
@@ -1065,7 +1068,9 @@ export class DustAPI {
           // Unexpected response format (neither an error nor a valid response)
           const err: APIError = {
             type: "unexpected_response_format",
-            message: `Unexpected response format from DustAPI calling ${res.value.response.url} : ${r.error.message}`,
+            message:
+              `Unexpected response format from DustAPI calling ` +
+              `${res.value.response.url} : ${r.error.message}`,
           };
           this._logger.error(
             {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -460,7 +460,7 @@ export class DustAPI {
               errorStr: JSON.stringify(e),
               errorSource: "processStreamedRunResponse",
             },
-            "Error streaming chunks."
+            "DustAPI error: streaming chunks"
           );
         }
       };
@@ -730,7 +730,7 @@ export class DustAPI {
             errorStr: JSON.stringify(e),
             errorSource: "streamAgentAnswerEvents",
           },
-          "Error streaming chunks."
+          "DustAPI error: streaming chunks"
         );
       }
     };

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1010,7 +1010,7 @@ export class DustAPI {
     return new Ok(r.value.data_source_views);
   }
 
-  async patcheDataSourceView(
+  async patchDataSourceView(
     dataSourceView: DataSourceViewType,
     patch: PatchDataSourceViewRequestType
   ) {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -894,7 +894,7 @@ export class DustAPI {
     try {
       const {
         data: { file: fileUploaded },
-      } = await axios.post<FileUploadedRequestResponseType>(
+      } = await axiosWithTimeout.post<FileUploadedRequestResponseType>(
         file.uploadUrl,
         formData,
         { headers: await this.baseHeaders() }
@@ -1013,10 +1013,12 @@ export class DustAPI {
 
   private async _fetchWithError(
     url: string,
-    init?: RequestInit
+    config?: AxiosRequestConfig,
   ): Promise<Result<{ response: Response; duration: number }, APIError>> {
     const now = Date.now();
     try {
+      const response = await axiosWithTimeout(url,...init, validateStatus: () => true);
+
       const res = await fetch(url, init);
       return new Ok({ response: res, duration: Date.now() - now });
     } catch (e) {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -730,7 +730,7 @@ export class DustAPI {
           {
             error: e,
             errorStr: JSON.stringify(e),
-            errorSource: "postUserMessage",
+            errorSource: "streamAgentAnswerEvents",
           },
           "Error streaming chunks."
         );

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -496,7 +496,7 @@ export class DustAPI {
     includes = [],
   }: {
     view?: AgentConfigurationViewType;
-    includes: "authors"[];
+    includes?: "authors"[];
   }) {
     // Function to generate query parameters.
     function getQueryString() {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -476,15 +476,10 @@ export class DustAPI {
 
   /**
    * This actions talks to the Dust production API to retrieve the list of data sources of the
-   * specified workspace id.
-   *
-   * @param workspaceId string the workspace id to fetch data sources for
+   * current workspace.
    */
-  async getDataSources(workspaceId: string) {
-    // Note for henry: do we need to override the workspace id here? (isn't it already derived from
-    // the credentials?)
+  async getDataSources() {
     const res = await this.request({
-      overrideWorkspaceId: workspaceId,
       method: "GET",
       path: "data_sources",
     });
@@ -496,10 +491,13 @@ export class DustAPI {
     return new Ok(r.value.data_sources);
   }
 
-  async getAgentConfigurations(
-    view?: AgentConfigurationViewType,
-    includes: "authors"[] = []
-  ) {
+  async getAgentConfigurations({
+    view,
+    includes = [],
+  }: {
+    view?: AgentConfigurationViewType;
+    includes: "authors"[];
+  }) {
     // Function to generate query parameters.
     function getQueryString() {
       const params = new URLSearchParams();
@@ -707,7 +705,7 @@ export class DustAPI {
     });
 
     const reader = res.value.response.body;
-    const logger = this._logger;
+    const logger = this._logger.child({});
 
     const streamEvents = async function* () {
       try {
@@ -813,15 +811,23 @@ export class DustAPI {
     return new Ok(r.value.tokens);
   }
 
-  async upsertFolder(
-    dataSourceId: string,
-    folderId: string,
-    timestamp: number,
-    title: string,
-    parentId: string | null,
-    parents: string[],
-    mimeType: string
-  ) {
+  async upsertFolder({
+    dataSourceId,
+    folderId,
+    timestamp,
+    title,
+    parentId,
+    parents,
+    mimeType,
+  }: {
+    dataSourceId: string;
+    folderId: string;
+    timestamp: number;
+    title: string;
+    parentId: string | null;
+    parents: string[];
+    mimeType: string;
+  }) {
     const res = await this.request({
       method: "POST",
       path: `data_sources/${dataSourceId}/folders/${encodeURIComponent(
@@ -844,7 +850,13 @@ export class DustAPI {
     return new Ok(r.value);
   }
 
-  async deleteFolder(dataSourceId: string, folderId: string) {
+  async deleteFolder({
+    dataSourceId,
+    folderId,
+  }: {
+    dataSourceId: string;
+    folderId: string;
+  }) {
     const res = await this.request({
       method: "DELETE",
       path: `data_sources/${dataSourceId}/folders/${encodeURIComponent(
@@ -919,7 +931,7 @@ export class DustAPI {
     }
   }
 
-  async deleteFile(fileID: string) {
+  async deleteFile({ fileID }: { fileID: string }) {
     const res = await this.request({
       method: "DELETE",
       path: `files/${fileID}`,
@@ -998,14 +1010,14 @@ export class DustAPI {
     return new Ok(r.value.data_source_views);
   }
 
-  async patchDataSourceView(
+  async patcheDataSourceView(
     dataSourceView: DataSourceViewType,
-    patchData: PatchDataSourceViewRequestType
+    patch: PatchDataSourceViewRequestType
   ) {
     const res = await this.request({
       method: "PATCH",
       path: `spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}`,
-      body: patchData,
+      body: patch,
     });
 
     const r = await this._resultFromResponse(DataSourceViewResponseSchema, res);

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -338,6 +338,7 @@ export interface LoggerInterface {
   info: (args: Record<string, unknown>, message: string) => void;
   trace: (args: Record<string, unknown>, message: string) => void;
   warn: (args: Record<string, unknown>, message: string) => void;
+  child: (args: Record<string, unknown>) => LoggerInterface;
 }
 
 const DataSourceViewCategoriesSchema = FlexibleEnumSchema<


### PR DESCRIPTION
## Description

Motivation is to prevent trickling ECONRESET. Moves sdk/js to Axios, disabling KeepAlive (can't be disabled with node fetch based on undici).
Improves error logging (we do want to log all errors)
Fixes logger not being properly bound.
Standardize method signatures

## Risk

Pretty high risk at it touches core front flows (running dust apps), will first test front-edge.
Risk on connector side is lower as it's retriable and easy to revert.

## Deploy Plan

- test on front-edge
- lock front
- deploy connectors
- observe result
- deploy front