### PR TITLE
enh(tracker): skip workflow for slack non-threaded messages

### DIFF
--- a/front/temporal/tracker/activities.ts
+++ b/front/temporal/tracker/activities.ts
@@ -427,11 +427,26 @@ export async function trackersGenerationActivity(
   }
 }
 
-export async function shouldRunTrackersActivity(
-  workspaceId: string,
-  dataSourceId: string,
-  documentId: string
-): Promise<boolean> {
+export async function shouldRunTrackersActivity({
+  workspaceId,
+  dataSourceId,
+  documentId,
+  dataSourceConnectorProvider,
+}: {
+  workspaceId: string;
+  dataSourceId: string;
+  documentId: string;
+  dataSourceConnectorProvider: ConnectorProvider | null;
+}): Promise<boolean> {
+  if (
+    dataSourceConnectorProvider === "slack" &&
+    !documentId.includes("-thread-")
+  ) {
+    // Special case for Slack -- we only run trackers for threads (and not for "non-threaded messages"
+    // otherwise we end up running the tracker twice a a thread is initially a non-threaded message.
+    return false;
+  }
+
   const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
 
   const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);

--- a/front/temporal/tracker/workflows.ts
+++ b/front/temporal/tracker/workflows.ts
@@ -45,11 +45,12 @@ export async function trackersGenerationWorkflow(
     signaled = true;
   });
 
-  const shouldRun = await shouldRunTrackersActivity(
+  const shouldRun = await shouldRunTrackersActivity({
     workspaceId,
     dataSourceId,
-    documentId
-  );
+    documentId,
+    dataSourceConnectorProvider,
+  });
 
   if (!shouldRun) {
     return;


### PR DESCRIPTION
## Description

Avoid double processing slack thread OPs that may appear first in the "non-threaded" messages before appearing as a thread document.

## Risk

We won't be processing slack content that isn't part of a thread with at least one reply. Unfortunate limitation but required due to the way our slack integration works.

## Deploy Plan

Deploy and kill all tracker workflows