### PR TITLE
Revert "Removed usage of get_content_node_parents"

### DIFF
--- a/connectors/src/api/get_content_node_parents.ts
+++ b/connectors/src/api/get_content_node_parents.ts
@@ -1,0 +1,77 @@
+import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
+import type { Request, Response } from "express";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import type { ContentNodeParentIdsBlob } from "@connectors/lib/api/content_nodes";
+import { getParentIdsForContentNodes } from "@connectors/lib/api/content_nodes";
+import logger from "@connectors/logger/logger";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+const GetContentNodesParentsRequestBodySchema = t.type({
+  internalIds: t.array(t.string),
+});
+
+export type GetContentNodesParentsRequestBody = t.TypeOf<
+  typeof GetContentNodesParentsRequestBodySchema
+>;
+
+type GetContentNodesResponseBody = WithConnectorsAPIErrorReponse<{
+  nodes: ContentNodeParentIdsBlob[];
+}>;
+
+const _getContentNodesParents = async (
+  req: Request<
+    { connector_id: string },
+    GetContentNodesResponseBody,
+    GetContentNodesParentsRequestBody
+  >,
+  res: Response<GetContentNodesResponseBody>
+) => {
+  const connector = await ConnectorResource.fetchById(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+    });
+  }
+
+  const bodyValidation = GetContentNodesParentsRequestBodySchema.decode(
+    req.body
+  );
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const { internalIds } = bodyValidation.right;
+
+  const parentsRes = await getParentIdsForContentNodes(connector, internalIds);
+  if (parentsRes.isErr()) {
+    logger.error(parentsRes.error, "Failed to get content node parents.");
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: parentsRes.error.message,
+      },
+    });
+  }
+
+  return res.status(200).json({ nodes: parentsRes.value });
+};
+
+export const getContentNodesParentsAPIHandler = withLogging(
+  _getContentNodesParents
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -13,6 +13,7 @@ import {
   getConnectorsAPIHandler,
 } from "@connectors/api/get_connector";
 import { getConnectorPermissionsAPIHandler } from "@connectors/api/get_connector_permissions";
+import { getContentNodesParentsAPIHandler } from "@connectors/api/get_content_node_parents";
 import { getContentNodesAPIHandler } from "@connectors/api/get_content_nodes";
 import { pauseConnectorAPIHandler } from "@connectors/api/pause_connector";
 import { resumeConnectorAPIHandler } from "@connectors/api/resume_connector";
@@ -110,6 +111,11 @@ export function startServer(port: number) {
   app.get(
     "/connectors/:connector_id/permissions",
     getConnectorPermissionsAPIHandler
+  );
+  app.post(
+    // must be POST because of body
+    "/connectors/:connector_id/content_nodes/parents",
+    getContentNodesParentsAPIHandler
   );
   app.post(
     // must be POST because of body

--- a/front/temporal/tracker/activities.ts
+++ b/front/temporal/tracker/activities.ts
@@ -11,7 +11,6 @@ import {
   Err,
   GPT_4O_MODEL_CONFIG,
   Ok,
-  removeNulls,
 } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import _ from "lodash";
@@ -485,19 +484,18 @@ async function getTrackersToRun(
       config.getConnectorsAPIConfig(),
       logger
     );
-    const parentsResult = await connectorsAPI.getContentNodes({
+    const parentsResult = await connectorsAPI.getContentNodesParents({
       connectorId: dataSource.connectorId,
       internalIds: [documentId],
-      includeParents: true,
     });
     if (parentsResult.isErr()) {
       throw parentsResult.error;
     }
 
-    docParentIds = removeNulls([
+    docParentIds = [
       documentId,
-      ...parentsResult.value.nodes.flatMap((node) => node.parentInternalIds),
-    ]);
+      ...parentsResult.value.nodes.flatMap((node) => node.parents),
+    ];
   }
 
   return TrackerConfigurationResource.fetchAllWatchedForDocument(auth, {

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -499,6 +499,36 @@ export class ConnectorsAPI {
     return this._resultFromResponse(res);
   }
 
+  async getContentNodesParents({
+    connectorId,
+    internalIds,
+  }: {
+    connectorId: string;
+    internalIds: string[];
+  }): Promise<
+    ConnectorsAPIResponse<{
+      nodes: {
+        internalId: string;
+        parents: string[];
+      }[];
+    }>
+  > {
+    const res = await this._fetchWithError(
+      `${this._url}/connectors/${encodeURIComponent(
+        connectorId
+      )}/content_nodes/parents`,
+      {
+        method: "POST",
+        headers: this.getDefaultHeaders(),
+        body: JSON.stringify({
+          internalIds,
+        }),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
   async getContentNodes<IncludeParents extends boolean>({
     connectorId,
     includeParents,


### PR DESCRIPTION
This is breaking tracker. Let's remove this once we have an equivalent replacement.

Reverts dust-tt/dust#992