### PR TITLE
[front/connectors] Deprecate `titleWithParentsContext`

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -702,7 +702,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     // Constructing Nodes for Code
     fullCodeInRepos.forEach((codeRepo) => {
-      const repo = uniqueRepos[parseInt(codeRepo.repoId)];
       nodes.push({
         provider: c.type,
         internalId: getCodeRootInternalId(codeRepo.repoId),
@@ -719,7 +718,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     // Constructing Nodes for Code Directories
     codeDirectories.forEach((directory) => {
-      const repo = uniqueRepos[parseInt(directory.repoId)];
       nodes.push({
         provider: c.type,
         internalId: directory.internalId,
@@ -736,7 +734,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     // Constructing Nodes for Code Files
     codeFiles.forEach((file) => {
-      const repo = uniqueRepos[parseInt(file.repoId)];
       nodes.push({
         provider: c.type,
         internalId: file.documentId,

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -614,7 +614,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         parentInternalId: null,
         type: "folder",
         title: repo.name,
-        titleWithParentsContext: `[${repo.name}] - Full repository`,
         sourceUrl: repo.url,
         expandable: true,
         permission: "read",
@@ -635,7 +634,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         parentInternalId: getRepositoryInternalId(repoId),
         type: "database",
         title: "Issues",
-        titleWithParentsContext: `[${repo.name}] Issues`,
         sourceUrl: repo.url + "/issues",
         expandable: false,
         permission: "read",
@@ -654,7 +652,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         parentInternalId: getRepositoryInternalId(repoId),
         type: "channel",
         title: "Discussions",
-        titleWithParentsContext: `[${repo.name}] Discussions`,
         sourceUrl: repo.url + "/discussions",
         expandable: false,
         permission: "read",
@@ -712,7 +709,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         parentInternalId: getRepositoryInternalId(codeRepo.repoId),
         type: "folder",
         title: "Code",
-        titleWithParentsContext: repo ? `[${repo.name}] Code` : "Code",
         sourceUrl: codeRepo.sourceUrl,
         expandable: true,
         permission: "read",
@@ -730,9 +726,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         parentInternalId: directory.parentInternalId,
         type: "folder",
         title: directory.dirName,
-        titleWithParentsContext: repo
-          ? `[${repo.name}] ${directory.dirName} (code)`
-          : directory.dirName,
         sourceUrl: directory.sourceUrl,
         expandable: true,
         permission: "read",
@@ -750,9 +743,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         parentInternalId: file.parentInternalId,
         type: "file",
         title: file.fileName,
-        titleWithParentsContext: repo
-          ? `[${repo.name}] ${file.fileName} (code)`
-          : file.fileName,
         sourceUrl: file.sourceUrl,
         expandable: false,
         permission: "read",

--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -422,7 +422,7 @@ function DataSourceViewSelectedNodes({
       {nodes.map((node) => (
         <Tree.Item
           key={node.internalId}
-          label={node.titleWithParentsContext ?? node.title}
+          label={node.title}
           type={node.expandable && viewType !== "tables" ? "node" : "leaf"}
           visual={getVisualForContentNode(node)}
           className="whitespace-nowrap"

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -122,7 +122,7 @@ export default function DataSourceSelectionSection({
                     return (
                       <Tree.Item
                         key={`${dsConfig.dataSourceView.sId}-${node.internalId}`}
-                        label={node.titleWithParentsContext ?? node.title}
+                        label={node.title}
                         type={node.expandable ? "node" : "leaf"}
                         visual={getVisualForContentNode(node)}
                         className="whitespace-nowrap"

--- a/front/components/trackers/TrackerDataSourceSelectedTree.tsx
+++ b/front/components/trackers/TrackerDataSourceSelectedTree.tsx
@@ -83,7 +83,7 @@ export const TrackerDataSourceSelectedTree = ({
                 return (
                   <Tree.Item
                     key={`${dsConfig.dataSourceView.sId}-${node.internalId}`}
-                    label={node.titleWithParentsContext ?? node.title}
+                    label={node.title}
                     type={node.expandable ? "node" : "leaf"}
                     visual={getVisualForContentNode(node)}
                     className="whitespace-nowrap"

--- a/types/src/front/api_handlers/public/spaces.ts
+++ b/types/src/front/api_handlers/public/spaces.ts
@@ -29,7 +29,6 @@ export type LightContentNode = {
   preventSelection?: boolean;
   sourceUrl: string | null;
   title: string;
-  titleWithParentsContext?: string;
   type: ContentNodeType;
 };
 

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -102,7 +102,6 @@ export interface BaseContentNode {
   parentInternalId: string | null;
   type: ContentNodeType;
   title: string;
-  titleWithParentsContext?: string;
   sourceUrl: string | null;
   expandable: boolean;
   preventSelection?: boolean;


### PR DESCRIPTION
## Description

- Closes [#1935](https://github.com/dust-tt/tasks/issues/1935)
- This PR removes `titleWithParentsContext` from `front` and `connectors` (not sent anymore, not used anymore).
- No UI regression expected, the feature did not work as per https://github.com/dust-tt/tasks/issues/1923
- The feature of adding a rich title exists in some other connectors (Zendesk), does not rely on `titleWithParentsContext` and will be migrated to core in [#9897](https://github.com/dust-tt/dust/issues/9897)

## Risk

- On the lower end.

## Deploy Plan

- Deploy connectors
- Deploy front.
