### PR TITLE
Upg: cleaner lock implementation

### DIFF
--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,0 +1,45 @@
+export class Lock {
+  private static locks = new Map<string, Promise<void>>();
+
+  static async executeWithLock<T>(
+    lockName: string,
+    callback: () => Promise<T>,
+    timeoutMs: number = 30000
+  ): Promise<T> {
+    const start = Date.now();
+
+    if (Lock.locks.has(lockName)) {
+      const currentLock = Lock.locks.get(lockName);
+      if (currentLock) {
+        const remainingTime = timeoutMs - (Date.now() - start);
+        if (remainingTime <= 0) {
+          throw new Error(`Lock acquisition timed out for ${lockName}`);
+        }
+
+        const timeoutPromise = new Promise((_, reject) => {
+          setTimeout(() => {
+            reject(new Error(`Lock acquisition timed out for ${lockName}`));
+          }, remainingTime);
+        });
+
+        await Promise.race([currentLock, timeoutPromise]);
+      }
+    }
+
+    // Initialize resolveLock with a no-op function to satisfy TypeScript
+    let resolveLock = () => {};
+    const lockPromise = new Promise<void>((resolve) => {
+      resolveLock = resolve;
+    });
+
+    Lock.locks.set(lockName, lockPromise);
+
+    try {
+      const result = await callback();
+      return result;
+    } finally {
+      Lock.locks.delete(lockName);
+      resolveLock();
+    }
+  }
+}

--- a/front/lib/wake_lock.ts
+++ b/front/lib/wake_lock.ts
@@ -1,13 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
 
-export async function wakeLock<T>(
-  autoCallback: () => Promise<T>,
-  lockName?: string
-): Promise<T> {
+export async function wakeLock<T>(autoCallback: () => Promise<T>): Promise<T> {
   if (!global.wakeLocks) {
     global.wakeLocks = new Set();
   }
-  lockName ??= uuidv4();
+  const lockName = uuidv4();
   global.wakeLocks.add(lockName);
   try {
     const r = await autoCallback();
@@ -17,11 +14,6 @@ export async function wakeLock<T>(
   }
 }
 
-// If a lockName is provided, checks if that lock is free, otherwise checks if all locks are free
-export function wakeLockIsFree(lockName?: string): boolean {
-  if (lockName) {
-    return !global.wakeLocks || !global.wakeLocks.has(lockName);
-  }
-
+export function wakeLockIsFree(): boolean {
   return !global.wakeLocks || global.wakeLocks.size === 0;
 }


### PR DESCRIPTION
## Description

I overlooked the reason for "wakeLock" initially (didn't dig enough) : prevent instant shutdown of pods.
To keep it simple and narrowed to the original usage, this PR put it back in it's original state and add a proper `Lock` mechanism (with timeout and easier to use). Limited to a single process but that's my need today (we have a redis system for distributed lock)

## Risk

Low, tested.

## Deploy Plan

Deploy `front`