### PR TITLE
Fix Dialog change assistant scope not working

### DIFF
--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -4,7 +4,6 @@ import {
   ChevronDownIcon,
   Chip,
   CompanyIcon,
-  Dialog,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -12,6 +12,13 @@ import {
   DustIcon,
   IconButton,
   LockIcon,
+  NewDialog,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogDescription,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
   Page,
   PopoverContent,
   PopoverRoot,
@@ -367,7 +374,7 @@ export function SharingDropdown({
   return (
     <div>
       {requestNewScope && confirmationModalData && (
-        <ScopeChangeModal
+        <ScopeChangeDialog
           show={requestNewScope !== null}
           confirmationModalData={confirmationModalData}
           usageText={confirmationModalData.showUsage ? usageText : undefined}
@@ -440,7 +447,7 @@ export function SharingChip({ scope }: { scope: AgentConfigurationScope }) {
   );
 }
 
-function ScopeChangeModal({
+function ScopeChangeDialog({
   show,
   confirmationModalData,
   usageText,
@@ -454,25 +461,45 @@ function ScopeChangeModal({
   setSharingScope: () => void;
 }) {
   return (
-    <Dialog
-      isOpen={show}
-      title={confirmationModalData.title}
-      onCancel={onClose}
-      validateLabel={confirmationModalData.confirmText}
-      validateVariant={confirmationModalData.variant}
-      onValidate={async () => {
-        setSharingScope();
-        onClose();
+    <NewDialog
+      open={show}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
       }}
-      alertDialog
     >
-      <div>
-        <div className="pb-2">
-          {usageText && <span className="font-bold">{usageText}&nbsp;</span>}
-          {confirmationModalData.text}
-        </div>
-        <div className="font-bold">Are you sure you want to proceed ?</div>
-      </div>
-    </Dialog>
+      <NewDialogContent>
+        <NewDialogHeader hideButton>
+          <NewDialogTitle>{confirmationModalData.title}</NewDialogTitle>
+          {usageText && (
+            <NewDialogDescription>{usageText}</NewDialogDescription>
+          )}
+        </NewDialogHeader>
+        <NewDialogContainer>
+          <div>
+            {confirmationModalData.text}
+            <div className="font-bold">Are you sure you want to proceed ?</div>
+          </div>
+        </NewDialogContainer>
+        <NewDialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: () => {
+              onClose();
+            },
+          }}
+          rightButtonProps={{
+            label: confirmationModalData.confirmText,
+            variant: "warning",
+            onClick: async () => {
+              setSharingScope();
+              onClose();
+            },
+          }}
+        />
+      </NewDialogContent>
+    </NewDialog>
   );
 }


### PR DESCRIPTION
## Description

Runner card: https://github.com/dust-tt/tasks/issues/1921

Migrating the Dialog displayed when we try to change the scope of an assistant, since it's open from a modal and the modal has been migrated to Radix, we need to use NewDialog that is also based on radix. 

Note: there's a glitch if we try to re-render the Dialog if we've already done it and there's a notification rendered. When the notification disappear, it closes the Dialog. Most likely because Notification also need to be moved to Radix. 

## Risk

Break the dialog? But was already broken. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
