### PR TITLE
[sparkle] - chore: enhance `DataTable` with `dropdownMenuProps`

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -51,6 +51,7 @@ declare module "@tanstack/react-table" {
 interface TBaseData {
   onClick?: () => void;
   moreMenuItems?: DropdownMenuItemProps[];
+  dropdownMenuProps?: React.ComponentPropsWithoutRef<typeof DropdownMenu>;
 }
 
 interface ColumnBreakpoint {
@@ -226,6 +227,7 @@ export function DataTable<TData extends TBaseData>({
               key={row.id}
               onClick={row.original.onClick}
               moreMenuItems={row.original.moreMenuItems}
+              dropdownMenuProps={row.original.dropdownMenuProps}
             >
               {row.getVisibleCells().map((cell) => {
                 const breakpoint = columnsBreakpoints[cell.column.id];
@@ -334,6 +336,7 @@ interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   onClick?: () => void;
   moreMenuItems?: DropdownMenuItemProps[];
   widthClassName: string;
+  dropdownMenuProps?: React.ComponentPropsWithoutRef<typeof DropdownMenu>;
 }
 
 DataTable.Row = function Row({
@@ -342,6 +345,7 @@ DataTable.Row = function Row({
   onClick,
   moreMenuItems,
   widthClassName,
+  dropdownMenuProps,
   ...props
 }: RowProps) {
   return (
@@ -358,7 +362,7 @@ DataTable.Row = function Row({
       {children}
       <td className="s-flex s-w-8 s-cursor-pointer s-items-center s-pl-1 s-text-element-600">
         {moreMenuItems && moreMenuItems.length > 0 && (
-          <DropdownMenu>
+          <DropdownMenu {...dropdownMenuProps}>
             <DropdownMenuTrigger asChild>
               <IconButton
                 icon={MoreIcon}
@@ -393,7 +397,6 @@ DataTable.Cell = function Cell({
   column,
   ...props
 }: CellProps) {
-  column.columnDef.minSize;
   return (
     <td
       style={getSize(column.columnDef)}

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -10,8 +10,16 @@ import { Input } from "@sparkle/components/Input";
 
 import {
   DataTable,
+  DropdownMenu,
   DropdownMenuItemProps,
   FolderIcon,
+  NewDialog,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogDescription,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
 } from "../index_with_tw_base";
 
 const meta = {
@@ -33,6 +41,7 @@ type Data = {
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
   moreMenuItems?: DropdownMenuItemProps[];
+  dropdownMenuProps?: React.ComponentPropsWithoutRef<typeof DropdownMenu>;
   roundedAvatar?: boolean;
 };
 
@@ -73,7 +82,6 @@ const data: Data[] = [
         disabled: true,
       },
     ],
-    onClick: () => alert("Design clicked"),
   },
   {
     name: "Very long name that should be truncated at some point to avoid overflow and make the table more readable",
@@ -89,7 +97,6 @@ const data: Data[] = [
         disabled: true,
       },
     ],
-    onClick: () => alert("Design clicked"),
   },
   {
     name: "design",
@@ -196,6 +203,28 @@ const columns: ColumnDef<Data>[] = [
 
 export const DataTableExample = () => {
   const [filter, setFilter] = React.useState<string>("");
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [selectedName, setSelectedName] = React.useState("");
+
+  const tableData = data.map((item) =>
+    item.moreMenuItems
+      ? {
+          ...item,
+          dropdownMenuProps: {
+            modal: false,
+          },
+          moreMenuItems: [
+            {
+              label: "Edit",
+              onClick: () => {
+                setSelectedName(item.name);
+                setDialogOpen(true);
+              },
+            },
+          ],
+        }
+      : item
+  );
 
   return (
     <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
@@ -206,11 +235,36 @@ export const DataTableExample = () => {
         onChange={(e) => setFilter(e.target.value)}
       />
       <DataTable
-        data={data}
+        data={tableData}
         filter={filter}
         filterColumn="name"
         columns={columns}
       />
+      <NewDialog open={dialogOpen} onOpenChange={(open) => setDialogOpen(open)}>
+        <NewDialogContent
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <NewDialogHeader>
+            <NewDialogTitle>Edit {selectedName}</NewDialogTitle>
+            <NewDialogDescription>
+              Make changes to your item here
+            </NewDialogDescription>
+          </NewDialogHeader>
+          <NewDialogContainer>Your dialog content here</NewDialogContainer>
+          <NewDialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+            }}
+            rightButtonProps={{
+              label: "Save",
+              variant: "primary",
+              onClick: () => setDialogOpen(false),
+            }}
+          />
+        </NewDialogContent>
+      </NewDialog>
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR enhances the `DataTable` component by adding a new `dropdownMenuProps` property that allows passing additional configuration to the dropdown menu of each row. This enables finer control over the dropdown menu behavior, such as disabling the modal focus trap when needed.

## Risk

Low

## Deploy Plan

None