### PR TITLE
[Microsoft] Fix: insert folder for spreadsheet

### DIFF
--- a/connectors/migrations/20250122_microsoft_spreadsheets_folder.ts
+++ b/connectors/migrations/20250122_microsoft_spreadsheets_folder.ts
@@ -1,33 +1,15 @@
-import {
-  concurrentExecutor,
-  getGoogleSheetTableId,
-  MIME_TYPES,
-} from "@dust-tt/types";
+import { concurrentExecutor, MIME_TYPES } from "@dust-tt/types";
 import _ from "lodash";
 import type { LoggerOptions } from "pino";
 import type pino from "pino";
 import { makeScript } from "scripts/helpers";
 
-import { getSourceUrlForGoogleDriveFiles } from "@connectors/connectors/google_drive";
-import { getLocalParents } from "@connectors/connectors/google_drive/lib";
-import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import {
-  updateDataSourceDocumentParents,
-  updateDataSourceTableParents,
-  upsertDataSourceFolder,
-} from "@connectors/lib/data_sources";
-import {
-  GoogleDriveFiles,
-  GoogleDriveFolders,
-  GoogleDriveSheet,
-} from "@connectors/lib/models/google_drive";
-import logger from "@connectors/logger/logger";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
-import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
 import { getParents } from "@connectors/connectors/microsoft/temporal/file";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
 
 async function migrateConnector(
   connector: ConnectorResource,

--- a/connectors/migrations/20250122_microsoft_spreadsheets_folder.ts
+++ b/connectors/migrations/20250122_microsoft_spreadsheets_folder.ts
@@ -1,0 +1,117 @@
+import {
+  concurrentExecutor,
+  getGoogleSheetTableId,
+  MIME_TYPES,
+} from "@dust-tt/types";
+import _ from "lodash";
+import type { LoggerOptions } from "pino";
+import type pino from "pino";
+import { makeScript } from "scripts/helpers";
+
+import { getSourceUrlForGoogleDriveFiles } from "@connectors/connectors/google_drive";
+import { getLocalParents } from "@connectors/connectors/google_drive/lib";
+import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import {
+  updateDataSourceDocumentParents,
+  updateDataSourceTableParents,
+  upsertDataSourceFolder,
+} from "@connectors/lib/data_sources";
+import {
+  GoogleDriveFiles,
+  GoogleDriveFolders,
+  GoogleDriveSheet,
+} from "@connectors/lib/models/google_drive";
+import logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
+import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
+import { getParents } from "@connectors/connectors/microsoft/temporal/file";
+
+async function migrateConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  parentLogger: pino.Logger<LoggerOptions & pino.ChildLoggerOptions>
+) {
+  const logger = parentLogger.child({ connectorId: connector.id });
+  logger.info("Starting migration");
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const spreadsheets = await MicrosoftNodeModel.findAll({
+    where: {
+      connectorId: connector.id,
+      nodeType: "worksheet",
+    },
+    attributes: ["internalId", "parentInternalId"],
+  });
+  // get unique parentInternalIds
+  const uniqueParentInternalIds = _.uniq(
+    spreadsheets.map((s) => s.parentInternalId ?? "error")
+  );
+
+  if (uniqueParentInternalIds.filter((id) => id === "error").length > 0) {
+    throw new Error("Error getting unique parentInternalIds");
+  }
+
+  const result = await concurrentExecutor(
+    uniqueParentInternalIds,
+    async (parentSpreadsheetId): Promise<number> => {
+      const parentSpreadsheet = await MicrosoftNodeResource.fetchByInternalId(
+        connector.id,
+        parentSpreadsheetId
+      );
+      if (!parentSpreadsheet) {
+        return 0;
+      }
+      const parents = await getParents({
+        connectorId: connector.id,
+        internalId: parentSpreadsheet.internalId,
+        startSyncTs: 0,
+      });
+      await upsertDataSourceFolder({
+        dataSourceConfig,
+        folderId: parentSpreadsheetId,
+        title: parentSpreadsheet.name ?? "Untitled spreadsheet",
+        parents,
+        parentId: parents[1] ?? null,
+        mimeType: MIME_TYPES.MICROSOFT.SPREADSHEET,
+        sourceUrl: parentSpreadsheet.webUrl ?? undefined,
+      });
+      return 1;
+    },
+    { concurrency: 32 }
+  );
+  return {
+    upserted: result.reduce((acc, curr) => acc + curr, 0),
+    notFound: result.filter((r) => r === 0).length,
+    total: uniqueParentInternalIds.length,
+  };
+}
+
+makeScript(
+  {
+    startId: { type: "number", demandOption: false },
+  },
+  async ({ execute, startId }, logger) => {
+    logger.info("Starting backfill");
+    const connectors = await ConnectorResource.listByType("microsoft", {});
+    // sort connectors by id
+    connectors.sort((a, b) => a.id - b.id);
+    // start from startId if provided
+    const startIndex = startId
+      ? connectors.findIndex((c) => c.id === startId)
+      : 0;
+    if (startIndex === -1) {
+      throw new Error(`Connector with id ${startId} not found`);
+    }
+    const slicedConnectors = connectors.slice(startIndex);
+    for (const connector of slicedConnectors) {
+      const result = await migrateConnector(connector, execute, logger);
+      logger.info(
+        { connectorId: connector.id, result },
+        "Backfilled connector"
+      );
+    }
+  }
+);

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -461,6 +461,10 @@ export async function deleteFile({
     file.mimeType === "text/csv"
   ) {
     await deleteAllSheets(dataSourceConfig, file);
+    await deleteDataSourceFolder({
+      dataSourceConfig,
+      folderId: file.internalId,
+    });
   } else {
     await deleteDataSourceDocument(dataSourceConfig, internalId);
   }

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -88,7 +88,7 @@ export const MIME_TYPES = {
   }),
   MICROSOFT: getMimeTypes({
     provider: "microsoft",
-    resourceTypes: ["FOLDER"], // for files and spreadsheets, we keep Microsoft's mime types
+    resourceTypes: ["FOLDER", "SPREADSHEET"], // for files and spreadsheets, we keep Microsoft's mime types
   }),
   NOTION: getMimeTypes({
     provider: "notion",

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -88,7 +88,10 @@ export const MIME_TYPES = {
   }),
   MICROSOFT: getMimeTypes({
     provider: "microsoft",
-    resourceTypes: ["FOLDER", "SPREADSHEET"], // for files and spreadsheets, we keep Microsoft's mime types
+    // for files, we keep Microsoft's mime types Spreadsheets, that contain many
+    // sheet, resemble folders and are stored as such, but with the special
+    // mimetype below
+    resourceTypes: ["FOLDER", "SPREADSHEET"],
   }),
   NOTION: getMimeTypes({
     provider: "notion",


### PR DESCRIPTION
Description
---
Closes #10150
Similar to #10009

To browse individual sheets, we must store the existence of the parent spreadsheet. It is stored as a folder (includes backfill)

Risk
---
low, risk having unwarranted folders which we can see easily / change easily

Deploy
---
connectors
run backfill
