### PR TITLE
Workspaces: Add column conversationsRetentionDays

### DIFF
--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -27,6 +27,7 @@ export class Workspace extends BaseModel<Workspace> {
   declare subscriptions: NonAttribute<Subscription[]>;
   declare whiteListedProviders: ModelProviderIdType[] | null;
   declare defaultEmbeddingProvider: EmbeddingProviderIdType | null;
+  declare conversationsRetentionDays: number | null;
 }
 Workspace.init(
   {
@@ -58,6 +59,10 @@ Workspace.init(
     ssoEnforced: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
+    },
+    conversationsRetentionDays: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
     whiteListedProviders: {
       type: DataTypes.ARRAY(DataTypes.STRING),

--- a/front/migrations/db/migration_144.sql
+++ b/front/migrations/db/migration_144.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jan 16, 2025
+ALTER TABLE "public"."workspaces" ADD COLUMN "conversationsRetentionDays" INTEGER;


### PR DESCRIPTION
## Description

Add a column `conversationsRetentionDays` to allow some workspaces to specify a number of days before conversations are deleted. 

## Risk

Column is nullable so should be quick.

## Deploy Plan

Run migration 144
Deploy front. 
