### PR TITLE
Upg: Remove all useless getSession() in endpoint

### DIFF
--- a/front/pages/api/app-status.ts
+++ b/front/pages/api/app-status.ts
@@ -6,7 +6,7 @@ import {
   getDustStatusMemoized,
   getProviderStatusMemoized,
 } from "@app/lib/api/status";
-import { getSession } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 
 export interface GetAppStatusResponseBody {
@@ -24,14 +24,10 @@ export interface GetAppStatusResponseBody {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetAppStatusResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetAppStatusResponseBody>>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- session is passed by the auth wrapper
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
-  if (!session) {
-    res.status(401).end();
-    return;
-  }
-
   if (req.method !== "GET") {
     return apiError(req, res, {
       status_code: 405,

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -2,7 +2,7 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { getSession } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { createWorkspace } from "@app/lib/iam/workspaces";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -11,14 +11,9 @@ import { createAndLogMembership } from "@app/pages/api/login";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<{ sId: string }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ sId: string }>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
-  if (!session) {
-    res.status(401).end();
-    return;
-  }
-
   if (req.method !== "POST") {
     return apiError(req, res, {
       status_code: 405,

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -499,4 +499,5 @@ export async function createAndLogMembership({
   return m;
 }
 
+// Note from seb: Should it be withSessionAuthentication?
 export default withLogging(handler);

--- a/front/pages/api/poke/admin.ts
+++ b/front/pages/api/poke/admin.ts
@@ -6,15 +6,16 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<AdminResponseType>>
+  res: NextApiResponse<WithAPIErrorResponse<AdminResponseType>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);
 
   if (!auth.isDustSuperUser()) {

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -5,7 +5,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { apiError } from "@app/logger/withlogging";
@@ -58,9 +59,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetPokePlansResponseBody | UpsertPokePlanResponseBody>
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);
 
   if (!auth.isDustSuperUser()) {

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -9,7 +9,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -27,9 +28,9 @@ async function handler(
     WithAPIErrorResponse<
       PokeCreateTemplateResponseBody | PokeFetchAssistantTemplateResponse
     >
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);
 
   if (!auth.isDustSuperUser()) {

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -9,7 +9,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { AssistantTemplateListType } from "@app/pages/api/w/[wId]/assistant/builder/templates";
@@ -28,9 +29,9 @@ async function handler(
     WithAPIErrorResponse<
       CreateTemplateResponseBody | PokeFetchAssistantTemplatesResponse
     >
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);
 
   if (!auth.isDustSuperUser()) {

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -6,7 +6,8 @@ import {
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 
 export type DeleteAgentConfigurationResponseBody = {
@@ -17,9 +18,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<DeleteAgentConfigurationResponseBody>
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -6,7 +6,8 @@ import {
   restoreAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 
 export type RestoreAgentConfigurationResponseBody = {
@@ -17,9 +18,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<RestoreAgentConfigurationResponseBody>
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -6,7 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
@@ -18,9 +19,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetAgentConfigurationsResponseBody | void>
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -6,7 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getPokeConversation } from "@app/lib/poke/conversations";
 import { apiError } from "@app/logger/withlogging";
 
@@ -16,9 +17,9 @@ export type GetConversationResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetConversationResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetConversationResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
@@ -4,7 +4,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -16,9 +17,9 @@ export type SetConfigResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<SetConfigResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<SetConfigResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
@@ -4,7 +4,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -16,9 +17,9 @@ export type GetDocumentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
@@ -2,7 +2,8 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
@@ -12,9 +13,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetDataSourcePermissionsResponseBody>
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -7,15 +7,16 @@ import { fromError } from "zod-validation-error";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceSearch } from "@app/lib/api/data_sources";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<DataSourceSearchResponseType>>
+  res: NextApiResponse<WithAPIErrorResponse<DataSourceSearchResponseType>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
@@ -4,7 +4,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -16,9 +17,9 @@ export type GetTablesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetTablesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetTablesResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -2,7 +2,8 @@ import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { internalSubscribeWorkspaceToFreeNoPlan } from "@app/lib/plans/subscription";
 import { apiError } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
@@ -13,9 +14,9 @@ export type DowngradeWorkspaceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<DowngradeWorkspaceResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<DowngradeWorkspaceResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -6,7 +6,8 @@ import { isWhitelistableFeature } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { apiError } from "@app/logger/withlogging";
 
@@ -24,9 +25,9 @@ async function handler(
     WithAPIErrorResponse<
       CreateOrDeleteFeatureFlagResponseBody | GetPokeFeaturesResponseBody
     >
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -9,7 +9,8 @@ import {
   deleteWorkspace,
   setInternalWorkspaceSegmentation,
 } from "@app/lib/api/workspace";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 
 export const WorkspaceTypeSchema = t.type({
@@ -30,9 +31,9 @@ async function handler(
     WithAPIErrorResponse<
       SegmentWorkspaceResponseBody | DeleteWorkspaceResponseBody
     >
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -9,7 +9,8 @@ import {
   getPendingInvitations,
   updateInvitationStatusAndRole,
 } from "@app/lib/api/invitation";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 
 const PokeDeleteInvitationRequestBodySchema = t.type({
@@ -24,9 +25,9 @@ type PokePostInvitationResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PokePostInvitationResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PokePostInvitationResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -4,7 +4,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getUserForWorkspace } from "@app/lib/api/user";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
@@ -16,9 +17,9 @@ export type RevokeUserResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<RevokeUserResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<RevokeUserResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -7,7 +7,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getUserForWorkspace } from "@app/lib/api/user";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
@@ -23,9 +24,9 @@ const PostRoleUserRequestBody = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostRoleUserResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostRoleUserResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -2,7 +2,8 @@ import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { pokeUpgradeWorkspaceToPlan } from "@app/lib/plans/subscription";
 import { apiError } from "@app/logger/withlogging";
 
@@ -12,9 +13,9 @@ export type UpgradeWorkspaceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<UpgradeWorkspaceResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<UpgradeWorkspaceResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -5,7 +5,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import {
   assertStripeSubscriptionIsValid,
   getStripeSubscription,
@@ -25,9 +26,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<UpgradeEnterpriseSuccessResponseBody>
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
     session,
     req.query.wId as string

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -11,7 +11,8 @@ import { Op } from "sequelize";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
@@ -69,9 +70,9 @@ const getPlanPriority = (planCode: string) => {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetPokeWorkspacesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetPokeWorkspacesResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);
 
   if (!auth.isDustSuperUser()) {

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -5,7 +5,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";
 import { apiError } from "@app/logger/withlogging";
 
@@ -17,7 +18,8 @@ type PostStripePortalResponseBody = {
 };
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostStripePortalResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostStripePortalResponseBody>>,
+  session: SessionWithUser
 ): Promise<void> {
   const bodyValidation = PostStripePortalRequestBody.decode(req.body);
   if (isLeft(bodyValidation)) {
@@ -32,7 +34,6 @@ async function handler(
   }
 
   const workspaceId = bodyValidation.right.workspaceId;
-  const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(session, workspaceId);
 
   const owner = auth.workspace();

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -9,7 +9,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { getSession } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
@@ -33,10 +33,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<PostUserMetadataResponseBody | GetUserResponseBody>
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
-
   // This functions retrieves the full user including all workspaces.
   const user = await getUserFromSession(session);
 

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getUserMetadata, setUserMetadata } from "@app/lib/api/user";
-import { getSession } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 
@@ -20,9 +20,9 @@ async function handler(
     WithAPIErrorResponse<
       PostUserMetadataResponseBody | GetUserMetadataResponseBody
     >
-  >
+  >,
+  session: SessionWithUser
 ): Promise<void> {
-  const session = await getSession(req, res);
   const user = await getUserFromSession(session);
 
   if (!user) {


### PR DESCRIPTION
## Description

All theses handlers are using `withSessionAuthentication()` that automatically:
- check if there is a valid session
- provide the session as the third arguments of the handler

Therefor, all theses getSession() calls are useless.

Note: we didn't catch it because of the way typescript consider `fn(a, b)` to be valid for an argument defined as `arg:fn(a, b, c)`. We could change the handler signature for a typed object to avoid this problem in the future (but outside of this PR scope).

## Risk

Low (most of them are poke stuff)

## Deploy Plan

Deploy `front`