### PR TITLE
[front] - refacto: `NewDialog` 🌊 5️⃣ 

### DIFF
--- a/front/components/spaces/AddToSpaceDialog.tsx
+++ b/front/components/spaces/AddToSpaceDialog.tsx
@@ -1,14 +1,19 @@
 import {
   Button,
-  Dialog,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  NewDialog,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
   ScrollArea,
   ScrollBar,
+  useSendNotification,
 } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceViewContentNode,
@@ -16,7 +21,7 @@ import type {
   LightWorkspaceType,
   SpaceType,
 } from "@dust-tt/types";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { useDataSourceViews } from "@app/lib/swr/data_source_views";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -133,45 +138,64 @@ export const AddToSpaceDialog = ({
   };
 
   return (
-    <Dialog
-      disabled={space === undefined}
-      isOpen={isOpen}
-      onCancel={() => onClose(false)}
-      onValidate={addToSpace}
-      title="Add to Space"
-      validateLabel="Save"
+    <NewDialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose(false);
+        }
+      }}
     >
-      {availableSpaces.length === 0 ? (
-        <div className="mt-1 text-left">
-          This data is already available in all spaces.
-        </div>
-      ) : (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              label={space ? space.name : "Select space"}
-              size="sm"
-              isSelect
-              variant="outline"
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="min-w-48 p-2">
-            <ScrollArea
-              className="flex max-h-72 flex-col overflow-y-auto"
-              hideScrollBar
-            >
-              {availableSpaces.map((currentSpace) => (
-                <DropdownMenuItem
-                  key={currentSpace.sId}
-                  label={currentSpace.name}
-                  onClick={() => setSpace(currentSpace)}
+      <NewDialogContent size="md">
+        <NewDialogHeader>
+          <NewDialogTitle>Add to Space</NewDialogTitle>
+        </NewDialogHeader>
+        <NewDialogContainer>
+          {availableSpaces.length === 0 ? (
+            <div className="mt-1 text-left">
+              This data is already available in all spaces.
+            </div>
+          ) : (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  label={space ? space.name : "Select space"}
+                  size="sm"
+                  isSelect
+                  variant="outline"
                 />
-              ))}
-              <ScrollBar className="py-0" />
-            </ScrollArea>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-    </Dialog>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="min-w-48 p-2">
+                <ScrollArea
+                  className="flex max-h-72 flex-col overflow-y-auto"
+                  hideScrollBar
+                >
+                  {availableSpaces.map((currentSpace) => (
+                    <DropdownMenuItem
+                      key={currentSpace.sId}
+                      label={currentSpace.name}
+                      onClick={() => setSpace(currentSpace)}
+                    />
+                  ))}
+                  <ScrollBar className="py-0" />
+                </ScrollArea>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </NewDialogContainer>
+        <NewDialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "primary",
+            onClick: addToSpace,
+          }}
+        />
+      </NewDialogContent>
+    </NewDialog>
   );
 };

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -30,10 +30,7 @@ import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManag
 import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
 import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
 import { useKillSwitches } from "@app/lib/swr/kill";
