### PR TITLE
feat: add magic key output in dust apps for struc output

### DIFF
--- a/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
+++ b/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
@@ -7,10 +7,14 @@ import {
   Collapsible,
   CommandLineIcon,
   ContentBlockWrapper,
+  DocumentIcon,
   Icon,
   TableIcon,
 } from "@dust-tt/sparkle";
-import type { DustAppRunActionType } from "@dust-tt/types";
+import type {
+  DustAppRunActionType,
+  SupportedFileContentType,
+} from "@dust-tt/types";
 import { getDustAppRunResultsFileTitle } from "@dust-tt/types";
 import { capitalize } from "lodash";
 import { useMemo } from "react";
@@ -18,6 +22,19 @@ import { useMemo } from "react";
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
 import { DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY } from "@app/lib/api/assistant/actions/constants";
+
+function ContentTypeIcon({
+  contentType,
+}: {
+  contentType: SupportedFileContentType;
+}) {
+  switch (contentType) {
+    case "text/csv":
+      return <Icon visual={TableIcon} />;
+    default:
+      return <Icon visual={DocumentIcon} />;
+  }
+}
 
 export function DustAppRunActionDetails({
   action,
@@ -106,7 +123,7 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
               })}
             >
               <CitationIcons>
-                <Icon visual={TableIcon} />
+                <ContentTypeIcon contentType={action.resultsFileContentType} />
               </CitationIcons>
               <CitationTitle>
                 {getDustAppRunResultsFileTitle({

--- a/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
+++ b/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
@@ -90,45 +90,51 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
 
   return (
     <div className="flex flex-col gap-4">
-      {action.resultsFileId && action.resultsFileSnippet && (
-        <div>
-          <span className="text-sm font-semibold text-foreground">Results</span>
-          <Citation
-            className="w-48 min-w-48 max-w-48"
-            containerClassName="my-2"
-            tooltip={getDustAppRunResultsFileTitle({
-              appName: action.appName,
-            })}
-          >
-            <CitationIcons>
-              <Icon visual={TableIcon} />
-            </CitationIcons>
-            <CitationTitle>
-              {getDustAppRunResultsFileTitle({
+      {action.resultsFileId &&
+        action.resultsFileSnippet &&
+        action.resultsFileContentType && (
+          <div>
+            <span className="text-sm font-semibold text-foreground">
+              Results
+            </span>
+            <Citation
+              className="w-48 min-w-48 max-w-48"
+              containerClassName="my-2"
+              tooltip={getDustAppRunResultsFileTitle({
                 appName: action.appName,
+                resultsFileContentType: action.resultsFileContentType,
               })}
-            </CitationTitle>
-          </Citation>
+            >
+              <CitationIcons>
+                <Icon visual={TableIcon} />
+              </CitationIcons>
+              <CitationTitle>
+                {getDustAppRunResultsFileTitle({
+                  appName: action.appName,
+                  resultsFileContentType: action.resultsFileContentType,
+                })}
+              </CitationTitle>
+            </Citation>
 
-          <Collapsible defaultOpen={false}>
-            <Collapsible.Button>
-              <span className="text-sm font-semibold text-muted-foreground">
-                Preview
-              </span>
-            </Collapsible.Button>
-            <Collapsible.Panel>
-              <div className="py-2">
-                <CodeBlock
-                  className="language-csv max-h-60 overflow-y-auto"
-                  wrapLongLines={true}
-                >
-                  {action.resultsFileSnippet}
-                </CodeBlock>
-              </div>
-            </Collapsible.Panel>
-          </Collapsible>
-        </div>
-      )}
+            <Collapsible defaultOpen={false}>
+              <Collapsible.Button>
+                <span className="text-sm font-semibold text-muted-foreground">
+                  Preview
+                </span>
+              </Collapsible.Button>
+              <Collapsible.Panel>
+                <div className="py-2">
+                  <CodeBlock
+                    className="language-csv max-h-60 overflow-y-auto"
+                    wrapLongLines={true}
+                  >
+                    {action.resultsFileSnippet}
+                  </CodeBlock>
+                </div>
+              </Collapsible.Panel>
+            </Collapsible>
+          </div>
+        )}
 
       <ContentBlockWrapper
         content={stringifiedOutput}

--- a/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
+++ b/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
@@ -105,15 +105,16 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
     return null;
   }
 
+  const shouldDisplayRawOutput =
+    !action.resultsFileId ||
+    (stringifiedOutput.length && stringifiedOutput != "{}");
+
   return (
     <div className="flex flex-col gap-4">
       {action.resultsFileId &&
         action.resultsFileSnippet &&
         action.resultsFileContentType && (
           <div>
-            <span className="text-sm font-semibold text-foreground">
-              Results
-            </span>
             <Citation
               className="w-48 min-w-48 max-w-48"
               containerClassName="my-2"
@@ -153,17 +154,19 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
           </div>
         )}
 
-      <ContentBlockWrapper
-        content={stringifiedOutput}
-        getContentToDownload={getContentToDownload}
-      >
-        <CodeBlock
-          className="language-json max-h-60 overflow-y-auto"
-          wrapLongLines={true}
+      {shouldDisplayRawOutput && (
+        <ContentBlockWrapper
+          content={stringifiedOutput}
+          getContentToDownload={getContentToDownload}
         >
-          {stringifiedOutput}
-        </CodeBlock>
-      </ContentBlockWrapper>
+          <CodeBlock
+            className="language-json max-h-60 overflow-y-auto"
+            wrapLongLines={true}
+          >
+            {stringifiedOutput}
+          </CodeBlock>
+        </ContentBlockWrapper>
+      )}
     </div>
   );
 }

--- a/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
+++ b/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
@@ -1,9 +1,14 @@
 import type { GetContentToDownloadFunction } from "@dust-tt/sparkle";
 import {
+  Citation,
+  CitationIcons,
+  CitationTitle,
   CodeBlock,
   Collapsible,
   CommandLineIcon,
   ContentBlockWrapper,
+  Icon,
+  TableIcon,
 } from "@dust-tt/sparkle";
 import type { DustAppRunActionType } from "@dust-tt/types";
 import { capitalize } from "lodash";
@@ -83,16 +88,52 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
   }
 
   return (
-    <ContentBlockWrapper
-      content={stringifiedOutput}
-      getContentToDownload={getContentToDownload}
-    >
-      <CodeBlock
-        className="language-json max-h-60 overflow-y-auto"
-        wrapLongLines={true}
+    <div className="flex flex-col gap-4">
+      {action.resultsFileId && action.resultsFileSnippet && (
+        <div>
+          <span className="text-sm font-semibold text-foreground">Results</span>
+          <Citation
+            className="w-48 min-w-48 max-w-48"
+            containerClassName="my-2"
+            tooltip={`${action.appName}_output.csv`}
+          >
+            <CitationIcons>
+              <Icon visual={TableIcon} />
+            </CitationIcons>
+            <CitationTitle>{`${action.appName}_output.csv`}</CitationTitle>
+          </Citation>
+
+          <Collapsible defaultOpen={false}>
+            <Collapsible.Button>
+              <span className="text-sm font-semibold text-muted-foreground">
+                Preview
+              </span>
+            </Collapsible.Button>
+            <Collapsible.Panel>
+              <div className="py-2">
+                <CodeBlock
+                  className="language-csv max-h-60 overflow-y-auto"
+                  wrapLongLines={true}
+                >
+                  {action.resultsFileSnippet}
+                </CodeBlock>
+              </div>
+            </Collapsible.Panel>
+          </Collapsible>
+        </div>
+      )}
+
+      <ContentBlockWrapper
+        content={stringifiedOutput}
+        getContentToDownload={getContentToDownload}
       >
-        {stringifiedOutput}
-      </CodeBlock>
-    </ContentBlockWrapper>
+        <CodeBlock
+          className="language-json max-h-60 overflow-y-auto"
+          wrapLongLines={true}
+        >
+          {stringifiedOutput}
+        </CodeBlock>
+      </ContentBlockWrapper>
+    </div>
   );
 }

--- a/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
+++ b/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
@@ -11,6 +11,7 @@ import {
   TableIcon,
 } from "@dust-tt/sparkle";
 import type { DustAppRunActionType } from "@dust-tt/types";
+import { getDustAppRunResultsFileTitle } from "@dust-tt/types";
 import { capitalize } from "lodash";
 import { useMemo } from "react";
 
@@ -95,12 +96,18 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
           <Citation
             className="w-48 min-w-48 max-w-48"
             containerClassName="my-2"
-            tooltip={`${action.appName}_output.csv`}
+            tooltip={getDustAppRunResultsFileTitle({
+              appName: action.appName,
+            })}
           >
             <CitationIcons>
               <Icon visual={TableIcon} />
             </CitationIcons>
-            <CitationTitle>{`${action.appName}_output.csv`}</CitationTitle>
+            <CitationTitle>
+              {getDustAppRunResultsFileTitle({
+                appName: action.appName,
+              })}
+            </CitationTitle>
           </Citation>
 
           <Collapsible defaultOpen={false}>

--- a/front/components/actions/tables_query/TablesQueryActionDetails.tsx
+++ b/front/components/actions/tables_query/TablesQueryActionDetails.tsx
@@ -145,19 +145,21 @@ function QueryTablesResults({
   }
 
   return (
-    <div>
+    <div className="flex flex-col">
       <span className="text-sm font-semibold text-foreground">Results</span>
-      <Citation
-        className="w-48 min-w-48 max-w-48"
-        containerClassName="my-2"
-        onClick={handleDownload}
-        tooltip={title}
-      >
-        <CitationIcons>
-          <Icon visual={TableIcon} />
-        </CitationIcons>
-        <CitationTitle>{title}</CitationTitle>
-      </Citation>
+      <div>
+        <Citation
+          className="w-48 min-w-48 max-w-48"
+          containerClassName="my-2"
+          onClick={handleDownload}
+          tooltip={title}
+        >
+          <CitationIcons>
+            <Icon visual={TableIcon} />
+          </CitationIcons>
+          <CitationTitle>{title}</CitationTitle>
+        </Citation>
+      </div>
 
       <Collapsible defaultOpen={false}>
         <Collapsible.Button>

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -519,7 +519,7 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
       }
     }
 
-    function isValidStructuredOutput(output: unknown): output is {
+    function containsValidStructuredOutput(output: unknown): output is {
       __dust_structured_output?: Array<
         Record<string, string | number | boolean>
       >;
@@ -560,7 +560,7 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
 
     // Check for structured output that should be converted to CSV
     if (
-      isValidStructuredOutput(sanitizedOutput) &&
+      containsValidStructuredOutput(sanitizedOutput) &&
       sanitizedOutput.__dust_structured_output
     ) {
       const fileTitle = getDustAppRunResultsFileTitle({

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -1,5 +1,10 @@
 import { DustAPI } from "@dust-tt/client";
 import type {
+  ActionGeneratedFileType,
+  AgentActionSpecification,
+  DatasetSchema,
+  DustAppParameters,
+  DustAppRunActionType,
   DustAppRunBlockEvent,
   DustAppRunConfigurationType,
   DustAppRunErrorEvent,
@@ -8,20 +13,19 @@ import type {
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelId,
+  Result,
+  SpecificationType,
 } from "@dust-tt/types";
-import type { DustAppParameters, DustAppRunActionType } from "@dust-tt/types";
-import type { AgentActionSpecification } from "@dust-tt/types";
-import type { SpecificationType } from "@dust-tt/types";
-import type { DatasetSchema } from "@dust-tt/types";
-import type { Result } from "@dust-tt/types";
 import {
   BaseAction,
+  Err,
   getHeaderFromGroupIds,
+  Ok,
   SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
 
 import { DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY } from "@app/lib/api/assistant/actions/constants";
+import { getToolResultOutputCsvFileAndSnippet } from "@app/lib/api/assistant/actions/result_file_helpers";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/generation";
@@ -32,6 +36,8 @@ import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
 import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AppResource } from "@app/lib/resources/app_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
@@ -51,6 +57,9 @@ interface DustAppRunActionBlob {
   functionCallId: string | null;
   functionCallName: string | null;
   step: number;
+  resultsFileId: string | null;
+  resultsFileSnippet: string | null;
+  generatedFiles: ActionGeneratedFileType[];
 }
 
 export class DustAppRunAction extends BaseAction {
@@ -68,10 +77,12 @@ export class DustAppRunAction extends BaseAction {
   readonly functionCallId: string | null;
   readonly functionCallName: string | null;
   readonly step: number;
+  readonly resultsFileId: string | null;
+  readonly resultsFileSnippet: string | null;
   readonly type = "dust_app_run_action";
 
   constructor(blob: DustAppRunActionBlob) {
-    super(blob.id, "dust_app_run_action");
+    super(blob.id, "dust_app_run_action", blob.generatedFiles || []);
 
     this.agentMessageId = blob.agentMessageId;
     this.appWorkspaceId = blob.appWorkspaceId;
@@ -83,6 +94,8 @@ export class DustAppRunAction extends BaseAction {
     this.functionCallId = blob.functionCallId;
     this.functionCallName = blob.functionCallName;
     this.step = blob.step;
+    this.resultsFileId = blob.resultsFileId;
+    this.resultsFileSnippet = blob.resultsFileSnippet;
   }
 
   renderForFunctionCall(): FunctionCallType {
@@ -95,6 +108,18 @@ export class DustAppRunAction extends BaseAction {
 
   async renderForMultiActionsModel(): Promise<FunctionMessageTypeModel> {
     let content = "";
+
+    const hasResultsFile = this.resultsFileId && this.resultsFileSnippet;
+    if (hasResultsFile) {
+      const attachment = getDustAppRunResultsFileAttachment({
+        resultsFileId: this.resultsFileId,
+        resultsFileSnippet: this.resultsFileSnippet,
+        includeSnippet: true,
+        appName: this.appName,
+      });
+
+      content += `${attachment}\n\n`;
+    }
 
     // Note action.output can be any valid JSON including null.
     content += `OUTPUT:\n`;
@@ -303,6 +328,8 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
       functionCallName: actionConfiguration.name,
       agentMessageId: agentMessage.agentMessageId,
       step,
+      resultsFileId: null,
+      resultsFileSnippet: null,
     });
 
     yield {
@@ -322,6 +349,9 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
         functionCallName: actionConfiguration.name,
         agentMessageId: agentMessage.agentMessageId,
         step,
+        resultsFileId: null,
+        resultsFileSnippet: null,
+        generatedFiles: [],
       }),
     };
 
@@ -462,6 +492,9 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
             output: null,
             agentMessageId: agentMessage.agentMessageId,
             step: action.step,
+            resultsFileId: null,
+            resultsFileSnippet: null,
+            generatedFiles: [],
           }),
         };
       }
@@ -486,12 +519,79 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
       }
     }
 
-    const output = sanitizeJSONOutput(lastBlockOutput);
+    function isValidStructuredOutput(output: unknown): output is {
+      __dust_structured_output?: Array<
+        Record<string, string | number | boolean>
+      >;
+    } {
+      return (
+        typeof output === "object" &&
+        output !== null &&
+        "__dust_structured_output" in output &&
+        Array.isArray(output.__dust_structured_output) &&
+        output.__dust_structured_output.length > 0 &&
+        output.__dust_structured_output.every(
+          (r) =>
+            typeof r === "object" &&
+            Object.values(r).every(
+              (v) =>
+                typeof v === "string" ||
+                typeof v === "number" ||
+                typeof v === "boolean"
+            )
+        )
+      );
+    }
 
-    // Update DustAppRunAction with the output of the last block.
+    const sanitizedOutput = sanitizeJSONOutput(lastBlockOutput);
+
+    const updateParams: {
+      resultsFileId: number | null;
+      resultsFileSnippet: string | null;
+      output: unknown | null;
+    } = {
+      resultsFileId: null,
+      resultsFileSnippet: null,
+      output: null,
+    };
+
+    let resultFile: ActionGeneratedFileType | null = null;
+
+    // Check for structured output that should be converted to CSV
+    if (
+      isValidStructuredOutput(sanitizedOutput) &&
+      sanitizedOutput.__dust_structured_output
+    ) {
+      const fileTitle = getDustAppRunResultsFileTitle({
+        appName: app.name,
+      });
+
+      const { file, snippet } = await getToolResultOutputCsvFileAndSnippet(
+        auth,
+        {
+          title: fileTitle,
+          conversationId: conversation.sId,
+          results: sanitizedOutput.__dust_structured_output,
+        }
+      );
+
+      resultFile = {
+        fileId: file.sId,
+        title: fileTitle,
+        contentType: file.contentType,
+        snippet: file.snippet,
+      };
+
+      delete sanitizedOutput.__dust_structured_output;
+      updateParams.resultsFileId = file.id;
+      updateParams.resultsFileSnippet = snippet;
+    }
+
+    // Update DustAppRunAction with the output and file references
     await action.update({
+      ...updateParams,
+      output: sanitizedOutput,
       runId: await dustRunId,
-      output,
     });
 
     logger.info(
@@ -517,9 +617,12 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
         functionCallId,
         functionCallName: actionConfiguration.name,
         runningBlock: null,
-        output,
+        output: sanitizedOutput,
         agentMessageId: agentMessage.agentMessageId,
         step: action.step,
+        resultsFileId: resultFile?.fileId ?? null,
+        resultsFileSnippet: updateParams.resultsFileSnippet,
+        generatedFiles: resultFile ? [resultFile] : [],
       }),
     };
   }
@@ -580,15 +683,38 @@ async function dustAppRunActionSpecification({
 // used outside of api/assistant. We allow a ModelId interface here because we don't have `sId` on
 // actions (the `sId` is on the `Message` object linked to the `UserMessage` parent of this action).
 export async function dustAppRunTypesFromAgentMessageIds(
+  auth: Authenticator,
   agentMessageIds: ModelId[]
 ): Promise<DustAppRunActionType[]> {
+  const owner = auth.getNonNullableWorkspace();
+
   const actions = await AgentDustAppRunAction.findAll({
     where: {
       agentMessageId: agentMessageIds,
     },
+    include: [
+      {
+        model: FileModel,
+        as: "resultsFile",
+      },
+    ],
   });
 
   return actions.map((action) => {
+    const resultsFile: ActionGeneratedFileType | null = action.resultsFile
+      ? {
+          fileId: FileResource.modelIdToSId({
+            id: action.resultsFile.id,
+            workspaceId: owner.id,
+          }),
+          title: getDustAppRunResultsFileTitle({
+            appName: action.appName,
+          }),
+          contentType: action.resultsFile.contentType,
+          snippet: action.resultsFileSnippet,
+        }
+      : null;
+
     return new DustAppRunAction({
       id: action.id,
       appWorkspaceId: action.appWorkspaceId,
@@ -601,6 +727,45 @@ export async function dustAppRunTypesFromAgentMessageIds(
       functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,
       step: action.step,
+      resultsFileId: resultsFile?.fileId ?? null,
+      resultsFileSnippet: action.resultsFileSnippet,
+      generatedFiles: resultsFile ? [resultsFile] : [],
     });
   });
+}
+
+export function getDustAppRunResultsFileTitle({
+  appName,
+}: {
+  appName: string;
+}): string {
+  return `${appName}_output.csv`;
+}
+
+export function getDustAppRunResultsFileAttachment({
+  resultsFileId,
+  resultsFileSnippet,
+  includeSnippet = true,
+  appName,
+}: {
+  resultsFileId: string | null;
+  resultsFileSnippet: string | null;
+  includeSnippet: boolean;
+  appName: string;
+}): string | null {
+  if (!resultsFileId || !resultsFileSnippet) {
+    return null;
+  }
+
+  const attachment =
+    `<file ` +
+    `id="${resultsFileId}" type="text/csv" title=${getDustAppRunResultsFileTitle(
+      { appName }
+    )}`;
+
+  if (!includeSnippet) {
+    return `${attachment} />`;
+  }
+
+  return `${attachment}>\n${resultsFileSnippet}\n</file>`;
 }

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -535,6 +535,7 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
             typeof r === "object" &&
             Object.values(r).every(
               (v) =>
+                !v ||
                 typeof v === "string" ||
                 typeof v === "number" ||
                 typeof v === "boolean"

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -19,6 +19,7 @@ import type {
 import {
   BaseAction,
   Err,
+  getDustAppRunResultsFileTitle,
   getHeaderFromGroupIds,
   Ok,
   SUPPORTED_MODEL_CONFIGS,
@@ -733,14 +734,6 @@ export async function dustAppRunTypesFromAgentMessageIds(
       generatedFiles: resultsFile ? [resultsFile] : [],
     });
   });
-}
-
-export function getDustAppRunResultsFileTitle({
-  appName,
-}: {
-  appName: string;
-}): string {
-  return `${appName}_output.csv`;
 }
 
 export function getDustAppRunResultsFileAttachment({

--- a/front/lib/api/assistant/actions/result_file_helpers.ts
+++ b/front/lib/api/assistant/actions/result_file_helpers.ts
@@ -1,0 +1,47 @@
+import { stringify } from "csv-stringify";
+
+import { generateCSVSnippet } from "@app/lib/api/csv";
+import { internalCreateToolOutputCsvFile } from "@app/lib/api/files/tool_output";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+
+export async function getToolResultOutputCsvFileAndSnippet(
+  auth: Authenticator,
+  {
+    title,
+    conversationId,
+    results,
+  }: {
+    title: string;
+    conversationId: string;
+    results: Array<Record<string, string | number | boolean>>;
+  }
+): Promise<{
+  file: FileResource;
+  snippet: string;
+}> {
+  const toCsv = (
+    records: Array<Record<string, string | number | boolean>>,
+    options: { header: boolean } = { header: true }
+  ): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      stringify(records, options, (err, data) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(data);
+      });
+    });
+  };
+
+  const csvOutput = await toCsv(results);
+
+  const file = await internalCreateToolOutputCsvFile(auth, {
+    title,
+    conversationId: conversationId,
+    content: csvOutput,
+    contentType: "text/csv",
+  });
+
+  return { file, snippet: generateCSVSnippet(csvOutput) };
+}

--- a/front/lib/api/assistant/actions/result_file_helpers.ts
+++ b/front/lib/api/assistant/actions/result_file_helpers.ts
@@ -14,14 +14,18 @@ export async function getToolResultOutputCsvFileAndSnippet(
   }: {
     title: string;
     conversationId: string;
-    results: Array<Record<string, string | number | boolean>>;
+    results: Array<
+      Record<string, string | number | boolean | null | undefined>
+    >;
   }
 ): Promise<{
   file: FileResource;
   snippet: string;
 }> {
   const toCsv = (
-    records: Array<Record<string, string | number | boolean>>,
+    records: Array<
+      Record<string, string | number | boolean | null | undefined>
+    >,
     options: { header: boolean } = { header: true }
   ): Promise<string> => {
     return new Promise((resolve, reject) => {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -144,7 +144,7 @@ async function batchRenderAgentMessages(
     })(),
     (async () =>
       retrievalActionTypesFromAgentMessageIds(auth, agentMessageIds))(),
-    (async () => dustAppRunTypesFromAgentMessageIds(agentMessageIds))(),
+    (async () => dustAppRunTypesFromAgentMessageIds(auth, agentMessageIds))(),
     (async () => tableQueryTypesFromAgentMessageIds(auth, agentMessageIds))(),
     (async () => processActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () => websearchActionTypesFromAgentMessageIds(agentMessageIds))(),

--- a/front/migrations/db/migration_145.sql
+++ b/front/migrations/db/migration_145.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jan 21, 2025
+ALTER TABLE "public"."agent_dust_app_run_actions"
+  ADD COLUMN "resultsFileId" integer REFERENCES "public"."files" ("id") ON DELETE SET NULL,
+  ADD COLUMN "resultsFileSnippet" text;
+
+-- Add index for resultsFileId
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "agent_dust_app_run_actions_results_file_id" ON "public"."agent_dust_app_run_actions" ("resultsFileId");

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -33,6 +33,8 @@ export interface DustAppRunActionType extends BaseAction {
   functionCallId: string | null;
   functionCallName: string | null;
   step: number;
+  resultsFileId: string | null;
+  resultsFileSnippet: string | null;
   type: "dust_app_run_action";
 }
 

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -1,5 +1,6 @@
 import { BaseAction } from "../../../front/assistant/actions/index";
 import { ModelId } from "../../../shared/model_id";
+import { SupportedFileContentType } from "../../files";
 
 export type DustAppRunConfigurationType = {
   id: ModelId;
@@ -35,6 +36,7 @@ export interface DustAppRunActionType extends BaseAction {
   step: number;
   resultsFileId: string | null;
   resultsFileSnippet: string | null;
+  resultsFileContentType: SupportedFileContentType | null;
   type: "dust_app_run_action";
 }
 
@@ -80,8 +82,10 @@ export type DustAppRunSuccessEvent = {
 
 export function getDustAppRunResultsFileTitle({
   appName,
+  resultsFileContentType,
 }: {
   appName: string;
+  resultsFileContentType: SupportedFileContentType;
 }): string {
-  return `${appName}_output.csv`;
+  return `${appName}_output.${resultsFileContentType}`;
 }

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -87,5 +87,10 @@ export function getDustAppRunResultsFileTitle({
   appName: string;
   resultsFileContentType: SupportedFileContentType;
 }): string {
-  return `${appName}_output.${resultsFileContentType}`;
+  const extension = resultsFileContentType.split("/").pop();
+  let title = `${appName}_output`;
+  if (extension) {
+    title += `.${extension}`;
+  }
+  return title;
 }

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -77,3 +77,11 @@ export type DustAppRunSuccessEvent = {
   messageId: string;
   action: DustAppRunActionType;
 };
+
+export function getDustAppRunResultsFileTitle({
+  appName,
+}: {
+  appName: string;
+}): string {
+  return `${appName}_output.csv`;
+}


### PR DESCRIPTION
## Description

When a Dust App outputs an array of objects in `__dust_structured_output`, automatically save a CSV and make it available for JIT table queries (similar to tables query output).

## Risk

Blast radius limited to dust app run

## Deploy Plan

Apply migration (prodbox) then deploy front