### PR TITLE
[front] Show prompt when clicking on login

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -115,7 +115,7 @@ export default function LandingLayout({
               label="Sign in"
               icon={LoginIcon}
               onClick={() => {
-                window.location.href = `/api/auth/login?returnTo=${postLoginReturnToUrl}`;
+                window.location.href = `/api/auth/login?prompt=login&returnTo=${postLoginReturnToUrl}`;
               }}
             />
           </div>


### PR DESCRIPTION
## Description

prompt=login is not enabled by default (to support multi regions flow), enable it when the user click on "Sign in" so that we always display the login popup here.

## Tests

- Login without any session anywhere
- Login after logout (should display login window again)
- Login while logged on other region (should also display login) 
- Login with user from different region (should be redirected to proper region)

## Risk

none

## Deploy Plan

deploy  front
