### PR TITLE
Flav/fix agent configurations return type

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -545,6 +545,8 @@ async function fetchWorkspaceAgentConfigurationsForView(
           GroupResource.modelIdToSId({ id, workspaceId: owner.id })
         )
       ),
+      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+      groupIds: [],
     };
 
     agentConfigurationTypes.push(agentConfigurationType);

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -135,6 +135,8 @@ export async function createConversation(
       owner,
       conversation
     ),
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
   };
 }
 
@@ -278,6 +280,8 @@ export async function getUserConversations(
           owner,
           p.conversation
         ),
+        // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+        groupIds: [],
       };
 
       return [...acc, conversation];
@@ -413,6 +417,8 @@ export async function getConversation(
       owner,
       conversation
     ),
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
   });
 }
 

--- a/front/lib/api/assistant/conversation/without_content.ts
+++ b/front/lib/api/assistant/conversation/without_content.ts
@@ -52,5 +52,7 @@ export async function getConversationWithoutContent(
       owner,
       conversation
     ),
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
   });
 }

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -215,6 +215,8 @@ function _getHelperGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -251,6 +253,8 @@ function _getGPT35TurboGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -296,6 +300,8 @@ function _getGPT4GlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -333,6 +339,8 @@ function _getO1GlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: false,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -370,6 +378,8 @@ function _getO1MiniGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: false,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -409,6 +419,8 @@ function _getO1HighReasoningGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: false,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -441,6 +453,8 @@ function _getClaudeInstantGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -480,6 +494,8 @@ function _getClaude2GlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -513,6 +529,8 @@ function _getClaude3HaikuGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -551,6 +569,8 @@ function _getClaude3OpusGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -593,6 +613,8 @@ function _getClaude3GlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -635,6 +657,8 @@ function _getMistralLargeGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -677,6 +701,8 @@ function _getMistralMediumGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -713,6 +739,8 @@ function _getMistralSmallGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -754,6 +782,8 @@ function _getGeminiProGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -797,6 +827,8 @@ function _getDeepSeekGlobalAgent({
     maxStepsPerRun: 3,
     visualizationEnabled: false,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -864,6 +896,8 @@ function _getManagedDataSourceAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: false,
       templateId: null,
+      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+      groupIds: [],
       requestedGroupIds: [],
     };
   }
@@ -891,6 +925,8 @@ function _getManagedDataSourceAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: false,
       templateId: null,
+      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+      groupIds: [],
       requestedGroupIds: [],
     };
   }
@@ -930,6 +966,8 @@ function _getManagedDataSourceAgent(
     maxStepsPerRun: 1,
     visualizationEnabled: false,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -1109,6 +1147,8 @@ function _getDustGlobalAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: true,
       templateId: null,
+      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+      groupIds: [],
       requestedGroupIds: [],
     };
   }
@@ -1136,6 +1176,8 @@ function _getDustGlobalAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: true,
       templateId: null,
+      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+      groupIds: [],
       requestedGroupIds: [],
     };
   }
@@ -1241,6 +1283,8 @@ function _getDustGlobalAgent(
     maxStepsPerRun: 3,
     visualizationEnabled: true,
     templateId: null,
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: [],
     requestedGroupIds: [],
   };
 }

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -49,6 +49,9 @@ export class AgentConfiguration extends BaseModel<AgentConfiguration> {
 
   declare requestedGroupIds: number[][];
 
+  // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+  declare groupIds?: number[];
+
   declare author: NonAttribute<UserModel>;
 }
 
@@ -127,6 +130,13 @@ AgentConfiguration.init(
     },
     requestedGroupIds: {
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT)),
+      allowNull: false,
+      defaultValue: [],
+    },
+
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
       allowNull: false,
       defaultValue: [],
     },

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -26,6 +26,9 @@ export class Conversation extends BaseModel<Conversation> {
 
   declare requestedGroupIds: number[][];
 
+  // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+  declare groupIds?: number[];
+
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 
@@ -56,6 +59,13 @@ Conversation.init(
     },
     requestedGroupIds: {
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT)),
+      allowNull: false,
+      defaultValue: [],
+    },
+
+    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+    groupIds: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
       allowNull: false,
       defaultValue: [],
     },

