### PR TITLE
[front] Replace parents splice/unshift logic with validation in `lib/api/data_sources.ts`

### DIFF
--- a/front/components/data_source/MultipleDocumentsUpload.tsx
+++ b/front/components/data_source/MultipleDocumentsUpload.tsx
@@ -122,7 +122,7 @@ export const MultipleDocumentsUpload = ({
             // Have to use the filename to avoid fileId becoming apparent in the UI.
             upsertArgs: {
               title: blob.filename,
-              name: blob.filename,
+              document_id: blob.filename,
             },
           });
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -286,8 +286,8 @@ export async function upsertDocument({
   }
   // parents and parentId must comply to the invariant parents[1] === parentId || (parentId === null && parents.length < 2)
   if (
-    documentParents[1] !== documentParentId &&
-    (documentParents.length >= 2 || documentParentId !== null)
+    (documentParents.length >= 2 || documentParentId !== null) &&
+    documentParents[1] !== documentParentId
   ) {
     return new Err(
       new DustError(
@@ -484,8 +484,8 @@ export async function upsertTable({
   }
   // parents and parentId must comply to the invariant parents[1] === parentId
   if (
-    tableParents[1] !== tableParentId &&
-    (tableParents.length >= 2 || tableParentId !== null)
+    (tableParents.length >= 2 || tableParentId !== null) &&
+    tableParents[1] !== tableParentId
   ) {
     return new Err(
       new DustError(

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -270,6 +270,33 @@ export async function upsertDocument({
     DustError
   >
 > {
+  // enforcing validation on the parents and parent_id
+  const documentId = name;
+  const documentParents = parents || [documentId];
+  const documentParentId = parent_id ?? null;
+
+  // parents must comply to the invariant parents[0] === document_id
+  if (documentParents[0] !== documentId) {
+    return new Err(
+      new DustError(
+        "invalid_parents",
+        "Invalid request body, parents[0] and document_id should be equal"
+      )
+    );
+  }
+  // parents and parentId must comply to the invariant parents[1] === parentId || (parentId === null && parents.length < 2)
+  if (
+    documentParents[1] !== documentParentId &&
+    (documentParents.length >= 2 || documentParentId !== null)
+  ) {
+    return new Err(
+      new DustError(
+        "invalid_parent_id",
+        "Invalid request body, parents[1] and parent_id should be equal"
+      )
+    );
+  }
+
   let sourceUrl: string | null = null;
   if (source_url) {
     const { valid: isSourceUrlValid, standardized: standardizedSourceUrl } =
@@ -315,33 +342,6 @@ export async function upsertDocument({
       new DustError(
         "text_or_section_required",
         "Invalid request body, `text` or `section` must be provided."
-      )
-    );
-  }
-
-  // enforcing validation on the parents and parent_id
-  const documentId = name;
-  const documentParents = parents || [documentId];
-  const documentParentId = parent_id ?? null;
-
-  // parents must comply to the invariant parents[0] === document_id
-  if (documentParents[0] !== documentId) {
-    return new Err(
-      new DustError(
-        "invalid_parents",
-        "Invalid request body, parents[0] and document_id should be equal"
-      )
-    );
-  }
-  // parents and parentId must comply to the invariant parents[1] === parentId || (parentId === null && parents.length < 2)
-  if (
-    documentParents[1] !== documentParentId &&
-    (documentParents.length >= 2 || documentParentId !== null)
-  ) {
-    return new Err(
-      new DustError(
-        "invalid_parent_id",
-        "Invalid request body, parents[1] and parent_id should be equal"
       )
     );
   }

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -228,7 +228,7 @@ export async function augmentDataSourceWithConnectorDetails(
 }
 
 export interface UpsertDocumentArgs {
-  name: string;
+  document_id: string;
   source_url?: string | null;
   text?: string | null;
   section?: FrontDataSourceDocumentSectionType | null;
@@ -244,7 +244,7 @@ export interface UpsertDocumentArgs {
 }
 
 export async function upsertDocument({
-  name,
+  document_id,
   source_url,
   text,
   section,
@@ -271,7 +271,7 @@ export async function upsertDocument({
   >
 > {
   // enforcing validation on the parents and parent_id
-  const documentId = name;
+  const documentId = document_id;
   const documentParents = parents || [documentId];
   const documentParentId = parent_id ?? null;
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -333,8 +333,11 @@ export async function upsertDocument({
       )
     );
   }
-  // parents and parentId must comply to the invariant parents[1] === parentId
-  if (documentParents[1] !== documentParentId) {
+  // parents and parentId must comply to the invariant parents[1] === parentId || (parentId === null && parents.length < 2)
+  if (
+    documentParents[1] !== documentParentId &&
+    (documentParents.length >= 2 || documentParentId !== null)
+  ) {
     return new Err(
       new DustError(
         "invalid_parent_id",
@@ -480,7 +483,10 @@ export async function upsertTable({
     );
   }
   // parents and parentId must comply to the invariant parents[1] === parentId
-  if (tableParents[1] !== tableParentId) {
+  if (
+    tableParents[1] !== tableParentId &&
+    (tableParents.length >= 2 || tableParentId !== null)
+  ) {
     return new Err(
       new DustError(
         "invalid_parent_id",

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -245,7 +245,7 @@ const upsertTableToDatasource: ProcessingFunction = async ({
   dataSource,
   upsertArgs,
 }) => {
-  const tableId = file.sId; // Use the file sId as the table id to make it easy to track the table back to the file.
+  const tableId = upsertArgs?.tableId ?? file.sId; // Use the file sId as a fallback for the table_id to make it easy to track the table back to the file.
   const upsertTableRes = await upsertTable({
     tableId,
     name: slugify(file.fileName),

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -207,14 +207,13 @@ const upsertDocumentToDatasource: ProcessingFunction = async ({
   upsertArgs,
 }) => {
   // Use the file id as the document id to make it easy to track the document back to the file.
-  const documentId = file.sId;
   const sourceUrl = file.getPrivateUrl(auth);
 
   const upsertDocumentRes = await upsertDocument({
-    name: documentId,
+    document_id: file.sId,
     source_url: sourceUrl,
     text: content,
-    parents: [documentId],
+    parents: [file.sId],
     tags: [`title:${file.fileName}`, `fileId:${file.sId}`],
     light_document_output: true,
     dataSource,

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -10,6 +10,7 @@ export type DustErrorCode =
   | "data_source_quota_error"
   | "text_or_section_required"
   | "invalid_url"
+  | "invalid_parents"
   | "invalid_parent_id"
   // Table
   | "missing_csv"

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
@@ -17,15 +17,10 @@ export interface UpsertFileToDataSourceRequestBody {
   fileId: string;
   upsertArgs?:
     | Pick<UpsertDocumentArgs, "document_id" | "title" | "tags">
-    | Pick<
+    | (Pick<
         UpsertTableArgs,
-        | "name"
-        | "title"
-        | "description"
-        | "tableId"
-        | "tags"
-        | "useAppForHeaderDetection"
-      >;
+        "name" | "title" | "description" | "tags" | "useAppForHeaderDetection"
+      > & { tableId: string | undefined }); // we actually don't always have a tableId, this is very dirty, but the refactoring should be done at the level of the whole upsertArgs mechanic
 }
 
 export interface UpsertFileToDataSourceResponseBody {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
@@ -1,6 +1,5 @@
 import type { FileType, WithAPIErrorResponse } from "@dust-tt/types";
-import type { NextApiRequest } from "next";
-import type { NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type {
@@ -17,7 +16,7 @@ import { apiError } from "@app/logger/withlogging";
 export interface UpsertFileToDataSourceRequestBody {
   fileId: string;
   upsertArgs?:
-    | Pick<UpsertDocumentArgs, "name" | "title" | "tags">
+    | Pick<UpsertDocumentArgs, "document_id" | "title" | "tags">
     | Pick<
         UpsertTableArgs,
         | "name"

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -118,7 +118,7 @@ async function handler(
       } = bodyValidation.right;
 
       const upsertResult = await upsertDocument({
-        name: documentId,
+        document_id: documentId,
         source_url,
         text,
         section,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -111,7 +111,7 @@ async function handler(
       } = bodyValidation.right;
 
       const upsertResult = await upsertDocument({
-        name,
+        document_id: name, // using the name as the document_id since we don't have one here
         source_url,
         text,
         section,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -10,6 +10,7 @@ import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { apiError } from "@app/logger/withlogging";
 
 export const config = {
@@ -93,11 +94,13 @@ async function handler(
         });
       }
 
+      const tableId = generateRandomModelSId();
       const upsertRes = await upsertTable({
         ...bodyValidation.right,
         async: bodyValidation.right.async ?? false,
         dataSource,
         auth,
+        tableId,
       });
 
       if (upsertRes.isErr()) {


### PR DESCRIPTION
## Description

- Follows up on #9309.
- Closes [#9938](https://github.com/dust-tt/dust/issues/9938)
- `upsertDocument` and `upsertTable` are able to mutate the parents data passed to them by changing it to comply to the invariants on parents (`parents[0] === node_id`, `parents[1] === parent_id`).
- This PR removes the behavior, replacing it with validation checks.
- This PR also removes the ability to omit the `tableId` in `upsertTable`, the caller now should define it and then pass it.
- Note regarding the `table_id` used in `upsertTable`: it is set beforehand (e.g. in `lib/api/files/upserts.ts`), uses the `file.sId` as a fallback and uses the content node ID if existing (unfortunately hidden in the `upsertArgs`, this could be improved but not necessary here).
- Tests:
  - Folders document upload (single file, multiple files)
  - Folders table upload
  - JIT
- Note: typing is getting ugly, some refactoring work is planned so won't interfere with it in this PR.

## Risk

- Blast radius limited to file uploads (not connectors).

## Deploy Plan

- Deploy front.
