### PR TITLE
Only display "View in xxx" if node has a sourceUrl

### DIFF
--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -201,8 +201,8 @@ export const getMenuItems = (
   const actions: ContentActionsMenu = [];
 
   // View in source:
-  // We have a source for all types of docs excepts folder docs unless manually set by the user.
-  if (!isFolder(dataSourceView.dataSource) || contentNode.sourceUrl) {
+  // We only push the view in if the content has a source URL.
+  if (contentNode.sourceUrl) {
     actions.push(makeViewSourceUrlContentAction(contentNode, dataSourceView));
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/1980.

We made the assumption in the code that all data sources except folder had a `sourceUrl`. This isn't true, this PR only push the option in the context menu if the content node has an actual `sourceUrl.`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
