### PR TITLE
fix(Zendesk) - use `comment.body` as a fallback for `comment.plain_body`

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -194,7 +194,7 @@ ${comments
       );
       author = null;
     }
-    return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${comment.plain_body.replace(/[\u2028\u2029]/g, "")}`; // removing line and paragraph separators
+    return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${(comment.plain_body || comment.body).replace(/[\u2028\u2029]/g, "")}`; // removing line and paragraph separators
   })
   .join("\n")}
 `.trim();


### PR DESCRIPTION
## Description

- We observed occurrences of the `plain_body` of Zendesk comment not being filled, causing the [activity to fail](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40dd.service%3Aconnectors-worker%20%40activityName%3AsyncZendeskTicketBatchActivity&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1736438945998&to_ts=1736442545998&live=true).
- After further analysic of the problematic comments, although unclear, it would appear as such the ticket was created through the API using `body` instead of `html_body`, which led the field `plain_body` to not be generated (link to [the doc](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/#bodies)).
- This PR suggests falling back to the field `body` in this case, which fixes at least the example analyzed (the body is extremely simple and does not require any kind of sanitization in the example).

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
