### PR TITLE
[Types] remove `provider` from `ContentNode`, rename `BaseContentNode` to `ContentNode`

### DIFF
--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -46,7 +46,6 @@ export function createContentNodeFromSpace(
   const spaceId = isConfluenceSpaceModel(space) ? space.spaceId : space.id;
 
   return {
-    provider: "confluence",
     internalId: makeSpaceInternalId(spaceId),
     parentInternalId: null,
     type: "folder",
@@ -66,7 +65,6 @@ export function createContentNodeFromPage(
   isExpandable = false
 ): ContentNode {
   return {
-    provider: "confluence",
     internalId: makePageInternalId(page.pageId),
     parentInternalId:
       parent.type === "space"

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -286,7 +286,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
         nodes = nodes.concat(
           page.map((repo) => ({
-            provider: c.type,
             internalId: getRepositoryInternalId(repo.id),
             parentInternalId: null,
             type: "folder",
@@ -358,7 +357,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
           if (latestIssue) {
             nodes.push({
-              provider: c.type,
               internalId: getIssuesInternalId(repoId),
               parentInternalId,
               type: "database",
@@ -373,7 +371,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
           if (latestDiscussion) {
             nodes.push({
-              provider: c.type,
               internalId: getDiscussionsInternalId(repoId),
               parentInternalId,
               type: "channel",
@@ -388,7 +385,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
           if (codeRepo) {
             nodes.push({
-              provider: c.type,
               internalId: getCodeRootInternalId(repoId),
               parentInternalId,
               type: "folder",
@@ -431,7 +427,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
           directories.forEach((directory) => {
             nodes.push({
-              provider: c.type,
               internalId: directory.internalId,
               parentInternalId,
               type: "folder",
@@ -446,7 +441,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
           files.forEach((file) => {
             nodes.push({
-              provider: c.type,
               internalId: file.documentId,
               parentInternalId,
               type: "file",
@@ -609,7 +603,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         return;
       }
       nodes.push({
-        provider: c.type,
         internalId: getRepositoryInternalId(repoId),
         parentInternalId: null,
         type: "folder",
@@ -630,7 +623,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         return;
       }
       nodes.push({
-        provider: c.type,
         internalId: getIssuesInternalId(repoId),
         parentInternalId: getRepositoryInternalId(repoId),
         type: "database",
@@ -649,7 +641,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         return;
       }
       nodes.push({
-        provider: c.type,
         internalId: getDiscussionsInternalId(repoId),
         parentInternalId: getRepositoryInternalId(repoId),
         type: "channel",
@@ -670,7 +661,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         return;
       }
       nodes.push({
-        provider: c.type,
         internalId: getIssueInternalId(repoId, issueNumber),
         parentInternalId: getIssuesInternalId(repoId),
         type: "file",
@@ -690,7 +680,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         return;
       }
       nodes.push({
-        provider: c.type,
         internalId: getDiscussionInternalId(repoId, discussionNumber),
         parentInternalId: getDiscussionsInternalId(repoId),
         type: "file",
@@ -707,7 +696,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     fullCodeInRepos.forEach((codeRepo) => {
       const repo = uniqueRepos[parseInt(codeRepo.repoId)];
       nodes.push({
-        provider: c.type,
         internalId: getCodeRootInternalId(codeRepo.repoId),
         parentInternalId: getRepositoryInternalId(codeRepo.repoId),
         type: "folder",
@@ -725,7 +713,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     codeDirectories.forEach((directory) => {
       const repo = uniqueRepos[parseInt(directory.repoId)];
       nodes.push({
-        provider: c.type,
         internalId: directory.internalId,
         parentInternalId: directory.parentInternalId,
         type: "folder",
@@ -745,7 +732,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     codeFiles.forEach((file) => {
       const repo = uniqueRepos[parseInt(file.repoId)];
       nodes.push({
-        provider: c.type,
         internalId: file.documentId,
         parentInternalId: file.parentInternalId,
         type: "file",

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -321,7 +321,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
               const type = getPermissionViewType(f);
 
               return {
-                provider: c.type,
                 internalId: getInternalId(f.driveFileId),
                 parentInternalId: null,
                 type,
@@ -345,7 +344,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
             nodes = nodes.concat(
               sheets.map((s) => {
                 return {
-                  provider: c.type,
                   internalId: getGoogleSheetContentNodeInternalId(
                     s.driveFileId,
                     s.driveSheetId
@@ -394,7 +392,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                 );
               }
               return {
-                provider: c.type,
                 internalId: getInternalId(driveObject.id),
                 parentInternalId:
                   // note: if the parent is null, the drive object falls at top-level
@@ -422,7 +419,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
           // Adding a fake "Shared with me" node, to allow the user to see their shared files
           // that are not living in a shared drive.
           nodes.push({
-            provider: c.type,
             internalId: getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID),
             parentInternalId: null,
             type: "folder" as const,
@@ -491,7 +487,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
               );
 
               return {
-                provider: c.type,
                 internalId: getInternalId(driveObject.id),
                 parentInternalId:
                   driveObject.parent && getInternalId(driveObject.parent),
@@ -678,7 +673,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         const sourceUrl = getSourceUrlForGoogleDriveFiles(f);
 
         return {
-          provider: "google_drive",
           internalId: getInternalId(f.driveFileId),
           parentInternalId: null,
           type,
@@ -718,7 +712,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     })();
 
     const sheetNodes: ContentNode[] = sheets.map((s) => ({
-      provider: "google_drive",
       internalId: getGoogleSheetContentNodeInternalId(
         s.driveFileId,
         s.driveSheetId
@@ -979,7 +972,6 @@ async function getFoldersAsContentNodes({
       }
       const sourceUrl = `https://drive.google.com/drive/folders/${f.folderId}`;
       return {
-        provider: "google_drive",
         internalId: getInternalId(f.folderId),
         parentInternalId: null,
         type: "folder",

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -1,5 +1,9 @@
-import type { ConnectorPermission, ContentNode, Result } from "@dust-tt/types";
-import type { ContentNodesViewType } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  ContentNode,
+  ContentNodesViewType,
+  Result,
+} from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
@@ -39,8 +43,10 @@ import type {
   RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
-import { ConnectorManagerError } from "@connectors/connectors/interface";
-import { BaseConnectorManager } from "@connectors/connectors/interface";
+import {
+  BaseConnectorManager,
+  ConnectorManagerError,
+} from "@connectors/connectors/interface";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
@@ -613,7 +619,6 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     const nodes: ContentNode[] = [];
     for (const helpCenter of helpCenters) {
       nodes.push({
-        provider: "intercom",
         internalId: getHelpCenterInternalId(
           this.connectorId,
           helpCenter.helpCenterId
@@ -630,7 +635,6 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     }
     for (const collection of collections) {
       nodes.push({
-        provider: "intercom",
         internalId: getHelpCenterCollectionInternalId(
           this.connectorId,
           collection.collectionId
@@ -652,7 +656,6 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     }
     for (const article of articles) {
       nodes.push({
-        provider: "intercom",
         internalId: getHelpCenterArticleInternalId(
           this.connectorId,
           article.articleId
@@ -674,7 +677,6 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     }
     if (isAllConversations) {
       nodes.push({
-        provider: "intercom",
         internalId: getTeamsInternalId(this.connectorId),
         parentInternalId: null,
         type: "channel",
@@ -691,7 +693,6 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     }
     for (const team of teams) {
       nodes.push({
-        provider: "intercom",
         internalId: getTeamInternalId(this.connectorId, team.teamId),
         parentInternalId: getTeamsInternalId(this.connectorId),
         type: "channel",

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -134,7 +134,6 @@ export async function retrieveIntercomConversationsPermissions({
   if (isReadPermissionsOnly) {
     if (isRootLevel && isAllConversationsSynced) {
       nodes.push({
-        provider: "intercom",
         internalId: allTeamsInternalId,
         parentInternalId: null,
         type: "channel",
@@ -148,7 +147,6 @@ export async function retrieveIntercomConversationsPermissions({
       });
     } else if (isRootLevel && hasTeamsWithReadPermission) {
       nodes.push({
-        provider: "intercom",
         internalId: allTeamsInternalId,
         parentInternalId: null,
         type: "channel",
@@ -165,7 +163,6 @@ export async function retrieveIntercomConversationsPermissions({
     if (parentInternalId === allTeamsInternalId) {
       teamsWithReadPermission.forEach((team) => {
         nodes.push({
-          provider: connector.type,
           internalId: getTeamInternalId(connectorId, team.teamId),
           parentInternalId: allTeamsInternalId,
           type: "folder",
@@ -183,7 +180,6 @@ export async function retrieveIntercomConversationsPermissions({
     const teams = await fetchIntercomTeams({ accessToken });
     if (isRootLevel) {
       nodes.push({
-        provider: "intercom",
         internalId: allTeamsInternalId,
         parentInternalId: null,
         type: "channel",
@@ -202,7 +198,6 @@ export async function retrieveIntercomConversationsPermissions({
           return teamFromDb.teamId === team.id;
         });
         nodes.push({
-          provider: connector.type,
           internalId: getTeamInternalId(connectorId, team.id),
           parentInternalId: allTeamsInternalId,
           type: "folder",

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -364,7 +364,6 @@ export async function retrieveIntercomHelpCentersPermissions({
         },
       });
       nodes = helpCentersFromDb.map((helpCenter) => ({
-        provider: connector.type,
         internalId: getHelpCenterInternalId(
           connectorId,
           helpCenter.helpCenterId
@@ -381,7 +380,6 @@ export async function retrieveIntercomHelpCentersPermissions({
     } else {
       const helpCenters = await fetchIntercomHelpCenters({ accessToken });
       nodes = helpCenters.map((helpCenter) => ({
-        provider: connector.type,
         internalId: getHelpCenterInternalId(connectorId, helpCenter.id),
         parentInternalId: null,
         type: "database",
@@ -425,7 +423,6 @@ export async function retrieveIntercomHelpCentersPermissions({
     });
     if (isReadPermissionsOnly) {
       nodes = collectionsInDb.map((collection) => ({
-        provider: connector.type,
         internalId: getHelpCenterCollectionInternalId(
           connectorId,
           collection.collectionId
@@ -452,7 +449,6 @@ export async function retrieveIntercomHelpCentersPermissions({
           (c) => c.collectionId === collection.id
         );
         return {
-          provider: connector.type,
           internalId: getHelpCenterCollectionInternalId(
             connectorId,
             collection.id
@@ -493,7 +489,6 @@ export async function retrieveIntercomHelpCentersPermissions({
       });
       const collectionNodes: ContentNode[] = collectionsInDb.map(
         (collection) => ({
-          provider: connector.type,
           internalId: getHelpCenterCollectionInternalId(
             connectorId,
             collection.collectionId
@@ -522,7 +517,6 @@ export async function retrieveIntercomHelpCentersPermissions({
         },
       });
       const articleNodes: ContentNode[] = articlesInDb.map((article) => ({
-        provider: connector.type,
         internalId: getHelpCenterArticleInternalId(
           connectorId,
           article.articleId

--- a/connectors/src/connectors/intercom/lib/permissions.ts
+++ b/connectors/src/connectors/intercom/lib/permissions.ts
@@ -50,7 +50,6 @@ export async function retrieveSelectedNodes({
     );
 
     collectionsNodes.push({
-      provider: connector.type,
       internalId: getHelpCenterCollectionInternalId(
         connectorId,
         collection.collectionId
@@ -79,7 +78,6 @@ export async function retrieveSelectedNodes({
     intercomWorkspace?.syncAllConversations === "scheduled_activate"
   ) {
     teamsNodes.push({
-      provider: connector.type,
       internalId: getTeamsInternalId(connectorId),
       parentInternalId: null,
       type: "channel",
@@ -100,7 +98,6 @@ export async function retrieveSelectedNodes({
   });
   teams.forEach((team) => {
     teamsNodes.push({
-      provider: connector.type,
       internalId: getTeamInternalId(connectorId, team.teamId),
       parentInternalId: getTeamsInternalId(connectorId),
       type: "folder",

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -17,7 +17,6 @@ export function getRootNodes(): ContentNode[] {
 
 export function getSitesRootAsContentNode(): ContentNode {
   return {
-    provider: "microsoft",
     internalId: internalIdFromTypeAndPath({
       itemAPIPath: "",
       nodeType: "sites-root",
@@ -36,7 +35,6 @@ export function getSitesRootAsContentNode(): ContentNode {
 
 export function getTeamsRootAsContentNode(): ContentNode {
   return {
-    provider: "microsoft",
     internalId: internalIdFromTypeAndPath({
       itemAPIPath: "",
       nodeType: "teams-root",
@@ -54,7 +52,6 @@ export function getTeamsRootAsContentNode(): ContentNode {
 }
 export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
   return {
-    provider: "microsoft",
     internalId: internalIdFromTypeAndPath({
       itemAPIPath: `/teams/${team.id}`,
       nodeType: "team",
@@ -80,7 +77,6 @@ export function getSiteAsContentNode(
     throw new Error("Site id is required");
   }
   return {
-    provider: "microsoft",
     internalId: internalIdFromTypeAndPath({
       itemAPIPath: getSiteAPIPath(site),
       nodeType: "site",
@@ -111,7 +107,6 @@ export function getChannelAsContentNode(
   }
 
   return {
-    provider: "microsoft",
     internalId: internalIdFromTypeAndPath({
       itemAPIPath: `/teams/${parentInternalId}/channels/${channel.id}`,
       nodeType: "channel",
@@ -136,7 +131,6 @@ export function getDriveAsContentNode(
     throw new Error("Drive id is required");
   }
   return {
-    provider: "microsoft",
     internalId: getDriveInternalId(drive),
     parentInternalId,
     type: "folder",
@@ -153,7 +147,6 @@ export function getFolderAsContentNode(
   parentInternalId: string
 ): ContentNode {
   return {
-    provider: "microsoft",
     internalId: getDriveItemInternalId(folder),
     parentInternalId,
     type: "folder",
@@ -171,7 +164,6 @@ export function getFileAsContentNode(
   parentInternalId: string
 ): ContentNode {
   return {
-    provider: "microsoft",
     internalId: getDriveItemInternalId(file),
     parentInternalId,
     type: "file",
@@ -207,7 +199,6 @@ export function getMicrosoftNodeAsContentNode(
   }
 
   return {
-    provider: "microsoft",
     internalId: node.internalId,
     parentInternalId: node.parentInternalId,
     type,

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -455,7 +455,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       const expandable = Boolean(hasChildrenByPageId[page.notionPageId]);
 
       return {
-        provider: c.type,
         internalId: nodeIdFromNotionId(page.notionPageId),
         parentInternalId:
           !page.parentId || page.parentId === "workspace"
@@ -479,7 +478,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
 
     const getDbNodes = async (db: NotionDatabase): Promise<ContentNode> => {
       return {
-        provider: c.type,
         internalId: nodeIdFromNotionId(db.notionDatabaseId),
         parentInternalId:
           !db.parentId || db.parentId === "workspace"
@@ -504,7 +502,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         // We also need to return a "fake" top-level folder call "Orphaned" to include resources
         // we haven't been able to find a parent for.
         folderNodes.push({
-          provider: c.type,
           // Orphaned resources in the database will have "unknown" as their parentId.
           internalId: nodeIdFromNotionId("unknown"),
           parentInternalId: null,
@@ -553,7 +550,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     const hasChildrenByPageId = await hasChildren(pages, this.connectorId);
     const pageNodes: ContentNode[] = await Promise.all(
       pages.map(async (page) => ({
-        provider: "notion",
         internalId: nodeIdFromNotionId(page.notionPageId),
         parentInternalId:
           !page.parentId || page.parentId === "workspace"
@@ -571,7 +567,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     );
 
     const dbNodes: ContentNode[] = dbs.map((db) => ({
-      provider: "notion",
       internalId: nodeIdFromNotionId(db.notionDatabaseId),
       parentInternalId:
         !db.parentId || db.parentId === "workspace"
@@ -593,7 +588,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       const orphanedCount = await getOrphanedCount(this.connectorId);
       if (orphanedCount > 0) {
         contentNodes.push({
-          provider: "notion",
           // Orphaned resources in the database will have "unknown" as their parentId.
           internalId: nodeIdFromNotionId("unknown"),
           parentInternalId: null,

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -1,11 +1,11 @@
 import type {
   ConnectorPermission,
   ContentNode,
+  ContentNodesViewType,
   ModelId,
   Result,
   SlackConfigurationType,
 } from "@dust-tt/types";
-import type { ContentNodesViewType } from "@dust-tt/types";
 import {
   Err,
   isSlackAutoReadPatterns,
@@ -20,8 +20,10 @@ import type {
   RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
-import { ConnectorManagerError } from "@connectors/connectors/interface";
-import { BaseConnectorManager } from "@connectors/connectors/interface";
+import {
+  BaseConnectorManager,
+  ConnectorManagerError,
+} from "@connectors/connectors/interface";
 import { getChannels } from "@connectors/connectors/slack//temporal/activities";
 import { getBotEnabled } from "@connectors/connectors/slack/bot";
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
@@ -397,7 +399,6 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       }
 
       const resources: ContentNode[] = slackChannels.map((ch) => ({
-        provider: "slack",
         internalId: slackChannelInternalIdFromSlackChannelId(ch.slackChannelId),
         parentInternalId: null,
         type: "channel",
@@ -621,7 +622,6 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     });
 
     const contentNodes: ContentNode[] = channels.map((ch) => ({
-      provider: "slack",
       internalId: slackChannelInternalIdFromSlackChannelId(ch.slackChannelId),
       parentInternalId: null,
       type: "channel",

--- a/connectors/src/connectors/snowflake/lib/content_nodes.ts
+++ b/connectors/src/connectors/snowflake/lib/content_nodes.ts
@@ -34,7 +34,6 @@ export const getContentNodeFromInternalId = (
 
   if (type === "database") {
     return {
-      provider: "snowflake",
       internalId: databaseName as string,
       parentInternalId: null,
       type: "folder",
@@ -49,7 +48,6 @@ export const getContentNodeFromInternalId = (
   }
   if (type === "schema") {
     return {
-      provider: "snowflake",
       internalId: `${databaseName}.${schemaName}`,
       parentInternalId: databaseName as string,
       type: "folder",
@@ -64,7 +62,6 @@ export const getContentNodeFromInternalId = (
   }
   if (type === "table") {
     return {
-      provider: "snowflake",
       internalId: `${databaseName}.${schemaName}.${tableName}`,
       parentInternalId: `${databaseName}.${schemaName}`,
       type: "database",

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -19,8 +19,10 @@ import type {
   RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
-import { ConnectorManagerError } from "@connectors/connectors/interface";
-import { BaseConnectorManager } from "@connectors/connectors/interface";
+import {
+  BaseConnectorManager,
+  ConnectorManagerError,
+} from "@connectors/connectors/interface";
 import {
   getDisplayNameForFolder,
   getDisplayNameForPage,
@@ -199,7 +201,6 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         .filter((f) => !excludedFoldersSet.has(f.url))
         .map((folder): ContentNode => {
           return {
-            provider: "webcrawler",
             internalId: folder.internalId,
             parentInternalId: folder.parentUrl
               ? stableIdForUrl({
@@ -222,7 +223,6 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
               normalizeFolderUrl(page.url)
             );
             return {
-              provider: "webcrawler",
               internalId: isFileAndFolder
                 ? stableIdForUrl({
                     url: normalizeFolderUrl(page.url),
@@ -274,7 +274,6 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
 
     folders.forEach((folder) => {
       nodes.push({
-        provider: "webcrawler",
         internalId: folder.internalId,
         parentInternalId: folder.parentUrl,
         title: getDisplayNameForFolder(folder),
@@ -288,7 +287,6 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     });
     pages.forEach((page) => {
       nodes.push({
-        provider: "webcrawler",
         internalId: page.documentId,
         parentInternalId: page.parentUrl,
         title: getDisplayNameForPage(page),

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -77,7 +77,6 @@ async function getRootLevelContentNodes(
         brandsInDatabase
           .find((b) => b.brandId === brand.id)
           ?.toContentNode(connectorId) ?? {
-          provider: "zendesk",
           internalId: getBrandInternalId({ connectorId, brandId: brand.id }),
           parentInternalId: null,
           type: "folder",
@@ -133,7 +132,6 @@ async function getBrandChildren(
     const ticketsNode: ContentNode = brandInDb?.getTicketsContentNode(
       connector.id
     ) ?? {
-      provider: "zendesk",
       internalId: getTicketsInternalId({ connectorId: connector.id, brandId }),
       parentInternalId: parentInternalId,
       type: "folder",
@@ -151,7 +149,6 @@ async function getBrandChildren(
       const helpCenterNode: ContentNode = brandInDb?.getHelpCenterContentNode(
         connector.id
       ) ?? {
-        provider: "zendesk",
         internalId: getHelpCenterInternalId({
           connectorId: connector.id,
           brandId,
@@ -212,7 +209,6 @@ async function getHelpCenterChildren(
         categoriesInDatabase
           .find((c) => c.categoryId === category.id)
           ?.toContentNode(connectorId) ?? {
-          provider: "zendesk",
           internalId: getCategoryInternalId({
             connectorId,
             brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -330,7 +330,6 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
   toContentNode(connectorId: number): ContentNode {
     const { brandId } = this;
     return {
-      provider: "zendesk",
       internalId: getBrandInternalId({ connectorId, brandId }),
       parentInternalId: null,
       type: "folder",
@@ -353,7 +352,6 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
   ): ContentNode & { parentInternalId: string } {
     const { brandId } = this;
     return {
-      provider: "zendesk",
       internalId: getHelpCenterInternalId({ connectorId, brandId }),
       parentInternalId: getBrandInternalId({ connectorId, brandId }),
       type: "folder",
@@ -375,7 +373,6 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
   ): ContentNode & { parentInternalId: string } {
     const { brandId } = this;
     return {
-      provider: "zendesk",
       internalId: getTicketsInternalId({ connectorId, brandId }),
       parentInternalId: getBrandInternalId({ connectorId, brandId }),
       type: "folder",
@@ -641,7 +638,6 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
   ): ContentNode {
     const { brandId, categoryId, permission } = this;
     return {
-      provider: "zendesk",
       internalId: getCategoryInternalId({ connectorId, brandId, categoryId }),
       parentInternalId: getHelpCenterInternalId({ connectorId, brandId }),
       type: "folder",
@@ -727,7 +723,6 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
   toContentNode(connectorId: number): ContentNode {
     const { brandId, ticketId } = this;
     return {
-      provider: "zendesk",
       internalId: getTicketInternalId({ connectorId, brandId, ticketId }),
       parentInternalId: getTicketsInternalId({ connectorId, brandId }),
       type: "file",
@@ -939,7 +934,6 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
   toContentNode(connectorId: number): ContentNode {
     const { brandId, categoryId, articleId } = this;
     return {
-      provider: "zendesk",
       internalId: getArticleInternalId({ connectorId, brandId, articleId }),
       parentInternalId: getCategoryInternalId({
         connectorId,

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -28,10 +28,10 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   APIError,
-  BaseContentNode,
   ConnectorPermission,
   ConnectorProvider,
   ConnectorType,
+  ContentNode,
   DataSourceType,
   LightWorkspaceType,
   UpdateConnectorRequestBody,
@@ -946,7 +946,7 @@ export async function confirmPrivateNodesSync({
   selectedNodes,
   confirm,
 }: {
-  selectedNodes: BaseContentNode[];
+  selectedNodes: ContentNode[];
   confirm: (n: ConfirmDataType) => Promise<boolean>;
 }): Promise<boolean> {
   // confirmation in case there are private nodes

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip,
   Tree,
 } from "@dust-tt/sparkle";
-import type { APIError, BaseContentNode } from "@dust-tt/types";
+import type { APIError, ContentNode } from "@dust-tt/types";
 import type { ReactNode } from "react";
 import React, { useCallback, useContext, useState } from "react";
 
@@ -17,7 +17,7 @@ import { classNames, timeAgoFrom } from "@app/lib/utils";
 
 const unselectedChildren = (
   selection: Record<string, ContentNodeTreeItemStatus>,
-  node: BaseContentNode
+  node: ContentNode
 ) =>
   Object.entries(selection).reduce((acc, [k, v]) => {
     const shouldUnselect = v.parents.includes(node.internalId);
@@ -32,7 +32,7 @@ const unselectedChildren = (
   }, {});
 
 export type UseResourcesHook = (parentId: string | null) => {
-  resources: BaseContentNode[];
+  resources: ContentNode[];
   isResourcesLoading: boolean;
   isResourcesError: boolean;
   resourcesError?: APIError | null;
@@ -40,7 +40,7 @@ export type UseResourcesHook = (parentId: string | null) => {
 
 export type ContentNodeTreeItemStatus = {
   isSelected: boolean;
-  node: BaseContentNode;
+  node: ContentNode;
   parents: string[];
 };
 
@@ -121,7 +121,7 @@ function ContentNodeTreeChildren({
   );
 
   const getCheckedState = useCallback(
-    (node: BaseContentNode) => {
+    (node: ContentNode) => {
       if (!selectedNodes) {
         return false;
       }

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -6,7 +6,7 @@ import {
   SlackLogo,
 } from "@dust-tt/sparkle";
 import type {
-  BaseContentNode,
+  ContentNode,
   DataSourceType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -52,7 +52,7 @@ export function SlackIntegration({
   }, [existingSelection, newSelection]);
 
   const customIsNodeChecked = useCallback(
-    (node: BaseContentNode) => {
+    (node: ContentNode) => {
       return (
         newSelection?.some((c) => c.slackChannelId === node.internalId) || false
       );

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -6,10 +6,10 @@ import {
   LockIcon,
   Square3Stack3DIcon,
 } from "@dust-tt/sparkle";
-import type { BaseContentNode } from "@dust-tt/types";
+import type { ContentNode } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 
-function getVisualForFileContentNode(node: BaseContentNode & { type: "file" }) {
+function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   if (node.expandable) {
     return DocumentPileIcon;
   }
@@ -17,7 +17,7 @@ function getVisualForFileContentNode(node: BaseContentNode & { type: "file" }) {
   return DocumentIcon;
 }
 
-export function getVisualForContentNode(node: BaseContentNode) {
+export function getVisualForContentNode(node: ContentNode) {
   switch (node.type) {
     case "channel":
       if (node.providerVisibility === "private") {
@@ -30,7 +30,7 @@ export function getVisualForContentNode(node: BaseContentNode) {
 
     case "file":
       return getVisualForFileContentNode(
-        node as BaseContentNode & { type: "file" }
+        node as ContentNode & { type: "file" }
       );
 
     case "folder":

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -1,12 +1,7 @@
 import { ModelId } from "../shared/model_id";
 import { DataSourceViewCategory } from "./api_handlers/public/spaces";
-import {
-  ConnectorStatusDetails,
-  DataSourceType,
-  DataSourceWithAgentsUsageType,
-  EditedByUser,
-} from "./data_source";
-import { BaseContentNode } from "./lib/connectors_api";
+import { ConnectorStatusDetails, DataSourceType, DataSourceWithAgentsUsageType, EditedByUser } from "./data_source";
+import { ContentNode } from "./lib/connectors_api";
 
 export interface DataSourceViewType {
   category: DataSourceViewCategory;
@@ -26,7 +21,7 @@ export type DataSourceViewsWithDetails = DataSourceViewType & {
   usage: DataSourceWithAgentsUsageType;
 };
 
-export type DataSourceViewContentNode = BaseContentNode & {
+export type DataSourceViewContentNode = ContentNode & {
   parentInternalIds: string[] | null;
 };
 

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -1,7 +1,4 @@
-import {
-  AdminCommandType,
-  AdminResponseType,
-} from "../../connectors/admin/cli";
+import { AdminCommandType, AdminResponseType } from "../../connectors/admin/cli";
 import { ConnectorsAPIError, isConnectorsAPIError } from "../../connectors/api";
 import { UpdateConnectorConfigurationType } from "../../connectors/api_handlers/connector_configuration";
 import { ConnectorCreateRequestBody } from "../../connectors/api_handlers/create_connector";
@@ -96,7 +93,7 @@ export const contentNodeTypeSortOrder: Record<ContentNodeType, number> = {
  * information. More details here:
  * https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
  */
-export interface BaseContentNode {
+export interface ContentNode {
   internalId: string;
   // The direct parent ID of this content node
   parentInternalId: string | null;
@@ -111,10 +108,6 @@ export interface BaseContentNode {
   lastUpdatedAt: number | null;
   providerVisibility?: "public" | "private";
 }
-
-export type ContentNode = BaseContentNode & {
-  provider: ConnectorProvider;
-};
 
 export type ContentNodeWithParentIds = ContentNode & {
   // A list of all parent IDs up to the root node, including the direct parent


### PR DESCRIPTION
## Description

- Close [#1934](https://github.com/dust-tt/tasks/issues/1934)
- This PR removes the `provider` field from `ContentNode` and renames `BaseContentNode` with `ContentNode`.
- Tested: editing space, assistantbuilder

## Risk

- Blast radius quite high.

## Deploy Plan

- Deploy front.
- Deploy connectors.
