### PR TITLE
fix(Zendesk) - fix handling of 404 on `/categories`

### DIFF
--- a/connectors/migrations/20250110_investigate_zendesk_hc.ts
+++ b/connectors/migrations/20250110_investigate_zendesk_hc.ts
@@ -1,0 +1,100 @@
+import { makeScript } from "scripts/helpers";
+
+import { isZendeskNotFoundError } from "@connectors/connectors/zendesk/lib/errors";
+import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
+import {
+  fetchZendeskBrand,
+  fetchZendeskCategoriesInBrand,
+  fetchZendeskCurrentUser,
+  getZendeskBrandSubdomain,
+} from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("zendesk", {});
+
+  for (const connector of connectors) {
+    const connectorId = connector.id;
+    if (connector.isPaused()) {
+      continue;
+    }
+    const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
+      connector.connectionId
+    );
+    const user = await fetchZendeskCurrentUser({ accessToken, subdomain });
+    const brandsOnDb = await ZendeskBrandResource.fetchByConnector(connector);
+    for (const brandOnDb of brandsOnDb) {
+      const { brandId } = brandOnDb;
+      if (!execute) {
+        logger.info({ brandId }, "DRY: Fetching brand");
+        continue;
+      }
+
+      const fetchedBrand = await fetchZendeskBrand({
+        brandId,
+        accessToken,
+        subdomain,
+      });
+      const brandSubdomain = await getZendeskBrandSubdomain({
+        brandId,
+        connectorId,
+        accessToken,
+        subdomain,
+      });
+
+      let couldFetchCategories;
+      try {
+        await fetchZendeskCategoriesInBrand(accessToken, {
+          brandSubdomain,
+          pageSize: ZENDESK_BATCH_SIZE,
+        });
+        couldFetchCategories = true;
+      } catch (e) {
+        if (isZendeskNotFoundError(e)) {
+          couldFetchCategories = false;
+          // if (fetchedBrand?.has_help_center) {
+          //   const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/articles.json`;
+          //   const res = await fetch(url, {
+          //     method: "GET",
+          //     headers: {
+          //       Authorization: `Bearer ${accessToken}`,
+          //       "Content-Type": "application/json",
+          //     },
+          //   });
+          //   const text = await res.text();
+          //   logger.error(
+          //     {
+          //       res,
+          //       brandSubdomain,
+          //       status: res.status,
+          //       statusText: res.statusText,
+          //       headers: res.headers,
+          //       text,
+          //       body: res.body,
+          //     },
+          //     "Failed to fetch categories"
+          //   );
+          //   await res.json();
+          // }
+        } else {
+          throw e;
+        }
+      }
+      logger.info(
+        {
+          connectorId,
+          brandId,
+          couldFetchCategories,
+          brandSubdomain,
+          hasHelpCenter: fetchedBrand?.has_help_center,
+          helpCenterState: fetchedBrand?.help_center_state,
+          userRole: user.role,
+          userActive: user.active,
+        },
+        `FETCH`
+      );
+    }
+  }
+});

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -9,10 +9,7 @@ import {
   forbidSyncZendeskTickets,
 } from "@connectors/connectors/zendesk/lib/ticket_permissions";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import {
-  createZendeskClient,
-  isBrandHelpCenterEnabled,
-} from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
@@ -50,8 +47,6 @@ export async function allowSyncZendeskBrand({
     return false;
   }
 
-  const helpCenterEnabled = isBrandHelpCenterEnabled(fetchedBrand);
-
   // creating the brand if it does not exist yet in db
   if (!brand) {
     await ZendeskBrandResource.makeNew({
@@ -61,7 +56,7 @@ export async function allowSyncZendeskBrand({
         brandId: fetchedBrand.id,
         name: fetchedBrand.name || "Brand",
         ticketsPermission: "read",
-        helpCenterPermission: helpCenterEnabled ? "read" : "none",
+        helpCenterPermission: fetchedBrand.has_help_center ? "read" : "none",
         url: fetchedBrand.url,
       },
     });
@@ -69,7 +64,7 @@ export async function allowSyncZendeskBrand({
 
   // setting the permissions for the brand:
   // can be redundant if already set when creating the brand but necessary because of the categories.
-  if (helpCenterEnabled) {
+  if (fetchedBrand.has_help_center) {
     // allow the categories
     await allowSyncZendeskHelpCenter({
       connectorId,

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -18,7 +18,6 @@ import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendes
 import {
   changeZendeskClientSubdomain,
   createZendeskClient,
-  isBrandHelpCenterEnabled,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
@@ -118,7 +117,6 @@ async function getBrandChildren(
   const {
     result: { brand: fetchedBrand },
   } = await zendeskApiClient.brand.show(brandId);
-  const helpCenterEnabled = isBrandHelpCenterEnabled(fetchedBrand);
 
   if (isReadPermissionsOnly) {
     if (brandInDb?.ticketsPermission === "read") {
@@ -126,7 +124,10 @@ async function getBrandChildren(
         brandInDb.getTicketsContentNode(connector.id, { expandable: true })
       );
     }
-    if (helpCenterEnabled && brandInDb?.helpCenterPermission === "read") {
+    if (
+      fetchedBrand.has_help_center &&
+      brandInDb?.helpCenterPermission === "read"
+    ) {
       nodes.push(brandInDb.getHelpCenterContentNode(connector.id));
     }
   } else {
@@ -147,7 +148,7 @@ async function getBrandChildren(
     nodes.push(ticketsNode);
 
     // only displaying the Help Center node if the brand has an enabled Help Center
-    if (helpCenterEnabled) {
+    if (fetchedBrand.has_help_center) {
       const helpCenterNode: ContentNode = brandInDb?.getHelpCenterContentNode(
         connector.id
       ) ?? {

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -247,17 +247,24 @@ export async function fetchZendeskCategoriesInBrand(
   hasMore: boolean;
   nextLink: string | null;
 }> {
-  const response = await fetchFromZendeskWithRetries({
-    url:
-      url ?? // using the URL if we got one, reconstructing it otherwise
-      `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories?page[size]=${pageSize}`,
-    accessToken,
-  });
-  return {
-    categories: response.categories,
-    hasMore: response.meta.has_more,
-    nextLink: response.links.next,
-  };
+  try {
+    const response = await fetchFromZendeskWithRetries({
+      url:
+        url ?? // using the URL if we got one, reconstructing it otherwise
+        `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories?page[size]=${pageSize}`,
+      accessToken,
+    });
+    return {
+      categories: response.categories,
+      hasMore: response.meta.has_more,
+      nextLink: response.links.next,
+    };
+  } catch (e) {
+    if (isZendeskNotFoundError(e)) {
+      return { categories: [], hasMore: false, nextLink: null };
+    }
+    throw e;
+  }
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -207,15 +207,6 @@ export async function fetchZendeskBrand({
 }
 
 /**
- * Finds out whether a brand has a help center enabled.
- * has_help_center can be true without having an enabled help center, which leads to 404 when retreving categories.
- * @param brand A brand fetched from the Zendesk API.
- */
-export function isBrandHelpCenterEnabled(brand: ZendeskFetchedBrand): boolean {
-  return brand.has_help_center && brand.help_center_state === "enabled";
-}
-
-/**
  * Fetches a single article from the Zendesk API.
  */
 export async function fetchZendeskArticle({


### PR DESCRIPTION
## Description

- Follows up on #9868 
- The check that was implemented is too restrictive, it is correct that filtering out restricted Help Centers will prevent every 404 error, however some Help Center are restricted but should still be synced.
- The root cause of the 404 error is not identified, this is entirely undocumented, according to the [doc](https://developer.zendesk.com/api-reference/help_center/help-center-api/categories/#list-categories) this endpoint should always return what the user can see, we observed in practice cases where Zendesk admins would get 404-ed.
- For now, having a 404 will thus be interpreted as having no category.
- A hypothesis is that the 404 errors observed are due to having an empty Help Center (correlated to having it restricted since it is created restricted).

## Risk

- Low

## Deploy Plan

- Deploy connectors.
