### PR TITLE
fix(core) - remove the indexes that refer to `"data_sources_documents"|"tables".parents`

### DIFF
--- a/core/src/stores/migrations/20250107_drop_parents_columns.sql
+++ b/core/src/stores/migrations/20250107_drop_parents_columns.sql
@@ -1,2 +1,5 @@
-ALTER TABLE data_sources_documents DROP COLUMN parents;
-ALTER TABLE tables DROP COLUMN parents;
+DROP INDEX IF EXISTS idx_data_sources_documents_parents_array;
+DROP INDEX IF EXISTS idx_tables_parents_array;
+
+ALTER TABLE data_sources_documents DROP COLUMN IF EXISTS parents;
+ALTER TABLE tables DROP COLUMN IF EXISTS parents;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -612,7 +612,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 35] = [
+pub const SQL_INDEXES: [&'static str; 33] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -659,16 +659,12 @@ pub const SQL_INDEXES: [&'static str; 35] = [
        ON data_sources_documents (data_source, document_id, created DESC);",
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_tags_array ON data_sources_documents USING GIN (tags_array);",
-    "CREATE INDEX IF NOT EXISTS
-       idx_data_sources_documents_parents_array ON data_sources_documents USING GIN (parents);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_databases_table_ids_hash ON databases (table_ids_hash);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_tables_data_source_table_id ON tables (data_source, table_id);",
     "CREATE INDEX IF NOT EXISTS
        idx_tables_tags_array ON tables USING GIN (tags_array);",
-    "CREATE INDEX IF NOT EXISTS
-       idx_tables_parents_array ON tables USING GIN (parents);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
         idx_sqlite_workers_url ON sqlite_workers (url);",
     "CREATE INDEX IF NOT EXISTS


### PR DESCRIPTION
## Description

- The columns `parents` in the tables `data_sources_documents` and `tables` (core) were dropped in #9806.
- The indexes referring to it were not removed from the `init_db`.
- This PR addresses that, and also drops the indexes in the migration.

## Risk

- n/a

## Deploy Plan

no deploy
