### PR TITLE
[front] Fixed signup/login/invitation flow

### DIFF
--- a/extension/app/src/pages/LoginPage.tsx
+++ b/extension/app/src/pages/LoginPage.tsx
@@ -75,7 +75,7 @@ export const LoginPage = () => {
                   label="Sign up"
                   onClick={() => {
                     window.open(
-                      "https://dust.tt/api/auth/login?returnTo=/api/login&screen_hint=signup",
+                      "https://dust.tt/api/auth/login?returnTo=/api/login&prompt=login&screen_hint=signup",
                       "_blank"
                     );
                   }}

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -13,7 +13,7 @@ import sgMail from "@sendgrid/mail";
 import { sign } from "jsonwebtoken";
 import { Op } from "sequelize";
 
-import { getAuth0ManagemementClient } from "@app/lib/api/auth0";
+import { getAuth0UsersFromEmail } from "@app/lib/api/auth0";
 import config from "@app/lib/api/config";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { getMembers } from "@app/lib/api/workspace";
@@ -380,16 +380,11 @@ export async function handleMembershipInvitations(
     activeOnly: true,
   });
 
-  const auth0Users = await getAuth0ManagemementClient().users.getAll({
-    q: invitationRequests
-      .map(
-        (invite) =>
-          `email:"${invite.email.replace(/([+\-&|!(){}[\]^"~*?:\\/])/g, "\\$1")}"`
-      )
-      .join(" OR "),
-  });
+  const auth0Users = await getAuth0UsersFromEmail(
+    invitationRequests.map((invite) => invite.email)
+  );
 
-  const otherRegionUsers = auth0Users.data
+  const otherRegionUsers = auth0Users
     .filter(
       (user) => user.app_metadata?.region !== regionConfig.getCurrentRegion()
     )

--- a/front/lib/api/regions/utils.ts
+++ b/front/lib/api/regions/utils.ts
@@ -1,9 +1,0 @@
-import type { NextApiRequest } from "next";
-
-import type { RegionType } from "@app/lib/api/regions/config";
-
-export function getRegionFromRequest(req: NextApiRequest): RegionType {
-  const host = req.headers.host || "";
-
-  return host.startsWith("eu.") ? "europe-west1" : "us-central1";
-}

--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -5,7 +5,7 @@ export function getSignUpUrl({
   signupCallbackUrl: string;
   invitationEmail?: string;
 }) {
-  let signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&screen_hint=signup`;
+  let signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&prompt=login&screen_hint=signup`;
 
   if (invitationEmail) {
     signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;

--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -65,9 +65,6 @@ const afterCallback: AfterCallbackPageRoute = async (
 
     const params = new URLSearchParams();
 
-    // Add the silent auth params.
-    params.set("prompt", "none");
-
     // Extract just the path from the full returnTo URL.
     if (state?.returnTo) {
       try {
@@ -105,7 +102,7 @@ export default handleAuth({
     // req.query is defined on NextApiRequest (page-router), but not on NextRequest (app-router).
     const query = ("query" in req ? req.query : {}) as Partial<AuthQuery>;
 
-    const { connection, screen_hint, login_hint, prompt = "login" } = query;
+    const { connection, screen_hint, login_hint, prompt } = query;
 
     const defaultAuthorizationParams: Partial<
       LoginOptions["authorizationParams"]
@@ -120,9 +117,8 @@ export default handleAuth({
 
     if (isString(screen_hint) && screen_hint === "signup") {
       defaultAuthorizationParams.screen_hint = screen_hint;
-    }
-
-    if (isString(prompt)) {
+    } else if (isString(prompt)) {
+      // `screen_hint` and `prompt` are mutually exclusive.
       defaultAuthorizationParams.prompt = prompt;
     }
 

--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -14,7 +14,6 @@ import config from "@app/lib/api/config";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import { checkUserRegionAffinity } from "@app/lib/api/regions/lookup";
-import { getRegionFromRequest } from "@app/lib/api/regions/utils";
 import { isEmailValid } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
@@ -51,7 +50,7 @@ const afterCallback: AfterCallbackPageRoute = async (
       targetRegion = regionWithAffinityRes.value.region;
     } else {
       // No region affinity found - keep user in their originally accessed region (from URL).
-      targetRegion = getRegionFromRequest(req);
+      targetRegion = multiRegionsConfig.getCurrentRegion();
     }
 
     // Update Auth0 metadata only once when not set.
@@ -121,8 +120,9 @@ export default handleAuth({
 
     if (isString(screen_hint) && screen_hint === "signup") {
       defaultAuthorizationParams.screen_hint = screen_hint;
-    } else if (isString(prompt)) {
-      // `screen_hint` and `prompt` are mutually exclusive.
+    }
+
+    if (isString(prompt)) {
       defaultAuthorizationParams.prompt = prompt;
     }
 


### PR DESCRIPTION
## Description

- Add auth0 call in invitation flow to filter out mails that are already registered on another domain
- If no region affinity is found, take the current region instead of guessing from request
- Fixes prompt / hint

### Tests scenarios

#### Simple sign in
- Click on sign in on region 1
- Sign in with user from region 2
- User is redirected to region 2
  => ok 

#### Simple sign up 
- Click on sign in on region 1
  => if user is already logged in in region 2, redirect to region 2 => ok
- Sign up , create user on non existing domain
- Get verification email
- Workspace created in requested region
  => ok

#### Sign up - existing domain
- Click on sign in on region 1
- Create user on domain existing in region 1
- Get verification email
- User is asked for consent (region 1)
- User can join or create workspace (if auto-join is not enabled)
  => ok

#### Sign up - existing domain in other region
- Click on sign in on region 2
- Create user on domain existing in region 1
- Get verification email
- User is redirected to region 1
- User is asked for consent (region 1)
- User can join or create workspace (if auto-join is not enabled)
  => ok

#### Invite new user
- From a workspace, on region 1, invite a user (user had no account previously).
- User clicks on invitation link
- User see invitation page, clicks on signup
  => no user logged => can create account => ok
  => another user logged in region 1 => error message displayed (user different from invited user), ok
  => another user logged in region 2 => redirect to region 2 with user logged in, invitation ignored

#### Invite existing user
- From a workspace, on region 1, invite a user who already has an account in region 1.
- User clicks on invitation link
- User see invitation page, clicks on signup
  => no user logged => can log in => ok
  => user is already logged in => ok 
  => another user logged in region 1 => error message displayed (user different from invited user), ok 
  => another user logged in region 2 => redirect to region 2 with user logged in, invitation ignored

#### Invite existing user on other region
- From a workspace, on region 1, invite a user who already has an account in region 2.
  => Error message is displayed => ok


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front