### PR TITLE
fix: non-streaming Google AI Studio API

### DIFF
--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -160,7 +160,13 @@ impl LLM for GoogleAiStudioLLM {
             logprobs,
             top_logprobs,
             None,
-            event_sender,
+            // Non-streaming API of gemini does not work correctly with hyper client.
+            // We create a dummy event sender to use the streaming API.
+            // TODO(@fontanierh): use ureq instead of hyper to fix this.
+            event_sender.or_else(|| {
+                let (sender, _) = tokio::sync::mpsc::unbounded_channel::<Value>();
+                Some(sender)
+            }),
             false, // don't disable provider streaming
             TransformSystemMessages::Keep,
             "GoogleAIStudio".to_string(),


### PR DESCRIPTION
## Description

It is quite suprising. This `CURL` works:

```bash
curl -X POST \            
  'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer REDACTED' \
  -d '{
    "messages": [
      {
        "role": "user",
        "content": "hi!"
      }
    ],
    "model": "gemini-1.5-flash-latest"
  }'
```

but this `hyper` / `reqwest` request does **not** work:
```rust
use reqwest;
use serde_json::json;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let client = reqwest::Client::new();
    
    let body = json!({
        "messages": [{
            "role": "user",
            "content": "hi!"
        }],
        "model": "gemini-1.5-flash-latest",
    });

    let res = client
        .post("https://generativelanguage.googleapis.com/v1beta/openai/chat/completions")
        .header("Content-Type", "application/json")
        .header("Authorization", "Bearer REDACTED")
        .body(body_str)
        .send()
        .await?;

    Ok(())
}
```

The same does work with `ureq` ...

```rust
use std::error::Error;

fn main() -> Result<(), Box<dyn Error>> {
    let body = json!({
        "messages": [{
            "role": "user",
            "content": "hi!"
        }],
        "model": "gemini-1.5-flash-latest"
    });

    let resp =
        ureq::post("https://generativelanguage.googleapis.com/v1beta/openai/chat/completions")
            .set("Content-Type", "application/json")
            .set("Authorization", &format!("Bearer {}", api_key))
            .send_json(body)?;

    Ok(())
}
```

In the meantime, we'll just keep using the streaming API even when not streaming the output -- this is what we've been doing before switching to the OpenAI format.

## Risk

N/A

## Deploy Plan

Deploy core