### PR TITLE
fix(parents) - Rely on the actual table ID when checking `parents[0] === tableId`

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -399,7 +399,7 @@ async function handler(
             },
           });
         }
-        if (parents[0] !== maybeTableId) {
+        if (parents[0] !== tableId) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {


### PR DESCRIPTION
## Description

- The previous behavior allowed passing an empty parents array in the absence of a table ID, which could later break the invariant on `parents[0] === tableId` and crash at the upsert in core.
- Instead of trying to allow passing `parents: []` and no `tableId`, this PR suggests being stricter by prohibiting empty parents arrays altogether.

## Risk

- Low, redundant with a check in `core`, so it only raises sooner and makes the error more explicit.

## Deploy Plan

- Deploy front.
