### PR TITLE
Add ability to sync templates from US

### DIFF
--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -97,6 +97,14 @@ export function TemplatesDataTable() {
       <div className="flex w-full items-center justify-between gap-3">
         <h2 className="text-md flex-grow pb-4 font-bold">Templates:</h2>
         <PokeButton
+          aria-label="Pull templates"
+          variant="outline"
+          size="sm"
+          asChild
+        >
+          <Link href="/poke/templates/new">Pull templates</Link>
+        </PokeButton>
+        <PokeButton
           aria-label="Create template"
           variant="outline"
           size="sm"

--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import React, { useState } from "react";
 
 import { PokeButton } from "@app/components/poke/shadcn/ui/button";
-import { usePokeRegion } from "@app/lib/swr/poke";
+import { config } from "@app/lib/api/regions/config";
 import { usePokeAssistantTemplates, usePokePullTemplates } from "@app/poke/swr";
 
 export interface TemplatesDisplayType {
@@ -94,13 +94,11 @@ export function TemplatesDataTable() {
   const data = prepareTemplatesForDisplay(assistantTemplates);
   const columns = makeColumnsForTemplates();
 
-  const { region } = usePokeRegion();
-
   return (
     <div className="border-material-200 my-4 flex w-full flex-col gap-2 rounded-lg border p-4">
       <div className="flex w-full items-center justify-between gap-3">
         <h2 className="text-md flex-grow pb-4 font-bold">Templates:</h2>
-        {region !== "us-central1" && (
+        {config.getDustRegionSyncEnabled() && (
           <PokeButton
             aria-label="Pull templates"
             variant="outline"

--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -6,7 +6,8 @@ import Link from "next/link";
 import React, { useState } from "react";
 
 import { PokeButton } from "@app/components/poke/shadcn/ui/button";
-import { usePokeAssistantTemplates } from "@app/poke/swr";
+import { usePokeRegion } from "@app/lib/swr/poke";
+import { usePokeAssistantTemplates, usePokePullTemplates } from "@app/poke/swr";
 
 export interface TemplatesDisplayType {
   id: string;
@@ -87,23 +88,32 @@ export function makeColumnsForTemplates() {
 export function TemplatesDataTable() {
   const { assistantTemplates, isAssistantTemplatesLoading } =
     usePokeAssistantTemplates();
+  const { doPull, isPulling } = usePokePullTemplates();
   const [templateSearch, setTemplateSearch] = useState<string>("");
 
   const data = prepareTemplatesForDisplay(assistantTemplates);
   const columns = makeColumnsForTemplates();
 
+  const { region } = usePokeRegion();
+
   return (
     <div className="border-material-200 my-4 flex w-full flex-col gap-2 rounded-lg border p-4">
       <div className="flex w-full items-center justify-between gap-3">
         <h2 className="text-md flex-grow pb-4 font-bold">Templates:</h2>
-        <PokeButton
-          aria-label="Pull templates"
-          variant="outline"
-          size="sm"
-          asChild
-        >
-          <Link href="/poke/templates/new">Pull templates</Link>
-        </PokeButton>
+        {region !== "us-central1" && (
+          <PokeButton
+            aria-label="Pull templates"
+            variant="outline"
+            size="sm"
+            disabled={isPulling}
+            asChild
+            onClick={async () => {
+              await doPull();
+            }}
+          >
+            <Link href="#">{isPulling ? <Spinner /> : "Pull templates"}</Link>
+          </PokeButton>
+        )}
         <PokeButton
           aria-label="Create template"
           variant="outline"

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -170,26 +170,6 @@ const config = {
   getStatusPageApiToken: (): string => {
     return EnvironmentConfig.getEnvVariable("STATUS_PAGE_API_TOKEN");
   },
-  getDustAppsSyncEnabled: (): boolean => {
-    return (
-      EnvironmentConfig.getOptionalEnvVariable("DUST_APPS_SYNC_ENABLED") ===
-      "true"
-    );
-  },
-  getDustAppsSyncMasterApiUrl: (): string => {
-    return EnvironmentConfig.getEnvVariable("DUST_APPS_SYNC_MASTER_API_URL");
-  },
-  getDustAppsSyncMasterWorkspaceId: (): string => {
-    return EnvironmentConfig.getEnvVariable(
-      "DUST_APPS_SYNC_MASTER_WORKSPACE_ID"
-    );
-  },
-  getDustAppsSyncMasterSpaceId: (): string => {
-    return EnvironmentConfig.getEnvVariable("DUST_APPS_SYNC_MASTER_SPACE_ID");
-  },
-  getDustAppsSyncMasterApiKey: (): string => {
-    return EnvironmentConfig.getEnvVariable("DUST_APPS_SYNC_MASTER_API_KEY");
-  },
 };
 
 export default config;

--- a/front/lib/api/regions/config.ts
+++ b/front/lib/api/regions/config.ts
@@ -34,4 +34,21 @@ export const config = {
       url: this.getRegionUrl(otherRegion),
     };
   },
+  getDustRegionSyncEnabled: (): boolean => {
+    return EnvironmentConfig.getEnvVariable("DUST_REGION") === "us-central1";
+  },
+  getDustRegionSyncMasterUrl: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_US_URL");
+  },
+  getDustAppsSyncMasterWorkspaceId: (): string => {
+    return EnvironmentConfig.getEnvVariable(
+      "DUST_APPS_SYNC_MASTER_WORKSPACE_ID"
+    );
+  },
+  getDustAppsSyncMasterSpaceId: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_APPS_SYNC_MASTER_SPACE_ID");
+  },
+  getDustAppsSyncMasterApiKey: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_APPS_SYNC_MASTER_API_KEY");
+  },
 };

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -122,6 +122,21 @@ export class TemplateResource extends BaseResource<TemplateModel> {
     });
   }
 
+  static async upsertByHandle(
+    blob: CreationAttributes<TemplateModel>
+  ): Promise<Result<TemplateResource, Error>> {
+    const existing = await TemplateModel.findOne({
+      where: { handle: blob.handle },
+    });
+
+    if (existing) {
+      await existing.update(blob);
+      return new Ok(new TemplateResource(TemplateModel, existing.get()));
+    }
+    const template = await TemplateResource.makeNew(blob);
+    return new Ok(template);
+  }
+
   static modelIdToSId({ id }: { id: ModelId }): string {
     return makeSId("template", {
       id,

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -8,9 +8,22 @@ import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
+import type { GetRegionResponseType } from "@app/pages/api/poke/region";
 import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
 import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
+
+export function usePokeRegion() {
+  const regionFetcher: Fetcher<GetRegionResponseType> = fetcher;
+
+  const { data, error } = useSWRWithDefaults("/api/poke/region", regionFetcher);
+
+  return {
+    region: useMemo(() => data?.region, [data]),
+    isRegionLoading: !error && !data,
+    isRegionError: error,
+  };
+}
 
 export function usePokeConnectorPermissions({
   owner,

--- a/front/lib/utils/apps.ts
+++ b/front/lib/utils/apps.ts
@@ -11,8 +11,9 @@ import {
 import { createParser } from "eventsource-parser";
 import _ from "lodash";
 
-import { default as apiConfig, default as config } from "@app/lib/api/config";
+import { default as config } from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
+import { config as regionConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
@@ -387,22 +388,22 @@ export async function synchronizeDustApps(
   auth: Authenticator,
   space: SpaceResource
 ): Promise<Result<ImportRes[], Error | CoreAPIError>> {
-  if (!apiConfig.getDustAppsSyncEnabled()) {
+  if (!regionConfig.getDustRegionSyncEnabled()) {
     return new Ok([]);
   }
 
   const syncMasterApi = new DustAPI(
-    apiConfig.getDustAPIConfig(),
+    config.getDustAPIConfig(),
     {
-      apiKey: apiConfig.getDustAppsSyncMasterApiKey(),
-      workspaceId: apiConfig.getDustAppsSyncMasterWorkspaceId(),
+      apiKey: regionConfig.getDustAppsSyncMasterApiKey(),
+      workspaceId: regionConfig.getDustAppsSyncMasterWorkspaceId(),
     },
     logger,
-    apiConfig.getDustAppsSyncMasterApiUrl()
+    regionConfig.getDustRegionSyncMasterUrl()
   );
 
   const exportRes = await syncMasterApi.exportApps({
-    appSpaceId: apiConfig.getDustAppsSyncMasterSpaceId(),
+    appSpaceId: regionConfig.getDustAppsSyncMasterSpaceId(),
   });
 
   if (exportRes.isErr()) {

--- a/front/pages/api/poke/region.test.ts
+++ b/front/pages/api/poke/region.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, vi } from "vitest";
+
+import { config } from "@app/lib/api/regions/config";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./region";
+
+vi.mock(import("../../../lib/api/regions/config"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    config: {
+      ...mod.config,
+      getCurrentRegion: vi.fn(),
+    },
+  };
+});
+
+describe("GET /api/poke/region", () => {
+  itInTransaction(
+    "returns correct region data when in us-central1",
+    async () => {
+      vi.mocked(config.getCurrentRegion).mockReturnValue("us-central1");
+      const { req, res } = await createPrivateApiMockRequest({
+        isSuperUser: true,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        region: "us-central1",
+      });
+    }
+  );
+
+  itInTransaction(
+    "returns correct region data when in europe-west1",
+    async () => {
+      vi.mocked(config.getCurrentRegion).mockReturnValue("europe-west1");
+      const { req, res } = await createPrivateApiMockRequest({
+        isSuperUser: true,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        region: "europe-west1",
+      });
+    }
+  );
+
+  itInTransaction("returns 200 when the user is a super user", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      region: expect.any(String),
+    });
+  });
+
+  itInTransaction("returns 404 when the user is not a super user", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      isSuperUser: false,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  });
+
+  itInTransaction("only supports GET method", async () => {
+    for (const method of ["DELETE", "POST", "PUT", "PATCH"] as const) {
+      const { req, res } = await createPrivateApiMockRequest({
+        method,
+        isSuperUser: true,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+    }
+  });
+});

--- a/front/pages/api/poke/region.ts
+++ b/front/pages/api/poke/region.ts
@@ -1,0 +1,50 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import { config } from "@app/lib/api/regions/config";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+
+export type GetRegionResponseType = {
+  region: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetRegionResponseType>>,
+  session: SessionWithUser
+) {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const currentRegion = config.getCurrentRegion();
+
+      return res.status(200).json({
+        region: currentRegion,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -1,0 +1,108 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { EnvironmentConfig } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import { config } from "@app/lib/api/regions/config";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { TemplateResource } from "@app/lib/resources/template_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
+import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
+
+export type PullTemplatesResponseBody = {
+  success: true;
+  count: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PullTemplatesResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  const currentRegion = config.getCurrentRegion();
+  if (currentRegion === "us-central1") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "This endpoint can only be called from non-main regions.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const mainRegionUrl = EnvironmentConfig.getEnvVariable("DUST_US_URL");
+      const response = await fetch(`${mainRegionUrl}/api/templates`, {
+        method: "GET",
+      });
+
+      if (!response.ok) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to fetch templates from main region.",
+          },
+        });
+      }
+
+      const templatesResponse: FetchAssistantTemplatesResponse =
+        await response.json();
+      let count = 0;
+
+      for (const templateFromList of templatesResponse.templates) {
+        const templateResponse = await fetch(
+          `${mainRegionUrl}/api/templates/${templateFromList.sId}`,
+          {
+            method: "GET",
+          }
+        );
+
+        if (!templateResponse.ok) {
+          logger.error(
+            `Failed to fetch template ${templateFromList.sId}: ${templateResponse.status}`
+          );
+          continue;
+        }
+
+        const template: FetchAssistantTemplateResponse =
+          await templateResponse.json();
+
+        await TemplateResource.upsertByHandle(template);
+
+        count++;
+      }
+
+      return res.status(200).json({
+        success: true,
+        count,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -1,5 +1,4 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
-import { EnvironmentConfig } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
@@ -34,8 +33,7 @@ async function handler(
     });
   }
 
-  const currentRegion = config.getCurrentRegion();
-  if (currentRegion === "us-central1") {
+  if (!config.getDustRegionSyncEnabled()) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -47,7 +45,7 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const mainRegionUrl = EnvironmentConfig.getEnvVariable("DUST_US_URL");
+      const mainRegionUrl = config.getDustRegionSyncMasterUrl();
       const response = await fetch(`${mainRegionUrl}/api/templates`, {
         method: "GET",
       });

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -13,7 +13,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type { Action } from "@app/lib/registry";
 import { getDustProdAction } from "@app/lib/registry";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { useConversation } from "@app/poke/swr";
+import { usePokeConversation } from "@app/poke/swr";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   workspaceId: string;
@@ -174,7 +174,7 @@ const ConversationPage = ({
   conversationDataSourceId,
   multiActionsApp,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const { conversation } = useConversation({ workspaceId, conversationId });
+  const { conversation } = usePokeConversation({ workspaceId, conversationId });
   return (
     <div className="min-h-screen bg-structure-50">
       <PokeNavbar />

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -51,7 +51,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { getTemporalConnectorsNamespaceConnection } from "@app/lib/temporal";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { useDocuments, useTables } from "@app/poke/swr";
+import { usePokeDocuments, usePokeTables } from "@app/poke/swr";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 
@@ -318,9 +318,9 @@ const DataSourcePage = ({
     total: totalDocuments,
     isDocumentsLoading,
     isDocumentsError,
-  } = useDocuments(owner, dataSource, limit, offsetDocument);
+  } = usePokeDocuments(owner, dataSource, limit, offsetDocument);
 
-  const { tables, total: totalTables } = useTables(
+  const { tables, total: totalTables } = usePokeTables(
     owner,
     dataSource,
     limit,

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -53,7 +53,7 @@ export function usePokeAssistantTemplate({
   };
 }
 
-export function useConversation({
+export function usePokeConversation({
   workspaceId,
   conversationId,
 }: {
@@ -78,7 +78,7 @@ export function useConversation({
   };
 }
 
-export function useDocuments(
+export function usePokeDocuments(
   owner: LightWorkspaceType,
   dataSource: DataSourceType,
   limit: number,
@@ -99,7 +99,7 @@ export function useDocuments(
   };
 }
 
-export function useTables(
+export function usePokeTables(
   owner: LightWorkspaceType,
   dataSource: DataSourceType,
   limit: number,

--- a/front/tests/utils/UserFactory.ts
+++ b/front/tests/utils/UserFactory.ts
@@ -7,12 +7,8 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { Factory } from "./factories";
 
 class UserFactory extends Factory<UserModel> {
-  async make(params: InferCreationAttributes<UserModel>) {
-    return UserModel.create(params);
-  }
-
-  basic() {
-    return this.params({
+  constructor() {
+    super({
       sId: generateRandomModelSId(),
       auth0Sub: faker.string.uuid(),
       provider: "google",
@@ -23,6 +19,22 @@ class UserFactory extends Factory<UserModel> {
       name: faker.person.fullName(),
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
+
+      isDustSuperUser: false,
+    });
+  }
+
+  async make(params: InferCreationAttributes<UserModel>) {
+    return UserModel.create(params);
+  }
+
+  basic() {
+    return this.params({});
+  }
+
+  superUser() {
+    return this.params({
+      isDustSuperUser: true,
     });
   }
 

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -40,9 +40,16 @@ import { getSession } from "../../lib/auth";
 export const createPrivateApiMockRequest = async ({
   method = "GET",
   role = "user",
-}: { method?: RequestMethod; role?: MembershipRoleType } = {}) => {
+  isSuperUser = false,
+}: {
+  method?: RequestMethod;
+  role?: MembershipRoleType;
+  isSuperUser?: boolean;
+} = {}) => {
   const workspace = await workspaceFactory().basic().create();
-  const user = await userFactory().basic().create();
+  const user = await (
+    isSuperUser ? userFactory().superUser() : userFactory().basic()
+  ).create();
   const globalGroup = await groupFactory().global(workspace).create();
 
   const membership = await membershipFactory()

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -16,6 +16,7 @@ export default async function setup() {
 
     // Add any other essential vars you need to keep
     FRONT_DATABASE_URI: process.env.FRONT_DATABASE_URI,
+    DUST_US_URL: "http://fake-url",
     LOG_LEVEL: process.env.TEST_LOG_LEVEL ?? "silent",
   };
 }


### PR DESCRIPTION
## Description

Show a button in the poke template page to a pull templates from US and upsert them locally.
Added endpoint to get the region (and show the button only if not US), added endpoint to pull.
Moved the sync (apps and pull) config to region config instead of the general config.
Removed 2 env vars to enforce US as the main region and reduce the possibility to wrongly setup the env vars.

https://github.com/user-attachments/assets/fe276f40-0651-4fbd-83d9-b3f842ce011b



## Tests

Both endpoints have tests.

## Risk

Low, new feature, hidden in poke.

## Deploy Plan

Deploy `front`