### PR TITLE
Fix Citation close button

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.368",
+  "version": "0.2.369",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.368",
+      "version": "0.2.369",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.368",
+  "version": "0.2.369",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -38,8 +38,8 @@ const Citation = React.forwardRef<HTMLDivElement, CitationProps>(
 
     const contentWithDescription = (
       <>
-        {!hasDescription && <CitationDescription>&nbsp;</CitationDescription>}
         {children}
+        {!hasDescription && <CitationDescription>&nbsp;</CitationDescription>}
       </>
     );
     const cardButton = (

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -36,6 +36,10 @@ const Citation = React.forwardRef<HTMLDivElement, CitationProps>(
       );
     }, [children]);
 
+    // IMPORTANT: The order of elements is crucial for event handling.
+    // The CitationDescription must always come after other elements to ensure
+    // proper event propagation (especially for the close button's click events).
+    // If auto-inserting a description, it must be appended after children.
     const contentWithDescription = (
       <>
         {children}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In https://github.com/dust-tt/dust/pull/9712/files#diff-6b38ddab3fcd9a716ea39f2f42215c7ad41fc34c28de3aedd1a19ece06fd80c9R31, the `Citation` was changed which led to nuking the close button. It was being drown under the implicit description. This PR fixes the order to ensure that the children remains above any implicit description.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
