### PR TITLE
[front] - refac: rename `NewDialog` -> `Dialog`

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -1,10 +1,10 @@
 import {
-  NewDialog,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@dust-tt/sparkle";
 import React from "react";
 import { createPortal } from "react-dom";
@@ -70,7 +70,7 @@ export function ConfirmDialog({
   closeDialogFn: () => void;
 }) {
   return (
-    <NewDialog
+    <Dialog
       open={confirmData != null}
       onOpenChange={(open) => {
         if (!open) {
@@ -79,14 +79,12 @@ export function ConfirmDialog({
         }
       }}
     >
-      <NewDialogContent size="md">
-        <NewDialogHeader hideButton>
-          <NewDialogTitle>{confirmData?.title ?? ""}</NewDialogTitle>
-          <NewDialogDescription>
-            {confirmData?.message ?? ""}
-          </NewDialogDescription>
-        </NewDialogHeader>
-        <NewDialogFooter
+      <DialogContent size="md">
+        <DialogHeader hideButton>
+          <DialogTitle>{confirmData?.title ?? ""}</DialogTitle>
+          <DialogDescription>{confirmData?.message ?? ""}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -104,7 +102,7 @@ export function ConfirmDialog({
             },
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -4,18 +4,18 @@ import {
   Button,
   CloudArrowLeftRightIcon,
   ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
   Hoverable,
   Icon,
   Input,
   LockIcon,
   Modal,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
-  NewDialogTrigger,
   Page,
   Sheet,
   SheetContainer,
@@ -402,25 +402,25 @@ function DataSourceEditionModal({
         )}
 
         <div className="flex items-center justify-center">
-          <NewDialog>
-            <NewDialogTrigger>
+          <Dialog>
+            <DialogTrigger>
               <Button
                 label="Edit Permissions"
                 icon={LockIcon}
                 variant="warning"
                 disabled={!isExtraConfigValid(extraConfig)}
               />
-            </NewDialogTrigger>
-            <NewDialogContent>
-              <NewDialogHeader>
-                <NewDialogTitle>Are you sure?</NewDialogTitle>
-              </NewDialogHeader>
-              <NewDialogContainer>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Are you sure?</DialogTitle>
+              </DialogHeader>
+              <DialogContainer>
                 The changes you are about to make may break existing{" "}
                 {connectorConfiguration.name} Data sources and the assistants
                 using them. Are you sure you want to continue?
-              </NewDialogContainer>
-              <NewDialogFooter
+              </DialogContainer>
+              <DialogFooter
                 leftButtonProps={{
                   label: "Cancel",
                   variant: "outline",
@@ -433,8 +433,8 @@ function DataSourceEditionModal({
                   },
                 }}
               />
-            </NewDialogContent>
-          </NewDialog>
+            </DialogContent>
+          </Dialog>
         </div>
       </>
     </DataSourceManagementModal>
@@ -537,30 +537,30 @@ function DataSourceDeletionModal({
           </div>
         </div>
         <div className="flex items-center justify-center">
-          <NewDialog>
-            <NewDialogTrigger>
+          <Dialog>
+            <DialogTrigger>
               <Button
                 label="Delete Connection"
                 icon={LockIcon}
                 variant="warning"
               />
-            </NewDialogTrigger>
-            <NewDialogContent>
-              <NewDialogHeader>
-                <NewDialogTitle>Are you sure?</NewDialogTitle>
-              </NewDialogHeader>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Are you sure?</DialogTitle>
+              </DialogHeader>
               {isLoading ? (
                 <div className="flex justify-center py-8">
                   <Spinner variant="dark" size="md" />
                 </div>
               ) : (
                 <>
-                  <NewDialogContainer>
+                  <DialogContainer>
                     The changes you are about to make will break existing
                     assistants using {connectorConfiguration.name}. Are you sure
                     you want to continue?
-                  </NewDialogContainer>
-                  <NewDialogFooter
+                  </DialogContainer>
+                  <DialogFooter
                     leftButtonProps={{
                       label: "Cancel",
                       variant: "outline",
@@ -575,8 +575,8 @@ function DataSourceDeletionModal({
                   />
                 </>
               )}
-            </NewDialogContent>
-          </NewDialog>
+            </DialogContent>
+          </Dialog>
         </div>
       </>
     </DataSourceManagementModal>

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -1,11 +1,11 @@
 import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Hoverable,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   Page,
 } from "@dust-tt/sparkle";
 import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
@@ -183,7 +183,7 @@ export function ReachedLimitPopup({
         isOpened={isFairUsageModalOpened}
         onClose={() => setIsFairUsageModalOpened(false)}
       />
-      <NewDialog
+      <Dialog
         open={isOpened}
         onOpenChange={(open) => {
           if (!open) {
@@ -191,12 +191,12 @@ export function ReachedLimitPopup({
           }
         }}
       >
-        <NewDialogContent>
-          <NewDialogHeader>
-            <NewDialogTitle>{title}</NewDialogTitle>
-          </NewDialogHeader>
-          <NewDialogContainer>{children}</NewDialogContainer>
-          <NewDialogFooter
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>{children}</DialogContainer>
+          <DialogFooter
             leftButtonProps={{
               label: "Cancel",
               variant: "outline",
@@ -207,8 +207,8 @@ export function ReachedLimitPopup({
               onClick: onValidate || (() => onClose()),
             }}
           />
-        </NewDialogContent>
-      </NewDialog>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/front/components/assistant/DeleteAssistantDialog.tsx
+++ b/front/components/assistant/DeleteAssistantDialog.tsx
@@ -1,11 +1,11 @@
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@dust-tt/sparkle";
 import type {
   LightAgentConfigurationType,
@@ -42,7 +42,7 @@ export function DeleteAssistantDialog({
   const doDelete = useDeleteAgentConfiguration({ owner, agentConfiguration });
 
   return (
-    <NewDialog
+    <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
@@ -50,10 +50,10 @@ export function DeleteAssistantDialog({
         }
       }}
     >
-      <NewDialogContent size="md" isAlertDialog>
-        <NewDialogHeader hideButton>
-          <NewDialogTitle>Deleting the assistant</NewDialogTitle>
-          <NewDialogDescription>
+      <DialogContent size="md" isAlertDialog>
+        <DialogHeader hideButton>
+          <DialogTitle>Deleting the assistant</DialogTitle>
+          <DialogDescription>
             {isPrivateAssistant ? (
               "Deleting the assistant will be permanent."
             ) : (
@@ -70,12 +70,12 @@ export function DeleteAssistantDialog({
                 This will permanently delete the assistant for everyone.
               </div>
             )}
-          </NewDialogDescription>
-        </NewDialogHeader>
-        <NewDialogContainer>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
           <div className="font-bold">Are you sure you want to proceed?</div>
-        </NewDialogContainer>
-        <NewDialogFooter
+        </DialogContainer>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -91,7 +91,7 @@ export function DeleteAssistantDialog({
             },
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/components/assistant/conversation/DeleteConversationsDialog.tsx
+++ b/front/components/assistant/conversation/DeleteConversationsDialog.tsx
@@ -1,11 +1,11 @@
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Spinner,
 } from "@dust-tt/sparkle";
 import React from "react";
@@ -38,22 +38,22 @@ export const DeleteConversationsDialog = ({
       : `Are you sure you want to delete ${selectedCount} conversation${selectedCount && selectedCount > 1 ? "s" : ""}?`;
 
   return (
-    <NewDialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <NewDialogContent>
-        <NewDialogHeader>
-          <NewDialogTitle>{title}</NewDialogTitle>
-          <NewDialogDescription>{description}</NewDialogDescription>
-        </NewDialogHeader>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         {isDeleting ? (
           <div className="flex justify-center py-8">
             <Spinner variant="dark" size="md" />
           </div>
         ) : (
           <>
-            <NewDialogContainer>
+            <DialogContainer>
               <b>This action cannot be undone.</b>
-            </NewDialogContainer>
-            <NewDialogFooter
+            </DialogContainer>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -69,7 +69,7 @@ export const DeleteConversationsDialog = ({
             />
           </>
         )}
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -4,6 +4,13 @@ import {
   ChevronDownIcon,
   Chip,
   CompanyIcon,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -11,13 +18,6 @@ import {
   DustIcon,
   IconButton,
   LockIcon,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   Page,
   PopoverContent,
   PopoverRoot,
@@ -463,7 +463,7 @@ function ScopeChangeDialog({
   setSharingScope: () => void;
 }) {
   return (
-    <NewDialog
+    <Dialog
       open={show}
       onOpenChange={(open) => {
         if (!open) {
@@ -471,20 +471,18 @@ function ScopeChangeDialog({
         }
       }}
     >
-      <NewDialogContent>
-        <NewDialogHeader hideButton>
-          <NewDialogTitle>{confirmationModalData.title}</NewDialogTitle>
-          {usageText && (
-            <NewDialogDescription>{usageText}</NewDialogDescription>
-          )}
-        </NewDialogHeader>
-        <NewDialogContainer>
+      <DialogContent>
+        <DialogHeader hideButton>
+          <DialogTitle>{confirmationModalData.title}</DialogTitle>
+          {usageText && <DialogDescription>{usageText}</DialogDescription>}
+        </DialogHeader>
+        <DialogContainer>
           <div>
             {confirmationModalData.text}
             <div className="font-bold">Are you sure you want to proceed ?</div>
           </div>
-        </NewDialogContainer>
-        <NewDialogFooter
+        </DialogContainer>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -501,7 +499,7 @@ function ScopeChangeDialog({
             },
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/components/assistant_builder/spaces/SpaceSelector.tsx
+++ b/front/components/assistant_builder/spaces/SpaceSelector.tsx
@@ -1,11 +1,11 @@
 import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Icon,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   RadioGroup,
   RadioGroupChoice,
   Separator,
@@ -123,7 +123,7 @@ export function SpaceSelector({
         })}
       </RadioGroup>
       <Separator />
-      <NewDialog
+      <Dialog
         open={isAlertDialogOpen}
         onOpenChange={(open) => {
           if (!open) {
@@ -131,23 +131,23 @@ export function SpaceSelector({
           }
         }}
       >
-        <NewDialogContent size="md" isAlertDialog>
-          <NewDialogHeader hideButton>
-            <NewDialogTitle>Changing source selection</NewDialogTitle>
-          </NewDialogHeader>
-          <NewDialogContainer>
+        <DialogContent size="md" isAlertDialog>
+          <DialogHeader hideButton>
+            <DialogTitle>Changing source selection</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
             An assistant can access one source of data only. The other tools are
             using a different source.
-          </NewDialogContainer>
-          <NewDialogFooter
+          </DialogContainer>
+          <DialogFooter
             rightButtonProps={{
               label: "Ok",
               variant: "outline",
               onClick: () => setAlertIsDialogOpen(false),
             }}
           />
-        </NewDialogContent>
-      </NewDialog>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -1,10 +1,10 @@
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
@@ -59,7 +59,7 @@ export function DeleteStaticDataSourceDialog({
   }, [isUsageLoading, isUsageError, usage, name]);
 
   return (
-    <NewDialog
+    <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
@@ -67,21 +67,21 @@ export function DeleteStaticDataSourceDialog({
         }
       }}
     >
-      <NewDialogContent>
-        <NewDialogHeader>
-          <NewDialogTitle>Confirm deletion</NewDialogTitle>
-        </NewDialogHeader>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm deletion</DialogTitle>
+        </DialogHeader>
         {isLoading ? (
           <div className="flex justify-center py-8">
             <Spinner variant="dark" size="md" />
           </div>
         ) : (
           <>
-            <NewDialogContainer>
+            <DialogContainer>
               {message}
               <b>Are you sure you want to delete ?</b>
-            </NewDialogContainer>
-            <NewDialogFooter
+            </DialogContainer>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -96,7 +96,7 @@ export function DeleteStaticDataSourceDialog({
             />
           </>
         )}
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -1,11 +1,11 @@
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Spinner,
   useSendNotification,
 } from "@dust-tt/sparkle";
@@ -66,7 +66,7 @@ export const DocumentOrTableDeleteDialog = ({
   };
 
   return (
-    <NewDialog
+    <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
@@ -74,24 +74,24 @@ export const DocumentOrTableDeleteDialog = ({
         }
       }}
     >
-      <NewDialogContent>
-        <NewDialogHeader>
-          <NewDialogTitle>Confirm deletion</NewDialogTitle>
-          <NewDialogDescription>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm deletion</DialogTitle>
+          <DialogDescription>
             Are you sure you want to delete {isTable ? "table" : "document"} '
             {contentNode.title}'?
-          </NewDialogDescription>
-        </NewDialogHeader>
+          </DialogDescription>
+        </DialogHeader>
         {isLoading ? (
           <div className="flex justify-center py-8">
             <Spinner variant="dark" size="md" />
           </div>
         ) : (
           <>
-            <NewDialogContainer>
+            <DialogContainer>
               <b>This action cannot be undone.</b>
-            </NewDialogContainer>
-            <NewDialogFooter
+            </DialogContainer>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -106,7 +106,7 @@ export const DocumentOrTableDeleteDialog = ({
             />
           </>
         )}
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/front/components/data_source/MultipleDocumentsUpload.tsx
+++ b/front/components/data_source/MultipleDocumentsUpload.tsx
@@ -1,10 +1,10 @@
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
   Spinner,
 } from "@dust-tt/sparkle";
 import type {
@@ -205,32 +205,32 @@ export const MultipleDocumentsUpload = ({
         onClose={() => setIsLimitPopupOpen(false)}
         owner={owner}
       />
-      <NewDialog open={isBulkFilesUploading !== null}>
-        <NewDialogContent
+      <Dialog open={isBulkFilesUploading !== null}>
+        <DialogContent
           size="md"
           isAlertDialog
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
-          <NewDialogHeader hideButton>
-            <NewDialogTitle>Uploading files</NewDialogTitle>
-            <NewDialogDescription>
+          <DialogHeader hideButton>
+            <DialogTitle>Uploading files</DialogTitle>
+            <DialogDescription>
               {isBulkFilesUploading && (
                 <>
                   Processing files {isBulkFilesUploading.completed} /{" "}
                   {isBulkFilesUploading.total}
                 </>
               )}
-            </NewDialogDescription>
-          </NewDialogHeader>
-          <NewDialogContainer>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogContainer>
             {isBulkFilesUploading && (
               <div className="flex justify-center">
                 <Spinner variant="dark" size="md" />
               </div>
             )}
-          </NewDialogContainer>
-        </NewDialogContent>
-      </NewDialog>
+          </DialogContainer>
+        </DialogContent>
+      </Dialog>
       <input
         className="hidden"
         type="file"

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -1,10 +1,10 @@
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { PluginWorkspaceResource } from "@dust-tt/types";
@@ -67,13 +67,13 @@ export function RunPluginDialog({
   );
 
   return (
-    <NewDialog open={true} onOpenChange={handleClose}>
-      <NewDialogContent className="w-auto bg-structure-50 sm:min-w-[600px] sm:max-w-[1000px]">
-        <NewDialogHeader>
-          <NewDialogTitle>Run {plugin.name} plugin</NewDialogTitle>
-          <NewDialogDescription>{plugin.description}</NewDialogDescription>
-        </NewDialogHeader>
-        <NewDialogContainer>
+    <Dialog open={true} onOpenChange={handleClose}>
+      <DialogContent className="w-auto bg-structure-50 sm:min-w-[600px] sm:max-w-[1000px]">
+        <DialogHeader>
+          <DialogTitle>Run {plugin.name} plugin</DialogTitle>
+          <DialogDescription>{plugin.description}</DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
           {isLoading ? (
             <Spinner />
           ) : !manifest ? (
@@ -125,8 +125,8 @@ export function RunPluginDialog({
               )}
             </>
           )}
-        </NewDialogContainer>
-      </NewDialogContent>
-    </NewDialog>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/components/poke/shadcn/ui/command.tsx
+++ b/front/components/poke/shadcn/ui/command.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  MagnifyingGlassIcon,
-  NewDialog,
-  NewDialogContent,
-} from "@dust-tt/sparkle";
+import { Dialog, DialogContent, MagnifyingGlassIcon } from "@dust-tt/sparkle";
 import type { DialogProps } from "@radix-ui/react-dialog";
 import { Command as CommandPrimitive } from "cmdk";
 import Link from "next/link";
@@ -117,16 +113,16 @@ const CommandDialog = ({
 
   return (
     <CommandContext.Provider value={commandContext}>
-      <NewDialog onOpenChange={onOpenChange} open={open} {...props}>
-        <NewDialogContent className={cn("overflow-hidden p-0", className)}>
+      <Dialog onOpenChange={onOpenChange} open={open} {...props}>
+        <DialogContent className={cn("overflow-hidden p-0", className)}>
           <Command
             shouldFilter={shouldFilter}
             className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
           >
             {children}
           </Command>
-        </NewDialogContent>
-      </NewDialog>
+        </DialogContent>
+      </Dialog>
     </CommandContext.Provider>
   );
 };

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -1,11 +1,11 @@
 import {
-  NewDialog,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
-  NewDialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { EnterpriseUpgradeFormType, WorkspaceType } from "@dust-tt/types";
@@ -95,18 +95,18 @@ export default function EnterpriseUpgradeDialog({
   };
 
   return (
-    <NewDialog open={open} onOpenChange={setOpen}>
-      <NewDialogTrigger asChild>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
         <PokeButton variant="outline">🏢 Upgrade to Enterprise</PokeButton>
-      </NewDialogTrigger>
-      <NewDialogContent className="bg-structure-50 sm:max-w-[600px]">
-        <NewDialogHeader>
-          <NewDialogTitle>Upgrade {owner.name} to Enterprise.</NewDialogTitle>
-          <NewDialogDescription>
+      </DialogTrigger>
+      <DialogContent className="bg-structure-50 sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Upgrade {owner.name} to Enterprise.</DialogTitle>
+          <DialogDescription>
             Select the enterprise plan and provide the Stripe subscription id of
             the customer.
-          </NewDialogDescription>
-        </NewDialogHeader>
+          </DialogDescription>
+        </DialogHeader>
         {error && <div className="text-red-500">{error}</div>}
         {isSubmitting && <Spinner />}
         {!isSubmitting && (
@@ -135,18 +135,18 @@ export default function EnterpriseUpgradeDialog({
                   />
                 </div>
               </div>
-              <NewDialogFooter>
+              <DialogFooter>
                 <PokeButton
                   type="submit"
                   className="border-warning-600 bg-warning-500 text-white"
                 >
                   Upgrade
                 </PokeButton>
-              </NewDialogFooter>
+              </DialogFooter>
             </form>
           </PokeForm>
         )}
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/components/providers/ProviderSetup.tsx
+++ b/front/components/providers/ProviderSetup.tsx
@@ -1,11 +1,11 @@
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { MouseEvent } from "react";
@@ -378,18 +378,18 @@ export function ProviderSetup({
       };
 
   return (
-    <NewDialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <NewDialogContent>
-        <NewDialogHeader>
-          <NewDialogTitle>{title}</NewDialogTitle>
-          <NewDialogDescription>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
             {instructions || (
               <p>Provide the necessary configuration for {title}.</p>
             )}
-          </NewDialogDescription>
-        </NewDialogHeader>
+          </DialogDescription>
+        </DialogHeader>
 
-        <NewDialogContainer>
+        <DialogContainer>
           <div className="flex flex-col gap-4">
             {renderFields()}
             <div className="text-sm">
@@ -405,9 +405,9 @@ export function ProviderSetup({
               )}
             </div>
           </div>
-        </NewDialogContainer>
+        </DialogContainer>
 
-        <NewDialogFooter
+        <DialogFooter
           leftButtonProps={
             enabled
               ? {
@@ -422,7 +422,7 @@ export function ProviderSetup({
           }
           rightButtonProps={rightButtonProps}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -1,17 +1,17 @@
 import {
   Button,
   CloudArrowLeftRightIcon,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   useSendNotification,
 } from "@dust-tt/sparkle";
 import type {
@@ -282,7 +282,7 @@ export const AddConnectionMenu = ({
   return (
     availableIntegrations.length > 0 && (
       <>
-        <NewDialog
+        <Dialog
           open={showUpgradePopup}
           onOpenChange={(open) => {
             if (!open) {
@@ -290,14 +290,14 @@ export const AddConnectionMenu = ({
             }
           }}
         >
-          <NewDialogContent size="md" isAlertDialog>
-            <NewDialogHeader hideButton>
-              <NewDialogTitle>${plan.name} plan</NewDialogTitle>
-            </NewDialogHeader>
-            <NewDialogContainer>
+          <DialogContent size="md" isAlertDialog>
+            <DialogHeader hideButton>
+              <DialogTitle>${plan.name} plan</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
               Unlock this managed data source by upgrading your plan.
-            </NewDialogContainer>
-            <NewDialogFooter
+            </DialogContainer>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -310,8 +310,8 @@ export const AddConnectionMenu = ({
                 },
               }}
             />
-          </NewDialogContent>
-        </NewDialog>
+          </DialogContent>
+        </Dialog>
 
         {connectorProvider === "snowflake" ? (
           <CreateOrUpdateConnectionSnowflakeModal
@@ -364,7 +364,7 @@ export const AddConnectionMenu = ({
             />
           )
         )}
-        <NewDialog
+        <Dialog
           open={showPreviewPopupForProvider.isOpen}
           onOpenChange={(open) => {
             if (!open) {
@@ -375,14 +375,14 @@ export const AddConnectionMenu = ({
             }
           }}
         >
-          <NewDialogContent size="md">
-            <NewDialogHeader>
-              <NewDialogTitle>Coming Soon!</NewDialogTitle>
-              <NewDialogDescription>
+          <DialogContent size="md">
+            <DialogHeader>
+              <DialogTitle>Coming Soon!</DialogTitle>
+              <DialogDescription>
                 Please email us at support@dust.tt for early access.
-              </NewDialogDescription>
-            </NewDialogHeader>
-            <NewDialogFooter
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -403,8 +403,8 @@ export const AddConnectionMenu = ({
                 },
               }}
             />
-          </NewDialogContent>
-        </NewDialog>
+          </DialogContent>
+        </Dialog>
 
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>

--- a/front/components/spaces/AddToSpaceDialog.tsx
+++ b/front/components/spaces/AddToSpaceDialog.tsx
@@ -1,15 +1,15 @@
 import {
   Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   ScrollArea,
   ScrollBar,
   useSendNotification,
@@ -138,7 +138,7 @@ export const AddToSpaceDialog = ({
   };
 
   return (
-    <NewDialog
+    <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
@@ -146,11 +146,11 @@ export const AddToSpaceDialog = ({
         }
       }}
     >
-      <NewDialogContent size="md">
-        <NewDialogHeader>
-          <NewDialogTitle>Add to Space</NewDialogTitle>
-        </NewDialogHeader>
-        <NewDialogContainer>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Add to Space</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
           {availableSpaces.length === 0 ? (
             <div className="mt-1 text-left">
               This data is already available in all spaces.
@@ -182,8 +182,8 @@ export const AddToSpaceDialog = ({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-        </NewDialogContainer>
-        <NewDialogFooter
+        </DialogContainer>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -195,7 +195,7 @@ export const AddToSpaceDialog = ({
             onClick: addToSpace,
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/front/components/spaces/ConfirmDeleteSpaceDialog.tsx
+++ b/front/components/spaces/ConfirmDeleteSpaceDialog.tsx
@@ -1,10 +1,10 @@
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { SpaceType } from "@dust-tt/types";
@@ -36,7 +36,7 @@ export function ConfirmDeleteSpaceDialog({
         : `No assistants are using this ${getSpaceName(space)}. Confirm permanent deletion?`;
 
   return (
-    <NewDialog
+    <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
@@ -44,18 +44,18 @@ export function ConfirmDeleteSpaceDialog({
         }
       }}
     >
-      <NewDialogContent>
-        <NewDialogHeader>
-          <NewDialogTitle>{`Deleting ${getSpaceName(space)}`}</NewDialogTitle>
-        </NewDialogHeader>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{`Deleting ${getSpaceName(space)}`}</DialogTitle>
+        </DialogHeader>
         {isDeleting ? (
           <div className="flex justify-center py-8">
             <Spinner variant="dark" size="md" />
           </div>
         ) : (
           <>
-            <NewDialogContainer>{message}</NewDialogContainer>
-            <NewDialogFooter
+            <DialogContainer>{message}</DialogContainer>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -70,7 +70,7 @@ export function ConfirmDeleteSpaceDialog({
             />
           </>
         )}
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -1,13 +1,13 @@
 import {
   Button,
   ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   InformationCircleIcon,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   PlusIcon,
   Tooltip,
   useSendNotification,
@@ -338,18 +338,16 @@ export function EditSpaceManagedDataSourcesViews({
         initialSelectedDataSources={filteredDataSourceViews}
       />
 
-      <NewDialog
+      <Dialog
         open={showNoConnectionDialog}
         onOpenChange={(open) => !open && setShowNoConnectionDialog(false)}
       >
-        <NewDialogContent>
-          <NewDialogHeader>
-            <NewDialogTitle>No connection set up</NewDialogTitle>
-          </NewDialogHeader>
-          <NewDialogContainer>
-            You have no connection set up.
-          </NewDialogContainer>
-          <NewDialogFooter
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>No connection set up</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>You have no connection set up.</DialogContainer>
+          <DialogFooter
             leftButtonProps={{
               label: "Close",
               variant: "outline",
@@ -361,8 +359,8 @@ export function EditSpaceManagedDataSourcesViews({
               onClick: handleGoToConnectionsManagement,
             }}
           />
-        </NewDialogContent>
-      </NewDialog>
+        </DialogContent>
+      </Dialog>
       <AwaitableDialog />
       {isSavingDisabled ? (
         <Tooltip

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -1,11 +1,11 @@
 import {
   Breadcrumbs,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@dust-tt/sparkle";
 import type {
   DataSourceViewCategory,
@@ -118,7 +118,7 @@ export function SpaceLayout({
           />
         )}
         {isAdmin && isLimitReached && (
-          <NewDialog
+          <Dialog
             open={isLimitReached && spaceCreationModalState.isOpen}
             onOpenChange={(open) => {
               if (!open) {
@@ -126,24 +126,24 @@ export function SpaceLayout({
               }
             }}
           >
-            <NewDialogContent size="md" isAlertDialog>
-              <NewDialogHeader hideButton>
-                <NewDialogTitle>You can't create more spaces.</NewDialogTitle>
-              </NewDialogHeader>
-              <NewDialogContainer>
+            <DialogContent size="md" isAlertDialog>
+              <DialogHeader hideButton>
+                <DialogTitle>You can't create more spaces.</DialogTitle>
+              </DialogHeader>
+              <DialogContainer>
                 {isEnterprise
                   ? "We're going to make changes to data permissions spaces soon and are limiting the creation of spaces for that reason. Reach out to us to learn more."
                   : "The maximum number of spaces for this workspace has been reached. Please reach out at support@dust.tt to learn more."}
-              </NewDialogContainer>
-              <NewDialogFooter
+              </DialogContainer>
+              <DialogFooter
                 rightButtonProps={{
                   label: "Ok",
                   variant: "outline",
                   onClick: closeSpaceCreationModal,
                 }}
               />
-            </NewDialogContent>
-          </NewDialog>
+            </DialogContent>
+          </Dialog>
         )}
       </AppLayout>
     </RootLayout>

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -1,14 +1,14 @@
 import {
   Avatar,
   Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
   ElementModal,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
-  NewDialogTrigger,
   Page,
   Spinner,
   useSendNotification,
@@ -97,31 +97,31 @@ export function ChangeMemberModal({
           </div>
           <div className="flex flex-none flex-col gap-2">
             <div className="flex-none">
-              <NewDialog>
-                <NewDialogTrigger asChild>
+              <Dialog>
+                <DialogTrigger asChild>
                   <Button
                     variant="warning"
                     label="Revoke member access"
                     size="sm"
                   />
-                </NewDialogTrigger>
-                <NewDialogContent>
-                  <NewDialogHeader>
-                    <NewDialogTitle>Confirm deletion</NewDialogTitle>
-                  </NewDialogHeader>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Confirm deletion</DialogTitle>
+                  </DialogHeader>
                   {isSaving ? (
                     <div className="flex justify-center py-8">
                       <Spinner variant="dark" size="md" />
                     </div>
                   ) : (
                     <>
-                      <NewDialogContainer>
+                      <DialogContainer>
                         <div>
                           Revoke access for user{" "}
                           <span className="font-bold">{member.fullName}</span>?
                         </div>
-                      </NewDialogContainer>
-                      <NewDialogFooter
+                      </DialogContainer>
+                      <DialogFooter
                         leftButtonProps={{
                           label: "Cancel",
                           variant: "outline",
@@ -142,8 +142,8 @@ export function ChangeMemberModal({
                       />
                     </>
                   )}
-                </NewDialogContent>
-              </NewDialog>
+                </DialogContent>
+              </Dialog>
             </div>
             <Page.P>
               Deleting a member will remove them from the workspace. They will

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -1,5 +1,11 @@
 import {
   Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   ExternalLinkIcon,
   Icon,
   IconButton,
@@ -7,12 +13,6 @@ import {
   Label,
   LockIcon,
   Modal,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   Page,
   Popup,
   RadioGroup,
@@ -836,7 +836,7 @@ function ToggleEnforceEnterpriseConnectionModal({
   const dialog = titleAndContent[owner.ssoEnforced ? "remove" : "enforce"];
 
   return (
-    <NewDialog
+    <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
@@ -844,12 +844,12 @@ function ToggleEnforceEnterpriseConnectionModal({
         }
       }}
     >
-      <NewDialogContent>
-        <NewDialogHeader>
-          <NewDialogTitle>{dialog.title}</NewDialogTitle>
-        </NewDialogHeader>
-        <NewDialogContainer>{dialog.content}</NewDialogContainer>
-        <NewDialogFooter
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{dialog.title}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>{dialog.content}</DialogContainer>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -863,8 +863,8 @@ function ToggleEnforceEnterpriseConnectionModal({
             },
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -911,7 +911,7 @@ function DisableEnterpriseConnectionModal({
   }
 
   return (
-    <NewDialog
+    <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
@@ -919,17 +919,17 @@ function DisableEnterpriseConnectionModal({
         }
       }}
     >
-      <NewDialogContent size="md">
-        <NewDialogHeader>
-          <NewDialogTitle>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>
             Disable ${strategyHumanReadable} Single Sign On
-          </NewDialogTitle>
-        </NewDialogHeader>
-        <NewDialogContainer>
+          </DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
           Anyone with an {strategyHumanReadable} account won't be able to access
           your Dust workspace anymore.
-        </NewDialogContainer>
-        <NewDialogFooter
+        </DialogContainer>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -942,7 +942,7 @@ function DisableEnterpriseConnectionModal({
             },
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/hooks/useAwaitableDialog.tsx
+++ b/front/hooks/useAwaitableDialog.tsx
@@ -1,11 +1,11 @@
 import type { Button } from "@dust-tt/sparkle";
 import {
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
@@ -65,7 +65,7 @@ export function useAwaitableDialog() {
     } = dialogState.props;
 
     return (
-      <NewDialog
+      <Dialog
         open={dialogState.isOpen}
         // If user dismisses the dialog some other way (e.g. clicking outside when not alert), treat it as cancel:
         onOpenChange={(open) => {
@@ -74,16 +74,16 @@ export function useAwaitableDialog() {
           }
         }}
       >
-        <NewDialogContent
+        <DialogContent
           isAlertDialog={alertDialog}
           trapFocusScope={!!alertDialog}
         >
-          <NewDialogHeader hideButton={true}>
-            <NewDialogTitle>{title}</NewDialogTitle>
-          </NewDialogHeader>
-          <NewDialogContainer>{children}</NewDialogContainer>
+          <DialogHeader hideButton={true}>
+            <DialogTitle>{title}</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>{children}</DialogContainer>
 
-          <NewDialogFooter
+          <DialogFooter
             leftButtonProps={
               cancelLabel
                 ? {
@@ -99,8 +99,8 @@ export function useAwaitableDialog() {
               onClick: handleConfirm,
             }}
           />
-        </NewDialogContent>
-      </NewDialog>
+        </DialogContent>
+      </Dialog>
     );
   };
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.372-rc-1",
+        "@dust-tt/sparkle": "0.2.372",
         "@dust-tt/types": "file:../types",
         "@heroicons/react": "^2.0.11",
         "@hookform/resolvers": "^3.3.4",
@@ -11326,9 +11326,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.372-rc-1",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.372-rc-1.tgz",
-      "integrity": "sha512-N85jM6DT2G8bmcPAVo3jdalr0VLuPq/odOkYvFyBRgzMLgo+UcEL6t8php+Wlm9Dd70EgN1/4kqX7FmzsLVx2g==",
+      "version": "0.2.372",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.372.tgz",
+      "integrity": "sha512-OmWGiOZqKf0sIq/d7mr2H7n0h1OTtVL9tQtu6qGAKiBMy54S54/VXHsEWT/GNRc8pNOr/rVPB5Fmw4CQrSMJcw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.371",
+        "@dust-tt/sparkle": "0.2.372-rc-1",
         "@dust-tt/types": "file:../types",
         "@heroicons/react": "^2.0.11",
         "@hookform/resolvers": "^3.3.4",
@@ -11326,9 +11326,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.371",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.371.tgz",
-      "integrity": "sha512-iwqmuNXHe6drXo9qVvUErXhb+zEf6qI+1Tqbp0BCvromIuWZZD3EaT6Y/TkJ0ERPI7r/vDpv9Pl3dgGLGlNCrQ==",
+      "version": "0.2.372-rc-1",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.372-rc-1.tgz",
+      "integrity": "sha512-N85jM6DT2G8bmcPAVo3jdalr0VLuPq/odOkYvFyBRgzMLgo+UcEL6t8php+Wlm9Dd70EgN1/4kqX7FmzsLVx2g==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.371",
+    "@dust-tt/sparkle": "0.2.372-rc-1",
     "@dust-tt/types": "file:../types",
     "@heroicons/react": "^2.0.11",
     "@hookform/resolvers": "^3.3.4",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.372-rc-1",
+    "@dust-tt/sparkle": "0.2.372",
     "@dust-tt/types": "file:../types",
     "@heroicons/react": "^2.0.11",
     "@hookform/resolvers": "^3.3.4",

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -1,17 +1,17 @@
 import {
   AssistantCard,
   ColorPicker,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
   EmojiPicker,
   Input,
   Markdown,
-  NewDialog,
-  NewDialogContent,
-  NewDialogHeader,
-  NewDialogTitle,
-  NewDialogTrigger,
   TextArea,
   useSendNotification,
 } from "@dust-tt/sparkle";
@@ -426,22 +426,22 @@ function PreviewDialog({ form }: { form: any }) {
   );
 
   return (
-    <NewDialog open={open} onOpenChange={setOpen}>
-      <NewDialogTrigger asChild>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
         <PokeButton variant="secondary">✨ Preview Template Card</PokeButton>
-      </NewDialogTrigger>
-      <NewDialogContent className="bg-structure-50 sm:max-w-[600px]">
-        <NewDialogHeader>
-          <NewDialogTitle>Preview</NewDialogTitle>
-        </NewDialogHeader>
+      </DialogTrigger>
+      <DialogContent className="bg-structure-50 sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Preview</DialogTitle>
+        </DialogHeader>
         <AssistantCard
           title={form.getValues("handle")}
           pictureUrl={avatarVisual}
           description={form.getValues("description") ?? ""}
           onClick={() => console.log("clicked")}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -4,13 +4,13 @@ import {
   ChatBubbleThoughtIcon,
   CloudArrowLeftRightIcon,
   ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Input,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   Page,
   SliderToggle,
   Spinner,
@@ -637,7 +637,7 @@ export default function LabsTranscriptsIndex({
         pageTitle="Dust - Transcripts processing"
         navChildren={<AssistantSidebarMenu owner={owner} />}
       >
-        <NewDialog
+        <Dialog
           open={isDeleteProviderDialogOpened}
           onOpenChange={(open) => {
             if (!open) {
@@ -645,15 +645,15 @@ export default function LabsTranscriptsIndex({
             }
           }}
         >
-          <NewDialogContent size="md">
-            <NewDialogHeader>
-              <NewDialogTitle>Disconnect transcripts provider</NewDialogTitle>
-            </NewDialogHeader>
-            <NewDialogContainer>
+          <DialogContent size="md">
+            <DialogHeader>
+              <DialogTitle>Disconnect transcripts provider</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
               This will stop the processing of your meeting transcripts and
               delete all history. You can reconnect anytime.
-            </NewDialogContainer>
-            <NewDialogFooter
+            </DialogContainer>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -667,8 +667,8 @@ export default function LabsTranscriptsIndex({
                 },
               }}
             />
-          </NewDialogContent>
-        </NewDialog>
+          </DialogContent>
+        </Dialog>
         <Page>
           <Page.Header
             title="Meeting transcripts processing"

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -3,6 +3,13 @@ import {
   Button,
   ClipboardCheckIcon,
   ClipboardIcon,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -10,13 +17,6 @@ import {
   IconButton,
   Input,
   Modal,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
-  NewDialogTrigger,
   Page,
   PlusIcon,
   ScrollArea,
@@ -194,19 +194,19 @@ export function APIKeys({
             window.open("https://docs.dust.tt/reference", "_blank");
           }}
         />
-        <NewDialog>
-          <NewDialogTrigger asChild>
+        <Dialog>
+          <DialogTrigger asChild>
             <Button
               label="Create API Key"
               icon={PlusIcon}
               disabled={isGenerating || isRevoking}
             />
-          </NewDialogTrigger>
-          <NewDialogContent size="md">
-            <NewDialogHeader>
-              <NewDialogTitle>New API Key</NewDialogTitle>
-            </NewDialogHeader>
-            <NewDialogContainer>
+          </DialogTrigger>
+          <DialogContent size="md">
+            <DialogHeader>
+              <DialogTitle>New API Key</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
               <Input
                 name="API Key"
                 placeholder="Type an API key name"
@@ -257,8 +257,8 @@ export function APIKeys({
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-            </NewDialogContainer>
-            <NewDialogFooter
+            </DialogContainer>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -274,8 +274,8 @@ export function APIKeys({
                 },
               }}
             />
-          </NewDialogContent>
-        </NewDialog>
+          </DialogContent>
+        </Dialog>
       </Page.Horizontal>
       <div className="space-y-4 divide-y divide-gray-200">
         <ul role="list" className="pt-4">

--- a/front/pages/w/[wId]/developers/dev-secrets.tsx
+++ b/front/pages/w/[wId]/developers/dev-secrets.tsx
@@ -2,13 +2,13 @@ import {
   BookOpenIcon,
   BracesIcon,
   Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Input,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   Page,
   PlusIcon,
   useSendNotification,
@@ -127,7 +127,7 @@ export default function SecretsPage({
   return (
     <>
       {secretToRevoke ? (
-        <NewDialog
+        <Dialog
           open={true}
           onOpenChange={(open) => {
             if (!open) {
@@ -135,15 +135,15 @@ export default function SecretsPage({
             }
           }}
         >
-          <NewDialogContent>
-            <NewDialogHeader>
-              <NewDialogTitle>Delete {secretToRevoke?.name}</NewDialogTitle>
-            </NewDialogHeader>
-            <NewDialogContainer>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete {secretToRevoke?.name}</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
               Are you sure you want to delete the secret{" "}
               <strong>{secretToRevoke?.name}</strong>?
-            </NewDialogContainer>
-            <NewDialogFooter
+            </DialogContainer>
+            <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
@@ -155,10 +155,10 @@ export default function SecretsPage({
                 onClick: () => handleRevoke(secretToRevoke),
               }}
             />
-          </NewDialogContent>
-        </NewDialog>
+          </DialogContent>
+        </Dialog>
       ) : null}
-      <NewDialog
+      <Dialog
         open={isNewSecretPromptOpen}
         onOpenChange={(open) => {
           if (!open) {
@@ -166,13 +166,13 @@ export default function SecretsPage({
           }
         }}
       >
-        <NewDialogContent size="lg">
-          <NewDialogHeader>
-            <NewDialogTitle>
+        <DialogContent size="lg">
+          <DialogHeader>
+            <DialogTitle>
               {isInputNameDisabled ? "Update" : "New"} Developer Secret
-            </NewDialogTitle>
-          </NewDialogHeader>
-          <NewDialogContainer>
+            </DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
             <Input
               message="Secret names must be alphanumeric and underscore characters only."
               name="Secret Name"
@@ -199,8 +199,8 @@ export default function SecretsPage({
               }
             />
             <p className="text-xs text-gray-500"></p>
-          </NewDialogContainer>
-          <NewDialogFooter
+          </DialogContainer>
+          <DialogFooter
             leftButtonProps={{
               label: "Cancel",
               variant: "outline",
@@ -212,8 +212,8 @@ export default function SecretsPage({
               onClick: () => handleGenerate(newDustAppSecret),
             }}
           />
-        </NewDialogContent>
-      </NewDialog>
+        </DialogContent>
+      </Dialog>
 
       <AppLayout
         subscription={subscription}

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -1,11 +1,11 @@
 import {
   Button,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Page,
   PlusIcon,
   Popup,
@@ -318,7 +318,7 @@ function DomainAutoJoinModal({
   }
 
   return (
-    <NewDialog
+    <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
@@ -326,12 +326,12 @@ function DomainAutoJoinModal({
         }
       }}
     >
-      <NewDialogContent size="md" isAlertDialog>
-        <NewDialogHeader hideButton>
-          <NewDialogTitle>{title}</NewDialogTitle>
-        </NewDialogHeader>
-        <NewDialogContainer>{description}</NewDialogContainer>
-        <NewDialogFooter
+      <DialogContent size="md" isAlertDialog>
+        <DialogHeader hideButton>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>{description}</DialogContainer>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -345,7 +345,7 @@ function DomainAutoJoinModal({
             },
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -2,18 +2,18 @@ import {
   Button,
   CardIcon,
   Chip,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   MoreIcon,
-  NewDialog,
-  NewDialogContainer,
-  NewDialogContent,
-  NewDialogDescription,
-  NewDialogFooter,
-  NewDialogHeader,
-  NewDialogTitle,
   Page,
   ShapesIcon,
   Spinner,
@@ -442,7 +442,7 @@ function SkipFreeTrialDialog({
   plan: SubscriptionType["plan"];
 }) {
   return (
-    <NewDialog
+    <Dialog
       open={show}
       onOpenChange={(open) => {
         if (!open) {
@@ -450,15 +450,15 @@ function SkipFreeTrialDialog({
         }
       }}
     >
-      <NewDialogContent size="md">
-        <NewDialogHeader>
-          <NewDialogTitle>End trial</NewDialogTitle>
-          <NewDialogDescription>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>End trial</DialogTitle>
+          <DialogDescription>
             Ending your trial will allow you to invite more than{" "}
             {plan.limits.users.maxUsers} members to your workspace.
-          </NewDialogDescription>
-        </NewDialogHeader>
-        <NewDialogContainer>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
           {isSaving ? (
             <div className="flex justify-center py-8">
               <Spinner variant="dark" size="md" />
@@ -492,8 +492,8 @@ function SkipFreeTrialDialog({
               );
             })()
           )}
-        </NewDialogContainer>
-        <NewDialogFooter
+        </DialogContainer>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -504,8 +504,8 @@ function SkipFreeTrialDialog({
             onClick: onValidate,
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -521,7 +521,7 @@ function CancelFreeTrialDialog({
   isSaving: boolean;
 }) {
   return (
-    <NewDialog
+    <Dialog
       open={show}
       onOpenChange={(open) => {
         if (!open) {
@@ -529,15 +529,15 @@ function CancelFreeTrialDialog({
         }
       }}
     >
-      <NewDialogContent size="md">
-        <NewDialogHeader>
-          <NewDialogTitle>Cancel subscription</NewDialogTitle>
-          <NewDialogDescription>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Cancel subscription</DialogTitle>
+          <DialogDescription>
             All your workspace data will be deleted and you will lose access to
             your Dust workspace.
-          </NewDialogDescription>
-        </NewDialogHeader>
-        <NewDialogContainer>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
           {isSaving ? (
             <div className="flex justify-center py-8">
               <Spinner variant="dark" size="md" />
@@ -545,8 +545,8 @@ function CancelFreeTrialDialog({
           ) : (
             <div className="font-bold">Are you sure you want to proceed?</div>
           )}
-        </NewDialogContainer>
-        <NewDialogFooter
+        </DialogContainer>
+        <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
@@ -557,7 +557,7 @@ function CancelFreeTrialDialog({
             onClick: onValidate,
           }}
         />
-      </NewDialogContent>
-    </NewDialog>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Description

This PR is a follow up of https://github.com/dust-tt/dust/pull/10162 which renames `NewDialog` into `Dialog`.

## Risk

Low

## Deploy Plan

- Publish sparkle
- Update and deploy front