### PR TITLE
no throw return an error

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -116,7 +116,7 @@ export async function joinChannel(
           )
         );
       }
-      throw e;
+      return new Err(e as Error);
     }
   }
 

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -116,6 +116,14 @@ export async function joinChannel(
           )
         );
       }
+      logger.error(
+        {
+          connectorId,
+          channelId,
+          error: e,
+        },
+        "Can't join the channel"
+      );
       return new Err(e as Error);
     }
   }


### PR DESCRIPTION
## Description
Fix slack channel join where we throw instead of returning an error

## Risk
Low

## Deploy Plan
Deploy front
