### PR TITLE
rename canList to canReadOrAdministrate

### DIFF
--- a/front/lib/api/resource_wrappers.ts
+++ b/front/lib/api/resource_wrappers.ts
@@ -25,8 +25,8 @@ type ResourceMap<U extends ResourceKey> = {
 
 type OptionsMap<U extends ResourceKey> = {
   [K in U]: {
+    requireCanReadOrAdministrate?: boolean;
     requireCanAdministrate?: boolean;
-    requireCanList?: boolean;
     requireCanRead?: boolean;
     requireCanWrite?: boolean;
   };
@@ -79,7 +79,7 @@ function hasPermission(
   options:
     | {
         requireCanAdministrate?: boolean;
-        requireCanList?: boolean;
+        requireCanReadOrAdministrate?: boolean;
         requireCanRead?: boolean;
         requireCanWrite?: boolean;
       }
@@ -90,7 +90,8 @@ function hasPermission(
     if (
       (options.requireCanAdministrate === true &&
         !resource.canAdministrate(auth)) ||
-      (options.requireCanList === true && !resource.canReadOrAdministrate(auth)) ||
+      (options.requireCanReadOrAdministrate === true &&
+        !resource.canReadOrAdministrate(auth)) ||
       (options.requireCanRead === true && !resource.canRead(auth)) ||
       (options.requireCanWrite === true && !resource.canWrite(auth))
     ) {

--- a/front/lib/api/resource_wrappers.ts
+++ b/front/lib/api/resource_wrappers.ts
@@ -90,7 +90,7 @@ function hasPermission(
     if (
       (options.requireCanAdministrate === true &&
         !resource.canAdministrate(auth)) ||
-      (options.requireCanList === true && !resource.canList(auth)) ||
+      (options.requireCanList === true && !resource.canReadOrAdministrate(auth)) ||
       (options.requireCanRead === true && !resource.canRead(auth)) ||
       (options.requireCanWrite === true && !resource.canWrite(auth))
     ) {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -253,7 +253,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     return dataSourceViews.filter(
       (dsv) =>
         (!dsv.space.isConversations() || includeConversationDataSources) &&
-        dsv.canList(auth)
+        dsv.canReadOrAdministrate(auth)
     );
   }
 

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -163,8 +163,8 @@ export abstract class ResourceWithSpace<
     return this.space.canAdministrate(auth);
   }
 
-  canList(auth: Authenticator) {
-    return this.space.canList(auth);
+  canReadOrAdministrate(auth: Authenticator) {
+    return this.space.canReadOrAdministrate(auth);
   }
 
   canRead(auth: Authenticator) {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -200,7 +200,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // using canRead() as we know that only members can read spaces (but admins can list them)
     // also, conversations space is not meant for members
     return spaces.filter(
-      (s) => s.canReadOrAdministrate(auth) && s.canRead(auth) && !s.isConversations()
+      (s) =>
+        s.canReadOrAdministrate(auth) && s.canRead(auth) && !s.isConversations()
     );
   }
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -200,7 +200,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // using canRead() as we know that only members can read spaces (but admins can list them)
     // also, conversations space is not meant for members
     return spaces.filter(
-      (s) => s.canList(auth) && s.canRead(auth) && !s.isConversations()
+      (s) => s.canReadOrAdministrate(auth) && s.canRead(auth) && !s.isConversations()
     );
   }
 
@@ -628,7 +628,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return auth.canRead(this.requestedPermissions());
   }
 
-  canList(auth: Authenticator) {
+  canReadOrAdministrate(auth: Authenticator) {
     return this.canRead(auth) || this.canAdministrate(auth);
   }
 

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -76,7 +76,7 @@ async function handler(
   if (
     !dataSourceView ||
     spaceId !== dataSourceView.space.sId ||
-    !dataSourceView.canList(auth)
+    !dataSourceView.canReadOrAdministrate(auth)
   ) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -87,7 +87,7 @@ async function handler(
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<void> {
-  if (!space.canList(auth)) {
+  if (!space.canReadOrAdministrate(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -120,5 +120,5 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -120,5 +120,7 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -229,6 +229,6 @@ async function handler(
 
 export default withPublicAPIAuthentication(
   withResourceFetchingFromRoute(handler, {
-    dataSourceView: { requireCanList: true },
+    dataSourceView: { requireCanReadOrAdministrate: true },
   })
 );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -153,7 +153,7 @@ async function handler(
   auth: Authenticator,
   { dataSourceView }: { dataSourceView: DataSourceViewResource }
 ): Promise<void> {
-  if (!dataSourceView.canList(auth)) {
+  if (!dataSourceView.canReadOrAdministrate(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -95,5 +95,5 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -95,5 +95,7 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -61,7 +61,7 @@ async function handler(
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<void> {
-  if (!space.canList(auth)) {
+  if (!space.canReadOrAdministrate(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -221,6 +221,6 @@ async function handler(
 
 export default withPublicAPIAuthentication(
   withResourceFetchingFromRoute(handler, {
-    dataSource: { requireCanList: true },
+    dataSource: { requireCanReadOrAdministrate: true },
   })
 );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -59,7 +59,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      if (!dataSource.canList(auth)) {
+      if (!dataSource.canReadOrAdministrate(auth)) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/index.ts
@@ -88,6 +88,6 @@ async function handler(
 
 export default withPublicAPIAuthentication(
   withResourceFetchingFromRoute(handler, {
-    dataSource: { requireCanList: true },
+    dataSource: { requireCanReadOrAdministrate: true },
   })
 );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/index.ts
@@ -34,7 +34,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      if (!dataSource.canList(auth)) {
+      if (!dataSource.canReadOrAdministrate(auth)) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -87,5 +87,5 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -58,7 +58,7 @@ async function handler(
 ): Promise<void> {
   const dataSources = await DataSourceResource.listBySpace(auth, space);
 
-  if (!space.canList(auth)) {
+  if (!space.canReadOrAdministrate(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -87,5 +87,7 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -117,5 +117,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -117,5 +117,7 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -37,7 +37,7 @@ async function handler(
   auth: Authenticator,
   { dataSourceView }: { dataSourceView: DataSourceViewResource }
 ): Promise<void> {
-  if (!dataSourceView.canList(auth)) {
+  if (!dataSourceView.canReadOrAdministrate(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -118,6 +118,6 @@ async function handler(
 
 export default withSessionAuthenticationForWorkspace(
   withResourceFetchingFromRoute(handler, {
-    dataSourceView: { requireCanList: true },
+    dataSourceView: { requireCanReadOrAdministrate: true },
   })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -26,7 +26,7 @@ async function handler(
   auth: Authenticator,
   { dataSourceView }: { dataSourceView: DataSourceViewResource }
 ): Promise<void> {
-  if (!dataSourceView.canList(auth)) {
+  if (!dataSourceView.canReadOrAdministrate(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -155,6 +155,6 @@ async function handler(
 
 export default withSessionAuthenticationForWorkspace(
   withResourceFetchingFromRoute(handler, {
-    dataSourceView: { requireCanList: true },
+    dataSourceView: { requireCanReadOrAdministrate: true },
   })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -22,7 +22,7 @@ async function handler(
   auth: Authenticator,
   { dataSourceView }: { dataSourceView: DataSourceViewResource }
 ): Promise<void> {
-  if (!dataSourceView.canList(auth)) {
+  if (!dataSourceView.canReadOrAdministrate(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -82,6 +82,6 @@ async function handler(
 
 export default withSessionAuthenticationForWorkspace(
   withResourceFetchingFromRoute(handler, {
-    dataSourceView: { requireCanList: true },
+    dataSourceView: { requireCanReadOrAdministrate: true },
   })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -231,5 +231,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -231,5 +231,7 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
@@ -168,5 +168,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
@@ -168,5 +168,7 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -502,5 +502,7 @@ const handleDataSourceWithProvider = async ({
 };
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -502,5 +502,5 @@ const handleDataSourceWithProvider = async ({
 };
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -241,5 +241,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -241,5 +241,7 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -103,5 +103,7 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
 );

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -103,5 +103,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, { space: { requireCanList: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanReadOrAdministrate: true } })
 );

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -63,7 +63,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   const isAdmin = auth.isAdmin();
 
-  if (!owner || !subscription || !space || !space.canList(auth)) {
+  if (!owner || !subscription || !space || !space.canReadOrAdministrate(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -67,7 +67,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   if (
     !dataSourceView ||
     dataSourceView.space.sId !== spaceId ||
-    !dataSourceView.canList(auth)
+    !dataSourceView.canReadOrAdministrate(auth)
   ) {
     return {
       notFound: true,

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
@@ -53,7 +53,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 
   const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
   const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space || !systemSpace || !space.canList(auth)) {
+  if (!space || !systemSpace || !space.canReadOrAdministrate(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
@@ -29,7 +29,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   }
 
   const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space || !space.canList(auth)) {
+  if (!space || !space.canReadOrAdministrate(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/spaces/index.tsx
+++ b/front/pages/w/[wId]/spaces/index.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements(
     );
     if (selection.lastSpaceId) {
       const space = await SpaceResource.fetchById(auth, selection.lastSpaceId);
-      if (space && space.canList(auth)) {
+      if (space && space.canReadOrAdministrate(auth)) {
         return {
           redirect: {
             destination: `/w/${owner.sId}/spaces/${space.sId}`,


### PR DESCRIPTION
## Description

Rename `canList` to `canReadOrAdministrate`. Motivation is clarity so that we only have 3 auth verbs: read, write, adminisrtrate (otherwise someone has to understand "list" whose intuitive understanding is not exactly read or administrate).

## Risk

None renaming

## Deploy Plan

N/A