### PR TITLE
[CoresNodes] Ignore discrepancies in parents in static data sources

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -85,6 +85,11 @@ export function computeNodesDiff({
               return false;
             }
             const coreValue = coreNode[key as keyof DataSourceViewContentNode];
+            // Special case for folder parents, the ones retrieved using getContentNodesForStaticDataSourceView do not
+            // contain any parentInternalIds.
+            if (provider === null && key === "parentInternalIds" && !value) {
+              return false;
+            }
             // Special case for expandable: if the core node is not expandable and the connectors one is, it means
             // that the difference comes from the fact that the node has no children: we omit from the log.
             if (key === "expandable" && value === true && coreValue === false) {


### PR DESCRIPTION
## Description

- `getContentNodesForStaticDataSourceView` does not populate the `parentInternalIds` field, whereas the content nodes we retrieve from core's search endpoint do (with only one parent equal to the node ID).
- This discrepancy shows up in the log, this PR removes it from the log.

## Tests

n/a

## Risk

- n/a, only affects the log in the shadow read.

## Deploy Plan

- Deploy front.