### PR TITLE
[front] Shadow read content nodes from `core`  and compute diff

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -82,10 +82,13 @@ export function computeNodesDiff({
       const coreNode = coreNodes[0];
       const diff = Object.fromEntries(
         Object.entries(connectorsNode)
-          .filter(
-            ([key, value]) =>
-              value !== coreNode[key as keyof DataSourceViewContentNode]
-          )
+          .filter(([key, value]) => {
+            const coreValue = coreNode[key as keyof DataSourceViewContentNode];
+            if (Array.isArray(value) && Array.isArray(coreValue)) {
+              return JSON.stringify(value) !== JSON.stringify(coreValue);
+            }
+            return value !== coreValue;
+          })
           .map(([key, value]) => [
             key,
             {

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -64,13 +64,19 @@ export function computeNodesDiff({
     const coreNodes = coreContentNodes.filter(
       (coreNode) => coreNode.internalId === connectorsNode.internalId
     );
-    if (coreNodes.length !== 1) {
+    if (coreNodes.length === 0) {
+      localLogger.info(
+        { internalId: connectorsNode.internalId },
+        "[CoreNodes] No core content node matching this internal ID"
+      );
+    } else if (coreNodes.length > 1) {
+      // this one should never ever happen, it's a real red flag
       localLogger.info(
         {
           internalId: connectorsNode.internalId,
           coreNodesId: coreNodes.map((n) => n.internalId),
         },
-        "[CoreNodes] Invalid match"
+        "[CoreNodes] Found more than one match"
       );
     } else {
       const coreNode = coreNodes[0];
@@ -100,6 +106,20 @@ export function computeNodesDiff({
       }
     }
   });
+  const extraCoreInternalIds = coreContentNodes
+    .filter(
+      (coreNode) =>
+        !connectorsContentNodes.some(
+          (n) => n.internalId === coreNode.internalId
+        )
+    )
+    .map((coreNode) => coreNode.internalId);
+  if (extraCoreInternalIds.length > 0) {
+    localLogger.info(
+      { extraCoreInternalIds },
+      "[CoreNodes] Received unexpected core nodes"
+    );
+  }
 }
 
 export function getContentNodeMetadata(

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -180,6 +180,7 @@ async function getContentNodesForDataSourceViewFromCore(
       node_ids: internalIds ?? dataSourceView.parentsIn ?? undefined,
       parent_id: parentId,
     },
+    options: { limit: 250 },
   });
 
   if (coreRes.isErr()) {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -169,6 +169,8 @@ async function getContentNodesForDataSourceViewFromCore(
   dataSourceView: DataSourceViewResource | DataSourceViewType,
   { internalIds, parentId, viewType }: GetContentNodesForDataSourceViewParams
 ): Promise<Result<GetContentNodesForDataSourceViewResult, Error>> {
+  // There's an early return possible on !dataSourceView.dataSource.connectorId && internalIds?.length === 0,
+  // won't include it for now as we are shadow-reading.
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   const coreRes = await coreAPI.searchNodes({

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -178,11 +178,11 @@ async function getContentNodesForManagedDataSourceViewFromCore(
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-  // TODO(2025-01-16 aubin): confirm that if no internalIds nor parentIds are provided, we get the root nodes of the data source view.
   const coreRes = await coreAPI.searchNodes({
     filter: {
       data_source_views: [makeCoreDataSourceViewFilter(dataSourceView)],
-      node_ids: internalIds,
+      // If no internalIds are provided, we use the parentsIn
+      node_ids: internalIds ?? dataSourceView.parentsIn ?? undefined,
       parent_id: parentId,
     },
   });


### PR DESCRIPTION
## Description

- Closes [#1937](https://github.com/dust-tt/tasks/issues/1937)
- Shadow reads the content nodes from core, compute and log the diff with the content nodes in connectors.

## Risk

- low since the nodes are not used.

## Deploy Plan

- Deploy front.
