### PR TITLE
fix(Snowflake) - fix the correspondence `internalId === parents[0]`

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -189,7 +189,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
           remoteDatabaseTableId: internalId,
           remoteDatabaseSecretId: connector.connectionId,
           tableDescription: "",
-          parents: [table.internalId, schemaId, table.databaseName],
+          parents: [internalId, schemaId, table.databaseName],
           parentId: schemaId,
           title: table.name,
           mimeType: MIME_TYPES.SNOWFLAKE.TABLE,


### PR DESCRIPTION
## Description

- The current implementation breaks the invariant on `internalId === parents[0]`.
- This is now prohibited in the API.

## Risk

Low.

## Deploy Plan

- Deploy connectors and let the activities get retried.