### PR TITLE
Refactor internal mime types

### DIFF
--- a/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
+++ b/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
@@ -1,4 +1,4 @@
-import { INTERCOM_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import { makeScript } from "scripts/helpers";
 
 import {
@@ -36,7 +36,7 @@ async function createFolderNodes(execute: boolean) {
         parents: [getTeamsInternalId(connector.id)],
         parentId: null,
         title: "Conversations",
-        mimeType: INTERCOM_MIME_TYPES.CONVERSATIONS,
+        mimeType: MIME_TYPES.INTERCOM["TEAMS-FOLDER"],
       });
     }
 
@@ -60,7 +60,7 @@ async function createFolderNodes(execute: boolean) {
             parents: [teamInternalId, getTeamsInternalId(connector.id)],
             parentId: getTeamsInternalId(connector.id),
             title: team.name,
-            mimeType: INTERCOM_MIME_TYPES.TEAM,
+            mimeType: MIME_TYPES.INTERCOM.TEAM,
           });
         }
       },
@@ -99,7 +99,7 @@ async function createFolderNodes(execute: boolean) {
             parents: [helpCenterInternalId],
             parentId: null,
             title: helpCenter.name,
-            mimeType: INTERCOM_MIME_TYPES.HELP_CENTER,
+            mimeType: MIME_TYPES.INTERCOM["HELP-CENTER"],
           });
         }
 
@@ -133,7 +133,7 @@ async function createFolderNodes(execute: boolean) {
                 parents: collectionParents,
                 parentId: collectionParents[1] || null,
                 title: collection.name,
-                mimeType: INTERCOM_MIME_TYPES.COLLECTION,
+                mimeType: MIME_TYPES.INTERCOM.COLLECTION,
               });
             }
           },

--- a/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
+++ b/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
@@ -36,7 +36,7 @@ async function createFolderNodes(execute: boolean) {
         parents: [getTeamsInternalId(connector.id)],
         parentId: null,
         title: "Conversations",
-        mimeType: MIME_TYPES.INTERCOM["TEAMS-FOLDER"],
+        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     }
 
@@ -99,7 +99,7 @@ async function createFolderNodes(execute: boolean) {
             parents: [helpCenterInternalId],
             parentId: null,
             title: helpCenter.name,
-            mimeType: MIME_TYPES.INTERCOM["HELP-CENTER"],
+            mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
           });
         }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -1,8 +1,8 @@
 import type { ModelId } from "@dust-tt/types";
 import {
-  CONFLUENCE_MIME_TYPES,
   ConfluenceClientError,
   isConfluenceNotFoundError,
+  MIME_TYPES,
 } from "@dust-tt/types";
 import { Op } from "sequelize";
 import TurndownService from "turndown";
@@ -222,7 +222,7 @@ export async function confluenceUpsertSpaceFolderActivity({
     parents: [makeSpaceInternalId(spaceId)],
     parentId: null,
     title: spaceName,
-    mimeType: CONFLUENCE_MIME_TYPES.SPACE,
+    mimeType: MIME_TYPES.CONFLUENCE.SPACE,
   });
 }
 
@@ -329,7 +329,7 @@ async function upsertConfluencePageToDataSource({
       timestampMs: lastPageVersionCreatedAt.getTime(),
       upsertContext: { sync_type: syncType },
       title: page.title,
-      mimeType: CONFLUENCE_MIME_TYPES.PAGE,
+      mimeType: MIME_TYPES.CONFLUENCE.PAGE,
       async: true,
     });
   }

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -960,7 +960,7 @@ export async function githubCodeSyncActivity({
     title: "Code",
     parents: [getCodeRootInternalId(repoId), getRepositoryInternalId(repoId)],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: MIME_TYPES.GITHUB["CODE.ROOT"],
+    mimeType: MIME_TYPES.GITHUB.CODE_ROOT,
   });
 
   let githubCodeRepository = await GithubCodeRepository.findOne({
@@ -1172,7 +1172,7 @@ export async function githubCodeSyncActivity({
               sync_type: isBatchSync ? "batch" : "incremental",
             },
             title: f.fileName,
-            mimeType: MIME_TYPES.GITHUB["CODE.FILE"],
+            mimeType: MIME_TYPES.GITHUB.CODE_FILE,
             async: true,
           });
 
@@ -1216,7 +1216,7 @@ export async function githubCodeSyncActivity({
           parents,
           parentId: parents[1],
           title: d.dirName,
-          mimeType: MIME_TYPES.GITHUB["CODE.DIRECTORY"],
+          mimeType: MIME_TYPES.GITHUB.CODE_DIRECTORY,
         });
 
         // Find directory or create it.
@@ -1422,6 +1422,6 @@ export async function githubUpsertCodeRootFolderActivity({
     title: "Code",
     parents: [getCodeRootInternalId(repoId), getRepositoryInternalId(repoId)],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: MIME_TYPES.GITHUB["CODE.ROOT"],
+    mimeType: MIME_TYPES.GITHUB.CODE_ROOT,
   });
 }

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
-import { assertNever, GITHUB_MIME_TYPES } from "@dust-tt/types";
+import { assertNever, MIME_TYPES } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import { hash as blake3 } from "blake3";
 import { promises as fs } from "fs";
@@ -308,7 +308,7 @@ export async function githubUpsertIssueActivity(
       sync_type: isBatchSync ? "batch" : "incremental",
     },
     title: issue.title,
-    mimeType: GITHUB_MIME_TYPES.ISSUE,
+    mimeType: MIME_TYPES.GITHUB.ISSUE,
     async: true,
   });
 
@@ -494,7 +494,7 @@ export async function githubUpsertDiscussionActivity(
       sync_type: isBatchSync ? "batch" : "incremental",
     },
     title: discussion.title,
-    mimeType: GITHUB_MIME_TYPES.DISCUSSION,
+    mimeType: MIME_TYPES.GITHUB.DISCUSSION,
     async: true,
   });
 
