### PR TITLE
[connectors] - fix: remove connectorId field from SlackChatBotMe…

### DIFF
--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -202,12 +202,6 @@ SlackChatBotMessage.init(
     updatedAt: {
       type: DataTypes.DATE,
     },
-    // TODO(2025-01-15 BIGINT): This should be inferred from the relationship.
-    connectorId: {
-      type: DataTypes.INTEGER,
-
-      allowNull: false,
-    },
     channelId: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -265,7 +265,10 @@ SlackChatBotMessage.init(
     indexes: [{ fields: ["connectorId", "channelId", "threadTs"] }],
   }
 );
-ConnectorModel.hasOne(SlackChatBotMessage);
+ConnectorModel.hasOne(SlackChatBotMessage, {
+  foreignKey: "connectorId",
+  onDelete: "RESTRICT",
+});
 
 export class SlackBotWhitelistModel extends BaseModel<SlackBotWhitelistModel> {
   declare createdAt: CreationOptional<Date>;


### PR DESCRIPTION
## Description

This PR aims at fixing some of the db ids on connectors that were hardcoded as `integer` and should have been inferred as `bigint`

## Risk

Low

## Deploy Plan

- Apply changes in EU