### PR TITLE
Fix BigInt usage with Sequelize

### DIFF
--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -202,6 +202,7 @@ SlackChatBotMessage.init(
     updatedAt: {
       type: DataTypes.DATE,
     },
+    // TODO(2025-01-15 BIGINT): This should be inferred from the relationship.
     connectorId: {
       type: DataTypes.INTEGER,
 

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -132,6 +132,7 @@ AgentConfiguration.init(
       allowNull: false,
       defaultValue: [],
     },
+    // TODO(2025-01-15 BIGINT): This should be inferred from the relationship.
     requestedGroupIds: {
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INTEGER)),
       allowNull: false,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -133,8 +133,9 @@ AgentConfiguration.init(
       defaultValue: [],
     },
     // TODO(2025-01-15 BIGINT): This should be inferred from the relationship.
+    // This is currently Integer in US and Bigint in EU. It needs to be backfilled.
     requestedGroupIds: {
-      type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INTEGER)),
+      type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT)),
       allowNull: false,
       defaultValue: [],
     },

--- a/front/lib/models/assistant/agent_message_content.ts
+++ b/front/lib/models/assistant/agent_message_content.ts
@@ -27,6 +27,7 @@ AgentMessageContent.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+    // TODO(2025-01-15 BIGINT): This should be inferred from the relationship.
     agentMessageId: {
       type: DataTypes.INTEGER,
       allowNull: false,

--- a/front/lib/models/assistant/agent_message_content.ts
+++ b/front/lib/models/assistant/agent_message_content.ts
@@ -27,11 +27,6 @@ AgentMessageContent.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    // TODO(2025-01-15 BIGINT): This should be inferred from the relationship.
-    agentMessageId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    },
     step: {
       type: DataTypes.INTEGER,
       allowNull: false,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -62,6 +62,7 @@ Conversation.init(
       allowNull: false,
       defaultValue: [],
     },
+    // TODO(2025-01-15 BIGINT): This should be inferred from the relationship.
     requestedGroupIds: {
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INTEGER)),
       allowNull: false,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -63,8 +63,9 @@ Conversation.init(
       defaultValue: [],
     },
     // TODO(2025-01-15 BIGINT): This should be inferred from the relationship.
+    // This is currently Integer in US and Bigint in EU. It needs to be backfilled.
     requestedGroupIds: {
-      type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INTEGER)),
+      type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT)),
       allowNull: false,
       defaultValue: [],
     },

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -173,13 +173,6 @@ MembershipInvitation.init(
       allowNull: false,
       defaultValue: "user",
     },
