### PR TITLE
[sparkle] - chore: ditch z-index classes

### DIFF
--- a/sparkle/.eslintrc.js
+++ b/sparkle/.eslintrc.js
@@ -25,20 +25,11 @@ module.exports = {
       "error",
       {
         groups: [
-          // Side effect imports.
           ["^\\u0000"],
-          // Node.js builtins prefixed with `node:`.
           ["^node:"],
-          // Packages.
-          // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
           ["^@?\\w"],
-          // @sparkle imports.
           ["^@sparkle"],
-          // Absolute imports and other imports such as Vue-style `@/foo`.
-          // Anything not matched in another group.
           ["^"],
-          // Relative imports.
-          // Anything that starts with a dot.
           ["^\\."],
         ],
       },
@@ -49,6 +40,13 @@ module.exports = {
       "error",
       {
         patterns: ["*/index_with_tw_base"],
+      },
+    ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector: "JSXAttribute[name.name='className'] Literal[value=/\\bs-z-/]",
+        message: "Usage of s-z- tailwind classes (z-index) is forbidden.",
       },
     ],
   },

--- a/sparkle/.eslintrc.js
+++ b/sparkle/.eslintrc.js
@@ -45,7 +45,8 @@ module.exports = {
     "no-restricted-syntax": [
       "error",
       {
-        selector: "JSXAttribute[name.name='className'] Literal[value=/\\bs-z-/]",
+        selector:
+          "JSXAttribute[name.name='className'] Literal[value=/\\bs-z-/]",
         message: "Usage of s-z- tailwind classes (z-index) is forbidden.",
       },
     ],

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.372",
+  "version": "0.2.373",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.372",
+      "version": "0.2.373",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.372",
+  "version": "0.2.373",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/BarHeader.tsx
+++ b/sparkle/src/components/BarHeader.tsx
@@ -35,7 +35,7 @@ export function BarHeader({
   return (
     <div
       className={classNames(
-        "s-fixed s-left-0 s-right-0 s-top-0 s-z-30 s-flex s-h-16 s-flex-row s-items-center s-gap-3 s-border-b s-px-4 s-backdrop-blur",
+        "s-fixed s-left-0 s-right-0 s-top-0 s-flex s-h-16 s-flex-row s-items-center s-gap-3 s-border-b s-px-4 s-backdrop-blur",
         "s-border-structure-300/30 s-bg-white/80",
         "dark:s-border-structure-300-dark/30 dark:s-bg-structure-50-dark/80",
         className

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -80,7 +80,6 @@ const CitationIndex = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "s-z-10",
         "s-flex s-h-4 s-w-4 s-items-center s-justify-center s-rounded-full s-bg-primary-600 s-text-xs s-font-medium s-text-primary-200",
         className
       )}
@@ -158,7 +157,7 @@ const CitationImage = React.forwardRef<HTMLDivElement, CitationImageProps>(
         <div
           className={cn(
             "s-absolute s-inset-0",
-            "s-z-0 s-h-full s-w-full",
+            "s-h-full s-w-full",
             "s-bg-primary-100/80",
             "s-backdrop-blur-sm",
             "s-transition s-duration-200",
@@ -197,7 +196,7 @@ const CitationLoading = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "s-absolute s-inset-0 s-z-20 s-flex s-h-full s-w-full s-items-center s-justify-center s-rounded-xl s-bg-primary-100/80 s-backdrop-blur-sm",
+        "s-absolute s-inset-0 s-flex s-h-full s-w-full s-items-center s-justify-center s-rounded-xl s-bg-primary-100/80 s-backdrop-blur-sm",
         className
       )}
       {...props}
@@ -218,7 +217,6 @@ const CitationTitle = React.forwardRef<HTMLDivElement, CitationTitleProps>(
       <div
         ref={ref}
         className={cn(
-          "s-z-10",
           "s-line-clamp-1 s-overflow-hidden s-text-ellipsis s-break-all",
           "s-text-sm s-font-medium s-text-foreground",
           className
@@ -245,7 +243,6 @@ const CitationDescription = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "s-z-10",
         "s-line-clamp-1 s-overflow-hidden s-text-ellipsis",
         "s-text-xs s-font-normal s-text-muted-foreground",
         className

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -18,7 +18,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "s-fixed s-inset-0 s-z-50 s-bg-muted-foreground/75 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
+      "s-fixed s-inset-0 s-bg-muted-foreground/75 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
       className
     )}
     {...props}
@@ -37,7 +37,7 @@ const sizeClasses: Record<DialogSizeType, string> = {
 };
 
 const dialogVariants = cva(
-  "s-fixed s-left-[50%] s-top-[50%] s-z-50 s-grid s-w-full s-overflow-hidden s-rounded-2xl s-border s-border-border s-translate-x-[-50%] s-translate-y-[-50%] s-border s-bg-background s-p-2 s-shadow-lg s-duration-200 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 data-[state=closed]:s-slide-out-to-left-1/2 data-[state=closed]:s-slide-out-to-top-[48%] data-[state=open]:s-slide-in-from-left-1/2 data-[state=open]:s-slide-in-from-top-[48%] s-sm:rounded-lg",
+  "s-fixed s-left-[50%] s-top-[50%] s-grid s-w-full s-overflow-hidden s-rounded-2xl s-border s-border-border s-translate-x-[-50%] s-translate-y-[-50%] s-border s-bg-background s-p-2 s-shadow-lg s-duration-200 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 data-[state=closed]:s-slide-out-to-left-1/2 data-[state=closed]:s-slide-out-to-top-[48%] data-[state=open]:s-slide-in-from-left-1/2 data-[state=open]:s-slide-in-from-top-[48%] s-sm:rounded-lg",
   {
     variants: {
       size: sizeClasses,
@@ -94,7 +94,7 @@ const DialogHeader = ({
 }: NewDialogHeaderProps) => (
   <div
     className={cn(
-      "s-z-50 s-flex s-flex-none s-flex-col s-gap-0 s-p-5 s-text-left",
+      "s-flex s-flex-none s-flex-col s-gap-0 s-p-5 s-text-left",
       className
     )}
     {...props}

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -16,7 +16,7 @@ export const menuStyleClasses = {
   inset: "s-pl-8",
   container: cn(
     "s-rounded-xl s-border s-border-hovering s-bg-white s-p-1 s-text-primary-950",
-    "s-z-50 s-min-w-[8rem] s-overflow-hidden",
+    "s-min-w-[8rem] s-overflow-hidden",
     "data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 data-[side=bottom]:s-slide-in-from-top-2 data-[side=left]:s-slide-in-from-right-2 data-[side=right]:s-slide-in-from-left-2 data-[side=top]:s-slide-in-from-bottom-2"
   ),
   item: cva(

--- a/sparkle/src/components/DropzoneOverlay.tsx
+++ b/sparkle/src/components/DropzoneOverlay.tsx
@@ -42,7 +42,7 @@ export default function DropzoneOverlay({
 
   return (
     <div
-      className="s-absolute s-inset-0 s-z-50 s-flex s-h-full s-w-full s-flex-col s-items-center s-justify-center s-gap-0 s-bg-white/80 s-text-element-800"
+      className="s-absolute s-inset-0 s-flex s-h-full s-w-full s-flex-col s-items-center s-justify-center s-gap-0 s-bg-white/80 s-text-element-800"
       onMouseLeave={() => {
         lottieRef.current?.setDirection(-1);
         lottieRef.current?.setSpeed(2);

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -129,7 +129,7 @@ export function Modal({
     <Transition show={isOpen} as={Fragment} appear={true}>
       <Dialog
         as="div"
-        className="s-fixed s-absolute s-inset-0 s-z-50 s-overflow-hidden"
+        className="s-fixed s-absolute s-inset-0 s-overflow-hidden"
         onClose={() => {
           // Close modal on outside click if no changes or not an alert.
           if (!hasChanged && !alertModal) {

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -157,7 +157,7 @@ const variantStyles = cva("", {
       secondary: "s-text-muted-foreground",
     },
     isSticky: {
-      true: "s-sticky s-top-0 s-z-10 s-border-b s-border-border-dark/80 s-bg-structure-100/90 s-backdrop-blur-sm",
+      true: "s-sticky s-top-0 s-border-b s-border-border-dark/80 s-bg-structure-100/90 s-backdrop-blur-sm",
     },
   },
   defaultVariants: {

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -116,7 +116,7 @@ function NotificationsList({
   notifications: (NotificationType & { id: string })[];
 }) {
   return (
-    <div className="s-pointer-events-none s-fixed s-bottom-0 s-right-0 s-z-60 s-w-96">
+    <div className="s-pointer-events-none s-fixed s-bottom-0 s-right-0 s-w-96">
       <div className="s-flex s-flex-col s-items-center s-justify-center s-gap-4 s-p-4">
         {notifications.map((n) => {
           return (

--- a/sparkle/src/components/Popover.tsx
+++ b/sparkle/src/components/Popover.tsx
@@ -38,7 +38,7 @@ const PopoverContent = React.forwardRef<
           "data-[side=left]:s-slide-in-from-right-2",
           "data-[side=right]:s-slide-in-from-left-2",
           "data-[side=top]:s-slide-in-from-bottom-2",
-          "s-z-50 s-rounded-xl s-border s-bg-background s-text-primary-950 s-shadow-md s-outline-none",
+          "s-rounded-xl s-border s-bg-background s-text-primary-950 s-shadow-md s-outline-none",
           fullWidth ? "s-grow" : "s-w-72 s-p-4",
           className
         )}

--- a/sparkle/src/components/Popup.tsx
+++ b/sparkle/src/components/Popup.tsx
@@ -40,7 +40,7 @@ export function Popup({
     >
       <div
         className={classNames(
-          "s-z-30 s-flex s-w-64 s-flex-col s-gap-3 s-rounded-xl s-border s-border-pink-100 s-bg-pink-50 s-p-4 s-shadow-xl",
+          "s-flex s-w-64 s-flex-col s-gap-3 s-rounded-xl s-border s-border-pink-100 s-bg-pink-50 s-p-4 s-shadow-xl",
           className || ""
         )}
       >

--- a/sparkle/src/components/RainbowEffect.tsx
+++ b/sparkle/src/components/RainbowEffect.tsx
@@ -48,7 +48,7 @@ export function RainbowEffect({
   const selectedSize = sizeStyles[size];
 
   const rainbowClassBlur = cn(
-    "s-absolute s-bottom-[14%] s-left-1/2 s-z-0 s--translate-x-1/2 s-animate-rainbow s-bg-rainbow-gradient s-bg-[length:200%]",
+    "s-absolute s-bottom-[14%] s-left-1/2 s--translate-x-1/2 s-animate-rainbow s-bg-rainbow-gradient s-bg-[length:200%]",
     "s-transition-all",
     selectedSize.height,
     selectedSize.width,

--- a/sparkle/src/components/Resizable.tsx
+++ b/sparkle/src/components/Resizable.tsx
@@ -35,7 +35,7 @@ const ResizableHandle = ({
     {...props}
   >
     {withHandle && (
-      <div className="s-z-10 s-flex s-h-4 s-w-3 s-items-center s-justify-center s-rounded-sm s-border s-bg-border">
+      <div className="s-flex s-h-4 s-w-3 s-items-center s-justify-center s-rounded-sm s-border s-bg-border">
         <Icon visual={GrabIcon} size="xs" />
       </div>
     )}

--- a/sparkle/src/components/ScrollArea.tsx
+++ b/sparkle/src/components/ScrollArea.tsx
@@ -28,7 +28,7 @@ const ScrollArea = React.forwardRef<
   return (
     <ScrollAreaPrimitive.Root
       ref={ref}
-      className={cn("s-relative s-z-20 s-overflow-hidden", className)}
+      className={cn("s-relative s-overflow-hidden", className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport className="s-h-full s-w-full s-rounded-[inherit]">

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "s-fixed s-inset-0 s-z-50 s-bg-muted-foreground/75 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
+      "s-fixed s-inset-0 s-bg-muted-foreground/75 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
       className
     )}
     {...props}
@@ -45,7 +45,7 @@ const sizeClasses: Record<SheetSizeType, string> = {
 };
 
 const sheetVariants = cva(
-  "s-fixed s-z-50 s-overflow-hidden s-bg-background s-transition s-ease-in-out data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-duration-300 data-[state=open]:s-duration-500 s-flex s-flex-col s-h-full s-w-full",
+  "s-fixed s-overflow-hidden s-bg-background s-transition s-ease-in-out data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-duration-300 data-[state=open]:s-duration-500 s-flex s-flex-col s-h-full s-w-full",
   {
     variants: {
       side: {
@@ -103,7 +103,7 @@ const SheetHeader = ({
 }: SheetHeaderProps) => (
   <div
     className={cn(
-      "s-z-50 s-flex s-flex-none s-flex-col s-gap-2 s-bg-background s-p-5 s-text-left s-shadow-tale-white",
+      "s-flex s-flex-none s-flex-col s-gap-2 s-bg-background s-p-5 s-text-left s-shadow-tale-white",
       className
     )}
     {...props}

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -21,7 +21,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={classNames(
-      "s-z-50 s-max-w-sm s-overflow-hidden s-whitespace-pre-wrap s-break-words s-rounded-md s-border s-bg-white s-px-3 s-py-1.5 s-text-sm s-shadow-md",
+      "s-max-w-sm s-overflow-hidden s-whitespace-pre-wrap s-break-words s-rounded-md s-border s-bg-white s-px-3 s-py-1.5 s-text-sm s-shadow-md",
       "s-animate-in s-fade-in-0 s-zoom-in-95",
       "data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=closed]:s-zoom-out-95 data-[side=bottom]:s-slide-in-from-top-2 data-[side=left]:s-slide-in-from-right-2 data-[side=right]:s-slide-in-from-left-2 data-[side=top]:s-slide-in-from-bottom-2",
       className || ""

--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -96,7 +96,7 @@ export function ContentBlockWrapper({
         className
       )}
     >
-      <div className="s-sticky s-top-11 s-z-[1] s-h-0">
+      <div className="s-sticky s-top-11 s-h-0">
         <div
           id="BlockActions"
           className="s-absolute s-bottom-0 s-right-2 s-flex s-h-11 s-items-center s-gap-1 s-py-2"
@@ -122,7 +122,7 @@ export function ContentBlockWrapper({
           )}
         </div>
       </div>
-      <div className={cn("s-z-0 s-w-full", innerClassName)}>{children}</div>
+      <div className={cn("s-w-full", innerClassName)}>{children}</div>
     </div>
   );
 }

--- a/sparkle/src/stories/AnimatedText.stories.tsx
+++ b/sparkle/src/stories/AnimatedText.stories.tsx
@@ -13,7 +13,7 @@ export default meta;
 export function AnimatedShinyTextDemo() {
   return (
     <div className="s-flex s-gap-3">
-      <div className="s-z-10 s-flex s-min-h-64 s-flex-col s-items-center s-justify-center s-gap-4">
+      <div className="s-flex s-min-h-64 s-flex-col s-items-center s-justify-center s-gap-4">
         <div className="s-rounded-2xl s-bg-muted s-p-4">
           <AnimatedText>Thinking...</AnimatedText>
         </div>
@@ -26,7 +26,7 @@ export function AnimatedShinyTextDemo() {
           <AnimatedText>Thinking a long long long long time</AnimatedText>
         </div>
       </div>
-      <div className="s-z-10 s-flex s-min-h-64 s-flex-col s-items-center s-justify-center s-gap-4">
+      <div className="s-flex s-min-h-64 s-flex-col s-items-center s-justify-center s-gap-4">
         <div className="s-rounded-2xl s-bg-highlight-50 s-p-4">
           <AnimatedText variant="highlight">Thinking...</AnimatedText>
         </div>


### PR DESCRIPTION
## Description

This PR aims at ditching all existing z-indexes on sparkle components and to add a linting rule to prevent from adding new ones.

As we are not doing anything extremely fancy for now there should be no need to use z-indexes. Also, adding z-indexes conflicts with indexes from Radix.

## Risk

Quite important blast radius UX wise

## Deploy Plan

- Publish sparkle RC
- Upgrade front 
- Publish sparkle
