### PR TITLE
Fix zendesk permissions setting and category parents

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -410,11 +410,10 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "help-center": {
           if (permission === "none") {
-            const updatedBrandHelpCenter = await forbidSyncZendeskHelpCenter({
-              connectorId,
-              brandId,
-            });
-            if (updatedBrandHelpCenter) {
+            const wasBrandHelpCenterUpdated = await forbidSyncZendeskHelpCenter(
+              { connectorId, brandId }
+            );
+            if (wasBrandHelpCenterUpdated) {
               toBeSignaledHelpCenterIds.add(brandId);
             }
           }
@@ -432,11 +431,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "tickets": {
           if (permission === "none") {
-            const updatedBrandTickets = await forbidSyncZendeskTickets({
+            const wasBrandUpdated = await forbidSyncZendeskTickets({
               connectorId,
               brandId,
             });
-            if (updatedBrandTickets) {
+            if (wasBrandUpdated) {
               toBeSignaledTicketsIds.add(brandId);
             }
           }
@@ -455,23 +454,23 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         case "category": {
           const { brandId, categoryId } = objectIds;
           if (permission === "none") {
-            const updatedCategory = await forbidSyncZendeskCategory({
+            const categoryWasUpdated = await forbidSyncZendeskCategory({
               connectorId,
               brandId,
               categoryId,
             });
-            if (updatedCategory) {
+            if (categoryWasUpdated) {
               toBeSignaledCategoryIds.add([brandId, categoryId]);
             }
           }
           if (permission === "read") {
-            const newCategory = await allowSyncZendeskCategory({
+            const categoryWasUpdated = await allowSyncZendeskCategory({
               connectorId,
               connectionId,
               categoryId,
               brandId,
             });
-            if (newCategory) {
+            if (categoryWasUpdated) {
               toBeSignaledCategoryIds.add([brandId, categoryId]);
             }
           }

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -385,6 +385,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       const { type, objectIds } = getIdsFromInternalId(connectorId, id);
       const { brandId } = objectIds;
       switch (type) {
+        // The brand is just a shortcut to set permissions for Help Center and Tickets at once.
         case "brand": {
           if (permission === "none") {
             const updatedBrand = await forbidSyncZendeskBrand({

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -388,21 +388,21 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         // The brand is just a shortcut to set permissions for Help Center and Tickets at once.
         case "brand": {
           if (permission === "none") {
-            const updatedBrand = await forbidSyncZendeskBrand({
+            const brandWasUnselected = await forbidSyncZendeskBrand({
               connectorId,
               brandId,
             });
-            if (updatedBrand) {
+            if (brandWasUnselected) {
               toBeSignaledBrandIds.add(brandId);
             }
           }
           if (permission === "read") {
-            const wasBrandUpdated = await allowSyncZendeskBrand({
+            const brandWasSelected = await allowSyncZendeskBrand({
               connectorId,
               connectionId,
               brandId,
             });
-            if (wasBrandUpdated) {
+            if (brandWasSelected) {
               toBeSignaledBrandIds.add(brandId);
             }
           }
@@ -410,20 +410,21 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "help-center": {
           if (permission === "none") {
-            const wasBrandHelpCenterUpdated = await forbidSyncZendeskHelpCenter(
-              { connectorId, brandId }
-            );
-            if (wasBrandHelpCenterUpdated) {
+            const helpCenterWasUnselected = await forbidSyncZendeskHelpCenter({
+              connectorId,
+              brandId,
+            });
+            if (helpCenterWasUnselected) {
               toBeSignaledHelpCenterIds.add(brandId);
             }
           }
           if (permission === "read") {
-            const wasBrandUpdated = await allowSyncZendeskHelpCenter({
+            const helpCenterWasSelected = await allowSyncZendeskHelpCenter({
               connectorId,
               connectionId,
               brandId,
             });
-            if (wasBrandUpdated) {
+            if (helpCenterWasSelected) {
               toBeSignaledHelpCenterIds.add(brandId);
             }
           }
@@ -431,21 +432,21 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "tickets": {
           if (permission === "none") {
-            const wasBrandUpdated = await forbidSyncZendeskTickets({
+            const ticketsWereUnselected = await forbidSyncZendeskTickets({
               connectorId,
               brandId,
             });
-            if (wasBrandUpdated) {
+            if (ticketsWereUnselected) {
               toBeSignaledTicketsIds.add(brandId);
             }
           }
           if (permission === "read") {
-            const wasBrandUpdated = await allowSyncZendeskTickets({
+            const ticketsWereSelected = await allowSyncZendeskTickets({
               connectorId,
               connectionId,
               brandId,
             });
-            if (wasBrandUpdated) {
+            if (ticketsWereSelected) {
               toBeSignaledTicketsIds.add(brandId);
             }
           }

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -635,7 +635,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       ...brandTickets.map((brand) =>
         brand.getTicketsContentNode(connectorId, { richTitle: true })
       ),
-      ...categories.map((category) => category.toContentNode(connectorId)),
+      ...categories.map((category) =>
+        category.toContentNode(connectorId, { expandable: true })
+      ),
       ...articles.map((article) => article.toContentNode(connectorId)),
       ...tickets.map((ticket) => ticket.toContentNode(connectorId)),
     ]);

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -71,7 +71,7 @@ export async function forbidSyncZendeskBrand({
 }: {
   connectorId: ModelId;
   brandId: number;
-}): Promise<ZendeskBrandResource | null> {
+}): Promise<boolean> {
   const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -81,12 +81,11 @@ export async function forbidSyncZendeskBrand({
       { connectorId, brandId },
       "[Zendesk] Brand not found, could not disable sync."
     );
-    return null;
+    return false;
   }
 
-  // updating the fields helpCenterPermission and ticketsPermission to "none" for the brand
   await brand.revokeHelpCenterPermissions();
   await brand.revokeTicketsPermissions();
 
-  return brand;
+  return true;
 }

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -6,7 +6,7 @@ import logger from "@connectors/logger/logger";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
 /**
- * Mark a brand as permission "read", with all its children (help center and tickets + children).
+ * Mark a brand as permission "read" in db to indicate it was explicitly selected by the user.
  * Creates the brand by fetching it from Zendesk if it does not exist in db.
  */
 export async function allowSyncZendeskBrand({
@@ -63,7 +63,7 @@ export async function allowSyncZendeskBrand({
 }
 
 /**
- * Mark a brand as permission "none", with all its children (help center and tickets + children).
+ * Mark a brand as permission "none" in db to indicate it was explicitly unselected by the user.
  */
 export async function forbidSyncZendeskBrand({
   connectorId,

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -78,7 +78,7 @@ export async function forbidSyncZendeskBrand({
   });
   if (!brand) {
     logger.error(
-      { brandId },
+      { connectorId, brandId },
       "[Zendesk] Brand not found, could not disable sync."
     );
     return null;

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -1,7 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
 
-import { forbidSyncZendeskHelpCenter } from "@connectors/connectors/zendesk/lib/help_center_permissions";
-import { forbidSyncZendeskTickets } from "@connectors/connectors/zendesk/lib/ticket_permissions";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
@@ -86,9 +84,9 @@ export async function forbidSyncZendeskBrand({
     return null;
   }
 
-  // revoke permissions for the two children resources (help center and tickets + respective children)
-  await forbidSyncZendeskHelpCenter({ connectorId, brandId });
-  await forbidSyncZendeskTickets({ connectorId, brandId });
+  // updating the fields helpCenterPermission and ticketsPermission to "none" for the brand
+  await brand.revokeHelpCenterPermissions();
+  await brand.revokeTicketsPermissions();
 
   return brand;
 }

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -108,7 +108,7 @@ export async function allowSyncZendeskCategory({
   brandId: number;
   categoryId: number;
 }): Promise<boolean> {
-  let category = await ZendeskCategoryResource.fetchByCategoryId({
+  const category = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
     brandId,
     categoryId,
@@ -146,7 +146,7 @@ export async function allowSyncZendeskCategory({
           brandId: fetchedBrand.id,
           name: fetchedBrand.name || "Brand",
           ticketsPermission: "none",
-          helpCenterPermission: "read",
+          helpCenterPermission: "none",
           url: fetchedBrand.url,
         },
       });
@@ -159,7 +159,7 @@ export async function allowSyncZendeskCategory({
     const { result: fetchedCategory } =
       await zendeskApiClient.helpcenter.categories.show(categoryId);
     if (fetchedCategory) {
-      category = await ZendeskCategoryResource.makeNew({
+      await ZendeskCategoryResource.makeNew({
         blob: {
           connectorId,
           brandId,

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -82,7 +82,7 @@ export async function forbidSyncZendeskHelpCenter({
   });
   if (!brand) {
     logger.error(
-      { brandId },
+      { connectorId, brandId },
       "[Zendesk] Brand not found, could not disable sync."
     );
     return null;
@@ -171,7 +171,10 @@ export async function allowSyncZendeskCategory({
         },
       });
     } else {
-      logger.error({ categoryId }, "[Zendesk] Category could not be fetched.");
+      logger.error(
+        { connectorId, categoryId },
+        "[Zendesk] Category could not be fetched."
+      );
       return null;
     }
   }
@@ -198,7 +201,7 @@ export async function forbidSyncZendeskCategory({
   });
   if (!category) {
     logger.error(
-      { categoryId },
+      { connectorId, categoryId },
       "[Zendesk] Category not found, could not disable sync."
     );
     return null;

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -1,14 +1,10 @@
 import type { ModelId } from "@dust-tt/types";
-import { MIME_TYPES } from "@dust-tt/types";
 
-import { getCategoryInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   changeZendeskClientSubdomain,
   createZendeskClient,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
@@ -108,30 +104,6 @@ export async function forbidSyncZendeskHelpCenter({
 
   // updating the field helpCenterPermission to "none" for the brand
   await brand.revokeHelpCenterPermissions();
-
-  // updating the parents for the already selected categories to remove the Help Center
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const selectedCategories =
-    await ZendeskCategoryResource.fetchByBrandIdReadOnly({
-      connectorId,
-      brandId,
-    });
-  for (const category of selectedCategories) {
-    const folderId = getCategoryInternalId({
-      connectorId,
-      brandId,
-      categoryId: category.categoryId,
-    });
-    await upsertDataSourceFolder({
-      dataSourceConfig,
-      folderId,
-      parents: [folderId],
-      parentId: null,
-      title: category.name,
-      mimeType: MIME_TYPES.ZENDESK.CATEGORY,
-      sourceUrl: category.url,
-    });
-  }
 
   return brand;
 }

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -6,7 +6,6 @@ import {
   createZendeskClient,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
   ZendeskArticleResource,
   ZendeskBrandResource,
@@ -14,7 +13,7 @@ import {
 } from "@connectors/resources/zendesk_resources";
 
 /**
- * Marks a help center as permission "read", optionally alongside all its children (categories and articles).
+ * Marks a help center as permission "read".
  * If we are in this function, it means that the user selected the Help Center in the UI.
  * Therefore, we don't need to check for the help_center_state and has_help_center attributes
  * since the box does not appear in the UI then.
@@ -28,12 +27,6 @@ export async function allowSyncZendeskHelpCenter({
   connectionId: string;
   brandId: number;
 }): Promise<boolean> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Zendesk] Connector not found.");
-    throw new Error("Connector not found");
-  }
-
   const zendeskApiClient = createZendeskClient(
     await getZendeskSubdomainAndAccessToken(connectionId)
   );
@@ -84,12 +77,6 @@ export async function forbidSyncZendeskHelpCenter({
   connectorId: ModelId;
   brandId: number;
 }): Promise<ZendeskBrandResource | null> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Zendesk] Connector not found.");
-    throw new Error("Connector not found");
-  }
-
   const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -7,7 +7,6 @@ import {
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import {
-  ZendeskArticleResource,
   ZendeskBrandResource,
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
@@ -205,13 +204,6 @@ export async function forbidSyncZendeskCategory({
     return null;
   }
   await category.revokePermissions();
-
-  // revoking the permissions for all the children articles
-  await ZendeskArticleResource.revokePermissionsForCategory({
-    connectorId,
-    brandId,
-    categoryId,
-  });
 
   return category;
 }

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -75,26 +75,6 @@ export async function allowSyncZendeskHelpCenter({
     });
   }
 
-  // updating the parents for the already selected categories to add the Help Center
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const selectedCategories =
-    await ZendeskCategoryResource.fetchByBrandIdReadOnly({
-      connectorId,
-      brandId,
-    });
-  for (const category of selectedCategories) {
-    const parents = category.getParentInternalIds(connectorId);
-    await upsertDataSourceFolder({
-      dataSourceConfig,
-      folderId: parents[0],
-      parents,
-      parentId: parents[1],
-      title: category.name,
-      mimeType: MIME_TYPES.ZENDESK.CATEGORY,
-      sourceUrl: category.url,
-    });
-  }
-
   return true;
 }
 

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -64,29 +64,6 @@ export async function allowSyncZendeskHelpCenter({
     });
   }
 
-  // updating permissions for all the children categories
-  await changeZendeskClientSubdomain(zendeskApiClient, {
-    connectorId,
-    brandId,
-  });
-  try {
-    const categories = await zendeskApiClient.helpcenter.categories.list();
-    categories.forEach((category) =>
-      allowSyncZendeskCategory({
-        connectionId,
-        connectorId,
-        categoryId: category.id,
-        brandId,
-      })
-    );
-  } catch (e) {
-    logger.error(
-      { connectorId, brandId },
-      "[Zendesk] Categories could not be fetched."
-    );
-    return false;
-  }
-
   return true;
 }
 

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -14,7 +14,7 @@ import {
 /**
  * Marks a help center as permission "read".
  * If we are in this function, it means that the user selected the Help Center in the UI.
- * Therefore, we don't need to check for the help_center_state and has_help_center attributes
+ * Therefore, we don't need to check for the has_help_center attributes
  * since the box does not appear in the UI then.
  */
 export async function allowSyncZendeskHelpCenter({
@@ -67,7 +67,7 @@ export async function allowSyncZendeskHelpCenter({
 }
 
 /**
- * Mark a help center as permission "none", optionally alongside all its children (categories and articles).
+ * Mark a help center as permission "none" in db to indicate it was explicitly selected by the user.
  */
 export async function forbidSyncZendeskHelpCenter({
   connectorId,
@@ -95,7 +95,7 @@ export async function forbidSyncZendeskHelpCenter({
 }
 
 /**
- * Marks a category with "read" permissions, alongside all its children articles.
+ * Marks a category with "read" permissions in db to indicate it was explicitly selected by the user.
  */
 export async function allowSyncZendeskCategory({
   connectorId,
@@ -182,7 +182,7 @@ export async function allowSyncZendeskCategory({
 }
 
 /**
- * Mark a category with "none" permissions alongside all its children articles.
+ * Mark a category with "none" permissions in db to indicate it was explicitly unselected by the user.
  */
 export async function forbidSyncZendeskCategory({
   connectorId,

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -116,6 +116,7 @@ export async function allowSyncZendeskCategory({
 
   if (category) {
     await category.grantPermissions();
+    return true;
   } else {
     const zendeskApiClient = createZendeskClient(
       await getZendeskSubdomainAndAccessToken(connectionId)
@@ -177,8 +178,8 @@ export async function allowSyncZendeskCategory({
       );
       return false;
     }
+    return true;
   }
-  return true;
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -75,7 +75,7 @@ export async function forbidSyncZendeskHelpCenter({
 }: {
   connectorId: ModelId;
   brandId: number;
-}): Promise<ZendeskBrandResource | null> {
+}): Promise<boolean> {
   const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -85,13 +85,13 @@ export async function forbidSyncZendeskHelpCenter({
       { connectorId, brandId },
       "[Zendesk] Brand not found, could not disable sync."
     );
-    return null;
+    return false;
   }
 
   // updating the field helpCenterPermission to "none" for the brand
   await brand.revokeHelpCenterPermissions();
 
-  return brand;
+  return true;
 }
 
 /**
@@ -107,7 +107,7 @@ export async function allowSyncZendeskCategory({
   connectionId: string;
   brandId: number;
   categoryId: number;
-}): Promise<ZendeskCategoryResource | null> {
+}): Promise<boolean> {
   let category = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
     brandId,
@@ -136,7 +136,7 @@ export async function allowSyncZendeskCategory({
           { connectorId, brandId },
           "[Zendesk] Brand could not be fetched."
         );
-        return null;
+        return false;
       }
 
       await ZendeskBrandResource.makeNew({
@@ -175,10 +175,10 @@ export async function allowSyncZendeskCategory({
         { connectorId, categoryId },
         "[Zendesk] Category could not be fetched."
       );
-      return null;
+      return false;
     }
   }
-  return category;
+  return true;
 }
 
 /**
@@ -192,7 +192,7 @@ export async function forbidSyncZendeskCategory({
   connectorId: ModelId;
   brandId: number;
   categoryId: number;
-}): Promise<ZendeskCategoryResource | null> {
+}): Promise<boolean> {
   // revoking the permissions for the category
   const category = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
@@ -204,9 +204,9 @@ export async function forbidSyncZendeskCategory({
       { connectorId, categoryId },
       "[Zendesk] Category not found, could not disable sync."
     );
-    return null;
+    return false;
   }
   await category.revokePermissions();
 
-  return category;
+  return true;
 }

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -296,11 +296,10 @@ export async function retrieveChildrenNodes({
     // If the parent is a category, we retrieve the list of articles for this category.
     case "category": {
       if (isReadPermissionsOnly) {
-        const articlesInDb =
-          await ZendeskArticleResource.fetchByCategoryIdReadOnly({
-            connectorId: connector.id,
-            ...objectIds,
-          });
+        const articlesInDb = await ZendeskArticleResource.fetchByCategoryId({
+          connectorId: connector.id,
+          ...objectIds,
+        });
         return articlesInDb.map((article) =>
           article.toContentNode(connector.id)
         );

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -191,13 +191,10 @@ async function getHelpCenterChildren(
     isReadPermissionsOnly: boolean;
   }
 ): Promise<ContentNode[]> {
-  /// it's ok to fetch read-only data here, if !isReadPermissionsOnly, we are only using the categories in db to
-  // check if they have read permissions
-  const categoriesInDatabase =
-    await ZendeskCategoryResource.fetchByBrandIdReadOnly({
-      connectorId,
-      brandId,
-    });
+  const categoriesInDatabase = await ZendeskCategoryResource.fetchByBrandId({
+    connectorId,
+    brandId,
+  });
   if (isReadPermissionsOnly) {
     return categoriesInDatabase.map((category) =>
       category.toContentNode(connectorId, { expandable: true })

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -54,7 +54,7 @@ export async function retrieveAllSelectedNodes(
   const categories =
     await ZendeskCategoryResource.fetchAllReadOnly(connectorId);
   const categoryNodes: ContentNode[] = categories.map((category) =>
-    category.toContentNode(connectorId)
+    category.toContentNode(connectorId, { expandable: true })
   );
 
   return [...helpCenterNodes, ...ticketNodes, ...categoryNodes];

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -51,17 +51,11 @@ export async function retrieveAllSelectedNodes(
       })
     );
 
-  // retrieving the categories that are not already shown through their Help Center being selected
   const categories =
     await ZendeskCategoryResource.fetchAllReadOnly(connectorId);
-  const categoryNodes: ContentNode[] = categories
-    .filter(
-      (category) =>
-        !brandsWithHelpCenter
-          .map((brand) => brand.brandId)
-          .includes(category.brandId)
-    )
-    .map((category) => category.toContentNode(connectorId));
+  const categoryNodes: ContentNode[] = categories.map((category) =>
+    category.toContentNode(connectorId)
+  );
 
   return [...helpCenterNodes, ...ticketNodes, ...categoryNodes];
 }

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -285,7 +285,7 @@ export async function retrieveChildrenNodes({
     // If the parent is a brand's tickets, we retrieve the list of tickets for the brand.
     case "tickets": {
       if (isReadPermissionsOnly) {
-        const ticketsInDb = await ZendeskTicketResource.fetchByBrandIdReadOnly({
+        const ticketsInDb = await ZendeskTicketResource.fetchByBrandId({
           connectorId: connector.id,
           brandId: objectIds.brandId,
         });

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -71,7 +71,7 @@ export async function deleteCategory({
 }
 
 /**
- * Syncs a category from Zendesk to the postgres db.
+ * Syncs a category from Zendesk to the postgres db and to the data_sources_folders.
  */
 export async function syncCategory({
   connectorId,

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -101,7 +101,7 @@ export async function syncCategory({
         connectorId,
         brandId,
         categoryId: category.id,
-        permission: "read",
+        permission: "none",
       },
     });
   } else {

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -134,5 +134,6 @@ export async function syncCategory({
     title: categoryInDb.name,
     mimeType: MIME_TYPES.ZENDESK.CATEGORY,
     sourceUrl: categoryInDb.url,
+    timestampMs: currentSyncDateMs,
   });
 }

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -15,7 +15,6 @@ import {
 } from "@connectors/lib/data_sources";
 import {
   ZendeskArticleResource,
-  ZendeskBrandResource,
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -77,12 +76,14 @@ export async function syncCategory({
   connectorId,
   brandId,
   category,
+  isHelpCenterSelected,
   currentSyncDateMs,
   dataSourceConfig,
 }: {
   connectorId: ModelId;
   brandId: number;
   category: ZendeskFetchedCategory;
+  isHelpCenterSelected: boolean;
   currentSyncDateMs: number;
   dataSourceConfig: DataSourceConfig;
 }): Promise<void> {
@@ -114,20 +115,15 @@ export async function syncCategory({
   }
 
   // upserting a folder to data_sources_folders (core)
-  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
-    connectorId,
-    brandId,
-  });
   const folderId = getCategoryInternalId({
     connectorId,
     brandId,
     categoryId: categoryInDb.categoryId,
   });
   // adding the parents to the array of parents iff the Help Center was selected
-  const parentId =
-    brandInDb?.helpCenterPermission === "read"
-      ? getHelpCenterInternalId({ connectorId, brandId })
-      : null;
+  const parentId = isHelpCenterSelected
+    ? getHelpCenterInternalId({ connectorId, brandId })
+    : null;
   const parents = parentId ? [folderId, parentId] : [folderId];
 
   await upsertDataSourceFolder({

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -71,7 +71,7 @@ export async function deleteCategory({
 }
 
 /**
- * Syncs a category from Zendesk to the postgres db and to the data_sources_folders.
+ * Syncs a category from Zendesk with both connectors (zendesk_categories) and core (data_sources_folders/nodes).
  */
 export async function syncCategory({
   connectorId,

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -64,7 +64,7 @@ export async function forbidSyncZendeskTickets({
 }: {
   connectorId: ModelId;
   brandId: number;
-}): Promise<ZendeskBrandResource | null> {
+}): Promise<boolean> {
   const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -74,10 +74,10 @@ export async function forbidSyncZendeskTickets({
       { connectorId, brandId },
       "[Zendesk] Brand not found, could not disable sync."
     );
-    return null;
+    return false;
   }
 
   // updating the field ticketsPermission to "none" for the brand
   await brand.revokeTicketsPermissions();
-  return brand;
+  return true;
 }

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -71,7 +71,7 @@ export async function forbidSyncZendeskTickets({
   });
   if (!brand) {
     logger.error(
-      { brandId },
+      { connectorId, brandId },
       "[Zendesk] Brand not found, could not disable sync."
     );
     return null;

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -3,10 +3,7 @@ import type { ModelId } from "@dust-tt/types";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
-import {
-  ZendeskBrandResource,
-  ZendeskTicketResource,
-} from "@connectors/resources/zendesk_resources";
+import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
 /**
  * Marks the node "Tickets" of a Brand as permission "read".
@@ -82,10 +79,5 @@ export async function forbidSyncZendeskTickets({
 
   // updating the field ticketsPermission to "none" for the brand
   await brand.revokeTicketsPermissions();
-  // revoking the permissions for all the children tickets
-  await ZendeskTicketResource.revokePermissionsForBrand({
-    connectorId,
-    brandId,
-  });
   return brand;
 }

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -79,5 +79,6 @@ export async function forbidSyncZendeskTickets({
 
   // updating the field ticketsPermission to "none" for the brand
   await brand.revokeTicketsPermissions();
+
   return true;
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -34,6 +34,7 @@ import {
   ZendeskCategoryResource,
   ZendeskConfigurationResource,
 } from "@connectors/resources/zendesk_resources";
+import { getCategoryInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 
 /**
  * This activity is responsible for updating the lastSyncStartTime of the connector to now.
@@ -349,6 +350,10 @@ export async function syncZendeskCategoryActivity({
 
   // if all rights were revoked, we have nothing to sync
   if (categoryInDb.permission === "none") {
+    await deleteDataSourceFolder({
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
+      folderId: getCategoryInternalId({ connectorId, brandId, categoryId }),
+    });
     return { shouldSyncArticles: false };
   }
 

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -150,6 +150,25 @@ export async function syncZendeskBrandActivity({
       title: helpCenterNode.title,
       mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
     });
+
+    // updating the parents for the already selected categories to add the Help Center
+    const selectedCategories =
+      await ZendeskCategoryResource.fetchByBrandIdReadOnly({
+        connectorId,
+        brandId,
+      });
+    for (const category of selectedCategories) {
+      const parents = category.getParentInternalIds(connectorId);
+      await upsertDataSourceFolder({
+        dataSourceConfig,
+        folderId: parents[0],
+        parents,
+        parentId: parents[1],
+        title: category.name,
+        mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+        sourceUrl: category.url,
+      });
+    }
   } else {
     await deleteDataSourceFolder({
       dataSourceConfig,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -175,6 +175,23 @@ export async function syncZendeskBrandActivity({
       dataSourceConfig,
       folderId: helpCenterNode.internalId,
     });
+
+    // deleting categories that were only synced because the Help Center was selected but were not explicitely selected by the user in the UI
+    const categoriesNotSelected =
+      await ZendeskCategoryResource.fetchBrandUnselectedCategories({
+        connectorId,
+        brandId,
+      });
+    for (const category of categoriesNotSelected) {
+      await deleteDataSourceFolder({
+        dataSourceConfig,
+        folderId: getCategoryInternalId({
+          connectorId,
+          brandId,
+          categoryId: category.categoryId,
+        }),
+      });
+    }
   }
 
   const ticketsNode = brandInDb.getTicketsContentNode(connectorId, {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -314,6 +314,7 @@ export async function syncZendeskCategoryBatchActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
@@ -324,6 +325,10 @@ export async function syncZendeskCategoryBatchActivity({
     connectorId,
     accessToken,
     subdomain,
+  });
+  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
+    connectorId,
+    brandId,
   });
 
   const { categories, hasMore, nextLink } = await fetchZendeskCategoriesInBrand(
@@ -338,6 +343,7 @@ export async function syncZendeskCategoryBatchActivity({
         connectorId,
         brandId,
         category,
+        isHelpCenterSelected: brandInDb?.helpCenterPermission === "read",
         currentSyncDateMs,
         dataSourceConfig,
       });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -382,6 +382,7 @@ export async function syncZendeskCategoryActivity({
     brandId,
   });
   const folderId = getCategoryInternalId({ connectorId, brandId, categoryId });
+  // adding the parents to the array of parents iff the Help Center was selected
   const parentId =
     brandInDb?.helpCenterPermission === "read"
       ? getHelpCenterInternalId({ connectorId, brandId })

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -400,6 +400,7 @@ export async function syncZendeskCategoryActivity({
       dataSourceConfig: dataSourceConfigFromConnector(connector),
       folderId: getCategoryInternalId({ connectorId, brandId, categoryId }),
     });
+    // note that the articles will be deleted in the garbage collection
     return { shouldSyncArticles: false };
   }
 

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -134,13 +134,12 @@ export async function syncZendeskBrandActivity({
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
-  // upserting three folders to data_sources_folders (core): brand, help center, tickets
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  // using the content node to get one source of truth regarding the parent relationship
   const helpCenterNode = brandInDb.getHelpCenterContentNode(connectorId, {
     richTitle: true,
   });
+  // syncing the folders in data_sources_folders (core) for the nodes that are selected among the Help Center and the Tickets
   if (brandInDb.helpCenterPermission === "read") {
     await upsertDataSourceFolder({
       dataSourceConfig,
@@ -176,7 +175,6 @@ export async function syncZendeskBrandActivity({
     });
   }
 
-  // using the content node to get one source of truth regarding the parent relationship
   const ticketsNode = brandInDb.getTicketsContentNode(connectorId, {
     richTitle: true,
   });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -148,6 +148,7 @@ export async function syncZendeskBrandActivity({
       parentId: null,
       title: helpCenterNode.title,
       mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+      timestampMs: currentSyncDateMs,
     });
 
     // updating the parents for the already selected categories to add the Help Center
@@ -166,6 +167,7 @@ export async function syncZendeskBrandActivity({
         title: category.name,
         mimeType: MIME_TYPES.ZENDESK.CATEGORY,
         sourceUrl: category.url,
+        timestampMs: currentSyncDateMs,
       });
     }
   } else {
@@ -186,6 +188,7 @@ export async function syncZendeskBrandActivity({
       parentId: null,
       title: ticketsNode.title,
       mimeType: MIME_TYPES.ZENDESK.TICKETS,
+      timestampMs: currentSyncDateMs,
     });
   } else {
     await deleteDataSourceFolder({

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -440,6 +440,7 @@ export async function syncZendeskCategoryActivity({
     title: categoryInDb.name,
     mimeType: MIME_TYPES.ZENDESK.CATEGORY,
     sourceUrl: fetchedCategory.html_url,
+    timestampMs: currentSyncDateMs,
   });
 
   // otherwise, we update the category name and lastUpsertedTs

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -158,6 +158,7 @@ export async function syncZendeskBrandActivity({
         brandId,
       });
     for (const category of selectedCategories) {
+      // here we can just take all the possible parents since we are syncing the categories through their Help Center
       const parents = category.getParentInternalIds(connectorId);
       await upsertDataSourceFolder({
         dataSourceConfig,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -130,32 +130,35 @@ export async function syncZendeskBrandActivity({
   // upserting three folders to data_sources_folders (core): brand, help center, tickets
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  // using the content node to get one source of truth regarding the parent relationship
-  const helpCenterNode = brandInDb.getHelpCenterContentNode(connectorId, {
-    richTitle: true,
-  });
-  await upsertDataSourceFolder({
-    dataSourceConfig,
-    folderId: helpCenterNode.internalId,
-    parents: [helpCenterNode.internalId],
-    parentId: null,
-    title: helpCenterNode.title,
-    mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
-  });
+  if (brandInDb.helpCenterPermission === "read") {
+    // using the content node to get one source of truth regarding the parent relationship
+    const helpCenterNode = brandInDb.getHelpCenterContentNode(connectorId, {
+      richTitle: true,
+    });
+    await upsertDataSourceFolder({
+      dataSourceConfig,
+      folderId: helpCenterNode.internalId,
+      parents: [helpCenterNode.internalId],
+      parentId: null,
+      title: helpCenterNode.title,
+      mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+    });
+  }
 
-  // using the content node to get one source of truth regarding the parent relationship
-  const ticketsNode = brandInDb.getTicketsContentNode(connectorId, {
-    richTitle: true,
-  });
-  await upsertDataSourceFolder({
-    dataSourceConfig,
-    folderId: ticketsNode.internalId,
-    parents: [ticketsNode.internalId],
-    parentId: null,
-    title: ticketsNode.title,
-    mimeType: MIME_TYPES.ZENDESK.TICKETS,
-  });
-
+  if (brandInDb.ticketsPermission === "read") {
+    // using the content node to get one source of truth regarding the parent relationship
+    const ticketsNode = brandInDb.getTicketsContentNode(connectorId, {
+      richTitle: true,
+    });
+    await upsertDataSourceFolder({
+      dataSourceConfig,
+      folderId: ticketsNode.internalId,
+      parents: [ticketsNode.internalId],
+      parentId: null,
+      title: ticketsNode.title,
+      mimeType: MIME_TYPES.ZENDESK.TICKETS,
+    });
+  }
   // updating the entry in db
   await brandInDb.update({
     name: fetchedBrand.name || "Brand",

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -2,7 +2,6 @@ import type { ModelId } from "@dust-tt/types";
 
 import {
   getArticleInternalId,
-  getBrandInternalId,
   getCategoryInternalId,
   getHelpCenterInternalId,
   getTicketInternalId,
@@ -246,10 +245,6 @@ export async function deleteBrandsWithNoPermissionActivity(
   await concurrentExecutor(
     brands,
     async (brandId) => {
-      await deleteDataSourceFolder({
-        dataSourceConfig,
-        folderId: getBrandInternalId({ connectorId, brandId }),
-      });
       await deleteDataSourceFolder({
         dataSourceConfig,
         folderId: getHelpCenterInternalId({ connectorId, brandId }),

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -327,7 +327,8 @@ export async function deleteTicketBatchActivity({
 }
 
 /**
- * Deletes a batch of categories from the db and from core.
+ * Deletes a batch of categories from connectors (zendesk_categories) and from core (data_sources_folders/nodes) for a brand.
+ * Only delete categories that are not explicitly selected by the user and that were synced through their Help Center.
  */
 export async function deleteCategoryBatchActivity({
   connectorId,

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -381,7 +381,7 @@ export async function deleteArticleBatchActivity({
 }
 
 /**
- * Deletes a batch of categories from the db.
+ * Deletes a batch of categories from the db and from core.
  */
 export async function deleteCategoryBatchActivity({
   connectorId,

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -35,28 +35,6 @@ import {
 } from "@connectors/resources/zendesk_resources";
 
 /**
- * Looks for empty Help Centers (no category with read permissions) and removes their permissions.
- */
-export async function checkEmptyHelpCentersActivity(
-  connectorId: ModelId
-): Promise<void> {
-  const brands =
-    await ZendeskBrandResource.fetchHelpCenterReadAllowedBrands(connectorId);
-
-  for (const brand of brands) {
-    const categoriesWithReadPermissions =
-      await ZendeskCategoryResource.fetchByBrandIdReadOnly({
-        connectorId,
-        brandId: brand.brandId,
-      });
-    const noMoreAllowedCategories = categoriesWithReadPermissions.length === 0;
-    if (noMoreAllowedCategories) {
-      await brand.revokeHelpCenterPermissions();
-    }
-  }
-}
-
-/**
  * Retrieves the IDs of the Brands whose tickets are to be deleted.
  */
 export async function getZendeskBrandsWithTicketsToDeleteActivity(

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -403,11 +403,12 @@ export async function deleteCategoryBatchActivity({
     dataSourceId: dataSourceConfig.dataSourceId,
   };
 
-  const categoryIds = await ZendeskCategoryResource.fetchByBrandId({
-    connectorId,
-    brandId,
-    batchSize: ZENDESK_BATCH_SIZE,
-  });
+  const categoryIds =
+    await ZendeskCategoryResource.fetchCategoriesNotSelectedInBrand({
+      connectorId,
+      brandId,
+      batchSize: ZENDESK_BATCH_SIZE,
+    });
 
   await concurrentExecutor(
     categoryIds,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -146,7 +146,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
                 description: fetchedCategory.description,
               },
             });
-            // upserting a folder to data_sources_folders (core)
+            // upserting a folder to data_sources_folders: here the Help Center is selected so it should appear in the parents
             const parents = category.getParentInternalIds(connectorId);
             await upsertDataSourceFolder({
               dataSourceConfig,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -141,7 +141,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
                 brandId,
                 name: fetchedCategory.name || "Category",
                 categoryId,
-                permission: "read",
+                permission: "none",
                 url: fetchedCategory.html_url,
                 description: fetchedCategory.description,
               },
@@ -166,7 +166,10 @@ export async function syncZendeskArticleUpdateBatchActivity({
           }
         }
         /// syncing the article if the category exists and is selected
-        if (category && category.permission === "read") {
+        if (
+          category &&
+          (category.permission === "read" || hasHelpCenterPermissions)
+        ) {
           return syncArticle({
             connectorId,
             category,

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -45,7 +45,6 @@ const {
   deleteTicketBatchActivity,
   deleteArticleBatchActivity,
   removeForbiddenCategoriesActivity,
-  removeEmptyCategoriesActivity,
 } = proxyActivities<typeof gc_activities>({
   startToCloseTimeout: "15 minutes",
 });
@@ -445,9 +444,6 @@ export async function zendeskGarbageCollectionWorkflow({
     const { hasMore } = await removeForbiddenCategoriesActivity(connectorId);
     hasMoreCategories = hasMore;
   }
-
-  // deleting the categories that have no article anymore
-  await removeEmptyCategoriesActivity(connectorId);
 
   // cleaning the articles and categories of the brands that have no permission on their Help Center anymore
   brandIds = await getZendeskBrandsWithHelpCenterToDeleteActivity(connectorId);

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -40,7 +40,6 @@ const {
   removeMissingArticleBatchActivity,
   getZendeskBrandsWithHelpCenterToDeleteActivity,
   getZendeskBrandsWithTicketsToDeleteActivity,
-  checkEmptyHelpCentersActivity,
   deleteBrandsWithNoPermissionActivity,
   deleteCategoryBatchActivity,
   deleteTicketBatchActivity,
@@ -449,9 +448,6 @@ export async function zendeskGarbageCollectionWorkflow({
 
   // deleting the categories that have no article anymore
   await removeEmptyCategoriesActivity(connectorId);
-
-  // updating the permissions of the Help Centers that have no category anymore for a cleanup at the next step
-  await checkEmptyHelpCentersActivity(connectorId);
 
   // cleaning the articles and categories of the brands that have no permission on their Help Center anymore
   brandIds = await getZendeskBrandsWithHelpCenterToDeleteActivity(connectorId);

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -43,7 +43,6 @@ const {
   deleteBrandsWithNoPermissionActivity,
   deleteCategoryBatchActivity,
   deleteTicketBatchActivity,
-  deleteArticleBatchActivity,
   removeForbiddenCategoriesActivity,
 } = proxyActivities<typeof gc_activities>({
   startToCloseTimeout: "15 minutes",
@@ -448,14 +447,6 @@ export async function zendeskGarbageCollectionWorkflow({
   // cleaning the articles and categories of the brands that have no permission on their Help Center anymore
   brandIds = await getZendeskBrandsWithHelpCenterToDeleteActivity(connectorId);
   for (const brandId of brandIds) {
-    let hasMoreArticles = true;
-    while (hasMoreArticles) {
-      const { hasMore } = await deleteArticleBatchActivity({
-        connectorId,
-        brandId,
-      });
-      hasMoreArticles = hasMore;
-    }
     let hasMoreCategories = true;
     while (hasMoreCategories) {
       const { hasMore } = await deleteCategoryBatchActivity({

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -508,9 +508,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     const categories = await ZendeskCategory.findAll({
       where: { connectorId, brandId, categoryId: { [Op.in]: categoryIds } },
     });
-    return categories.map(
-      (category) => category && new this(this.model, category.get())
-    );
+    return categories.map((category) => new this(this.model, category.get()));
   }
 
   static async fetchReadOnlyCategoryIdsByBrandId({
@@ -564,9 +562,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     const categories = await ZendeskCategory.findAll({
       where: { connectorId, brandId, permission: "read" },
     });
-    return categories.map(
-      (category) => category && new this(this.model, category.get())
-    );
+    return categories.map((category) => new this(this.model, category.get()));
   }
 
   static async fetchBrandUnselectedCategories({

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -810,7 +810,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     return tickets.map((ticket) => new this(this.model, ticket.get()));
   }
 
-  static async fetchByBrandIdReadOnly({
+  static async fetchByBrandId({
     connectorId,
     brandId,
   }: {
@@ -818,7 +818,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     brandId: number;
   }): Promise<ZendeskTicketResource[]> {
     const tickets = await ZendeskTicket.findAll({
-      where: { connectorId, brandId, permission: "read" },
+      where: { connectorId, brandId },
     });
     return tickets.map((ticket) => new this(this.model, ticket.get()));
   }
@@ -871,19 +871,6 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     transaction: Transaction
   ) {
     await ZendeskTicket.destroy({ where: { connectorId }, transaction });
-  }
-
-  static async revokePermissionsForBrand({
-    connectorId,
-    brandId,
-  }: {
-    connectorId: number;
-    brandId: number;
-  }): Promise<void> {
-    await ZendeskTicket.update(
-      { permission: "none" },
-      { where: { connectorId, brandId } }
-    );
   }
 }
 

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -537,7 +537,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return categories.map((category) => category.get().brandId);
   }
 
-  static async fetchByBrandId({
+  static async fetchCategoriesNotSelectedInBrand({
     connectorId,
     brandId,
     batchSize = null,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -1049,21 +1049,6 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     return articles.map((article) => new this(this.model, article.get()));
   }
 
-  static async fetchByCategoryIdReadOnly({
-    connectorId,
-    brandId,
-    categoryId,
-  }: {
-    connectorId: number;
-    brandId: number;
-    categoryId: number;
-  }): Promise<ZendeskArticleResource[]> {
-    const articles = await ZendeskArticle.findAll({
-      where: { connectorId, brandId, categoryId, permission: "read" },
-    });
-    return articles.map((article) => new this(this.model, article.get()));
-  }
-
   static async fetchArticleIdsByBrandId({
     connectorId,
     brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -1084,32 +1084,4 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
   ) {
     await ZendeskArticle.destroy({ where: { connectorId }, transaction });
   }
-
-  static async revokePermissionsForBrand({
-    connectorId,
-    brandId,
-  }: {
-    connectorId: number;
-    brandId: number;
-  }) {
-    await ZendeskArticle.update(
-      { permission: "none" },
-      { where: { connectorId, brandId } }
-    );
-  }
-
-  static async revokePermissionsForCategory({
-    connectorId,
-    brandId,
-    categoryId,
-  }: {
-    connectorId: number;
-    brandId: number;
-    categoryId: number;
-  }) {
-    await ZendeskArticle.update(
-      { permission: "none" },
-      { where: { connectorId, brandId, categoryId } }
-    );
-  }
 }

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -569,6 +569,15 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     );
   }
 
+  static async fetchAllReadOnly(
+    connectorId: number
+  ): Promise<ZendeskCategoryResource[]> {
+    const categories = await ZendeskCategory.findAll({
+      where: { connectorId, permission: "read" },
+    });
+    return categories.map((category) => new this(this.model, category.get()));
+  }
+
   static async deleteByCategoryId({
     connectorId,
     brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -1036,23 +1036,6 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     return articles.map((article) => new this(this.model, article.get()));
   }
 
-  static async fetchArticleIdsByBrandId({
-    connectorId,
-    brandId,
-    batchSize = null,
-  }: {
-    connectorId: number;
-    brandId: number;
-    batchSize?: number | null;
-  }): Promise<number[]> {
-    const articles = await ZendeskArticle.findAll({
-      attributes: ["articleId"],
-      where: { connectorId, brandId },
-      ...(batchSize && { limit: batchSize }),
-    });
-    return articles.map((article) => article.get().articleId);
-  }
-
   static async deleteByArticleId({
     connectorId,
     brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -552,6 +552,19 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return categories.map((category) => category.get().categoryId);
   }
 
+  static async fetchByBrandId({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }): Promise<ZendeskCategoryResource[]> {
+    const categories = await ZendeskCategory.findAll({
+      where: { connectorId, brandId },
+    });
+    return categories.map((category) => new this(this.model, category.get()));
+  }
+
   static async fetchByBrandIdReadOnly({
     connectorId,
     brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -757,6 +757,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
       expandable: false,
       permission: this.permission,
       lastUpdatedAt: this.updatedAt.getTime(),
+      preventSelection: true,
     };
   }
 
@@ -957,6 +958,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
       expandable: false,
       permission: this.permission,
       lastUpdatedAt: this.updatedAt.getTime(),
+      preventSelection: true,
     };
   }
 

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -569,6 +569,19 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     );
   }
 
+  static async fetchBrandUnselectedCategories({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }): Promise<ZendeskCategoryResource[]> {
+    const categories = await ZendeskCategory.findAll({
+      where: { connectorId, brandId, permission: "none" },
+    });
+    return categories.map((category) => new this(this.model, category.get()));
+  }
+
   static async fetchAllReadOnly(
     connectorId: number
   ): Promise<ZendeskCategoryResource[]> {

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -77,7 +77,12 @@ export function computeNodesDiff({
               return false;
             }
             // Custom exclusion rules. The goal here is to avoid logging irrelevant differences, scoping by connector.
-            if (key === "parentInternalId" && provider === "snowflake") {
+            // For Snowflake and Zendesk we fixed how parents were computed in the core folders but not in connectors.
+            if (
+              ["parentInternalIds", "parentInternalId"].includes(key) &&
+              provider &&
+              ["snowflake", "zendesk"].includes(provider)
+            ) {
               return false;
             }
             const coreValue = coreNode[key as keyof DataSourceViewContentNode];

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -110,7 +110,6 @@ export const MIME_TYPES = {
   ZENDESK: getMimeTypes({
     provider: "zendesk",
     resourceTypes: [
-      "BRAND",
       "HELP_CENTER",
       "CATEGORY",
       "ARTICLE",

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -109,13 +109,7 @@ export const MIME_TYPES = {
   }),
   ZENDESK: getMimeTypes({
     provider: "zendesk",
-    resourceTypes: [
-      "HELP_CENTER",
-      "CATEGORY",
-      "ARTICLE",
-      "TICKETS",
-      "TICKET",
-    ],
+    resourceTypes: ["HELP_CENTER", "CATEGORY", "ARTICLE", "TICKETS", "TICKET"],
   }),
 };
 


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/1987
- The permissions setting was broken at various places.
- This PR fixes that.
- The scope of the garbage collection is reduced by keeping empty categories and Help Centers (no reason to clean these up).
- This PR also passes the correct parents when upserting a folder for a category (pass the Help Center iff selected).

## Risk

- Blast radius scoped to the Zendesk connector, but affects everything related (permissions setting, data source views, assistant builder).
- Tested extensively.

## Deploy Plan

- Deploy connectors.
- Deploy front.
