### PR TITLE
[content-nodes] Fill `provider_visibility` in `data_source_nodes` from `connectors` -> `api/v1`

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -18,6 +18,7 @@ export type SlackChannelType = {
   slackId: string;
   permission: ConnectorPermission;
   agentConfigurationId: string | null;
+  private: boolean;
 };
 
 export async function updateSlackChannelInConnectorsDb({
@@ -60,6 +61,7 @@ export async function updateSlackChannelInConnectorsDb({
     slackId: channel.slackChannelId,
     permission: channel.permission,
     agentConfigurationId: channel.agentConfigurationId,
+    private: channel.private,
   };
 }
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -257,6 +257,7 @@ export async function syncChannel(
       parents: [slackChannelInternalIdFromSlackChannelId(channelId)],
       mimeType: MIME_TYPES.SLACK.CHANNEL,
       sourceUrl: getSlackChannelSourceUrl(channelId, slackConfiguration),
+      providerVisibility: channel.private ? "private" : "public",
     });
   }
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -9,6 +9,7 @@ import type {
   CoreAPIFolder,
   CoreAPITable,
   PostDataSourceDocumentRequestBody,
+  ProviderVisibility,
 } from "@dust-tt/types";
 import {
   isValidDate,
@@ -1254,7 +1255,7 @@ export async function _upsertDataSourceFolder({
   title: string;
   mimeType: string;
   sourceUrl?: string;
-  providerVisibility?: string;
+  providerVisibility?: ProviderVisibility;
 }) {
   const now = new Date();
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1244,6 +1244,7 @@ export async function _upsertDataSourceFolder({
   title,
   mimeType,
   sourceUrl,
+  providerVisibility,
 }: {
   dataSourceConfig: DataSourceConfig;
   folderId: string;
@@ -1253,6 +1254,7 @@ export async function _upsertDataSourceFolder({
   title: string;
   mimeType: string;
   sourceUrl?: string;
+  providerVisibility?: string;
 }) {
   const now = new Date();
 
@@ -1265,6 +1267,7 @@ export async function _upsertDataSourceFolder({
     parents,
     mimeType,
     sourceUrl: sourceUrl ?? null,
+    providerVisibility: providerVisibility || null,
   });
 
   if (r.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -121,6 +121,7 @@ async function handler(
         title,
         mime_type,
         source_url,
+        provider_visibility,
       } = r.data;
       if (parentId && parents && parents[1] !== parentId) {
         return apiError(req, res, {
@@ -155,6 +156,7 @@ async function handler(
         title: title,
         mimeType: mime_type,
         sourceUrl: source_url ?? null,
+        providerVisibility: provider_visibility,
       });
 
       if (upsertRes.isErr()) {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -862,7 +862,7 @@ export class DustAPI {
     parents: string[];
     mimeType: string;
     sourceUrl: string | null;
-    providerVisibility: string | null;
+    providerVisibility: "public" | "private" | null;
   }) {
     const res = await this.request({
       method: "POST",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -852,6 +852,7 @@ export class DustAPI {
     parents,
     mimeType,
     sourceUrl,
+    providerVisibility,
   }: {
     dataSourceId: string;
     folderId: string;
@@ -861,6 +862,7 @@ export class DustAPI {
     parents: string[];
     mimeType: string;
     sourceUrl: string | null;
+    providerVisibility: string | null;
   }) {
     const res = await this.request({
       method: "POST",
@@ -874,6 +876,7 @@ export class DustAPI {
         parents,
         mime_type: mimeType,
         source_url: sourceUrl,
+        provider_visibility: providerVisibility,
       },
     });
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2145,6 +2145,8 @@ export type UpsertFolderResponseType = z.infer<
   typeof UpsertFolderResponseSchema
 >;
 
+const ProviderVisibilitySchema = FlexibleEnumSchema<"public" | "private">();
+
 export const UpsertDataSourceFolderRequestSchema = z.object({
   timestamp: z.number(),
   parents: z.array(z.string()).nullable().optional(),
@@ -2152,7 +2154,7 @@ export const UpsertDataSourceFolderRequestSchema = z.object({
   title: z.string(),
   mime_type: z.string(),
   source_url: z.string().nullable().optional(),
-  provider_visibility: z.string().nullable().optional(),
+  provider_visibility: ProviderVisibilitySchema.nullable().optional(),
 });
 export type UpsertDataSourceFolderRequestType = z.infer<
   typeof UpsertDataSourceFolderRequestSchema

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2152,6 +2152,7 @@ export const UpsertDataSourceFolderRequestSchema = z.object({
   title: z.string(),
   mime_type: z.string(),
   source_url: z.string().nullable().optional(),
+  provider_visibility: z.string().nullable().optional(),
 });
 export type UpsertDataSourceFolderRequestType = z.infer<
   typeof UpsertDataSourceFolderRequestSchema

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -56,6 +56,7 @@ export type ConnectorType = {
  */
 export type ConnectorPermission = "read" | "write" | "read_write" | "none";
 export type ContentNodeType = "file" | "folder" | "database" | "channel";
+export type ProviderVisibility = "public" | "private";
 
 /*
  * This constant defines the priority order for sorting content nodes by their type.
@@ -107,7 +108,7 @@ export interface ContentNode {
   preventSelection?: boolean;
   permission: ConnectorPermission;
   lastUpdatedAt: number | null;
-  providerVisibility?: "public" | "private";
+  providerVisibility?: ProviderVisibility;
 }
 
 export type ContentNodeWithParentIds = ContentNode & {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -26,6 +26,7 @@ import {
 import { LightWorkspaceType } from "../../front/user";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
+import { ProviderVisibility } from "./connectors_api";
 
 export const MAX_CHUNK_SIZE = 512;
 
@@ -1558,7 +1559,7 @@ export class CoreAPI {
     title: string;
     mimeType: string;
     sourceUrl?: string | null;
-    providerVisibility: string | null | undefined;
+    providerVisibility: ProviderVisibility | null | undefined;
   }): Promise<CoreAPIResponse<{ folder: CoreAPIFolder }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${projectId}/data_sources/${encodeURIComponent(

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1547,6 +1547,7 @@ export class CoreAPI {
     title,
     mimeType,
     sourceUrl,
+    providerVisibility,
   }: {
     projectId: string;
     dataSourceId: string;
@@ -1557,6 +1558,7 @@ export class CoreAPI {
     title: string;
     mimeType: string;
     sourceUrl?: string | null;
+    providerVisibility: string | null | undefined;
   }): Promise<CoreAPIResponse<{ folder: CoreAPIFolder }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${projectId}/data_sources/${encodeURIComponent(
@@ -1575,6 +1577,7 @@ export class CoreAPI {
           parents,
           mime_type: mimeType,
           source_url: sourceUrl,
+          provider_visibility: providerVisibility,
         }),
       }
     );


### PR DESCRIPTION
## Description

- Closes [#9952](https://github.com/dust-tt/dust/issues/9952)
- This PR fills the `providerVisibility`, passing from `connectors` to `/api/v1` and ultimately to `core` (which already supports it in its API).
- It also adds a type for it in `types` instead of using `"private" | "public"` repeatedly.
- Tested locally on Slack (only connector affected).

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Deploy connectors.
