### PR TITLE
[CoresNodes] Make nodes for Slack channels and GitHub issues/discussions non-expandable

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -12,6 +12,8 @@ import type logger from "@app/logger/logger";
 
 export const NON_EXPANDABLE_NODES_MIME_TYPES = [
   MIME_TYPES.SLACK.CHANNEL,
+  MIME_TYPES.GITHUB.DISCUSSIONS,
+  MIME_TYPES.GITHUB.ISSUES,
 ] as readonly string[];
 
 export function getContentNodeInternalIdFromTableId(

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -10,6 +10,10 @@ import { assertNever, MIME_TYPES } from "@dust-tt/types";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type logger from "@app/logger/logger";
 
+export const NON_EXPANDABLE_NODES_MIME_TYPES = [
+  MIME_TYPES.SLACK.CHANNEL,
+] as readonly string[];
+
 export function getContentNodeInternalIdFromTableId(
   dataSourceView: DataSourceViewResource | DataSourceViewType,
   tableId: string

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -15,6 +15,7 @@ import {
   computeNodesDiff,
   getContentNodeInternalIdFromTableId,
   getContentNodeMetadata,
+  NON_EXPANDABLE_NODES_MIME_TYPES,
 } from "@app/lib/api/content_nodes";
 import type { OffsetPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
@@ -225,7 +226,9 @@ async function getContentNodesForDataSourceViewFromCore(
         providerVisibility: node.provider_visibility,
         parentInternalIds: node.parents,
         type,
-        expandable: node.has_children,
+        expandable:
+          !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
+          node.has_children,
       };
     }),
     total: coreRes.value.nodes.length,


### PR DESCRIPTION
## Description

- In the content nodes returned by connectors, Slack channels are never expandable (business logic).
- The same goes for GitHub issues and discussions.
- The default used by core is to make a node expandable if it has children, which creates a discrepancy logged [here](https://app.datadoghq.eu/logs?query=CoreNodes%20%40provider%3Aslack%20%40internalId%3Aslack-channel-%2A%20%40diff.expandable.connectors%3Afalse%20%40diff.expandable.core%3Atrue&agg_m=count&agg_m_source=base&agg_q=%40provider&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1737721912334&to_ts=1737725512334&live=true).
- This PR adds an exclusion rule for Slack.

## Tests


## Risk

- n/a, shadow read only.

## Deploy Plan

- Deploy front.