### PR TITLE
Use listByEmail instead of fetchByEmail for user validation

### DIFF
--- a/front/pages/api/v1/w/[wId]/members/validate.ts
+++ b/front/pages/api/v1/w/[wId]/members/validate.ts
@@ -35,26 +35,32 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const user = await UserResource.fetchByEmail(email);
-
+      const users = await UserResource.listByEmail(email);
       const workspace = auth.getNonNullableWorkspace();
 
-      if (!user) {
+      if (!users.length) {
         return res.status(200).json({
           valid: false,
         });
       }
 
-      const workspaceMembership =
-        await MembershipResource.getActiveMembershipOfUserInWorkspace({
-          user,
-          workspace,
-        });
+      // Check memberships for all users with this email until we find an active one
+      for (const user of users) {
+        const workspaceMembership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace,
+          });
 
-      const valid = !!workspaceMembership;
+        if (workspaceMembership) {
+          return res.status(200).json({
+            valid: true,
+          });
+        }
+      }
 
       return res.status(200).json({
-        valid,
+        valid: false,
       });
 
     default:


### PR DESCRIPTION
## Description

Users that use extensions with email validation (e.g Zendesk extension) and have several accounts with different auth methods on Dust might see error messages because we were using fetchByEmail and not necessarily fetching the right user. 

This PR fixes that by listing all users with that email and checking for workspace membership.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
