### PR TITLE
Add Poke Plugin to set connector error and pause.

### DIFF
--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -21,6 +21,10 @@ const whitelistedCommands = [
     command: "find-url",
   },
   { majorCommand: "slack", command: "whitelist-bot" },
+  {
+    majorCommand: "connectors",
+    command: "set-error",
+  },
 ];
 
 const _adminAPIHandler = async (

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -1,3 +1,3 @@
 export * from "./garbage_collect_google_drive_document";
-export * from "./operations";
 export * from "./mark_connector_as_error";
+export * from "./operations";

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -1,2 +1,3 @@
 export * from "./garbage_collect_google_drive_document";
 export * from "./operations";
+export * from "./mark_connector_as_error";

--- a/front/lib/api/poke/plugins/data_sources/mark_connector_as_error.ts
+++ b/front/lib/api/poke/plugins/data_sources/mark_connector_as_error.ts
@@ -1,0 +1,84 @@
+import {
+  AdminCommandType,
+  assertNever,
+  CONNECTORS_ERROR_TYPES,
+  ConnectorsAPI,
+  Err,
+  Ok,
+} from "@dust-tt/types";
+
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+import { isManaged, isWebsite } from "@app/lib/data_sources";
+
+export const markConnectorAsErrorPlugin = createPlugin(
+  {
+    id: "mark-connector-as-error",
+    name: "Mark connector as error",
+    description: "Mark a connector as errored with a specific error type",
+    resourceTypes: ["data_sources"],
+    args: {
+      errorType: {
+        type: "enum",
+        label: "Error Type",
+        description: "Select error type to set",
+        values: CONNECTORS_ERROR_TYPES,
+      },
+    },
+  },
+  async (auth, dataSourceId, args) => {
+    if (!dataSourceId) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    if (!isManaged(dataSource) && !isWebsite(dataSource)) {
+      return new Err(new Error("Data source is not managed or website."));
+    }
+
+    const { connectorId } = dataSource;
+    if (!connectorId) {
+      return new Err(new Error("No connector on datasource."));
+    }
+
+    const { errorType } = args;
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    // First set the error.
+    const setErrorCommand: AdminCommandType = {
+      majorCommand: "connectors",
+      command: "set-error",
+      args: {
+        connectorId: connectorId.toString(),
+        error: errorType,
+        wId: auth.getNonNullableWorkspace().sId,
+        dsId: dataSource.sId,
+      },
+    };
+
+    const setErrorRes = await connectorsAPI.admin(setErrorCommand);
+    if (setErrorRes.isErr()) {
+      return new Err(new Error(setErrorRes.error.message));
+    }
+
+    // Then pause it.
+    const pauseRes = await connectorsAPI.pauseConnector(connectorId.toString());
+    if (pauseRes.isErr()) {
+      return new Err(new Error(pauseRes.error.message));
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Connector ${connectorId} marked as ${errorType} and paused.`,
+    });
+  }
+);

--- a/front/lib/api/poke/plugins/data_sources/mark_connector_as_error.ts
+++ b/front/lib/api/poke/plugins/data_sources/mark_connector_as_error.ts
@@ -1,17 +1,11 @@
-import {
-  AdminCommandType,
-  assertNever,
-  CONNECTORS_ERROR_TYPES,
-  ConnectorsAPI,
-  Err,
-  Ok,
-} from "@dust-tt/types";
+import type { AdminCommandType } from "@dust-tt/types";
+import { CONNECTORS_ERROR_TYPES, ConnectorsAPI, Err, Ok } from "@dust-tt/types";
 
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
+import { isManaged, isWebsite } from "@app/lib/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
-import { isManaged, isWebsite } from "@app/lib/data_sources";
 
 export const markConnectorAsErrorPlugin = createPlugin(
   {

--- a/front/lib/api/poke/plugins/data_sources/operations.ts
+++ b/front/lib/api/poke/plugins/data_sources/operations.ts
@@ -52,13 +52,11 @@ export const connectorOperationsPlugin = createPlugin(
     }
 
     const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
-
     if (!dataSource) {
       return new Err(new Error("Data source not found."));
     }
 
     const { connectorId } = dataSource;
-
     if (!connectorId) {
       return new Err(new Error("No connector on datasource."));
     }

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -14,7 +14,7 @@ import { Err, Ok, Result } from "../../shared/result";
 
 export type ConnectorsAPIResponse<T> = Result<T, ConnectorsAPIError>;
 export type ConnectorSyncStatus = "succeeded" | "failed";
-const CONNECTORS_ERROR_TYPES = [
+export const CONNECTORS_ERROR_TYPES = [
   "oauth_token_revoked",
   "third_party_internal_error",
   "webcrawling_error",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a Poke plugin to mark a connector as error (e.g `oauth_token_revoked`) this is very handy as Eng runner.

<img width="711" alt="image" src="https://github.com/user-attachments/assets/434984b3-062d-4cbf-b78a-8201f285f6cd" />

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [ ] Deploy connectors
- [ ] Deploy front
