### PR TITLE
[Nodes Core] Fill and backfill Microsoft's source urls

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -437,6 +437,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
         internalId: getDriveItemInternalId(item),
         parentInternalId: null,
         mimeType: null,
+        webUrl: item.webUrl ?? null,
       };
     }
     case "file": {
@@ -447,6 +448,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
         internalId: getDriveItemInternalId(item),
         parentInternalId: null,
         mimeType: item.file?.mimeType ?? null,
+        webUrl: item.webUrl ?? null,
       };
     }
     case "drive": {
@@ -457,6 +459,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
         internalId: getDriveInternalId(item),
         parentInternalId: null,
         mimeType: null,
+        webUrl: item.webUrl ?? null,
       };
     }
     case "site": {
@@ -470,6 +473,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
         }),
         mimeType: null,
         parentInternalId: null,
+        webUrl: item.webUrl ?? null,
       };
     }
     case "team":

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -34,6 +34,7 @@ export type MicrosoftNode = {
   internalId: string;
   parentInternalId: string | null;
   mimeType: string | null;
+  webUrl: string | null;
 };
 
 export function isMicrosoftDriveItem(obj: unknown): obj is DriveItem {

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -210,6 +210,7 @@ export async function getRootNodesToSyncFromResources(
         parentId: null,
         title: createdOrUpdatedResource.name ?? "",
         mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+        sourceUrl: createdOrUpdatedResource.webUrl ?? undefined,
       }),
     { concurrency: 5 }
   );
@@ -482,6 +483,7 @@ export async function syncFiles({
         parentId: parentsOfParent[0],
         title: createdOrUpdatedResource.name ?? "",
         mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+        sourceUrl: createdOrUpdatedResource.webUrl ?? undefined,
       }),
     { concurrency: 5 }
   );
@@ -656,6 +658,7 @@ export async function syncDeltaForRootNodesInDrive({
           parentId: null,
           title: blob.name ?? "",
           mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+          sourceUrl: blob.webUrl ?? undefined,
         });
 
         // add parent information to new node resource. for the toplevel folder,
@@ -872,6 +875,7 @@ async function updateDescendantsParentsInCore({
     parentId: parents[1] || null,
     title: folder.name ?? "",
     mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    sourceUrl: folder.webUrl ?? undefined,
   });
 
   await concurrentExecutor(

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -44,6 +44,7 @@ async function upsertSpreadsheetInDb(
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     lastUpsertedTs: new Date(),
     parentInternalId,
+    webUrl: file.webUrl ?? null,
   });
 }
 
@@ -51,7 +52,7 @@ async function upsertWorksheetInDb(
   connector: ConnectorResource,
   internalId: string,
   worksheet: microsoftgraph.WorkbookWorksheet,
-  parentInternalId: string
+  spreadsheet: microsoftgraph.DriveItem
 ) {
   return MicrosoftNodeResource.upsert({
     internalId,
@@ -61,7 +62,10 @@ async function upsertWorksheetInDb(
     name: worksheet.name ?? "",
     mimeType: "text/csv",
     lastUpsertedTs: new Date(),
-    parentInternalId,
+    parentInternalId: getDriveItemInternalId(spreadsheet),
+    // At our current comprehension, there are no easily findable source url to
+    // directly access the worksheet, so we link to the parent spreadsheet
+    webUrl: spreadsheet.webUrl ?? null,
   });
 }
 
@@ -104,6 +108,9 @@ async function upsertMSTable(
     title: `${spreadsheet.name} - ${worksheet.name}`,
     mimeType:
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    // At our current comprehension, there are no easily findable source url to
+    // directly access the worksheet, so we link to the parent spreadsheet
+    sourceUrl: spreadsheet.webUrl ?? undefined,
   });
 
   logger.info(loggerArgs, "[Spreadsheet] Table upserted.");
@@ -231,7 +238,7 @@ async function processSheet({
       connector,
       worksheetInternalId,
       worksheet,
-      spreadsheetInternalId
+      spreadsheet
     );
 
     return new Ok(null);

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -401,6 +401,7 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
         name: node.name,
         parentInternalId: node.parentInternalId,
         mimeType: node.mimeType,
+        webUrl: node.webUrl,
       }))
     );
 

