### PR TITLE
feat(tracker): handle multiple docs in maintained scope

### DIFF
--- a/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_retrieval.ts
+++ b/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_retrieval.ts
@@ -69,6 +69,7 @@ const DocTrackerRetrievalActionValueSchema = t.array(
     created: t.Integer,
     document_id: t.string,
     timestamp: t.Integer,
+    title: t.union([t.string, t.null]),
     tags: t.array(t.string),
     parents: t.array(t.string),
     source_url: t.union([t.string, t.null]),
@@ -77,12 +78,17 @@ const DocTrackerRetrievalActionValueSchema = t.array(
     text: t.union([t.string, t.null, t.undefined]),
     chunk_count: t.Integer,
     chunks: t.array(
-      t.type({
-        text: t.string,
-        hash: t.string,
-        offset: t.Integer,
-        score: t.number,
-      })
+      t.intersection([
+        t.type({
+          text: t.string,
+          hash: t.string,
+          offset: t.Integer,
+          score: t.number,
+        }),
+        t.partial({
+          expanded_offsets: t.array(t.Integer),
+        }),
+      ])
     ),
     token_count: t.Integer,
   })

--- a/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_score_docs.ts
+++ b/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_score_docs.ts
@@ -9,6 +9,7 @@ export async function callDocTrackerScoreDocsAction(
   {
     watchedDocDiff,
     maintainedDocuments,
+    prompt,
     providerId,
     modelId,
   }: {
@@ -20,6 +21,7 @@ export async function callDocTrackerScoreDocsAction(
       dataSourceId: string;
       documentId: string;
     }>;
+    prompt: string | null;
     providerId: string;
     modelId: string;
   }
@@ -36,6 +38,7 @@ export async function callDocTrackerScoreDocsAction(
     input: {
       watched_diff: watchedDocDiff,
       maintained_documents: maintainedDocuments,
+      prompt,
     },
     responseValueSchema: DocTrackerScoreDocsActionResultSchema,
   });

--- a/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_score_docs.ts
+++ b/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_score_docs.ts
@@ -1,0 +1,62 @@
+import * as t from "io-ts";
+
+import { callAction } from "@app/lib/actions/helpers";
+import type { Authenticator } from "@app/lib/auth";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
+
+export async function callDocTrackerScoreDocsAction(
+  auth: Authenticator,
+  {
+    watchedDocDiff,
+    maintainedDocuments,
+    providerId,
+    modelId,
+  }: {
+    watchedDocDiff: string;
+    maintainedDocuments: Array<{
+      content: string;
+      title: string | null;
+      sourceUrl: string | null;
+      dataSourceId: string;
+      documentId: string;
+    }>;
+    providerId: string;
+    modelId: string;
+  }
+): Promise<DocTrackerScoreDocsActionResult> {
+  const action = DustProdActionRegistry["doc-tracker-score-docs"];
+
+  const config = cloneBaseConfig(action.config);
+  config.SUGGEST_CHANGES.provider_id = providerId;
+  config.SUGGEST_CHANGES.model_id = modelId;
+
+  const res = await callAction(auth, {
+    action,
+    config,
+    input: {
+      watched_diff: watchedDocDiff,
+      maintained_documents: maintainedDocuments,
+    },
+    responseValueSchema: DocTrackerScoreDocsActionResultSchema,
+  });
+
+  if (res.isErr()) {
+    throw res.error;
+  }
+
+  return res.value;
+}
+
+const DocTrackerScoreDocsActionResultSchema = t.array(
+  t.type({
+    documentId: t.string,
+    dataSourceId: t.string,
+    score: t.number,
+    title: t.union([t.string, t.null, t.undefined]),
+    sourceUrl: t.union([t.string, t.null, t.undefined]),
+  })
+);
+
+type DocTrackerScoreDocsActionResult = t.TypeOf<
+  typeof DocTrackerScoreDocsActionResultSchema
+>;

