### PR TITLE
fix(Confluence) - inline `getConfluenceSpaceUrl` when the db entry is available

### DIFF
--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -34,16 +34,6 @@ function isConfluenceSpaceModel(
   );
 }
 
-export function getConfluenceSpaceUrl(
-  space: ConfluenceSpace | ConfluenceSpaceType,
-  baseUrl: string
-) {
-  const urlSuffix = isConfluenceSpaceModel(space)
-    ? space.urlSuffix
-    : space._links.webui;
-  return `${baseUrl}/wiki${urlSuffix}`;
-}
-
 export function createContentNodeFromSpace(
   space: ConfluenceSpace | ConfluenceSpaceType,
   baseUrl: string,
@@ -51,13 +41,16 @@ export function createContentNodeFromSpace(
   { isExpandable }: { isExpandable: boolean }
 ): ContentNode {
   const spaceId = isConfluenceSpaceModel(space) ? space.spaceId : space.id;
+  const urlSuffix = isConfluenceSpaceModel(space)
+    ? space.urlSuffix
+    : space._links.webui;
 
   return {
     internalId: makeSpaceInternalId(spaceId),
     parentInternalId: null,
     type: "folder",
     title: space.name || "Unnamed Space",
-    sourceUrl: getConfluenceSpaceUrl(space, baseUrl),
+    sourceUrl: `${baseUrl}/wiki${urlSuffix}`,
     expandable: isExpandable,
     permission,
     lastUpdatedAt: null,

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -23,7 +23,6 @@ import {
   makePageInternalId,
   makeSpaceInternalId,
 } from "@connectors/connectors/confluence/lib/internal_ids";
-import { getConfluenceSpaceUrl } from "@connectors/connectors/confluence/lib/permissions";
 import { makeConfluenceDocumentUrl } from "@connectors/connectors/confluence/temporal/workflow_ids";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
@@ -231,8 +230,7 @@ export async function confluenceUpsertSpaceFolderActivity({
     parentId: null,
     title: spaceName,
     mimeType: MIME_TYPES.CONFLUENCE.SPACE,
-    sourceUrl:
-      spaceInDb?.urlSuffix && getConfluenceSpaceUrl(spaceInDb, baseUrl),
+    sourceUrl: spaceInDb?.urlSuffix && `${baseUrl}/wiki${spaceInDb.urlSuffix}`,
   });
 }
 


### PR DESCRIPTION
## Description

- This PR fixes [failing activities](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40dd.service%3Aconnectors-worker%20%40error_stack%3A%22TypeError%3A%20Cannot%20read%20properties%20of%20undefined%20%28reading%20%27webui%27%29%0A%20%20%20%20at%20getConfluenceSpaceUrl%20%28%2Fapp%2Fsrc%2Fconnectors%2Fconfluence%2Flib%2Fpermissions.ts%3A43%3A20%29%0A%20%20%20%20at%20confluenceUpsertSpaceFolderActivity%20%28%2Fapp%2Fsrc%2Fconnectors%2Fconfluence%2Ftemporal%2Factivities.ts%3A235%3A31%29%0A%20%20%20%20at%20process.processTicksAndRejections%20%28node%3Ainternal%2Fprocess%2Ftask_queues%3A95%3A5%29%0A%20%20%20%20at%20ConfluenceCastKnownErrorsInterceptor.execute%20%28%2Fapp%2Fsrc%2Fconnectors%2Fconfluence%2Ftemporal%2Fcast_known_errors.ts%3A18%3A14%29%0A%20%20%20%20at%20ActivityInboundLogInterceptor.execute%20%28%2Fapp%2Fsrc%2Flib%2Ftemporal_monitoring.ts%3A96%3A14%29%0A%20%20%20%20at%20Activity.execute%20%28%2Fapp%2Fnode_modules%2F%40temporalio%2Fworker%2Fsrc%2Factivity.ts%3A103%3A14%29%0A%20%20%20%20at%20%3Canonymous%3E%20%28%2Fapp%2Fnode_modules%2F%40temporalio%2Fworker%2Fsrc%2Factivity.ts%3A130%3A24%29%0A%20%20%20%20at%20%3Canonymous%3E%20%28%2Fapp%2Fnode_modules%2F%40temporalio%2Fworker%2Fsrc%2Fworker.ts%3A979%3A24%29%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZRz1ZTb3kP3ZAAAABhBWlJ6MVo2YkFBRDZYcDlpY1E3c0p3QVkAAAAkMDE5NDczZDUtY2M4ZS00ZjJiLTk2MzYtMGQyNGY3ZDU4NzBiAAAA0g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1737023760841&to_ts=1737110160841&live=true) due to a missing attribute in a SELECT.
- Instead of calling the function `getConfluenceSpaceUrl` and having it recheck that the space provided is a SpaceModel we directly inline the code path for it when a db entry is available.

## Risk

- Low but should be monitored to see if it unblocks the activities.

## Deploy Plan

- Deploy connectors.