--- a/front/migrations/20250116_backfill_microsoft_source_url.ts
+++ b/front/migrations/20250116_backfill_microsoft_source_url.ts
@@ -1,0 +1,134 @@
+import type { Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
+
+import {
+  getConnectorsReplicaDbConnection,
+  getCorePrimaryDbConnection,
+} from "@app/lib/production_checks/utils";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 128;
+
+async function backfillDataSource(
+  frontDataSource: DataSourceModel,
+  coreSequelize: Sequelize,
+  connectorsSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  logger.info("Processing data source");
+
+  // get datasource id from core
+  const rows: { id: number }[] = await coreSequelize.query(
+    `SELECT id FROM data_sources WHERE data_source_id = :dataSourceId;`,
+    {
+      replacements: { dataSourceId: frontDataSource.dustAPIDataSourceId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  if (rows.length === 0) {
+    logger.error(`Data source ${frontDataSource.id} not found in core`);
+    return;
+  }
+
+  const dataSourceId = rows[0].id;
+
+  await backfillNodes(
+    frontDataSource,
+    dataSourceId,
+    coreSequelize,
+    connectorsSequelize,
+    execute,
+    logger
+  );
+}
+
+async function backfillNodes(
+  frontDataSource: DataSourceModel,
+  dataSourceId: number,
+  coreSequelize: Sequelize,
+  connectorsSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  logger.info("Processing nodes");
+
+  // processing the spreadsheets chunk by chunk
+  let lastId = 0;
+  let rows: { id: number; internalId: string; webUrl: string }[] = [];
+
+  do {
+    // querying connectors for the next batch of spreadsheets
+
+    rows = await connectorsSequelize.query(
+      `SELECT id, "internalId", "webUrl"
+       FROM microsoft_nodes
+       WHERE id > :lastId
+         AND "connectorId" = :connectorId
+       ORDER BY id
+       LIMIT :batchSize;`,
+      {
+        replacements: {
+          batchSize: BATCH_SIZE,
+          lastId,
+          connectorId: frontDataSource.connectorId,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    if (rows.length === 0) {
+      break;
+    }
+    // reconstructing the URLs and node IDs
+    const urls = rows.map((row) => row.webUrl);
+    const nodeIds = rows.map((row) => row.internalId);
+
+    if (execute) {
+      // updating on core on the nodeIds
+      await coreSequelize.query(
+        `UPDATE data_sources_nodes
+         SET source_url = urls.url
+         FROM (SELECT unnest(ARRAY [:nodeIds]::text[]) as node_id,
+                      unnest(ARRAY [:urls]::text[])    as url) urls
+         WHERE data_sources_nodes.data_source = :dataSourceId AND data_sources_nodes.node_id = urls.node_id;`,
+        { replacements: { urls, nodeIds, dataSourceId } }
+      );
+      logger.info(
+        `Updated ${rows.length} spreadsheets from id ${rows[0].id} to id ${rows[rows.length - 1].id}.`
+      );
+    } else {
+      logger.info(
+        `Would update ${rows.length} spreadsheets from id ${rows[0].id} to id ${rows[rows.length - 1].id}.`
+      );
+    }
+
+    lastId = rows[rows.length - 1].id;
+  } while (rows.length === BATCH_SIZE);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const coreSequelize = getCorePrimaryDbConnection();
+  const connectorsSequelize = getConnectorsReplicaDbConnection();
+  const frontDataSources = await DataSourceModel.findAll({
+    where: { connectorProvider: "microsoft" },
+  });
+  logger.info(`Found ${frontDataSources.length} Microsoft data sources`);
+
+  for (const frontDataSource of frontDataSources) {
+    await backfillDataSource(
+      frontDataSource,
+      coreSequelize,
+      connectorsSequelize,
+      execute,
+      logger.child({
+        dataSourceId: frontDataSource.id,
+        connectorId: frontDataSource.connectorId,
+        name: frontDataSource.name,
+      })
+    );
+  }
+});


### PR DESCRIPTION
Description
---
- Part of [#9949](https://github.com/dust-tt/dust/issues/9949)
- Part of [#9950](https://github.com/dust-tt/dust/issues/9950)
- This PR fills ~and backfills~ the `sourceUrl` correctly for all microsoft nodes

~While we'll run a backfill and could avoid backfilling documents, this would increase the script complexity for almost no gain (it's quite fast)~

As per issue, backfill is discarded see https://github.com/dust-tt/dust/issues/9950#issuecomment-2598462482
Keeping it in the PR in case we change minds and end up needing it so it doesn't get lost

## Risk
low

## Deploy Plan
- connectors
~- run backfill~

