### PR TITLE
dustAPI: sanitize axios errors

### DIFF
--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -89,6 +89,16 @@ const axiosNoKeepAlive = axios.create({
   httpsAgent: new https.Agent({ keepAlive: false }),
 });
 
+const sanitizedError = (e: unknown) => {
+  if (axios.isAxiosError(e)) {
+    return {
+      ...e,
+      config: undefined,
+    };
+  }
+  return e;
+};
+
 type RequestArgsType = {
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   path: string;
@@ -1058,7 +1068,7 @@ export class DustAPI {
           url,
           duration,
           connectorsError: err,
-          error: e,
+          error: sanitizedError(e),
         },
         "DustAPI error"
       );


### PR DESCRIPTION
## Description

Config includes raw information about the request we don't want to log into datadog.
Example: https://app.datadoghq.eu/logs?query=%22DustAPI%20error%22%20service%3Afront&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZRLukEQsD1TEgAAABhBWlJMdWt1SEFBQXFZWndiWE4ycjdnQlgAAAAkMDE5NDRiYmEtNGQ3NS00M2NlLTg2ZTItOTVjMzIxYWMwNTc0AAAXKg&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&storage=hot&stream_sort=service%2Casc&viz=stream&from_ts=1736436681094&to_ts=1736437581094&live=true

## Risk

N/A

## Deploy Plan

- deploy `front`