### PR TITLE
enh(Zendesk) - handle Help Center deletions

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -192,7 +192,7 @@ export async function getZendeskHelpCenterReadAllowedBrandIdsActivity(
   const brandsWithHelpCenter =
     await ZendeskBrandResource.fetchHelpCenterReadAllowedBrandIds(connectorId);
 
-  // cleaning up brands that don't have an enabled help center anymore
+  // cleaning up Brands (resp. Help Centers) that don't exist on Zendesk anymore (resp. have been deleted)
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -17,7 +17,6 @@ import {
   fetchZendeskTicketComments,
   fetchZendeskTickets,
   getZendeskBrandSubdomain,
-  isBrandHelpCenterEnabled,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -214,7 +213,7 @@ export async function getZendeskHelpCenterReadAllowedBrandIdsActivity(
     if (!fetchedBrand) {
       await brandInDb?.revokeTicketsPermissions();
       await brandInDb?.revokeHelpCenterPermissions();
-    } else if (!isBrandHelpCenterEnabled(fetchedBrand)) {
+    } else if (!fetchedBrand.has_help_center) {
       await brandInDb?.revokeHelpCenterPermissions();
     }
   }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -17,6 +17,7 @@ import {
   fetchZendeskTicketComments,
   fetchZendeskTickets,
   getZendeskBrandSubdomain,
+  isBrandHelpCenterEnabled,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -213,11 +214,7 @@ export async function getZendeskHelpCenterReadAllowedBrandIdsActivity(
     if (!fetchedBrand) {
       await brandInDb?.revokeTicketsPermissions();
       await brandInDb?.revokeHelpCenterPermissions();
-    } else if (
-      // TODO(2025-01-10 aubin): replace this with the generic function isBrandHelpCenterEnabled
-      !fetchedBrand.has_help_center ||
-      fetchedBrand.help_center_state !== "enabled"
-    ) {
+    } else if (!isBrandHelpCenterEnabled(fetchedBrand)) {
       await brandInDb?.revokeHelpCenterPermissions();
     }
   }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -189,7 +189,9 @@ export async function getZendeskHelpCenterReadAllowedBrandIdsActivity(
   // fetching the brands that have a Help Center selected as a whole
   const brandsWithHelpCenter =
     await ZendeskBrandResource.fetchHelpCenterReadAllowedBrandIds(connectorId);
-  // fetching the brands that have at least one Category selected
+  // fetching the brands that have at least one Category selected:
+  // we need to do that because we can only fetch diffs at the brand level.
+  // We will filter later on the categories allowed.
   const brandWithCategories =
     await ZendeskCategoryResource.fetchBrandIdsOfReadOnlyCategories(
       connectorId


### PR DESCRIPTION
## Description

- Follow up on #9868.
- Currently, deleting or disabling a Help Center on Zendesk causes the subsequent fetches to fail with 404 errors.
- This PR checks for deleted/disabled Help Centers before the incremental sync and sets the `helpCenterPermission` of the brand to `none` if applicable.
- New invariants:
  - `helpCenterPermission` is never set to `read` without checking for `isBrandHelpCenterEnabled` or directly clicking on the help center in the UI (node appears if we passed the check `isBrandHelpCenterEnabled`).
  - Fetching Help Center data is either triggered through a sync (in which case the check was performed), or happens after doing this check (incremental).
- The brand help centers that are disabled are cleaned up by the garbage collect, the syncs only handle setting the `helpCenterPermission`.
- Note: even if `help_center_state` is set to "disabled" here, the Help Center still exists, and the admins still have access to it: https://support.zendesk.com/hc/en-us/articles/4408829088026-Deactivating-your-Help-Center.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
