### PR TITLE
[sparkle] - fix: `CitationClose`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.366",
+  "version": "0.2.367",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.366",
+      "version": "0.2.367",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.366",
+  "version": "0.2.367",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -176,11 +176,7 @@ const CitationIcons = React.forwardRef<
   return (
     <div
       ref={ref}
-      className={cn(
-        "s-z-10",
-        "s-flex s-items-center s-gap-2 s-pb-1",
-        className
-      )}
+      className={cn("s-flex s-items-center s-gap-2 s-pb-1", className)}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Description

This PR aims at fixing the `CitationClose` component which was never triggered because of a `z-index` on the `CitationIcons`. This was causing the file attachment in the input to not be removable.

## Risk

Low

## Deploy Plan

- Publish sparkle
- New PR upgrading sparkle version in front