### PR TITLE
Remove Zendesk brand folders

### DIFF
--- a/connectors/migrations/20250120_delete_zendesk_brand_folders.ts
+++ b/connectors/migrations/20250120_delete_zendesk_brand_folders.ts
@@ -1,0 +1,116 @@
+import { MIME_TYPES } from "@dust-tt/types";
+import { makeScript } from "scripts/helpers";
+
+import { getBrandInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import {
+  deleteDataSourceFolder,
+  upsertDataSourceFolder,
+} from "@connectors/lib/data_sources";
+import type Logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import {
+  ZendeskBrandResource,
+  ZendeskCategoryResource,
+} from "@connectors/resources/zendesk_resources";
+
+const FOLDER_CONCURRENCY = 10;
+
+async function migrateConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const connectorId = connector.id;
+
+  const brands = await ZendeskBrandResource.fetchByConnector(connector);
+  if (execute) {
+    await concurrentExecutor(
+      brands,
+      async (brand) => {
+        /// same code as in the connector
+        const brandInternalId = getBrandInternalId({
+          connectorId,
+          brandId: brand.brandId,
+        });
+        // deleting the brand folder
+        await deleteDataSourceFolder({
+          dataSourceConfig,
+          folderId: brandInternalId,
+        });
+
+        // upserting the folders for HC and T to update their parents
+        const helpCenterNode = brand.getHelpCenterContentNode(connectorId, {
+          richTitle: true,
+        });
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId: helpCenterNode.internalId,
+          parents: [helpCenterNode.internalId],
+          parentId: null,
+          title: helpCenterNode.title,
+          mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+        });
+
+        const ticketsNode = brand.getTicketsContentNode(connectorId, {
+          richTitle: true,
+        });
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId: ticketsNode.internalId,
+          parents: [ticketsNode.internalId],
+          parentId: null,
+          title: ticketsNode.title,
+          mimeType: MIME_TYPES.ZENDESK.TICKETS,
+        });
+      },
+      { concurrency: FOLDER_CONCURRENCY }
+    );
+    logger.info(
+      `Updated ${brands.length} brands for connector ${connector.id}`
+    );
+  } else {
+    logger.info(`Found ${brands.length} brands for connector ${connector.id}`);
+  }
+
+  // upserting the folders for categories to update their parents
+  const categories = await ZendeskCategoryResource.fetchByConnector(connector);
+  if (execute) {
+    await concurrentExecutor(
+      categories,
+      async (category) => {
+        /// same code as in the connector
+        const parents = category.getParentInternalIds(connectorId);
+        await upsertDataSourceFolder({
+          dataSourceConfig: dataSourceConfigFromConnector(connector),
+          folderId: parents[0],
+          parents,
+          parentId: parents[1],
+          title: category.name,
+          mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+        });
+      },
+      { concurrency: FOLDER_CONCURRENCY }
+    );
+    logger.info(
+      `Updated ${brands.length} categories for connector ${connector.id}`
+    );
+  } else {
+    logger.info(
+      `Found ${brands.length} categories for connector ${connector.id}`
+    );
+  }
+}
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("zendesk", {});
+
+  for (const connector of connectors) {
+    await migrateConnector(
+      connector,
+      execute,
+      logger.child({ connectorId: connector.id })
+    );
+  }
+});

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -135,8 +135,8 @@ export async function syncZendeskBrandActivity({
   await upsertDataSourceFolder({
     dataSourceConfig,
     folderId: helpCenterNode.internalId,
-    parents: [helpCenterNode.internalId, helpCenterNode.parentInternalId],
-    parentId: helpCenterNode.parentInternalId,
+    parents: [helpCenterNode.internalId],
+    parentId: null,
     title: helpCenterNode.title,
     mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
   });
@@ -146,8 +146,8 @@ export async function syncZendeskBrandActivity({
   await upsertDataSourceFolder({
     dataSourceConfig,
     folderId: ticketsNode.internalId,
-    parents: [ticketsNode.internalId, ticketsNode.parentInternalId],
-    parentId: ticketsNode.parentInternalId,
+    parents: [ticketsNode.internalId],
+    parentId: null,
     title: ticketsNode.title,
     mimeType: MIME_TYPES.ZENDESK.TICKETS,
   });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -2,7 +2,6 @@ import type { ModelId } from "@dust-tt/types";
 import { MIME_TYPES } from "@dust-tt/types";
 import _ from "lodash";
 
-import { getBrandInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import { syncCategory } from "@connectors/connectors/zendesk/lib/sync_category";
 import { syncTicket } from "@connectors/connectors/zendesk/lib/sync_ticket";
@@ -130,17 +129,6 @@ export async function syncZendeskBrandActivity({
 
   // upserting three folders to data_sources_folders (core): brand, help center, tickets
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-
-  const brandInternalId = getBrandInternalId({ connectorId, brandId });
-  await upsertDataSourceFolder({
-    dataSourceConfig,
-    folderId: brandInternalId,
-    parents: [brandInternalId],
-    parentId: null,
-    title: brandInDb.name,
-    mimeType: MIME_TYPES.ZENDESK.BRAND,
-    sourceUrl: fetchedBrand?.url || brandInDb.url,
-  });
 
   // using the content node to get one source of truth regarding the parent relationship
   const helpCenterNode = brandInDb.getHelpCenterContentNode(connectorId);

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -131,7 +131,9 @@ export async function syncZendeskBrandActivity({
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   // using the content node to get one source of truth regarding the parent relationship
-  const helpCenterNode = brandInDb.getHelpCenterContentNode(connectorId);
+  const helpCenterNode = brandInDb.getHelpCenterContentNode(connectorId, {
+    richTitle: true,
+  });
   await upsertDataSourceFolder({
     dataSourceConfig,
     folderId: helpCenterNode.internalId,
@@ -142,7 +144,9 @@ export async function syncZendeskBrandActivity({
   });
 
   // using the content node to get one source of truth regarding the parent relationship
-  const ticketsNode = brandInDb.getTicketsContentNode(connectorId);
+  const ticketsNode = brandInDb.getTicketsContentNode(connectorId, {
+    richTitle: true,
+  });
   await upsertDataSourceFolder({
     dataSourceConfig,
     folderId: ticketsNode.internalId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -729,13 +729,12 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     };
   }
 
-  getParentInternalIds(connectorId: number): [string, string, string] {
+  getParentInternalIds(connectorId: number): [string, string] {
     const { brandId, ticketId } = this;
-    /// Tickets have two parents: the Tickets and the Brand.
+    /// Tickets have one parent beside themselves: the Tickets.
     return [
       getTicketInternalId({ connectorId, brandId, ticketId }),
       getTicketsInternalId({ connectorId, brandId }),
-      getBrandInternalId({ connectorId, brandId }),
     ];
   }
 
@@ -943,14 +942,13 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     };
   }
 
-  getParentInternalIds(connectorId: number): [string, string, string, string] {
+  getParentInternalIds(connectorId: number): [string, string, string] {
     const { brandId, categoryId, articleId } = this;
-    /// Articles have three parents: the Category, the Help Center and the Brand.
+    /// Articles have two parents: the Category and the Help Center.
     return [
       getArticleInternalId({ connectorId, brandId, articleId }),
       getCategoryInternalId({ connectorId, brandId, categoryId }),
       getHelpCenterInternalId({ connectorId, brandId }),
-      getBrandInternalId({ connectorId, brandId }),
     ];
   }
 

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -646,13 +646,12 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     };
   }
 
-  getParentInternalIds(connectorId: number): [string, string, string] {
+  getParentInternalIds(connectorId: number): [string, string] {
     /// Categories have two parents: the Help Center and the Brand.
     const { brandId, categoryId } = this;
     return [
       getCategoryInternalId({ connectorId, brandId, categoryId }),
       getHelpCenterInternalId({ connectorId, brandId }),
-      getBrandInternalId({ connectorId, brandId }),
     ];
   }
 }

--- a/front/migrations/20250120_trim_zendesk_parents.ts
+++ b/front/migrations/20250120_trim_zendesk_parents.ts
@@ -57,11 +57,11 @@ async function migrateDataSource({
              WHERE id IN (
                  SELECT id
                  FROM data_sources_nodes
-                 WHERE data_source = 1
-                   AND node_id LIKE 'zendesk-ticket-%'
-                   AND id > 1
+                 WHERE data_source = :coreDataSourceId
+                   AND node_id LIKE :pattern
+                   AND id > :nextId
                  ORDER BY timestamp, id
-                 LIMIT 100
+                 LIMIT :batchSize
              )
              RETURNING id;`,
           {

--- a/front/migrations/20250120_trim_zendesk_parents.ts
+++ b/front/migrations/20250120_trim_zendesk_parents.ts
@@ -12,11 +12,13 @@ async function migrateDataSource({
   frontDataSource,
   coreSequelize,
   pattern,
+  parentsLength,
   execute,
   logger,
 }: {
   frontDataSource: DataSourceModel;
   coreSequelize: Sequelize;
+  parentsLength: number;
   pattern: string;
   execute: boolean;
   logger: typeof Logger;
@@ -53,7 +55,7 @@ async function migrateDataSource({
       if (execute) {
         return coreSequelize.query(
           `UPDATE data_sources_nodes
-             SET parents = parents[1:ARRAY_LENGTH(parents, 1) - 1]
+             SET parents = parents[1: :parentsLength]
              WHERE id IN (
                  SELECT id
                  FROM data_sources_nodes
@@ -68,6 +70,7 @@ async function migrateDataSource({
             replacements: {
               nextId,
               coreDataSourceId,
+              parentsLength,
               batchSize: QUERY_BATCH_SIZE,
               pattern,
             },
@@ -106,6 +109,7 @@ makeScript({}, async ({ execute }, logger) => {
       frontDataSource,
       coreSequelize,
       pattern: "zendesk-ticket-%",
+      parentsLength: 2,
       execute,
       logger: logger.child({
         dataSourceId: frontDataSource.id,
@@ -117,6 +121,7 @@ makeScript({}, async ({ execute }, logger) => {
       frontDataSource,
       coreSequelize,
       pattern: "zendesk-article-%",
+      parentsLength: 3,
       execute,
       logger: logger.child({
         dataSourceId: frontDataSource.id,

--- a/front/migrations/20250120_trim_zendesk_parents.ts
+++ b/front/migrations/20250120_trim_zendesk_parents.ts
@@ -1,0 +1,128 @@
+import assert from "assert";
+import type { Sequelize } from "sequelize";
+
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const QUERY_BATCH_SIZE = 1024;
+
+async function migrateDataSource({
+  frontDataSource,
+  coreSequelize,
+  pattern,
+  execute,
+  logger,
+}: {
+  frontDataSource: DataSourceModel;
+  coreSequelize: Sequelize;
+  pattern: string;
+  execute: boolean;
+  logger: typeof Logger;
+}) {
+  logger.info("MIGRATE");
+
+  // Retrieve the core data source.
+  const [coreDataSourceRows] = (await coreSequelize.query(
+    `SELECT id, data_source_id
+     FROM data_sources
+     WHERE project = :project
+       AND data_source_id = :dataSourceId;`,
+    {
+      replacements: {
+        project: frontDataSource.dustAPIProjectId,
+        dataSourceId: frontDataSource.dustAPIDataSourceId,
+      },
+    }
+  )) as { id: number; data_source_id: string }[][];
+
+  assert(
+    coreDataSourceRows.length === 1 &&
+      coreDataSourceRows[0].data_source_id ===
+        frontDataSource.dustAPIDataSourceId,
+    "Core data source mismatch"
+  );
+  const coreDataSourceId = coreDataSourceRows[0].id;
+
+  // Loop over all the documents in the data source (can be a big loop).
+  let nextId = 0;
+
+  for (;;) {
+    const [updatedRows] = (await (async () => {
+      if (execute) {
+        return coreSequelize.query(
+          `UPDATE data_sources_nodes
+             SET parents = parents[1:ARRAY_LENGTH(parents, 1) - 1]
+             WHERE id IN (
+                 SELECT id
+                 FROM data_sources_nodes
+                 WHERE data_source = 1
+                   AND node_id LIKE 'zendesk-ticket-%'
+                   AND id > 1
+                 ORDER BY timestamp, id
+                 LIMIT 100
+             )
+             RETURNING id;`,
+          {
+            replacements: {
+              nextId,
+              coreDataSourceId,
+              batchSize: QUERY_BATCH_SIZE,
+              pattern,
+            },
+          }
+        );
+      }
+    })()) as { id: number }[][];
+
+    if (updatedRows.length === 0) {
+      logger.info("DONE");
+      break;
+    }
+
+    logger.info(
+      {
+        firstRow: updatedRows[0],
+        lastRow: updatedRows.length > 1 && updatedRows[updatedRows.length - 1],
+      },
+      `Update ${updatedRows.length} nodes.`
+    );
+
+    nextId = updatedRows[updatedRows.length - 1].id;
+  }
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const coreSequelize = getCorePrimaryDbConnection();
+
+  const frontDataSources = await DataSourceModel.findAll({
+    where: { connectorProvider: "zendesk" },
+  });
+  logger.info(`Found ${frontDataSources.length} Zendesk data sources`);
+
+  for (const frontDataSource of frontDataSources) {
+    await migrateDataSource({
+      frontDataSource,
+      coreSequelize,
+      pattern: "zendesk-ticket-%",
+      execute,
+      logger: logger.child({
+        dataSourceId: frontDataSource.id,
+        connectorProvider: frontDataSource.connectorProvider,
+        pattern: "zendesk-ticket-%",
+      }),
+    });
+    await migrateDataSource({
+      frontDataSource,
+      coreSequelize,
+      pattern: "zendesk-article-%",
+      execute,
+      logger: logger.child({
+        dataSourceId: frontDataSource.id,
+        connectorProvider: frontDataSource.connectorProvider,
+        pattern: "zendesk-article-%",
+      }),
+    });
+  }
+});

--- a/front/migrations/20250120_trim_zendesk_parents.ts
+++ b/front/migrations/20250120_trim_zendesk_parents.ts
@@ -62,7 +62,7 @@ async function migrateDataSource({
                  WHERE data_source = :coreDataSourceId
                    AND node_id LIKE :pattern
                    AND id > :nextId
-                 ORDER BY timestamp, id
+                 ORDER BY id
                  LIMIT :batchSize
              )
              RETURNING id;`,


### PR DESCRIPTION
## Description

- Part of [#1987](https://github.com/dust-tt/tasks/issues/1987)
- This PR removes the brand nodes from `core` and updates the parents passed to `core` accordingly.
- The node still exists in `/permissions` as a shortcut for selecting both the Help Center and the Tickets.
- The actual content of the task (making sure the roots are upserted without parents or with parents that are roots) will be tackled in a follow up PR.
- No migration required in front as mentioned in the issue.
- The migration scripts are idempotent, which allows running them whilst having new entries being upserted by connectors.
- Note that this will naturally create discrepancies between what is returned by `connectors` and `core`, will make an attempt at preventing these in an upcoming PR (code is shared between `/permissions` and `/content-nodes` so not trivial to do cleanly).

## Risk

- Should not affect assistants, rollbackable by creating an adapted version of the script.

## Deploy Plan

- Deploy connectors.
- Run the two migration scripts.