### PR TITLE
[sdk] Expect stream body when used in browser env

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -276,7 +276,9 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
           req,
           res,
           auth,
-          null as U extends true ? Authenticator : null
+          (opts.allowUserOutsideCurrentWorkspace
+            ? auth
+            : null) as U extends true ? Authenticator : null
         );
       }
 

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -276,9 +276,7 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
           req,
           res,
           auth,
-          (opts.allowUserOutsideCurrentWorkspace
-            ? auth
-            : null) as U extends true ? Authenticator : null
+          null as U extends true ? Authenticator : null
         );
       }
 

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -70,10 +70,14 @@ interface DustResponse {
   status: number;
   ok: boolean;
   url: string;
-  body: Readable;
+  body: Readable | string;
 }
 
 const textFromResponse = async (response: DustResponse): Promise<string> => {
+  if (typeof response.body === "string") {
+    return response.body;
+  }
+
   const stream = response.body;
 
   return new Promise((resolve, reject) => {
@@ -1044,7 +1048,7 @@ export class DustAPI {
   ): Promise<Result<{ response: DustResponse; duration: number }, APIError>> {
     const now = Date.now();
     try {
-      const res = await axiosNoKeepAlive<Readable>(url, {
+      const res = await axiosNoKeepAlive<Readable | string>(url, {
         validateStatus: () => true,
         responseType: "stream",
         ...config,


### PR DESCRIPTION
## Description

In a browser environment, the axios library does not support streaming responses in the same way it does in a Node.js environment. Even when you setting responseType: "stream", we receive a string in response.body

(this is required for extension)

## Risk

none

## Deploy Plan

publish sdk
