### PR TITLE
Use NewDialog for ConfirmDialog component

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -79,7 +79,7 @@ export function ConfirmDialog({
         }
       }}
     >
-      <NewDialogContent size="md" isAlertDialog>
+      <NewDialogContent size="md">
         <NewDialogHeader hideButton>
           <NewDialogTitle>{confirmData?.title ?? ""}</NewDialogTitle>
           <NewDialogDescription>

--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -1,4 +1,11 @@
-import { ElementDialog } from "@dust-tt/sparkle";
+import {
+  NewDialog,
+  NewDialogContent,
+  NewDialogDescription,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
+} from "@dust-tt/sparkle";
 import React from "react";
 import { createPortal } from "react-dom";
 
@@ -63,22 +70,41 @@ export function ConfirmDialog({
   closeDialogFn: () => void;
 }) {
   return (
-    <ElementDialog
-      openOnElement={confirmData}
-      title={confirmData?.title || ""}
-      closeDialogFn={closeDialogFn}
-      onCancel={(closingFn) => {
-        resolveConfirm(false);
-        closingFn();
+    <NewDialog
+      open={confirmData != null}
+      onOpenChange={(open) => {
+        if (!open) {
+          resolveConfirm(false);
+          closeDialogFn();
+        }
       }}
-      onValidate={(closingFn) => {
-        resolveConfirm(true);
-        closingFn();
-      }}
-      validateLabel={confirmData?.validateLabel}
-      validateVariant={confirmData?.validateVariant}
     >
-      {confirmData?.message}
-    </ElementDialog>
+      <NewDialogContent size="md" isAlertDialog>
+        <NewDialogHeader hideButton>
+          <NewDialogTitle>{confirmData?.title ?? ""}</NewDialogTitle>
+          <NewDialogDescription>
+            {confirmData?.message ?? ""}
+          </NewDialogDescription>
+        </NewDialogHeader>
+        <NewDialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: () => {
+              resolveConfirm(false);
+              closeDialogFn();
+            },
+          }}
+          rightButtonProps={{
+            label: confirmData?.validateLabel ?? "OK",
+            variant: "warning",
+            onClick: async () => {
+              resolveConfirm(true);
+              closeDialogFn();
+            },
+          }}
+        />
+      </NewDialogContent>
+    </NewDialog>
   );
 }


### PR DESCRIPTION
## Description

Use the NewDialog component so it works when opened from a modal (migrated to Radix).
Runner card: https://github.com/dust-tt/tasks/issues/1917

Note that I'm not sure this will fix the runner card, I wonder if there's an underlying issue because they have tons of chanels. 
But in any case this should be fixed. 

## Risk

Break this component? 

## Deploy Plan

Deploy front. 
