### PR TITLE
Fix wording message count usage of an assistant when not used

### DIFF
--- a/front/components/assistant/Usage.tsx
+++ b/front/components/assistant/Usage.tsx
@@ -31,11 +31,10 @@ export function assistantUsageMessage({
 
   if (usage) {
     const days = usage.timePeriodSec / (60 * 60 * 24);
+    const nb = usage.messageCount || 0;
 
     if (shortVersion) {
-      const messageCount = boldIfRequested(
-        `${usage.messageCount} message${pluralize(usage.messageCount)}`
-      );
+      const messageCount = boldIfRequested(`${nb} message${pluralize(nb)}`);
 
       return (
         <>
@@ -43,9 +42,7 @@ export function assistantUsageMessage({
         </>
       );
     }
-    const messageCount = boldIfRequested(
-      `${usage.messageCount} time${pluralize(usage.messageCount)}`
-    );
+    const messageCount = boldIfRequested(`${nb} time${pluralize(nb)}`);
 
     return (
       <>


### PR DESCRIPTION
## Description

Fix these "null" wordings when assistant was unused: 
<img width="676" alt="Screenshot 2025-01-08 at 15 29 20" src="https://github.com/user-attachments/assets/64482de5-8750-43d4-a13a-3d4ecb8d1bcc" />
<img width="576" alt="Screenshot 2025-01-08 at 15 29 28" src="https://github.com/user-attachments/assets/5911878b-1558-405a-931d-09800fce3625" />


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
