### PR TITLE
enh(Zendesk) - add a check for user being an admin upon update

### DIFF
--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -72,6 +72,14 @@ const _postConnectorUpdateAPIHandler = async (
             message: updateRes.error.message,
           },
         });
+      case "USER_NOT_ADMIN":
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "connector_authorization_error",
+            message: updateRes.error.message,
+          },
+        });
       case "INVALID_CONFIGURATION":
         return apiError(req, res, {
           status_code: 400,

--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -72,7 +72,7 @@ const _postConnectorUpdateAPIHandler = async (
             message: updateRes.error.message,
           },
         });
-      case "USER_NOT_ADMIN":
+      case "CONNECTOR_OAUTH_USER_MISSING_RIGHTS":
         return apiError(req, res, {
           status_code: 401,
           api_error: {

--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -76,7 +76,7 @@ const _postConnectorUpdateAPIHandler = async (
         return apiError(req, res, {
           status_code: 401,
           api_error: {
-            type: "connector_authorization_error",
+            type: "connector_oauth_user_missing_rights",
             message: updateRes.error.message,
           },
         });

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -1,11 +1,11 @@
 import type {
+  ConnectorConfiguration,
   ConnectorPermission,
   ContentNode,
   ContentNodesViewType,
   ModelId,
   Result,
 } from "@dust-tt/types";
-import type { ConnectorConfiguration } from "@dust-tt/types";
 
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
@@ -13,7 +13,8 @@ export type CreateConnectorErrorCode = "INVALID_CONFIGURATION";
 
 export type UpdateConnectorErrorCode =
   | "INVALID_CONFIGURATION"
-  | "CONNECTOR_OAUTH_TARGET_MISMATCH";
+  | "CONNECTOR_OAUTH_TARGET_MISMATCH"
+  | "USER_NOT_ADMIN";
 
 export type RetrievePermissionsErrorCode =
   | "INVALID_PARENT_INTERNAL_ID"

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -14,7 +14,7 @@ export type CreateConnectorErrorCode = "INVALID_CONFIGURATION";
 export type UpdateConnectorErrorCode =
   | "INVALID_CONFIGURATION"
   | "CONNECTOR_OAUTH_TARGET_MISMATCH"
-  | "USER_NOT_ADMIN";
+  | "CONNECTOR_OAUTH_USER_MISSING_RIGHTS";
 
 export type RetrievePermissionsErrorCode =
   | "INVALID_PARENT_INTERNAL_ID"

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -167,7 +167,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       if (!isUserAdmin(zendeskUser)) {
         return new Err(
           new ConnectorManagerError(
-            "USER_NOT_ADMIN",
+            "CONNECTOR_OAUTH_USER_MISSING_RIGHTS",
             "New authenticated user is not an admin"
           )
         );

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -459,6 +459,10 @@ export async function fetchZendeskCurrentUser({
   return response.user;
 }
 
+export function isUserAdmin(user: ZendeskFetchedUser): boolean {
+  return user.active && user.role === "admin";
+}
+
 /**
  * Fetches a multiple users at once from the Zendesk API.
  * May run multiple queries, more precisely we need userCount // 100 + 1 API calls.

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -1,17 +1,5 @@
 import type { NotificationType } from "@dust-tt/sparkle";
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
-  NewDialogTrigger,
-  Spinner,
-} from "@dust-tt/sparkle";
-import { SheetContainer, SheetTitle } from "@dust-tt/sparkle";
-import { SheetHeader } from "@dust-tt/sparkle";
-import {
   Avatar,
   Button,
   CloudArrowLeftRightIcon,
@@ -21,12 +9,23 @@ import {
   Input,
   LockIcon,
   Modal,
+  NewDialog,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
+  NewDialogTrigger,
   Page,
   Sheet,
+  SheetContainer,
   SheetContent,
+  SheetHeader,
+  SheetTitle,
+  Spinner,
   TrashIcon,
+  useSendNotification,
 } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
 import type {
   APIError,
   BaseContentNode,
@@ -203,6 +202,16 @@ async function updateConnectorConnectionId(
     return {
       success: false,
       error: CONNECTOR_TYPE_TO_MISMATCH_ERROR[provider as ConnectorProvider],
+    };
+  }
+  if (
+    error.type === "connector_authorization_error" &&
+    provider === "zendesk"
+  ) {
+    return {
+      success: false,
+      error:
+        "The authenticated user does not have sufficient rights on Zendesk.",
     };
   }
   return {

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -207,7 +207,8 @@ async function updateConnectorConnectionId(
   if (error.type === "connector_oauth_user_missing_rights") {
     return {
       success: false,
-      error: "The authenticated user does not have sufficient rights.",
+      error:
+        "The authenticated user needs higher permissions from your service provider.",
     };
   }
   return {

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -204,16 +204,10 @@ async function updateConnectorConnectionId(
       error: CONNECTOR_TYPE_TO_MISMATCH_ERROR[provider as ConnectorProvider],
     };
   }
-  if (
-    error.type === "connector_oauth_user_missing_rights" &&
-    // not adding a CONNECTOR_TYPE_TO_USER_RIGHTS_ERROR for now since this is a Zendesk-specific feature,
-    // will be added if more than 1 provider is affected (would fall back on the default error message for now).
-    provider === "zendesk"
-  ) {
+  if (error.type === "connector_oauth_user_missing_rights") {
     return {
       success: false,
-      error:
-        "The authenticated user does not have sufficient rights on Zendesk.",
+      error: "The authenticated user does not have sufficient rights.",
     };
   }
   return {

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -205,7 +205,9 @@ async function updateConnectorConnectionId(
     };
   }
   if (
-    error.type === "connector_authorization_error" &&
+    error.type === "connector_oauth_user_missing_rights" &&
+    // not adding a CONNECTOR_TYPE_TO_USER_RIGHTS_ERROR for now since this is a Zendesk-specific feature,
+    // will be added if more than 1 provider is affected (would fall back on the default error message for now).
     provider === "zendesk"
   ) {
     return {

--- a/types/src/connectors/api.ts
+++ b/types/src/connectors/api.ts
@@ -12,6 +12,7 @@ export type ConnectorsAPIErrorType =
   | "connector_update_error"
   | "connector_update_unauthorized"
   | "connector_oauth_target_mismatch"
+  | "connector_oauth_user_missing_rights"
   | "connector_oauth_error"
   | "connector_authorization_error"
   | "slack_channel_not_found"


### PR DESCRIPTION
## Description

- Using `update` on an existing Zendesk connector does not check for the user being an admin.
- This is caught later on in the incremental workflow by throwing `ExternalOAuthError` but can be caught directly during the update.

## Risk

## Deploy Plan

- Deploy front.
- Deploy connectors.
