### PR TITLE
Specify service account to use for gcloud builds submit

### DIFF
--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -54,7 +54,7 @@ fi
 cd "$WORKING_DIR"
 
 # Prepare the build command
-BUILD_CMD=(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild.yaml")
+BUILD_CMD=(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild.yaml" --service-account="cloudbuild-publisher@${PROJECT_ID}.iam.gserviceaccount.com")
 
 if [ -n "$GCLOUD_IGNORE_FILE" ]; then
     BUILD_CMD+=(--ignore-file="$GCLOUD_IGNORE_FILE")

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -41,7 +41,7 @@ steps:
 
 timeout: 1200s
 
-serviceAccount: "projects/${_PROJECT_ID}/serviceAccounts/cloudbuild-publisher@${_PROJECT_ID}.iam.gserviceaccount.com"
+serviceAccount: "cloudbuild-publisher@${_PROJECT_ID}.iam.gserviceaccount.com"
 
 availableSecrets:
   secretManager:


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes [this](https://github.com/dust-tt/dust/actions/runs/12674872223/job/35324790301) CI error to use the right service account when doing `gcloud builds submit` (see doc [here](https://cloud.google.com/sdk/gcloud/reference/builds/submit#--service-account)). 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
