### PR TITLE
Update usage query to filter out private assistants and only count them

### DIFF
--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -8,6 +8,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
+import { pluralize } from "@dust-tt/types";
 import { useMemo, useState } from "react";
 
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
@@ -52,8 +53,8 @@ export function DeleteStaticDataSourceDialog({
     if (!usage) {
       return "No usage data available.";
     }
-    if (usage.count > 0) {
-      return `${usage.count} assistants currently use "${name}": ${usage.agentNames.join(", ")}.`;
+    if (usage.totalAgentCount > 0) {
+      return `${usage.totalAgentCount} assistants currently use "${name}": ${usage.publicAgentNames.join(", ")}${usage.privateAgentCount > 0 ? ` and ${usage.privateAgentCount} private agent${pluralize(usage.privateAgentCount)}.` : "."}.`;
     }
     return `No assistants are using "${name}".`;
   }, [isUsageLoading, isUsageError, usage, name]);

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -109,7 +109,7 @@ export function EditSpaceManagedDataSourcesViews({
     );
 
     const deletedViewsWithUsage = deletedViews.filter(
-      (dv) => dv.usage.count > 0
+      (dv) => dv.usage.totalAgentCount > 0
     );
     if (deletedViewsWithUsage.length > 0) {
       const confirmed = await showDialog({
@@ -126,8 +126,8 @@ export function EditSpaceManagedDataSourcesViews({
               <p key={view.sId} className="font-medium">
                 {getDisplayNameForDataSource(view.dataSource)}{" "}
                 <span className="italic text-muted-foreground">
-                  (used by {view.usage.count} assistant
-                  {view.usage.count > 1 ? "s" : ""})
+                  (used by {view.usage.totalAgentCount} assistant
+                  {view.usage.totalAgentCount > 1 ? "s" : ""})
                 </span>
               </p>
             ))}

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -21,7 +21,11 @@ import type {
   SpaceType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { DATA_SOURCE_VIEW_CATEGORIES, removeNulls } from "@dust-tt/types";
+import {
+  DATA_SOURCE_VIEW_CATEGORIES,
+  pluralize,
+  removeNulls,
+} from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
 import type { ComponentType } from "react";
 import { useState } from "react";
@@ -80,7 +84,7 @@ const getTableColumns = () => {
     },
     {
       header: "Used by",
-      accessorFn: (row: RowData) => row.usage.count,
+      accessorFn: (row: RowData) => row.usage.totalAgentCount,
       meta: {
         width: "6rem",
       },
@@ -89,9 +93,9 @@ const getTableColumns = () => {
           {info.row.original.usage ? (
             <DataTable.CellContent
               icon={RobotIcon}
-              title={`Used by ${info.row.original.usage.agentNames.join(", ")}`}
+              title={`Used by ${info.row.original.usage.publicAgentNames.join(", ")} ${info.row.original.usage.privateAgentCount > 0 ? ` and ${info.row.original.usage.privateAgentCount} private agent${pluralize(info.row.original.usage.privateAgentCount)}.` : "."}.`}
             >
-              {info.row.original.usage.count}
+              {info.row.original.usage.totalAgentCount}
             </DataTable.CellContent>
           ) : null}
         </>

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -131,7 +131,8 @@ const getTableColumns = ({
 
   const usedByColumn = {
     header: "Used by",
-    accessorFn: (row: RowData) => row.dataSourceView.usage?.count ?? 0,
+    accessorFn: (row: RowData) =>
+      row.dataSourceView.usage?.totalAgentCount ?? 0,
     id: "usedBy",
     meta: {
       width: "6rem",

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -8,6 +8,7 @@ import {
   ScrollArea,
 } from "@dust-tt/sparkle";
 import type { DataSourceWithAgentsUsageType } from "@dust-tt/types";
+import { pluralize } from "@dust-tt/types";
 
 export const UsedByButton = ({
   usage,
@@ -16,13 +17,13 @@ export const UsedByButton = ({
   usage: DataSourceWithAgentsUsageType;
   onItemClick: (assistantSid: string) => void;
 }) => {
-  return usage.count === 0 ? (
+  return usage.totalAgentCount === 0 ? (
     <Button
       icon={RobotIcon}
       variant="ghost"
       isSelect={false}
       size="sm"
-      label={`${usage.count}`}
+      label={`${usage.totalAgentCount}`}
       disabled
     />
   ) : (
@@ -33,21 +34,27 @@ export const UsedByButton = ({
           variant="ghost"
           isSelect={true}
           size="sm"
-          label={`${usage.count}`}
+          label={`${usage.totalAgentCount}`}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="max-w-[300px]">
         <ScrollArea className="border-1 h-[130px]">
-          {usage.agentNames.map((name) => (
+          {usage.publicAgentNames.map((name) => (
             <DropdownMenuItem
               key={`assistant-picker-${name}`}
-              label={name}
+              label={`@${name}`}
               onClick={(e) => {
                 e.stopPropagation();
                 onItemClick(name);
               }}
             />
           ))}
+          {usage.privateAgentCount > 0 && (
+            <DropdownMenuItem
+              label={`+ ${usage.privateAgentCount} private agent${pluralize(usage.privateAgentCount)}`}
+              disabled={true}
+            />
+          )}
         </ScrollArea>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -79,8 +79,11 @@ async function handler(
 
       const viewsUsedByAgentsName = viewsUsageByAgentsRes.reduce(
         (acc, usageRes) => {
-          if (usageRes.isOk() && usageRes.value.count > 0) {
-            usageRes.value.agentNames.forEach((name) => acc.add(name));
+          if (usageRes.isOk() && usageRes.value.totalAgentCount > 0) {
+            usageRes.value.publicAgentNames.forEach((name) => acc.add(name));
+            if (usageRes.value.privateAgentCount > 0) {
+              acc.add(`${usageRes.value.privateAgentCount} private agents`);
+            }
           }
 
           return acc;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -121,13 +121,13 @@ async function handler(
       const force = req.query.force === "true";
       if (!force) {
         const usageRes = await dataSourceView.getUsagesByAgents(auth);
-        if (usageRes.isErr() || usageRes.value.count > 0) {
+        if (usageRes.isErr() || usageRes.value.totalAgentCount > 0) {
           return apiError(req, res, {
             status_code: 401,
             api_error: {
               type: "data_source_error",
               message: usageRes.isOk()
-                ? `The data source view is in use by ${usageRes.value.agentNames.join(", ")} and cannot be deleted.`
+                ? `The data source view is in use by ${usageRes.value.publicAgentNames.join(", ")}${usageRes.value.privateAgentCount > 0 ? `${usageRes.value.privateAgentCount} private agent(s)` : ""} and cannot be deleted.`
                 : "The data source view is in use and cannot be deleted.",
             },
           });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -118,8 +118,9 @@ async function handler(
                     fetchConnectorErrorMessage: null,
                   },
                   usage: usages[dataSourceView.id] || {
-                    count: 0,
-                    agentNames: [],
+                    totalAgentCount: 0,
+                    privateAgentCount: 0,
+                    publicAgentNames: [],
                   },
                 };
               }
@@ -130,8 +131,9 @@ async function handler(
                 ...dataSourceView,
                 dataSource: augmentedDataSource,
                 usage: usages[dataSourceView.id] || {
-                  count: 0,
-                  agentNames: [],
+                  totalAgentCount: 0,
+                  privateAgentCount: 0,
+                  publicAgentNames: [],
                 },
               };
             })

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -61,8 +61,9 @@ async function handler(
         categories[category] = {
           count: 0,
           usage: {
-            count: 0,
-            agentNames: [],
+            totalAgentCount: 0,
+            privateAgentCount: 0,
+            publicAgentNames: [],
           },
         };
 
@@ -83,13 +84,16 @@ async function handler(
             const usage = usages[dsView.id];
 
             if (usage) {
-              categories[category].usage.agentNames = categories[
+              categories[category].usage.publicAgentNames = categories[
                 category
-              ].usage.agentNames.concat(usage.agentNames);
-              categories[category].usage.agentNames = uniq(
-                categories[category].usage.agentNames
+              ].usage.publicAgentNames.concat(usage.publicAgentNames);
+              categories[category].usage.publicAgentNames = uniq(
+                categories[category].usage.publicAgentNames
               );
-              categories[category].usage.count += usage.count;
+              categories[category].usage.totalAgentCount +=
+                usage.totalAgentCount;
+              categories[category].usage.privateAgentCount +=
+                usage.privateAgentCount;
             }
           }
         }

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -110,8 +110,9 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
   ConnectorStatusDetails;
 
 export type DataSourceWithAgentsUsageType = {
-  count: number;
-  agentNames: string[];
+  totalAgentCount: number;
+  privateAgentCount: number;
+  publicAgentNames: string[];
 };
 
 export function isDataSourceNameValid(name: string): Result<void, string> {


### PR DESCRIPTION
## Description

Goal of this PR was to filter out names of private assistants from the usage queries and instead retrieve the count of private assistants.

I'm having second thoughts were I think it would be better to keep them and instead and only manage the 404 we have when we click on those. Will discuss more with Ed. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
