### PR TITLE
[front] - deps: upgrade @dust-tt/sparkle to ^0.2.370

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.369",
+        "@dust-tt/sparkle": "^0.2.370",
         "@dust-tt/types": "file:../types",
         "@heroicons/react": "^2.0.11",
         "@hookform/resolvers": "^3.3.4",
@@ -11453,9 +11453,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.369",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.369.tgz",
-      "integrity": "sha512-Um9kzJcvNLJt8Im9zyt/E+JlqYp9FCkaY420Ve3qrdjuj6Pz51sIdJXhiasuXiHVPZ5yOOVVJB36ir9XStiGKQ==",
+      "version": "0.2.370",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.370.tgz",
+      "integrity": "sha512-HxqpqvD3hpUbfn8fDcrMAdRvyLXA2kYswwzXfAhJdBh5CYk8U526BUEiSqTw44jNLcGQbtoWIfiMiJ67eXqrjA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.369",
+    "@dust-tt/sparkle": "^0.2.370",
     "@dust-tt/types": "file:../types",
     "@heroicons/react": "^2.0.11",
     "@hookform/resolvers": "^3.3.4",


### PR DESCRIPTION
## Description

This PR aims at bumping sparkle version in front to `0.2.370` to ship the following changes: https://github.com/dust-tt/dust/pull/10108

## Risk

Low

## Deploy Plan

Deploy `front`