### PR TITLE
[front] fix build by removing duplicate types

### DIFF
--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -1,4 +1,7 @@
-import { AdminCommandType, AdminResponseType } from "../../connectors/admin/cli";
+import {
+  AdminCommandType,
+  AdminResponseType,
+} from "../../connectors/admin/cli";
 import { ConnectorsAPIError, isConnectorsAPIError } from "../../connectors/api";
 import { UpdateConnectorConfigurationType } from "../../connectors/api_handlers/connector_configuration";
 import { ConnectorCreateRequestBody } from "../../connectors/api_handlers/create_connector";

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -1,7 +1,4 @@
-import {
-  AdminCommandType,
-  AdminResponseType,
-} from "../../connectors/admin/cli";
+import { AdminCommandType, AdminResponseType } from "../../connectors/admin/cli";
 import { ConnectorsAPIError, isConnectorsAPIError } from "../../connectors/api";
 import { UpdateConnectorConfigurationType } from "../../connectors/api_handlers/connector_configuration";
 import { ConnectorCreateRequestBody } from "../../connectors/api_handlers/create_connector";
@@ -56,6 +53,7 @@ export type ConnectorType = {
  */
 export type ConnectorPermission = "read" | "write" | "read_write" | "none";
 export type ContentNodeType = "file" | "folder" | "database" | "channel";
+// currently used for Slack, for which channels can be public or private
 export type ProviderVisibility = "public" | "private";
 
 /*
@@ -69,9 +67,6 @@ export const contentNodeTypeSortOrder: Record<ContentNodeType, number> = {
   database: 3,
   channel: 4,
 };
-
-// currently used for slack, for which channels can be public or private
-export type ProviderVisibility = "private" | "public";
 
 /**
  * A ContentNode represents a connector related node. As an example:


### PR DESCRIPTION
## Description

- The two PRs https://github.com/dust-tt/dust/pull/10012 and https://github.com/dust-tt/dust/pull/9988 were merged closely in time and the rebase did not raise a conflict on a part that actually created an error.
- This PR fixes that.

## Risk

- Low.

## Deploy Plan

- Deploy front.