### PR TITLE
Fix assistant sharing dropdown

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -312,6 +312,7 @@ export function AssistantDetails({
               newScope={agentConfiguration.scope}
               disabled={isUpdatingScope}
               setNewScope={(scope) => updateScope(scope)}
+              origin="modal"
             />
           )}
         </div>

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -196,6 +196,7 @@ export function SharingButton({
                 initialScope={initialScope}
                 newScope={newScope}
                 setNewScope={setNewScope}
+                origin="page"
               />
               <div className="text-sm text-element-700">
                 <div>
@@ -305,6 +306,7 @@ interface SharingDropdownProps {
   initialScope: AgentConfigurationScope;
   newScope: AgentConfigurationScope;
   setNewScope: (scope: NonGlobalScope) => void;
+  origin: "page" | "modal";
 }
 
 /*
@@ -317,6 +319,7 @@ export function SharingDropdown({
   initialScope,
   newScope,
   setNewScope,
+  origin,
 }: SharingDropdownProps) {
   const [requestNewScope, setModalNewScope] = useState<NonGlobalScope | null>(
     null
@@ -383,7 +386,7 @@ export function SharingDropdown({
           }
         />
       )}
-      <DropdownMenu>
+      <DropdownMenu modal={origin === "modal"}>
         <DropdownMenuTrigger disabled={!allowedToChange} asChild>
           <div className="group flex cursor-pointer items-center gap-2">
             <SharingChip scope={newScope} />


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1941

Temporary fix. At the moment we need to set modal=false for a dropdown to work if not from a modal since we migrated to Radix. We have this dropdown in two places, one from a modal one from the builder. 

https://dust4ai.slack.com/archives/C050SM8NSPK/p1736435756794949

## Risk

Can be rolled back.

## Deploy Plan

Deploy front. 