### PR TITLE
Add capacity to fallback on Azure OpenAI for embeddings

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -30,6 +30,7 @@ use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
 
+use super::azure_openai::AzureOpenAIEmbedder;
 use super::openai_compatible_helpers::{
     openai_compatible_chat_completion, OpenAIError, TransformSystemMessages,
 };
@@ -1114,11 +1115,19 @@ impl Embedder for OpenAIEmbedder {
     }
 }
 
-pub struct OpenAIProvider {}
+pub struct OpenAIProvider {
+    fallback_embeddings_to_azure: bool,
+}
 
 impl OpenAIProvider {
     pub fn new() -> Self {
-        OpenAIProvider {}
+        let fallback_embeddings_to_azure = std::env::var("OPENAI_EMBEDDINGS_AZURE_FALLBACK")
+            .map(|value| value.to_lowercase() == "true")
+            .unwrap_or(false);
+
+        OpenAIProvider {
+            fallback_embeddings_to_azure,
+        }
     }
 }
 
@@ -1177,6 +1186,10 @@ impl Provider for OpenAIProvider {
     }
 
     fn embedder(&self, id: String) -> Box<dyn Embedder + Sync + Send> {
-        Box::new(OpenAIEmbedder::new(id))
+        if self.fallback_embeddings_to_azure {
+            Box::new(AzureOpenAIEmbedder::new(id))
+        } else {
+            Box::new(OpenAIEmbedder::new(id))
+        }
     }
 }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -509,7 +509,7 @@ pub async fn completion(
 /// AzureOpenAILLM).
 ///
 
-fn get_model_id_from_internal_embeddings_id(model_id: &str) -> &str {
+pub fn get_model_id_from_internal_embeddings_id(model_id: &str) -> &str {
     match model_id {
         "text-embedding-3-large-1536" => "text-embedding-3-large",
         _ => model_id,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds capacity to fallback on Azure Open AI embeddings by setting the environment variable `OPENAI_EMBEDDINGS_AZURE_FALLBACK`.

EDIT: More changes were required to make Azure Open AI embeddings work. This version is fully tested locally and works.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

We need to add the two falling env variables in production:
- `AZURE_OPENAI_API_KEY`
- `AZURE_OPENAI_ENDPOINT`

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
