### PR TITLE
[front] - fix: `api-keys` layout

### DIFF
--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -1,6 +1,7 @@
 import {
   BookOpenIcon,
   Button,
+  ClipboardCheckIcon,
   ClipboardIcon,
   DropdownMenu,
   DropdownMenuContent,
@@ -22,6 +23,7 @@ import {
   ScrollBar,
   ShapesIcon,
   Spinner,
+  useCopyToClipboard,
 } from "@dust-tt/sparkle";
 import type {
   GroupType,
@@ -81,6 +83,8 @@ export function APIKeys({
   groups: GroupType[];
 }) {
   const { mutate } = useSWRConfig();
+  const [isCopiedWorkspaceId, copyWorkspaceId] = useCopyToClipboard();
+  const [isCopiedApiKey, copyApiKey] = useCopyToClipboard();
   const [newApiKeyName, setNewApiKeyName] = useState("");
   const [newApiKeyGroup, setNewApiKeyGroup] = useState<GroupType>(
     _.find(groups, (g) => g.kind === "global") || groups[0]
@@ -141,32 +145,38 @@ export function APIKeys({
       >
         <div className="mt-4">
           <p className="text-sm text-gray-700">
-            Your API key will remain visible for 10 minutes only. <br />
-            You can use it to authenticate with the Dust API. <br />
+            Your API key will remain visible for 10 minutes only. You can use it
+            to authenticate with the Dust API.
           </p>
           <br />
           <div className="mt-4">
             <Page.H variant="h5">Workspace ID</Page.H>
-            <Page.Horizontal align="stretch">
-              <pre>{owner.sId}</pre>
+            <Page.Horizontal align="center">
+              <pre className="font-mono flex-grow overflow-x-auto rounded bg-slate-50 p-2">
+                {owner.sId}
+              </pre>
               <IconButton
                 tooltip="Copy to clipboard"
-                icon={ClipboardIcon}
-                onClick={() => {
-                  void navigator.clipboard.writeText(owner.sId);
+                icon={isCopiedWorkspaceId ? ClipboardCheckIcon : ClipboardIcon}
+                onClick={async () => {
+                  await copyWorkspaceId(owner.sId);
                 }}
               />
             </Page.Horizontal>
           </div>
           <div className="mt-4">
             <Page.H variant="h5">API Key</Page.H>
-            <Page.Horizontal align="stretch">
-              <pre>{keys[0]?.secret}</pre>
+            <Page.Horizontal align="center">
+              <pre className="font-mono flex-grow overflow-x-auto rounded bg-slate-50 p-2">
+                {keys[0]?.secret}
+              </pre>
               <IconButton
                 tooltip="Copy to clipboard"
-                icon={ClipboardIcon}
-                onClick={() => {
-                  void navigator.clipboard.writeText(keys[0]?.secret);
+                icon={isCopiedApiKey ? ClipboardCheckIcon : ClipboardIcon}
+                onClick={async () => {
+                  if (keys[0]?.secret) {
+                    await copyApiKey(keys[0].secret);
+                  }
                 }}
               />
             </Page.Horizontal>
@@ -185,7 +195,7 @@ export function APIKeys({
           }}
         />
         <NewDialog>
-          <NewDialogTrigger>
+          <NewDialogTrigger asChild>
             <Button
               label="Create API Key"
               icon={PlusIcon}


### PR DESCRIPTION
## Description

This PR aims at fixing the layout of the API keys modal
<img width="364" alt="Screenshot 2025-01-17 at 16 29 34" src="https://github.com/user-attachments/assets/89ada45a-6179-46fe-933f-892b555b66c2" />

**References:**
- https://github.com/dust-tt/dust/issues/9975

## Risk

Low

## Deploy Plan

Deploy `front`