### PR TITLE
[.github] - fix: enable manual triggering of Revert Workflow

### DIFF
--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -1,7 +1,7 @@
 name: Revert Workflow
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       regions:
         description: "Regions to revert"


### PR DESCRIPTION
 ## Description

Change trigger for Revert Workflow from `workflow_call` to `workflow_dispatch` to allow manual execution

## Risk

Low

## Deploy Plan

Merge