### PR TITLE
Ext: bump Sparkle and fix Citation close button

### DIFF
--- a/extension/app/src/components/input_bar/InputBarCitations.tsx
+++ b/extension/app/src/components/input_bar/InputBarCitations.tsx
@@ -31,6 +31,11 @@ export function InputBarCitations({
           key={`cf-${blob.id}`}
           className="w-48"
           isLoading={blob.isUploading}
+          action={
+            <CitationClose
+              onClick={() => fileUploaderService.removeFile(blob.id)}
+            />
+          }
         >
           {isImage ? (
             <>
@@ -45,9 +50,6 @@ export function InputBarCitations({
             </CitationIcons>
           )}
           <CitationTitle>{blob.id}</CitationTitle>
-          <CitationClose
-            onClick={() => fileUploaderService.removeFile(blob.id)}
-          />
         </Citation>
       );
     }

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dust-tt/client": "^1.0.18",
-        "@dust-tt/sparkle": "^0.2.354",
+        "@dust-tt/sparkle": "^0.2.365",
         "@tailwindcss/forms": "^0.5.9",
         "@tiptap/extension-character-count": "^2.9.1",
         "@tiptap/extension-mention": "^2.9.1",
@@ -258,9 +258,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.354",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.354.tgz",
-      "integrity": "sha512-S6s7LfhQDJk84AFwe93Lys/OfHHs/Fji+UL1AmrzCP2pnFx8JavF0bGGnWSHOUDCoWz69eOsjEewoQb+7ZJZdA==",
+      "version": "0.2.365",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.365.tgz",
+      "integrity": "sha512-9IKPOaWrcj5XbOXHK9m7yi3uzzsSQKvNkDc+IsOOZbE4HvnmCavWry+W6iFPMZdxCsFUHi4kJsX/rK1/mbrtog==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@dust-tt/client": "^1.0.18",
-    "@dust-tt/sparkle": "^0.2.354",
+    "@dust-tt/sparkle": "^0.2.365",
     "@tailwindcss/forms": "^0.5.9",
     "@tiptap/extension-character-count": "^2.9.1",
     "@tiptap/extension-mention": "^2.9.1",


### PR DESCRIPTION
## Description

Bumping Sparkle and fixing the citation component. The close button was off due to a recent update on Sparkle.

## Risk

/

## Deploy Plan

Submit new package to test then release. 
