### PR TITLE
[extension] Allow to blacklist URLs

### DIFF
--- a/extension/app/src/components/conversation/AttachFragment.tsx
+++ b/extension/app/src/components/conversation/AttachFragment.tsx
@@ -33,8 +33,6 @@ export const AttachFragment = ({
   const { currentDomain, currentUrl } = useCurrentUrlAndDomain();
   const blacklistedConfig: string[] = owner.blacklistedDomains ?? [];
 
-  console.log(blacklistedConfig);
-
   const isBlacklisted =
     currentDomain === "chrome" ||
     blacklistedConfig.some((d) =>

--- a/extension/app/src/components/conversation/AttachFragment.tsx
+++ b/extension/app/src/components/conversation/AttachFragment.tsx
@@ -1,7 +1,7 @@
 import type { ExtensionWorkspaceType } from "@dust-tt/client";
 import { Button, CameraIcon, DocumentPlusIcon } from "@dust-tt/sparkle";
 import { InputBarContext } from "@extension/components/input_bar/InputBarContext";
-import { useCurrentDomain } from "@extension/hooks/useCurrentDomain";
+import { useCurrentUrlAndDomain } from "@extension/hooks/useCurrentDomain";
 import type { FileUploaderService } from "@extension/hooks/useFileUploaderService";
 import { useContext, useEffect } from "react";
 
@@ -30,11 +30,18 @@ export const AttachFragment = ({
   }, [attachPageBlinking]);
 
   // Blacklisting logic to disable share buttons.
-  const currentDomain = useCurrentDomain();
-  const blacklistedDomains: string[] = owner.blacklistedDomains ?? [];
+  const { currentDomain, currentUrl } = useCurrentUrlAndDomain();
+  const blacklistedConfig: string[] = owner.blacklistedDomains ?? [];
+
+  console.log(blacklistedConfig);
+
   const isBlacklisted =
     currentDomain === "chrome" ||
-    blacklistedDomains.some((d) => currentDomain.endsWith(d));
+    blacklistedConfig.some((d) =>
+      d.startsWith("http://") || d.startsWith("https://")
+        ? currentUrl.startsWith(d)
+        : currentDomain.endsWith(d)
+    );
 
   return (
     <>

--- a/extension/app/src/hooks/useCurrentDomain.ts
+++ b/extension/app/src/hooks/useCurrentDomain.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 
-export const useCurrentDomain = () => {
+export const useCurrentUrlAndDomain = () => {
   const [currentDomain, setCurrentDomain] = useState<string>("");
+  const [currentUrl, setCurrentUrl] = useState<string>("");
 
   useEffect(() => {
     // Function to update domain from tab.
@@ -10,13 +11,16 @@ export const useCurrentDomain = () => {
         try {
           const url = new URL(tab.url);
           if (url.protocol.startsWith("http")) {
+            setCurrentUrl(tab.url);
             setCurrentDomain(url.hostname);
           }
           if (url.protocol.startsWith("chrome")) {
+            setCurrentUrl("");
             setCurrentDomain("chrome");
           }
         } catch (e) {
           console.error("Invalid URL:", e);
+          setCurrentUrl("");
           setCurrentDomain("");
         }
       }
@@ -62,5 +66,5 @@ export const useCurrentDomain = () => {
     };
   }, []);
 
-  return currentDomain;
+  return { currentDomain, currentUrl };
 };

--- a/extension/app/src/lib/auth.ts
+++ b/extension/app/src/lib/auth.ts
@@ -123,6 +123,7 @@ const fetchMe = async (
     },
   });
   const me = await response.json();
+
   if (!response.ok) {
     return new Err(new AuthError(me.error.type, me.error.message));
   }

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -68,7 +68,9 @@ export function WorkspaceInfoTable({
               <PokeTableCell>{workspaceVerifiedDomain?.domain}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
-              <PokeTableCell>Extension blacklisted domains</PokeTableCell>
+              <PokeTableCell className="max-w-48">
+                Extension blacklisted domains/URLs
+              </PokeTableCell>
               <PokeTableCell>
                 {extensionConfig?.blacklistedDomains.length
                   ? extensionConfig.blacklistedDomains.join(", ")

--- a/front/lib/api/poke/plugins/workspaces/extension_blacklist_domains.ts
+++ b/front/lib/api/poke/plugins/workspaces/extension_blacklist_domains.ts
@@ -7,15 +7,16 @@ import { isDomain } from "@app/lib/utils";
 export const extensionBlacklistDomainsPlugin = createPlugin(
   {
     id: "extension-blacklist-domains",
-    name: "Extension Blacklist Domains",
-    description: "Update the list of blacklisted domains for the extension",
+    name: "Extension Blacklist Domains/URLs",
+    description:
+      "Update the list of blacklisted domains/URLs for the extension",
     resourceTypes: ["workspaces"],
     args: {
       domains: {
         type: "string",
-        label: "Blacklisted domains",
+        label: "Blacklisted domains/URLs",
         description:
-          "Comma-separated list of domains to blacklist for the extension. This will override the existing list (if any).",
+          "Comma-separated list of domains or URLs to blacklist for the extension. This will override the existing list (if any).",
       },
     },
   },
@@ -30,7 +31,7 @@ export const extensionBlacklistDomainsPlugin = createPlugin(
     if (!areDomainsValid(domains)) {
       return new Err(
         new Error(
-          "One or more domains are invalid. Please check the domain format."
+          "One or more domains or URLs are invalid. Please check the values format."
         )
       );
     }
@@ -42,7 +43,7 @@ export const extensionBlacklistDomainsPlugin = createPlugin(
 
     return new Ok({
       display: "text",
-      value: `Blacklisted domains updated.`,
+      value: `Blacklisted domains/URLs updated.`,
     });
   }
 );
@@ -53,6 +54,16 @@ function areDomainsValid(domains: string[]): boolean {
   }
 
   return domains.every((domain) => {
+    if (domain.startsWith("http://") || domain.startsWith("https://")) {
+      try {
+        new URL(`http://${domain}`);
+      } catch (_) {
+        return false;
+      }
+
+      return true;
+    }
+
     if (domain.length > 253) {
       return false;
     }


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1972

## Description

Update the extension blacklist to support domains and URLs
URLs will match as a prefix ( blacklisting https://dust.tt/page will blacklist all urls starting with https://dust.tt/page )
Domain still work as before ( blacklisting dust.tt will blacklist all urls on *.dust.tt )

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front, publish extension
