### PR TITLE
More secure path traversal handling

### DIFF
--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -3,6 +3,9 @@ import { NextResponse } from "next/server";
 
 export function middleware(request: NextRequest) {
   const url = request.nextUrl.pathname;
+
+  // We test decodedURL as attackers could hide the traversal patterns behind encodings. Ideally we
+  // should as well check nested encodings but will start with this.
   const decodedUrl = decodeURIComponent(url);
 
   // Check for various path traversal patterns

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -4,9 +4,16 @@ import { NextResponse } from "next/server";
 export function middleware(request: NextRequest) {
   const url = request.nextUrl.pathname;
 
-  // We test decodedURL as attackers could hide the traversal patterns behind encodings. Ideally we
-  // should as well check nested encodings but will start with this.
-  const decodedUrl = decodeURIComponent(url);
+  // The CASA test attempts to at least double encode the string to bypass checks hence why we
+  // attempt to handle nested encoding up to 8 times.
+  let decodedUrl = url;
+  let count = 0;
+  let prevUrl;
+  do {
+    prevUrl = decodedUrl;
+    decodedUrl = decodeURIComponent(prevUrl);
+    count++;
+  } while (decodedUrl !== prevUrl && count <= 8);
 
   // Check for various path traversal patterns
   const dangerous = [


### PR DESCRIPTION
## Description

I really hate the loop but I thiiiiink we need it and for regular URL this should not recurse.

For https://github.com/dust-tt/tasks/issues/1894

(the CASA remediation item explicitely states recursive encoding so pretty sure we need to protect against it)

## Risk

Low easy to rollback and tested locally

## Deploy Plan

- deploy `front`