### PR TITLE
[content-nodes] Add a log and update the doc for `lastUpdatedAt`

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -158,7 +158,7 @@ export const config = {
  *                 description: 'Reserved for internal use, should not be set. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order.'
  *               timestamp:
  *                 type: number
- *                 description: Unix timestamp (in seconds) for the document (e.g. 1698225000). Can be null or omitted.
+ *                 description: Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000).
  *               light_document_output:
  *                 type: boolean
  *                 description: If true, a lightweight version of the document will be returned in the response (excluding the text, chunks and vectors). Defaults to false.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -389,9 +389,14 @@ async function handler(
       }
 
       // TODO(content-node): get rid of this once the use of timestamp columns in core has been rationalized
-      if (!auth.isSystemKey()) {
+      if (!auth.isSystemKey() && r.data.timestamp) {
         logger.info(
-          { timestamp: r.data.timestamp, currentDate: Date.now() },
+          {
+            workspaceId: owner.id,
+            dataSourceId: dataSource.sId,
+            timestamp: r.data.timestamp,
+            currentDate: Date.now(),
+          },
           "[ContentNode] User-set timestamp."
         );
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -388,6 +388,14 @@ async function handler(
         });
       }
 
+      // TODO(content-node): get rid of this once the use of timestamp columns in core has been rationalized
+      if (!auth.isSystemKey()) {
+        logger.info(
+          { timestamp: r.data.timestamp, currentDate: Date.now() },
+          "[ContentNode] User-set timestamp."
+        );
+      }
+
       let sourceUrl: string | null = null;
       if (r.data.source_url) {
         const { valid: isSourceUrlValid, standardized: standardizedSourceUrl } =

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -308,6 +308,12 @@ async function handler(
         mimeType = r.data.mime_type;
         title = r.data.title;
       } else {
+        // TODO(content-node): get rid of this once the use of timestamp columns in core has been rationalized
+        logger.info(
+          { timestamp: r.data.timestamp, currentDate: Date.now() },
+          "[ContentNode] User-set timestamp."
+        );
+
         // If the request is from a regular API key, the request must not provide mimeType.
         if (r.data.mime_type) {
           return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -309,11 +309,17 @@ async function handler(
         title = r.data.title;
       } else {
         // TODO(content-node): get rid of this once the use of timestamp columns in core has been rationalized
-        logger.info(
-          { timestamp: r.data.timestamp, currentDate: Date.now() },
-          "[ContentNode] User-set timestamp."
-        );
-
+        if (r.data.timestamp) {
+          logger.info(
+            {
+              workspaceId: owner.id,
+              dataSourceId: dataSource.sId,
+              timestamp: r.data.timestamp,
+              currentDate: Date.now(),
+            },
+            "[ContentNode] User-set timestamp."
+          );
+        }
         // If the request is from a regular API key, the request must not provide mimeType.
         if (r.data.mime_type) {
           return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -104,7 +104,7 @@ import { apiError } from "@app/logger/withlogging";
  *                 description: Description of the table
  *               timestamp:
  *                 type: number
- *                 description: Timestamp of the table
+ *                 description: Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000).
  *               tags:
  *                 type: array
  *                 items:

--- a/front/pages/api/v1/w/[wId]/spaces/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/index.ts
@@ -22,7 +22,7 @@ export type GetSpacesResponseBody =
  * @swagger
  * /api/v1/w/{wId}/spaces:
  *   get:
- *     summary: List Spaces accessible.
+ *     summary: List available spaces.
  *     description: Retrieves a list of accessible spaces for the authenticated workspace.
  *     tags:
  *       - Spaces

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -3296,7 +3296,7 @@
     },
     "/api/v1/w/{wId}/spaces": {
       "get": {
-        "summary": "List Spaces accessible.",
+        "summary": "List available spaces.",
         "description": "Retrieves a list of accessible spaces for the authenticated workspace.",
         "tags": [
           "Spaces"

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2017,7 +2017,7 @@
                   },
                   "timestamp": {
                     "type": "number",
-                    "description": "Unix timestamp (in seconds) for the document (e.g. 1698225000). Can be null or omitted."
+                    "description": "Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000)."
                   },
                   "light_document_output": {
                     "type": "boolean",
@@ -3185,7 +3185,7 @@
                   },
                   "timestamp": {
                     "type": "number",
-                    "description": "Timestamp of the table"
+                    "description": "Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000)."
                   },
                   "tags": {
                     "type": "array",


### PR DESCRIPTION
## Description

- Closes [#9849](https://github.com/dust-tt/dust/issues/9849).
- This PR updates the documentation of `/api/v1` to discourage the use of timestamp in upserted documents/tables.
- This PR also adds a log to track user-specified timestamps.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Update public documentation.
