### PR TITLE
[front] - fix: update @dust-tt/sparkle and @dust-tt/client packages

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dust-tt/client": "^1.0.24",
-        "@dust-tt/sparkle": "^0.2.365",
+        "@dust-tt/sparkle": "^0.2.367",
         "@tailwindcss/forms": "^0.5.9",
         "@tiptap/extension-character-count": "^2.9.1",
         "@tiptap/extension-mention": "^2.9.1",
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.365",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.365.tgz",
-      "integrity": "sha512-9IKPOaWrcj5XbOXHK9m7yi3uzzsSQKvNkDc+IsOOZbE4HvnmCavWry+W6iFPMZdxCsFUHi4kJsX/rK1/mbrtog==",
+      "version": "0.2.367",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.367.tgz",
+      "integrity": "sha512-nHXvJJPrrhHr0B0bKLoD5aKEheV/miE3XW9SUjhuqSXRUcFoqxtcLSksDYC9+0u9y+Y7ucb+ppD8/LZ0nzK4qQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -291,6 +291,7 @@
         "react-dropdown-menu": "^0.0.2",
         "react-katex": "^3.0.1",
         "react-markdown": "^8.0.7",
+        "react-resizable-panels": "^2.1.7",
         "react-syntax-highlighter": "^15.6.1",
         "rehype-katex": "^7.0.1",
         "remark-directive": "^2.0.1",
@@ -10130,6 +10131,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.7.tgz",
+      "integrity": "sha512-JtT6gI+nURzhMYQYsx8DKkx6bSoOGFp7A3CwMrOb8y5jFHFyqwo9m68UhmXRw57fRVJksFn1TSlm3ywEQ9vMgA==",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-router": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@dust-tt/client": "^1.0.24",
-    "@dust-tt/sparkle": "^0.2.365",
+    "@dust-tt/sparkle": "^0.2.367",
     "@tailwindcss/forms": "^0.5.9",
     "@tiptap/extension-character-count": "^2.9.1",
     "@tiptap/extension-mention": "^2.9.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.366",
+        "@dust-tt/sparkle": "0.2.367",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -143,7 +143,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",
@@ -11454,9 +11454,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.366",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.366.tgz",
-      "integrity": "sha512-ehcPJplRiVthtxkE184cB/+uDYA1LoStvDOIhAyVEhdLtzbb3ltf+zjSlvchmn8kcN0kyPa2kh+cGUCQv3jq4Q==",
+      "version": "0.2.367",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.367.tgz",
+      "integrity": "sha512-nHXvJJPrrhHr0B0bKLoD5aKEheV/miE3XW9SUjhuqSXRUcFoqxtcLSksDYC9+0u9y+Y7ucb+ppD8/LZ0nzK4qQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.366",
+    "@dust-tt/sparkle": "0.2.367",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

 - Bumped @dust-tt/sparkle version from 0.2.366 to 0.2.367
 - Upgraded @dust-tt/client version from 1.0.23 to 1.0.24 to include the latest changes and fixes

## Risk

Low

## Deploy Plan

Deploy front