### PR TITLE
Log on parents that refer to missing `data_source_node`

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -167,9 +167,9 @@ impl PostgresStore {
             .get(0);
         if count != upsert_params.parents.len() as i64 {
             info!(
-                data_source_id = data_source_id,
-                node_id = node_id,
-                parents = ?upsert_params.parents,
+                data_source_id = data_source_row_id,
+                node_id = upsert_params.node_id,
+                parents = &upsert_params.parents,
                 operation = "upsert_node",
                 "[KWSEARCH] invariant_parent_exist_in_nodes"
             );
@@ -1485,9 +1485,9 @@ impl Store for PostgresStore {
             .get(0);
         if count != parents.len() as i64 {
             info!(
-                data_source_id = data_source_id,
-                node_id = node_id,
-                parents = ?parents,
+                data_source_id = data_source_row_id,
+                node_id = document_id,
+                parents = &parents,
                 operation = "update_document_parents",
                 "[KWSEARCH] invariant_parent_exist_in_nodes"
             );
@@ -2840,9 +2840,9 @@ impl Store for PostgresStore {
             .get(0);
         if count != parents.len() as i64 {
             info!(
-                data_source_id = data_source_id,
-                node_id = node_id,
-                parents = ?parents,
+                data_source_id = data_source_row_id,
+                node_id = table_id,
+                parents = &parents,
                 operation = "update_table_parents",
                 "[KWSEARCH] invariant_parent_exist_in_nodes"
             );

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1,17 +1,3 @@
-use anyhow::{anyhow, Result};
-use async_trait::async_trait;
-use bb8::Pool;
-use bb8_postgres::PostgresConnectionManager;
-use futures::future::try_join_all;
-use serde_json::Value;
-use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashMap, HashSet};
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::str::FromStr;
-use tokio_postgres::types::ToSql;
-use tokio_postgres::{NoTls, Transaction};
-
 use crate::data_sources::data_source::DocumentStatus;
 use crate::data_sources::node::{Node, NodeType};
 use crate::{
@@ -38,6 +24,20 @@ use crate::{
     stores::store::{Store, POSTGRES_TABLES, SQL_FUNCTIONS, SQL_INDEXES},
     utils,
 };
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
+use futures::future::try_join_all;
+use serde_json::Value;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::str::FromStr;
+use tokio_postgres::types::ToSql;
+use tokio_postgres::{NoTls, Transaction};
+use tracing::log::info;
 
 use super::store::{DocumentCreateParams, FolderUpsertParams, TableUpsertParams};
 
@@ -166,9 +166,13 @@ impl PostgresStore {
             .await?
             .get(0);
         if count != upsert_params.parents.len() as i64 {
-            return Err(anyhow!(
-                "Some parents refer to non-existing data_sources_nodes."
-            ));
+            info!(
+                data_source_id = data_source_id,
+                node_id = node_id,
+                parents = ?payload.parents,
+                operation = "upsert_node",
+                "[KWSEARCH] invariant_parent_exist_in_nodes"
+            );
         }
 
         let created = utils::now();

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -169,7 +169,7 @@ impl PostgresStore {
             info!(
                 data_source_id = data_source_id,
                 node_id = node_id,
-                parents = ?payload.parents,
+                parents = ?upsert_params.parents,
                 operation = "upsert_node",
                 "[KWSEARCH] invariant_parent_exist_in_nodes"
             );

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -172,7 +172,7 @@ impl PostgresStore {
                 node_id = upsert_params.node_id,
                 parents = ?upsert_params.parents,
                 operation = "upsert_node",
-                "[KWSEARCH] invariant_parent_exist_in_nodes"
+                "[KWSEARCH] invariant_parents_missing_in_nodes"
             );
         }
 

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1488,7 +1488,7 @@ impl Store for PostgresStore {
                 data_source_id = data_source_id,
                 node_id = node_id,
                 parents = ?parents,
-                operation = "update_parents",
+                operation = "update_document_parents",
                 "[KWSEARCH] invariant_parent_exist_in_nodes"
             );
         }

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1487,7 +1487,7 @@ impl Store for PostgresStore {
                 node_id = document_id,
                 parents = ?parents,
                 operation = "update_document_parents",
-                "[KWSEARCH] invariant_parent_exist_in_nodes"
+                "[KWSEARCH] invariant_parents_missing_in_nodes"
             );
         }
 
@@ -2831,7 +2831,7 @@ impl Store for PostgresStore {
                 node_id = table_id,
                 parents = ?parents,
                 operation = "update_table_parents",
-                "[KWSEARCH] invariant_parent_exist_in_nodes"
+                "[KWSEARCH] invariant_parents_missing_in_nodes"
             );
         }
 

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1491,14 +1491,6 @@ impl Store for PostgresStore {
             );
         }
 
-        // Update parents on tables table (TODO: remove this once we migrate to nodes table).
-        tx.execute(
-            "UPDATE data_sources_documents SET parents = $1 \
-            WHERE data_source = $2 AND document_id = $3 AND status = 'latest'",
-            &[&parents, &data_source_row_id, &document_id],
-        )
-        .await?;
-
         // Update parents on nodes table.
         tx.execute(
             "UPDATE data_sources_nodes SET parents = $1 \

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1,3 +1,18 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
+use futures::future::try_join_all;
+use serde_json::Value;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::str::FromStr;
+use tokio_postgres::types::ToSql;
+use tokio_postgres::{NoTls, Transaction};
+use tracing::info;
+
 use crate::data_sources::data_source::DocumentStatus;
 use crate::data_sources::node::{Node, NodeType};
 use crate::{
@@ -24,20 +39,6 @@ use crate::{
     stores::store::{Store, POSTGRES_TABLES, SQL_FUNCTIONS, SQL_INDEXES},
     utils,
 };
-use anyhow::{anyhow, Result};
-use async_trait::async_trait;
-use bb8::Pool;
-use bb8_postgres::PostgresConnectionManager;
-use futures::future::try_join_all;
-use serde_json::Value;
-use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashMap, HashSet};
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::str::FromStr;
-use tokio_postgres::types::ToSql;
-use tokio_postgres::{NoTls, Transaction};
-use tracing::info;
 
 use super::store::{DocumentCreateParams, FolderUpsertParams, TableUpsertParams};
 

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -37,7 +37,7 @@ use std::hash::Hasher;
 use std::str::FromStr;
 use tokio_postgres::types::ToSql;
 use tokio_postgres::{NoTls, Transaction};
-use tracing::log::info;
+use tracing::info;
 
 use super::store::{DocumentCreateParams, FolderUpsertParams, TableUpsertParams};
 

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1473,17 +1473,14 @@ impl Store for PostgresStore {
         let tx = c.transaction().await?;
 
         // Check that all parents exist in data_sources_nodes.
-        let stmt_check = c
-            .prepare(
+        let count: u64 = tx
+            .execute(
                 "SELECT COUNT(*) FROM data_sources_nodes
                  WHERE data_source = $1 AND node_id = ANY($2)",
+                &[&data_source_row_id, &parents],
             )
             .await?;
-        let count: i64 = tx
-            .query_one(&stmt_check, &[&data_source_row_id, &parents])
-            .await?
-            .get(0);
-        if count != parents.len() as i64 {
+        if count != parents.len() as u64 {
             info!(
                 data_source_id = data_source_row_id,
                 node_id = document_id,
@@ -2828,17 +2825,14 @@ impl Store for PostgresStore {
         let tx = c.transaction().await?;
 
         // Check that all parents exist in data_sources_nodes.
-        let stmt_check = c
-            .prepare(
+        let count: u64 = tx
+            .execute(
                 "SELECT COUNT(*) FROM data_sources_nodes
                  WHERE data_source = $1 AND node_id = ANY($2)",
+                &[&data_source_row_id, &parents],
             )
             .await?;
-        let count: i64 = tx
-            .query_one(&stmt_check, &[&data_source_row_id, &parents])
-            .await?
-            .get(0);
-        if count != parents.len() as i64 {
+        if count != parents.len() as u64 {
             info!(
                 data_source_id = data_source_row_id,
                 node_id = table_id,

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -169,7 +169,7 @@ impl PostgresStore {
             info!(
                 data_source_id = data_source_row_id,
                 node_id = upsert_params.node_id,
-                parents = &upsert_params.parents,
+                parents = ?upsert_params.parents,
                 operation = "upsert_node",
                 "[KWSEARCH] invariant_parent_exist_in_nodes"
             );
@@ -1487,7 +1487,7 @@ impl Store for PostgresStore {
             info!(
                 data_source_id = data_source_row_id,
                 node_id = document_id,
-                parents = &parents,
+                parents = ?parents,
                 operation = "update_document_parents",
                 "[KWSEARCH] invariant_parent_exist_in_nodes"
             );
@@ -2842,7 +2842,7 @@ impl Store for PostgresStore {
             info!(
                 data_source_id = data_source_row_id,
                 node_id = table_id,
-                parents = &parents,
+                parents = ?parents,
                 operation = "update_table_parents",
                 "[KWSEARCH] invariant_parent_exist_in_nodes"
             );


### PR DESCRIPTION
## Description

- Close [#9800](https://github.com/dust-tt/dust/issues/9800)
- Every parent ID passed in the parents of a node should reference an existing `node_id`.
- This PR starts with a log, which will be replaced with a hard check once we confirm all connectors enforce this rule.
- Tested by deleting some `data_source_folders` and `data_source_nodes` locally and forcing a resync of documents that belong to these folders.

## Risk

- Low as it is a log for now.

## Deploy Plan

- Deploy core.
