### PR TITLE
[content-nodes] Refactor computation of `expandable` and `preventSelection` properties

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -117,199 +117,81 @@ export function getContentNodeMetadata(
   viewType: "tables" | "documents"
 ): {
   type: ContentNodeType;
-  expandable: boolean;
-  preventSelection?: boolean;
 } {
   switch (node.mime_type) {
     case MIME_TYPES.CONFLUENCE.PAGE:
-      return {
-        type: "file",
-        expandable: node.has_children,
-      };
+      return { type: "file" };
     case MIME_TYPES.CONFLUENCE.SPACE:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.GITHUB.REPOSITORY:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.GITHUB.CODE_ROOT:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.GITHUB.CODE_DIRECTORY:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.GITHUB.CODE_FILE:
-      return {
-        type: "file",
-        expandable: false,
-      };
+      return { type: "file" };
     case MIME_TYPES.GITHUB.ISSUES:
-      return {
-        type: "database",
-        expandable: false,
-      };
+      return { type: "database" };
     case MIME_TYPES.GITHUB.ISSUE:
-      return {
-        type: "file",
-        expandable: false,
-      };
+      return { type: "file" };
     case MIME_TYPES.GITHUB.DISCUSSIONS:
-      return {
-        type: "channel",
-        expandable: false,
-      };
+      return { type: "channel" };
     case MIME_TYPES.GITHUB.DISCUSSION:
-      return {
-        type: "file",
-        expandable: false,
-      };
+      return { type: "file" };
     case MIME_TYPES.GOOGLE_DRIVE.FOLDER:
-      return {
-        type: "folder",
-        expandable: node.has_children,
-      };
+      return { type: "folder" };
     case MIME_TYPES.INTERCOM.COLLECTION:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.INTERCOM.TEAMS_FOLDER:
-      return {
-        type: "channel",
-        expandable: true,
-      };
+      return { type: "channel" };
     case MIME_TYPES.INTERCOM.CONVERSATION:
-      return {
-        type: "file",
-        expandable: false,
-      };
+      return { type: "file" };
     case MIME_TYPES.INTERCOM.TEAM:
-      return {
-        type: "folder",
-        expandable: false,
-      };
+      return { type: "folder" };
     case MIME_TYPES.INTERCOM.HELP_CENTER:
-      return {
-        type: "database",
-        expandable: true,
-      };
+      return { type: "database" };
     case MIME_TYPES.INTERCOM.ARTICLE:
-      return {
-        type: "file",
-        expandable: false,
-      };
+      return { type: "file" };
     case MIME_TYPES.MICROSOFT.FOLDER:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.NOTION.UNKNOWN_FOLDER:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.NOTION.DATABASE:
-      return {
-        type: "database",
-        expandable: true,
-      };
+      return { type: "database" };
     case MIME_TYPES.NOTION.PAGE:
-      return {
-        type: "file",
-        expandable: node.has_children,
-      };
+      return { type: "file" };
     case MIME_TYPES.SLACK.CHANNEL:
-      return {
-        type: "channel",
-        expandable: false,
-      };
+      return { type: "channel" };
     case MIME_TYPES.SLACK.THREAD:
-      return {
-        type: "file",
-        expandable: false,
-      };
+      return { type: "file" };
     case MIME_TYPES.SLACK.MESSAGES:
-      return {
-        type: "file",
-        expandable: true,
-      };
+      return { type: "file" };
     case MIME_TYPES.SNOWFLAKE.DATABASE:
-      return {
-        type: "folder",
-        expandable: true,
-        preventSelection: false,
-      };
+      return { type: "folder" };
     case MIME_TYPES.SNOWFLAKE.SCHEMA:
-      return {
-        type: "folder",
-        expandable: true,
-        preventSelection: false,
-      };
+      return { type: "folder" };
     case MIME_TYPES.SNOWFLAKE.TABLE:
-      return {
-        type: "database",
-        expandable: false,
-        preventSelection: false,
-      };
+      return { type: "database" };
     case MIME_TYPES.WEBCRAWLER.FOLDER:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.ZENDESK.BRAND:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.ZENDESK.HELP_CENTER:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.ZENDESK.CATEGORY:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.ZENDESK.ARTICLE:
-      return {
-        type: "file",
-        expandable: false,
-      };
+      return { type: "file" };
     case MIME_TYPES.ZENDESK.TICKETS:
-      return {
-        type: "folder",
-        expandable: true,
-      };
+      return { type: "folder" };
     case MIME_TYPES.ZENDESK.TICKET:
-      return {
-        type: "file",
-        expandable: false,
-      };
+      return { type: "file" };
     default:
-      let expandable = false;
       let type: ContentNodeType = "file";
-      if (
-        node.mime_type ===
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" &&
-        viewType === "tables"
-      ) {
-        expandable = true;
-      }
       if (node.mime_type === "text/csv") {
         type = viewType === "tables" ? "database" : "file";
       }
-      return {
-        type,
-        expandable,
-      };
+      return { type };
   }
 }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -70,6 +70,9 @@ export function computeNodesDiff({
       const diff = Object.fromEntries(
         Object.entries(connectorsNode)
           .filter(([key, value]) => {
+            if (key === "preventSelection") {
+              return false;
+            }
             const coreValue = coreNode[key as keyof DataSourceViewContentNode];
             if (Array.isArray(value) && Array.isArray(coreValue)) {
               return JSON.stringify(value) !== JSON.stringify(coreValue);

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -189,10 +189,7 @@ async function getContentNodesForDataSourceViewFromCore(
 
   return new Ok({
     nodes: coreRes.value.nodes.map((node) => {
-      const { type, preventSelection, expandable } = getContentNodeMetadata(
-        node,
-        viewType
-      );
+      const { type } = getContentNodeMetadata(node, viewType);
       return {
         internalId: node.node_id,
         parentInternalId: node.parent_id ?? null,
@@ -203,8 +200,7 @@ async function getContentNodesForDataSourceViewFromCore(
         providerVisibility: node.provider_visibility,
         parentInternalIds: node.parents,
         type,
-        preventSelection,
-        expandable,
+        expandable: node.has_children,
       };
     }),
     total: coreRes.value.nodes.length,


### PR DESCRIPTION
## Description

- Part of [#10051](https://github.com/dust-tt/dust/issues/10051)
- This PR uses the `has_children` field from `core`'s response to infer the `expandable` property.
- This PR also removes the preventSelection property: it is more of a permission thing and is not actually set to true outside of `/permissions` and in `/content-nodes`.
- The `type` property is left untouched (TBC).

## Risk

- Low.

## Deploy Plan

- Deploy front.
