### PR TITLE
enh(Zendesk) - Replace calls to `node-zendesk` with our wrapper

### DIFF
--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -1,7 +1,7 @@
 import type { ModelId } from "@dust-tt/types";
 
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { fetchZendeskBrand } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
@@ -24,12 +24,13 @@ export async function allowSyncZendeskBrand({
   });
 
   // fetching the brand from Zendesk
-  const zendeskApiClient = createZendeskClient(
-    await getZendeskSubdomainAndAccessToken(connectionId)
-  );
-  const {
-    result: { brand: fetchedBrand },
-  } = await zendeskApiClient.brand.show(brandId);
+  const { subdomain, accessToken } =
+    await getZendeskSubdomainAndAccessToken(connectionId);
+  const fetchedBrand = await fetchZendeskBrand({
+    brandId,
+    subdomain,
+    accessToken,
+  });
 
   if (!fetchedBrand) {
     logger.error(

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -1,7 +1,7 @@
 import type { ModelId } from "@dust-tt/types";
 
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { fetchZendeskBrand } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
@@ -27,12 +27,13 @@ export async function allowSyncZendeskTickets({
     return true;
   }
   // fetching the brand from Zendesk
-  const zendeskApiClient = createZendeskClient(
-    await getZendeskSubdomainAndAccessToken(connectionId)
-  );
-  const {
-    result: { brand: fetchedBrand },
-  } = await zendeskApiClient.brand.show(brandId);
+  const { subdomain, accessToken } =
+    await getZendeskSubdomainAndAccessToken(connectionId);
+  const fetchedBrand = await fetchZendeskBrand({
+    brandId,
+    subdomain,
+    accessToken,
+  });
 
   if (fetchedBrand) {
     await ZendeskBrandResource.makeNew({

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -231,6 +231,30 @@ export async function fetchZendeskArticle({
 }
 
 /**
+ * Fetches a single category from the Zendesk API.
+ */
+export async function fetchZendeskCategory({
+  brandSubdomain,
+  accessToken,
+  categoryId,
+}: {
+  brandSubdomain: string;
+  accessToken: string;
+  categoryId: number;
+}): Promise<ZendeskFetchedCategory | null> {
+  const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories/${categoryId}`;
+  try {
+    const response = await fetchFromZendeskWithRetries({ url, accessToken });
+    return response?.category ?? null;
+  } catch (e) {
+    if (isZendeskNotFoundError(e)) {
+      return null;
+    }
+    throw e;
+  }
+}
+
+/**
  * Fetches a batch of categories from the Zendesk API.
  */
 export async function fetchZendeskCategoriesInBrand(

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -120,12 +120,14 @@ export async function syncZendeskBrandActivity({
     );
   }
 
-  const zendeskApiClient = createZendeskClient(
-    await getZendeskSubdomainAndAccessToken(connector.connectionId)
+  const { subdomain, accessToken } = await getZendeskSubdomainAndAccessToken(
+    connector.connectionId
   );
-  const {
-    result: { brand: fetchedBrand },
-  } = await zendeskApiClient.brand.show(brandId);
+  const fetchedBrand = await fetchZendeskBrand({
+    subdomain,
+    accessToken,
+    brandId,
+  });
 
   // if the brand is not on Zendesk anymore, we delete it
   if (!fetchedBrand) {


### PR DESCRIPTION
## Description

- This PR improves handling of 403 errors by using our wrapper instead of the library `node-zendesk`, which does not have the good stuff (useful errors, correct bubbling up).
- In an effort to get rid of the dependency to `node-zendesk`, this PR squeezes out a few other calls to `node-zendesk`.

## Tests

- Forced a sync of a brand on my local setup, check that the brand is correctly synced.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.