### PR TITLE
Properly handles notion database internalId

### DIFF
--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -6,9 +6,6 @@ import type {
 import type { ConnectorProvider } from "@dust-tt/types";
 import {
   assertNever,
-  getGoogleSheetTableIdFromContentNodeInternalId,
-  getMicrosoftSheetContentNodeInternalIdFromTableId,
-  getNotionDatabaseTableIdFromContentNodeInternalId,
   isGoogleSheetContentNodeInternalId,
 } from "@dust-tt/types";
 
@@ -286,29 +283,19 @@ export function getTableIdForContentNode(
   }
 
   switch (dataSource.connectorProvider) {
-    case "notion":
-      return getNotionDatabaseTableIdFromContentNodeInternalId(
-        contentNode.internalId
-      );
-
     case "google_drive":
       if (!isGoogleSheetContentNodeInternalId(contentNode.internalId)) {
         throw new Error(
           `Google Drive ContentNode internalId ${contentNode.internalId} is not a Google Sheet internal ID`
         );
       }
-      return getGoogleSheetTableIdFromContentNodeInternalId(
-        contentNode.internalId
-      );
-
-    case "microsoft":
-      return getMicrosoftSheetContentNodeInternalIdFromTableId(
-        contentNode.internalId
-      );
+      return contentNode.internalId;
 
     // For static tables, the tableId is the contentNode internalId.
     case null:
     case "snowflake":
+    case "microsoft":
+    case "notion":
       return contentNode.internalId;
 
     case "confluence":

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -3,13 +3,7 @@ import type {
   CoreAPIContentNode,
   DataSourceViewType,
 } from "@dust-tt/types";
-import {
-  assertNever,
-  getGoogleSheetContentNodeInternalIdFromTableId,
-  getMicrosoftSheetContentNodeInternalIdFromTableId,
-  getNotionDatabaseContentNodeInternalIdFromTableId,
-  MIME_TYPES,
-} from "@dust-tt/types";
+import { assertNever, MIME_TYPES } from "@dust-tt/types";
 
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 
@@ -20,18 +14,11 @@ export function getContentNodeInternalIdFromTableId(
   const { dataSource } = dataSourceView;
 
   switch (dataSource.connectorProvider) {
-    case "google_drive":
-      return getGoogleSheetContentNodeInternalIdFromTableId(tableId);
-
-    case "notion":
-      return getNotionDatabaseContentNodeInternalIdFromTableId(tableId);
-
-    case "microsoft":
-      return getMicrosoftSheetContentNodeInternalIdFromTableId(tableId);
-
-    // For static and snowflake tables, the contentNode internalId is the tableId.
     case null:
+    case "microsoft":
     case "snowflake":
+    case "google_drive":
+    case "notion":
       return tableId;
 
     case "intercom":

--- a/types/src/connectors/google_drive.ts
+++ b/types/src/connectors/google_drive.ts
@@ -19,15 +19,6 @@ export function getGoogleSheetContentNodeInternalId(
   return getGoogleSheetTableId(googleFileId, googleSheetId);
 }
 
-// Get the Content Node Id for a sheet within a Google Spreadsheet from the
-// table ID.
-// In this case, the table ID is the same as the Content Node ID.
-export function getGoogleSheetContentNodeInternalIdFromTableId(
-  tableId: string
-): string {
-  return tableId;
-}
-
 // Recover the Google-provided file ID and the ID of the sheet within the
 // spreadsheet from the Content Node ID of a sheet.
 export function getGoogleIdsFromSheetContentNodeInternalId(
@@ -40,14 +31,6 @@ export function getGoogleIdsFromSheetContentNodeInternalId(
   const googleFileId = parts[0].replace("google-spreadsheet-", "");
   const googleSheetId = parts[1];
   return { googleFileId, googleSheetId };
-}
-
-// Get the Table ID for a sheet within a Google Spreadsheet from the
-// Content Node ID of the sheet.
-export function getGoogleSheetTableIdFromContentNodeInternalId(
-  internalId: string
-): string {
-  return internalId;
 }
 
 // Check if a Content Node ID is a valid Content Node ID for a sheet within a

--- a/types/src/connectors/microsoft.ts
+++ b/types/src/connectors/microsoft.ts
@@ -4,12 +4,6 @@ export function microsoftIncrementalSyncWorkflowId(connectorId: ModelId) {
   return `microsoft-incrementalSync-${connectorId}`;
 }
 
-export function getMicrosoftSheetContentNodeInternalIdFromTableId(
-  tableId: string
-): string {
-  return tableId;
-}
-
 export function microsoftGarbageCollectionWorkflowId(connectorId: ModelId) {
   return `microsoft-garbageCollection-${connectorId}`;
 }

--- a/types/src/connectors/notion.ts
+++ b/types/src/connectors/notion.ts
@@ -85,16 +85,3 @@ export function getNotionDatabaseTableIdFromContentNodeInternalId(
   // so we can just use the same function.
   return getNotionDatabaseTableId(internalId);
 }
-
-// Recover the Content Node ID for a Notion database (which is also the notion-provided database ID)
-// from the Table ID.
-export function getNotionDatabaseContentNodeInternalIdFromTableId(
-  tableId: string
-): string {
-  if (!tableId.startsWith("notion-")) {
-    throw new Error(
-      `Invalid tableId format. Expected a tableId in the format notion-<databaseId>`
-    );
-  }
-  return tableId.replace("notion-", "");
-}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since https://github.com/dust-tt/dust/pull/9300 using the query table on Notion databases is broken.

This PR addresses an inconsistency in how Notion database IDs are handled across different parts of the system:

1. Current situation:
   - In the `connectors` service: Notion database IDs are stored without the `notion-` prefix
   - In the `core` service: Notion database IDs include the `notion-` prefix

2. The issue arises when using tables in `DATABASE_*` blocks:
   - These requests hit the endpoint `/data_source_views/[dsvId]/tables`
   - This endpoint uses `core` (instead of `connectors`) to verify if tables are properly stored and queryable
   - We were incorrectly removing the `notion-` prefix, causing failed table lookups in `core` where IDs are stored with the prefix

3. Solution:
   - All rows in `core` have been backfilled in a previous PR
   - The addition/removal of the `notion-` prefix is now exclusively handled within the `connectors` service

⚠️ We will need to manually fix assistants created since then as they have been stored with double `notion-` prefix.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
May impact database lookups and Assistant Builder. Will test on front-edge first. Rollback possible but assistants created during deployment will need patching.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
