### PR TITLE
Fill and backfill `sourceUrl` for Zendesk resources

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -119,5 +119,6 @@ export async function syncCategory({
     parentId: parents[1],
     title: categoryInDb.name,
     mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+    sourceUrl: categoryInDb.url,
   });
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -139,6 +139,7 @@ export async function syncZendeskBrandActivity({
     parentId: null,
     title: brandInDb.name,
     mimeType: MIME_TYPES.ZENDESK.BRAND,
+    sourceUrl: fetchedBrand?.url || brandInDb.url,
   });
 
   // using the content node to get one source of truth regarding the parent relationship
@@ -367,6 +368,7 @@ export async function syncZendeskCategoryActivity({
     parentId: parents[1],
     title: categoryInDb.name,
     mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+    sourceUrl: fetchedCategory.html_url,
   });
 
   // otherwise, we update the category name and lastUpsertedTs

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -155,6 +155,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
               parentId: parents[1],
               title: category.name,
               mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+              sourceUrl: category.url,
             });
           } else {
             /// ignoring these to proceed with the other articles, but these might have to be checked at some point

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -784,6 +784,7 @@ export async function upsertDataSourceTableFromCsv({
   useAppForHeaderDetection,
   title,
   mimeType,
+  sourceUrl,
 }: {
   dataSourceConfig: DataSourceConfig;
   tableId: string;
@@ -797,6 +798,7 @@ export async function upsertDataSourceTableFromCsv({
   useAppForHeaderDetection?: boolean;
   title: string;
   mimeType: string;
+  sourceUrl?: string;
 }) {
   const localLogger = logger.child({ ...loggerArgs, tableId, tableName });
   const statsDTags = [
@@ -837,6 +839,7 @@ export async function upsertDataSourceTableFromCsv({
     mimeType,
     timestamp: null,
     tags: null,
+    source_url: sourceUrl,
   };
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -839,7 +839,7 @@ export async function upsertDataSourceTableFromCsv({
     mimeType,
     timestamp: null,
     tags: null,
-    source_url: sourceUrl,
+    sourceUrl,
   };
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1243,6 +1243,7 @@ export async function _upsertDataSourceFolder({
   parentId,
   title,
   mimeType,
+  sourceUrl,
 }: {
   dataSourceConfig: DataSourceConfig;
   folderId: string;
@@ -1251,6 +1252,7 @@ export async function _upsertDataSourceFolder({
   parentId: string | null;
   title: string;
   mimeType: string;
+  sourceUrl?: string;
 }) {
   const now = new Date();
 
@@ -1262,6 +1264,7 @@ export async function _upsertDataSourceFolder({
     parentId,
     parents,
     mimeType,
+    sourceUrl: sourceUrl ?? null,
   });
 
   if (r.isErr()) {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -153,7 +153,7 @@ async function _upsertDataSourceDocument({
       const dustRequestPayload: PostDataSourceDocumentRequestBody = {
         text: null,
         section: documentContent,
-        source_url: documentUrl,
+        source_url: documentUrl ?? null,
         timestamp,
         title,
         mime_type: mimeType,
@@ -839,7 +839,7 @@ export async function upsertDataSourceTableFromCsv({
     mimeType,
     timestamp: null,
     tags: null,
-    sourceUrl,
+    sourceUrl: sourceUrl ?? null,
   };
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {

--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -112,6 +112,7 @@ export const TableUploadOrEditModal = ({
             useAppForHeaderDetection,
             title: table.name,
             mimeType: "text/csv",
+            sourceUrl: null,
             timestamp: undefined,
             tags: undefined,
             parentId: undefined,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -575,6 +575,7 @@ export async function upsertTable({
     useAppForHeaderDetection: useApp,
     title,
     mimeType,
+    sourceUrl: standardizedSourceUrl,
   });
 
   return tableRes;
@@ -763,6 +764,7 @@ export async function handleDataSourceTableCSVUpsert({
     useAppForHeaderDetection,
     title: params.title,
     mimeType: params.mimeType,
+    sourceUrl: params.sourceUrl ?? null,
   });
 
   if (tableRes.isErr()) {

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -451,7 +451,7 @@ export interface UpsertTableArgs {
   useAppForHeaderDetection?: boolean;
   title: string;
   mimeType: string;
-  sourceUrl: string | null;
+  sourceUrl?: string | null;
 }
 
 export async function upsertTable({

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -712,6 +712,7 @@ export async function handleDataSourceTableCSVUpsert({
         detectedHeaders,
         title: params.title,
         mimeType: params.mimeType,
+        sourceUrl: params.sourceUrl ?? null,
       },
     });
     if (enqueueRes.isErr()) {

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -272,6 +272,7 @@ const upsertTableToDatasource: ProcessingFunction = async ({
     useAppForHeaderDetection: true,
     title: upsertTitle ?? file.fileName,
     mimeType: file.contentType,
+    sourceUrl: file.getPrivateUrl(auth),
 
     // Used to override defaults, for manual file uploads where some fields are user-defined.
     ...restArgs,

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -141,6 +141,7 @@ export async function upsertTableFromCsv({
   detectedHeaders,
   title,
   mimeType,
+  sourceUrl,
 }: {
   auth: Authenticator;
   dataSource: DataSourceResource;
@@ -157,6 +158,7 @@ export async function upsertTableFromCsv({
   detectedHeaders?: DetectedHeadersType;
   title: string;
   mimeType: string;
+  sourceUrl: string | null;
 }): Promise<Result<{ table: CoreAPITable }, TableOperationError>> {
   const csvRowsRes = csv
     ? await rowsFromCsv({
@@ -253,6 +255,7 @@ export async function upsertTableFromCsv({
     parents: tableParents,
     title,
     mimeType,
+    sourceUrl,
   });
 
   if (tableRes.isErr()) {

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -52,6 +52,7 @@ export const EnqueueUpsertTable = t.type({
   detectedHeaders: t.union([DetectedHeaders, t.undefined]),
   title: t.string,
   mimeType: t.string,
+  sourceUrl: t.union([t.string, t.undefined, t.null]),
 });
 
 type EnqueueUpsertDocumentType = t.TypeOf<typeof EnqueueUpsertDocument>;

--- a/front/migrations/20250115_backfill_zendesk_source_url.ts
+++ b/front/migrations/20250115_backfill_zendesk_source_url.ts
@@ -1,0 +1,265 @@
+import type { ModelId } from "@dust-tt/types";
+import type { Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
+
+import {
+  getConnectorsReplicaDbConnection,
+  getCorePrimaryDbConnection,
+} from "@app/lib/production_checks/utils";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 128;
+
+// Copy-pasted from zendesk/lib/id_conversions.ts
+function getBrandInternalId({
+  connectorId,
+  brandId,
+}: {
+  connectorId: ModelId;
+  brandId: number;
+}): string {
+  return `zendesk-brand-${connectorId}-${brandId}`;
+}
+
+// Copy-pasted from zendesk/lib/id_conversions.ts
+function getCategoryInternalId({
+  connectorId,
+  brandId,
+  categoryId,
+}: {
+  connectorId: ModelId;
+  brandId: number;
+  categoryId: number;
+}): string {
+  return `zendesk-category-${connectorId}-${brandId}-${categoryId}`;
+}
+
+// Copy-pasted from zendesk/lib/id_conversions.ts
+function getArticleInternalId({
+  connectorId,
+  brandId,
+  articleId,
+}: {
+  connectorId: ModelId;
+  brandId: number;
+  articleId: number;
+}): string {
+  return `zendesk-article-${connectorId}-${brandId}-${articleId}`;
+}
+
+// Copy-pasted from zendesk/lib/id_conversions.ts
+function getTicketInternalId({
+  connectorId,
+  brandId,
+  ticketId,
+}: {
+  connectorId: ModelId;
+  brandId: number;
+  ticketId: number;
+}): string {
+  return `zendesk-ticket-${connectorId}-${brandId}-${ticketId}`;
+}
+
+async function updateNodes(
+  coreSequelize: Sequelize,
+  nodeIds: string[],
+  urls: string[]
+) {
+  await coreSequelize.query(
+    `UPDATE data_sources_nodes
+     SET source_url = urls.url
+     FROM (SELECT unnest(ARRAY [:nodeIds]::text[]) as node_id,
+                  unnest(ARRAY [:urls]::text[])    as url) urls
+     WHERE data_sources_nodes.node_id = urls.node_id;`,
+    { replacements: { urls, nodeIds } }
+  );
+}
+
+async function backfillBrands(
+  coreSequelize: Sequelize,
+  connectorsSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  logger.info("Processing brands");
+
+  // processing the brands all at once (~50 brands at time of writing)
+  const rows: { brandId: number; url: string; connectorId: number }[] =
+    await connectorsSequelize.query(
+      `SELECT "brandId", "url", "connectorId"
+       FROM zendesk_brands;`,
+      { type: QueryTypes.SELECT }
+    );
+
+  const urls = rows.map((row) => row.url);
+  const nodeIds = rows.map((row) => {
+    const { brandId, connectorId } = row;
+    return getBrandInternalId({ connectorId, brandId });
+  });
+  if (execute) {
+    await updateNodes(coreSequelize, nodeIds, urls);
+    logger.info(`Updated ${rows.length} brands.`);
+  } else {
+    logger.info(
+      `Would update ${rows.length} nodes, sample: ${nodeIds.slice(0, 5).join(", ")}, ${urls.slice(0, 5).join(", ")}`
+    );
+  }
+}
+
+async function backfillCategories(
+  coreSequelize: Sequelize,
+  connectorsSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  logger.info("Processing categories");
+
+  // processing the categories all at once (~200 categories at time of writing)
+  const rows: {
+    categoryId: number;
+    brandId: number;
+    url: string;
+    connectorId: number;
+  }[] = await connectorsSequelize.query(
+    `SELECT "categoryId", "brandId", "url", "connectorId"
+     FROM zendesk_categories;`,
+    { type: QueryTypes.SELECT }
+  );
+
+  const urls = rows.map((row) => row.url);
+  const nodeIds = rows.map((row) => {
+    const { categoryId, brandId, connectorId } = row;
+    return getCategoryInternalId({ connectorId, brandId, categoryId });
+  });
+  if (execute) {
+    await updateNodes(coreSequelize, nodeIds, urls);
+    logger.info(`Updated ${rows.length} categories.`);
+  } else {
+    logger.info(
+      `Would update ${rows.length} nodes, sample: ${nodeIds.slice(0, 5).join(", ")}, ${urls.slice(0, 5).join(", ")}`
+    );
+  }
+}
+
+async function backfillArticles(
+  coreSequelize: Sequelize,
+  connectorsSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  logger.info("Processing articles");
+
+  // processing the articles chunk by chunk (~8k articles at time of writing)
+  let lastId = 0;
+  let rows: {
+    id: number;
+    articleId: number;
+    brandId: number;
+    url: string;
+    connectorId: number;
+  }[] = [];
+
+  do {
+    rows = await connectorsSequelize.query(
+      `SELECT id, "articleId", "brandId", "url", "connectorId"
+       FROM zendesk_articles
+       WHERE id > :lastId
+       ORDER BY id
+       LIMIT :batchSize;`,
+      {
+        replacements: { batchSize: BATCH_SIZE, lastId },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    const urls = rows.map((row) => row.url);
+    const nodeIds = rows.map((row) => {
+      const { articleId, brandId, connectorId } = row;
+      return getArticleInternalId({ connectorId, brandId, articleId });
+    });
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    if (execute) {
+      await updateNodes(coreSequelize, nodeIds, urls);
+      logger.info(
+        `Updated ${rows.length} articles from id ${rows[0].id} to id ${rows[rows.length - 1].id}.`
+      );
+    } else {
+      logger.info(
+        `Would update ${rows.length} articles from id ${rows[0].id} to id ${rows[rows.length - 1].id}.`
+      );
+    }
+
+    lastId = rows[rows.length - 1].id;
+  } while (rows.length === BATCH_SIZE);
+}
+
+async function backfillTickets(
+  coreSequelize: Sequelize,
+  connectorsSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  logger.info("Processing tickets");
+
+  // processing the tickets chunk by chunk (>1.5M tickets at time of writing)
+  let lastId = 0;
+  let rows: {
+    id: number;
+    ticketId: number;
+    brandId: number;
+    url: string;
+    connectorId: number;
+  }[] = [];
+
+  do {
+    rows = await connectorsSequelize.query(
+      `SELECT id, "ticketId", "brandId", "url", "connectorId"
+       FROM zendesk_tickets
+       WHERE id > :lastId
+       ORDER BY id
+       LIMIT :batchSize;`,
+      {
+        replacements: { batchSize: BATCH_SIZE, lastId },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    const urls = rows.map((row) => row.url);
+    const nodeIds = rows.map((row) => {
+      const { ticketId, brandId, connectorId } = row;
+      return getTicketInternalId({ connectorId, brandId, ticketId });
+    });
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    if (execute) {
+      await updateNodes(coreSequelize, nodeIds, urls);
+      logger.info(
+        `Updated ${rows.length} tickets from id ${rows[0].id} to id ${rows[rows.length - 1].id}.`
+      );
+    } else {
+      logger.info(
+        `Would update ${rows.length} tickets from id ${rows[0].id} to id ${rows[rows.length - 1].id}.`
+      );
+    }
+
+    lastId = rows[rows.length - 1].id;
+  } while (rows.length === BATCH_SIZE);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const coreSequelize = getCorePrimaryDbConnection();
+  const connectorsSequelize = getConnectorsReplicaDbConnection();
+
+  await backfillBrands(coreSequelize, connectorsSequelize, execute, logger);
+  await backfillCategories(coreSequelize, connectorsSequelize, execute, logger);
+  await backfillArticles(coreSequelize, connectorsSequelize, execute, logger);
+  await backfillTickets(coreSequelize, connectorsSequelize, execute, logger);
+});

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -120,6 +120,7 @@ async function handler(
         parents,
         title,
         mime_type,
+        source_url,
       } = r.data;
       if (parentId && parents && parents[1] !== parentId) {
         return apiError(req, res, {
@@ -153,6 +154,7 @@ async function handler(
         parents: parents || [fId],
         title: title,
         mimeType: mime_type,
+        sourceUrl: source_url,
       });
 
       if (upsertRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -154,7 +154,7 @@ async function handler(
         parents: parents || [fId],
         title: title,
         mimeType: mime_type,
-        sourceUrl: source_url,
+        sourceUrl: source_url ?? null,
       });
 
       if (upsertRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -280,6 +280,7 @@ async function handler(
         parent_id: parentId,
         remote_database_table_id: remoteDatabaseTableId,
         remote_database_secret_id: remoteDatabaseSecretId,
+        source_url: sourceUrl,
       } = r.data;
 
       let mimeType: string;
@@ -438,6 +439,7 @@ async function handler(
         remoteDatabaseSecretId: remoteDatabaseSecretId ?? null,
         title,
         mimeType,
+        sourceUrl: sourceUrl ?? null,
       });
 
       if (upsertRes.isErr()) {

--- a/front/temporal/upsert_tables/activities.ts
+++ b/front/temporal/upsert_tables/activities.ts
@@ -92,6 +92,7 @@ export async function upsertTableActivity(
     detectedHeaders: upsertQueueItem.detectedHeaders,
     title: upsertQueueItem.title,
     mimeType: upsertQueueItem.mimeType,
+    sourceUrl: upsertQueueItem.sourceUrl ?? null,
   });
 
   if (tableRes.isErr()) {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -59,15 +59,14 @@ import {
   TokenizeResponseSchema,
   UpsertFolderResponseSchema,
 } from "./types";
-
-export * from "./types";
-
 import type { AxiosRequestConfig } from "axios";
 import axios from "axios";
 import { createParser } from "eventsource-parser";
 import http from "http";
 import https from "https";
 import { Readable } from "stream";
+
+export * from "./types";
 
 interface DustResponse {
   status: number;
@@ -832,6 +831,7 @@ export class DustAPI {
     parentId,
     parents,
     mimeType,
+    sourceUrl,
   }: {
     dataSourceId: string;
     folderId: string;
@@ -840,6 +840,7 @@ export class DustAPI {
     parentId: string | null;
     parents: string[];
     mimeType: string;
+    sourceUrl: string | null;
   }) {
     const res = await this.request({
       method: "POST",
@@ -852,6 +853,7 @@ export class DustAPI {
         parent_id: parentId,
         parents,
         mime_type: mimeType,
+        source_url: sourceUrl,
       },
     });
 

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -59,14 +59,15 @@ import {
   TokenizeResponseSchema,
   UpsertFolderResponseSchema,
 } from "./types";
+
+export * from "./types";
+
 import type { AxiosRequestConfig } from "axios";
 import axios from "axios";
 import { createParser } from "eventsource-parser";
 import http from "http";
 import https from "https";
 import { Readable } from "stream";
-
-export * from "./types";
 
 interface DustResponse {
   status: number;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2086,6 +2086,7 @@ export const UpsertDatabaseTableRequestSchema = z.object({
   remote_database_secret_id: z.string().nullable().optional(),
   title: z.string(),
   mime_type: z.string(),
+  source_url: z.string().nullable().optional(),
 });
 
 export type UpsertDatabaseTableRequestType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2150,6 +2150,7 @@ export const UpsertDataSourceFolderRequestSchema = z.object({
   parent_id: z.string().nullable().optional(),
   title: z.string(),
   mime_type: z.string(),
+  source_url: z.string().nullable().optional(),
 });
 export type UpsertDataSourceFolderRequestType = z.infer<
   typeof UpsertDataSourceFolderRequestSchema

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2151,7 +2151,7 @@ export const UpsertDataSourceFolderRequestSchema = z.object({
   parent_id: z.string().nullable().optional(),
   title: z.string(),
   mime_type: z.string(),
-  source_url: z.string().nullable(),
+  source_url: z.string().nullable().optional(),
 });
 export type UpsertDataSourceFolderRequestType = z.infer<
   typeof UpsertDataSourceFolderRequestSchema

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2150,7 +2150,7 @@ export const UpsertDataSourceFolderRequestSchema = z.object({
   parent_id: z.string().nullable().optional(),
   title: z.string(),
   mime_type: z.string(),
-  source_url: z.string().nullable().optional(),
+  source_url: z.string().nullable(),
 });
 export type UpsertDataSourceFolderRequestType = z.infer<
   typeof UpsertDataSourceFolderRequestSchema

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2016,6 +2016,7 @@ export const UpsertTableFromCsvRequestSchema = z.intersection(
       async: z.boolean().optional(),
       title: z.string(),
       mimeType: z.string(),
+      sourceUrl: z.string().nullable().optional(),
     })
     .transform((o) => ({
       name: o.name,
@@ -2029,6 +2030,7 @@ export const UpsertTableFromCsvRequestSchema = z.intersection(
       async: o.async,
       title: o.title,
       mimeType: o.mimeType,
+      sourceUrl: o.sourceUrl,
     })),
   z.union([
     z.object({ csv: z.string(), tableId: z.undefined() }).transform((o) => ({

--- a/types/src/front/api_handlers/public/data_sources.ts
+++ b/types/src/front/api_handlers/public/data_sources.ts
@@ -94,6 +94,7 @@ export const UpsertTableFromCsvRequestSchema = t.intersection([
     async: t.union([t.boolean, t.undefined]),
     title: t.string,
     mimeType: t.string,
+    sourceUrl: t.union([t.string, t.undefined, t.null]),
   }),
   // csv is optional when editing an existing table.
   t.union([

--- a/types/src/front/api_handlers/public/data_sources.ts
+++ b/types/src/front/api_handlers/public/data_sources.ts
@@ -75,6 +75,7 @@ export const PatchDataSourceTableRequestBodySchema = t.type({
   useAppForHeaderDetection: t.union([t.boolean, t.undefined]),
   title: t.string,
   mimeType: t.string,
+  sourceUrl: t.union([t.string, t.undefined, t.null]),
 });
 
 export type PatchDataSourceTableRequestBody = t.TypeOf<

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -16,7 +16,13 @@ import { dustManagedCredentials } from "../../front/lib/api/credentials";
 import { EmbeddingProviderIdType } from "../../front/lib/assistant";
 import { Project } from "../../front/project";
 import { CredentialsType } from "../../front/provider";
-import { BlockType, RunConfig, RunRunType, RunStatus, TraceType } from "../../front/run";
+import {
+  BlockType,
+  RunConfig,
+  RunRunType,
+  RunStatus,
+  TraceType,
+} from "../../front/run";
 import { LightWorkspaceType } from "../../front/user";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1543,6 +1543,7 @@ export class CoreAPI {
     parents,
     title,
     mimeType,
+    sourceUrl,
   }: {
     projectId: string;
     dataSourceId: string;
@@ -1552,6 +1553,7 @@ export class CoreAPI {
     parents: string[];
     title: string;
     mimeType: string;
+    sourceUrl: string | null;
   }): Promise<CoreAPIResponse<{ folder: CoreAPIFolder }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${projectId}/data_sources/${encodeURIComponent(
@@ -1569,6 +1571,7 @@ export class CoreAPI {
           parent_id: parentId,
           parents,
           mime_type: mimeType,
+          source_url: sourceUrl,
         }),
       }
     );

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1550,7 +1550,7 @@ export class CoreAPI {
     parents: string[];
     title: string;
     mimeType: string;
-    sourceUrl: string | null;
+    sourceUrl?: string | null;
   }): Promise<CoreAPIResponse<{ folder: CoreAPIFolder }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${projectId}/data_sources/${encodeURIComponent(

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -16,13 +16,7 @@ import { dustManagedCredentials } from "../../front/lib/api/credentials";
 import { EmbeddingProviderIdType } from "../../front/lib/assistant";
 import { Project } from "../../front/project";
 import { CredentialsType } from "../../front/provider";
-import {
-  BlockType,
-  RunConfig,
-  RunRunType,
-  RunStatus,
-  TraceType,
-} from "../../front/run";
+import { BlockType, RunConfig, RunRunType, RunStatus, TraceType } from "../../front/run";
 import { LightWorkspaceType } from "../../front/user";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
@@ -1113,6 +1107,7 @@ export class CoreAPI {
     remoteDatabaseSecretId,
     title,
     mimeType,
+    sourceUrl,
   }: {
     projectId: string;
     dataSourceId: string;
@@ -1127,6 +1122,7 @@ export class CoreAPI {
     remoteDatabaseSecretId?: string | null;
     title: string;
     mimeType: string;
+    sourceUrl: string | null;
   }): Promise<CoreAPIResponse<{ table: CoreAPITable }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
@@ -1149,6 +1145,7 @@ export class CoreAPI {
           remote_database_secret_id: remoteDatabaseSecretId ?? null,
           title,
           mime_type: mimeType,
+          source_url: sourceUrl,
         }),
       }
     );


### PR DESCRIPTION
## Description

- Part of [#9949](https://github.com/dust-tt/dust/issues/9949)
- Part of [#9950](https://github.com/dust-tt/dust/issues/9950)
- This PR adds the `sourceUrl` parameter to the client and the endpoint in `api/v1` for tables and folders (already there for documents, named `documentUrl`).
- This PR fills and backfills the `sourceUrl` correctly for Zendesk instances:
  - Brands (same logic as in the content nodes in `toContentNode`).
  - Categories (same logic as in the content nodes in `toContentNode`).
  - not help centers and tickets (don't have an URL), articles and documents already OK.
- This PR also fills the `sourceUrl` for folders upserts.

<img width="359" alt="Screenshot 2025-01-16 at 7 23 42 AM" src="https://github.com/user-attachments/assets/6b148611-bb83-4f31-aa13-7e19c405f2a3" />

- Backfill script tested with various batch sizes: > total number of tickets, 1, 2.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Deploy connectors.
- Run the backfill.