### PR TITLE
Upgrade tika dev to use OCR, fallback to original file if no processed file content

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     ports:
       - 6379:6379
   apache-tika:
-    image: apache/tika:2.9.2.1
+    image: apache/tika:2.9.2.1-full
     ports:
       - "9998:9998"
   elasticsearch:


### PR DESCRIPTION
## Description

Upgrade tika image to use the full version (which does OCR) so we support extracting text from PDF images (and more).
There is an infra PR to do the same in prod.

Also updated a bit the file include to render the original file if the processed file has no content (we will usually hit the size limit but it's worth trying)

## Tests

I have a PDF where the text is an image, it wasn't working before, i updated my tika locally, it's working now.

## Risk

Low

## Deploy Plan

Deploy `front`