@@ -960,7 +960,7 @@ export async function githubCodeSyncActivity({
     title: "Code",
     parents: [getCodeRootInternalId(repoId), getRepositoryInternalId(repoId)],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: GITHUB_MIME_TYPES.CODE_ROOT,
+    mimeType: MIME_TYPES.GITHUB["CODE.ROOT"],
   });
 
   let githubCodeRepository = await GithubCodeRepository.findOne({
@@ -1172,7 +1172,7 @@ export async function githubCodeSyncActivity({
               sync_type: isBatchSync ? "batch" : "incremental",
             },
             title: f.fileName,
-            mimeType: GITHUB_MIME_TYPES.CODE_FILE,
+            mimeType: MIME_TYPES.GITHUB["CODE.FILE"],
             async: true,
           });
 
@@ -1216,7 +1216,7 @@ export async function githubCodeSyncActivity({
           parents,
           parentId: parents[1],
           title: d.dirName,
-          mimeType: GITHUB_MIME_TYPES.CODE_DIRECTORY,
+          mimeType: MIME_TYPES.GITHUB["CODE.DIRECTORY"],
         });
 
         // Find directory or create it.
@@ -1356,7 +1356,7 @@ export async function githubUpsertRepositoryFolderActivity({
     title: repoName,
     parents: [getRepositoryInternalId(repoId)],
     parentId: null,
-    mimeType: GITHUB_MIME_TYPES.REPOSITORY,
+    mimeType: MIME_TYPES.GITHUB.REPOSITORY,
   });
 }
 
@@ -1377,7 +1377,7 @@ export async function githubUpsertIssuesFolderActivity({
     title: "Issues",
     parents: [getIssuesInternalId(repoId), getRepositoryInternalId(repoId)],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: GITHUB_MIME_TYPES.ISSUES,
+    mimeType: MIME_TYPES.GITHUB.ISSUES,
   });
 }
 
@@ -1401,7 +1401,7 @@ export async function githubUpsertDiscussionsFolderActivity({
       getRepositoryInternalId(repoId),
     ],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: GITHUB_MIME_TYPES.DISCUSSIONS,
+    mimeType: MIME_TYPES.GITHUB.DISCUSSIONS,
   });
 }
 
@@ -1422,6 +1422,6 @@ export async function githubUpsertCodeRootFolderActivity({
     title: "Code",
     parents: [getCodeRootInternalId(repoId), getRepositoryInternalId(repoId)],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: GITHUB_MIME_TYPES.CODE_ROOT,
+    mimeType: MIME_TYPES.GITHUB["CODE.ROOT"],
   });
 }

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { GOOGLE_DRIVE_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import { uuid4 } from "@temporalio/workflow";
 import type { drive_v3 } from "googleapis";
 import type { GaxiosResponse, OAuth2Client } from "googleapis-common";
@@ -74,7 +74,7 @@ export async function upsertSharedWithMeFolder(connectorId: ModelId) {
     parents: [folderId],
     parentId: null,
     title: "Shared with me",
-    mimeType: GOOGLE_DRIVE_MIME_TYPES.FOLDER,
+    mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
   });
 }
 
@@ -515,7 +515,7 @@ export async function incrementalSync(
           parents,
           parentId: parents[1] || null,
           title: driveFile.name ?? "",
-          mimeType: GOOGLE_DRIVE_MIME_TYPES.FOLDER,
+          mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
         });
 
         await GoogleDriveFiles.upsert({
@@ -860,7 +860,7 @@ export async function markFolderAsVisited(
     parents,
     parentId: parents[1] || null,
     title: file.name ?? "",
-    mimeType: GOOGLE_DRIVE_MIME_TYPES.FOLDER,
+    mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
   });
 
   await GoogleDriveFiles.upsert({

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -176,7 +176,7 @@ export async function syncHelpCenterOnlyActivity({
     title: helpCenterOnIntercom.display_name || "Help Center",
     parents: [helpCenterInternalId],
     parentId: null,
-    mimeType: MIME_TYPES.INTERCOM["HELP-CENTER"],
+    mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
   });
 
   // If all children collections are not allowed anymore we delete the Help Center data
@@ -744,6 +744,6 @@ export async function upsertIntercomTeamsFolderActivity({
     title: "Conversations",
     parents: [getTeamsInternalId(connectorId)],
     parentId: null,
-    mimeType: MIME_TYPES.INTERCOM["TEAMS-FOLDER"],
+    mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
   });
 }

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { INTERCOM_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
@@ -176,7 +176,7 @@ export async function syncHelpCenterOnlyActivity({
     title: helpCenterOnIntercom.display_name || "Help Center",
     parents: [helpCenterInternalId],
     parentId: null,
-    mimeType: INTERCOM_MIME_TYPES.HELP_CENTER,
+    mimeType: MIME_TYPES.INTERCOM["HELP-CENTER"],
   });
 
   // If all children collections are not allowed anymore we delete the Help Center data
@@ -509,7 +509,7 @@ export async function syncTeamOnlyActivity({
     title: teamOnIntercom.name,
     parents: [teamInternalId, getTeamsInternalId(connectorId)],
     parentId: getTeamsInternalId(connectorId),
-    mimeType: INTERCOM_MIME_TYPES.TEAM,
+    mimeType: MIME_TYPES.INTERCOM.TEAM,
   });
 
   return true;
@@ -744,6 +744,6 @@ export async function upsertIntercomTeamsFolderActivity({
     title: "Conversations",
     parents: [getTeamsInternalId(connectorId)],
     parentId: null,
-    mimeType: INTERCOM_MIME_TYPES.CONVERSATIONS,
+    mimeType: MIME_TYPES.INTERCOM["TEAMS-FOLDER"],
   });
 }

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { INTERCOM_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import TurndownService from "turndown";
 
 import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
@@ -332,7 +332,7 @@ export async function syncConversation({
       sync_type: syncType,
     },
     title: convoTitle,
-    mimeType: INTERCOM_MIME_TYPES.CONVERSATION,
+    mimeType: MIME_TYPES.INTERCOM.CONVERSATION,
     async: true,
   });
 }

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { INTERCOM_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import TurndownService from "turndown";
 
 import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
@@ -229,7 +229,7 @@ export async function upsertCollectionWithChildren({
     title: collection.name,
     parents: collectionParents,
     parentId: collectionParents[1],
-    mimeType: INTERCOM_MIME_TYPES.COLLECTION,
+    mimeType: MIME_TYPES.INTERCOM.COLLECTION,
   });
 
   // Then we call ourself recursively on the children collections
@@ -429,7 +429,7 @@ export async function upsertArticle({
         sync_type: "batch",
       },
       title: article.title,
-      mimeType: INTERCOM_MIME_TYPES.ARTICLE,
+      mimeType: MIME_TYPES.INTERCOM.ARTICLE,
       async: true,
     });
     await articleOnDb.update({

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1,9 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import {
-  cacheWithRedis,
-  MICROSOFT_MIME_TYPES,
-  removeNulls,
-} from "@dust-tt/types";
+import { cacheWithRedis, MIME_TYPES, removeNulls } from "@dust-tt/types";
 import type { Client } from "@microsoft/microsoft-graph-client";
 import { GraphError } from "@microsoft/microsoft-graph-client";
 import type { DriveItem } from "@microsoft/microsoft-graph-types";
@@ -213,7 +209,7 @@ export async function getRootNodesToSyncFromResources(
         parents: [createdOrUpdatedResource.internalId],
         parentId: null,
         title: createdOrUpdatedResource.name ?? "",
-        mimeType: MICROSOFT_MIME_TYPES.FOLDER,
+        mimeType: MIME_TYPES.MICROSOFT.FOLDER,
       }),
     { concurrency: 5 }
   );
@@ -485,7 +481,7 @@ export async function syncFiles({
         parents: [createdOrUpdatedResource.internalId, ...parentsOfParent],
         parentId: parentsOfParent[0],
         title: createdOrUpdatedResource.name ?? "",
-        mimeType: MICROSOFT_MIME_TYPES.FOLDER,
+        mimeType: MIME_TYPES.MICROSOFT.FOLDER,
       }),
     { concurrency: 5 }
   );
