### PR TITLE
[Nodes Core] Allow "root" query to get root content nodes of a datasource

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -191,7 +191,11 @@ async function getContentNodesForDataSourceViewFromCore(
   const node_ids =
     internalIds ?? parentId ? undefined : dataSourceView.parentsIn ?? undefined;
   const parent_id =
-    parentId ?? (dataSourceView.parentsIn ? undefined : ROOT_PARENT_ID);
+    parentId ?? internalIds
+      ? undefined
+      : dataSourceView.parentsIn
+        ? undefined
+        : ROOT_PARENT_ID;
 
   const coreRes = await coreAPI.searchNodes({
     filter: {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -173,12 +173,28 @@ async function getContentNodesForDataSourceViewFromCore(
   // won't include it for now as we are shadow-reading.
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
+  // We use searchNodes to fetch the content nodes from core:
+  // - either a specific list of nodes provided by internalIds if they are set;
+  // - or all the direct children of the parent_id, if specified;
+  // - or all the roots of the data source view, if no parent_id nor internalIds
+  //   are provided.
+
+  // In the latter case, the view might either have "parentsIn" set, in which
+  // case the "roots" of the data source view are the nodes in parentsIn, so we
+  // set node_ids to parentsIn. Otherwise, the "roots" of the data source view
+  // are the root nodes of the data source, obtained by the special parent_id
+  // "root".
+
+  // In any case, there is a data_source_view filter, which is always applied.
+  const node_ids =
+    internalIds ?? parentId ? undefined : dataSourceView.parentsIn ?? undefined;
+  const parent_id = parentId ?? (dataSourceView.parentsIn ? undefined : "root");
+
   const coreRes = await coreAPI.searchNodes({
     filter: {
       data_source_views: [makeCoreDataSourceViewFilter(dataSourceView)],
-      // If no internalIds are provided, we use the parentsIn
-      node_ids: internalIds ?? dataSourceView.parentsIn ?? undefined,
-      parent_id: parentId,
+      node_ids,
+      parent_id,
     },
     options: { limit: 250 },
   });

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -165,6 +165,8 @@ function makeCoreDataSourceViewFilter(
   };
 }
 
+const ROOT_PARENT_ID = "root";
+
 async function getContentNodesForDataSourceViewFromCore(
   dataSourceView: DataSourceViewResource | DataSourceViewType,
   { internalIds, parentId, viewType }: GetContentNodesForDataSourceViewParams
@@ -188,7 +190,8 @@ async function getContentNodesForDataSourceViewFromCore(
   // In any case, there is a data_source_view filter, which is always applied.
   const node_ids =
     internalIds ?? parentId ? undefined : dataSourceView.parentsIn ?? undefined;
-  const parent_id = parentId ?? (dataSourceView.parentsIn ? undefined : "root");
+  const parent_id =
+    parentId ?? (dataSourceView.parentsIn ? undefined : ROOT_PARENT_ID);
 
   const coreRes = await coreAPI.searchNodes({
     filter: {


### PR DESCRIPTION
## Description
Fixes #10052 by allowing a call to search nodes with the "root" parent_id

## Risk
na (endpoint not used, only shadow read)

## Deploy Plan
core
front
