### PR TITLE
Assistant Detail modal displays error messag if you don't have access

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -13,6 +13,7 @@ import {
   HandThumbDownIcon,
   HandThumbUpIcon,
   InformationCircleIcon,
+  LockIcon,
   Page,
   Sheet,
   SheetContainer,
@@ -267,11 +268,14 @@ export function AssistantDetails({
 }: AssistantDetailsProps) {
   const [isUpdatingScope, setIsUpdatingScope] = useState(false);
   const [selectedTab, setSelectedTab] = useState("info");
-  const { agentConfiguration, isAgentConfigurationValidating } =
-    useAgentConfiguration({
-      workspaceId: owner.sId,
-      agentConfigurationId: assistantId,
-    });
+  const {
+    agentConfiguration,
+    isAgentConfigurationValidating,
+    isAgentConfigurationError,
+  } = useAgentConfiguration({
+    workspaceId: owner.sId,
+    agentConfigurationId: assistantId,
+  });
 
   const doUpdateScope = useUpdateAgentScope({
     owner,
@@ -379,6 +383,18 @@ export function AssistantDetails({
                 />
               )}
             </div>
+          )}
+          {isAgentConfigurationError?.error.type ===
+            "agent_configuration_not_found" && (
+            <ContentMessage
+              variant="amber"
+              title="Not Available"
+              icon={LockIcon}
+              size="md"
+            >
+              This is a private assistant that can't be shared with other
+              workspace members.
+            </ContentMessage>
           )}
         </SheetContainer>
       </SheetContent>


### PR DESCRIPTION
## Description

On the usage dropdown from datasource views we can click on the list of assistant using the data. If the assistant is private then the modal is empty. This adds an error message: 

<kbd>
<img width="580" alt="Screenshot 2025-01-13 at 14 26 40" src="https://github.com/user-attachments/assets/5f7e7ea4-517c-493d-9fc3-ee9992e462e0" />
</kbd>

Initially I started this: https://github.com/dust-tt/dust/pull/9924/files but was not happy with it so I discussed with Ed and we start with that and will improve to display the name of the authors if the current user is admin, so they know who to reach out before editing the data.

## Risk

Can be rolled back. 

## Deploy Plan

deploy front. 
