### PR TITLE
[CoreNodes] Omit special cases from the logged diff

### DIFF
--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -209,7 +209,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
                 })
               : null,
             title: getDisplayNameForFolder(folder),
-            sourceUrl: null,
+            sourceUrl: folder.url,
             expandable: true,
             permission: "read",
             type: "folder",

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -50,15 +50,13 @@ export function computeNodesDiff({
   provider: ConnectorProvider | null;
   localLogger: typeof logger;
 }) {
+  const missingInternalIds: string[] = [];
   connectorsContentNodes.forEach((connectorsNode) => {
     const coreNodes = coreContentNodes.filter(
       (coreNode) => coreNode.internalId === connectorsNode.internalId
     );
     if (coreNodes.length === 0) {
-      localLogger.info(
-        { internalId: connectorsNode.internalId },
-        "[CoreNodes] No core content node matching this internal ID"
-      );
+      missingInternalIds.push(connectorsNode.internalId);
     } else if (coreNodes.length > 1) {
       // this one should never ever happen, it's a real red flag
       localLogger.info(
@@ -137,6 +135,12 @@ export function computeNodesDiff({
       }
     }
   });
+  if (missingInternalIds.length > 0) {
+    localLogger.info(
+      { missingInternalIds },
+      "[CoreNodes] Missing nodes from core"
+    );
+  }
   const extraCoreInternalIds = coreContentNodes
     .filter(
       (coreNode) =>

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -92,6 +92,16 @@ export function computeNodesDiff({
             if (key === "expandable" && value === true && coreValue === false) {
               return false;
             }
+            // Special case for Slack's providerVisibility: we only check if providerVisibility === "private" so
+            // having a falsy value in core and "public" in connectors is the same.
+            if (
+              key === "providerVisibility" &&
+              provider === "slack" &&
+              value === "public" &&
+              !coreValue
+            ) {
+              return false;
+            }
             if (Array.isArray(value) && Array.isArray(coreValue)) {
               return JSON.stringify(value) !== JSON.stringify(coreValue);
             }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -87,6 +87,11 @@ export function computeNodesDiff({
               return false;
             }
             const coreValue = coreNode[key as keyof DataSourceViewContentNode];
+            // Special case for expandable: if the core node is not expandable and the connectors one is, it means
+            // that the difference comes from the fact that the node has no children: we omit from the log.
+            if (key === "expandable" && value === true && coreValue === false) {
+              return false;
+            }
             if (Array.isArray(value) && Array.isArray(coreValue)) {
               return JSON.stringify(value) !== JSON.stringify(coreValue);
             }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -102,6 +102,16 @@ export function computeNodesDiff({
             ) {
               return false;
             }
+            // Special case for Slack's permission:
+            // connectors uses "read_write" for selected nodes whereas we always set it to "read" for nodes from core.
+            if (
+              key === "permission" &&
+              provider === "slack" &&
+              value === "read_write" &&
+              coreValue === "read"
+            ) {
+              return false;
+            }
             if (Array.isArray(value) && Array.isArray(coreValue)) {
               return JSON.stringify(value) !== JSON.stringify(coreValue);
             }


### PR DESCRIPTION
## Description

- This PR adds the following exclusion rules from the diff logged in front:
  - `expandable`, in the case where `core`'s node is not expandable and `connectors`' is.
  - `providerVisibility` for Slack if falsy in core and "public" in connectors: `undefined`/`null` means public by default.
  - `permission` for Slack if equal to "read_write" in connectors and "read" in core, as per the [design doc](https://www.notion.so/dust-tt/Design-Doc-Moving-nodes-from-connectors-to-core-17328599d941803fbbdfef92b548529f?pvs=4#17528599d94180b5bc6fc52020b67b47) this is not currently relied on in front.
- In this case `core` is more accurate: it anticipates on the fact that the node has no children.
- Note that the case `connectors` not expandable and `core` expandable is not excluded here since this is a change in behavior.
- This PR also adds the `sourceUrl` in the content nodes returned by connectors for Webcrawler folders. This pops up in the log, and adding it to connectors is less effort than removing it from the log (although both small).
- This PR also groups the missing nodes logs in a single log instead of having one log "No core content node matching this internal ID" for each node that is missing.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy front.
- Deploy connectors.