### PR TITLE
feat: add support for logprobs in OAI chat completions

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1795,6 +1795,7 @@ impl LLM for AnthropicLLM {
             }),
             completions: AssistantChatMessage::try_from(c).into_iter().collect(),
             provider_request_id: request_id,
+            logprobs: None,
         })
     }
 }

--- a/core/src/providers/deepseek.rs
+++ b/core/src/providers/deepseek.rs
@@ -3,9 +3,9 @@ use crate::providers::embedder::Embedder;
 use crate::providers::llm::ChatFunction;
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
 use crate::providers::openai::{
-    chat_completion, streamed_chat_completion, to_openai_messages, OpenAIChatMessage,
-    OpenAIChatMessageContent, OpenAIContentBlock, OpenAITextContent, OpenAITextContentType,
-    OpenAITool, OpenAIToolChoice,
+    chat_completion, logprobs_from_choices, streamed_chat_completion, to_openai_messages,
+    OpenAIChatMessage, OpenAIChatMessageContent, OpenAIContentBlock, OpenAITextContent,
+    OpenAITextContentType, OpenAITool, OpenAIToolChoice,
 };
 use crate::providers::provider::{Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, o200k_base_singleton, CoreBPE};
@@ -196,6 +196,7 @@ impl LLM for DeepseekLLM {
                 None,
                 None,
                 None,
+                None,
                 event_sender.clone(),
             )
             .await?
@@ -227,6 +228,7 @@ impl LLM for DeepseekLLM {
                 None,
                 None,
                 None,
+                None,
             )
             .await?
         };
@@ -247,6 +249,7 @@ impl LLM for DeepseekLLM {
                 completion_tokens: usage.completion_tokens.unwrap_or(0),
             }),
             provider_request_id: request_id,
+            logprobs: logprobs_from_choices(&c.choices),
         })
     }
 }

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -662,6 +662,7 @@ impl LLM for GoogleAiStudioLLM {
                 completion_tokens: c.candidates_token_count.unwrap_or(0) as u64,
             }),
             provider_request_id: None,
+            logprobs: None,
         })
     }
 }

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -87,6 +87,12 @@ pub struct LLMTokenUsage {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct LLMChatLogprob {
+    pub token: String,
+    pub logprob: f32,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct LLMChatGeneration {
     pub created: u64,
     pub provider: String,
@@ -94,6 +100,8 @@ pub struct LLMChatGeneration {
     pub completions: Vec<AssistantChatMessage>,
     pub usage: Option<LLMTokenUsage>,
     pub provider_request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<Vec<LLMChatLogprob>>,
 }
 
 #[async_trait]

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -1030,6 +1030,7 @@ impl LLM for MistralAILLM {
                 prompt_tokens: u.prompt_tokens,
             }),
             provider_request_id: request_id,
+            logprobs: None,
         })
     }
 

--- a/core/src/providers/togetherai.rs
+++ b/core/src/providers/togetherai.rs
@@ -3,9 +3,9 @@ use crate::providers::embedder::Embedder;
 use crate::providers::llm::ChatFunction;
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
 use crate::providers::openai::{
-    chat_completion, streamed_chat_completion, to_openai_messages, OpenAIChatMessage,
-    OpenAIChatMessageContent, OpenAIContentBlock, OpenAITextContent, OpenAITextContentType,
-    OpenAITool, OpenAIToolChoice,
+    chat_completion, logprobs_from_choices, streamed_chat_completion, to_openai_messages,
+    OpenAIChatMessage, OpenAIChatMessageContent, OpenAIContentBlock, OpenAITextContent,
+    OpenAITextContentType, OpenAITool, OpenAIToolChoice,
 };
 use crate::providers::provider::{Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, o200k_base_singleton, CoreBPE};
@@ -196,6 +196,7 @@ impl LLM for TogetherAILLM {
                 None,
                 None,
                 None,
+                None,
                 event_sender.clone(),
             )
             .await?
@@ -227,6 +228,7 @@ impl LLM for TogetherAILLM {
                 None,
                 None,
                 None,
+                None,
             )
             .await?
         };
@@ -247,6 +249,7 @@ impl LLM for TogetherAILLM {
                 completion_tokens: usage.completion_tokens.unwrap_or(0),
             }),
             provider_request_id: request_id,
+            logprobs: logprobs_from_choices(&c.choices),
         })
     }
 }

--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -135,6 +135,12 @@ export default function Chat({
     onBlockUpdate(b);
   };
 
+  const handleLogprobsChange = (logprobs: boolean) => {
+    const b = shallowBlockClone(block);
+    b.config.logprobs = logprobs;
+    onBlockUpdate(b);
+  };
+
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
   const [functionsExpanded, setFunctionsExpanded] = useState(false);
   const [newStop, setNewStop] = useState("");
@@ -370,6 +376,16 @@ export default function Chat({
                     readOnly={readOnly}
                     value={block.spec.top_p}
                     onChange={(e) => handleTopPChange(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+                <div className="flex flex-initial">logprobs:</div>
+                <div className="flex flex-initial font-normal">
+                  <input
+                    type="checkbox"
+                    checked={block.config.logprobs}
+                    onChange={(e) => handleLogprobsChange(e.target.checked)}
                   />
                 </div>
               </div>

--- a/front/lib/config.ts
+++ b/front/lib/config.ts
@@ -32,6 +32,11 @@ export function extractConfig(spec: SpecificationType): BlockRunConfig {
               ? spec[i].config.use_cache
               : false
             : false,
+          logprobs: spec[i].config
+            ? spec[i].config.logprobs
+              ? spec[i].config.logprobs
+              : false
+            : false,
         };
         break;
       case "input":

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -106,7 +106,8 @@ const isRunnable = (
       if (
         key != "use_cache" &&
         key != "error_as_output" &&
-        key != "function_call"
+        key != "function_call" &&
+        key != "logprobs"
       ) {
         if (!config[name][key] || config[name][key].length == 0) {
           return false;


### PR DESCRIPTION
## Description

I need logprobs for Tracker and they are now available on Open AI chat completion API.

a boolean "logprobs" is passed in the request body, and the JSON output from OAI looks like this:
```
{
  "id": "...",
  "object": "chat.completion",
  "created": 1736351625,
  "model": "gpt-4o-2024-08-06",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Hi there! How can I assist you today?",
        "refusal": null
      },
      "logprobs": {
        "content": [
          {
            "token": "Hi",
            "logprob": -1.136884,
            "bytes": [72, 105],
            "top_logprobs": []
          },
          {
            "token": " there",
            "logprob": -0.0017021986,
            "bytes": [32, 116, 104, 101, 114, 101],
            "top_logprobs": []
          },
          {
            "token": "!",
            "logprob": 0.0,
            "bytes": [33],
            "top_logprobs": []
          },
          ...
        ],
        "refusal": null
      },
      "finish_reason": "stop"
    }
  ],
  "usage": {
    ...
  },
  "system_fingerprint": "..."
}
```

Exposed on the dust app block a a checkbox in "advanced" (`config.logprobs`, passed as `extras`):

<img width="954" alt="Screenshot 2025-01-08 at 16 56 07" src="https://github.com/user-attachments/assets/4af4766f-82ce-4794-a784-64258e6afa5a" />

We return it in the block output as an array of `{token: str, logprob: float}`


## Risk

Critical path, but well tested both with and without logprobs and streaming + non-streaming.

## Deploy Plan

Deploy core and front