### PR TITLE
Upg: use statsD to send temporal metrics.

### DIFF
--- a/alerting/temporal/package-lock.json
+++ b/alerting/temporal/package-lock.json
@@ -8,9 +8,9 @@
       "name": "temporal-promql-to-dd.ts",
       "version": "0.1.0",
       "dependencies": {
-        "@datadog/datadog-api-client": "^1.17.0",
         "axios": "^1.5.1",
         "dd-trace": "^5.1.0",
+        "hot-shots": "^10.2.1",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -29,26 +29,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@datadog/datadog-api-client": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.17.0.tgz",
-      "integrity": "sha512-iZuQmJDe+7PRzWZ40fYp/IfDJS9uNONBZvNNpjOjn1j9XplzlloJtyX1clRm/Hql7qHfK5+xrJR1HT4p1X/zRw==",
-      "dependencies": {
-        "@types/buffer-from": "^1.1.0",
-        "@types/node": "*",
-        "@types/pako": "^1.0.3",
-        "buffer-from": "^1.1.2",
-        "cross-fetch": "^3.1.5",
-        "es6-promise": "^4.2.8",
-        "form-data": "^4.0.0",
-        "loglevel": "^1.8.1",
-        "pako": "^2.0.4",
-        "url-parse": "^1.4.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@datadog/native-appsec": {
@@ -261,14 +241,6 @@
       "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
       "dev": true
     },
-    "node_modules/@types/buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-BLFpLBcN+RPKUsFxqRkMiwqTOOdi+TrKr5OpLJ9qCnUdSxS6S80+QRX/mIhfR66u0Ykc4QTkReaejOM2ILh+9Q==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.12.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
@@ -276,11 +248,6 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
-    },
-    "node_modules/@types/pako": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.5.tgz",
-      "integrity": "sha512-cg6x1RjMyCYoAdhOyNC/144EqhdHJXXZiiTgN3o+ZtOu4+ZQVN5msZgNyxzDI1w+dMYDdRamDzto3+bkR3FFQQ=="
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -331,10 +298,14 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.3",
@@ -357,14 +328,6 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
     },
     "node_modules/crypto-randomuuid": {
       "version": "1.0.0",
@@ -457,15 +420,16 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
     "node_modules/event-lite": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
       "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw=="
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -497,6 +461,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/hot-shots": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-10.2.1.tgz",
+      "integrity": "sha512-tmjcyZkG/qADhcdC7UjAp8D7v7W2DOYFgaZ48fYMuayMQmVVUg8fntKmrjes/b40ef6yZ+qt1lB8kuEDfLC4zw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.x"
       }
     },
     "node_modules/ieee754": {
@@ -592,18 +567,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
-    "node_modules/loglevel": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
-      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/loglevel"
-      }
-    },
     "node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
@@ -669,6 +632,12 @@
         "msgpack": "bin/msgpack"
       }
     },
+    "node_modules/nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "optional": true
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -678,25 +647,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/node-gyp-build": {
       "version": "3.9.0",
@@ -729,11 +679,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -772,16 +717,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -828,11 +763,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
       "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw=="
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -902,13 +832,18 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+    "node_modules/unix-dgram": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.6.tgz",
+      "integrity": "sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==",
+      "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
+        "bindings": "^1.5.0",
+        "nan": "^2.16.0"
+      },
+      "engines": {
+        "node": ">=0.10.48"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -916,20 +851,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/alerting/temporal/package.json
+++ b/alerting/temporal/package.json
@@ -11,9 +11,9 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "^1.17.0",
     "axios": "^1.5.1",
     "dd-trace": "^5.1.0",
+    "hot-shots": "^10.2.1",
     "zod": "^3.22.4"
   }
 }

--- a/alerting/temporal/src/index.ts
+++ b/alerting/temporal/src/index.ts
@@ -1,9 +1,10 @@
-import { client, v2 } from "@datadog/datadog-api-client";
+import assert from "assert";
 import axios from "axios";
 import { Agent } from "https";
 import { z } from "zod";
 import * as fs from "fs";
 import { collectMetricsFromQdrant } from "./qdrant";
