### PR TITLE
Upsert gdrive spreadsheets as data_sources_folders

### DIFF
--- a/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
+++ b/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
@@ -1,6 +1,6 @@
 import { makeScript } from "scripts/helpers";
-import { QueryTypes } from "sequelize";
 
+import { getSourceUrlForGoogleDriveFiles } from "@connectors/connectors/google_drive";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import {
@@ -10,20 +10,11 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { sequelizeConnection } from "@connectors/resources/storage";
 
-const BATCH_SIZE = 256;
 const DRIVE_CONCURRENCY = 10;
-
-interface GoogleDriveSpreadsheetFileRecord {
-  driveFileId: string;
-  dustFileId: string;
-  name: string;
-  id: number;
-  connectorId: number;
-}
 
 async function upsertFoldersForConnector(
   connector: ConnectorResource,
@@ -32,82 +23,63 @@ async function upsertFoldersForConnector(
 ) {
   logger.info(`Processing Spreadsheets for connector ${connector.id}`);
 
-  let nextId = 0;
-  let updatedRowsCount = 0;
-  do {
-    const spreadsheetMimeType = "application/vnd.google-apps.spreadsheet";
-    const [spreadsheetRows] = (await sequelizeConnection.query<
-      GoogleDriveSpreadsheetFileRecord[]
-    >(
-      `
-          SELECT gdf.id, gdf."driveFileId", gdf."dustFileId", gdf."connectorId", gdf."name"
-          FROM googleDriveFiles gdf
-          WHERE gdf.id > :nextId AND gdf."mimeType" = :spreadsheetMimeType AND gdf."connectorId" = :connectorId
-          ORDER BY gdf.id
-          LIMIT :batchSize;`,
-      {
-        replacements: {
-          batchSize: BATCH_SIZE,
-          nextId,
-          spreadsheetMimeType,
-          connectorId: connector.id,
-        },
-        type: QueryTypes.SELECT,
-      }
-    )) as [GoogleDriveSpreadsheetFileRecord[], unknown];
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const spreadsheetMimeType = "application/vnd.google-apps.spreadsheet";
+  const spreadsheets = await GoogleDriveFiles.findAll({
+    where: {
+      connectorId: connector.id,
+      mimeType: spreadsheetMimeType,
+    },
+  });
 
-    if (!spreadsheetRows || spreadsheetRows.length === 0) {
-      break;
-    }
-
-    nextId = spreadsheetRows[spreadsheetRows.length - 1]!.id;
-    updatedRowsCount += spreadsheetRows.length;
-
-    // Upsert spreadsheets as folders
-    const startSyncTs = new Date().getTime();
-    await concurrentExecutor(
-      spreadsheetRows,
-      async (spreadsheetRow) => {
-        const { connectorId, driveFileId } = spreadsheetRow;
-        const authCredentials = await getAuthObject(connectorId.toString());
-        const spreadsheet = await getGoogleDriveObject(
-          authCredentials,
-          driveFileId
-        );
-        if (!spreadsheet) {
-          throw new Error(`Spreadsheet ${driveFileId} not found`);
-        }
-        const parentGoogleIds = await getFileParentsMemoized(
-          connectorId,
-          authCredentials,
-          spreadsheet,
-          startSyncTs
-        );
-        const parents = parentGoogleIds.map((parent) => getInternalId(parent));
-        if (execute) {
-          await upsertDataSourceFolder({
-            dataSourceConfig: dataSourceConfigFromConnector(connector),
-            folderId: getInternalId(spreadsheet.id),
-            parents,
-            parentId: parents[1] || null,
-            title: spreadsheetRow.name,
-            mimeType: "application/vnd.google-apps.spreadsheet",
-          });
-        }
-      },
-      { concurrency: DRIVE_CONCURRENCY }
-    );
-  } while (updatedRowsCount === BATCH_SIZE);
-
-  if (execute) {
-    logger.info(
-      `--> Finished processing ${updatedRowsCount} spreadsheet files for connector ${connector.id}`
-    );
-  } else {
-    logger.info(
-      `--> Would have processed ${updatedRowsCount} spreadsheet files for connector ${connector.id}`
-    );
+  if (!spreadsheets || spreadsheets.length === 0) {
+    logger.info(`No spreadsheets found for connector ${connector.id}`);
+    return;
   }
+
+  // Upsert spreadsheets as folders
+  const startSyncTs = new Date().getTime();
+  await concurrentExecutor(
+    spreadsheets,
+    async (spreadsheet) => {
+      const { connectorId, driveFileId } = spreadsheet;
+      const authCredentials = await getAuthObject(connector.connectionId);
+      const driveSpreadsheet = await getGoogleDriveObject(
+        authCredentials,
+        driveFileId
+      );
+      if (!driveSpreadsheet) {
+        logger.error(`Spreadsheet ${driveFileId} not found`);
+        return;
+      }
+      const parentGoogleIds = await getFileParentsMemoized(
+        connectorId,
+        authCredentials,
+        driveSpreadsheet,
+        startSyncTs
+      );
+      const parents = parentGoogleIds.map((parent) => getInternalId(parent));
+      if (execute) {
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId: getInternalId(driveSpreadsheet.id),
+          parents,
+          parentId: parents[1] || null,
+          title: spreadsheet.name,
+          mimeType: "application/vnd.google-apps.spreadsheet",
+          sourceUrl: getSourceUrlForGoogleDriveFiles(driveSpreadsheet),
+        });
+        logger.info(
+          `Upserted spreadsheet folder ${getInternalId(driveSpreadsheet.id)} for ${spreadsheet.name}`
+        );
+      } else {
+        logger.info(
+          `Would upsert spreadsheet folder ${getInternalId(driveSpreadsheet.id)} for ${spreadsheet.name}`
+        );
+      }
+    },
+    { concurrency: DRIVE_CONCURRENCY }
+  );
 }
 
 makeScript({}, async ({ execute }, logger) => {

--- a/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
+++ b/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
@@ -27,6 +27,7 @@ async function upsertFoldersForConnector(
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const spreadsheetMimeType = "application/vnd.google-apps.spreadsheet";
+  // The 5 connectors with the most spreadsheets: 35k, 20k, 13k, 8k, 7k -> No need fo batching
   const spreadsheets = await GoogleDriveFiles.findAll({
     where: {
       connectorId: connector.id,

--- a/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
+++ b/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
@@ -1,3 +1,4 @@
+import { MIME_TYPES } from "@dust-tt/types";
 import { makeScript } from "scripts/helpers";
 
 import { getSourceUrlForGoogleDriveFiles } from "@connectors/connectors/google_drive";
@@ -66,7 +67,7 @@ async function upsertFoldersForConnector(
           parents,
           parentId: parents[1] || null,
           title: spreadsheet.name,
-          mimeType: "application/vnd.google-apps.spreadsheet",
+          mimeType: MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
           sourceUrl: getSourceUrlForGoogleDriveFiles(driveSpreadsheet),
         });
         logger.info(

--- a/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
+++ b/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
@@ -1,0 +1,119 @@
+import { makeScript } from "scripts/helpers";
+import { QueryTypes } from "sequelize";
+
+import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
+import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
+import {
+  getAuthObject,
+  getInternalId,
+} from "@connectors/connectors/google_drive/temporal/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import type { Logger } from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { sequelizeConnection } from "@connectors/resources/storage";
+
+const BATCH_SIZE = 256;
+const DRIVE_CONCURRENCY = 10;
+
+interface GoogleDriveSpreadsheetFileRecord {
+  driveFileId: string;
+  dustFileId: string;
+  name: string;
+  id: number;
+  connectorId: number;
+}
+
+async function upsertFoldersForConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  logger: Logger
+) {
+  logger.info(`Processing Spreadsheets for connector ${connector.id}`);
+
+  let nextId = 0;
+  let updatedRowsCount = 0;
+  do {
+    const spreadsheetMimeType = "application/vnd.google-apps.spreadsheet";
+    const [spreadsheetRows] = (await sequelizeConnection.query<
+      GoogleDriveSpreadsheetFileRecord[]
+    >(
+      `
+          SELECT gdf.id, gdf."driveFileId", gdf."dustFileId", gdf."connectorId", gdf."name"
+          FROM googleDriveFiles gdf
+          WHERE gdf.id > :nextId AND gdf."mimeType" = :spreadsheetMimeType AND gdf."connectorId" = :connectorId
+          ORDER BY gdf.id
+          LIMIT :batchSize;`,
+      {
+        replacements: {
+          batchSize: BATCH_SIZE,
+          nextId,
+          spreadsheetMimeType,
+          connectorId: connector.id,
+        },
+        type: QueryTypes.SELECT,
+      }
+    )) as [GoogleDriveSpreadsheetFileRecord[], unknown];
+
+    if (!spreadsheetRows || spreadsheetRows.length === 0) {
+      break;
+    }
+
+    nextId = spreadsheetRows[spreadsheetRows.length - 1]!.id;
+    updatedRowsCount += spreadsheetRows.length;
+
+    // Upsert spreadsheets as folders
+    const startSyncTs = new Date().getTime();
+    await concurrentExecutor(
+      spreadsheetRows,
+      async (spreadsheetRow) => {
+        const { connectorId, driveFileId } = spreadsheetRow;
+        const authCredentials = await getAuthObject(connectorId.toString());
+        const spreadsheet = await getGoogleDriveObject(
+          authCredentials,
+          driveFileId
+        );
+        if (!spreadsheet) {
+          throw new Error(`Spreadsheet ${driveFileId} not found`);
+        }
+        const parentGoogleIds = await getFileParentsMemoized(
+          connectorId,
+          authCredentials,
+          spreadsheet,
+          startSyncTs
+        );
+        const parents = parentGoogleIds.map((parent) => getInternalId(parent));
+        if (execute) {
+          await upsertDataSourceFolder({
+            dataSourceConfig: dataSourceConfigFromConnector(connector),
+            folderId: getInternalId(spreadsheet.id),
+            parents,
+            parentId: parents[1] || null,
+            title: spreadsheetRow.name,
+            mimeType: "application/vnd.google-apps.spreadsheet",
+          });
+        }
+      },
+      { concurrency: DRIVE_CONCURRENCY }
+    );
+  } while (updatedRowsCount === BATCH_SIZE);
+
+  if (execute) {
+    logger.info(
+      `--> Finished processing ${updatedRowsCount} spreadsheet files for connector ${connector.id}`
+    );
+  } else {
+    logger.info(
+      `--> Would have processed ${updatedRowsCount} spreadsheet files for connector ${connector.id}`
+    );
+  }
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  // We only have 469 of them, so we can just do them all
+  const connectors = await ConnectorResource.listByType("google_drive", {});
+  for (const connector of connectors) {
+    await upsertFoldersForConnector(connector, execute, logger);
+  }
+});

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -510,7 +510,7 @@ export async function syncSpreadSheet(
         parents,
         parentId: parents[0] || null,
         title: spreadsheet.data.properties?.title ?? "Untitled Spreadsheet",
-        mimeType: file.mimeType,
+        mimeType: "application/vnd.google-apps.spreadsheet",
       });
 
       const successfulSheetIdImports: number[] = [];

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -11,7 +11,10 @@ import type { sheets_v4 } from "googleapis";
 import { google } from "googleapis";
 import type { OAuth2Client } from "googleapis-common";
 
-import { getSourceUrlForGoogleDriveSheet } from "@connectors/connectors/google_drive";
+import {
+  getSourceUrlForGoogleDriveFiles,
+  getSourceUrlForGoogleDriveSheet,
+} from "@connectors/connectors/google_drive";
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -511,6 +514,7 @@ export async function syncSpreadSheet(
         parentId: parents[1] || null,
         title: spreadsheet.data.properties?.title ?? "Untitled Spreadsheet",
         mimeType: "application/vnd.google-apps.spreadsheet",
+        sourceUrl: getSourceUrlForGoogleDriveFiles(file),
       });
 
       const successfulSheetIdImports: number[] = [];

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -2,6 +2,7 @@ import type { ModelId } from "@dust-tt/types";
 import {
   getGoogleSheetTableId,
   InvalidStructuredDataHeaderError,
+  MIME_TYPES,
   slugify,
 } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
@@ -513,7 +514,7 @@ export async function syncSpreadSheet(
         parents,
         parentId: parents[1] || null,
         title: spreadsheet.data.properties?.title ?? "Untitled Spreadsheet",
-        mimeType: "application/vnd.google-apps.spreadsheet",
+        mimeType: MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
         sourceUrl: getSourceUrlForGoogleDriveFiles(file),
       });
 

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -614,7 +614,7 @@ export async function deleteSpreadsheet(
     "[Spreadsheet] Deleting Google Spreadsheet."
   );
 
-  // Delete the folder that contains the sheets.
+  // Delete the spreadsheet folder, that contains the sheets.
   await deleteDataSourceFolder({
     dataSourceConfig: dataSourceConfigFromConnector(connector),
     folderId: getInternalId(file.driveFileId),

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -508,7 +508,7 @@ export async function syncSpreadSheet(
         dataSourceConfig: dataSourceConfigFromConnector(connector),
         folderId: getInternalId(file.id),
         parents,
-        parentId: parents[0] || null,
+        parentId: parents[1] || null,
         title: spreadsheet.data.properties?.title ?? "Untitled Spreadsheet",
         mimeType: "application/vnd.google-apps.spreadsheet",
       });

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -72,7 +72,7 @@ export const MIME_TYPES = {
   }),
   GOOGLE_DRIVE: getMimeTypes({
     provider: "google_drive",
-    resourceTypes: ["FOLDER"], // for files and spreadsheets, we keep Google's mime types
+    resourceTypes: ["FOLDER", "SPREADSHEET"], // for files and spreadsheets, we keep Google's mime types
   }),
   INTERCOM: getMimeTypes({
     provider: "intercom",

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -72,7 +72,9 @@ export const MIME_TYPES = {
   }),
   GOOGLE_DRIVE: getMimeTypes({
     provider: "google_drive",
-    resourceTypes: ["FOLDER", "SPREADSHEET"], // for files and spreadsheets, we keep Google's mime types
+    // Spreadsheets are handled as data_source_folders for sheets
+    // For other files and sheets, we keep Google's mime types
+    resourceTypes: ["FOLDER", "SPREADSHEET"],
   }),
   INTERCOM: getMimeTypes({
     provider: "intercom",


### PR DESCRIPTION
## Description
- Make sure gdrive spreadsheets are uploaded as data_source_folders
- Backfill: upsert existing gdrive spreadsheets into core data_source_folders
- Part of https://github.com/dust-tt/dust/issues/10009#issue-2790681403

## Risk
- Break gdrive spreadsheet upsert (low, because tested locally)
- No workflow change nor activity params change -> should be temporal-friendly

## Deploy Plan
Deploy connectors
Run backfill on prodbox
