### PR TITLE
[stripe] - refactor: handle missing subscriptions gracefully

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -297,7 +297,7 @@ async function handler(
                 event,
                 stripeSubscriptionId: invoice.subscription,
               },
-              `[Stripe Webhook] Subscription ${invoice.subscription} not found.`
+              "[Stripe Webhook] Subscription not found."
             );
             return res.status(200).json({ success: true });
           }
@@ -338,7 +338,7 @@ async function handler(
                 event,
                 stripeSubscriptionId: invoice.subscription,
               },
-              `[Stripe Webhook] Subscription ${invoice.subscription} not found.`
+              "[Stripe Webhook] Subscription not found."
             );
             return res.status(200).json({ success: true });
           }
@@ -449,7 +449,7 @@ async function handler(
                   event,
                   stripeSubscriptionId: stripeSubscription.id,
                 },
-                `[Stripe Webhook] Subscription ${stripeSubscription.id} not found.`
+                "[Stripe Webhook] Subscription not found."
               );
               return res.status(200).json({ success: true });
             }
@@ -533,7 +533,7 @@ async function handler(
                   event,
                   stripeSubscriptionId: stripeSubscription.id,
                 },
-                `[Stripe Webhook] Subscription ${stripeSubscription.id} not found.`
+                "[Stripe Webhook] Subscription not found."
               );
               return res.status(200).json({ success: true });
             }
@@ -665,7 +665,7 @@ async function handler(
                 event,
                 stripeSubscriptionId: stripeSubscription.id,
               },
-              `[Stripe Webhook] Subscription ${stripeSubscription.id} not found.`
+              "[Stripe Webhook] Subscription not found."
             );
             return res.status(200).json({ success: true });
           }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -299,6 +299,8 @@ async function handler(
               },
               "[Stripe Webhook] Subscription not found."
             );
+            // We return a 200 here to handle multiple regions, DD will watch
+            // the warnings and create an alert if this log appears in all regions
             return res.status(200).json({ success: true });
           }
           await subscription.update({ paymentFailingSince: null });
@@ -340,6 +342,8 @@ async function handler(
               },
               "[Stripe Webhook] Subscription not found."
             );
+            // We return a 200 here to handle multiple regions, DD will watch
+            // the warnings and create an alert if this log appears in all regions
             return res.status(200).json({ success: true });
           }
 
@@ -451,6 +455,8 @@ async function handler(
                 },
                 "[Stripe Webhook] Subscription not found."
               );
+              // We return a 200 here to handle multiple regions, DD will watch
+              // the warnings and create an alert if this log appears in all regions
               return res.status(200).json({ success: true });
             }
             await subscription.update({
@@ -535,6 +541,8 @@ async function handler(
                 },
                 "[Stripe Webhook] Subscription not found."
               );
+              // We return a 200 here to handle multiple regions, DD will watch
+              // the warnings and create an alert if this log appears in all regions
               return res.status(200).json({ success: true });
             }
             if (subscription.trialing) {
@@ -667,6 +675,8 @@ async function handler(
               },
               "[Stripe Webhook] Subscription not found."
             );
+            // We return a 200 here to handle multiple regions, DD will watch
+            // the warnings and create an alert if this log appears in all regions
             return res.status(200).json({ success: true });
           }
 


### PR DESCRIPTION
## Description

This PR makes sure that we no longer throw 500 when not able to find a subscription. This change is required because of the new EU cluster. 

We will create an alert in DD if the same warning occurs in both regions.

## Risk

Touches stripe, so blast radius not negligible 

## Deploy Plan

Deploy `front`
