### PR TITLE
Ext allow external open

### DIFF
--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -373,16 +373,18 @@ chrome.runtime.onMessage.addListener(
 /**
  * Listener for messages sent from external websites that are whitelisted on the manifest.
  * It allows to open the side panel and navigate to a specific conversation.
+ *
+ * We return true to keep the message channel open for async response.
  */
 chrome.runtime.onMessageExternal.addListener((request) => {
-  // If the message is not valid or the conversationId is not valid, ignore it.
-  // Return true to keep the message channel open.
   if (
     request.action !== "openSidePanel" ||
     !request.conversationId ||
     !request.workspaceId ||
-    !/^[a-zA-Z0-9_-]{10,}$/.test(request.conversationId)
+    !/^[a-zA-Z0-9_-]{10,}$/.test(request.conversationId) ||
+    !/^[a-zA-Z0-9_-]{10,}$/.test(request.workspaceId)
   ) {
+    log("[onMessageExternal] Invalid params:", request);
     return true;
   }
 
@@ -393,19 +395,68 @@ chrome.runtime.onMessageExternal.addListener((request) => {
           windowId: tabs[0].windowId,
         })
         .then(() => {
-          // Set a timeout to ensure it's loaded. Ugly but works.
-          setTimeout(() => {
-            const params = JSON.stringify({
-              conversationId: request.conversationId,
-            });
-            void chrome.runtime.sendMessage({
-              type: "EXT_ROUTE_CHANGE",
-              pathname: "/run",
-              search: `?${params}`,
-            });
-          }, 1000);
+          chrome.storage.local.get(
+            ["extensionReady", "user"],
+            ({ extensionReady, user }) => {
+              if (request.workspaceId != user?.selectedWorkspace) {
+                log("[onMessageExternal] User selected another workspace.");
+                return;
+              }
+
+              const sendMessage = () => {
+                const params = JSON.stringify({
+                  conversationId: request.conversationId,
+                });
+                void chrome.runtime.sendMessage({
+                  type: "EXT_ROUTE_CHANGE",
+                  pathname: "/run",
+                  search: `?${params}`,
+                });
+              };
+
+              if (!extensionReady) {
+                let retries = 0;
+                const MAX_RETRIES = 15;
+                const RETRY_INTERVAL = 500; // Check every 500ms 15 times = 7.5s total.
+
+                const checkReady = () => {
+                  if (retries >= MAX_RETRIES) {
+                    log(
+                      "[onMessageExternal] Max retries reached waiting for extension ready."
+                    );
+                    return;
+                  }
+
+                  chrome.storage.local.get(
+                    ["extensionReady"],
+                    ({ extensionReady }) => {
+                      if (chrome.runtime.lastError) {
+                        log(
+                          "[onMessageExternal] Error checking extension ready:",
+                          chrome.runtime.lastError
+                        );
+                        return;
+                      }
+
+                      if (extensionReady) {
+                        sendMessage();
+                      } else {
+                        retries++;
+                        setTimeout(checkReady, RETRY_INTERVAL);
+                      }
+                    }
+                  );
+                };
+                checkReady();
+              } else {
+                sendMessage();
+              }
+            }
+          );
         })
-        .catch((err) => console.error("Error opening side panel:", err));
+        .catch((err) => {
+          log("[onMessageExternal] Error opening side panel:", err);
+        });
     }
   });
 

--- a/extension/app/src/pages/ConversationPage.tsx
+++ b/extension/app/src/pages/ConversationPage.tsx
@@ -20,11 +20,13 @@ export const ConversationPage = ({
   const navigate = useNavigate();
   const { conversationId } = useParams();
 
-  const { conversation, isConversationLoading } = usePublicConversation({
-    conversationId: conversationId ?? null,
-  });
+  const { conversation, isConversationLoading, conversationError } =
+    usePublicConversation({
+      conversationId: conversationId ?? null,
+    });
 
-  if (!conversationId) {
+  // @ts-expect-error conversationError has a type
+  if (!conversationId || conversationError?.type === "conversation_not_found") {
     navigate("/");
     return;
   }

--- a/extension/app/src/pages/RunPage.tsx
+++ b/extension/app/src/pages/RunPage.tsx
@@ -16,6 +16,11 @@ export const RunPage = () => {
     const run = async () => {
       const params = JSON.parse(decodeURI(location.search.substr(1)));
 
+      if (params.conversationId) {
+        await navigate(`/conversations/${params.conversationId}`);
+        return;
+      }
+
       const files = await fileUploaderService.uploadContentTab({
         includeContent: params.includeContent,
         includeCapture: params.includeCapture,

--- a/extension/config/manifest.base.json
+++ b/extension/config/manifest.base.json
@@ -34,5 +34,12 @@
     "scripting",
     "contextMenus"
   ],
-  "host_permissions": ["<all_urls>"]
+  "host_permissions": ["<all_urls>"],
+  "externally_connectable": {
+    "matches": [
+      "https://dust.tt/*",
+      "https://alan.com/sales-tools/*",
+      "https://alanhealth.lightning.force.com/*"
+    ]
+  }
 }


### PR DESCRIPTION
## Description

Allow some domain to send a message to the extension to open the sidepanel on a given conversation. 

We check that the message was sent for a workspace that is the currently selected workspace, if not we don't try to redirect to the conversation. If the conversation is not found we will redirect back to homepage. 

The only tricky part was making sure the ext would be ready to receive the message. It's super convenient that I've been able to reuse the run page. 

## Risk

We test the format of conversation and workspace Id, and that it's the selected workspace id of the user. 
We don't test that the conversation id belongs to the current workspace, the user will be redirected back to homepage if they have a 404. Seems reasonable. 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
