### PR TITLE
Loosen CSP for in production google-analytics

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -1,9 +1,9 @@
 const path = require("path");
 
 const CONTENT_SECURITY_POLICIES =
-  `script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com;` +
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com;` +
   ` style-src 'self' 'unsafe-inline' *.typekit.net;` +
-  ` connect-src 'self';` +
+  ` connect-src 'self' *.google-analytics.com;` +
   ` object-src 'none';` +
   ` form-action 'self';` +
   ` base-uri 'self';` +


### PR DESCRIPTION
## Description

Loosen to unblock Google Analytics in production

![Screenshot from 2025-01-09 13-55-42](https://github.com/user-attachments/assets/ea089352-063d-47d7-96d1-ee34c72ab5d0)


## Risk

N/A

## Deploy Plan

- deploy `front`