### PR TITLE
Fix datasource tree for table query action when it's a folder

### DIFF
--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -40,7 +40,6 @@ import { getVisualForContentNode } from "@app/lib/content_nodes";
 import {
   canBeExpanded,
   getDisplayNameForDataSource,
-  isFolder,
 } from "@app/lib/data_sources";
 import {
   useDataSourceViewContentNodes,
@@ -219,12 +218,7 @@ function getDataSourceConfigurationsForTableAction(
           dsConfigs[table.dataSourceViewId] = {
             workspaceId: table.workspaceId,
             dataSourceViewId: table.dataSourceViewId,
-            filter: {
-              parents:
-                dataSourceView && isFolder(dataSourceView.dataSource)
-                  ? null
-                  : { in: [], not: [] },
-            },
+            filter: { parents: dataSourceView ? { in: [], not: [] } : null },
           };
         }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1929

The tree view for query table when tables are in a folder were wrongly displayed on the Assistant details modal. 

![Screenshot 2025-01-15 at 10 57 47](https://github.com/user-attachments/assets/35ef2667-6c5d-4a9c-9d4d-19da80464006)

![Screenshot 2025-01-15 at 10 57 33](https://github.com/user-attachments/assets/e8b7d60f-d265-4054-b7ce-4c2e6f8699c6)


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
