### PR TITLE
[front] Compute and store active user stats

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -2,7 +2,6 @@ import {
   Avatar,
   BarChartIcon,
   Button,
-  Card,
   CardGrid,
   ChatBubbleLeftRightIcon,
   ChatBubbleThoughtIcon,
@@ -25,6 +24,7 @@ import {
   TabsList,
   TabsTrigger,
   Tooltip,
+  ValueCard,
 } from "@dust-tt/sparkle";
 import type {
   AgentConfigurationScope,
@@ -142,48 +142,49 @@ function AssistantDetailsPerformance({
         <Spinner />
       ) : (
         <CardGrid>
-          <Card variant="primary" size="md">
-            <div className="flex h-24 w-full flex-col gap-1 text-sm">
-              <div className="flex w-full gap-1 font-medium text-foreground">
-                <div className="w-full">Active Users</div>
-              </div>
-              <div className="flex flex-col gap-1 text-lg font-bold">
-                {agentAnalytics?.users ? (
-                  <>
-                    <div className="truncate text-element-900">
-                      {agentAnalytics.users.length}
-                    </div>
+          <ValueCard
+            title="Active Users"
+            content={
+              <div className="text-lg font-semibold text-foreground">
+                <div className="flex flex-col gap-1 text-lg font-bold">
+                  {agentAnalytics?.users ? (
+                    <>
+                      <div className="truncate text-element-900">
+                        {agentAnalytics.users.length}
+                      </div>
 
-                    <Avatar.Stack size="md" hasMagnifier={false}>
-                      {removeNulls(agentAnalytics.users.map((top) => top.user))
-                        .slice(0, 5)
-                        .map((user) => (
-                          <Tooltip
-                            key={user.id}
-                            trigger={
-                              <Avatar
-                                size="sm"
-                                name={user.fullName}
-                                visual={user.image}
-                              />
-                            }
-                            label={user.fullName}
-                          />
-                        ))}
-                    </Avatar.Stack>
-                  </>
-                ) : (
-                  "-"
-                )}
+                      <Avatar.Stack size="md" hasMagnifier={false}>
+                        {removeNulls(
+                          agentAnalytics.users.map((top) => top.user)
+                        )
+                          .slice(0, 5)
+                          .map((user) => (
+                            <Tooltip
+                              key={user.id}
+                              trigger={
+                                <Avatar
+                                  size="sm"
+                                  name={user.fullName}
+                                  visual={user.image}
+                                />
+                              }
+                              label={user.fullName}
+                            />
+                          ))}
+                      </Avatar.Stack>
+                    </>
+                  ) : (
+                    "-"
+                  )}
+                </div>
               </div>
-            </div>
-          </Card>
+            }
+            className="h-32"
+          />
 
-          <Card variant="primary" size="md">
-            <div className="flex h-24 w-full flex-col gap-1 text-sm">
-              <div className="flex w-full gap-1 font-medium text-foreground">
-                <div className="w-full">Reactions</div>
-              </div>
+          <ValueCard
+            title="Reactions"
+            content={
               <div className="flex flex-row gap-2 text-lg font-bold">
                 {agentConfiguration.scope !== "global" &&
                 agentAnalytics?.feedbacks ? (
@@ -205,13 +206,12 @@ function AssistantDetailsPerformance({
                   "-"
                 )}
               </div>
-            </div>
-          </Card>
-          <Card variant="primary" size="md">
-            <div className="flex h-24 w-full flex-col gap-1 text-sm">
-              <div className="flex w-full gap-1 font-medium text-foreground">
-                <div className="w-full">Conversations</div>
-              </div>
+            }
+            className="h-32"
+          />
+          <ValueCard
+            title="Conversations"
+            content={
               <div className="flex flex-row gap-2 text-lg font-bold">
                 <div className="flex flex-row items-center">
                   <div>
@@ -224,13 +224,12 @@ function AssistantDetailsPerformance({
                   </div>
                 </div>
               </div>
-            </div>
-          </Card>
-          <Card variant="primary" size="md">
-            <div className="flex h-24 w-full flex-col gap-1 text-sm">
-              <div className="flex w-full gap-1 font-medium text-foreground">
-                <div className="w-full">Messages</div>
-              </div>
+            }
+            className="h-32"
+          />
+          <ValueCard
+            title="Messages"
+            content={
               <div className="flex flex-row gap-2 text-lg font-bold">
                 <div className="flex flex-row items-center">
                   <div>
@@ -243,8 +242,9 @@ function AssistantDetailsPerformance({
                   </div>
                 </div>
               </div>
-            </div>
-          </Card>
+            }
+            className="h-32"
+          />
         </CardGrid>
       )}
       {agentConfiguration.scope !== "global" && (

--- a/front/components/assistant/AssistantsTable.tsx
+++ b/front/components/assistant/AssistantsTable.tsx
@@ -26,7 +26,10 @@ import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 
 import { DeleteAssistantDialog } from "@app/components/assistant/DeleteAssistantDialog";
-import { assistantUsageMessage } from "@app/components/assistant/Usage";
+import {
+  assistantActiveUsersMessage,
+  assistantUsageMessage,
+} from "@app/components/assistant/Usage";
 import { SCOPE_INFO } from "@app/components/assistant_builder/Sharing";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
 
@@ -124,6 +127,29 @@ const getTableColumns = () => {
             trigger={
               <span className="px-2">
                 {info.row.original.usage?.messageCount ?? 0}
+              </span>
+            }
+          />
+        </DataTable.CellContent>
+      ),
+      meta: {
+        width: "6rem",
+      },
+    },
+    {
+      header: "Active Users",
+      accessorKey: "usage.userCount",
+      cell: (info: CellContext<RowData, AgentUsageType | undefined>) => (
+        <DataTable.CellContent>
+          <Tooltip
+            label={assistantActiveUsersMessage({
+              usage: info.row.original.usage || null,
+              isLoading: false,
+              isError: false,
+            })}
+            trigger={
+              <span className="px-2">
+                {info.row.original.usage?.userCount ?? 0}
               </span>
             }
           />
@@ -236,6 +262,8 @@ export function AssistantsTable({
           name: agentConfiguration.name,
           usage: agentConfiguration.usage ?? {
             messageCount: 0,
+            conversationCount: 0,
+            userCount: 0,
             timePeriodSec: 30 * 24 * 60 * 60,
           },
           description: agentConfiguration.description,

--- a/front/components/assistant/Usage.tsx
+++ b/front/components/assistant/Usage.tsx
@@ -52,3 +52,32 @@ export function assistantUsageMessage({
     );
   }
 }
+
+export function assistantActiveUsersMessage({
+  usage,
+  isLoading,
+  isError,
+}: {
+  usage: AgentUsageType | null;
+  isLoading: boolean;
+  isError: boolean;
+}): ReactNode {
+  if (isError) {
+    return "Error loading usage data.";
+  }
+
+  if (isLoading) {
+    return "Loading usage data...";
+  }
+
+  if (usage) {
+    const days = usage.timePeriodSec / (60 * 60 * 24);
+    const nb = usage.userCount || 0;
+
+    return (
+      <>
+        {nb} active user{pluralize(nb)} over the last {days} days
+      </>
+    );
+  }
+}

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics.ts
@@ -127,7 +127,7 @@ async function handler(
           }))
           .filter((r) => r.user),
         mentions: {
-          messageCount: mentionCounts?.count ?? 0,
+          messageCount: mentionCounts?.messageCount ?? 0,
           conversationCount: mentionCounts?.conversationCount ?? 0,
           timePeriodSec: mentionCounts?.timePeriodSec ?? period * 60 * 60 * 24,
         },

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -120,10 +120,7 @@ async function handler(
           usageMap[agentConfiguration.sId]
             ? {
                 ...agentConfiguration,
-                usage: {
-                  messageCount: usageMap[agentConfiguration.sId].messageCount,
-                  timePeriodSec: usageMap[agentConfiguration.sId].timePeriodSec,
-                },
+                usage: _.omit(usageMap[agentConfiguration.sId], ["agentId"]),
               }
             : agentConfiguration
         );

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -781,6 +781,8 @@ export type AgentConfigurationViewType = z.infer<
 
 const AgentUsageTypeSchema = z.object({
   messageCount: z.number(),
+  conversationCount: z.number(),
+  userCount: z.number(),
   timePeriodSec: z.number(),
 });
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -173,6 +173,8 @@ export type AgentsGetViewType =
 
 export type AgentUsageType = {
   messageCount: number;
+  conversationCount: number;
+  userCount: number;
   timePeriodSec: number;
 };
 


### PR DESCRIPTION
## Description

Add users count in assistant usage workflow
Display active users in assistant manager
Simplify and remove duplicate types

## Risk

agentMentionsCount query might be slower, to be monitored. Should not be an issue as it's executed in background workflow 

## Deploy Plan

deploy front