### PR TITLE
feat: parse and expose DeepSeek's reasoning content

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -557,6 +557,7 @@ impl TryFrom<ChatResponse> for AssistantChatMessage {
             role: ChatMessageRole::Assistant,
             name: None,
             content: text_content,
+            reasoning_content: None,
             function_call,
             function_calls,
         })

--- a/core/src/providers/chat_messages.rs
+++ b/core/src/providers/chat_messages.rs
@@ -76,6 +76,8 @@ pub struct AssistantChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub function_call: Option<ChatFunctionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_calls: Option<Vec<ChatFunctionCall>>,

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -237,6 +237,7 @@ impl TryFrom<&MistralChatMessage> for AssistantChatMessage {
 
         Ok(AssistantChatMessage {
             content,
+            reasoning_content: None,
             role,
             name: None,
             function_call,

--- a/core/src/providers/openai_compatible_helpers.rs
+++ b/core/src/providers/openai_compatible_helpers.rs
@@ -252,6 +252,8 @@ pub struct OpenAIChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<OpenAIChatMessageContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<OpenAIToolCall>>,
@@ -263,6 +265,8 @@ pub struct OpenAIChatMessage {
 pub struct OpenAICompletionChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub role: OpenAIChatMessageRole,
@@ -331,6 +335,10 @@ impl TryFrom<&OpenAICompletionChatMessage> for AssistantChatMessage {
             Some(c) => Some(c.clone()),
             None => None,
         };
+        let reasoning_content = match cm.reasoning_content.as_ref() {
+            Some(c) => Some(c.clone()),
+            None => None,
+        };
 
         let function_calls = if let Some(tool_calls) = cm.tool_calls.as_ref() {
             let cfc = tool_calls
@@ -360,6 +368,7 @@ impl TryFrom<&OpenAICompletionChatMessage> for AssistantChatMessage {
 
         Ok(AssistantChatMessage {
             content,
+            reasoning_content,
             role,
             name,
             function_call,
@@ -429,6 +438,7 @@ impl TryFrom<&ChatMessage> for OpenAIChatMessage {
                     Some(c) => Some(OpenAIChatMessageContent::try_from(c)?),
                     None => None,
                 },
+                reasoning_content: None,
                 name: assistant_msg.name.clone(),
                 role: OpenAIChatMessageRole::from(&assistant_msg.role),
                 tool_calls: match assistant_msg.function_calls.as_ref() {
@@ -443,6 +453,7 @@ impl TryFrom<&ChatMessage> for OpenAIChatMessage {
             }),
             ChatMessage::Function(function_msg) => Ok(OpenAIChatMessage {
                 content: Some(OpenAIChatMessageContent::try_from(&function_msg.content)?),
+                reasoning_content: None,
                 name: None,
                 role: OpenAIChatMessageRole::Tool,
                 tool_calls: None,
@@ -450,6 +461,7 @@ impl TryFrom<&ChatMessage> for OpenAIChatMessage {
             }),
             ChatMessage::System(system_msg) => Ok(OpenAIChatMessage {
                 content: Some(OpenAIChatMessageContent::try_from(&system_msg.content)?),
+                reasoning_content: None,
                 name: None,
                 role: OpenAIChatMessageRole::from(&system_msg.role),
                 tool_calls: None,
@@ -457,6 +469,7 @@ impl TryFrom<&ChatMessage> for OpenAIChatMessage {
             }),
             ChatMessage::User(user_msg) => Ok(OpenAIChatMessage {
                 content: Some(OpenAIChatMessageContent::try_from(&user_msg.content)?),
+                reasoning_content: None,
                 name: user_msg.name.clone(),
                 role: OpenAIChatMessageRole::from(&user_msg.role),
                 tool_calls: None,
@@ -806,6 +819,7 @@ fn to_openai_messages(
                         // Case 3: there's more than one content, the content isn't text or we don't want to squash them => keep structured format
                         (_, _, _) => Some(OpenAIChatMessageContent::Structured(contents)),
                     },
+                    reasoning_content: None,
                 }
             }
         })
@@ -829,6 +843,7 @@ fn to_openai_messages(
                         .collect()
                 }),
                 content: m.content,
+                reasoning_content: None,
             }
         })
         // Remove system messages if requested.
@@ -1215,6 +1230,7 @@ async fn streamed_chat_completion(
                 .map(|c| OpenAIChatChoice {
                     message: OpenAICompletionChatMessage {
                         content: Some("".to_string()),
+                        reasoning_content: None,
                         name: None,
                         role: OpenAIChatMessageRole::System,
                         tool_calls: None,
@@ -1270,6 +1286,14 @@ async fn streamed_chat_completion(
                             ));
                         }
                     },
+                };
+
+                match a.choices[j].delta.get("reasoning_content") {
+                    None => (),
+                    Some(reasoning_content) => {
+                        c.choices[j].message.reasoning_content =
+                            Some(reasoning_content.as_str().unwrap_or("").to_string());
+                    }
                 };
 
                 if let Some(tool_calls) = a.choices[j]
@@ -1343,6 +1367,10 @@ async fn streamed_chat_completion(
     // for all messages, edit the content and strip leading and trailing spaces and \n
     for m in completion.choices.iter_mut() {
         m.message.content = match m.message.content.as_ref() {
+            None => None,
+            Some(c) => Some(c.trim().to_string()),
+        };
+        m.message.reasoning_content = match m.message.reasoning_content.as_ref() {
             None => None,
             Some(c) => Some(c.trim().to_string()),
         };
@@ -1494,6 +1522,10 @@ async fn chat_completion(
     // for all messages, edit the content and strip leading and trailing spaces and \n
     for m in completion.choices.iter_mut() {
         m.message.content = match m.message.content.as_ref() {
+            None => None,
+            Some(c) => Some(c.trim().to_string()),
+        };
+        m.message.reasoning_content = match m.message.reasoning_content.as_ref() {
             None => None,
             Some(c) => Some(c.trim().to_string()),
         };


### PR DESCRIPTION
## Description

Unlike OpenAI, DeepSeek exposes the CoT generated by reasoning models.
They use a separate `reasoning_content` field at the same level as `content`. 

We could potentially work on supporting this in assistant thoughts, but there's no rush as we cannot use R1 for assistants yet, due to the lack of tools support (we could try adding our own tools support via XML or something like that)

<img width="927" alt="Screenshot 2025-01-21 at 12 19 27" src="https://github.com/user-attachments/assets/721f3b17-3362-4d50-9bc2-d8545dac7def" />


## Risk

N/A -- if not defined this field is not serialized nor parsed.

## Deploy Plan

Deploy core