-import {
-  useSpaceDataSourceViews,
-  useSpaceDataSourceViewsWithDetails,
-} from "@app/lib/swr/spaces";
+import { useSpaceDataSourceViews, useSpaceDataSourceViewsWithDetails } from "@app/lib/swr/spaces";
 
 interface EditSpaceManagedDataSourcesViewsProps {
   dataSourceView?: DataSourceViewType;
@@ -297,7 +294,6 @@ export function EditSpaceManagedDataSourcesViews({
     />
   );
 
-  console.log("HELLO");
   return isAdmin ? (
     <>
       <SpaceManagedDatasourcesViewsModal

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -1,12 +1,17 @@
 import {
   Button,
   ContentMessage,
-  Dialog,
   InformationCircleIcon,
+  NewDialog,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
   PlusIcon,
   Tooltip,
+  useSendNotification,
 } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceViewSelectionConfigurations,
@@ -292,6 +297,7 @@ export function EditSpaceManagedDataSourcesViews({
     />
   );
 
+  console.log("HELLO");
   return isAdmin ? (
     <>
       <SpaceManagedDatasourcesViewsModal
@@ -320,20 +326,36 @@ export function EditSpaceManagedDataSourcesViews({
         }}
         initialSelectedDataSources={filteredDataSourceViews}
       />
-      <Dialog
-        isOpen={showNoConnectionDialog}
-        onCancel={() => setShowNoConnectionDialog(false)}
-        cancelLabel="Close"
-        validateLabel="Go to connections management"
-        onValidate={() => {
-          void router.push(
-            `/w/${owner.sId}/spaces/${systemSpace.sId}/categories/managed`
-          );
-        }}
-        title="No connection set up"
+
+      <NewDialog
+        open={showNoConnectionDialog}
+        onOpenChange={(open) => !open && setShowNoConnectionDialog(false)}
       >
-        <p>You have no connection set up.</p>
-      </Dialog>
+        <NewDialogContent>
+          <NewDialogHeader>
+            <NewDialogTitle>No connection set up</NewDialogTitle>
+          </NewDialogHeader>
+          <NewDialogContainer>
+            You have no connection set up.
+          </NewDialogContainer>
+          <NewDialogFooter
+            leftButtonProps={{
+              label: "Close",
+              variant: "outline",
+              onClick: () => setShowNoConnectionDialog(false),
+            }}
+            rightButtonProps={{
+              label: "Go to connections management",
+              variant: "primary",
+              onClick: () => {
+                void router.push(
+                  `/w/${owner.sId}/spaces/${systemSpace.sId}/categories/managed`
+                );
+              },
+            }}
+          />
+        </NewDialogContent>
+      </NewDialog>
       <AwaitableDialog />
       {isSavingDisabled ? (
         <Tooltip

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -30,7 +30,10 @@ import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManag
 import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
 import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
 import { useKillSwitches } from "@app/lib/swr/kill";
-import { useSpaceDataSourceViews, useSpaceDataSourceViewsWithDetails } from "@app/lib/swr/spaces";
+import {
+  useSpaceDataSourceViews,
+  useSpaceDataSourceViewsWithDetails,
+} from "@app/lib/swr/spaces";
 
 interface EditSpaceManagedDataSourcesViewsProps {
   dataSourceView?: DataSourceViewType;
@@ -273,6 +276,16 @@ export function EditSpaceManagedDataSourcesViews({
     return false;
   }
 
+  function handleCloseDataSourcesModal() {
+    setShowDataSourcesModal(false);
+  }
+
+  function handleGoToConnectionsManagement() {
+    void router.push(
+      `/w/${owner?.sId}/spaces/${systemSpace?.sId}/categories/managed`
+    );
+  }
+
   const addToSpaceButton = (
     <Button
       label={
@@ -338,16 +351,12 @@ export function EditSpaceManagedDataSourcesViews({
             leftButtonProps={{
               label: "Close",
               variant: "outline",
-              onClick: () => setShowNoConnectionDialog(false),
+              onClick: handleCloseDataSourcesModal,
             }}
             rightButtonProps={{
               label: "Go to connections management",
               variant: "primary",
-              onClick: () => {
-                void router.push(
-                  `/w/${owner.sId}/spaces/${systemSpace.sId}/categories/managed`
-                );
-              },
+              onClick: handleGoToConnectionsManagement,
             }}
           />
         </NewDialogContent>

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -1,4 +1,12 @@
-import { Breadcrumbs, Dialog } from "@dust-tt/sparkle";
+import {
+  Breadcrumbs,
+  NewDialog,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
+} from "@dust-tt/sparkle";
 import type {
   DataSourceViewCategory,
   DataSourceViewType,
@@ -110,18 +118,32 @@ export function SpaceLayout({
           />
         )}
         {isAdmin && isLimitReached && (
-          <Dialog
-            alertDialog
-            isOpen={isLimitReached && spaceCreationModalState.isOpen}
-            title="You can't create more spaces."
-            onValidate={closeSpaceCreationModal}
+          <NewDialog
+            open={isLimitReached && spaceCreationModalState.isOpen}
+            onOpenChange={(open) => {
+              if (!open) {
+                closeSpaceCreationModal();
+              }
+            }}
           >
-            <div>
-              {isEnterprise
-                ? "We're going to make changes to data permissions spaces soon and are limiting the creation of spaces for that reason. Reach out to us to learn more."
-                : "The maximum number of spaces for this workspace has been reached. Please reach out at support@dust.tt to learn more."}
-            </div>
-          </Dialog>
+            <NewDialogContent size="md" isAlertDialog>
+              <NewDialogHeader hideButton>
+                <NewDialogTitle>You can't create more spaces.</NewDialogTitle>
+              </NewDialogHeader>
+              <NewDialogContainer>
+                {isEnterprise
+                  ? "We're going to make changes to data permissions spaces soon and are limiting the creation of spaces for that reason. Reach out to us to learn more."
+                  : "The maximum number of spaces for this workspace has been reached. Please reach out at support@dust.tt to learn more."}
+              </NewDialogContainer>
+              <NewDialogFooter
+                rightButtonProps={{
+                  label: "Ok",
+                  variant: "outline",
+                  onClick: closeSpaceCreationModal,
+                }}
+              />
+            </NewDialogContent>
+          </NewDialog>
         )}
       </AppLayout>
     </RootLayout>

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Dialog,
   ExternalLinkIcon,
   Icon,
   IconButton,
@@ -837,18 +836,35 @@ function ToggleEnforceEnterpriseConnectionModal({
   const dialog = titleAndContent[owner.ssoEnforced ? "remove" : "enforce"];
 
   return (
-    <Dialog
-      isOpen={isOpen}
-      title={dialog.title}
-      onValidate={async () => {
-        await handleToggleSsoEnforced(!owner.ssoEnforced);
+    <NewDialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose(false);
+        }
       }}
-      onCancel={() => onClose(false)}
-      validateLabel={dialog.validateLabel}
-      validateVariant="warning"
     >
-      <div>{dialog.content}</div>
-    </Dialog>
+      <NewDialogContent>
+        <NewDialogHeader>
+          <NewDialogTitle>{dialog.title}</NewDialogTitle>
+        </NewDialogHeader>
+        <NewDialogContainer>{dialog.content}</NewDialogContainer>
+        <NewDialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: () => onClose(false),
+          }}
+          rightButtonProps={{
+            label: dialog.validateLabel,
+            variant: "warning",
+            onClick: async () => {
+              await handleToggleSsoEnforced(!owner.ssoEnforced);
+            },
+          }}
+        />
+      </NewDialogContent>
+    </NewDialog>
   );
 }
 

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -23,7 +23,14 @@ import {
   ShapesIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { GroupType, KeyType, ModelId, SubscriptionType, UserType, WorkspaceType } from "@dust-tt/types";
+import type {
+  GroupType,
+  KeyType,
+  ModelId,
+  SubscriptionType,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { prettifyGroupName } from "@dust-tt/types";
 import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";

--- a/front/pages/w/[wId]/developers/dev-secrets.tsx
+++ b/front/pages/w/[wId]/developers/dev-secrets.tsx
@@ -2,12 +2,17 @@ import {
   BookOpenIcon,
   BracesIcon,
   Button,
-  Dialog,
   Input,
+  NewDialog,
+  NewDialogContainer,
+  NewDialogContent,
+  NewDialogFooter,
+  NewDialogHeader,
+  NewDialogTitle,
   Page,
   PlusIcon,
+  useSendNotification,
 } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
 import type {
   DustAppSecretType,
   SubscriptionType,
@@ -122,53 +127,94 @@ export default function SecretsPage({
   return (
     <>
       {secretToRevoke ? (
-        <Dialog
-          isOpen={true}
-          title={`Delete ${secretToRevoke?.name}`}
-          onValidate={() => handleRevoke(secretToRevoke)}
-          onCancel={() => setSecretToRevoke(null)}
+        <NewDialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSecretToRevoke(null);
+            }
+          }}
         >
-          <p className="text-sm text-gray-700">
-            Are you sure you want to delete the secret{" "}
-            <strong>{secretToRevoke?.name}</strong>?
-          </p>
-        </Dialog>
+          <NewDialogContent>
+            <NewDialogHeader>
+              <NewDialogTitle>Delete {secretToRevoke?.name}</NewDialogTitle>
+            </NewDialogHeader>
+            <NewDialogContainer>
+              Are you sure you want to delete the secret{" "}
+              <strong>{secretToRevoke?.name}</strong>?
+            </NewDialogContainer>
+            <NewDialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: () => setSecretToRevoke(null),
+              }}
+              rightButtonProps={{
+                label: "Delete",
+                variant: "warning",
+                onClick: () => handleRevoke(secretToRevoke),
+              }}
+            />
+          </NewDialogContent>
+        </NewDialog>
       ) : null}
-      <Dialog
-        isOpen={isNewSecretPromptOpen}
-        title={`${isInputNameDisabled ? "Update" : "New"} Developer Secret`}
-        onValidate={() => handleGenerate(newDustAppSecret)}
-        onCancel={() => setIsNewSecretPromptOpen(false)}
+      <NewDialog
+        open={isNewSecretPromptOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsNewSecretPromptOpen(false);
+          }
+        }}
       >
-        <Input
-          name="Secret Name"
-          placeholder="SECRET_NAME"
-          value={newDustAppSecret.name}
-          disabled={isInputNameDisabled}
-          onChange={(e) =>
-            setNewDustAppSecret({
-              ...newDustAppSecret,
-              name: cleanSecretName(e.target.value),
-            })
-          }
-        />
-        <p className="text-xs text-gray-500">
-          Secret names must be alphanumeric and underscore characters only.
-        </p>
-        <br />
+        <NewDialogContent size="lg">
+          <NewDialogHeader>
+            <NewDialogTitle>
+              {isInputNameDisabled ? "Update" : "New"} Developer Secret
+            </NewDialogTitle>
+          </NewDialogHeader>
+          <NewDialogContainer>
+            <Input
+              message="Secret names must be alphanumeric and underscore characters only."
+              name="Secret Name"
+              placeholder="SECRET_NAME"
+              value={newDustAppSecret.name}
+              disabled={isInputNameDisabled}
+              onChange={(e) =>
+                setNewDustAppSecret({
+                  ...newDustAppSecret,
+                  name: cleanSecretName(e.target.value),
+                })
+              }
+            />
+            <Input
+              message="Secret values are encrypted and stored securely in our database."
+              name="Secret value"
+              placeholder="Type the secret value"
+              value={newDustAppSecret.value}
+              onChange={(e) =>
+                setNewDustAppSecret({
+                  ...newDustAppSecret,
+                  value: e.target.value,
+                })
+              }
+            />
+            <p className="text-xs text-gray-500"></p>
+          </NewDialogContainer>
+          <NewDialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: () => setIsNewSecretPromptOpen(false),
+            }}
+            rightButtonProps={{
+              label: isInputNameDisabled ? "Update" : "Create",
+              variant: "primary",
+              onClick: () => handleGenerate(newDustAppSecret),
+            }}
+          />
+        </NewDialogContent>
+      </NewDialog>
 
-        <Input
-          name="Secret value"
-          placeholder="Type the secret value"
-          value={newDustAppSecret.value}
-          onChange={(e) =>
-            setNewDustAppSecret({ ...newDustAppSecret, value: e.target.value })
-          }
-        />
-        <p className="text-xs text-gray-500">
-          Secret values are encrypted and stored securely in our database.
-        </p>
-      </Dialog>
       <AppLayout
         subscription={subscription}
         owner={owner}


### PR DESCRIPTION
## Description

This PR resumes the efforts on refactoring front to use the `NewDialog` component instead of `Dialog`.

There will be a last PR to refactor `AwaitableDialog` and `Navigation`.

## Risk

Broken UX

## Deploy Plan

Deploy `front`.