### PR TITLE
Fix GitHub mime types migration script

### DIFF
--- a/front/migrations/20250113_backfill_github_mime_types.ts
+++ b/front/migrations/20250113_backfill_github_mime_types.ts
@@ -109,7 +109,7 @@ async function backfillDataSource(
     if (execute) {
       await coreSequelize.query(
         `WITH pairs AS (
-            SELECT UNNEST(:ids) as id, UNNEST(:mimeTypes) as mime_type
+            SELECT UNNEST(ARRAY[:ids]) as id, UNNEST(ARRAY[:mimeTypes]) as mime_type
         )
          UPDATE data_sources_nodes dsn
          SET mime_type = p.mime_type


### PR DESCRIPTION
## Description

- Merged #9916 too fast, forgot to push this one commit.
- The unnest syntax was incorrect.

## Risk

n/a

## Deploy Plan

n/a (it's a script)
