### PR TITLE
Fix the documents `sourceUrl` backfill script

### DIFF
--- a/front/migrations/20250116_backfill_documents_source_url.ts
+++ b/front/migrations/20250116_backfill_documents_source_url.ts
@@ -48,6 +48,13 @@ async function migrateDataSource({
   let nextId = null;
 
   for (;;) {
+    if (nextId === null) {
+      logger.info(`Fetching documents with timestamp >= ${nextTimestamp}`);
+    } else {
+      logger.info(
+        `Fetching documents with timestamp >= ${nextTimestamp} and id > ${nextId}`
+      );
+    }
     const [updatedRows] = (await (async () => {
       // If nextId is null, we only filter by timestamp.
       if (nextId === null) {
@@ -149,19 +156,17 @@ async function migrateDataSource({
     })()) as { id: number; timestamp: number }[][];
 
     if (updatedRows.length === 0) {
+      logger.info("DONE");
       break;
     }
 
-    if (!execute) {
-      logger.info(
-        {
-          firstRow: updatedRows[0],
-          lastRow:
-            updatedRows.length > 1 && updatedRows[updatedRows.length - 1],
-        },
-        `Would update ${updatedRows.length} nodes.`
-      );
-    }
+    logger.info(
+      {
+        firstRow: updatedRows[0],
+        lastRow: updatedRows.length > 1 && updatedRows[updatedRows.length - 1],
+      },
+      `Update ${updatedRows.length} nodes.`
+    );
 
     // If all documents have the same timestamp, we set nextId to the last id.
     nextId =

--- a/front/migrations/20250116_backfill_documents_source_url.ts
+++ b/front/migrations/20250116_backfill_documents_source_url.ts
@@ -168,13 +168,24 @@ async function migrateDataSource({
       `Update ${updatedRows.length} nodes.`
     );
 
+    // If we are just getting out of a pagination on ids,
+    // we have to set a conservative value for the timestamp
+    // as we may have reached a timestamp too high due to having filtered on the ids.
+    if (
+      nextId !== null &&
+      updatedRows[0].timestamp !== updatedRows[updatedRows.length - 1].timestamp
+    ) {
+      // There is no way to set the timestamp based on updatedRows, setting the most conservative value possible here.
+      nextTimestamp += 1;
+    } else {
+      // If we are scrolling through the timestamps, we can set the nextTimestamp to the last timestamp (same if all documents have the same timestamp, which is a no-op).
+      nextTimestamp = updatedRows[updatedRows.length - 1].timestamp;
+    }
     // If all documents have the same timestamp, we set nextId to the last id.
     nextId =
       updatedRows[0].timestamp === updatedRows[updatedRows.length - 1].timestamp
         ? updatedRows[updatedRows.length - 1].id
         : null;
-
-    nextTimestamp = updatedRows[updatedRows.length - 1].timestamp;
   }
 }
 


### PR DESCRIPTION
## Description

- This PR fixes the method used to scroll through timestamps when backfilling documents' `sourceUrl`s.
- The algorithm employed was incorrect and failed to select all documents:
  - Previously, it scrolled through the timestamps, if `firstTimestamp === lastTimestamp` we then scroll through the IDs in addition.
  - This method falls short on the last iteration of scrolling through the IDs, since we scrolled through the IDs we may have missed some rows with a higher timestamp but with a lower ID than `nextId`, meaning that the next timestamp cursor (`updatedRows[updatedRows.length - 1].timestamp`) will be overestimated.

## Risk

- 1 column affected, data load will be monitored.

## Deploy Plan

- no deploy planned
