### PR TITLE
[.github] - fix: add permissions to list-tags workflow

### DIFF
--- a/.github/workflows/list-tags.yaml
+++ b/.github/workflows/list-tags.yaml
@@ -34,6 +34,10 @@ on:
 
 jobs:
   list-tags:
+    permissions:
+      contents: read
+      id-token: write
+
     runs-on: ubuntu-latest
     steps:
       - name: Set project ID


### PR DESCRIPTION
## Description

This PR fixes the permissions of the list tags workflow.

## Risk

Low

## Deploy Plan

Merge