### PR TITLE
[Front] Duplicate `getContentNodesForManagedDataSourceView` for shadow read

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -1,9 +1,14 @@
-import type { DataSourceViewType } from "@dust-tt/types";
+import type {
+  ContentNodeType,
+  CoreAPIContentNode,
+  DataSourceViewType,
+} from "@dust-tt/types";
 import {
   assertNever,
   getGoogleSheetContentNodeInternalIdFromTableId,
   getMicrosoftSheetContentNodeInternalIdFromTableId,
   getNotionDatabaseContentNodeInternalIdFromTableId,
+  MIME_TYPES,
 } from "@dust-tt/types";
 
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -41,5 +46,199 @@ export function getContentNodeInternalIdFromTableId(
 
     default:
       assertNever(dataSource.connectorProvider);
+  }
+}
+
+export function getContentNodeMetadata(
+  node: CoreAPIContentNode,
+  viewType: "tables" | "documents"
+): {
+  type: ContentNodeType;
+  expandable: boolean;
+  preventSelection?: boolean;
+} {
+  // TODO(2025-01-15 aubin) - remove the dev comments
+  // unless mentioned otherwise, the following is taken from retrieveBatchContentNodes in each connector's index.ts
+  switch (node.mime_type) {
+    case MIME_TYPES.CONFLUENCE.PAGE: // taken from createContentNodeFromPage
+      return {
+        type: "file",
+        expandable: node.has_children, // this should match checkPageHasChildren in confluence/lib/permissions.ts, which does a check in db
+      };
+    case MIME_TYPES.CONFLUENCE.SPACE: // taken from createContentNodeFromSpace
+      return {
+        type: "folder",
+        expandable: true, // isExpandable set to false only in getPermissions with permissions = none (which we won't replace)
+      };
+    case MIME_TYPES.GITHUB.REPOSITORY:
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.GITHUB.CODE_ROOT:
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.GITHUB.CODE_DIRECTORY:
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.GITHUB.CODE_FILE:
+      return {
+        type: "file",
+        expandable: false,
+      };
+    case MIME_TYPES.GITHUB.ISSUES:
+      return {
+        type: "database",
+        expandable: false, // surprising
+      };
+    case MIME_TYPES.GITHUB.ISSUE:
+      return {
+        type: "file",
+        expandable: false,
+      };
+    case MIME_TYPES.GITHUB.DISCUSSIONS:
+      return {
+        type: "channel",
+        expandable: false, // surprising
+      };
+    case MIME_TYPES.GITHUB.DISCUSSION:
+      return {
+        type: "file",
+        expandable: false,
+      };
+    case MIME_TYPES.GOOGLE_DRIVE.FOLDER: // see isDriveObjectExpandable
+      return {
+        type: "folder",
+        expandable: node.has_children, // tricky since it's actually false if the node only has directories as descendants
+      };
+    case MIME_TYPES.INTERCOM.COLLECTION:
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.INTERCOM.TEAMS_FOLDER:
+      return {
+        type: "channel",
+        expandable: true,
+      };
+    case MIME_TYPES.INTERCOM.CONVERSATION:
+      return {
+        type: "file",
+        expandable: false,
+      };
+    case MIME_TYPES.INTERCOM.TEAM:
+      return {
+        type: "folder", // actually set to "channel" in retrieveBatchContentNodes, but folder in retrievePermissions, have to check with the author
+        expandable: false,
+      };
+    case MIME_TYPES.INTERCOM.HELP_CENTER:
+      return {
+        type: "database",
+        expandable: true,
+      };
+    case MIME_TYPES.INTERCOM.ARTICLE:
+      return {
+        type: "file",
+        expandable: false,
+      };
+    case MIME_TYPES.MICROSOFT.FOLDER: // see getMicrosoftNodeAsContentNode
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    // we have to do something for other microsoft objects, there is some logic in getMicrosoftNodeAsContentNode
+    case MIME_TYPES.NOTION.UNKNOWN_FOLDER:
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.NOTION.DATABASE:
+      return {
+        type: "database",
+        expandable: true,
+      };
+    case MIME_TYPES.NOTION.PAGE:
+      return {
+        type: "file",
+        expandable: node.has_children, // hoping that this matches the output of hasChildren in notion/lib/parents.ts
+      };
+    case MIME_TYPES.SLACK.CHANNEL:
+      return {
+        type: "channel",
+        expandable: false, // surprising
+      };
+    case MIME_TYPES.SLACK.THREAD: // these are never showed, not implement in retrieveBatchContentNodes
+      return {
+        type: "file",
+        expandable: false,
+      };
+    case MIME_TYPES.SLACK.MESSAGES: // these are never showed, not implement in retrieveBatchContentNodes
+      return {
+        type: "file",
+        expandable: true,
+      };
+    case MIME_TYPES.SNOWFLAKE.DATABASE: // see getContentNodeFromInternalId in snowflake/lib/content_nodes.ts
+      return {
+        type: "folder",
+        expandable: true,
+        preventSelection: false,
+      };
+    case MIME_TYPES.SNOWFLAKE.SCHEMA: // see getContentNodeFromInternalId in snowflake/lib/content_nodes.ts
+      return {
+        type: "folder",
+        expandable: true,
+        preventSelection: false,
+      };
+    case MIME_TYPES.SNOWFLAKE.TABLE: // see getContentNodeFromInternalId in snowflake/lib/content_nodes.ts
+      return {
+        type: "database",
+        expandable: false,
+        preventSelection: false,
+      };
+    case MIME_TYPES.WEBCRAWLER.FOLDER:
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.ZENDESK.BRAND: // see toContentNode method in zendesk_resources.ts
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.ZENDESK.HELP_CENTER: // see toContentNode method in zendesk_resources.ts
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.ZENDESK.CATEGORY: // see toContentNode method in zendesk_resources.ts
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.ZENDESK.ARTICLE: // see toContentNode method in zendesk_resources.ts
+      return {
+        type: "file",
+        expandable: false,
+      };
+    case MIME_TYPES.ZENDESK.TICKETS: // see toContentNode method in zendesk_resources.ts
+      return {
+        type: "folder",
+        expandable: true,
+      };
+    case MIME_TYPES.ZENDESK.TICKET: // see toContentNode method in zendesk_resources.ts
+      return {
+        type: "file",
+        expandable: false,
+      };
+    // need some magic for Google Drive and Microsoft files
+    default:
+      return {
+        type: "file",
+        expandable: false,
+      };
   }
 }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -236,9 +236,23 @@ export function getContentNodeMetadata(
       };
     // need some magic for Google Drive and Microsoft files
     default:
+      let expandable = false;
+      if (
+        node.mime_type ===
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" &&
+        viewType === "tables"
+      ) {
+        expandable = true;
+      }
+      let type: ContentNodeType;
+      if (node.mime_type === "text/csv") {
+        type = viewType === "tables" ? "database" : "file";
+      } else {
+        type = "file"; // in the connector, we rely on the Microsoft-specific nodeType, which can be "channel", "folder" or "file", there is currently no way of knowing
+      }
       return {
-        type: "file",
-        expandable: false,
+        type,
+        expandable,
       };
   }
 }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -234,9 +234,11 @@ export function getContentNodeMetadata(
         type: "file",
         expandable: false,
       };
-    // need some magic for Google Drive and Microsoft files
+    // handling google drive and microsoft files
     default:
+      // the default match Google Drive
       let expandable = false;
+      let type: ContentNodeType = "file";
       if (
         node.mime_type ===
           "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" &&
@@ -244,11 +246,8 @@ export function getContentNodeMetadata(
       ) {
         expandable = true;
       }
-      let type: ContentNodeType;
       if (node.mime_type === "text/csv") {
         type = viewType === "tables" ? "database" : "file";
-      } else {
-        type = "file"; // in the connector, we rely on the Microsoft-specific nodeType, which can be "channel", "folder" or "file", there is currently no way of knowing
       }
       return {
         type,

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -44,6 +44,20 @@ export function sectionFullText(
   );
 }
 
+export type CoreAPIContentNode = {
+  data_source_id: string;
+  data_source_internal_id: string;
+  node_id: string;
+  node_type: "Document" | "Table" | "Folder";
+  timestamp: number;
+  title: string;
+  mime_type: string;
+  provider_visibility: "private" | "public" | null;
+  parent_id: string | null;
+  parents: string[];
+  source_url: string[];
+};
+
 export type CoreAPIDocument = {
   data_source_id: string;
   created: number;

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -56,6 +56,7 @@ export type CoreAPIContentNode = {
   parent_id: string | null;
   parents: string[];
   source_url: string | null;
+  has_children: boolean;
 };
 
 export type CoreAPIDocument = {

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -55,7 +55,7 @@ export type CoreAPIContentNode = {
   provider_visibility: "private" | "public" | null;
   parent_id: string | null;
   parents: string[];
-  source_url: string[];
+  source_url: string | null;
 };
 
 export type CoreAPIDocument = {

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -44,21 +44,6 @@ export function sectionFullText(
   );
 }
 
-export type CoreAPIContentNode = {
-  data_source_id: string;
-  data_source_internal_id: string;
-  node_id: string;
-  node_type: "Document" | "Table" | "Folder";
-  timestamp: number;
-  title: string;
-  mime_type: string;
-  provider_visibility: "private" | "public" | null;
-  parent_id: string | null;
-  parents: string[];
-  source_url: string | null;
-  has_children: boolean;
-};
-
 export type CoreAPIDocument = {
   data_source_id: string;
   created: number;

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -13,6 +13,7 @@ export * from "./connectors/notion";
 export * from "./connectors/slack";
 export * from "./connectors/snowflake";
 export * from "./connectors/webcrawler";
+export * from "./core/content_node";
 export * from "./core/data_source";
 export * from "./front/api_handlers/internal/agent_configuration";
 export * from "./front/api_handlers/internal/assistant";


### PR DESCRIPTION
## Description

- Closes [#9864](https://github.com/dust-tt/dust/issues/9864)
- The added function is not called at the moment (shadow read not in place yet).
- The function currently fills the `type` field with the old meaning for it, the rule applied on mime types should be extracted from `getContentNodeMetadata` and used wherever the old `type` was needed (to compute icons for instance).

## Risk

- n/a, function not called

## Deploy Plan

- Deploy front.