--- a/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_score_docs.ts
+++ b/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_score_docs.ts
@@ -27,8 +27,8 @@ export async function callDocTrackerScoreDocsAction(
   const action = DustProdActionRegistry["doc-tracker-score-docs"];
 
   const config = cloneBaseConfig(action.config);
-  config.SUGGEST_CHANGES.provider_id = providerId;
-  config.SUGGEST_CHANGES.model_id = modelId;
+  config.MODEL.provider_id = providerId;
+  config.MODEL.model_id = modelId;
 
   const res = await callAction(auth, {
     action,

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -280,7 +280,7 @@ TrackerGenerationModel.init(
     },
     maintainedDocumentId: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
   },
   {
@@ -309,8 +309,7 @@ TrackerGenerationModel.belongsTo(DataSourceModel, {
 });
 
 DataSourceModel.hasMany(TrackerGenerationModel, {
-  foreignKey: { allowNull: false },
-  onDelete: "RESTRICT",
+  foreignKey: { allowNull: true },
   as: "maintainedDocumentDataSource",
 });
 TrackerGenerationModel.belongsTo(DataSourceModel, {

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -237,11 +237,14 @@ export class TrackerGenerationModel extends SoftDeletableModel<TrackerGeneration
   declare trackerConfigurationId: ForeignKey<TrackerConfigurationModel["id"]>;
   declare dataSourceId: ForeignKey<DataSourceModel["id"]>;
   declare documentId: string;
+  declare maintainedDocumentDataSourceId: ForeignKey<DataSourceModel["id"]>;
+  declare maintainedDocumentId: string;
 
   declare consumedAt: Date | null;
 
   declare trackerConfiguration: NonAttribute<TrackerConfigurationModel>;
   declare dataSource: NonAttribute<DataSourceModel>;
+  declare maintainedDocumentDataSource: NonAttribute<DataSourceModel>;
 }
 
 TrackerGenerationModel.init(
@@ -275,6 +278,10 @@ TrackerGenerationModel.init(
       type: DataTypes.DATE,
       allowNull: true,
     },
+    maintainedDocumentId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
   },
   {
     modelName: "tracker_generation",
@@ -299,4 +306,14 @@ DataSourceModel.hasMany(TrackerGenerationModel, {
 TrackerGenerationModel.belongsTo(DataSourceModel, {
   foreignKey: { allowNull: false },
   as: "dataSource",
+});
+
+DataSourceModel.hasMany(TrackerGenerationModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+  as: "maintainedDocumentDataSource",
+});
+TrackerGenerationModel.belongsTo(DataSourceModel, {
+  foreignKey: { allowNull: false },
+  as: "maintainedDocumentDataSource",
 });

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -141,7 +141,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "N0RrhyTXfq",
       appHash:
-        "af4ab848b1e4f13afffdf2a9672bb2613e278ed5ee55a3a1c67a013e7036daee",
+        "ba5637f356c55676c7e175719bbd4fa5059c5a99a519ec75aea78b452e2168dc",
       appSpaceId: PRODUCTION_DUST_APPS_SPACE_ID,
     },
     config: {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -136,6 +136,20 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
+  "doc-tracker-score-docs": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "N0RrhyTXfq",
+      appHash:
+        "af4ab848b1e4f13afffdf2a9672bb2613e278ed5ee55a3a1c67a013e7036daee",
+      appSpaceId: PRODUCTION_DUST_APPS_SPACE_ID,
+    },
+    config: {
+      MODEL: {
+        use_cache: false,
+      },
+    },
+  },
   "doc-tracker-suggest-changes": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -146,7 +146,7 @@ export const DustProdActionRegistry = createActionRegistry({
     },
     config: {
       MODEL: {
-        use_cache: false,
+        use_cache: true,
       },
     },
   },

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -236,15 +236,27 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
     thinking,
     dataSourceId,
     documentId,
+    maintainedDocumentId,
+    maintainedDocumentDataSourceId,
   }: {
     generation: string;
     thinking: string | null;
     dataSourceId: string;
     documentId: string;
+    maintainedDocumentId: string;
+    maintainedDocumentDataSourceId: string;
   }) {
     const dataSourceModelId = getResourceIdFromSId(dataSourceId);
     if (!dataSourceModelId) {
       throw new Error(`Invalid data source ID: ${dataSourceId}`);
+    }
+    const maintainedDocumentDataSourceModelId = getResourceIdFromSId(
+      maintainedDocumentDataSourceId
+    );
+    if (!maintainedDocumentDataSourceModelId) {
+      throw new Error(
+        `Invalid maintained data source ID: ${maintainedDocumentDataSourceId}`
+      );
     }
 
     await TrackerGenerationModel.create({
@@ -252,6 +264,8 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
       thinking,
       dataSourceId: dataSourceModelId,
       documentId,
+      maintainedDocumentId: maintainedDocumentId,
+      maintainedDocumentDataSourceId: maintainedDocumentDataSourceModelId,
       trackerConfigurationId: this.id,
     });
   }

--- a/front/migrations/db/migration_140.sql
+++ b/front/migrations/db/migration_140.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jan 10, 2025
+ALTER TABLE "public"."tracker_generations" ADD COLUMN "maintainedDocumentId" VARCHAR(255);
+ALTER TABLE "public"."tracker_generations" ADD COLUMN "maintainedDocumentDataSourceId" INTEGER REFERENCES "public"."data_sources" ("id") ON DELETE RESTRICT;


### PR DESCRIPTION
## Description

Tracker maintained scope can include several documents. The current version of the tracker generation workflow only processes a single document (the document whose chunk was matched by semantic search). 
This is a significant limitation, especially for tracker with maintained scopes that include several small documents, and in situations where a single diff should lead to several documents being updated.

This PR addresses the issues by:
- increasing retrieval top K, such that more chunks are returned, possibly from several document (keeping a targetDocumentTokens to retrieve more than 512 tokens per document)
- adding a "score documents" step, where a cheaper model decides which document should be updated (based on logprobs)
- running the change suggestion for all document that pass the filter (i.e logprob of updating the document is greater of logprob of updating no document)

## Risk

there's a SQL migration (we now store a ref to the maintained document that should be updated on tracker generation)


## Deploy Plan

Apply migration (prodbox) then deploy front