### PR TITLE
fix(`api/v1`) - fix the parents validation in `tables/index`

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -399,7 +399,7 @@ async function handler(
             },
           });
         }
-        if (parents[0] !== req.query.documentId) {
+        if (parents[0] !== maybeTableId) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {


### PR DESCRIPTION
## Description

- The endpoint in `api/v1` on `tables/index` relied on by Snowflake only (`upsertDataSourceRemoteTable`) implements an incorrect validation on parents.
- This endpoint adds an extra `tableId` implicit generation that may break the parents comparison.
- The bottom line here is to rationalize between the use of `tables/index` and `tables/[tId]/index`, which won't be addressed in this PR.

## Risk

- Low

## Deploy Plan

- Deploy front