### PR TITLE
[Nodes core] Clean gdrive parents - script improvement

### DIFF
--- a/connectors/migrations/20250122_gdrive_clean_parents.ts
+++ b/connectors/migrations/20250122_gdrive_clean_parents.ts
@@ -188,7 +188,7 @@ async function processFilesBatch({
       }
       return 1;
     },
-    { concurrency: 16 }
+    { concurrency: 32 }
   );
   return result.reduce((acc, curr) => acc + curr, 0);
 }
@@ -233,7 +233,7 @@ async function processSheetsBatch({
       }
       return 1;
     },
-    { concurrency: 16 }
+    { concurrency: 32 }
   );
   return result.reduce((acc, curr) => acc + curr, 0);
 }


### PR DESCRIPTION
Description
---
script is too slow to update parents
if files are under a drive that we sync completely, then we don't need to update them. It's likely a lot of files are like that.

The script skips those files, and moves concurrency to 32

Risks
---
we risk missing files we should update. Let's (me+reviewer) check the logic twice.

Deploy
---
na
