### PR TITLE
When merging users, we want to migrate also their assistants

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/user_identity_merge.ts
+++ b/front/lib/api/poke/plugins/workspaces/user_identity_merge.ts
@@ -34,6 +34,7 @@ export const userIdentityMergePlugin = createPlugin(
     }
 
     const mergeResult = await mergeUserIdentities({
+      auth,
       primaryUserId,
       secondaryUserId,
     });


### PR DESCRIPTION
## Description

When we merge two users, if they had private assistant with their old user they will be lost when they get access with their new user. 

So this updates the merge script to also migrate the assistants. I've added a check on the workspace, just in case the users has multiple memberships we don't want to migrate an assistant to another workspace. Is it normal that there was no check on the workspace at all when we fetch the users? 

## Risk

Break the script, migrate wrong assistants. 
Can be rolled back. 

## Deploy Plan

Deploy front. 