### PR TITLE
fixing csp for hubspot tracking and removing blank link

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -105,7 +105,6 @@ export default function LandingLayout({
               variant="outline"
               size="sm"
               label="Request a demo"
-              target="_blank"
             />
             <Button
               variant="highlight"

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -2,10 +2,10 @@ const path = require("path");
 
 const CONTENT_SECURITY_POLICIES = [
   "default-src 'none';",
-  `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net;`,
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net;;`,
   `style-src 'self' 'unsafe-inline' *.typekit.net;`,
   `img-src 'self' data: https:;`,
-  `connect-src 'self' blob: *.google-analytics.com cdn.jsdelivr.net *.hsforms.com;`,
+  `connect-src 'self' blob: *.google-analytics.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net forms-eu1.hscollectedforms.net;`,
   `frame-src 'self' *.wistia.net viz.dust.tt *.hsforms.net;`,
   `font-src 'self' data: *.typekit.net;`,
   `object-src 'none';`,


### PR DESCRIPTION
## Description

CSP block our tracking cookies scripts from Hubspot, which are necessary to monitor how people reached our pages.


