### PR TITLE
[sparkle] - refacto: introduce `NewDialog`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.357",
+  "version": "0.2.358",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.357",
+      "version": "0.2.358",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.357",
+  "version": "0.2.358",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -24,7 +24,8 @@ export const menuStyleClasses = {
     {
       variants: {
         variant: {
-          default: "focus:s-text-primary-950 hover:s-bg-primary-150 focus:s-bg-primary-150",
+          default:
+            "focus:s-text-primary-950 hover:s-bg-primary-150 focus:s-bg-primary-150",
           warning:
             "s-text-warning-500 hover:s-bg-warning-50 focus:s-bg-warning-50 active:s-bg-warning-100",
         },

--- a/sparkle/src/components/NewDialog.tsx
+++ b/sparkle/src/components/NewDialog.tsx
@@ -37,7 +37,7 @@ const sizeClasses: Record<DialogSizeType, string> = {
 };
 
 const dialogVariants = cva(
-  "s-fixed s-left-[50%] s-top-[50%] s-z-50 s-translate-x-[-50%] s-translate-y-[-50%] s-bg-background s-duration-200 s-flex s-flex-col data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 s-rounded-xl s-border s-border-border",
+  "s-fixed s-left-[50%] s-top-[50%] s-z-50 s-translate-x-[-50%] s-translate-y-[-50%] s-bg-background s-duration-200 s-flex s-flex-col data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 s-overflow-hidden s-rounded-2xl s-border s-border-border",
   {
     variants: {
       size: sizeClasses,
@@ -94,13 +94,13 @@ const NewDialogHeader = ({
 }: NewNewDialogHeaderProps) => (
   <div
     className={cn(
-      "s-z-50 s-flex s-flex-none s-flex-col s-gap-2 s-rounded-t-xl s-border-b s-bg-background s-p-5 s-text-left",
+      "s-z-50 s-flex s-flex-none s-flex-col s-gap-0 s-p-5 s-text-left",
       className
     )}
     {...props}
   >
     {children}
-    <NewDialogClose asChild className="s-absolute s-right-3 s-top-4">
+    <NewDialogClose asChild className="s-absolute s-right-3 s-top-3">
       {!hideButton && <Button icon={XMarkIcon} variant="ghost" size="sm" />}
     </NewDialogClose>
   </div>
@@ -134,7 +134,7 @@ const NewDialogFooter = ({
 }: NewDialogFooterProps) => (
   <div
     className={cn(
-      "s-flex s-flex-none s-flex-row s-gap-2 s-px-3 s-py-3",
+      "s-flex s-flex-none s-flex-row s-justify-end s-gap-2 s-px-3 s-py-3",
       className
     )}
     {...props}

--- a/sparkle/src/components/NewDialog.tsx
+++ b/sparkle/src/components/NewDialog.tsx
@@ -1,0 +1,199 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { FocusScope } from "@radix-ui/react-focus-scope";
+import { cva } from "class-variance-authority";
+import * as React from "react";
+
+import { Button, ScrollArea } from "@sparkle/components";
+import { XMarkIcon } from "@sparkle/icons";
+import { cn } from "@sparkle/lib/utils";
+
+const NewDialog = DialogPrimitive.Root;
+const NewDialogTrigger = DialogPrimitive.Trigger;
+const NewDialogClose = DialogPrimitive.Close;
+const NewDialogPortal = DialogPrimitive.Portal;
+
+const NewDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    className={cn(
+      "s-fixed s-inset-0 s-z-50 s-bg-muted-foreground/75 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+NewDialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DIALOG_SIZES = ["md", "lg", "xl"] as const;
+type DialogSizeType = (typeof DIALOG_SIZES)[number];
+
+const sizeClasses: Record<DialogSizeType, string> = {
+  md: "sm:s-max-w-md",
+  lg: "sm:s-max-w-xl",
+  xl: "sm:s-max-w-3xl",
+};
+
+const dialogVariants = cva(
+  "s-fixed s-left-[50%] s-top-[50%] s-z-50 s-translate-x-[-50%] s-translate-y-[-50%] s-bg-background s-duration-200 s-flex s-flex-col data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 s-rounded-xl s-border s-border-border",
+  {
+    variants: {
+      size: sizeClasses,
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }
+);
+
+interface NewDialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  size?: DialogSizeType;
+  trapFocusScope?: boolean;
+  isAlertDialog?: boolean;
+}
+
+const NewDialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  NewDialogContentProps
+>(
+  (
+    { className, children, size, trapFocusScope, isAlertDialog, ...props },
+    ref
+  ) => (
+    <NewDialogPortal>
+      <NewDialogOverlay />
+      <FocusScope trapped={trapFocusScope} asChild>
+        <DialogPrimitive.Content
+          ref={ref}
+          className={cn(dialogVariants({ size }), className)}
+          onInteractOutside={
+            isAlertDialog ? (e) => e.preventDefault() : props.onInteractOutside
+          }
+          {...props}
+        >
+          {children}
+        </DialogPrimitive.Content>
+      </FocusScope>
+    </NewDialogPortal>
+  )
+);
+NewDialogContent.displayName = DialogPrimitive.Content.displayName;
+
+interface NewNewDialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  hideButton?: boolean;
+}
+
+const NewDialogHeader = ({
+  className,
+  children,
+  hideButton = false,
+  ...props
+}: NewNewDialogHeaderProps) => (
+  <div
+    className={cn(
+      "s-z-50 s-flex s-flex-none s-flex-col s-gap-2 s-rounded-t-xl s-border-b s-bg-background s-p-5 s-text-left",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <NewDialogClose asChild className="s-absolute s-right-3 s-top-4">
+      {!hideButton && <Button icon={XMarkIcon} variant="ghost" size="sm" />}
+    </NewDialogClose>
+  </div>
+);
+NewDialogHeader.displayName = "NewDialogHeader";
+
+const NewDialogContainer = ({
+  children,
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <ScrollArea className="s-w-full s-flex-grow">
+    <div className="s-relative s-flex s-flex-col s-gap-2 s-p-5 s-text-left s-text-sm s-text-foreground">
+      {children}
+    </div>
+  </ScrollArea>
+);
+NewDialogContainer.displayName = "DialogContainer";
+
+interface NewDialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  leftButtonProps?: React.ComponentProps<typeof Button>;
+  rightButtonProps?: React.ComponentProps<typeof Button>;
+  dialogCloseClassName?: string;
+}
+
+const NewDialogFooter = ({
+  className,
+  children,
+  leftButtonProps,
+  rightButtonProps,
+  dialogCloseClassName,
+  ...props
+}: NewDialogFooterProps) => (
+  <div
+    className={cn(
+      "s-flex s-flex-none s-flex-row s-gap-2 s-px-3 s-py-3",
+      className
+    )}
+    {...props}
+  >
+    {leftButtonProps &&
+      (leftButtonProps.disabled ? (
+        <Button {...leftButtonProps} />
+      ) : (
+        <NewDialogClose className={dialogCloseClassName} asChild>
+          <Button {...leftButtonProps} />
+        </NewDialogClose>
+      ))}
+    {rightButtonProps &&
+      (rightButtonProps.disabled ? (
+        <Button {...rightButtonProps} />
+      ) : (
+        <NewDialogClose className={dialogCloseClassName} asChild>
+          <Button {...rightButtonProps} />
+        </NewDialogClose>
+      ))}
+    {children}
+  </div>
+);
+NewDialogFooter.displayName = "DialogFooter";
+
+const NewDialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("s-text-lg s-font-semibold s-text-foreground", className)}
+    {...props}
+  />
+));
+NewDialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const NewDialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("s-text-sm s-text-muted-foreground", className)}
+    {...props}
+  />
+));
+NewDialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  NewDialog,
+  NewDialogClose,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogDescription,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogOverlay,
+  NewDialogPortal,
+  NewDialogTitle,
+  NewDialogTrigger,
+};

--- a/sparkle/src/components/NewDialog.tsx
+++ b/sparkle/src/components/NewDialog.tsx
@@ -37,7 +37,7 @@ const sizeClasses: Record<DialogSizeType, string> = {
 };
 
 const dialogVariants = cva(
-  "s-fixed s-left-[50%] s-top-[50%] s-z-50 s-translate-x-[-50%] s-translate-y-[-50%] s-bg-background s-duration-200 s-flex s-flex-col data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 s-overflow-hidden s-rounded-2xl s-border s-border-border",
+  "s-fixed s-left-[50%] s-top-[50%] s-z-50 s-grid s-w-full s-overflow-hidden s-rounded-2xl s-border s-border-border s-translate-x-[-50%] s-translate-y-[-50%] s-gap-4 s-border s-bg-background s-p-6 s-shadow-lg s-duration-200 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 data-[state=closed]:s-slide-out-to-left-1/2 data-[state=closed]:s-slide-out-to-top-[48%] data-[state=open]:s-slide-in-from-left-1/2 data-[state=open]:s-slide-in-from-top-[48%] s-sm:rounded-lg",
   {
     variants: {
       size: sizeClasses,

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -76,6 +76,19 @@ export { LinkWrapper } from "./LinkWrapper";
 export * from "./markdown";
 export { Modal } from "./Modal";
 export * from "./NavigationList";
+export {
+  NewDialog,
+  NewDialogClose,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogDescription,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogOverlay,
+  NewDialogPortal,
+  NewDialogTitle,
+  NewDialogTrigger,
+} from "./NewDialog";
 export type { NotificationType } from "./Notification";
 export { Notification, useSendNotification } from "./Notification";
 export { Page } from "./Page";

--- a/sparkle/src/stories/NewDialog.stories.tsx
+++ b/sparkle/src/stories/NewDialog.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { Button } from "@sparkle/components";
+
+import {
+  NewDialog,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogDescription,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
+  NewDialogTrigger,
+} from "../index_with_tw_base";
+
+const meta: Meta<typeof NewDialog> = {
+  title: "Components/NewDialog",
+  component: NewDialog,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof NewDialog>;
+
+export const Basic: Story = {
+  render: () => (
+    <NewDialog>
+      <NewDialogTrigger asChild>
+        <Button label="Open NewDialog" />
+      </NewDialogTrigger>
+      <NewDialogContent>
+        <NewDialogHeader>
+          <NewDialogTitle>Edit Profile</NewDialogTitle>
+          <NewDialogDescription>
+            Make changes to your profile settings here
+          </NewDialogDescription>
+        </NewDialogHeader>
+        <NewDialogContainer>
+          <p className="s-text-sm s-text-muted-foreground">
+            Your profile details will be updated based on the information you
+            provide.
+          </p>
+        </NewDialogContainer>
+        <NewDialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "ghost",
+          }}
+          rightButtonProps={{
+            label: "Save Changes",
+            variant: "primary",
+          }}
+        />
+      </NewDialogContent>
+    </NewDialog>
+  ),
+};
+
+export const WithForm: Story = {
+  render: () => (
+    <NewDialog>
+      <NewDialogTrigger asChild>
+        <Button label="Edit User" />
+      </NewDialogTrigger>
+      <NewDialogContent size="lg">
+        <NewDialogHeader>
+          <NewDialogTitle>Edit User Settings</NewDialogTitle>
+        </NewDialogHeader>
+        <NewDialogContainer>
+          <div className="s-grid s-gap-4 s-py-4">
+            <div className="s-grid s-gap-2">
+              <label className="s-text-sm s-font-medium">Name</label>
+              <input
+                className="s-border-input s-rounded-md s-border s-bg-transparent s-px-3 s-py-1 s-text-sm"
+                placeholder="Enter name..."
+              />
+            </div>
+            <div className="s-grid s-gap-2">
+              <label className="s-text-sm s-font-medium">Email</label>
+              <input
+                className="s-border-input s-rounded-md s-border s-bg-transparent s-px-3 s-py-1 s-text-sm"
+                placeholder="Enter email..."
+                type="email"
+              />
+            </div>
+          </div>
+        </NewDialogContainer>
+        <NewDialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "ghost",
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "primary",
+          }}
+        />
+      </NewDialogContent>
+    </NewDialog>
+  ),
+};
+
+export const AlertNewDialog: Story = {
+  render: () => (
+    <NewDialog>
+      <NewDialogTrigger asChild>
+        <Button variant="warning" label="Delete Account" />
+      </NewDialogTrigger>
+      <NewDialogContent size="md">
+        <NewDialogHeader>
+          <NewDialogTitle>Are you absolutely sure?</NewDialogTitle>
+          <NewDialogDescription>
+            This action cannot be undone. This will permanently delete your
+            account and remove your data from our servers.
+          </NewDialogDescription>
+        </NewDialogHeader>
+        <NewDialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "ghost",
+          }}
+          rightButtonProps={{
+            label: "Delete Account",
+            variant: "warning",
+          }}
+        />
+      </NewDialogContent>
+    </NewDialog>
+  ),
+};
+
+export const LargeContent: Story = {
+  render: () => (
+    <NewDialog>
+      <NewDialogTrigger asChild>
+        <Button label="View Terms" />
+      </NewDialogTrigger>
+      <NewDialogContent size="xl">
+        <NewDialogHeader>
+          <NewDialogTitle>Terms of Service</NewDialogTitle>
+        </NewDialogHeader>
+        <NewDialogContainer>
+          <div className="s-space-y-4">
+            <h3 className="s-font-semibold">1. Introduction</h3>
+            <p className="s-text-sm s-text-muted-foreground">
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quod
+              possimus sit modi reprehenderit sed dolorem nisi nostrum,
+              dignissimos tempora eligendi!
+            </p>
+            <h3 className="s-font-semibold">2. Terms of Use</h3>
+            <p className="s-text-sm s-text-muted-foreground">
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quod
+              possimus sit modi reprehenderit sed dolorem nisi nostrum,
+              dignissimos tempora eligendi!
+            </p>
+            <h3 className="s-font-semibold">3. Privacy Policy</h3>
+            <p className="s-text-sm s-text-muted-foreground">
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quod
+              possimus sit modi reprehenderit sed dolorem nisi nostrum,
+              dignissimos tempora eligendi!
+            </p>
+          </div>
+        </NewDialogContainer>
+      </NewDialogContent>
+    </NewDialog>
+  ),
+};

--- a/sparkle/src/stories/NewDialog.stories.tsx
+++ b/sparkle/src/stories/NewDialog.stories.tsx
@@ -37,19 +37,17 @@ export const Basic: Story = {
           </NewDialogDescription>
         </NewDialogHeader>
         <NewDialogContainer>
-          <p className="s-text-sm s-text-muted-foreground">
-            Your profile details will be updated based on the information you
-            provide.
-          </p>
+          Your profile details will be updated based on the information you
+          provide.
         </NewDialogContainer>
         <NewDialogFooter
           leftButtonProps={{
             label: "Cancel",
-            variant: "ghost",
+            variant: "outline",
           }}
           rightButtonProps={{
             label: "Save Changes",
-            variant: "primary",
+            variant: "highlight",
           }}
         />
       </NewDialogContent>


### PR DESCRIPTION
## Description

This PR introduces a new `Dialog` component relying on `radix`. It follows similar patterns as the ones used in `Sheet`.

Components will be renamed without the `New*` prefix once fully migrated.

## Risk

Low, not being used anywhere yet

## Deploy Plan

- Publish sparkle
- Migrate front to use it
