### PR TITLE
Remove extra hook call to list conversations

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -65,6 +65,9 @@ export function ConversationContainer({
 
   const { mutateConversations } = useConversations({
     workspaceId: owner.sId,
+    options: {
+      disabled: true, // We don't need to fetch conversations here.
+    },
   });
 
   const { mutateMessages } = useConversationMessages({
@@ -168,7 +171,7 @@ export function ConversationContainer({
         }
       );
       await mutateConversations();
-      await scrollConversationsToTop();
+      scrollConversationsToTop();
     } catch (err) {
       // If the API errors, the original data will be
       // rolled back by SWR automatically.
@@ -237,7 +240,7 @@ export function ConversationContainer({
           { shallow: true }
         );
         await mutateConversations();
-        await scrollConversationsToTop();
+        scrollConversationsToTop();
 
         return new Ok(undefined);
       }

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -54,12 +54,19 @@ export function useConversation({
   };
 }
 
-export function useConversations({ workspaceId }: { workspaceId: string }) {
+export function useConversations({
+  workspaceId,
+  options,
+}: {
+  workspaceId: string;
+  options?: { disabled: boolean };
+}) {
   const conversationFetcher: Fetcher<GetConversationsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${workspaceId}/assistant/conversations`,
-    conversationFetcher
+    conversationFetcher,
+    options
   );
 
   return {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In https://github.com/dust-tt/dust/issues/9792 some new hooks were added in the `ConversationContainer`. Those hooks are only used to access the mutator but haven't be disabled and are responsible for extra API calls in the layout. This PR ensures that this hooks are disabled in this context.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
