### PR TITLE
[front] Fix query to nodes search endpoint

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -189,13 +189,15 @@ async function getContentNodesForDataSourceViewFromCore(
 
   // In any case, there is a data_source_view filter, which is always applied.
   const node_ids =
-    internalIds ?? parentId ? undefined : dataSourceView.parentsIn ?? undefined;
+    internalIds ??
+    (parentId ? undefined : dataSourceView.parentsIn ?? undefined);
   const parent_id =
-    parentId ?? internalIds
+    parentId ??
+    (internalIds
       ? undefined
       : dataSourceView.parentsIn
         ? undefined
-        : ROOT_PARENT_ID;
+        : ROOT_PARENT_ID);
 
   const coreRes = await coreAPI.searchNodes({
     filter: {


### PR DESCRIPTION
## Description

- The condition chaining used to define the body of the request made to core's node search endpoint was incorrect (missing parentheses).
- This PR fixes that.

## Risk

- Low, only affects the log for now.

## Deploy Plan

- Deploy front.
