### PR TITLE
[front] Enforce parents validation in document and tables upsertion

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -486,13 +486,35 @@ async function handler(
         });
       }
 
+      // Enforce parents consistency: we expect users to either not pass them (recommended) or pass them correctly.
+      const parentsDisclaimerMessage =
+        "The use of the parents field is discouraged, this field is intended for internal uses only.";
+      if (r.data.parents) {
+        if (r.data.parents.length === 0) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid parents: parents must have at least one element.\n${parentsDisclaimerMessage}`,
+            },
+          });
+        }
+        if (r.data.parents[0] !== req.query.documentId) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid parents: parents[0] should be equal to document_id.\n${parentsDisclaimerMessage}`,
+            },
+          });
+        }
+      }
       if (r.data.parent_id && r.data.parents?.[1] !== r.data.parent_id) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message:
-              "Invalid parent id: parents[1] and parent_id should be equal",
+            message: `Invalid parent id: parents[1] and parent_id should be equal.\n${parentsDisclaimerMessage}`,
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -509,7 +509,7 @@ async function handler(
           });
         }
       }
-      if (r.data.parent_id && r.data.parents?.[1] !== r.data.parent_id) {
+      if (r.data.parents?.[1] !== r.data.parent_id) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -150,15 +150,15 @@ export const config = {
  *                 description: Tags to associate with the document.
  *               parent_id:
  *                 type: string
- *                 description: Direct parent document ID to associate with the document.
+ *                 description: Reserved for internal use, should be left empty. Document ID of the direct parent to associate with the document.
  *               parents:
  *                 type: array
  *                 items:
  *                   type: string
- *                 description: 'Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order'
+ *                 description: Reserved for internal use, should be left empty. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order.
  *               timestamp:
  *                 type: number
- *                 description: Unix timestamp (in seconds) for the document (e.g. 1698225000). Can be null or omitted.
+ *                 description: Unix timestamp (in seconds) for the document (e.gå. 1698225000). Can be null or omitted.
  *               light_document_output:
  *                 type: boolean
  *                 description: If true, a lightweight version of the document will be returned in the response (excluding the text, chunks and vectors). Defaults to false.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -158,7 +158,7 @@ export const config = {
  *                 description: 'Reserved for internal use, should be left empty. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order.'
  *               timestamp:
  *                 type: number
- *                 description: Unix timestamp (in seconds) for the document (e.gå. 1698225000). Can be null or omitted.
+ *                 description: Unix timestamp (in seconds) for the document (e.g. 1698225000). Can be null or omitted.
  *               light_document_output:
  *                 type: boolean
  *                 description: If true, a lightweight version of the document will be returned in the response (excluding the text, chunks and vectors). Defaults to false.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -150,12 +150,12 @@ export const config = {
  *                 description: Tags to associate with the document.
  *               parent_id:
  *                 type: string
- *                 description: 'Reserved for internal use, should be left empty. Document ID of the direct parent to associate with the document.'
+ *                 description: 'Reserved for internal use, should not be set. Document ID of the direct parent to associate with the document.'
  *               parents:
  *                 type: array
  *                 items:
  *                   type: string
- *                 description: 'Reserved for internal use, should be left empty. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order.'
+ *                 description: 'Reserved for internal use, should not be set. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order.'
  *               timestamp:
  *                 type: number
  *                 description: Unix timestamp (in seconds) for the document (e.g. 1698225000). Can be null or omitted.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -24,7 +24,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { enqueueUpsertDocument } from "@app/lib/upsert_queue";
 import logger from "@app/logger/logger";
-import { apiError, statsDClient } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const config = {
   api: {
@@ -517,18 +517,6 @@ async function handler(
             message: `Invalid parent id: parents[1] and parent_id should be equal.\n${parentsDisclaimerMessage}`,
           },
         });
-      }
-
-      const statsDTags = [
-        `data_source_id:${dataSource.id}`,
-        `workspace_id:${owner.sId}`,
-        `data_source_name:${dataSource.name}`,
-        `document_id:${req.query.documentId}`,
-      ];
-      if (!r.data.parents || r.data.parents.length === 0) {
-        statsDClient.increment("document_empty_parents.count", 1, statsDTags);
-      } else if (r.data.parents[0] != req.query.documentId) {
-        statsDClient.increment("document_no_self_ref.count", 1, statsDTags);
       }
 
       const documentId = req.query.documentId as string;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -150,12 +150,12 @@ export const config = {
  *                 description: Tags to associate with the document.
  *               parent_id:
  *                 type: string
- *                 description: Reserved for internal use, should be left empty. Document ID of the direct parent to associate with the document.
+ *                 description: 'Reserved for internal use, should be left empty. Document ID of the direct parent to associate with the document.'
  *               parents:
  *                 type: array
  *                 items:
  *                   type: string
- *                 description: Reserved for internal use, should be left empty. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order.
+ *                 description: 'Reserved for internal use, should be left empty. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order.'
  *               timestamp:
  *                 type: number
  *                 description: Unix timestamp (in seconds) for the document (e.gå. 1698225000). Can be null or omitted.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -373,13 +373,35 @@ async function handler(
         });
       }
 
+      // Enforce parents consistency: we expect users to either not pass them (recommended) or pass them correctly.
+      const parentsDisclaimerMessage =
+        "The use of the parents field is discouraged, this field is intended for internal uses only.";
+      if (parents) {
+        if (parents.length === 0) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid parents: parents must have at least one element.\n${parentsDisclaimerMessage}`,
+            },
+          });
+        }
+        if (parents[0] !== req.query.documentId) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid parents: parents[0] should be equal to document_id.\n${parentsDisclaimerMessage}`,
+            },
+          });
+        }
+      }
       if (parentId && parents?.[1] !== parentId) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message:
