### PR TITLE
[CoreNodes] Thin out the logged diff

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -100,6 +100,14 @@ export function computeNodesDiff({
             if (key === "sourceUrl" && value === null && coreValue !== null) {
               return false;
             }
+            // Special case for the titles of Webcrawler folders: we add a trailing slash in core but not in connectors.
+            if (
+              key === "title" &&
+              provider === "webcrawler" &&
+              coreValue === `${value}/`
+            ) {
+              return false;
+            }
             // Special case for expandable: if the core node is not expandable and the connectors one is, it means
             // that the difference comes from the fact that the node has no children: we omit from the log.
             if (key === "expandable" && value === true && coreValue === false) {

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -96,6 +96,10 @@ export function computeNodesDiff({
             if (provider === null && key === "parentInternalIds" && !value) {
               return false;
             }
+            // Ignore sourceUrls returned by core but left empty by connectors.
+            if (key === "sourceUrl" && value === null && coreValue !== null) {
+              return false;
+            }
             // Special case for expandable: if the core node is not expandable and the connectors one is, it means
             // that the difference comes from the fact that the node has no children: we omit from the log.
             if (key === "expandable" && value === true && coreValue === false) {


### PR DESCRIPTION
## Description

- This PR removes some false positive from the logged diff.
  - Ignore source URLs if returned by core but empty in connectors.
  - Ignore the fact that on webcrawler folders, core returns the same title than connectors but with an extra trailing `/`.
- `computeNodesDiff` is getting criminally ugly, the good point is that any mistake due to having basically 0 type in it cannot do any harm besides not correctly removing false positives.

## Tests

## Risk

- n/a (shadow read, log only).

## Deploy Plan

- Deploy front.