### PR TITLE
fix(Snowflake) - Fix `data_sources_folders` sync

### DIFF
--- a/connectors/migrations/db/migration_47.sql
+++ b/connectors/migrations/db/migration_47.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jan 21, 2025
+ALTER TABLE "public"."remote_databases" ADD COLUMN "permission" VARCHAR(255) NOT NULL DEFAULT 'selected';
+ALTER TABLE "public"."remote_schemas" ADD COLUMN "permission" VARCHAR(255) NOT NULL DEFAULT 'selected';

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -348,12 +348,7 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     if (connectorAndCredentialsRes.isErr()) {
       switch (connectorAndCredentialsRes.error.code) {
         case "connector_not_found":
-          return new Err(
-            new ConnectorManagerError(
-              "CONNECTOR_NOT_FOUND",
-              "Connector not found"
-            )
-          );
+          throw new Error("Snowflake connector not found");
         case "invalid_credentials":
           return new Err(
             new ConnectorManagerError(

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -168,7 +168,6 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
       },
       { where: { connectorId: c.id } }
     );
-    await launchSnowflakeSyncWorkflow(c.id);
     // We launch the workflow again so it syncs immediately.
     await launchSnowflakeSyncWorkflow(c.id);
 

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -319,7 +319,7 @@ export const saveNodesFromPermissions = async ({
           fromDatabase: database,
         });
         if (fetchedSchemasRes.isErr()) {
-          throw new Error(fetchedSchemasRes.error.message);
+          return new Err(new Error(fetchedSchemasRes.error.message));
         }
         for (const schema of fetchedSchemasRes.value) {
           const existingSchema = await RemoteSchemaModel.findOne({

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -191,10 +191,7 @@ export const fetchSyncedChildren = async ({
         },
       });
       const schemaContentNodes = schemas.map((schema) =>
-        getContentNodeFromInternalId(
-          [schema.databaseName, schema.name].join("."),
-          "read"
-        )
+        getContentNodeFromInternalId(schema.internalId, "read")
       );
       return new Ok(schemaContentNodes);
     }

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -199,8 +199,9 @@ export const fetchSyncedChildren = async ({
       return new Ok(schemaContentNodes);
     }
 
-    // Otherwise we will fetch all the schemas we have full access to (the one in db with permission: "selected"),
-    // + the schemas for the tables that was explicitly selected.
+    // Otherwise, we will fetch all the schemas we have full access to,
+    // which are the ones in db with permission: "selected" (the ones with "inherited" are absorbed in the case above).
+    // + the schemas for the tables that were explicitly selected.
     const [availableSchemas, availableTables] = await Promise.all([
       RemoteSchemaModel.findAll({
         where: {

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -123,7 +123,7 @@ export const fetchAvailableChildrenInSnowflake = async ({
 };
 
 /**
- * Retrieves the existing content nodes for a parent in our database.
+ * Retrieves the selected content nodes for a parent in our database.
  * They are the content nodes that we were given access to by the admin.
  */
 export const fetchReadNodes = async ({

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -313,7 +313,7 @@ export const saveNodesFromPermissions = async ({
             permission: "selected",
           });
         }
-        // pushing the schemas in db with permission: "inherited"
+        // pushing the schemas in db with permission: "inherited" if they don't already exist
         const fetchedSchemasRes = await fetchSchemas({
           credentials,
           fromDatabase: database,
@@ -422,6 +422,10 @@ export const saveNodesFromPermissions = async ({
  * Retrieves the parent IDs of a content node in hierarchical order.
  * The first ID is the internal ID of the content node itself.
  * Quite straightforward for Snowflake as we can extract the parent IDs from the internalId.
+ *
+ * Note that this part may cause discrepancies between the response of core and the response of the connector since
+ * core will consider parents starting from the root (what was selected by the user).
+ * If such logs were to pop up they will be ignored.
  */
 export const getContentNodeParents = ({
   internalId,

--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -83,6 +83,16 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
   for (const db of unselectedDatabases) {
     await deleteDataSourceFolder({ dataSourceConfig, folderId: db.internalId });
     await db.destroy();
+    for (const schema of allSchemas.filter(
+      (schema) =>
+        schema.databaseName === db.name && schema.permission === "inherited"
+    )) {
+      await deleteDataSourceFolder({
+        dataSourceConfig,
+        folderId: schema.internalId,
+      });
+      await schema.destroy();
+    }
   }
 
   // removing the unselected schemas (from core and connectors)

--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -1,8 +1,10 @@
 import type { ModelId } from "@dust-tt/types";
 import { isSnowflakeCredentials, MIME_TYPES } from "@dust-tt/types";
+import { EXCLUDE_SCHEMAS } from "@dust-tt/types/src";
 
 import {
   connectToSnowflake,
+  fetchSchemas,
   fetchTables,
   isConnectionReadonly,
 } from "@connectors/connectors/snowflake/lib/snowflake_api";
@@ -158,6 +160,31 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
         parentId: null,
         mimeType: MIME_TYPES.SNOWFLAKE.DATABASE,
       });
+
+      // adding all the schemas in db if not already found
+      const fetchedSchemasRes = await fetchSchemas({
+        credentials,
+        fromDatabase: db.name,
+      });
+      if (fetchedSchemasRes.isErr()) {
+        throw new Error(fetchedSchemasRes.error.message);
+      }
+
+      const schemasMissingFromDb = fetchedSchemasRes.value
+        .filter((row) => !EXCLUDE_SCHEMAS.includes(row.name))
+        // we only upsert schemas that are not already in the database, which prevents us from overriding the permissions of a schema that was selected in the UI
+        .filter((row) => !allSchemas.map((s) => s.name).includes(row.name));
+
+      for (const schema of schemasMissingFromDb) {
+        const internalId = [db.name, schema.name].join(".");
+        await RemoteSchemaModel.create({
+          connectorId,
+          internalId,
+          name: schema.name,
+          databaseName: db.name,
+          permission: "inherited",
+        });
+      }
     }
   }
 

--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -1,6 +1,9 @@
 import type { ModelId } from "@dust-tt/types";
-import { isSnowflakeCredentials, MIME_TYPES } from "@dust-tt/types";
-import { EXCLUDE_SCHEMAS } from "@dust-tt/types/src";
+import {
+  EXCLUDE_SCHEMAS,
+  isSnowflakeCredentials,
+  MIME_TYPES,
+} from "@dust-tt/types";
 
 import {
   connectToSnowflake,

--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -177,13 +177,14 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
 
       for (const schema of schemasMissingFromDb) {
         const internalId = [db.name, schema.name].join(".");
-        await RemoteSchemaModel.create({
+        const createdSchema = await RemoteSchemaModel.create({
           connectorId,
           internalId,
           name: schema.name,
           databaseName: db.name,
           permission: "inherited",
         });
+        allSchemas.push(createdSchema);
       }
     }
   }

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -13,6 +13,7 @@ export class RemoteDatabaseModel extends BaseModel<RemoteDatabaseModel> {
 
   declare internalId: string;
   declare name: string;
+  declare permission: "selected" | "unselected";
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -36,6 +37,10 @@ RemoteDatabaseModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+    permission: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
   },
   {
     sequelize: sequelizeConnection,
@@ -55,6 +60,7 @@ export class RemoteSchemaModel extends BaseModel<RemoteSchemaModel> {
 
   declare internalId: string;
   declare name: string;
+  declare permission: "selected" | "unselected" | "inherited";
 
   declare databaseName: string;
 
@@ -67,6 +73,10 @@ RemoteSchemaModel.init(
       allowNull: false,
     },
     name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    permission: {
       type: DataTypes.STRING,
       allowNull: false,
     },

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectorProvider,
   ContentNodeType,
   CoreAPIContentNode,
   DataSourceViewContentNode,
@@ -41,10 +42,12 @@ export function getContentNodeInternalIdFromTableId(
 export function computeNodesDiff({
   connectorsContentNodes,
   coreContentNodes,
+  provider,
   localLogger,
 }: {
   connectorsContentNodes: DataSourceViewContentNode[];
   coreContentNodes: DataSourceViewContentNode[];
+  provider: ConnectorProvider;
   localLogger: typeof logger;
 }) {
   connectorsContentNodes.forEach((connectorsNode) => {
@@ -70,7 +73,11 @@ export function computeNodesDiff({
       const diff = Object.fromEntries(
         Object.entries(connectorsNode)
           .filter(([key, value]) => {
-            if (key === "preventSelection") {
+            if (["preventSelection", "lastUpdatedAt"].includes(key)) {
+              return false;
+            }
+            // Custom exclusion rules. The goal here is to avoid logging irrelevant differences, scoping by connector.
+            if (key === "parentInternalId" && provider === "snowflake") {
               return false;
             }
             const coreValue = coreNode[key as keyof DataSourceViewContentNode];


### PR DESCRIPTION
## Description

- This PR deletes the data_sources_folders for databases and schemas when unselected from the UI.
- Since no state is passed onto the workflows for storing the information that a database or schema was deleted (we either have or don't have the entry in db but don't know about the ones that were deleted), this PR does the deletion in the `setPermissions`, which is not ideal but was chosen as a way to not change the data model of the connector.
- This PR correctly sets the parents of the databases, schemas and tables in Snowflake by checking why each of these resources were synced: whether it was because they were selected or because their parent was selected, and setting their parents accordingly.
- No backfill needed, we can just wait for the sync to kick in (the previous state is captured by the migration that adds "selected" as a default value for the permission).

## Risk

- Blast radius: permission selection, content node display in AssistantBuilder and data source view selections.

## Deploy Plan

- Run `migration_47.sql` in all regions.
- Deploy connectors.
- Deploy front.