-              "Invalid parent id: parents[1] and parent_id should be equal",
+            message: `Invalid parent id: parents[1] and parent_id should be equal.\n${parentsDisclaimerMessage}`,
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -114,10 +114,10 @@ import { apiError } from "@app/logger/withlogging";
  *                 type: array
  *                 items:
  *                   type: string
- *                   description: 'Reserved for internal use, should be left empty. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order'
+ *                   description: 'Reserved for internal use, should not be set. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order'
  *               parent_id:
  *                 type: string
- *                 description: 'Reserved for internal use, should be left empty. ID of the direct parent to associate with the table'
+ *                 description: 'Reserved for internal use, should not be set. ID of the direct parent to associate with the table'
  *               mime_type:
  *                 type: string
  *                 description: Mime type of the table

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -114,10 +114,10 @@ import { apiError } from "@app/logger/withlogging";
  *                 type: array
  *                 items:
  *                   type: string
- *                   description: Reserved for internal use, should be left empty. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order.
+ *                   description: 'Reserved for internal use, should be left empty. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order'
  *               parent_id:
  *                 type: string
- *                 description: Reserved for internal use, should be left empty. ID of the direct parent to associate with the table.
+ *                 description: 'Reserved for internal use, should be left empty. ID of the direct parent to associate with the table'
  *               mime_type:
  *                 type: string
  *                 description: Mime type of the table

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -114,10 +114,10 @@ import { apiError } from "@app/logger/withlogging";
  *                 type: array
  *                 items:
  *                   type: string
- *                   description: 'Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order'
+ *                   description: Reserved for internal use, should be left empty. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order.
  *               parent_id:
  *                 type: string
- *                 description: Direct parent id of this table
+ *                 description: Reserved for internal use, should be left empty. ID of the direct parent to associate with the table.
  *               mime_type:
  *                 type: string
  *                 description: Mime type of the table

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -396,7 +396,7 @@ async function handler(
           });
         }
       }
-      if (parentId && parents?.[1] !== parentId) {
+      if (parents?.[1] !== parentId) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2006,14 +2006,14 @@
                   },
                   "parent_id": {
                     "type": "string",
-                    "description": "Direct parent document ID to associate with the document."
+                    "description": "Reserved for internal use, should be left empty. Document ID of the direct parent to associate with the document."
                   },
                   "parents": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order"
+                    "description": "Reserved for internal use, should be left empty. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order."
                   },
                   "timestamp": {
                     "type": "number",
@@ -3198,12 +3198,12 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "description": "Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order"
+                      "description": "Reserved for internal use, should be left empty. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order"
                     }
                   },
                   "parent_id": {
                     "type": "string",
-                    "description": "Direct parent id of this table"
+                    "description": "Reserved for internal use, should be left empty. ID of the direct parent to associate with the table"
                   },
                   "mime_type": {
                     "type": "string",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2006,14 +2006,14 @@
                   },
                   "parent_id": {
                     "type": "string",
-                    "description": "Reserved for internal use, should be left empty. Document ID of the direct parent to associate with the document."
+                    "description": "Reserved for internal use, should not be set. Document ID of the direct parent to associate with the document."
                   },
                   "parents": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "Reserved for internal use, should be left empty. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order."
+                    "description": "Reserved for internal use, should not be set. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order."
                   },
                   "timestamp": {
                     "type": "number",
@@ -3198,12 +3198,12 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "description": "Reserved for internal use, should be left empty. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order"
+                      "description": "Reserved for internal use, should not be set. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order"
                     }
                   },
                   "parent_id": {
                     "type": "string",
-                    "description": "Reserved for internal use, should be left empty. ID of the direct parent to associate with the table"
+                    "description": "Reserved for internal use, should not be set. ID of the direct parent to associate with the table"
                   },
                   "mime_type": {
                     "type": "string",


### PR DESCRIPTION
## Description

- Part of #9365
- Part of #8758 
- Add validation on the parents passed in POST on `api/v1`.
- Leans heavily towards not passing them in the error messages and documentation (connectors not concerned since it passes them correctly, typing in `connectors/lib/data_sources` enforces passing `parentId` and `parents`).

## Risk

- Could return 400 incorrectly.
- To be monitored.

## Deploy Plan

- Deploy front.
