### PR TITLE
Specify service account when building image in gcloud

### DIFF
--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -41,6 +41,8 @@ steps:
 
 timeout: 1200s
 
+serviceAccount: "projects/${_PROJECT_ID}/serviceAccounts/cloudbuild-publisher@${_PROJECT_ID}.iam.gserviceaccount.com"
+
 availableSecrets:
   secretManager:
     - versionName: projects/$_PROJECT_ID/secrets/DEPOT_TOKEN/versions/latest


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR ensures we specify the service account to use when doing `gcloud build` (see [doc](https://cloud.google.com/build/docs/build-config-file-schema#serviceaccount)).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
