### PR TITLE
[front] - fix: agent feedback in table

### DIFF
--- a/front/components/assistant/AssistantsTable.tsx
+++ b/front/components/assistant/AssistantsTable.tsx
@@ -156,7 +156,7 @@ const getTableColumns = () => {
     },
     {
       header: "Feedback",
-      accessorKey: "feedback",
+      accessorFn: (row: RowData) => row.feedbacks,
       cell: (info: CellContext<RowData, { up: number; down: number }>) => {
         if (info.row.original.scope === "global") {
           return "-";


### PR DESCRIPTION
## Description

This PR fixes the rendering of feedbacks in the `AssistantTable`. The property was not accessed properly.

## Risk

Low

## Deploy Plan

Deploy `front`