### PR TITLE
Fix `managedDataSourceGCGdriveCheck` production check

### DIFF
--- a/front/lib/production_checks/managed_ds.ts
+++ b/front/lib/production_checks/managed_ds.ts
@@ -10,7 +10,6 @@ import {
 export type CoreDSDocument = {
   id: number;
   document_id: string;
-  parents: string[];
 };
 
 export async function getCoreDocuments(
@@ -55,7 +54,7 @@ export async function getCoreDocuments(
     );
   }
   const coreDocumentsData = await coreReplica.query(
-    `SELECT id, document_id, parents FROM data_sources_documents WHERE "data_source" = :coreDsId AND status = 'latest'`,
+    `SELECT id, document_id FROM data_sources_documents WHERE "data_source" = :coreDsId AND status = 'latest'`,
     {
       replacements: {
         coreDsId: coreDs[0].id,


### PR DESCRIPTION
## Description

- The `managedDataSourceGCGdriveCheck` production check failed with `Could not get core documents` errors (logs [here](https://app.datadoghq.eu/logs?query=%22Production%20check%20failed%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZSIYFLgVk_wigAAABhBWlNJWUY4MUFBQ2R2VlBJME90enZBRFgAAAAkMDE5NDg4NjEtMmVjZi00MGU1LWEwYWEtZTRjODkyYjMxYzZhABHWLg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1737443817638&to_ts=1737458217638&live=true))
- The underlying SELECT query that was run relied on a `parents` column that was dropped recently and not removed from the query.
- The parents were not used either way.
- This PR removes the missing column from the query.

## Risk

- Low

## Deploy Plan

- Deploy front.