### PR TITLE
[.github] - refactor: remove condition on main branch for deploy job

### DIFF
--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -102,7 +102,6 @@ jobs:
             --project-id=$GCLOUD_PROJECT_ID
 
   deploy:
-    if: github.ref == 'refs/heads/main'
     needs: [notify-start, build]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

This PR removes condition to only enable connectors deployment from the `main` branch

## Risk

N/A

## Deploy Plan

N/A