### PR TITLE
[landing-page] Fix link to customer story

### DIFF
--- a/front/components/home/content/Solutions/configs/supportConfig.tsx
+++ b/front/components/home/content/Solutions/configs/supportConfig.tsx
@@ -193,7 +193,7 @@ export const Stories: CustomerStory[] = [
     title: "Pennylane's journey to deploy Dust for Customer Care teams",
     content:
       "Dust evolved from a simple support tool into an integral part of Pennylane's operations.",
-    href: "https://blog.dust.tt/pennylane-dust-customer-support-journey/",
+    href: "https://blog.dust.tt/pennylane-customer-support-journey/",
     src: "https://blog.dust.tt/content/images/size/w2000/2024/12/pennylane_dust_customer_story.png",
   },
   {


### PR DESCRIPTION
## Description

- Closes [#1983](https://github.com/dust-tt/tasks/issues/1983)
- The link to the customer story was incorrect, this PR fixes that.

## Risk

- n/a

## Deploy Plan

- Deploy front