@@ -659,7 +655,7 @@ export async function syncDeltaForRootNodesInDrive({
           parents: [blob.internalId],
           parentId: null,
           title: blob.name ?? "",
-          mimeType: MICROSOFT_MIME_TYPES.FOLDER,
+          mimeType: MIME_TYPES.MICROSOFT.FOLDER,
         });
 
         // add parent information to new node resource. for the toplevel folder,
@@ -875,7 +871,7 @@ async function updateDescendantsParentsInCore({
     parents,
     parentId: parents[1] || null,
     title: folder.name ?? "",
-    mimeType: MICROSOFT_MIME_TYPES.FOLDER,
+    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   });
 
   await concurrentExecutor(

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -2,7 +2,7 @@ import type { ContentNode, ContentNodesViewType, Result } from "@dust-tt/types";
 import {
   Err,
   getOAuthConnectionAccessToken,
-  NOTION_MIME_TYPES,
+  MIME_TYPES,
   Ok,
 } from "@dust-tt/types";
 import _ from "lodash";
@@ -104,7 +104,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       parents: [folderId],
       parentId: null,
       title: "Orphaned Resources",
-      mimeType: NOTION_MIME_TYPES.UNKNOWN_FOLDER,
+      mimeType: MIME_TYPES.NOTION["UNKNOWN-FOLDER"],
     });
 
     try {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -104,7 +104,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       parents: [folderId],
       parentId: null,
       title: "Orphaned Resources",
-      mimeType: MIME_TYPES.NOTION["UNKNOWN-FOLDER"],
+      mimeType: MIME_TYPES.NOTION.UNKNOWN_FOLDER,
     });
 
     try {

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -7,7 +7,7 @@ import type {
 import {
   assertNever,
   getNotionDatabaseTableId,
-  NOTION_MIME_TYPES,
+  MIME_TYPES,
   slugify,
 } from "@dust-tt/types";
 import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";
@@ -1829,7 +1829,7 @@ export async function renderAndUpsertPageFromCache({
               parents: parents,
               parentId: parents[1] || null,
               title: parentDb.title ?? "Untitled Notion Database",
-              mimeType: NOTION_MIME_TYPES.DATABASE,
+              mimeType: MIME_TYPES.NOTION.DATABASE,
             }),
           localLogger
         );
@@ -2053,7 +2053,7 @@ export async function renderAndUpsertPageFromCache({
         sync_type: isFullSync ? "batch" : "incremental",
       },
       title: title ?? "",
-      mimeType: NOTION_MIME_TYPES.PAGE,
+      mimeType: MIME_TYPES.NOTION.PAGE,
       async: true,
     });
   }
@@ -2550,7 +2550,7 @@ export async function upsertDatabaseStructuredDataFromCache({
         parents: parentIds,
         parentId: parentIds[1] || null,
         title: dbModel.title ?? "Untitled Notion Database",
-        mimeType: NOTION_MIME_TYPES.DATABASE,
+        mimeType: MIME_TYPES.NOTION.DATABASE,
       }),
     localLogger
   );
@@ -2611,7 +2611,7 @@ export async function upsertDatabaseStructuredDataFromCache({
           sync_type: "batch",
         },
         title: databaseName,
-        mimeType: NOTION_MIME_TYPES.DATABASE,
+        mimeType: MIME_TYPES.NOTION.DATABASE,
         async: true,
       });
     } else {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1,9 +1,5 @@
 import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
-import {
-  cacheWithRedis,
-  safeSubstring,
-  SLACK_MIME_TYPES,
-} from "@dust-tt/types";
+import { cacheWithRedis, MIME_TYPES, safeSubstring } from "@dust-tt/types";
 import type {
   CodedError,
   WebAPIPlatformError,
@@ -258,7 +254,7 @@ export async function syncChannel(
       title: `#${channel.name}`,
       parentId: null,
       parents: [slackChannelInternalIdFromSlackChannelId(channelId)],
-      mimeType: SLACK_MIME_TYPES.CHANNEL,
+      mimeType: MIME_TYPES.SLACK.CHANNEL,
     });
   }
 
@@ -636,7 +632,7 @@ export async function syncNonThreaded(
       sync_type: isBatchSync ? "batch" : "incremental",
     },
     title: tags.find((t) => t.startsWith("title:"))?.split(":")[1] ?? "",
-    mimeType: SLACK_MIME_TYPES.MESSAGES,
+    mimeType: MIME_TYPES.SLACK.MESSAGES,
     async: true,
   });
 }
@@ -850,7 +846,7 @@ export async function syncThread(
       sync_type: isBatchSync ? "batch" : "incremental",
     },
     title: tags.find((t) => t.startsWith("title:"))?.split(":")[1] ?? "",
