### PR TITLE
[ContentNodes] Refactor the `type` property and add a mapping `mimeType` -> icon

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -187,18 +187,16 @@ export function computeNodesDiff({
   }
 }
 
-export function getContentNodeMetadata(node: CoreAPIContentNode): {
-  type: ContentNodeType;
-} {
+export function getContentNodeType(node: CoreAPIContentNode): ContentNodeType {
   // this is approximate and will be cleaned up when we turn ContentNodeType into the same nodeType as in core
   // the main point is that it correctly identifies documents as files as this is used in ContentNodeTree
   switch (node.node_type) {
     case "Table":
-      return { type: "database" };
+      return "database";
     case "Folder":
-      return { type: "folder" };
+      return "folder";
     case "Document":
-      return { type: "file" };
+      return "file";
     default:
       assertNever(node.node_type);
   }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -5,7 +5,7 @@ import type {
   DataSourceViewContentNode,
   DataSourceViewType,
 } from "@dust-tt/types";
-import { assertNever, MIME_TYPES } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type logger from "@app/logger/logger";
@@ -187,82 +187,19 @@ export function computeNodesDiff({
   }
 }
 
-export function getContentNodeMetadata(
-  node: CoreAPIContentNode,
-  viewType: "tables" | "documents"
-): {
+export function getContentNodeMetadata(node: CoreAPIContentNode): {
   type: ContentNodeType;
 } {
-  switch (node.mime_type) {
-    case MIME_TYPES.CONFLUENCE.PAGE:
-      return { type: "file" };
-    case MIME_TYPES.CONFLUENCE.SPACE:
-      return { type: "folder" };
-    case MIME_TYPES.GITHUB.REPOSITORY:
-      return { type: "folder" };
-    case MIME_TYPES.GITHUB.CODE_ROOT:
-      return { type: "folder" };
-    case MIME_TYPES.GITHUB.CODE_DIRECTORY:
-      return { type: "folder" };
-    case MIME_TYPES.GITHUB.CODE_FILE:
-      return { type: "file" };
-    case MIME_TYPES.GITHUB.ISSUES:
+  // this is approximate and will be cleaned up when we turn ContentNodeType into the same nodeType as in core
+  // the main point is that it correctly identifies documents as files as this is used in ContentNodeTree
+  switch (node.node_type) {
+    case "Table":
       return { type: "database" };
-    case MIME_TYPES.GITHUB.ISSUE:
-      return { type: "file" };
-    case MIME_TYPES.GITHUB.DISCUSSIONS:
-      return { type: "channel" };
-    case MIME_TYPES.GITHUB.DISCUSSION:
-      return { type: "file" };
-    case MIME_TYPES.GOOGLE_DRIVE.FOLDER:
+    case "Folder":
       return { type: "folder" };
-    case MIME_TYPES.INTERCOM.COLLECTION:
-      return { type: "folder" };
-    case MIME_TYPES.INTERCOM.TEAMS_FOLDER:
-      return { type: "channel" };
-    case MIME_TYPES.INTERCOM.CONVERSATION:
-      return { type: "file" };
-    case MIME_TYPES.INTERCOM.TEAM:
-      return { type: "folder" };
-    case MIME_TYPES.INTERCOM.ARTICLE:
-      return { type: "file" };
-    case MIME_TYPES.MICROSOFT.FOLDER:
-      return { type: "folder" };
-    case MIME_TYPES.NOTION.UNKNOWN_FOLDER:
-      return { type: "folder" };
-    case MIME_TYPES.NOTION.DATABASE:
-      return { type: "database" };
-    case MIME_TYPES.NOTION.PAGE:
-      return { type: "file" };
-    case MIME_TYPES.SLACK.CHANNEL:
-      return { type: "channel" };
-    case MIME_TYPES.SLACK.THREAD:
-      return { type: "file" };
-    case MIME_TYPES.SLACK.MESSAGES:
-      return { type: "file" };
-    case MIME_TYPES.SNOWFLAKE.DATABASE:
-      return { type: "folder" };
-    case MIME_TYPES.SNOWFLAKE.SCHEMA:
-      return { type: "folder" };
-    case MIME_TYPES.SNOWFLAKE.TABLE:
-      return { type: "database" };
-    case MIME_TYPES.WEBCRAWLER.FOLDER:
-      return { type: "folder" };
-    case MIME_TYPES.ZENDESK.HELP_CENTER:
-      return { type: "folder" };
-    case MIME_TYPES.ZENDESK.CATEGORY:
-      return { type: "folder" };
-    case MIME_TYPES.ZENDESK.ARTICLE:
-      return { type: "file" };
-    case MIME_TYPES.ZENDESK.TICKETS:
-      return { type: "folder" };
-    case MIME_TYPES.ZENDESK.TICKET:
+    case "Document":
       return { type: "file" };
     default:
-      let type: ContentNodeType = "file";
-      if (node.mime_type === "text/csv") {
-        type = viewType === "tables" ? "database" : "file";
-      }
-      return { type };
+      assertNever(node.node_type);
   }
 }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -190,6 +190,7 @@ export function computeNodesDiff({
 export function getContentNodeType(node: CoreAPIContentNode): ContentNodeType {
   // this is approximate and will be cleaned up when we turn ContentNodeType into the same nodeType as in core
   // the main point is that it correctly identifies documents as files as this is used in ContentNodeTree
+  // TODO(2025-01-27 aubin): clean this up
   switch (node.node_type) {
     case "Table":
       return "database";

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -5,7 +5,7 @@ import type {
   DataSourceViewContentNode,
   DataSourceViewType,
 } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+import { assertNever, MIME_TYPES } from "@dust-tt/types";
 
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type logger from "@app/logger/logger";

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -255,6 +255,7 @@ async function getContentNodesForDataSourceViewFromCore(
         expandable:
           !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
           node.has_children,
+        mimeType: node.mime_type,
       };
     }),
     total: coreRes.value.nodes.length,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -22,7 +22,7 @@ import config from "@app/lib/api/config";
 import {
   computeNodesDiff,
   getContentNodeInternalIdFromTableId,
-  getContentNodeMetadata,
+  getContentNodeType,
   NON_EXPANDABLE_NODES_MIME_TYPES,
 } from "@app/lib/api/content_nodes";
 import type { OffsetPaginationParams } from "@app/lib/api/pagination";
@@ -241,7 +241,7 @@ async function getContentNodesForDataSourceViewFromCore(
 
   return new Ok({
     nodes: filteredNodes.map((node) => {
-      const { type } = getContentNodeMetadata(node);
+      const type = getContentNodeType(node);
       return {
         internalId: node.node_id,
         parentInternalId: node.parent_id ?? null,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -241,7 +241,6 @@ async function getContentNodesForDataSourceViewFromCore(
 
   return new Ok({
     nodes: filteredNodes.map((node) => {
-      const type = getContentNodeType(node);
       return {
         internalId: node.node_id,
         parentInternalId: node.parent_id ?? null,
@@ -251,7 +250,7 @@ async function getContentNodesForDataSourceViewFromCore(
         lastUpdatedAt: node.timestamp,
         providerVisibility: node.provider_visibility,
         parentInternalIds: node.parents,
-        type,
+        type: getContentNodeType(node),
         expandable:
           !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
           node.has_children,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -241,7 +241,7 @@ async function getContentNodesForDataSourceViewFromCore(
 
   return new Ok({
     nodes: filteredNodes.map((node) => {
-      const { type } = getContentNodeMetadata(node, viewType);
+      const { type } = getContentNodeMetadata(node);
       return {
         internalId: node.node_id,
         parentInternalId: node.parent_id ?? null,

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -65,21 +65,22 @@ function getVisualForContentNodeBasedOnType(node: ContentNode) {
 }
 
 function getVisualForContentNodeBasedOnMimeType(node: ContentNode) {
-  if (node.mimeType) {
-    if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
-      if (node.providerVisibility === "private") {
-        return LockIcon;
-      }
-      return ChatBubbleLeftRightIcon;
+  if (!node.mimeType) {
+    throw new Error(
+      "Unreachable: getVisualForContentNodeBasedOnMimeType called on a node that does not have a mime type"
+    );
+  }
+  if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
+    if (node.providerVisibility === "private") {
+      return LockIcon;
     }
-    if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
-      return Square3Stack3DIcon;
-    }
-    if (FILE_MIME_TYPES.includes(node.mimeType)) {
-      return getVisualForFileContentNode(
-        node as ContentNode & { type: "file" }
-      );
-    }
+    return ChatBubbleLeftRightIcon;
+  }
+  if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
+    return Square3Stack3DIcon;
+  }
+  if (FILE_MIME_TYPES.includes(node.mimeType)) {
+    return getVisualForFileContentNode(node as ContentNode & { type: "file" });
   }
   switch (node.type) {
     case "database":

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -62,20 +62,16 @@ function getVisualForContentNodeBaseOnType(node: ContentNode) {
 }
 
 function getVisualForContentNodeBasedOnMimeType(node: ContentNode) {
-  if (!node.mimeType) {
-    // putting a default value here to please TS,
-    // but mimeType should always be defined in a world where we get it from core (currently kept for retro-compatibility with connectors' /content_nodes endpoints)
-    return getVisualForFileContentNode(node as ContentNode & { type: "file" });
-  }
-
-  if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
-    if (node.providerVisibility === "private") {
-      return LockIcon;
+  if (node.mimeType) {
+    if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
+      if (node.providerVisibility === "private") {
+        return LockIcon;
+      }
+      return ChatBubbleLeftRightIcon;
     }
-    return ChatBubbleLeftRightIcon;
-  }
-  if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
-    return Square3Stack3DIcon;
+    if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
+      return Square3Stack3DIcon;
+    }
   }
   switch (node.type) {
     case "database":

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -18,6 +18,9 @@ const CHANNEL_MIME_TYPES = [
 // Mime types that should be represented with a Database icon but are not of type "table".
 const DATABASE_MIME_TYPES = [MIME_TYPES.GITHUB.ISSUES] as readonly string[];
 
+// Mime types that should be represented with a File icon but are not of type "document".
+const FILE_MIME_TYPES = [MIME_TYPES.WEBCRAWLER.FOLDER] as readonly string[];
+
 function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   if (node.expandable) {
     return DocumentPileIcon;
@@ -71,6 +74,11 @@ function getVisualForContentNodeBasedOnMimeType(node: ContentNode) {
     }
     if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
       return Square3Stack3DIcon;
+    }
+    if (FILE_MIME_TYPES.includes(node.mimeType)) {
+      return getVisualForFileContentNode(
+        node as ContentNode & { type: "file" }
+      );
     }
   }
   switch (node.type) {

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -40,7 +40,7 @@ export function getVisualForContentNode(
   }
 }
 
-function getVisualForContentNodeBaseOnType(node: ContentNode) {
+function getVisualForContentNodeBasedOnType(node: ContentNode) {
   switch (node.type) {
     case "channel":
       if (node.providerVisibility === "private") {

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -36,7 +36,7 @@ export function getVisualForContentNode(
   if (useMimeType) {
     return getVisualForContentNodeBasedOnMimeType(node);
   } else {
-    return getVisualForContentNodeBaseOnType(node);
+    return getVisualForContentNodeBasedOnType(node);
   }
 }
 

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -15,27 +15,8 @@ const CHANNEL_MIME_TYPES = [
   MIME_TYPES.SLACK.CHANNEL,
 ] as readonly string[];
 
-// Mime types that should be represented with a Database icon.
-const DATABASE_MIME_TYPES = [
-  MIME_TYPES.GITHUB.ISSUES,
-  MIME_TYPES.SNOWFLAKE.TABLE,
-] as readonly string[];
-
-// Mime types that should be represented with a Folder icon.
-const FOLDER_MIME_TYPES = [
-  MIME_TYPES.CONFLUENCE.SPACE,
-  MIME_TYPES.GOOGLE_DRIVE.FOLDER,
-  MIME_TYPES.INTERCOM.TEAM,
-  MIME_TYPES.MICROSOFT.FOLDER,
-  MIME_TYPES.NOTION.UNKNOWN_FOLDER,
-  MIME_TYPES.SNOWFLAKE.DATABASE,
-  MIME_TYPES.SNOWFLAKE.SCHEMA,
-  MIME_TYPES.WEBCRAWLER.FOLDER,
-  MIME_TYPES.ZENDESK.BRAND,
-  MIME_TYPES.ZENDESK.HELP_CENTER,
-  MIME_TYPES.ZENDESK.CATEGORY,
-  MIME_TYPES.ZENDESK.TICKETS,
-] as readonly string[];
+// Mime types that should be represented with a Database icon but are not of type "table".
+const DATABASE_MIME_TYPES = [MIME_TYPES.GITHUB.ISSUES] as readonly string[];
 
 function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   if (node.expandable) {
@@ -96,9 +77,15 @@ function getVisualForContentNodeBasedOnMimeType(node: ContentNode) {
   if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
     return Square3Stack3DIcon;
   }
-  if (FOLDER_MIME_TYPES.includes(node.mimeType)) {
-    return FolderIcon;
+  switch (node.type) {
+    case "database":
+      return Square3Stack3DIcon;
+    case "folder":
+      return FolderIcon;
+    // TODO(2025-01-24 aubin) once we remove the "channel" type, change this to case "file" and add an assertNever
+    default:
+      return getVisualForFileContentNode(
+        node as ContentNode & { type: "file" }
+      );
   }
-  // TODO(2025-01-17 aubin): we have an issue here in that depending on the view type we sometimes want to render "text/csv" as databases or as files
-  return getVisualForFileContentNode(node as ContentNode & { type: "file" });
 }

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -7,7 +7,35 @@ import {
   Square3Stack3DIcon,
 } from "@dust-tt/sparkle";
 import type { ContentNode } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+import { assertNever, MIME_TYPES } from "@dust-tt/types";
+
+// Mime types that should be represented with a Channel icon.
+const CHANNEL_MIME_TYPES = [
+  MIME_TYPES.GITHUB.DISCUSSIONS,
+  MIME_TYPES.SLACK.CHANNEL,
+] as readonly string[];
+
+// Mime types that should be represented with a Database icon.
+const DATABASE_MIME_TYPES = [
+  MIME_TYPES.GITHUB.ISSUES,
+  MIME_TYPES.SNOWFLAKE.TABLE,
+] as readonly string[];
+
+// Mime types that should be represented with a Folder icon.
+const FOLDER_MIME_TYPES = [
+  MIME_TYPES.CONFLUENCE.SPACE,
+  MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+  MIME_TYPES.INTERCOM.TEAM,
+  MIME_TYPES.MICROSOFT.FOLDER,
+  MIME_TYPES.NOTION.UNKNOWN_FOLDER,
+  MIME_TYPES.SNOWFLAKE.DATABASE,
+  MIME_TYPES.SNOWFLAKE.SCHEMA,
+  MIME_TYPES.WEBCRAWLER.FOLDER,
+  MIME_TYPES.ZENDESK.BRAND,
+  MIME_TYPES.ZENDESK.HELP_CENTER,
+  MIME_TYPES.ZENDESK.CATEGORY,
+  MIME_TYPES.ZENDESK.TICKETS,
+] as readonly string[];
 
 function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   if (node.expandable) {
@@ -17,7 +45,18 @@ function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   return DocumentIcon;
 }
 
-export function getVisualForContentNode(node: ContentNode) {
+export function getVisualForContentNode(
+  node: ContentNode,
+  useMimeType = false
+) {
+  if (useMimeType) {
+    return getVisualForContentNodeBasedOnMimeType(node);
+  } else {
+    return getVisualForContentNodeBaseOnType(node);
+  }
+}
+
+function getVisualForContentNodeBaseOnType(node: ContentNode) {
   switch (node.type) {
     case "channel":
       if (node.providerVisibility === "private") {
@@ -39,4 +78,27 @@ export function getVisualForContentNode(node: ContentNode) {
     default:
       assertNever(node.type);
   }
+}
+
+function getVisualForContentNodeBasedOnMimeType(node: ContentNode) {
+  if (!node.mimeType) {
+    // putting a default value here to please TS,
+    // but mimeType should always be defined in a world where we get it from core (currently kept for retro-compatibility with connectors' /content_nodes endpoints)
+    return getVisualForFileContentNode(node as ContentNode & { type: "file" });
+  }
+
+  if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
+    if (node.providerVisibility === "private") {
+      return LockIcon;
+    }
+    return ChatBubbleLeftRightIcon;
+  }
+  if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
+    return Square3Stack3DIcon;
+  }
+  if (FOLDER_MIME_TYPES.includes(node.mimeType)) {
+    return FolderIcon;
+  }
+  // TODO(2025-01-17 aubin): we have an issue here in that depending on the view type we sometimes want to render "text/csv" as databases or as files
+  return getVisualForFileContentNode(node as ContentNode & { type: "file" });
 }

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -110,6 +110,7 @@ export interface ContentNode {
   permission: ConnectorPermission;
   lastUpdatedAt: number | null;
   providerVisibility?: ProviderVisibility;
+  mimeType?: string;
 }
 
 export type ContentNodeWithParentIds = ContentNode & {


### PR DESCRIPTION
## Description

- Part of [#10051](https://github.com/dust-tt/dust/issues/10051)
- This PR rationalizes the conversion `CoreAPIContentNode.node_type -> ContentNodeType` with the mapping table -> database, document -> file, folder -> folder. The idea is to monitor the log and handle each difference downstream.
- This PR adds a function that maps the node found in `core` to the right icon for display.

## Risk

- Low (shadow read).

## Deploy Plan

- Deploy front.
