### PR TITLE
fix: o1 temperature must always be 1.0

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -944,7 +944,7 @@ impl LLM for OpenAILLM {
             &messages,
             functions,
             function_call,
-            temperature,
+            if model_is_o1 { 1.0 } else { temperature },
             top_p,
             n,
             stop,


### PR DESCRIPTION
## Description

Removed this when refactoring

## Risk

N/A

## Deploy Plan

Deploy core