### PR TITLE
Force select account when using Social SSO

### DIFF
--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -130,10 +130,6 @@ export default handleAuth({
       defaultAuthorizationParams.login_hint = login_hint;
     }
 
-    if (isString(prompt)) {
-      defaultAuthorizationParams.prompt = prompt;
-    }
-
     return {
       authorizationParams: defaultAuthorizationParams,
       returnTo: "/api/login", // Note from seb, I think this is not used

--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -106,12 +106,7 @@ export default handleAuth({
     // req.query is defined on NextApiRequest (page-router), but not on NextRequest (app-router).
     const query = ("query" in req ? req.query : {}) as Partial<AuthQuery>;
 
-    const {
-      connection,
-      screen_hint,
-      login_hint,
-      prompt = "select_account",
-    } = query;
+    const { connection, screen_hint, login_hint, prompt = "login" } = query;
 
     const defaultAuthorizationParams: Partial<
       LoginOptions["authorizationParams"]
@@ -126,6 +121,9 @@ export default handleAuth({
 
     if (isString(screen_hint) && screen_hint === "signup") {
       defaultAuthorizationParams.screen_hint = screen_hint;
+    } else if (isString(prompt)) {
+      // `screen_hint` and `prompt` are mutually exclusive.
+      defaultAuthorizationParams.prompt = prompt;
     }
 
     if (isString(login_hint) && isEmailValid(login_hint)) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Superset of https://github.com/dust-tt/dust/pull/10079.

In our current Auth0 configuration, users rarely need to log in again. They are automatically redirected to their Identity Provider (IdP) session without seeing the login screen. This can be problematic for customers who have multiple accounts. Despite exploring many resources on modifying the upstream parameter prompt ([documentation](https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters))), none were successful. This PR takes a further step by explicitly setting the prompt to `login` when a user attempts to log in. This parameter is mutually exclusive with the signup hint that users receive when invited to Dust.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
