### PR TITLE
[Nodes core] gdrive clean parents script update again

### DIFF
--- a/connectors/migrations/20250122_gdrive_clean_parents.ts
+++ b/connectors/migrations/20250122_gdrive_clean_parents.ts
@@ -171,7 +171,7 @@ async function processFilesBatch({
       }
       return 1;
     },
-    { concurrency: 32 }
+    { concurrency: 4 }
   );
   return result.reduce((acc, curr) => acc + curr, 0);
 }
@@ -207,16 +207,23 @@ async function processSheetsBatch({
         return 0;
       }
       if (execute) {
-        await updateDataSourceTableParents({
-          dataSourceConfig,
-          tableId: getGoogleSheetTableId(sheet.driveFileId, sheet.driveSheetId),
-          parents,
-          parentId: parents[1] || null,
-        });
+        try {
+          await updateDataSourceTableParents({
+            dataSourceConfig,
+            tableId: getGoogleSheetTableId(
+              sheet.driveFileId,
+              sheet.driveSheetId
+            ),
+            parents,
+            parentId: parents[1] || null,
+          });
+        } catch (e) {
+          logger.error({ error: e }, "Sheet backfill issue");
+        }
       }
       return 1;
     },
-    { concurrency: 32 }
+    { concurrency: 4 }
   );
   return result.reduce((acc, curr) => acc + curr, 0);
 }


### PR DESCRIPTION
Description
---
An error on a missing table id occurred.
Since it's once at the very end of the script, safe to skip IMO provided we check the error is sporadical.

Also, downing concurrency to 4 to limit timeout errors

Risk
---
missing some table updates -> will count on the script log

Deploy
---
finish backfill
check number of errors is very low
