### PR TITLE
Attempt to fix stuck Github workflows

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -216,8 +216,7 @@ export async function getRepoIssuesPage(
         { err: err.message },
         "[Github] Failed to get repo issues page. Bad credentials."
       );
-
-      return [];
+      throw new ExternalOAuthTokenError(err);
     }
 
     throw err;

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -25,7 +25,6 @@ const {
 
 const {
   githubGetReposResultPageActivity,
-  githubGetRepoIssuesResultPageActivity,
   githubGetRepoDiscussionsResultPageActivity,
   githubIssueGarbageCollectActivity,
   githubDiscussionGarbageCollectActivity,
@@ -36,11 +35,12 @@ const {
   startToCloseTimeout: "5 minute",
 });
 
-const { githubRepoGarbageCollectActivity } = proxyActivities<typeof activities>(
-  {
-    startToCloseTimeout: "20 minute",
-  }
-);
+const {
+  githubGetRepoIssuesResultPageActivity,
+  githubRepoGarbageCollectActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "20 minute",
+});
 
 const { githubUpsertIssueActivity, githubUpsertDiscussionActivity } =
   proxyActivities<typeof activities>({


### PR DESCRIPTION
## Description

Some workflows raise errors on `githubGetRepoIssuesResultPageActivity`, can be a `startToCloseTimeout` or some `Bad Credentials` ("Bad credentials" is sent here when a token needs refresh I guess). 

See logs here: https://app.datadoghq.eu/logs?query=status%3Aerror%20%40dd.env%3Aprod%20%40dd.service%3Aconnectors-worker%20%40activityName%3AgithubGetRepoIssuesResultPageActivity&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1735809163567&to_ts=1736413963567&live=true

I added a log to monitor it, but will lower it if we can.

This PR does 2 things to attempt to fix it: 
1/ Increase the startToCloseTimeout from 5 to 20 minutes.
2/ Catch the BadCredential error (we do something similar on getIssue).

Can be reviewed with hidden whitespaces!


## Risk

Can be rolled back

## Deploy Plan

Deploy connectors.