### PR TITLE
Transform Stream Refactoring and Fix Stream Conversion

### DIFF
--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -4,13 +4,14 @@ import { isLeft } from "fp-ts/Either";
 import { Parser } from "htmlparser2";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { PassThrough, Readable, Transform } from "stream";
+import { Readable } from "stream";
 
-import { Err, Ok, Result } from "./result";
+import { Err, Ok, Result } from "../result";
 import {
   readableStreamToReadable,
   RequestInitWithDuplex,
-} from "./utils/streams";
+} from "../utils/streams";
+import { transformStream } from "./transform";
 
 // Define the codec for the response.
 const TikaResponseCodec = t.type({
@@ -66,83 +67,6 @@ export function isTextExtractionSupportedContentType(
 
 const DEFAULT_HANDLER = "text";
 
-async function transformStream(
-  input: Readable,
-  prefix: string,
-  pageSelector: string
-) {
-  // If we have a page selector, we need to parse the stream and return another stream.
-  let insidePage = false;
-  let pageNumber = 0;
-  let pageDepth = 0;
-  let buffer = "";
-
-  const parser = new Parser(
-    {
-      onopentag(name, attribs) {
-        // Check if the current tag is the page selector.
-        // If it is, we are inside a page.
-        // This assumes that we don't have nested pages.
-        if (name === "div" && attribs.class === pageSelector) {
-          if (!insidePage) {
-            buffer += `\n${prefix}: ${pageNumber}\n`;
-          }
-          insidePage = true;
-          pageNumber++;
-          pageDepth = 1;
-        } else if (insidePage) {
-          // If we are inside a page, increment the page depth to handle nested divs.
-          // This is required to know when we are done with the page.
-          pageDepth++;
-        }
-      },
-      ontext(text) {
-        // If we are inside a page, append the text to the current page content.
-        if (insidePage) {
-          buffer += text.replace("&#13;", "").trim() + " ";
-        }
-      },
-      onclosetag() {
-        // If we are inside a page, decrement the page depth.
-        if (insidePage) {
-          pageDepth--;
-          // If the page depth is 0, we are done with the page.
-          if (pageDepth === 0) {
-            insidePage = false;
-          }
-        }
-      },
-      onerror(err) {
-        throw new Error(err.message);
-      },
-    },
-    { decodeEntities: true }
-  );
-
-  const htmlParsingTransform = new Transform({
-    construct(callback) {
-      callback();
-    },
-
-    transform(chunk, encoding, callback) {
-      parser.write(chunk.toString());
-      callback(null, buffer);
-      buffer = "";
-    },
-
-    flush(callback) {
-      parser.end();
-      callback(null, buffer);
-    },
-  });
-
-  const streamB = new PassThrough();
-
-  input.pipe(htmlParsingTransform).pipe(streamB);
-
-  return streamB;
-}
-
 export class TextExtraction {
   constructor(readonly url: string) {}
 
@@ -164,12 +88,6 @@ export class TextExtraction {
     fileStream: Readable,
     contentType: SupportedContentTypes
   ): Promise<Readable> {
-    // // Add error handler to input stream
-    // fileStream.on("error", (error) => {
-    //   console.error("Input stream error:", error);
-    //   throw error;
-    // });
-
     const response = await fetch(`${this.url}/tika/`, {
       method: "PUT",
       headers: {

--- a/types/src/shared/text_extraction/transform.ts
+++ b/types/src/shared/text_extraction/transform.ts
@@ -1,0 +1,182 @@
+import { Parser } from "htmlparser2";
+import { Readable, Transform } from "stream";
+
+interface ParserState {
+  insidePage: boolean;
+  pageDepth: number;
+  pageNumber: number;
+  currentPageBuffer: string;
+}
+
+export function createPageMetadataPrefix({
+  pageNumber,
+  prefix,
+}: {
+  pageNumber: number;
+  prefix: string;
+}): string {
+  return `${prefix}: ${pageNumber}`;
+}
+
+/**
+ * A Transform stream that processes HTML data from a Readable stream, extracts text from specific
+ * "page" <div> elements (identified by a known CSS class), and prefixes each extracted page's text
+ * with some custom metadata. Each complete page is pushed downstream as it is encountered.
+ *
+ * @param input - A Node.js Readable stream containing HTML
+ * @param prefix - A prefix string included in the page metadata
+ * @param pageSelector - The CSS class on <div> that identifies a page boundary
+ * @returns A new Readable stream that emits text for each page, prefixed by metadata
+ *
+ * How it works:
+ * 1. We create a single HTML parser (Parser) instance that listens to events:
+ *    - onopentag: Detects when we enter a <div class="pageSelector"> (or nested)
+ *    - ontext: Accumulates text if we are currently inside a page div
+ *    - onclosetag: Detects when we leave a page div; if that ends the page div,
+ *      we emit the stored text plus metadata
+ *    - onerror: Destroys the transform if a parsing error occurs
+ *
+ * 2. We wrap this parser in a Node Transform stream so we can:
+ *    - pipe HTML input into it (input.pipe(htmlParsingTransform))
+ *    - feed data chunks into the parser
+ *    - flush final content in _flush if the stream ends while still inside a page
+ *
+ * 3. Each completed page is emitted downstream in text form with a custom prefix block
+ */
+export function transformStream(
+  input: Readable,
+  prefix: string,
+  pageSelector: string
+): Readable {
+  // Track parser state.
+  const state: ParserState = {
+    insidePage: false,
+    pageDepth: 0,
+    pageNumber: 0,
+    currentPageBuffer: "",
+  };
+
+  // Create a single parser instance for the entire stream.
+  const parser = new Parser(
+    {
+      onopentag(name, attribs) {
+        // If this open tag is <div class="pageSelector">, we've encountered a new page.
+        // We'll track nested divs in case they exist inside the page container.
+        if (name === "div" && attribs.class === pageSelector) {
+          if (!state.insidePage) {
+            state.insidePage = true;
+            state.pageDepth = 1;
+          } else {
+            state.pageDepth++;
+          }
+        } else if (state.insidePage) {
+          // If we're already inside a page, any new tag increases the nesting depth.
+          state.pageDepth++;
+        }
+      },
+
+      ontext(text) {
+        // If in the page region, accumulate the text, removing or replacing artifacts
+        if (state.insidePage) {
+          // Replaces &#13; (carriage return) with nothing, and trims the text.
+          // Append a space to keep some spacing between tokens
+          state.currentPageBuffer += text.replace("&#13;", "").trim() + " ";
+        }
+      },
+
+      onclosetag() {
+        // If we're inside a page, decrement the nesting depth each time a tag closes.
+        if (state.insidePage) {
+          state.pageDepth--;
+
+          // If pageDepth==0, we've closed the outermost page div => a page is complete.
+          if (state.pageDepth === 0) {
+            state.insidePage = false;
+
+            // If there's any text in the buffer, emit it as a new chunk prefixed with metadata.
+            if (state.currentPageBuffer.trim()) {
+              htmlParsingTransform.push(
+                `\n${createPageMetadataPrefix({
+                  pageNumber: state.pageNumber,
+                  prefix,
+                })}\n${state.currentPageBuffer.trim()}\n`
+              );
+            }
+
+            // Reset for next page.
+            state.pageNumber++;
+            state.currentPageBuffer = "";
+          }
+        }
+      },
+
+      onerror(err) {
+        // If we encounter a parser error, destroy the transform with that error.
+        htmlParsingTransform.destroy(err);
+      },
+    },
+    { decodeEntities: true } // Instruct parser to decode HTML entities like &amp.
+  );
+
+  // Create transform stream.
+  const htmlParsingTransform = new Transform({
+    objectMode: true,
+
+    transform(chunk: Buffer, _encoding, callback) {
+      try {
+        parser.write(chunk.toString());
+        callback();
+      } catch (error) {
+        if (error instanceof Error) {
+          callback(error);
+        } else {
+          callback(
+            new Error(
+              typeof error === "string"
+                ? error
+                : "Unknown error in htmlParsingTransform.transform()"
+            )
+          );
+        }
+      }
+    },
+
+    flush(callback) {
+      try {
+        // Signal to the parser that we're done (end of the HTML input).
+        parser.end();
+
+        // If we ended the stream while still inside a page, emit any leftover text.
+        if (state.insidePage && state.currentPageBuffer.trim()) {
+          this.push(
+            `\n${createPageMetadataPrefix({
+              pageNumber: state.pageNumber,
+              prefix,
+            })}\n${state.currentPageBuffer.trim()}\n`
+          );
+        }
+
+        callback();
+      } catch (error) {
+        if (error instanceof Error) {
+          callback(error);
+        } else {
+          callback(
+            new Error(
+              typeof error === "string"
+                ? error
+                : "Unknown error in htmlParsingTransform.flush()"
+            )
+          );
+        }
+      }
+    },
+  });
+
+  // Handle errors on both streams.
+  input.on("error", (error) => htmlParsingTransform.destroy(error));
+  htmlParsingTransform.on("error", (error) => input.destroy(error));
+
+  // Pipe the input HTML stream through our transform and return the result
+  return input.pipe(htmlParsingTransform);
+}

--- a/types/src/shared/utils/streams.ts
+++ b/types/src/shared/utils/streams.ts
@@ -1,73 +1,14 @@
 import { Readable } from "stream";
+import type { ReadableStream as NodeReadableStream } from "stream/web";
 
-/**
- * This file contains utility functions for converting between different stream types.
- *
- * The two main functions are:
- *
- * 1. readableToReadableStream: Converts a Node.js Readable stream to a Web API ReadableStream.
- *    This is useful when working with APIs or environments that expect Web Streams.
- *
- * 2. readableStreamToReadable: Converts a Web API ReadableStream to a Node.js Readable stream.
- *    This allows for compatibility with Node.js stream-based APIs and operations.
- *
- * These functions enable seamless interoperability between Node.js streams and Web Streams,
- * facilitating data processing across different stream implementations.
- */
-
-// Define a type for the RequestInit object with duplex set to "half" because the official types are lagging behind
+// Define a type for the RequestInit object with duplex set to "half" because the official types are
+// lagging behind.
 export interface RequestInitWithDuplex extends RequestInit {
   duplex: "half";
 }
 
-export function readableToReadableStream(readable: Readable) {
-  return new ReadableStream({
-    start(controller) {
-      readable.on("data", (chunk) => {
-        controller.enqueue(chunk);
-      });
-      readable.on("end", () => {
-        controller.close();
-      });
-      readable.on("error", (err) => {
-        controller.error(err);
-      });
-    },
-    cancel() {
-      readable.destroy();
-    },
-  });
-}
-
-export function readableStreamToReadable(readableStream: ReadableStream) {
-  const reader = readableStream.getReader();
-  let reading = false;
-
-  return new Readable({
-    read() {
-      if (reading) {
-        return;
-      } // Prevent concurrent reads
-
-      reading = true;
-      reader.read().then(
-        ({ done, value }) => {
-          reading = false;
-          if (done) {
-            this.push(null);
-          } else {
-            // Only request more data if push() returns true
-            // This properly implements backpressure
-            if (!this.push(value)) {
-              reading = true; // Pause reading until more data is requested
-            }
-          }
-        },
-        (error) => {
-          reading = false;
-          this.destroy(error);
-        }
-      );
-    },
-  });
+export function readableStreamToReadable<T = unknown>(
+  webStream: ReadableStream<T>
+): Readable {
+  return Readable.fromWeb(webStream as NodeReadableStream<T>);
 }


### PR DESCRIPTION
## Description
Fixes two critical issues with our streaming implementation in text extraction:

1. Stream Conversion and Backpressure:
   - Previous implementation for converting between `Readable` and `ReadableStream` did not respect stream principles, leading to broken backpressure
   - Node.js streams are designed to handle complex logic including backpressure, ensuring data flows smoothly while maintaining efficient memory footprint 
   - A previous attempted fix was reverted due to causing memory usage spikes (PR https://github.com/dust-tt/dust/pull/9811)
   - Current implementation fails to respect backpressure by not checking the return value of `this.push(value)` to determine if downstream can handle more data
   - Replaces custom code with Node's Experimental APIs (introduced in Node 17.0) that make conversion easier and ensure proper backpressure handling

2. Page Transform Stream Content Loss:
   - The transform page stream could drop parts of pages when content spanned multiple chunks
   - This occurred because buffer was being resetted for each chunk, losing state between chunks
   - Refactors the transform stream to maintain a single global parser for the entire stream
   - Adds proper handling to emit the last chunk when flushing the transform stream
   - Ensures page content integrity is maintained regardless of how it's split across chunks

## Risk
Medium - While the changes improve reliability, they touch critical text extraction code. Tested with several files locally, no issues to report. Safe to rollback.

## Deploy Plan