--- a/front/migrations/20240906_2_backfill_agents_groupIds.ts
+++ b/front/migrations/20240906_2_backfill_agents_groupIds.ts
@@ -46,7 +46,6 @@ async function updateAgentsForWorkspace(
 
   // no need to update agents that already have groupIds
   const agents = allAgents.filter(
-    // @ts-expect-error `groupIds` was removed.
     (agent) => !agent.groupIds || agent.groupIds.length === 0
   );
 
@@ -106,7 +105,6 @@ async function updateAgent(
 
   if (execute) {
     await AgentConfiguration.update(
-      // @ts-expect-error `groupIds` was removed.
       { groupIds },
       { where: { sId: agent.sId } }
     );

--- a/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
+++ b/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
@@ -69,12 +69,10 @@ makeScript({}, async ({ execute }, logger) => {
 
       if (execute) {
         logger.info(
-          // @ts-expect-error `groupIds` was removed.
           { agentId: agent.sId, newGroupIds, prevGroupIds: agent.groupIds },
           `Backfilling agent group IDs`
         );
         await agent.update({
-          // @ts-expect-error `groupIds` was removed.
           groupIds,
         });
       }

--- a/front/migrations/20240927_backfill_conversations_groupIds.ts
+++ b/front/migrations/20240927_backfill_conversations_groupIds.ts
@@ -117,7 +117,6 @@ async function updateConversation(
         where: { sId: agentConfigurationIds },
       })
     )
-      // @ts-expect-error `groupIds` was removed.
       .map((agent) => agent.groupIds)
       .flat()
   );

--- a/front/migrations/db/migration_143.sql
+++ b/front/migrations/db/migration_143.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jan 15, 2025
+ALTER TABLE "public"."conversations" ADD COLUMN "groupIds" INTEGER[] NOT NULL DEFAULT ARRAY[]::INTEGER[];
+ALTER TABLE "public"."agent_configurations" ADD COLUMN "groupIds" INTEGER[] NOT NULL DEFAULT ARRAY[]::INTEGER[];

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -817,6 +817,7 @@ const LightAgentConfigurationSchema = z.object({
   maxStepsPerRun: z.number(),
   visualizationEnabled: z.boolean(),
   templateId: z.string().nullable(),
+  groupIds: z.array(z.string()).optional(),
   requestedGroupIds: z.array(z.array(z.string())),
 });
 
@@ -955,6 +956,7 @@ const ConversationWithoutContentSchema = z.object({
   sId: z.string(),
   title: z.string().nullable(),
   visibility: ConversationVisibilitySchema,
+  groupIds: z.array(z.string()).optional(),
   requestedGroupIds: z.array(z.array(z.string())),
 });
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -232,6 +232,9 @@ export type LightAgentConfigurationType = {
   // Example: [[1,2], [3,4]] means (1 OR 2) AND (3 OR 4)
   requestedGroupIds: string[][];
 
+  // TODO(2024-11-04 flav) `groupIds` clean up.
+  groupIds: string[];
+
   reasoningEffort?: AgentReasoningEffort;
 };
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -232,8 +232,8 @@ export type LightAgentConfigurationType = {
   // Example: [[1,2], [3,4]] means (1 OR 2) AND (3 OR 4)
   requestedGroupIds: string[][];
 
-  // TODO(2024-11-04 flav) `groupIds` clean up.
-  groupIds: string[];
+  // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+  groupIds?: string[];
 
   reasoningEffort?: AgentReasoningEffort;
 };

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -203,8 +203,8 @@ export type ConversationWithoutContentType = {
   visibility: ConversationVisibility;
   requestedGroupIds: string[][];
 
-  // TODO(2024-11-04 flav) `group-id` clean-up.
-  groupIds: string[];
+  // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
+  groupIds?: string[];
 };
 
 /**

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -202,6 +202,9 @@ export type ConversationWithoutContentType = {
   title: string | null;
   visibility: ConversationVisibility;
   requestedGroupIds: string[][];
+
+  // TODO(2024-11-04 flav) `group-id` clean-up.
+  groupIds: string[];
 };
 
 /**


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
https://github.com/dust-tt/dust/pull/9998 broke listing agent configurations and conversations from the Chrome extension.

This PR fakes the legacy attributes `groupIds` (not used in the Chrome extension) anyway. It's temporary, to resume normal operation on the Chrome extension. This PR also make it optional in the SDK JS ensuring we will be able to phase it out in the near future.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

~Re-create the `groupIds` columns in production before deploying this.~

Filled were not yet removed in production. Adding migration for posterity.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
