### PR TITLE
Implement viewType-based filtering in `getContentNodesForDatasourceViewFromCore`

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -407,6 +407,7 @@ export async function getContentNodesForDataSourceView(
     dataSourceId: dataSourceView.dataSource.sId,
     dataSourceViewId: dataSourceView.sId,
     provider: dataSourceView.dataSource.connectorProvider,
+    viewType: params.viewType,
   });
 
   // shadow read from core

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -1,5 +1,6 @@
 import type {
   ContentNodesViewType,
+  CoreAPIContentNode,
   CoreAPIDatasourceViewFilter,
   CoreAPIError,
   DataSourceViewContentNode,
@@ -7,7 +8,14 @@ import type {
   PatchDataSourceViewType,
   Result,
 } from "@dust-tt/types";
-import { ConnectorsAPI, CoreAPI, Err, Ok, removeNulls } from "@dust-tt/types";
+import {
+  assertNever,
+  ConnectorsAPI,
+  CoreAPI,
+  Err,
+  Ok,
+  removeNulls,
+} from "@dust-tt/types";
 import assert from "assert";
 
 import config from "@app/lib/api/config";
@@ -157,6 +165,22 @@ async function getContentNodesForManagedDataSourceView(
   }
 }
 
+function filterNodesByViewType(
+  nodes: CoreAPIContentNode[],
+  viewType: ContentNodesViewType
+) {
+  switch (viewType) {
+    case "documents":
+      return nodes;
+    case "tables":
+      return nodes.filter(
+        (node) => node.has_children || node.node_type === "Table"
+      );
+    default:
+      assertNever(viewType);
+  }
+}
+
 function makeCoreDataSourceViewFilter(
   dataSourceView: DataSourceViewResource | DataSourceViewType
 ): CoreAPIDatasourceViewFilter {
@@ -213,8 +237,10 @@ async function getContentNodesForDataSourceViewFromCore(
     return new Err(new Error(coreRes.error.message));
   }
 
+  const filteredNodes = filterNodesByViewType(coreRes.value.nodes, viewType);
+
   return new Ok({
-    nodes: coreRes.value.nodes.map((node) => {
+    nodes: filteredNodes.map((node) => {
       const { type } = getContentNodeMetadata(node, viewType);
       return {
         internalId: node.node_id,


### PR DESCRIPTION
## Description

- Closes [#10152](https://github.com/dust-tt/dust/issues/10152)
- This PR implements the following logic in `getContentNodesForDatasourceViewFromCore`: in `"tables"` view type, we only keep the nodes that are tables or nodes that have children (because they may have tables in their descendants), in `"documents"` view type we keep all nodes.
- The logic this PR replicates is currently spread across all connectors, a check has confirmed that only Google Drive, Notion ([here](https://github.com/dust-tt/dust/blob/d6a509c5ae0f7ec8b25d83549dfbbb7ac7728fb3/connectors/src/connectors/notion/index.ts#L473)) and Microsoft implement a logic based on this view type.
- Note: the logic implemented in this PR may be slightly off, which we'll monitor using the logged diff, and we expect to allow certain differences for the sake of having one single readable way of doing things.

## Tests

## Risk

- none at the moment (shadow-read).

## Deploy Plan

- Deploy front.
