### PR TITLE
[Nodes Core] Clean google drive parents

### DIFF
--- a/connectors/migrations/20250122_gdrive_clean_parents.ts
+++ b/connectors/migrations/20250122_gdrive_clean_parents.ts
@@ -1,0 +1,78 @@
+import { getLocalParents } from "@connectors/connectors/google_drive/lib";
+import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { concurrentExecutor, CoreAPI, EnvironmentConfig } from "@dust-tt/types";
+import pino, { LoggerOptions } from "pino";
+import { makeScript } from "scripts/helpers";
+import { QueryTypes, Sequelize } from "sequelize";
+
+async function migrateConnector(
+  coreSequelize: Sequelize,
+  connector: ConnectorResource,
+  execute: boolean,
+  parentLogger: pino.Logger<LoggerOptions & pino.ChildLoggerOptions>
+) {
+  const logger = parentLogger.child({ connectorId: connector.id });
+  logger.info("Starting migration");
+  const files = await GoogleDriveFiles.findAll({
+    where: {
+      connectorId: connector.id,
+    },
+    attributes: ["id", "dustFileId"],
+  });
+
+  // get datasource id from core
+  const rows: { id: number }[] = await coreSequelize.query(
+    `SELECT id FROM data_sources WHERE data_source_id = :dataSourceId;`,
+    {
+      replacements: { dataSourceId: connector.dataSourceId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  if (rows.length === 0) {
+    logger.error(`Data source ${connector.dataSourceId} not found in core`);
+    return;
+  }
+
+  const dataSourceId = rows[0]?.id;
+
+  concurrentExecutor(
+    files,
+    async (file) => {
+      const parents = await getLocalParents(
+        connector.id,
+        file.dustFileId,
+        "migrate_parents"
+      );
+      if (execute) {
+        coreSequelize.query(
+          `UPDATE data_sources_nodes SET parents = :parents WHERE data_source = :dataSourceId AND node_id = :nodeId`,
+          {
+            replacements: {
+              parents: parents,
+              dataSourceId,
+              nodeId: file.dustFileId,
+            },
+          }
+        );
+      }
+    },
+    { concurrency: 32 }
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("google_drive", {});
+  const coreSequelize = getCorePrimaryDbConnection();
+
+  for (const connector of connectors) {
+    await migrateConnector(coreSequelize, connector, execute, logger);
+  }
+});
+
+function getCorePrimaryDbConnection() {
+  return new Sequelize(EnvironmentConfig.getEnvVariable("CORE_DATABASE_URI"), {
+    logging: false,
+  });
+}

--- a/connectors/migrations/20250122_gdrive_clean_parents.ts
+++ b/connectors/migrations/20250122_gdrive_clean_parents.ts
@@ -36,6 +36,7 @@ async function migrateConnector(
   });
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const startTimeTs = new Date().getTime();
 
   // update using front API to update both elasticsearch and postgres
   await concurrentExecutor(
@@ -44,7 +45,7 @@ async function migrateConnector(
       const parents = await getLocalParents(
         connector.id,
         file.dustFileId,
-        "migrate_parents"
+        `${connector.id}:${startTimeTs}:migrate_parents`
       );
       if (execute) {
         // check if file is a folder
@@ -92,7 +93,7 @@ async function migrateConnector(
       const parents = await getLocalParents(
         connector.id,
         getGoogleSheetTableId(sheet.driveFileId, sheet.driveSheetId),
-        "migrate_parents"
+        `${connector.id}:${startTimeTs}:migrate_parents`
       );
       if (execute) {
         await updateDataSourceTableParents({

--- a/connectors/migrations/20250122_gdrive_clean_parents.ts
+++ b/connectors/migrations/20250122_gdrive_clean_parents.ts
@@ -50,8 +50,8 @@ async function migrateConnector(
       if (execute) {
         // check if file is a folder
         if (
-          file.mimeType === MIME_TYPES.GOOGLE_DRIVE.FOLDER ||
-          file.mimeType === MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET
+          file.mimeType === "application/vnd.google-apps.folder" ||
+          file.mimeType === "application/vnd.google-apps.spreadsheet"
         ) {
           await upsertDataSourceFolder({
             dataSourceConfig,
@@ -59,7 +59,10 @@ async function migrateConnector(
             parents,
             parentId: parents[1] || null,
             title: file.name,
-            mimeType: file.mimeType,
+            mimeType:
+              file.mimeType === "application/vnd.google-apps.folder"
+                ? MIME_TYPES.GOOGLE_DRIVE.FOLDER
+                : MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
             sourceUrl: getSourceUrlForGoogleDriveFiles(file),
           });
         } else {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -43,7 +43,7 @@ import {
   driveObjectToDustType,
   getAuthObject,
   getDriveClient,
-  getDriveId,
+  getDriveFileId,
   getInternalId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import type {
@@ -263,7 +263,8 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     }
 
     try {
-      const parentDriveId = parentInternalId && getDriveId(parentInternalId);
+      const parentDriveId =
+        parentInternalId && getDriveFileId(parentInternalId);
       if (filterPermission === "read") {
         if (parentDriveId === null) {
           // Return the list of folders explicitly selected by the user.
@@ -543,7 +544,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     const addedFolderIds: string[] = [];
     const removedFolderIds: string[] = [];
     for (const [internalId, permission] of Object.entries(permissions)) {
-      const id = getDriveId(internalId);
+      const id = getDriveFileId(internalId);
       if (permission === "none") {
         removedFolderIds.push(id);
         await GoogleDriveFolders.destroy({
@@ -601,7 +602,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
   }): Promise<Result<ContentNode[], Error>> {
     const driveFileIds = internalIds
       .filter((id) => !isGoogleSheetContentNodeInternalId(id))
-      .map(getDriveId);
+      .map(getDriveFileId);
     const sheetIds = internalIds
       .filter((id) => isGoogleSheetContentNodeInternalId(id))
       .map(getGoogleIdsFromSheetContentNodeInternalId);

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -8,7 +8,7 @@ import type { InferAttributes, WhereOptions } from "sequelize";
 
 import { isGoogleDriveSpreadSheetFile } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
-  getDriveId,
+  getDriveFileId,
   getInternalId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import {
@@ -78,7 +78,7 @@ async function _getLocalParents(
     const object = await GoogleDriveFiles.findOne({
       where: {
         connectorId,
-        driveFileId: getDriveId(contentNodeInternalId),
+        driveFileId: getDriveFileId(contentNodeInternalId),
       },
     });
     parentId = object?.parentId ? getInternalId(object.parentId) : null;

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -63,8 +63,6 @@ async function _getLocalParents(
   contentNodeInternalId: string,
   memoizationKey: string
 ): Promise<string[]> {
-  const parents: string[] = [contentNodeInternalId];
-
   let parentId: string | null = null;
 
   if (isGoogleSheetContentNodeInternalId(contentNodeInternalId)) {
@@ -81,8 +79,15 @@ async function _getLocalParents(
         driveFileId: getDriveFileId(contentNodeInternalId),
       },
     });
-    parentId = object?.parentId ? getInternalId(object.parentId) : null;
+    if (!object) {
+      // edge case: If the object is not in our database, it has no local
+      // parents.
+      return [];
+    }
+    parentId = object.parentId ? getInternalId(object.parentId) : null;
   }
+
+  const parents: string[] = [contentNodeInternalId];
 
   if (!parentId) {
     return parents;

--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -1,12 +1,12 @@
 import type { ModelId } from "@dust-tt/types";
 import { cacheWithRedis } from "@dust-tt/types";
 import type { OAuth2Client } from "googleapis-common";
+import { Op } from "sequelize";
 
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
+import { GoogleDriveFolders } from "@connectors/lib/models/google_drive";
 import mainLogger from "@connectors/logger/logger";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
-import { GoogleDriveFolders } from "@connectors/lib/models/google_drive";
-import { Op } from "sequelize";
 
 // TODO(nodes-core): monitor and follow-up with either normalizing
 // the situation or throwing an error

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -13,7 +13,7 @@ export function getInternalId(driveFileId: string): string {
   return `gdrive-${driveFileId}`;
 }
 
-export function getDriveId(documentId: string): string {
+export function getDriveFileId(documentId: string): string {
   return documentId.replace(/^gdrive-/, "");
 }
 


### PR DESCRIPTION
## Description
Part of https://github.com/dust-tt/tasks/issues/1988

Ensures the invariant that "root node => no parents or one of the parents is also a root node" is enforced

Here, "root" means "user selected", via setPermissions.

Done at parent computation by pruning those who aren't in or below selected roots (+ backfill)

### Notes
- Checked all folder upserts from google drive
  - led to see that all parents are computed regardless of whether they are in selected roots
- checked the logic folder A / subfolder B: select B, sync, select A, sync, deselect A, sync => B should have no parents
  - actually, for google drive this is has been changed; contrary to what I thought, parent selection now deselects children.

## Risk
Migration changes parents for google drive. Blast radius important.
- 2 reviewers
- local tests:
	- synced stuff without PR => saw it was wrong
	- synced stuff with the PR => saw it was right
	- backfilled => saw it fixed the wrong stuff above, checked searchNodes root returned the right stuff
	- checked it didn't break other parents by exploring the tree on front (using core for content nodes :+1:)

- how to rollback if needed => revert this PR (straightforward) + run inverted backfill

Note that issues will be seen from the content nodes diff log

## Deploy
- connectors
- run backfill

