### PR TITLE
feat: add magic key output in dust apps for doc output

### DIFF
--- a/front/lib/api/assistant/actions/result_file_helpers.ts
+++ b/front/lib/api/assistant/actions/result_file_helpers.ts
@@ -1,7 +1,7 @@
 import { stringify } from "csv-stringify";
 
 import { generateCSVSnippet } from "@app/lib/api/csv";
-import { internalCreateToolOutputCsvFile } from "@app/lib/api/files/tool_output";
+import { internalCreateToolOutputFile } from "@app/lib/api/files/tool_output";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 
@@ -40,7 +40,7 @@ export async function getToolResultOutputCsvFileAndSnippet(
 
   const csvOutput = await toCsv(results);
 
-  const file = await internalCreateToolOutputCsvFile(auth, {
+  const file = await internalCreateToolOutputFile(auth, {
     title,
     conversationId: conversationId,
     content: csvOutput,
@@ -48,4 +48,26 @@ export async function getToolResultOutputCsvFileAndSnippet(
   });
 
   return { file, snippet: generateCSVSnippet(csvOutput) };
+}
+
+export async function getToolResultOutputPlainTextFileAndSnippet(
+  auth: Authenticator,
+  {
+    title,
+    conversationId,
+    content,
+  }: {
+    title: string;
+    conversationId: string;
+    content: string;
+  }
+): Promise<{ file: FileResource; snippet: string | null }> {
+  const file = await internalCreateToolOutputFile(auth, {
+    title,
+    conversationId,
+    content,
+    contentType: "text/plain",
+  });
+
+  return { file, snippet: file.snippet };
 }

--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -6,7 +6,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 
-export async function internalCreateToolOutputCsvFile(
+export async function internalCreateToolOutputFile(
   auth: Authenticator,
   {
     title,
@@ -17,7 +17,7 @@ export async function internalCreateToolOutputCsvFile(
     title: string;
     conversationId: string;
     content: string;
-    contentType: "text/csv";
+    contentType: "text/csv" | "text/plain";
   }
 ): Promise<FileResource> {
   const workspace = auth.getNonNullableWorkspace();


### PR DESCRIPTION
## Description

Support for dust apps document file outputs.
Same as https://github.com/dust-tt/dust/pull/10125, but for semantic search

## Risk

Blast radius limited to dust app run action

## Deploy Plan

Deploy front