+import statsDClient from "hot-shots";
 
 /**
  * This service polls the Temporal Cloud Prometheus endpoint and submits the metrics to Datadog.
@@ -21,22 +22,12 @@ const TARGET_METRIC_NAMES = [
   "temporal_cloud_v0_schedule_rate_limited_count",
 ];
 
-const requireEnvVar = (variableName: string): string => {
-  const value = process.env[variableName];
-  if (!value) {
-    throw new Error(`Missing environment variable ${variableName}`);
-  }
-  return value;
-};
+const { METRICS_CLIENT_CERT, METRICS_CLIENT_KEY, TEMPORAL_CLOUD_BASE_URL } =
+  process.env;
 
-// Required env variables
-const METRICS_CLIENT_CERT = requireEnvVar("METRICS_CLIENT_CERT");
-const METRICS_CLIENT_KEY = requireEnvVar("METRICS_CLIENT_KEY");
-const TEMPORAL_CLOUD_BASE_URL = requireEnvVar("TEMPORAL_CLOUD_BASE_URL");
-
-// This automatically pulls API keys from env vars DD_API_KEY
-const configuration = client.createConfiguration();
-//End Required env variables
+assert(METRICS_CLIENT_CERT, "METRICS_CLIENT_CERT env var is not set.");
+assert(METRICS_CLIENT_KEY, "METRICS_CLIENT_KEY env var is not set.");
+assert(TEMPORAL_CLOUD_BASE_URL, "TEMPORAL_CLOUD_BASE_URL env var is not set.");
 
 const PROM_LABELS_URL = `${TEMPORAL_CLOUD_BASE_URL}/prometheus/api/v1/label/__name__/values`;
 const PROM_QUERY_URL = `${TEMPORAL_CLOUD_BASE_URL}/prometheus/api/v1/query_range`;
@@ -53,11 +44,9 @@ const QUERY_WINDOW_SECONDS = 1 * 60;
 
 const HISTOGRAM_QUANTILES = [0.5, 0.9, 0.95, 0.99];
 
-configuration.setServerVariables({
-  site: "datadoghq.eu", // We're using the EU site for Datadog
+const statsD = new statsDClient({
+  prefix: DATADOG_METRIC_PREFIX,
 });
-const datadogMetricsApi = new v2.MetricsApi(configuration);
-const logApi = new v2.LogsApi(configuration);
 
 const setTimeoutAsync = async (millis: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, millis));
@@ -196,25 +185,18 @@ const queryPrometheusCount = async (
 const convertPrometheusCountToDatadogRateSeries = (
   metricName: string,
   metricData: MetricData
-): v2.MetricSeries[] =>
-  metricData.result.map((prometheusMetric) => ({
-    // We need to inform datadog of the interval for this metric
-    interval: PROMETHEUS_STEP_SECONDS,
-    // Make it easier for the datadog user to understand what this metric is
-    metric: DATADOG_METRIC_PREFIX + metricName.split("_count")[0] + "_rate1m",
-    // Type 2 is a "rate" metric
-    type: 2,
-    points: prometheusMetric.values.map(([timestamp, value]) => {
-      return {
-        timestamp: timestamp,
-        value: parseFloat(value),
-      };
-    }),
-    tags: Object.entries(prometheusMetric.metric)
+): void => {
+  metricData.result.forEach((prometheusMetric) => {
+    const metric = metricName.split("_count")[0] + "_rate1m";
+    const tags = Object.entries(prometheusMetric.metric)
       .filter(([key]) => key !== "__rollup__")
-      // Datadog tags can't be longer than 200 characters
-      .map(([key, value]) => `${key}:${value.substring(0, 200)}`),
-  }));
+      .map(([key, value]) => `${key}:${value.substring(0, 200)}`);
+
+    prometheusMetric.values.forEach(([_timestamp, value]) => {
+      statsD.gauge(metric, parseFloat(value), tags);
+    });
+  });
+};
 
 const queryPrometheusHistogram = async (
   metricName: string,
@@ -246,27 +228,18 @@ const convertPrometheusHistogramToDatadogGuageSeries = (
   metricName: string,
   quantile: number,
   metricData: MetricData
-): v2.MetricSeries[] =>
-  metricData.result.map((prometheusMetric) => ({
-    // Make it easier for the datadog user to understand what this metric is
-    metric:
-      DATADOG_METRIC_PREFIX +
-      metricName.split("_bucket")[0] +
-      "_P" +
-      quantile * 100,
-    // Type 2 is a "guage" metric
-    type: 3,
-    points: prometheusMetric.values.map(([timestamp, value]) => {
-      return {
-        timestamp: timestamp,
-        value: parseFloat(value),
-      };
-    }),
-    tags: Object.entries(prometheusMetric.metric)
+): void => {
+  metricData.result.forEach((prometheusMetric) => {
+    const metric = metricName.split("_bucket")[0] + "_P" + quantile * 100;
+    const tags = Object.entries(prometheusMetric.metric)
       .filter(([key]) => key !== "__rollup__")
-      // Datadog tags can't be longer than 200 characters
-      .map(([key, value]) => `${key}:${value.substring(0, 200)}`),
-  }));
+      .map(([key, value]) => `${key}:${value.substring(0, 200)}`);
+
+    prometheusMetric.values.forEach(([_timestamp, value]) => {
+      statsD.gauge(metric, parseFloat(value), tags);
+    });
+  });
+};
 
 const main = async () => {
   const metricsName = await getMetricNames();
@@ -278,69 +251,49 @@ const main = async () => {
   while (true) {
     const queryWindow = generateQueryWindow();
 
-    console.log({
-      level: "info",
-      message: "Collecting metrics from temporal cloud.",
-      startDate: new Date(
-        queryWindow.startSecondsSinceEpoch * 1000
-      ).toISOString(),
-      endDate: new Date(queryWindow.endSecondsSinceEpoch * 1000).toISOString(),
-    });
+    statsD.increment("temporal_metrics.collection.start");
 
-    const countSeries = (
-      await Promise.all(
-        countMetricNames.map(async (metricName) =>
-          convertPrometheusCountToDatadogRateSeries(
-            metricName,
-            await queryPrometheusCount(metricName, generateQueryWindow())
-          )
+    // Process count metrics
+    await Promise.all(
+      countMetricNames.map(async (metricName) => {
+        const data = await queryPrometheusCount(
+          metricName,
+          generateQueryWindow()
+        );
+        convertPrometheusCountToDatadogRateSeries(metricName, data);
+      })
+    );
+
+    // Process histogram metrics
+    await Promise.all(
+      histogramMetricNames.map(async (metricName) =>
+        Promise.all(
+          HISTOGRAM_QUANTILES.map(async (quantile) => {
+            const data = await queryPrometheusHistogram(
+              metricName,
+              quantile,
+              generateQueryWindow()
+            );
+            convertPrometheusHistogramToDatadogGuageSeries(
+              metricName,
+              quantile,
+              data
+            );
+          })
         )
       )
-    ).flat();
+    );
 
-    const guageSeries = (
-      await Promise.all(
-        histogramMetricNames.map(async (metricName) =>
-          Promise.all(
-            HISTOGRAM_QUANTILES.map(async (quantile) =>
-              convertPrometheusHistogramToDatadogGuageSeries(
-                metricName,
-                quantile,
-                await queryPrometheusHistogram(
-                  metricName,
-                  quantile,
-                  generateQueryWindow()
-                )
-              )
-            )
-          )
-        )
-      )
-    ).flat(2);
+    statsD.increment("temporal_metrics.collection.success");
 
-    console.log({
-      level: "info",
-      message: "Submitting Temporal metrics to Datadog",
-    });
-    await datadogMetricsApi.submitMetrics({
-      body: { series: [...countSeries, ...guageSeries] },
-    });
-
-    console.log({
-      level: "info",
-      message: "Submitting Qdrant metrics to Datadog",
-    });
+    // Collect Qdrant metrics
     await collectMetricsFromQdrant();
-
-    console.log({ level: "info", message: "Pausing for 60s" });
     await setTimeoutAsync(60 * 1000);
   }
 };
 
+// Update error handling to use StatsD
 main().catch((error) => {
-  console.log({
-    level: "error",
-    message: "Error in main loop. Closing healthcheck server.",
-    error,
-  });
+  statsD.increment("temporal_metrics.collection.error");
+  console.error("Error in main loop:", error);
 });

--- a/alerting/temporal/src/index.ts
+++ b/alerting/temporal/src/index.ts
@@ -193,7 +193,7 @@ const convertPrometheusCountToDatadogRateSeries = (
       .map(([key, value]) => `${key}:${value.substring(0, 200)}`);
 
     prometheusMetric.values.forEach(([_timestamp, value]) => {
-      statsD.gauge(metric, parseFloat(value), tags);
+      statsD.increment(metric, parseFloat(value), 1.0, tags);
     });
   });
 };

--- a/alerting/temporal/src/index.ts
+++ b/alerting/temporal/src/index.ts
@@ -233,6 +233,7 @@ const convertPrometheusHistogramToDatadogGuageSeries = (
     const metric = metricName.split("_bucket")[0] + "_P" + quantile * 100;
     const tags = Object.entries(prometheusMetric.metric)
       .filter(([key]) => key !== "__rollup__")
+      // Datadog tags can't be longer than 200 characters
       .map(([key, value]) => `${key}:${value.substring(0, 200)}`);
 
     prometheusMetric.values.forEach(([_timestamp, value]) => {

--- a/alerting/temporal/src/qdrant/index.ts
+++ b/alerting/temporal/src/qdrant/index.ts
@@ -107,11 +107,7 @@ async function fetchPrometheusMetrics(clusterNodeUrl: string): Promise<void> {
       // Ignore comments.
       .filter((l: string) => !l.startsWith("#"));
 
-    const tags = [
-      `cluster:${clusterName}`,
-      `node:${node}`,
-      `region:${process.env.DUST_REGION}`,
-    ];
+    const tags = [`cluster:${clusterName}`, `node:${node}`];
 
     for (const metric of metricLines) {
       const metricDetails = extractMetricDetails(metric);

--- a/alerting/temporal/src/qdrant/index.ts
+++ b/alerting/temporal/src/qdrant/index.ts
@@ -1,11 +1,6 @@
-import axios from "axios";
-
-import { client, v2 } from "@datadog/datadog-api-client";
 import assert from "assert";
-import {
-  COUNT,
-  GAUGE,
-} from "@datadog/datadog-api-client/dist/packages/datadog-api-client-v2/models/MetricIntakeType";
+import axios from "axios";
+import { StatsD } from "hot-shots";
 
 const { QDRANT_NODES, QDRANT_MONITORING_API_KEY } = process.env;
 
@@ -35,15 +30,8 @@ const QDRANT_METRICS_TO_WATCH: Record<
   ],
 };
 
-// This automatically pulls API keys from env vars DD_API_KEY.
-const configuration = client.createConfiguration();
-
-configuration.setServerVariables({
-  site: "datadoghq.eu", // We're using the EU site for Datadog.
-});
-
-const datadogMetricsApi = new v2.MetricsApi(configuration);
 const qdrantClusters = QDRANT_NODES.split(",");
+const statsClient = new StatsD();
 
 // Example: "https://node-3-xyz123abc-456-789-xyz-cloud.example.com:6333".
 const NODE_AND_CLUSTER_REGEXP = /https:\/\/(node-\d+)-(.+)\:\d+/;
@@ -97,16 +85,11 @@ function formatMetricName(rawMetricName: string) {
   return `qdrant.${rawMetricName.replace("_", ".")}`;
 }
 
-async function fetchPrometheusMetrics(
-  clusterNodeUrl: string
-): Promise<v2.MetricSeries[]> {
-  const metrics: v2.MetricSeries[] = [];
-
+async function fetchPrometheusMetrics(clusterNodeUrl: string): Promise<void> {
   const found = clusterNodeUrl.match(NODE_AND_CLUSTER_REGEXP);
   if (!found) {
     console.error(`Invalid node url ${clusterNodeUrl} -- skipping`);
-
-    return [];
+    return;
   }
 
   const [, node, clusterName] = found;
@@ -124,10 +107,7 @@ async function fetchPrometheusMetrics(
       // Ignore comments.
       .filter((l: string) => !l.startsWith("#"));
 
-    // Create a single timestamp for all Prometheus metrics retrievals to ensure histogram consistency.
-    const timestamp = Math.floor(Date.now() / 1000);
-    const clusterTags = [
-      "resource:qdrant",
+    const tags = [
       `cluster:${clusterName}`,
       `node:${node}`,
       `region:${process.env.DUST_REGION}`,
@@ -141,62 +121,25 @@ async function fetchPrometheusMetrics(
       }
 
       const { name, labels, value } = metricDetails;
-
       const metricName = formatMetricName(name);
-      const metricTags: Array<string> = [
-        ...clusterTags,
+      const metricTags = [
+        ...tags,
         ...Object.entries(labels).map(([key, value]) => `${key}:${value}`),
       ];
 
-      // Use the raw metric name to determine if it should be reported.
       if (QDRANT_METRICS_TO_WATCH.gauge_metrics.includes(name)) {
-        metrics.push({
-          metric: metricName,
-          points: [
-            {
-              timestamp,
-              value: parseFloat(value),
-            },
-          ],
-          tags: metricTags,
-          type: GAUGE,
-        });
+        statsClient.gauge(metricName, parseFloat(value), metricTags);
       } else if (QDRANT_METRICS_TO_WATCH.count_metrics.includes(name)) {
-        metrics.push({
-          metric: metricName,
-          points: [
-            {
-              timestamp,
-              value: parseInt(value),
-            },
-          ],
-          tags: metricTags,
-          type: COUNT,
-        });
+        statsClient.increment(metricName, parseInt(value), metricTags);
       }
     }
   } catch (error) {
     console.error("Error fetching Prometheus metrics:", error);
   }
-
-  return metrics;
-}
-
-// Send metrics to Datadog.
-async function sendMetricsToDatadog(metrics: v2.MetricSeries[]) {
-  try {
-    await datadogMetricsApi.submitMetrics({ body: { series: metrics } });
-  } catch (error) {
-    console.error("Error sending metrics to Datadog:", error);
-  }
 }
 
 export async function collectMetricsFromQdrant() {
   for (const clusterNodeUrl of qdrantClusters) {
-    const metricsForCluster = await fetchPrometheusMetrics(clusterNodeUrl);
-
-    if (metricsForCluster.length > 0) {
-      await sendMetricsToDatadog(metricsForCluster);
-    }
+    await fetchPrometheusMetrics(clusterNodeUrl);
   }
 }

--- a/alerting/temporal/src/qdrant/index.ts
+++ b/alerting/temporal/src/qdrant/index.ts
@@ -130,6 +130,7 @@ async function fetchPrometheusMetrics(
       "resource:qdrant",
       `cluster:${clusterName}`,
       `node:${node}`,
+      `region:${process.env.DUST_REGION}`,
     ];
 
     for (const metric of metricLines) {


### PR DESCRIPTION
## Description

Refactor alerting to send them via statsD (faster, more reliable and automatically get the tags defined on the agent)

## Risk

Low

## Deploy Plan

Deploy `alerting_temporal`
Remove `DD_*` env vars from alerting-temporal.