### PR TITLE
[Nodes Core] Create CoreAPI's searchNodes

### DIFF
--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -178,11 +178,11 @@ pub struct CoreContentNode {
     #[serde(flatten)]
     pub base: Node,
     pub has_children: bool,
-    pub parent_title: String,
+    pub parent_title: Option<String>,
 }
 
 impl CoreContentNode {
-    pub fn new(base: Node, has_children: bool, parent_title: String) -> Self {
+    pub fn new(base: Node, has_children: bool, parent_title: Option<String>) -> Self {
         CoreContentNode {
             base,
             has_children,

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -373,8 +373,7 @@ impl ElasticsearchSearchStore {
                     .parent_id
                     .as_ref()
                     .and_then(|pid| parent_titles_map.get(pid))
-                    .cloned()
-                    .unwrap_or_default();
+                    .cloned();
 
                 CoreContentNode::new(node, has_children, parent_title)
             })

--- a/types/src/core/content_node.ts
+++ b/types/src/core/content_node.ts
@@ -1,0 +1,22 @@
+import {
+  ContentNodeType,
+  ProviderVisibility,
+} from "../front/lib/connectors_api";
+
+type CoreAPIContentNodeType = "Document" | "Table" | "Folder";
+
+export type CoreAPIContentNode = {
+  data_source_id: string;
+  data_source_internal_id: string;
+  node_id: string;
+  node_type: CoreAPIContentNodeType;
+  timestamp: number;
+  title: string;
+  mime_type: string;
+  provider_visibility?: ProviderVisibility;
+  parent_id?: string;
+  parents: string[];
+  source_url?: string;
+  has_children: boolean;
+  parent_title: string;
+};

--- a/types/src/core/content_node.ts
+++ b/types/src/core/content_node.ts
@@ -1,7 +1,4 @@
-import {
-  ContentNodeType,
-  ProviderVisibility,
-} from "../front/lib/connectors_api";
+import { ProviderVisibility } from "../front/lib/connectors_api";
 
 type CoreAPIContentNodeType = "Document" | "Table" | "Folder";
 
@@ -18,5 +15,5 @@ export type CoreAPIContentNode = {
   parents: string[];
   source_url?: string;
   has_children: boolean;
-  parent_title: string;
+  parent_title?: string;
 };

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -69,6 +69,9 @@ export const contentNodeTypeSortOrder: Record<ContentNodeType, number> = {
   channel: 4,
 };
 
+// currently used for slack, for which channels can be public or private
+export type ProviderVisibility = "private" | "public";
+
 /**
  * A ContentNode represents a connector related node. As an example:
  * - Notion: Top-level pages (possibly manually added lower level ones)
@@ -107,7 +110,7 @@ export interface ContentNode {
   preventSelection?: boolean;
   permission: ConnectorPermission;
   lastUpdatedAt: number | null;
-  providerVisibility?: "public" | "private";
+  providerVisibility?: ProviderVisibility;
 }
 
 export type ContentNodeWithParentIds = ContentNode & {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1,5 +1,6 @@
 import { createParser } from "eventsource-parser";
 
+import { CoreAPIContentNode } from "../../core/content_node";
 import {
   CoreAPIDataSource,
   CoreAPIDataSourceConfig,
@@ -166,6 +167,22 @@ export type CoreAPISearchFilter = {
     gt: number | null;
     lt: number | null;
   } | null;
+};
+
+export type CoreAPISearchOptions = {
+  limit?: number;
+  offset?: number;
+};
+
+export type CoreAPIDatasourceViewFilter = {
+  data_source_id: string;
+  view_filter: string[];
+};
+
+export type CoreAPINodesSearchFilter = {
+  data_source_views: CoreAPIDatasourceViewFilter[];
+  node_ids?: string[];
+  parent_id?: string;
 };
 
 export class CoreAPI {
@@ -1507,6 +1524,33 @@ export class CoreAPI {
         method: "GET",
       }
     );
+    return this._resultFromResponse(response);
+  }
+
+  async searchNodes({
+    query,
+    filter,
+    options,
+  }: {
+    query?: string;
+    filter: CoreAPINodesSearchFilter;
+    options?: CoreAPISearchOptions;
+  }): Promise<
+    CoreAPIResponse<{
+      nodes: CoreAPIContentNode[];
+    }>
+  > {
+    const response = await this._fetchWithError(`${this._url}/nodes/search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query,
+        filter,
+        options,
+      }),
+    });
     return this._resultFromResponse(response);
   }
 


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1936

Complete CoreAPI in types to call the search endpoint

Also makes parent_title optional

Risks
---
na

Deploy
---
core