-    mimeType: SLACK_MIME_TYPES.THREAD,
+    mimeType: MIME_TYPES.SLACK.THREAD,
     async: true,
   });
 }

--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { isSnowflakeCredentials, SNOWFLAKE_MIME_TYPES } from "@dust-tt/types";
+import { isSnowflakeCredentials, MIME_TYPES } from "@dust-tt/types";
 
 import {
   connectToSnowflake,
@@ -168,7 +168,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
           title: table.databaseName,
           parents: [table.databaseName],
           parentId: null,
-          mimeType: SNOWFLAKE_MIME_TYPES.DATABASE,
+          mimeType: MIME_TYPES.SNOWFLAKE.DATABASE,
         });
 
         // upsert a folder for the schema (child of the database)
@@ -179,7 +179,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
           title: table.schemaName,
           parents: [schemaId, table.databaseName],
           parentId: table.databaseName,
-          mimeType: SNOWFLAKE_MIME_TYPES.SCHEMA,
+          mimeType: MIME_TYPES.SNOWFLAKE.SCHEMA,
         });
 
         await upsertDataSourceRemoteTable({
@@ -192,7 +192,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
           parents: [table.internalId, schemaId, table.databaseName],
           parentId: schemaId,
           title: table.name,
-          mimeType: SNOWFLAKE_MIME_TYPES.TABLE,
+          mimeType: MIME_TYPES.SNOWFLAKE.TABLE,
         });
         await table.update({
           lastUpsertedAt: new Date(),

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,9 +1,9 @@
 import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
 import {
+  MIME_TYPES,
   stripNullBytes,
   WEBCRAWLER_MAX_DEPTH,
   WEBCRAWLER_MAX_PAGES,
-  WEBCRAWLER_MIME_TYPES,
 } from "@dust-tt/types";
 import { validateUrl } from "@dust-tt/types/src/shared/utils/url_utils";
 import { Context } from "@temporalio/activity";
@@ -292,7 +292,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
             parents,
             parentId: parents[1] || null,
             title: folder,
-            mimeType: WEBCRAWLER_MIME_TYPES.FOLDER,
+            mimeType: MIME_TYPES.WEBCRAWLER.FOLDER,
           });
 
           createdFolders.add(folder);

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { ZENDESK_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import TurndownService from "turndown";
 
 import type {
@@ -176,7 +176,7 @@ export async function syncArticle({
       loggerArgs: { ...loggerArgs, articleId: article.id },
       upsertContext: { sync_type: "batch" },
       title: article.title,
-      mimeType: ZENDESK_MIME_TYPES.ARTICLE,
+      mimeType: MIME_TYPES.ZENDESK.ARTICLE,
       async: true,
     });
     await articleInDb.update({ lastUpsertedTs: new Date(currentSyncDateMs) });

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { ZENDESK_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 
 import type { ZendeskFetchedCategory } from "@connectors/@types/node-zendesk";
 import {
@@ -118,6 +118,6 @@ export async function syncCategory({
     parents,
     parentId: parents[1],
     title: categoryInDb.name,
-    mimeType: ZENDESK_MIME_TYPES.CATEGORY,
+    mimeType: MIME_TYPES.ZENDESK.CATEGORY,
   });
 }

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { ZENDESK_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import TurndownService from "turndown";
 
 import type {
@@ -237,7 +237,7 @@ ${comments
       loggerArgs: { ...loggerArgs, ticketId: ticket.id },
       upsertContext: { sync_type: "batch" },
       title: ticket.subject,
-      mimeType: ZENDESK_MIME_TYPES.TICKET,
+      mimeType: MIME_TYPES.ZENDESK.TICKET,
       async: true,
     });
     await ticketInDb.update({ lastUpsertedTs: new Date(currentSyncDateMs) });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -148,7 +148,7 @@ export async function syncZendeskBrandActivity({
     parents: [helpCenterNode.internalId, helpCenterNode.parentInternalId],
     parentId: helpCenterNode.parentInternalId,
     title: helpCenterNode.title,
-    mimeType: MIME_TYPES.ZENDESK.HELPCENTER,
+    mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
   });
 
   // using the content node to get one source of truth regarding the parent relationship

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { ZENDESK_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import _ from "lodash";
 
 import { getBrandInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
@@ -137,7 +137,7 @@ export async function syncZendeskBrandActivity({
     parents: [brandInternalId],
     parentId: null,
     title: brandInDb.name,
-    mimeType: ZENDESK_MIME_TYPES.BRAND,
+    mimeType: MIME_TYPES.ZENDESK.BRAND,
   });
 
   // using the content node to get one source of truth regarding the parent relationship
@@ -148,7 +148,7 @@ export async function syncZendeskBrandActivity({
     parents: [helpCenterNode.internalId, helpCenterNode.parentInternalId],
     parentId: helpCenterNode.parentInternalId,
     title: helpCenterNode.title,
-    mimeType: ZENDESK_MIME_TYPES.HELP_CENTER,
+    mimeType: MIME_TYPES.ZENDESK.HELPCENTER,
   });
 
   // using the content node to get one source of truth regarding the parent relationship
@@ -159,7 +159,7 @@ export async function syncZendeskBrandActivity({
     parents: [ticketsNode.internalId, ticketsNode.parentInternalId],
     parentId: ticketsNode.parentInternalId,
     title: ticketsNode.title,
-    mimeType: ZENDESK_MIME_TYPES.TICKETS,
+    mimeType: MIME_TYPES.ZENDESK.TICKETS,
   });
 
   // updating the entry in db
@@ -335,7 +335,7 @@ export async function syncZendeskCategoryActivity({
     parents,
     parentId: parents[1],
     title: categoryInDb.name,
-    mimeType: ZENDESK_MIME_TYPES.CATEGORY,
+    mimeType: MIME_TYPES.ZENDESK.CATEGORY,
   });
 
   // otherwise, we update the category name and lastUpsertedTs

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { ZENDESK_MIME_TYPES } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import {
@@ -154,7 +154,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
               parents,
               parentId: parents[1],
               title: category.name,
-              mimeType: ZENDESK_MIME_TYPES.CATEGORY,
+              mimeType: MIME_TYPES.ZENDESK.CATEGORY,
             });
           } else {
             /// ignoring these to proceed with the other articles, but these might have to be checked at some point

--- a/front/migrations/20250113_backfill_github_mime_types.ts
+++ b/front/migrations/20250113_backfill_github_mime_types.ts
@@ -1,0 +1,155 @@
+import { MIME_TYPES } from "@dust-tt/types";
+import assert from "assert";
+import type { Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
+
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const { CORE_DATABASE_URI } = process.env;
+const BATCH_SIZE = 16;
+
+type GithubContentNodeType = "REPO_CODE" | "REPO_CODE_DIR" | "REPO_CODE_FILE";
+
+/**
+ * Gets the type of the GitHub content node from its internal id.
+ * Copy-pasted from connectors/src/connectors/github/lib/utils.ts
+ */
+function matchGithubInternalIdType(internalId: string): {
+  type: GithubContentNodeType;
+  repoId: number;
+} {
+  // All code from repo is selected, format = "github-code-12345678"
+  if (/^github-code-\d+$/.test(internalId)) {
+    return {
+      type: "REPO_CODE",
+      repoId: parseInt(internalId.replace(/^github-code-/, ""), 10),
+    };
+  }
+  // A code directory is selected, format = "github-code-12345678-dir-s0Up1n0u"
+  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(internalId)) {
+    return {
+      type: "REPO_CODE_DIR",
+      repoId: parseInt(
+        internalId.replace(/^github-code-(\d+)-dir-.*/, "$1"),
+        10
+      ),
+    };
+  }
+  // A code file is selected, format = "github-code-12345678-file-s0Up1n0u"
+  if (/^github-code-\d+-file-[a-f0-9]+$/.test(internalId)) {
+    return {
+      type: "REPO_CODE_FILE",
+      repoId: parseInt(
+        internalId.replace(/^github-code-(\d+)-file-.*/, "$1"),
+        10
+      ),
+    };
+  }
+  throw new Error(`Invalid Github internal id (code-only): ${internalId}`);
+}
+
+async function backfillDataSource(
+  frontDataSource: DataSourceModel,
+  coreSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  logger.info("Processing data source");
+
+  let nextId = 0;
+  let updatedRowsCount;
+  do {
+    const rows: { id: number; node_id: string }[] = await coreSequelize.query(
+      `
+          SELECT dsn.id, dsn.node_id
+          FROM data_sources_nodes dsn
+                   JOIN data_sources ds ON ds.id = dsn.data_source
+          WHERE dsn.id > :nextId
+            AND ds.data_source_id = :dataSourceId
+            AND ds.project = :projectId
+            AND dsn.node_id LIKE 'github-code-%' -- leverages the btree
+          ORDER BY dsn.id
+          LIMIT :batchSize;`,
+      {
+        replacements: {
+          dataSourceId: frontDataSource.dustAPIDataSourceId,
+          projectId: frontDataSource.dustAPIProjectId,
+          batchSize: BATCH_SIZE,
+          nextId,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    if (rows.length == 0) {
+      logger.info({ nextId }, `Finished processing data source.`);
+      break;
+    }
+    nextId = rows[rows.length - 1].id;
+    updatedRowsCount = rows.length;
+
+    if (execute) {
+      await coreSequelize.query(
+        `WITH pairs AS (
+            SELECT UNNEST(:ids) as id, UNNEST(:mimeTypes) as mime_type
+        )
+         UPDATE data_sources_nodes dsn
+         SET mime_type = p.mime_type
+         FROM pairs p
+         WHERE dsn.id = p.id;`,
+        {
+          replacements: {
+            mimeTypes: rows.map((row) => {
+              switch (matchGithubInternalIdType(row.node_id).type) {
+                case "REPO_CODE":
+                  return MIME_TYPES.GITHUB.CODE_ROOT;
+                case "REPO_CODE_DIR":
+                  return MIME_TYPES.GITHUB.CODE_DIRECTORY;
+                case "REPO_CODE_FILE":
+                  return MIME_TYPES.GITHUB.CODE_FILE;
+                default:
+                  throw new Error(
+                    `Unreachable: unrecognized node_id: ${row.node_id}`
+                  );
+              }
+            }),
+            ids: rows.map((row) => row.id),
+          },
+        }
+      );
+      logger.info(
+        `Updated chunk from ${rows[0].id} to ${rows[rows.length - 1].id}`
+      );
+    } else {
+      logger.info(
+        `Would update chunk from ${rows[0].id} to ${rows[rows.length - 1].id}`
+      );
+    }
+  } while (updatedRowsCount === BATCH_SIZE);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  assert(CORE_DATABASE_URI, "CORE_DATABASE_URI is required");
+
+  const coreSequelize = getCorePrimaryDbConnection();
+
+  const frontDataSources = await DataSourceModel.findAll({
+    where: { connectorProvider: "github" },
+  });
+  logger.info(`Found ${frontDataSources.length} GitHub data sources`);
+
+  for (const frontDataSource of frontDataSources) {
+    await backfillDataSource(
+      frontDataSource,
+      coreSequelize,
+      execute,
+      logger.child({
+        dataSourceId: frontDataSource.id,
+        connectorId: frontDataSource.connectorId,
+      })
+    );
+  }
+});

--- a/front/migrations/20250113_backfill_zendesk_hc_mime_types.ts
+++ b/front/migrations/20250113_backfill_zendesk_hc_mime_types.ts
@@ -1,0 +1,96 @@
+import { MIME_TYPES } from "@dust-tt/types";
+import assert from "assert";
+import type { Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
+
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const { CORE_DATABASE_URI } = process.env;
+const BATCH_SIZE = 16;
+
+async function backfillDataSource(
+  frontDataSource: DataSourceModel,
+  coreSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  logger.info("Processing data source");
+
+  let nextId = 0;
+  let updatedRowsCount;
+  do {
+    const rows: { id: number }[] = await coreSequelize.query(
+      `
+          SELECT dsn.id
+          FROM data_sources_nodes dsn
+                   JOIN data_sources ds ON ds.id = dsn.data_source
+          WHERE dsn.id > :nextId
+            AND ds.data_source_id = :dataSourceId
+            AND ds.project = :projectId
+            AND dsn.node_id LIKE 'zendesk-help-center-%'
+          ORDER BY dsn.id
+          LIMIT :batchSize;`,
+      {
+        replacements: {
+          dataSourceId: frontDataSource.dustAPIDataSourceId,
+          projectId: frontDataSource.dustAPIProjectId,
+          batchSize: BATCH_SIZE,
+          nextId,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    if (rows.length == 0) {
+      logger.info({ nextId }, `Finished processing data source.`);
+      break;
+    }
+    nextId = rows[rows.length - 1].id;
+    updatedRowsCount = rows.length;
+
+    if (execute) {
+      await coreSequelize.query(
+        `UPDATE data_sources_nodes SET mime_type = :mimeType WHERE id IN (:ids)`,
+        {
+          replacements: {
+            mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+            ids: rows.map((row) => row.id),
+          },
+        }
+      );
+      logger.info(
+        `Updated chunk from ${rows[0].id} to ${rows[rows.length - 1].id}`
+      );
+    } else {
+      logger.info(
+        `Would update chunk from ${rows[0].id} to ${rows[rows.length - 1].id}`
+      );
+    }
+  } while (updatedRowsCount === BATCH_SIZE);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  assert(CORE_DATABASE_URI, "CORE_DATABASE_URI is required");
+
+  const coreSequelize = getCorePrimaryDbConnection();
+
+  const frontDataSources = await DataSourceModel.findAll({
+    where: { connectorProvider: "zendesk" },
+  });
+  logger.info(`Found ${frontDataSources.length} Zendesk data sources`);
+
+  for (const frontDataSource of frontDataSources) {
+    await backfillDataSource(
+      frontDataSource,
+      coreSequelize,
+      execute,
+      logger.child({
+        dataSourceId: frontDataSource.id,
+        connectorId: frontDataSource.connectorId,
+      })
+    );
+  }
+});

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -1,99 +1,124 @@
-export const CONFLUENCE_MIME_TYPES = {
-  SPACE: "application/vnd.dust.confluence.space",
-  PAGE: "application/vnd.dust.confluence.page",
+import { ConnectorProvider } from "../front/data_source";
+
+function getMimeTypes<
+  P extends ConnectorProvider,
+  T extends Uppercase<string>[]
+>({
+  provider,
+  resourceTypes,
+}: {
+  provider: P;
+  resourceTypes: T;
+}): {
+  [K in T[number]]: `application/vnd.dust.${P}.${Lowercase<K>}`;
+} {
+  return resourceTypes.reduce(
+    (acc, s) => ({
+      ...acc,
+      s: `application/vnd.dust.${provider.replace("_", "")}.${s.toLowerCase()}`,
+    }),
+    {} as {
+      [K in T[number]]: `application/vnd.dust.${P}.${Lowercase<K>}`;
+    }
+  );
+}
+
+export const MIME_TYPES = {
+  CONFLUENCE: getMimeTypes({
+    provider: "confluence",
+    resourceTypes: ["SPACE", "PAGE"],
+  }),
+  GITHUB: getMimeTypes({
+    provider: "github",
+    resourceTypes: [
+      "REPOSITORY",
+      "CODE.ROOT",
+      "CODE.DIRECTORY",
+      "CODE.FILE",
+      "ISSUES",
+      "ISSUE",
+      "DISCUSSIONS",
+      "DISCUSSION",
+    ],
+  }),
+  GOOGLE_DRIVE: getMimeTypes({
+    // @ts-expect-error: we have an inconsistency here in that we have been using "googledrive" in the mime type instead of the ConnectorProvider "google_drive"
+    provider: "googledrive", // TODO: see if we backfill into google_drive
+    resourceTypes: ["FOLDER"], // for files and spreadsheets, we keep Google's mime types
+  }),
+  INTERCOM: getMimeTypes({
+    provider: "intercom",
+    resourceTypes: [
+      "COLLECTION",
+      "TEAMS-FOLDER",
+      "CONVERSATION",
+      "TEAM",
+      "HELP-CENTER",
+      "ARTICLE",
+    ],
+  }),
+  MICROSOFT: getMimeTypes({
+    provider: "microsoft",
+    resourceTypes: ["FOLDER"], // for files and spreadsheets, we keep Microsoft's mime types
+  }),
+  NOTION: getMimeTypes({
+    provider: "notion",
+    resourceTypes: ["UNKNOWN-FOLDER", "DATABASE", "PAGE"],
+  }),
+  SLACK: getMimeTypes({
+    provider: "slack",
+    resourceTypes: ["CHANNEL", "THREAD", "MESSAGES"],
+  }),
+  SNOWFLAKE: getMimeTypes({
+    provider: "snowflake",
+    resourceTypes: ["DATABASE", "SCHEMA", "TABLE"],
+  }),
+  WEBCRAWLER: getMimeTypes({
+    provider: "webcrawler",
+    resourceTypes: ["FOLDER"], // pages are upserted as text/html, not an internal mime type
+  }),
+  ZENDESK: getMimeTypes({
+    provider: "zendesk",
+    resourceTypes: [
+      "BRAND",
+      "HELPCENTER", // TODO: see if we backfill into HELP-CENTER
+      "CATEGORY",
+      "ARTICLE",
+      "TICKETS",
+      "TICKET",
+    ],
+  }),
 };
 
 export type ConfluenceMimeType =
-  (typeof CONFLUENCE_MIME_TYPES)[keyof typeof CONFLUENCE_MIME_TYPES];
-
-export const GITHUB_MIME_TYPES = {
-  REPOSITORY: "application/vnd.dust.github.repository",
-  CODE_ROOT: "application/vnd.dust.github.code.root",
-  CODE_DIRECTORY: "application/vnd.dust.github.code.directory",
-  CODE_FILE: "application/vnd.dust.github.code.file",
-  ISSUES: "application/vnd.dust.github.issues",
-  ISSUE: "application/vnd.dust.github.issue",
-  DISCUSSIONS: "application/vnd.dust.github.discussions",
-  DISCUSSION: "application/vnd.dust.github.discussion",
-};
+  (typeof MIME_TYPES.CONFLUENCE)[keyof typeof MIME_TYPES.CONFLUENCE];
 
 export type GithubMimeType =
-  (typeof GITHUB_MIME_TYPES)[keyof typeof GITHUB_MIME_TYPES];
-
-export const GOOGLE_DRIVE_MIME_TYPES = {
-  FOLDER: "application/vnd.dust.googledrive.folder",
-  // for files and spreadsheets, we keep Google's mime types
-};
+  (typeof MIME_TYPES.GITHUB)[keyof typeof MIME_TYPES.GITHUB];
 
 export type GoogleDriveMimeType =
-  (typeof GOOGLE_DRIVE_MIME_TYPES)[keyof typeof GOOGLE_DRIVE_MIME_TYPES];
-
-export const INTERCOM_MIME_TYPES = {
-  COLLECTION: "application/vnd.dust.intercom.collection",
-  CONVERSATIONS: "application/vnd.dust.intercom.teams-folder",
-  CONVERSATION: "application/vnd.dust.intercom.conversation",
-  TEAM: "application/vnd.dust.intercom.team",
-  HELP_CENTER: "application/vnd.dust.intercom.help-center",
-  ARTICLE: "application/vnd.dust.intercom.article",
-};
+  (typeof MIME_TYPES.GOOGLE_DRIVE)[keyof typeof MIME_TYPES.GOOGLE_DRIVE];
 
 export type IntercomMimeType =
-  (typeof INTERCOM_MIME_TYPES)[keyof typeof INTERCOM_MIME_TYPES];
-
-export const MICROSOFT_MIME_TYPES = {
-  FOLDER: "application/vnd.dust.microsoft.folder",
-  // for files and spreadsheets, we keep Microsoft's mime types
-};
+  (typeof MIME_TYPES.INTERCOM)[keyof typeof MIME_TYPES.INTERCOM];
 
 export type MicrosoftMimeType =
-  (typeof MICROSOFT_MIME_TYPES)[keyof typeof MICROSOFT_MIME_TYPES];
-
-export const NOTION_MIME_TYPES = {
-  UNKNOWN_FOLDER: "application/vnd.dust.notion.unknown-folder",
-  DATABASE: "application/vnd.dust.notion.database",
-  PAGE: "application/vnd.dust.notion.page",
-};
+  (typeof MIME_TYPES.MICROSOFT)[keyof typeof MIME_TYPES.MICROSOFT];
 
 export type NotionMimeType =
-  (typeof NOTION_MIME_TYPES)[keyof typeof NOTION_MIME_TYPES];
-
-export const SLACK_MIME_TYPES = {
-  CHANNEL: "application/vnd.dust.slack.channel",
-  THREAD: "application/vnd.dust.slack.thread",
-  MESSAGES: "application/vnd.dust.slack.messages",
-};
+  (typeof MIME_TYPES.NOTION)[keyof typeof MIME_TYPES.NOTION];
 
 export type SlackMimeType =
-  (typeof SLACK_MIME_TYPES)[keyof typeof SLACK_MIME_TYPES];
-
-export const SNOWFLAKE_MIME_TYPES = {
-  DATABASE: "application/vnd.snowflake.database",
-  SCHEMA: "application/vnd.snowflake.schema",
-  TABLE: "application/vnd.snowflake.table",
-};
+  (typeof MIME_TYPES.SLACK)[keyof typeof MIME_TYPES.SLACK];
 
 export type SnowflakeMimeType =
-  (typeof SNOWFLAKE_MIME_TYPES)[keyof typeof SNOWFLAKE_MIME_TYPES];
-
-export const WEBCRAWLER_MIME_TYPES = {
-  FOLDER: "application/vnd.dust.webcrawler.folder",
-  // pages are upserted as text/html, not an internal mime type
-};
+  (typeof MIME_TYPES.SNOWFLAKE)[keyof typeof MIME_TYPES.SNOWFLAKE];
 
 export type WebcrawlerMimeType =
-  (typeof WEBCRAWLER_MIME_TYPES)[keyof typeof WEBCRAWLER_MIME_TYPES];
-
-export const ZENDESK_MIME_TYPES = {
-  BRAND: "application/vnd.dust.zendesk.brand",
-  HELP_CENTER: "application/vnd.dust.zendesk.helpcenter",
-  CATEGORY: "application/vnd.dust.zendesk.category",
-  ARTICLE: "application/vnd.dust.zendesk.article",
-  TICKETS: "application/vnd.dust.zendesk.tickets",
-  TICKET: "application/vnd.dust.zendesk.ticket",
-};
+  (typeof MIME_TYPES.WEBCRAWLER)[keyof typeof MIME_TYPES.WEBCRAWLER];
 
 export type ZendeskMimeType =
-  (typeof ZENDESK_MIME_TYPES)[keyof typeof ZENDESK_MIME_TYPES];
+  (typeof MIME_TYPES.ZENDESK)[keyof typeof MIME_TYPES.ZENDESK];
 
 export type DustMimeType =
   | ConfluenceMimeType

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -16,6 +16,13 @@ type UnderscoreToDash<T extends string> = T extends `${infer A}_${infer B}`
   ? UnderscoreToDash<`${A}-${B}`> // operates recursively to replace all underscores
   : T;
 
+/**
+ * This function generates mime types for a given provider and resource types.
+ * The mime types are in the format `application/vnd.dust.PROVIDER.RESOURCE_TYPE`.
+ * Notes:
+ * - The underscores in the provider name are stripped in the generated mime type.
+ * - The underscores in the resource type are replaced with dashes in the generated mime type.
+ */
 function getMimeTypes<
   P extends ConnectorProvider,
   T extends Uppercase<string>[]

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -2,7 +2,7 @@ import { ConnectorProvider } from "../front/data_source";
 
 /**
  * This is a utility type that indicates that we removed all underscores from a string.
- * This is used because we don't want underscores in mime types.
+ * This is used because we don't want underscores in mime types and remove them from connector providers.
  */
 type WithoutUnderscores<T extends string> = T extends `${infer A}_${infer B}`
   ? WithoutUnderscores<`${A}${B}`> // operates recursively to remove all underscores

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -40,7 +40,7 @@ function getMimeTypes<
   return resourceTypes.reduce(
     (acc, s) => ({
       ...acc,
-      s: `application/vnd.dust.${provider.replace("_", "")}.${s
+      [s]: `application/vnd.dust.${provider.replace("_", "")}.${s
         .replace("_", "-")
         .toLowerCase()}`,
     }),

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -109,7 +109,7 @@ export const MIME_TYPES = {
     provider: "zendesk",
     resourceTypes: [
       "BRAND",
-      "HELPCENTER", // TODO: see if we backfill into HELP-CENTER
+      "HELP_CENTER",
       "CATEGORY",
       "ARTICLE",
       "TICKETS",

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -8,6 +8,14 @@ type WithoutUnderscores<T extends string> = T extends `${infer A}_${infer B}`
   ? WithoutUnderscores<`${A}${B}`> // operates recursively to remove all underscores
   : T;
 
+/**
+ * This is a utility type that indicates that we replaced all underscores with dashes in a string.
+ * We don't want underscores in mime types but want to type out the type with one: MIME_TYPE.CAT.SOU_PI_NOU
+ */
+type UnderscoreToDash<T extends string> = T extends `${infer A}_${infer B}`
+  ? UnderscoreToDash<`${A}-${B}`> // operates recursively to replace all underscores
+  : T;
+
 function getMimeTypes<
   P extends ConnectorProvider,
   T extends Uppercase<string>[]
@@ -18,15 +26,21 @@ function getMimeTypes<
   provider: P;
   resourceTypes: T;
 }): {
-  [K in T[number]]: `application/vnd.dust.${WithoutUnderscores<P>}.${Lowercase<K>}`;
+  [K in T[number]]: `application/vnd.dust.${WithoutUnderscores<P>}.${Lowercase<
+    UnderscoreToDash<K>
+  >}`;
 } {
   return resourceTypes.reduce(
     (acc, s) => ({
       ...acc,
-      s: `application/vnd.dust.${provider.replace("_", "")}.${s.toLowerCase()}`,
+      s: `application/vnd.dust.${provider.replace("_", "")}.${s
+        .replace("_", "-")
+        .toLowerCase()}`,
     }),
     {} as {
-      [K in T[number]]: `application/vnd.dust.${WithoutUnderscores<P>}.${Lowercase<K>}`;
+      [K in T[number]]: `application/vnd.dust.${WithoutUnderscores<P>}.${Lowercase<
+        UnderscoreToDash<K>
+      >}`;
     }
   );
 }
@@ -57,10 +71,10 @@ export const MIME_TYPES = {
     provider: "intercom",
     resourceTypes: [
       "COLLECTION",
-      "TEAMS-FOLDER",
+      "TEAMS_FOLDER",
       "CONVERSATION",
       "TEAM",
-      "HELP-CENTER",
+      "HELP_CENTER",
       "ARTICLE",
     ],
   }),
@@ -70,7 +84,7 @@ export const MIME_TYPES = {
   }),
   NOTION: getMimeTypes({
     provider: "notion",
-    resourceTypes: ["UNKNOWN-FOLDER", "DATABASE", "PAGE"],
+    resourceTypes: ["UNKNOWN_FOLDER", "DATABASE", "PAGE"],
   }),
   SLACK: getMimeTypes({
     provider: "slack",

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -61,9 +61,9 @@ export const MIME_TYPES = {
     provider: "github",
     resourceTypes: [
       "REPOSITORY",
-      "CODE.ROOT",
-      "CODE.DIRECTORY",
-      "CODE.FILE",
+      "CODE_ROOT",
+      "CODE_DIRECTORY",
+      "CODE_FILE",
       "ISSUES",
       "ISSUE",
       "DISCUSSIONS",

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -1,5 +1,13 @@
 import { ConnectorProvider } from "../front/data_source";
 
+/**
+ * This is a utility type that indicates that we removed all underscores from a string.
+ * This is used because we don't want underscores in mime types.
+ */
+type WithoutUnderscores<T extends string> = T extends `${infer A}_${infer B}`
+  ? WithoutUnderscores<`${A}${B}`> // operates recursively to remove all underscores
+  : T;
+
 function getMimeTypes<
   P extends ConnectorProvider,
   T extends Uppercase<string>[]
@@ -10,7 +18,7 @@ function getMimeTypes<
   provider: P;
   resourceTypes: T;
 }): {
-  [K in T[number]]: `application/vnd.dust.${P}.${Lowercase<K>}`;
+  [K in T[number]]: `application/vnd.dust.${WithoutUnderscores<P>}.${Lowercase<K>}`;
 } {
   return resourceTypes.reduce(
     (acc, s) => ({
@@ -18,7 +26,7 @@ function getMimeTypes<
       s: `application/vnd.dust.${provider.replace("_", "")}.${s.toLowerCase()}`,
     }),
     {} as {
-      [K in T[number]]: `application/vnd.dust.${P}.${Lowercase<K>}`;
+      [K in T[number]]: `application/vnd.dust.${WithoutUnderscores<P>}.${Lowercase<K>}`;
     }
   );
 }
@@ -42,8 +50,7 @@ export const MIME_TYPES = {
     ],
   }),
   GOOGLE_DRIVE: getMimeTypes({
-    // @ts-expect-error: we have an inconsistency here in that we have been using "googledrive" in the mime type instead of the ConnectorProvider "google_drive"
-    provider: "googledrive", // TODO: see if we backfill into google_drive
+    provider: "google_drive",
     resourceTypes: ["FOLDER"], // for files and spreadsheets, we keep Google's mime types
   }),
   INTERCOM: getMimeTypes({


### PR DESCRIPTION
## Description

- Closes [#9486](https://github.com/dust-tt/dust/issues/9486)
- This PR adds a generic function that computes the mime type given a provider and a resource name, returning a result following the pattern of `application/vnd.dust.${provider}.${resource}`.
- This PR should not imply any functional change.
- The idea here is that the function `getMimeTypes` codes the exacts same thing in type and in code, if this correspondence is correct then the PR is easy to test since every entry (e.g. `MIME_TYPES.CONFLUENCE.PAGE`) has a complete type.
- Note: we cannot type the argument `mimeType` in the upsert functions with a more narrow type because certain providers (google, microsoft) provide an arbitrary mimeType that can only be described as a string for files.

## Risk

- Introducing inconsistencies in the mime types.
- Inconsistencies will have to be backfilled.

## Deploy Plan

- Deploy connectors.
- Run `20250113_backfill_github_mime_types.ts`.
- Run `20250113_backfill_zendesk_hc_mime_types.ts`.
