### PR TITLE
[sparkle] - fix(Citation): tooltip

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.369",
+  "version": "0.2.370",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.369",
+      "version": "0.2.370",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.369",
+  "version": "0.2.370",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -47,9 +47,11 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
         <TooltipTrigger asChild={tooltipTriggerAsChild}>
           {trigger}
         </TooltipTrigger>
-        <TooltipContent {...props} ref={ref}>
-          {label}
-        </TooltipContent>
+        <TooltipPortal>
+          <TooltipContent {...props} ref={ref}>
+            {label}
+          </TooltipContent>
+        </TooltipPortal>
       </TooltipRoot>
     </TooltipProvider>
   )

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -41,7 +41,7 @@ export const CitationsExample = () => (
         <CitationIcons>
           <Icon visual={SlackLogo} size="sm" />
         </CitationIcons>
-        <CitationTitle>Slack thread</CitationTitle>
+        <CitationTitle>Citation w/ tooltip</CitationTitle>
         <CitationDescription>
           @ed at 16:32 This is the latest ve
         </CitationDescription>

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -33,7 +33,26 @@ export const CitationsExample = () => (
   <div className="s-flex s-flex-col s-gap-8">
     Example of attachement
     <CitationGrid>
-      <Citation onClick={() => alert("Card clicked")} className="s-w-48">
+      <Citation
+        onClick={() => alert("Card clicked")}
+        className="s-w-48"
+        tooltip="@ed at 16:32 This is the latest ve"
+      >
+        <CitationIcons>
+          <Icon visual={SlackLogo} size="sm" />
+        </CitationIcons>
+        <CitationTitle>Slack thread</CitationTitle>
+        <CitationDescription>
+          @ed at 16:32 This is the latest ve
+        </CitationDescription>
+      </Citation>
+    </CitationGrid>
+    <CitationGrid>
+      <Citation
+        onClick={() => alert("Card clicked")}
+        className="s-w-48"
+        tooltip="@ed at 16:32 This is the latest ve"
+      >
         <CitationIcons>
           <Icon visual={SlackLogo} size="sm" />
         </CitationIcons>


### PR DESCRIPTION
## Description

This PR aims at fixing the use of the `tooltip` props in `Citation`, which was incorrectly rendered because of a radix stacking context.

Explanation: the `CitationGrid` component uses a `@container , which creates a new stacking context which confines the tooltip’s positioning. To free the tooltip from that confined stacking context, we need to render the tooltip content via a `portal` so that it’s appended to the <body> (or another top-level container), rather than living inside the CitationGrid.

## Risk

Low

## Deploy Plan

- Publish sparkle
- Bump sparkle version in front