### PR TITLE
[Microsoft] Avoid code path for root deletion leading to errors

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -933,7 +933,11 @@ export async function microsoftDeletionActivity({
   const results = await concurrentExecutor(
     nodeIdsToDelete,
     async (nodeId) =>
-      recursiveNodeDeletion(nodeId, connectorId, dataSourceConfig),
+      recursiveNodeDeletion({
+        nodeId,
+        connectorId,
+        dataSourceConfig,
+      }),
     { concurrency: DELETE_CONCURRENCY }
   );
 
@@ -1202,11 +1206,11 @@ async function scrubRemovedFolders({
         dataSourceConfig,
       });
     } else if (node.nodeType === "folder") {
-      await recursiveNodeDeletion(
-        node.internalId,
-        connector.id,
-        dataSourceConfig
-      );
+      await recursiveNodeDeletion({
+        nodeId: node.internalId,
+        connectorId: connector.id,
+        dataSourceConfig,
+      });
     }
   }
 }


### PR DESCRIPTION
Description
---
Causing thread
[here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1737604067840149)

We should never delete nodes that are still marked as "root" (i.e. user selected). We had prevented that at the source in a previous PR

Here, a path leading to it is as follows:
- Folder A is selected for sync, subfolder AA isn't, subsubfolder AAA is;
- AA is moved out of A, in a part of the drive that's not selected;
- in that case we'll recursively delete AA---but we should not delete AAA since the user has selected it for sync

This is fixed by this PR

Risk
---
low --- simple change, logic only prevent deleting a root node

Deploy
---
connectors