### PR TITLE
[core] Enforce parents and parents validity

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1509,13 +1509,11 @@ async fn data_sources_documents_update_parents(
     let project = project::Project::new_from_id(project_id);
 
     if payload.parents.get(0) != Some(&document_id) {
-        info!(
-            data_source_id = data_source_id,
-            node_id = document_id,
-            parents = ?payload.parents,
-            node_type = "document",
-            operation = "update_parents",
-            "[KWSEARCH] invariant_first_parent_self"
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_parents",
+            "Failed to update document parents - parents[0] and document_id should be equal",
+            None,
         );
     }
 
@@ -1532,20 +1530,11 @@ async fn data_sources_documents_update_parents(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check when the log below does not pop
-                // return error_response(
-                //     StatusCode::BAD_REQUEST,
-                //     "invalid_parent_id",
-                //     "Failed to update document parents - parent_id should not be null if parents[1] is defined",
-                //     None,
-                // );
-                info!(
-                    data_source_id = data_source_id,
-                    node_id = document_id,
-                    parents = ?payload.parents,
-                    node_type = "document",
-                    operation = "update_parents",
-                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_parent_id",
+                    "Failed to update document parents - parent_id should not be null if parents[1] is defined",
+                    None,
                 );
             }
         }
@@ -1702,53 +1691,32 @@ async fn data_sources_documents_upsert(
     };
 
     if payload.parents.get(0) != Some(&payload.document_id) {
-        info!(
-            data_source_id = data_source_id,
-            node_id = payload.document_id,
-            parents = ?payload.parents,
-            node_type = "document",
-            operation = "upsert",
-            "[KWSEARCH] invariant_first_parent_self"
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_parents",
+            "Failed to upsert document - parents[0] and document_id should be equal",
+            None,
         );
     }
 
     match &payload.parent_id {
         Some(parent_id) => {
             if payload.parents.get(1) != Some(parent_id) {
-                info!(
-                    data_source_id = data_source_id,
-                    node_id = payload.document_id,
-                    parent_id = parent_id,
-                    parents = ?payload.parents,
-                    node_type = "document",
-                    operation = "upsert",
-                    "[KWSEARCH] invariant_parent_id_equal_parent_1"
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_parent_id",
+                    "Failed to upsert document - parents[1] and parent_id should be equal",
+                    None,
                 );
-                // TODO(fontanierh): Temporary, as we need to let some jobs go through.
-                // return error_response(
-                //     StatusCode::BAD_REQUEST,
-                //     "invalid_parent_id",
-                //     "Failed to upsert document - parents[1] and parent_id should be equal",
-                //     None,
-                // );
             }
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check when the log below does not pop
-                // return error_response(
-                //     StatusCode::BAD_REQUEST,
-                //     "invalid_parent_id",
-                //     "Failed to upsert document - parent_id should not be null if parents[1] is defined",
-                //     None,
-                // );
-                info!(
-                    data_source_id = data_source_id,
-                    node_id = payload.document_id,
-                    parents = ?payload.parents,
-                    node_type = "document",
-                    operation = "upsert",
-                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_parent_id",
+                    "Failed to upsert document - parent_id should not be null if parents[1] is defined",
+                    None,
                 );
             }
         }
@@ -2203,13 +2171,11 @@ async fn tables_upsert(
     let project = project::Project::new_from_id(project_id);
 
     if payload.parents.get(0) != Some(&payload.table_id) {
-        info!(
-            data_source_id = data_source_id,
-            node_id = payload.table_id,
-            parents = ?payload.parents,
-            node_type = "table",
-            operation = "upsert",
-            "[KWSEARCH] invariant_first_parent_self"
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_parents",
+            "Failed to upsert table - parents[0] and table_id should be equal",
+            None,
         );
     }
 
@@ -2226,21 +2192,12 @@ async fn tables_upsert(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check when the log below does not pop
-                //     return error_response(
-                //         StatusCode::BAD_REQUEST,
-                //         "invalid_parent_id",
-                //         "Failed to upsert table - parent_id should not be null if parents[1] is defined",
-                //         None,
-                //     );
-                info!(
-                    data_source_id = data_source_id,
-                    node_id = payload.table_id,
-                    parents = ?payload.parents,
-                    node_type = "table",
-                    operation = "upsert",
-                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
-                );
+                return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_parent_id",
+                        "Failed to upsert table - parent_id should not be null if parents[1] is defined",
+                        None,
+                    );
             }
         }
     }
@@ -2500,13 +2457,11 @@ async fn tables_update_parents(
     let project = project::Project::new_from_id(project_id);
 
     if payload.parents.get(0) != Some(&table_id) {
-        info!(
-            data_source_id = data_source_id,
-            node_id = table_id,
-            parents = ?payload.parents,
-            node_type = "table",
-            operation = "update_parents",
-            "[KWSEARCH] invariant_first_parent_self"
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_parents",
+            "Failed to update table parents - parents[0] and table_id should be equal",
+            None,
         );
     }
 
@@ -2523,21 +2478,12 @@ async fn tables_update_parents(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check when the log below does not pop
-                //     return error_response(
-                //         StatusCode::BAD_REQUEST,
-                //         "invalid_parent_id",
-                //         "Failed to update table parents - parent_id should not be null if parents[1] is defined",
-                //         None,
-                //     );
-                info!(
-                    data_source_id = data_source_id,
-                    node_id = table_id,
-                    parents = ?payload.parents,
-                    node_type = "table",
-                    operation = "update_parents",
-                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
-                );
+                return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_parent_id",
+                        "Failed to update table parents - parent_id should not be null if parents[1] is defined",
+                        None,
+                    );
             }
         }
     }
@@ -2934,13 +2880,11 @@ async fn folders_upsert(
     let project = project::Project::new_from_id(project_id);
 
     if payload.parents.get(0) != Some(&payload.folder_id) {
-        info!(
-            data_source_id = data_source_id,
-            node_id = payload.folder_id,
-            parents = ?payload.parents,
-            node_type = "folder",
-            operation = "upsert",
-            "[KWSEARCH] invariant_first_parent_self"
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_parents",
+            "Failed to upsert folder - parents[0] and folder_id should be equal",
+            None,
         );
     }
 
@@ -2957,21 +2901,12 @@ async fn folders_upsert(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check when the log below does not pop
-                //     return error_response(
-                //         StatusCode::BAD_REQUEST,
-                //         "invalid_parent_id",
-                //         "Failed to upsert folder - parent_id should not be null if parents[1] is defined",
-                //         None,
-                //     );
-                info!(
-                    data_source_id = data_source_id,
-                    node_id = payload.folder_id,
-                    parents = ?payload.parents,
-                    node_type = "folder",
-                    operation = "upsert",
-                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
-                );
+                return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_parent_id",
+                        "Failed to upsert folder - parent_id should not be null if parents[1] is defined",
+                        None,
+                    );
             }
         }
     }


### PR DESCRIPTION
## Description

- Closes [#1871](https://github.com/dust-tt/tasks/issues/1871)
- [Log here](https://app.datadoghq.eu/logs?query=KWSEARCH%20-%40node_id%3Azendesk-%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1735723025933&to_ts=1736327825933&live=true).
- Replace every log on inconsistent parents with an error return.

## Risk

- Low, controlled by the existence of the log.

## Deploy Plan

- Deploy core.
