### PR TITLE
Fix Zendesk article parents

### DIFF
--- a/connectors/migrations/20250123_resync_zendesk_help_centers.ts
+++ b/connectors/migrations/20250123_resync_zendesk_help_centers.ts
@@ -1,0 +1,53 @@
+import { makeScript } from "scripts/helpers";
+
+import { launchZendeskSyncWorkflow } from "@connectors/connectors/zendesk/temporal/client";
+import type Logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import {
+  ZendeskBrandResource,
+  ZendeskCategoryResource,
+} from "@connectors/resources/zendesk_resources";
+
+async function migrateConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  parentLogger: typeof Logger
+) {
+  const logger = parentLogger.child({ connectorId: connector.id });
+
+  const helpCenterBrandIds =
+    await ZendeskBrandResource.fetchHelpCenterReadAllowedBrandIds(connector.id);
+
+  const allCategoryIds =
+    await ZendeskCategoryResource.fetchByConnector(connector);
+  const categoryIds = allCategoryIds
+    .filter(
+      (c) => c.permission === "read" && !helpCenterBrandIds.includes(c.brandId) // skipping categories that will be synced through the Help Center
+    )
+    .map((c) => {
+      const { categoryId, brandId } = c;
+      return { brandId, categoryId };
+    });
+
+  if (execute) {
+    const res = await launchZendeskSyncWorkflow(connector, {
+      helpCenterBrandIds,
+      categoryIds,
+    });
+    if (res.isErr()) {
+      logger.error({ error: res.error }, "ERR");
+    } else {
+      logger.info({ categoryIds, helpCenterBrandIds }, "LIVE");
+    }
+  } else {
+    logger.info({ categoryIds, helpCenterBrandIds }, "DRY");
+  }
+}
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("zendesk", {});
+  logger.info(`Found ${connectors.length} Zendesk connectors`);
+
+  for (const connector of connectors) {
+    await migrateConnector(connector, execute, logger);
+  }
+});

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -56,6 +56,7 @@ export async function syncArticle({
   section,
   user,
   currentSyncDateMs,
+  helpCenterIsAllowed,
   dataSourceConfig,
   loggerArgs,
   forceResync,
@@ -66,6 +67,7 @@ export async function syncArticle({
   section: ZendeskFetchedSection | null;
   category: ZendeskCategoryResource;
   user: ZendeskFetchedUser | null;
+  helpCenterIsAllowed: boolean;
   currentSyncDateMs: number;
   loggerArgs: Record<string, string | number | null>;
   forceResync: boolean;
@@ -159,7 +161,10 @@ export async function syncArticle({
       articleId: article.id,
     });
 
-    const parents = articleInDb.getParentInternalIds(connectorId);
+    const parents = articleInDb.getParentInternalIds(
+      connectorId,
+      helpCenterIsAllowed
+    );
     await upsertDataSourceDocument({
       dataSourceConfig,
       documentId,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -471,7 +471,6 @@ export async function syncZendeskArticleBatchActivity({
   categoryId,
   currentSyncDateMs,
   helpCenterIsAllowed,
-  forceResync,
   url,
 }: {
   connectorId: ModelId;
@@ -479,7 +478,6 @@ export async function syncZendeskArticleBatchActivity({
   categoryId: number;
   currentSyncDateMs: number;
   helpCenterIsAllowed: boolean;
-  forceResync: boolean;
   url: string | null;
 }): Promise<{ hasMore: boolean; nextLink: string | null }> {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -546,7 +544,6 @@ export async function syncZendeskArticleBatchActivity({
         helpCenterIsAllowed,
         currentSyncDateMs,
         loggerArgs,
-        forceResync,
       }),
     {
       concurrency: 10,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -379,7 +379,10 @@ export async function syncZendeskCategoryActivity({
   categoryId: number;
   brandId: number;
   currentSyncDateMs: number;
-}): Promise<{ shouldSyncArticles: boolean }> {
+}): Promise<{
+  shouldSyncArticles: boolean;
+  helpCenterIsAllowed: boolean | null;
+}> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
@@ -395,14 +398,14 @@ export async function syncZendeskCategoryActivity({
     );
   }
 
-  // if all rights were revoked, we have nothing to sync
+  // Remove the category if was explicitly unselected in the UI.
   if (categoryInDb.permission === "none") {
     await deleteDataSourceFolder({
       dataSourceConfig: dataSourceConfigFromConnector(connector),
       folderId: getCategoryInternalId({ connectorId, brandId, categoryId }),
     });
     // note that the articles will be deleted in the garbage collection
-    return { shouldSyncArticles: false };
+    return { shouldSyncArticles: false, helpCenterIsAllowed: null };
   }
 
   const zendeskApiClient = createZendeskClient(
@@ -418,7 +421,7 @@ export async function syncZendeskCategoryActivity({
     await zendeskApiClient.helpcenter.categories.show(categoryId);
   if (!fetchedCategory) {
     await categoryInDb.revokePermissions();
-    return { shouldSyncArticles: false };
+    return { shouldSyncArticles: false, helpCenterIsAllowed: null };
   }
 
   // upserting a folder to data_sources_folders (core)
@@ -452,7 +455,10 @@ export async function syncZendeskCategoryActivity({
     description: fetchedCategory.description,
     lastUpsertedTs: new Date(currentSyncDateMs),
   });
-  return { shouldSyncArticles: true };
+  return {
+    shouldSyncArticles: true,
+    helpCenterIsAllowed: brandInDb?.helpCenterPermission === "read",
+  };
 }
 
 /**
@@ -464,6 +470,7 @@ export async function syncZendeskArticleBatchActivity({
   brandId,
   categoryId,
   currentSyncDateMs,
+  helpCenterIsAllowed,
   forceResync,
   url,
 }: {
@@ -471,6 +478,7 @@ export async function syncZendeskArticleBatchActivity({
   brandId: number;
   categoryId: number;
   currentSyncDateMs: number;
+  helpCenterIsAllowed: boolean;
   forceResync: boolean;
   url: string | null;
 }): Promise<{ hasMore: boolean; nextLink: string | null }> {
@@ -535,6 +543,7 @@ export async function syncZendeskArticleBatchActivity({
           sections.find((section) => section.id === article.section_id) || null,
         user: users.find((user) => user.id === article.author_id) || null,
         dataSourceConfig,
+        helpCenterIsAllowed,
         currentSyncDateMs,
         loggerArgs,
         forceResync,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -176,6 +176,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
             article,
             section,
             user,
+            helpCenterIsAllowed: hasHelpCenterPermissions,
             dataSourceConfig,
             currentSyncDateMs,
             loggerArgs,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -180,7 +180,6 @@ export async function syncZendeskArticleUpdateBatchActivity({
             dataSourceConfig,
             currentSyncDateMs,
             loggerArgs,
-            forceResync: false,
           });
         }
       }

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -166,13 +166,10 @@ export async function zendeskSyncWorkflow({
   while (brandHelpCenterIds.size > 0) {
     const brandIdsToProcess = new Set(brandHelpCenterIds);
     for (const brandId of brandIdsToProcess) {
-      const relatedSignal = brandHelpCenterSignals.get(brandId);
-      const forceResync = relatedSignal?.forceResync || false;
-
       await executeChild(zendeskBrandHelpCenterSyncWorkflow, {
         workflowId: `${workflowId}-help-center-${brandId}`,
         searchAttributes: parentSearchAttributes,
-        args: [{ connectorId, brandId, currentSyncDateMs, forceResync }],
+        args: [{ connectorId, brandId, currentSyncDateMs }],
         memo,
       });
       brandHelpCenterIds.delete(brandId);
@@ -196,8 +193,6 @@ export async function zendeskSyncWorkflow({
   while (categoryIds.size > 0) {
     const categoryIdsToProcess = new Set(categoryIds);
     for (const categoryId of categoryIdsToProcess) {
-      const relatedSignal = categorySignals.get(categoryId);
-      const forceResync = relatedSignal?.forceResync || false;
       const brandId = categoryBrands[categoryId];
       if (!brandId) {
         throw new Error(
@@ -208,9 +203,7 @@ export async function zendeskSyncWorkflow({
       await executeChild(zendeskCategorySyncWorkflow, {
         workflowId: `${workflowId}-category-${categoryId}`,
         searchAttributes: parentSearchAttributes,
-        args: [
-          { connectorId, categoryId, brandId, currentSyncDateMs, forceResync },
-        ],
+        args: [{ connectorId, categoryId, brandId, currentSyncDateMs }],
         memo,
       });
       categoryIds.delete(categoryId);
@@ -290,7 +283,6 @@ export async function zendeskBrandSyncWorkflow({
       connectorId,
       brandId,
       currentSyncDateMs,
-      forceResync,
     });
   }
   if (ticketsAllowed) {
@@ -311,12 +303,10 @@ export async function zendeskBrandHelpCenterSyncWorkflow({
   connectorId,
   brandId,
   currentSyncDateMs,
-  forceResync,
 }: {
   connectorId: ModelId;
   brandId: number;
   currentSyncDateMs: number;
-  forceResync: boolean;
 }) {
   const { helpCenterAllowed } = await syncZendeskBrandActivity({
     connectorId,
@@ -328,7 +318,6 @@ export async function zendeskBrandHelpCenterSyncWorkflow({
       connectorId,
       brandId,
       currentSyncDateMs,
-      forceResync,
     });
   }
 }
@@ -371,13 +360,11 @@ export async function zendeskCategorySyncWorkflow({
   categoryId,
   brandId,
   currentSyncDateMs,
-  forceResync,
 }: {
   connectorId: ModelId;
   categoryId: number;
   brandId: number;
   currentSyncDateMs: number;
-  forceResync: boolean;
 }) {
   const { shouldSyncArticles, helpCenterIsAllowed } =
     await syncZendeskCategoryActivity({
@@ -394,7 +381,6 @@ export async function zendeskCategorySyncWorkflow({
         categoryId,
         currentSyncDateMs,
         helpCenterIsAllowed: helpCenterIsAllowed === true,
-        forceResync,
         url,
       })
     );
@@ -483,12 +469,10 @@ async function runZendeskBrandHelpCenterSyncActivities({
   connectorId,
   brandId,
   currentSyncDateMs,
-  forceResync,
 }: {
   connectorId: ModelId;
   brandId: number;
   currentSyncDateMs: number;
-  forceResync: boolean;
 }) {
   const categoryIdsToSync = new Set<number>();
 
@@ -517,7 +501,6 @@ async function runZendeskBrandHelpCenterSyncActivities({
         categoryId,
         helpCenterIsAllowed: true, // We know the Help Center is allowed because we're in this function.
         currentSyncDateMs,
-        forceResync,
         url,
       })
     );

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -379,12 +379,13 @@ export async function zendeskCategorySyncWorkflow({
   currentSyncDateMs: number;
   forceResync: boolean;
 }) {
-  const { shouldSyncArticles } = await syncZendeskCategoryActivity({
-    connectorId,
-    categoryId,
-    currentSyncDateMs,
-    brandId,
-  });
+  const { shouldSyncArticles, helpCenterIsAllowed } =
+    await syncZendeskCategoryActivity({
+      connectorId,
+      categoryId,
+      currentSyncDateMs,
+      brandId,
+    });
   if (shouldSyncArticles) {
     await runZendeskActivityWithPagination((url) =>
       syncZendeskArticleBatchActivity({
@@ -392,6 +393,7 @@ export async function zendeskCategorySyncWorkflow({
         brandId,
         categoryId,
         currentSyncDateMs,
+        helpCenterIsAllowed: helpCenterIsAllowed === true,
         forceResync,
         url,
       })
@@ -513,6 +515,7 @@ async function runZendeskBrandHelpCenterSyncActivities({
         connectorId,
         brandId,
         categoryId,
+        helpCenterIsAllowed: true, // We know the Help Center is allowed because we're in this function.
         currentSyncDateMs,
         forceResync,
         url,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -962,14 +962,19 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     };
   }
 
-  getParentInternalIds(connectorId: number): [string, string, string] {
+  getParentInternalIds(
+    connectorId: number,
+    includeHelpCenter: boolean = true
+  ): [string, string, string] | [string, string] {
     const { brandId, categoryId, articleId } = this;
-    /// Articles have two parents: the Category and the Help Center.
-    return [
+    const parents: [string, string] = [
       getArticleInternalId({ connectorId, brandId, articleId }),
       getCategoryInternalId({ connectorId, brandId, categoryId }),
-      getHelpCenterInternalId({ connectorId, brandId }),
     ];
+
+    return includeHelpCenter
+      ? [...parents, getHelpCenterInternalId({ connectorId, brandId })]
+      : parents;
   }
 
   /**


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/1987
- Currently, article parents always include the Help Center, even if it was not selected by the user.
- This PR removes it if the Help Center was not selected by the user.
- This PR also removes the `forceResync` for articles (now always true) to allow updating the parents when selecting a Help Center/Category.

## Risk

- Low, only affects the parents of articles.

## Deploy Plan

- Stop all Zendesk connectors.
- Deploy connectors.
- Resume all Zendesk connectors.
- Run `20250123_resync_zendesk_help_centers.ts` (launches sync workflows).
