### PR TITLE
feat: add  __dust_conversation_history magic input for dust apps

### DIFF
--- a/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
+++ b/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
@@ -11,6 +11,7 @@ import { useMemo } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
+import { DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY } from "@app/lib/api/assistant/actions/constants";
 
 export function DustAppRunActionDetails({
   action,
@@ -51,12 +52,14 @@ function DustAppRunParamsDetails({ action }: { action: DustAppRunActionType }) {
 
   return (
     <div className="flex flex-col gap-0.5">
-      {Object.entries(params).map(([k, v], idx) => (
-        <p key={idx}>
-          <span className="font-semibold">{capitalize(k)}:</span>
-          {` ${v}`}
-        </p>
-      ))}
+      {Object.entries(params)
+        .filter(([k]) => k !== DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY)
+        .map(([k, v], idx) => (
+          <p key={idx}>
+            <span className="font-semibold">{capitalize(k)}:</span>
+            {` ${v}`}
+          </p>
+        ))}
     </div>
   );
 }

--- a/front/lib/api/assistant/actions/constants.ts
+++ b/front/lib/api/assistant/actions/constants.ts
@@ -29,3 +29,6 @@ export const DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION = `The ta
 export const DEFAULT_CONVERSATION_SEARCH_ACTION_NAME =
   "search_conversation_files";
 export const DEFAULT_CONVERSATION_SEARCH_ACTION_DATA_DESCRIPTION = `Search within the 'searchable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``;
+
+export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
+  "__dust_conversation_history";

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -17,6 +17,7 @@ import type { Result } from "@dust-tt/types";
 import { BaseAction, getHeaderFromGroupIds } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
+import { DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY } from "@app/lib/api/assistant/actions/constants";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import config from "@app/lib/api/config";
@@ -154,6 +155,13 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
     if (datasetName) {
       // We have a dataset name we need to find associated schema.
       schema = await getDatasetSchema(auth, app, datasetName);
+      // remove from the schema the magic input key
+      if (schema) {
+        schema = schema.filter(
+          (s) => s.key !== DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY
+        );
+      }
+
       if (!schema) {
         return new Err(
           new Error(
@@ -257,6 +265,25 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
       }
     }
 
+    // Fetch the dataset schema again to check whether the magic input key is present.
+    const appSpec = JSON.parse(
+      app.savedSpecification || "[]"
+    ) as SpecificationType;
+    const inputSpec = appSpec.find((b) => b.type === "input");
+    const inputConfig = inputSpec ? appConfig[inputSpec.name] : null;
+    const datasetName: string | null = inputConfig ? inputConfig.dataset : null;
+
+    let schema: DatasetSchema | null = null;
+    if (datasetName) {
+      schema = await getDatasetSchema(auth, app, datasetName);
+    }
+    let shouldIncludeConversationHistory = false;
+    if (
+      schema?.find((s) => s.key === DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY)
+    ) {
+      shouldIncludeConversationHistory = true;
+    }
+
     // Create the AgentDustAppRunAction object in the database and yield an event for the generation
     // of the params. We store the action here as the params have been generated, if an error occurs
     // later on, the action won't have an output but the error will be stored on the parent agent
@@ -313,6 +340,12 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
 
     // As we run the app (using a system API key here), we do force using the workspace credentials so
     // that the app executes in the exact same conditions in which they were developed.
+    if (shouldIncludeConversationHistory) {
+      params[DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY] = JSON.stringify(
+        conversation.content
+      );
+    }
+
     const runRes = await api.runAppStreamed(
       {
         workspaceId: actionConfiguration.appWorkspaceId,


### PR DESCRIPTION
## Description

Allows accessing the conversation history from custom dust app runs by defining a key in the input dataset "__dust_conversation_history".

This param is not rendered in the UI and is excluded from input generation.

## Risk

N/A should be transparent for users that don't use it.

## Deploy Plan

Deploy front