### PR TITLE
Bump sdk to add optionnal created on conversation schema

### DIFF
--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -947,6 +947,7 @@ export type ConversationVisibility = z.infer<
 const ConversationWithoutContentSchema = z.object({
   id: ModelIdSchema,
   created: z.number(),
+  updated: z.number().optional(),
   owner: WorkspaceSchema,
   sId: z.string(),
   title: z.string().nullable(),


### PR DESCRIPTION
## Description

Bumping the sdk to add an optional `updatded` on Conversation schema. 
This field was introduced recently on the api on this PR: https://github.com/dust-tt/dust/pull/9792/files

Will use it to sort conversations by last used on the extension, as we now do on the web version.

## Risk

New parameter is optional and already populated. 

## Deploy Plan

Publish new sdk version.