### PR TITLE
Restrict v1 list spaces

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -197,12 +197,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async listWorkspaceSpacesAsMember(auth: Authenticator) {
     const spaces = await this.baseFetch(auth);
 
-    // using canRead() as we know that only members can read spaces (but admins can list them)
-    // also, conversations space is not meant for members
-    return spaces.filter(
-      (s) =>
-        s.canReadOrAdministrate(auth) && s.canRead(auth) && !s.isConversations()
-    );
+    // Filtering to the spaces the auth can read that are not conversations.
+    return spaces.filter((s) => s.canRead(auth) && !s.isConversations());
   }
 
   static async listWorkspaceDefaultSpaces(

--- a/front/pages/api/v1/w/[wId]/spaces/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/index.ts
@@ -22,8 +22,8 @@ export type GetSpacesResponseBody =
  * @swagger
  * /api/v1/w/{wId}/spaces:
  *   get:
- *     summary: List Workspace Spaces
- *     description: Retrieves a list of spaces for the authenticated workspace.
+ *     summary: List Spaces accessible.
+ *     description: Retrieves a list of accessible spaces for the authenticated workspace.
  *     tags:
  *       - Spaces
  *     security:

--- a/front/pages/api/v1/w/[wId]/spaces/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/index.ts
@@ -65,7 +65,7 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      const allSpaces = await SpaceResource.listWorkspaceSpaces(auth);
+      const allSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
 
       // conversations space should not be shown
       const spaces = allSpaces.filter(


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1838

API/v1 (used for Make/Pipeddream) would list all spaces instead of just the ones accessible by the API key.

## Risk

Low. Better auth.

## Deploy Plan

- deploy `front`