### PR TITLE
[Login flow] Remove duplicate signup for new users joining by email

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -154,6 +154,14 @@ function getMembershipInvitationUrlForToken(
   return `${config.getClientFacingUrl()}/w/${owner.sId}/join/?t=${invitationToken}`;
 }
 
+export function getTokenFromMembershipInvitationUrl(
+  url: string
+): string | null {
+  const urlObj = new URL(url);
+  const token = urlObj.searchParams.get("t");
+  return token;
+}
+
 export function getMembershipInvitationUrl(
   owner: LightWorkspaceType,
   invitationId: number

--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -1,0 +1,15 @@
+export function getSignUpUrl({
+  signupCallbackUrl,
+  invitationEmail,
+}: {
+  signupCallbackUrl: string;
+  invitationEmail?: string;
+}) {
+  let signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&screen_hint=signup`;
+
+  if (invitationEmail) {
+    signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
+  }
+
+  return signUpUrl;
+}

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -7,6 +7,7 @@ import { Err, isDevelopment, Ok } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
+import { getTokenFromMembershipInvitationUrl } from "@app/lib/api/invitation";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
 import { getSession } from "@app/lib/auth";
 import { AuthFlowError, SSOEnforcedError } from "@app/lib/iam/errors";
@@ -33,13 +34,12 @@ import { RegionLookupClient } from "@app/lib/multi_regions/region_lookup_client"
 import { subscriptionForWorkspace } from "@app/lib/plans/subscription";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { getSignUpUrl } from "@app/lib/signup";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
-import { getSignUpUrl } from "@app/lib/signup";
-import { getTokenFromMembershipInvitationUrl } from "@app/lib/api/invitation";
 
 // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as
 // all the checks (decoding the JWT) have been run before. Simply create the membership if

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -422,10 +422,11 @@ async function handler(
     targetWorkspace = workspace;
   } else {
     if (userCreated) {
-      // If user is newly created, check if there is a pending invitation for
-      // the user. If present, redirect to directly to the link of the "signup"
-      // button in the "signup" page, which will redirect to the workspace
-      // welcome page (see comment's PR)
+      // When user is just created, check whether they have a pending
+      // invitation. If they do, it is assumed they are coming from the
+      // invitation link and have seen the join page; we redirect (after auth0
+      // login) to this URL with inviteToken appended. The user will then end up
+      // on the workspace's welcome page (see comment's PR)
       const pendingInvitationAndWorkspace =
         await getPendingMembershipInvitationWithWorkspaceForEmail(user.email);
       if (pendingInvitationAndWorkspace) {

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -38,22 +38,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
-
-export function getSignUpUrl({
-  signupCallbackUrl,
-  invitationEmail,
-}: {
-  signupCallbackUrl: string;
-  invitationEmail?: string;
-}) {
-  let signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&screen_hint=signup`;
-
-  if (invitationEmail) {
-    signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
-  }
-
-  return signUpUrl;
-}
+import { getSignUpUrl } from "@app/lib/signup";
 
 // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as
 // all the checks (decoding the JWT) have been run before. Simply create the membership if

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -39,6 +39,7 @@ import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 import { getSignUpUrl } from "@app/lib/signup";
+import { getTokenFromMembershipInvitationUrl } from "@app/lib/api/invitation";
 
 // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as
 // all the checks (decoding the JWT) have been run before. Simply create the membership if
@@ -429,7 +430,7 @@ async function handler(
       if (pendingInvitationAndWorkspace) {
         const { invitation: pendingInvitation } = pendingInvitationAndWorkspace;
         const signUpUrl = getSignUpUrl({
-          signupCallbackUrl: pendingInvitation.inviteLink,
+          signupCallbackUrl: `/api/login?inviteToken=${getTokenFromMembershipInvitationUrl(pendingInvitation.inviteLink)}`,
           invitationEmail: pendingInvitation.inviteEmail,
         });
         res.redirect(signUpUrl);

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -423,8 +423,9 @@ async function handler(
   } else {
     if (userCreated) {
       // If user is newly created, check if there is a pending invitation for
-      // the user. If present, redirect to the signup callback for workspace,
-      // which will redirect to the workspace welcome page (see comment's PR)
+      // the user. If present, redirect to directly to the link of the "signup"
+      // button in the "signup" page, which will redirect to the workspace
+      // welcome page (see comment's PR)
       const pendingInvitationAndWorkspace =
         await getPendingMembershipInvitationWithWorkspaceForEmail(user.email);
       if (pendingInvitationAndWorkspace) {

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -11,7 +11,7 @@ import {
 } from "@app/lib/api/workspace";
 import { getPendingMembershipInvitationForToken } from "@app/lib/iam/invitations";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
-import { getSignUpUrl } from "@app/pages/api/login";
+import { getSignUpUrl } from "@app/lib/signup";
 
 /**
  * 3 ways to end up here:

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/api/workspace";
 import { getPendingMembershipInvitationForToken } from "@app/lib/iam/invitations";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
+import { getSignUpUrl } from "@app/pages/api/login";
 
 /**
  * 3 ways to end up here:
@@ -137,11 +138,10 @@ export default function Join({
   signUpCallbackUrl,
   workspace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  let signUpUrl = `/api/auth/login?returnTo=${signUpCallbackUrl}&screen_hint=signup`;
-
-  if (invitationEmail) {
-    signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
-  }
+  const signUpUrl = getSignUpUrl({
+    signupCallbackUrl: signUpCallbackUrl,
+    invitationEmail: invitationEmail ?? undefined,
+  });
 
   return (
     <OnboardingLayout


### PR DESCRIPTION
Description
---
Fixes #9053

People that are not yet dust users and get invited on a workspace see a "join workspace" page with a signup button ![image](https://github.com/user-attachments/assets/26a7f5ee-12b9-4136-8d2d-34decb6d7c0d)

When signing up, an account is created for them on auth0, then their user & membership rows are created on dust but they are redirected again to the same "join workspace" page which generates confusion (see issue)

This PR fixes that by redirecting new users directly to the callback after clicking on sign up, which will itself redirect to the workspace welcome page (setup first & last name, I'm a pro, etc.) 
![image](https://github.com/user-attachments/assets/ece02034-14de-41a0-8bfa-b8412e0e1fcb)


In doing so, it follows the strong assumption from previous PR #6034 that all new users with pending invitations meant to follow those invitations---and as such already saw the "join workspace" page once.

Risks
---
Impacts login of all new users. While potential for issues is limited, caution is warranted:

+ checked that the "join workspace" page does not change state, we don't miss anything in skipping it and going directly to welcome
+ tested locally
+ 2* reviewers

Deploy
---
front
