### PR TITLE
feat: add link to maintained document in tracker email

### DIFF
--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -237,14 +237,16 @@ export class TrackerGenerationModel extends SoftDeletableModel<TrackerGeneration
   declare trackerConfigurationId: ForeignKey<TrackerConfigurationModel["id"]>;
   declare dataSourceId: ForeignKey<DataSourceModel["id"]>;
   declare documentId: string;
-  declare maintainedDocumentDataSourceId: ForeignKey<DataSourceModel["id"]>;
-  declare maintainedDocumentId: string;
+  declare maintainedDocumentDataSourceId: ForeignKey<
+    DataSourceModel["id"]
+  > | null;
+  declare maintainedDocumentId: string | null;
 
   declare consumedAt: Date | null;
 
   declare trackerConfiguration: NonAttribute<TrackerConfigurationModel>;
   declare dataSource: NonAttribute<DataSourceModel>;
-  declare maintainedDocumentDataSource: NonAttribute<DataSourceModel>;
+  declare maintainedDocumentDataSource: NonAttribute<DataSourceModel> | null;
 }
 
 TrackerGenerationModel.init(

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -437,6 +437,11 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
               as: "dataSource",
               required: true,
             },
+            {
+              model: DataSourceModel,
+              as: "maintainedDocumentDataSource",
+              required: false,
+            },
           ],
         },
       ],
@@ -701,6 +706,17 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
             dustAPIProjectId: g.dataSource.dustAPIProjectId,
             dustAPIDataSourceId: g.dataSource.dustAPIDataSourceId,
           },
+          maintainedDataSource: g.maintainedDocumentDataSource
+            ? {
+                id: g.maintainedDocumentDataSource.id,
+                name: dataSourceName,
+                dustAPIProjectId:
+                  g.maintainedDocumentDataSource.dustAPIProjectId,
+                dustAPIDataSourceId:
+                  g.maintainedDocumentDataSource.dustAPIDataSourceId,
+              }
+            : null,
+          maintainedDocumentId: g.maintainedDocumentId,
         };
       });
     }

--- a/front/scripts/send_tracker_generations.ts
+++ b/front/scripts/send_tracker_generations.ts
@@ -1,0 +1,101 @@
+import { sendTrackerWithGenerationEmail } from "@app/lib/api/tracker";
+import { TrackerGenerationModel } from "@app/lib/models/doc_tracker";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { isEmailValid } from "@app/lib/utils";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript(
+  {
+    generationIds: {
+      type: "array",
+      demandOption: true,
+      description: "List of generation IDs",
+    },
+    email: {
+      type: "string",
+      demandOption: true,
+      description: "Email address to send to",
+    },
+  },
+  async ({ execute, generationIds, email }, logger) => {
+    try {
+      // Validate email
+      if (!isEmailValid(email)) {
+        throw new Error("Invalid email address");
+      }
+
+      // Parse and validate generation IDs
+      const ids = generationIds.map((id) => parseInt(id));
+      if (ids.some((id) => isNaN(id))) {
+        throw new Error("Invalid generation IDs - must be numbers");
+      }
+
+      if (execute) {
+        // Fetch generations with their data sources
+        const generations = await TrackerGenerationModel.findAll({
+          where: {
+            id: ids,
+          },
+          include: [
+            {
+              model: DataSourceModel,
+              required: true,
+            },
+            {
+              model: DataSourceModel,
+              as: "maintainedDocumentDataSource",
+              required: false,
+            },
+          ],
+        });
+
+        if (generations.length === 0) {
+          throw new Error("No generations found with the provided IDs");
+        }
+
+        // Convert to TrackerGenerationToProcess format
+        const generationsToProcess = generations.map((g) => ({
+          id: g.id,
+          content: g.content,
+          thinking: g.thinking,
+          documentId: g.documentId,
+          dataSource: {
+            id: g.dataSource.id,
+            name: g.dataSource.name,
+            dustAPIProjectId: g.dataSource.dustAPIProjectId,
+            dustAPIDataSourceId: g.dataSource.dustAPIDataSourceId,
+          },
+          maintainedDocumentId: g.maintainedDocumentId,
+          maintainedDataSource: g.maintainedDocumentDataSource
+            ? {
+                id: g.maintainedDocumentDataSource.id,
+                name: g.maintainedDocumentDataSource.name,
+                dustAPIProjectId:
+                  g.maintainedDocumentDataSource.dustAPIProjectId,
+                dustAPIDataSourceId:
+                  g.maintainedDocumentDataSource.dustAPIDataSourceId,
+              }
+            : null,
+        }));
+
+        // Send email
+        await sendTrackerWithGenerationEmail({
+          name: "Manual Generation Email",
+          recipient: email,
+          generations: generationsToProcess,
+          localLogger: logger,
+        });
+
+        logger.info({}, "Email sent successfully");
+      } else {
+        logger.info(
+          { generationIds: ids, email },
+          "Dry run - would send email with these parameters"
+        );
+      }
+    } finally {
+      await frontSequelize.close();
+    }
+  }
+);

--- a/types/src/front/tracker.ts
+++ b/types/src/front/tracker.ts
@@ -68,15 +68,19 @@ export type TrackerIdWorkspaceId = {
   workspaceId: string;
 };
 
+export type TrackerDataSource = {
+  id: ModelId;
+  name: string;
+  dustAPIProjectId: string;
+  dustAPIDataSourceId: string;
+};
+
 export type TrackerGenerationToProcess = {
   id: ModelId;
   content: string;
   thinking: string | null;
   documentId: string;
-  dataSource: {
-    id: ModelId;
-    name: string;
-    dustAPIProjectId: string;
-    dustAPIDataSourceId: string;
-  };
+  dataSource: TrackerDataSource;
+  maintainedDataSource: TrackerDataSource | null;
+  maintainedDocumentId: string | null;
 };


### PR DESCRIPTION
## Description

Maintained scope can contain many docs. We now keep track of which document needs an update on the DB table, so it's useful to include this in the emails we send.

## Risk

N/A (feature not released yet)

## Deploy Plan

Deploy front. this deploy plan needs to be detailed because Danger thinks there is a data model change in this PR due to files modified in `**/lib/models`. In reality, there's no such data model change in the PR, I just updated the typescript type to match the reality.