### PR TITLE
[auth0] Add maxAge 0 to make sure we actually logout when we want to log out

### DIFF
--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -110,6 +110,7 @@ export default handleAuth({
       LoginOptions["authorizationParams"]
     > = {
       scope: "openid profile email",
+      max_age: 0,
     };
 
     // Set the Auth0 connection based on the provided connection param, redirecting the user to the correct screen.


### PR DESCRIPTION
## Description

Currently users can't ever switch accounts on Dust. When you log-out, and you log-in again, you're automagically sent back to the account you logged out from. Not expected behavior.


https://github.com/user-attachments/assets/ea924f1b-9c05-45a8-822d-8eea978ee888

Adding maxAge=0 will actually log you out and ask to re-login


https://github.com/user-attachments/assets/33f7752c-ec72-4130-8e14-cb323d088e47

## Risk

We might want to take a look at SSO on front-edge

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