-    invitedUserId: {
-      type: DataTypes.INTEGER,
-      references: {
-        model: "users",
-        key: "id",
-      },
-    },
   },
   {
     modelName: "membership_invitation",

--- a/front/lib/resources/storage/models/apps.ts
+++ b/front/lib/resources/storage/models/apps.ts
@@ -32,11 +32,6 @@ export class AppModel extends SoftDeletableModel<AppModel> {
 }
 AppModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -159,11 +154,6 @@ export class Dataset extends BaseModel<Dataset> {
 }
 Dataset.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -222,22 +212,6 @@ Clone.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    fromId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: "apps",
-        key: "id",
-      },
-    },
-    toId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: "apps",
-        key: "id",
-      },
     },
   },
   {

--- a/front/lib/resources/storage/models/data_source.ts
+++ b/front/lib/resources/storage/models/data_source.ts
@@ -37,11 +37,6 @@ export class DataSourceModel extends SoftDeletableModel<DataSourceModel> {
 
 DataSourceModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -32,11 +32,6 @@ export class DataSourceViewModel extends SoftDeletableModel<DataSourceViewModel>
 }
 DataSourceViewModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/resources/storage/models/kill_switches.ts
+++ b/front/lib/resources/storage/models/kill_switches.ts
@@ -14,11 +14,6 @@ export class KillSwitchModel extends BaseModel<KillSwitchModel> {
 }
 KillSwitchModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -26,11 +26,6 @@ export class SpaceModel extends SoftDeletableModel<SpaceModel> {
 }
 SpaceModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -4,13 +4,14 @@ import { isLeft } from "fp-ts/Either";
 import { Parser } from "htmlparser2";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { PassThrough, Readable, Transform } from "stream";
+import { Readable } from "stream";
 
-import { Err, Ok, Result } from "./result";
+import { Err, Ok, Result } from "../result";
 import {
   readableStreamToReadable,
   RequestInitWithDuplex,
-} from "./utils/streams";
+} from "../utils/streams";
+import { transformStream } from "./transform";
 
 // Define the codec for the response.
 const TikaResponseCodec = t.type({
@@ -66,83 +67,6 @@ export function isTextExtractionSupportedContentType(
 
 const DEFAULT_HANDLER = "text";
 
-async function transformStream(
-  input: Readable,
-  prefix: string,
-  pageSelector: string
-) {
-  // If we have a page selector, we need to parse the stream and return another stream.
-  let insidePage = false;
-  let pageNumber = 0;
-  let pageDepth = 0;
-  let buffer = "";
-
-  const parser = new Parser(
-    {
-      onopentag(name, attribs) {
-        // Check if the current tag is the page selector.
-        // If it is, we are inside a page.
-        // This assumes that we don't have nested pages.
-        if (name === "div" && attribs.class === pageSelector) {
-          if (!insidePage) {
-            buffer += `\n${prefix}: ${pageNumber}\n`;
-          }
-          insidePage = true;
-          pageNumber++;
-          pageDepth = 1;
-        } else if (insidePage) {
-          // If we are inside a page, increment the page depth to handle nested divs.
-          // This is required to know when we are done with the page.
-          pageDepth++;
-        }
-      },
-      ontext(text) {
-        // If we are inside a page, append the text to the current page content.
-        if (insidePage) {
-          buffer += text.replace("&#13;", "").trim() + " ";
-        }
-      },
-      onclosetag() {
-        // If we are inside a page, decrement the page depth.
-        if (insidePage) {
-          pageDepth--;
-          // If the page depth is 0, we are done with the page.
-          if (pageDepth === 0) {
-            insidePage = false;
-          }
-        }
-      },
-      onerror(err) {
-        throw new Error(err.message);
-      },
-    },
-    { decodeEntities: true }
-  );
-
-  const htmlParsingTransform = new Transform({
-    construct(callback) {
-      callback();
-    },
-
-    transform(chunk, encoding, callback) {
-      parser.write(chunk.toString());
-      callback(null, buffer);
-      buffer = "";
-    },
-
-    flush(callback) {
-      parser.end();
-      callback(null, buffer);
-    },
-  });
-
-  const streamB = new PassThrough();
-
-  input.pipe(htmlParsingTransform).pipe(streamB);
-
-  return streamB;
-}
-
 export class TextExtraction {
   constructor(readonly url: string) {}
 
@@ -164,12 +88,6 @@ export class TextExtraction {
     fileStream: Readable,
     contentType: SupportedContentTypes
   ): Promise<Readable> {
-    // // Add error handler to input stream
-    // fileStream.on("error", (error) => {
-    //   console.error("Input stream error:", error);
-    //   throw error;
-    // });
-
     const response = await fetch(`${this.url}/tika/`, {
       method: "PUT",
       headers: {

--- a/types/src/shared/text_extraction/transform.ts
+++ b/types/src/shared/text_extraction/transform.ts
@@ -1,0 +1,182 @@
+import { Parser } from "htmlparser2";
+import { Readable, Transform } from "stream";
+
+interface ParserState {
+  insidePage: boolean;
+  pageDepth: number;
+  pageNumber: number;
+  currentPageBuffer: string;
+}
+
+export function createPageMetadataPrefix({
+  pageNumber,
+  prefix,
+}: {
+  pageNumber: number;
+  prefix: string;
+}): string {
+  return `${prefix}: ${pageNumber}`;
+}
+
+/**
+ * A Transform stream that processes HTML data from a Readable stream, extracts text from specific
+ * "page" <div> elements (identified by a known CSS class), and prefixes each extracted page's text
+ * with some custom metadata. Each complete page is pushed downstream as it is encountered.
+ *
+ * @param input - A Node.js Readable stream containing HTML
+ * @param prefix - A prefix string included in the page metadata
+ * @param pageSelector - The CSS class on <div> that identifies a page boundary
+ * @returns A new Readable stream that emits text for each page, prefixed by metadata
+ *
+ * How it works:
+ * 1. We create a single HTML parser (Parser) instance that listens to events:
+ *    - onopentag: Detects when we enter a <div class="pageSelector"> (or nested)
+ *    - ontext: Accumulates text if we are currently inside a page div
+ *    - onclosetag: Detects when we leave a page div; if that ends the page div,
+ *      we emit the stored text plus metadata
+ *    - onerror: Destroys the transform if a parsing error occurs
+ *
+ * 2. We wrap this parser in a Node Transform stream so we can:
+ *    - pipe HTML input into it (input.pipe(htmlParsingTransform))
+ *    - feed data chunks into the parser
+ *    - flush final content in _flush if the stream ends while still inside a page
+ *
+ * 3. Each completed page is emitted downstream in text form with a custom prefix block
+ */
+export function transformStream(
+  input: Readable,
+  prefix: string,
+  pageSelector: string
+): Readable {
+  // Track parser state.
+  const state: ParserState = {
+    insidePage: false,
+    pageDepth: 0,
+    pageNumber: 0,
+    currentPageBuffer: "",
+  };
+
+  // Create a single parser instance for the entire stream.
+  const parser = new Parser(
+    {
+      onopentag(name, attribs) {
+        // If this open tag is <div class="pageSelector">, we've encountered a new page.
+        // We'll track nested divs in case they exist inside the page container.
+        if (name === "div" && attribs.class === pageSelector) {
+          if (!state.insidePage) {
+            state.insidePage = true;
+            state.pageDepth = 1;
+          } else {
+            state.pageDepth++;
+          }
+        } else if (state.insidePage) {
+          // If we're already inside a page, any new tag increases the nesting depth.
+          state.pageDepth++;
+        }
+      },
+
+      ontext(text) {
+        // If in the page region, accumulate the text, removing or replacing artifacts
+        if (state.insidePage) {
+          // Replaces &#13; (carriage return) with nothing, and trims the text.
+          // Append a space to keep some spacing between tokens
+          state.currentPageBuffer += text.replace("&#13;", "").trim() + " ";
+        }
+      },
+
+      onclosetag() {
+        // If we're inside a page, decrement the nesting depth each time a tag closes.
+        if (state.insidePage) {
+          state.pageDepth--;
+
+          // If pageDepth==0, we've closed the outermost page div => a page is complete.
+          if (state.pageDepth === 0) {
+            state.insidePage = false;
+
+            // If there's any text in the buffer, emit it as a new chunk prefixed with metadata.
+            if (state.currentPageBuffer.trim()) {
+              htmlParsingTransform.push(
+                `\n${createPageMetadataPrefix({
+                  pageNumber: state.pageNumber,
+                  prefix,
+                })}\n${state.currentPageBuffer.trim()}\n`
+              );
+            }
+
+            // Reset for next page.
+            state.pageNumber++;
+            state.currentPageBuffer = "";
+          }
+        }
+      },
+
+      onerror(err) {
+        // If we encounter a parser error, destroy the transform with that error.
+        htmlParsingTransform.destroy(err);
+      },
+    },
+    { decodeEntities: true } // Instruct parser to decode HTML entities like &amp.
+  );
+
+  // Create transform stream.
+  const htmlParsingTransform = new Transform({
+    objectMode: true,
+
+    transform(chunk: Buffer, _encoding, callback) {
+      try {
+        parser.write(chunk.toString());
+        callback();
+      } catch (error) {
+        if (error instanceof Error) {
+          callback(error);
+        } else {
+          callback(
+            new Error(
+              typeof error === "string"
+                ? error
+                : "Unknown error in htmlParsingTransform.transform()"
+            )
+          );
+        }
+      }
+    },
+
+    flush(callback) {
+      try {
+        // Signal to the parser that we're done (end of the HTML input).
+        parser.end();
+
+        // If we ended the stream while still inside a page, emit any leftover text.
+        if (state.insidePage && state.currentPageBuffer.trim()) {
+          this.push(
+            `\n${createPageMetadataPrefix({
+              pageNumber: state.pageNumber,
+              prefix,
+            })}\n${state.currentPageBuffer.trim()}\n`
+          );
+        }
+
+        callback();
+      } catch (error) {
+        if (error instanceof Error) {
+          callback(error);
+        } else {
+          callback(
+            new Error(
+              typeof error === "string"
+                ? error
+                : "Unknown error in htmlParsingTransform.flush()"
+            )
+          );
+        }
+      }
+    },
+  });
+
+  // Handle errors on both streams.
+  input.on("error", (error) => htmlParsingTransform.destroy(error));
+  htmlParsingTransform.on("error", (error) => input.destroy(error));
+
+  // Pipe the input HTML stream through our transform and return the result
+  return input.pipe(htmlParsingTransform);
+}

--- a/types/src/shared/utils/streams.ts
+++ b/types/src/shared/utils/streams.ts
@@ -1,73 +1,14 @@
 import { Readable } from "stream";
+import type { ReadableStream as NodeReadableStream } from "stream/web";
 
-/**
- * This file contains utility functions for converting between different stream types.
- *
- * The two main functions are:
- *
- * 1. readableToReadableStream: Converts a Node.js Readable stream to a Web API ReadableStream.
- *    This is useful when working with APIs or environments that expect Web Streams.
- *
- * 2. readableStreamToReadable: Converts a Web API ReadableStream to a Node.js Readable stream.
- *    This allows for compatibility with Node.js stream-based APIs and operations.
- *
- * These functions enable seamless interoperability between Node.js streams and Web Streams,
- * facilitating data processing across different stream implementations.
- */
-
-// Define a type for the RequestInit object with duplex set to "half" because the official types are lagging behind
+// Define a type for the RequestInit object with duplex set to "half" because the official types are
+// lagging behind.
 export interface RequestInitWithDuplex extends RequestInit {
   duplex: "half";
 }
 
-export function readableToReadableStream(readable: Readable) {
-  return new ReadableStream({
-    start(controller) {
-      readable.on("data", (chunk) => {
-        controller.enqueue(chunk);
-      });
-      readable.on("end", () => {
-        controller.close();
-      });
-      readable.on("error", (err) => {
-        controller.error(err);
-      });
-    },
-    cancel() {
-      readable.destroy();
-    },
-  });
-}
-
-export function readableStreamToReadable(readableStream: ReadableStream) {
-  const reader = readableStream.getReader();
-  let reading = false;
-
-  return new Readable({
-    read() {
-      if (reading) {
-        return;
-      } // Prevent concurrent reads
-
-      reading = true;
-      reader.read().then(
-        ({ done, value }) => {
-          reading = false;
-          if (done) {
-            this.push(null);
-          } else {
-            // Only request more data if push() returns true
-            // This properly implements backpressure
-            if (!this.push(value)) {
-              reading = true; // Pause reading until more data is requested
-            }
-          }
-        },
-        (error) => {
-          reading = false;
-          this.destroy(error);
-        }
-      );
-    },
-  });
+export function readableStreamToReadable<T = unknown>(
+  webStream: ReadableStream<T>
+): Readable {
+  return Readable.fromWeb(webStream as NodeReadableStream<T>);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While setting up EU databases, we noticed that some ids were still created as `Integer` rather than `BigInt`. The issue stems from Sequelize that let's you override a field used in a relationships.

All primary ids are properly initialized as `BigInt` because the `BaseModel` overrides this. However, we will need to fix all relationships ids.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- US DB is already aligned, EU DB will be re-created once this is merged.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
