### PR TITLE
Stopped propagation of Dropdown trigger click

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.361",
+  "version": "0.2.362",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.361",
+      "version": "0.2.362",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.361",
+  "version": "0.2.362",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -365,7 +365,7 @@ DataTable.Row = function Row({
           <DropdownMenu {...dropdownMenuProps}>
             <DropdownMenuTrigger
               // Necessary to allow clicking the dropdown in a table cell without clicking on the cell
-              onKeyUp={(event) => event.stopPropagation()}
+              // See https://github.com/radix-ui/primitives/issues/1242
               onClick={(event) => {
                 event.stopPropagation();
               }}
@@ -382,7 +382,14 @@ DataTable.Row = function Row({
             <DropdownMenuContent align="end">
               <DropdownMenuGroup>
                 {moreMenuItems?.map((item, index) => (
-                  <DropdownMenuItem key={index} {...item} />
+                  <DropdownMenuItem
+                    key={index}
+                    {...item}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      item.onClick?.(event);
+                    }}
+                  />
                 ))}
               </DropdownMenuGroup>
             </DropdownMenuContent>

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -363,7 +363,14 @@ DataTable.Row = function Row({
       <td className="s-flex s-w-8 s-cursor-pointer s-items-center s-pl-1 s-text-element-600">
         {moreMenuItems && moreMenuItems.length > 0 && (
           <DropdownMenu {...dropdownMenuProps}>
-            <DropdownMenuTrigger asChild>
+            <DropdownMenuTrigger
+              // Necessary to allow clicking the dropdown in a table cell without clicking on the cell
+              onKeyUp={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+              asChild
+            >
               <IconButton
                 icon={MoreIcon}
                 size="sm"

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -201,6 +201,7 @@ const columns: ColumnDef<Data>[] = [
   },
 ];
 
+// TODO: Fix 'Edit' changing the order of the rows
 export const DataTableExample = () => {
   const [filter, setFilter] = React.useState<string>("");
   const [dialogOpen, setDialogOpen] = React.useState(false);


### PR DESCRIPTION
## Description
See https://github.com/dust-tt/tasks/issues/1958#issue-2780331447
Solution hinted in https://github.com/radix-ui/primitives/issues/1242
-> The dropdown trigger click was propagated to the DataTable Row

## Risk
Low

## Deploy Plan
Publish sparkle, deploy Front
