### PR TITLE
Upg: allow selecting specific files in folders for assistants

### DIFF
--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -349,11 +349,7 @@ function DataSourceViewsSection({
           return (
             <Tree.Item
               key={`${dsConfig.dataSourceViewId}-${JSON.stringify(dsConfig.filter)}`}
-              type={
-                canBeExpanded(viewType, dataSourceView?.dataSource)
-                  ? "node"
-                  : "leaf"
-              }
+              type={canBeExpanded(dataSourceView?.dataSource) ? "node" : "leaf"}
               label={dataSourceName}
               visual={dsLogo ?? FolderIcon}
               className="whitespace-nowrap"

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -96,7 +96,7 @@ export default function DataSourceSelectionSection({
                 <Tree.Item
                   key={dsConfig.dataSourceView.sId}
                   type={
-                    canBeExpanded(viewType, dsConfig.dataSourceView.dataSource)
+                    canBeExpanded(dsConfig.dataSourceView.dataSource)
                       ? "node"
                       : "leaf"
                   } // todo make useConnectorPermissions hook work for non managed ds (Folders)

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -472,9 +472,7 @@ export function DataSourceViewSelector({
         label={getDisplayNameForDataSource(dataSourceView.dataSource)}
         visual={LogoComponent}
         defaultCollapsed={defaultCollapsed}
-        type={
-          canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
-        }
+        type={canBeExpanded(dataSourceView.dataSource) ? "node" : "leaf"}
         checkbox={
           hideCheckbox || (!isRootSelectable && !hasActiveSelection)
             ? undefined

--- a/front/components/trackers/TrackerDataSourceSelectedTree.tsx
+++ b/front/components/trackers/TrackerDataSourceSelectedTree.tsx
@@ -57,7 +57,7 @@ export const TrackerDataSourceSelectedTree = ({
             <Tree.Item
               key={dsConfig.dataSourceView.sId}
               type={
-                canBeExpanded("documents", dsConfig.dataSourceView.dataSource)
+                canBeExpanded(dsConfig.dataSourceView.dataSource)
                   ? "node"
                   : "leaf"
               } // todo make useConnectorPermissions hook work for non managed ds (Folders)

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -1,6 +1,5 @@
 import type {
   ConnectorProvider,
-  ContentNodesViewType,
   CoreAPIDocument,
   DataSourceType,
   DataSourceViewType,
@@ -96,16 +95,11 @@ export function supportsStructuredData(ds: DataSource): boolean {
   );
 }
 
-export function canBeExpanded(
-  viewType: ContentNodesViewType,
-  ds?: DataSource
-): boolean {
+export function canBeExpanded(ds?: DataSource): boolean {
   if (!ds) {
     return false;
   }
-  // Folders with viewType "documents" are always considered leaf items.
-  // For viewType "tables", folders are not leaf items because users need to select a specific table.
-  return !isFolder(ds) || viewType === "tables";
+  return true;
 }
 
 export function getDataSourceNameFromView(dsv: DataSourceViewType): string {


### PR DESCRIPTION
## Description

Now that folder documents have their parents correctly set, we can select them individually for assistant !

## Risk

Low, worst case, missing files when expanding.

## Deploy Plan

Deploy `front`