### PR TITLE
[front] - refacto: `Navigation`

### DIFF
--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -74,7 +74,7 @@ export function Navigation({
       {/*Desktop sidebar*/}
       <div
         className={cn(
-          "hidden flex-none overflow-hidden transition-[width] duration-150 ease-out lg:flex lg:flex-col",
+          "transition-width hidden flex-none overflow-hidden duration-150 ease-out lg:flex lg:flex-col",
           isNavigationBarOpen ? "w-80" : "w-0"
         )}
       >

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -1,9 +1,15 @@
-import { XMarkIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  MenuIcon,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@dust-tt/sparkle";
 import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
-import { Bars3Icon } from "@heroicons/react/20/solid";
+import { Transition } from "@headlessui/react";
 import React, { Fragment, useContext } from "react";
-
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import {
   NavigationSidebar,
@@ -40,80 +46,32 @@ export function Navigation({
   return (
     <div className="flex shrink-0 overflow-x-hidden">
       {/* Mobile sidebar */}
-      <div className="fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6">
-        <button
-          type="button"
-          className="-m-2.5 p-2.5 text-gray-700 lg:hidden"
-          onClick={() => setSidebarOpen(true)}
+      <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+        <div className="fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6">
+          <SheetTrigger asChild>
+            <Button
+              variant="ghost"
+              icon={MenuIcon}
+              onClick={() => setSidebarOpen(true)}
+            />
+          </SheetTrigger>
+        </div>
+        <SheetContent
+          side="left"
+          className="flex w-full max-w-xs flex-1 border-r border-slate-800 p-0"
         >
-          <span className="sr-only">Open sidebar</span>
-          <Bars3Icon className="h-5 w-5" aria-hidden="true" />
-        </button>
-      </div>
-      <Transition.Root show={sidebarOpen} as={Fragment}>
-        <Dialog
-          as="div"
-          className="relative z-50 lg:hidden"
-          onClose={setSidebarOpen}
-        >
-          <Transition.Child
-            as={Fragment}
-            enter="transition-opacity ease-linear duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="transition-opacity ease-linear duration-300"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
+          <SheetHeader>
+            <SheetTitle className="hidden" />
+          </SheetHeader>
+          <NavigationSidebar
+            subscription={subscription}
+            owner={owner}
+            subNavigation={subNavigation}
           >
-            <div className="fixed inset-0 bg-gray-900/80" />
-          </Transition.Child>
-
-          <div className="fixed inset-0 flex">
-            <Transition.Child
-              as={Fragment}
-              enter="transition ease-in-out duration-300 transform"
-              enterFrom="-translate-x-full"
-              enterTo="translate-x-0"
-              leave="transition ease-in-out duration-300 transform"
-              leaveFrom="translate-x-0"
-              leaveTo="-translate-x-full"
-            >
-              <Dialog.Panel className="relative mr-16 flex w-full max-w-xs flex-1">
-                <Transition.Child
-                  as={Fragment}
-                  enter="ease-in-out duration-300"
-                  enterFrom="opacity-0"
-                  enterTo="opacity-100"
-                  leave="ease-in-out duration-300"
-                  leaveFrom="opacity-100"
-                  leaveTo="opacity-0"
-                >
-                  <div className="absolute left-full top-0 flex w-16 justify-center pt-5">
-                    <button
-                      type="button"
-                      className="-m-2.5 p-2.5"
-                      onClick={() => setSidebarOpen(false)}
-                    >
-                      <span className="sr-only">Close sidebar</span>
-                      <XMarkIcon
-                        className="h-6 w-6 text-white"
-                        aria-hidden="true"
-                      />
-                    </button>
-                  </div>
-                </Transition.Child>
-                <NavigationSidebar
-                  subscription={subscription}
-                  owner={owner}
-                  subNavigation={subNavigation}
-                >
-                  {navChildren && navChildren}
-                </NavigationSidebar>
-              </Dialog.Panel>
-            </Transition.Child>
-          </div>
-        </Dialog>
-      </Transition.Root>
+            {navChildren && navChildren}
+          </NavigationSidebar>
+        </SheetContent>
+      </Sheet>
 
       {/*Desktop sidebar*/}
       <Transition
@@ -136,6 +94,7 @@ export function Navigation({
           </NavigationSidebar>
         </div>
       </Transition>
+
       <div
         className={classNames(
           "fixed z-40 hidden lg:top-1/2 lg:flex",

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  cn,
   MenuIcon,
   Sheet,
   SheetContent,
@@ -8,8 +9,8 @@ import {
   SheetTrigger,
 } from "@dust-tt/sparkle";
 import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
-import { Transition } from "@headlessui/react";
-import React, { Fragment, useContext } from "react";
+import React, { useContext } from "react";
+
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import {
   NavigationSidebar,
@@ -56,10 +57,7 @@ export function Navigation({
             />
           </SheetTrigger>
         </div>
-        <SheetContent
-          side="left"
-          className="flex w-full max-w-xs flex-1 border-r border-slate-800 p-0"
-        >
+        <SheetContent side="left" className="flex w-full max-w-xs flex-1 p-0">
           <SheetHeader>
             <SheetTitle className="hidden" />
           </SheetHeader>
@@ -74,15 +72,11 @@ export function Navigation({
       </Sheet>
 
       {/*Desktop sidebar*/}
-      <Transition
-        show={isNavigationBarOpen}
-        as={Fragment}
-        enter="transition-all duration-150 ease-out"
-        enterFrom="flex-none lg:w-0 h-full"
-        enterTo="flex flex-1 lg:w-80"
-        leave="transition-all duration-150 ease-out"
-        leaveFrom="flex flex-1 lg:w-80"
-        leaveTo="flex-none h-full lg:w-0"
+      <div
+        className={cn(
+          "hidden flex-none overflow-hidden transition-[width] duration-150 ease-out lg:flex lg:flex-col",
+          isNavigationBarOpen ? "w-80" : "w-0"
+        )}
       >
         <div className="hidden flex-1 lg:inset-y-0 lg:z-0 lg:flex lg:w-80 lg:flex-col">
           <NavigationSidebar
@@ -93,7 +87,7 @@ export function Navigation({
             {navChildren && navChildren}
           </NavigationSidebar>
         </div>
-      </Transition>
+      </div>
 
       <div
         className={classNames(

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.367",
+        "@dust-tt/sparkle": "0.2.368",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11454,9 +11454,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.367",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.367.tgz",
-      "integrity": "sha512-nHXvJJPrrhHr0B0bKLoD5aKEheV/miE3XW9SUjhuqSXRUcFoqxtcLSksDYC9+0u9y+Y7ucb+ppD8/LZ0nzK4qQ==",
+      "version": "0.2.368",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.368.tgz",
+      "integrity": "sha512-a6AEo/wOHfaLwhNKr8hqpK4i447pTb0Hht8WJCoyFmtQcoFZcWwFmY5RBohSBjKDYzTtZDa/w+1brXN0z1+hcw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.367",
+    "@dust-tt/sparkle": "0.2.368",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -138,6 +138,9 @@ module.exports = {
             opacity: 0,
           },
         },
+        transitionProperty: {
+          width: "width",
+        },
         fadeout: {
           "0%": {
             opacity: "1",


### PR DESCRIPTION
## Description

This PR aims at refactoring the `Navigation` component to no longer use the `Dialog` component and no longer rely on headless for transition.

## Risk

Low, broken UX

## Deploy Plan

Deploy `front`