### PR TITLE
fix: force upsert all snowflake tables after credentials update

### DIFF
--- a/connectors/migrations/20250108_snowflake_resert_last_upserted_on_tables.ts
+++ b/connectors/migrations/20250108_snowflake_resert_last_upserted_on_tables.ts
@@ -1,0 +1,24 @@
+import { makeScript } from "scripts/helpers";
+
+import { RemoteTableModel } from "@connectors/lib/models/remote_databases";
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info("Resetting lastUpsertedAt on all snowflake tables.");
+
+  if (!execute) {
+    logger.info("Nothing to do in dry run, skipping.");
+    return;
+  }
+
+  await RemoteTableModel.update(
+    {
+      lastUpsertedAt: null,
+    },
+    {
+      // Do it for every single remote table.
+      where: {},
+    }
+  );
+
+  logger.info("Done.");
+});


### PR DESCRIPTION
## Description

When snowflake credentials are updated, we create a new secret for the credentials and update the connector with it.
`core` should be updated with the new credentials via the connector's sync process, but this doesn't actually happen as we don't re-upsert tables that already exist and have a non-null `lastUpsertedAt`.

This fixes the issue by first setting lastUpsertedAt=NULL on all remote tables for the connector when doing a credentials update.
Also added a migration script that will set lastUpsertedAt=NULL on every remote table in connectors, effectively forcing a resync for all existing tables.

## Risk

We'll re-upsert every table but it's not a heavy operation

## Deploy Plan

- Deploy connectors
- Run migration script