### PR TITLE
[Nodes Core] Clean Microsoft parents

### DIFF
--- a/connectors/migrations/20250125_microsoft_folder_parents_fix.ts
+++ b/connectors/migrations/20250125_microsoft_folder_parents_fix.ts
@@ -1,0 +1,99 @@
+import { concurrentExecutor, MIME_TYPES } from "@dust-tt/types";
+import _ from "lodash";
+import type { LoggerOptions } from "pino";
+import type pino from "pino";
+import { makeScript } from "scripts/helpers";
+
+import { getParents } from "@connectors/connectors/microsoft/temporal/file";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
+
+async function backfillConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  parentLogger: pino.Logger<LoggerOptions & pino.ChildLoggerOptions>
+) {
+  const startSyncTs = Date.now();
+  const logger = parentLogger.child({
+    connectorId: connector.id,
+    execute,
+  });
+  logger.info("Starting backfill");
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const folders = await MicrosoftNodeModel.findAll({
+    where: {
+      connectorId: connector.id,
+      nodeType: "folder",
+    },
+    attributes: ["internalId"],
+  });
+
+  const result = await concurrentExecutor(
+    folders,
+    async (folder): Promise<number> => {
+      const folderResource = await MicrosoftNodeResource.fetchByInternalId(
+        connector.id,
+        folder.internalId
+      );
+      if (!folderResource) {
+        throw new Error(
+          "Unexpected error fetching folder resource from folder model"
+        );
+      }
+      const parents = await getParents({
+        connectorId: connector.id,
+        internalId: folderResource.internalId,
+        startSyncTs,
+      });
+      if (execute) {
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId: folderResource.internalId,
+          title: folderResource.name ?? "Untitled folder",
+          parents,
+          parentId: parents[1] ?? null,
+          mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+          sourceUrl: folderResource.webUrl ?? undefined,
+        });
+      }
+      return 1;
+    },
+    { concurrency: 4 }
+  );
+  return {
+    upserted: result.reduce((acc, curr) => acc + curr, 0),
+    notFound: result.filter((r) => r === 0).length,
+    total: folders.length,
+  };
+}
+
+makeScript(
+  {
+    startId: { type: "number", demandOption: false },
+  },
+  async ({ execute, startId }, logger) => {
+    logger.info("Starting backfill");
+    const connectors = await ConnectorResource.listByType("microsoft", {});
+    // sort connectors by id
+    connectors.sort((a, b) => a.id - b.id);
+    // start from startId if provided
+    const startIndex = startId
+      ? connectors.findIndex((c) => c.id === startId)
+      : 0;
+    if (startIndex === -1) {
+      throw new Error(`Connector with id ${startId} not found`);
+    }
+    const slicedConnectors = connectors.slice(startIndex);
+    for (const connector of slicedConnectors) {
+      const result = await backfillConnector(connector, execute, logger);
+      logger.info(
+        { connectorId: connector.id, result, execute },
+        "Backfilled connector"
+      );
+    }
+  }
+);

--- a/connectors/migrations/20250125_microsoft_folder_parents_fix.ts
+++ b/connectors/migrations/20250125_microsoft_folder_parents_fix.ts
@@ -1,5 +1,4 @@
 import { concurrentExecutor, MIME_TYPES } from "@dust-tt/types";
-import _ from "lodash";
 import type { LoggerOptions } from "pino";
 import type pino from "pino";
 import { makeScript } from "scripts/helpers";

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -651,22 +651,6 @@ export async function syncDeltaForRootNodesInDrive({
           blob
         );
 
-        const parents = await getParents({
-          connectorId,
-          internalId: blob.internalId,
-          startSyncTs,
-        });
-
-        await upsertDataSourceFolder({
-          dataSourceConfig,
-          folderId: blob.internalId,
-          parents,
-          parentId: parents[1] || null,
-          title: blob.name ?? "",
-          mimeType: MIME_TYPES.MICROSOFT.FOLDER,
-          sourceUrl: blob.webUrl ?? undefined,
-        });
-
         // add parent information to new node resource. for the toplevel folder,
         // parent is null
         // todo check filter
@@ -679,6 +663,27 @@ export async function syncDeltaForRootNodesInDrive({
         await resource.update({
           parentInternalId,
           lastSeenTs: new Date(),
+        });
+
+        const parents = await getParents({
+          connectorId,
+          internalId: blob.internalId,
+          startSyncTs,
+        });
+
+        logger.info(
+          { parents, title: blob.name, internalId: blob.internalId },
+          "Upserting folder"
+        );
+
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId: blob.internalId,
+          parents,
+          parentId: parents[1] || null,
+          title: blob.name ?? "",
+          mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+          sourceUrl: blob.webUrl ?? undefined,
         });
 
         if (isMoved) {

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -481,7 +481,7 @@ export async function syncFiles({
         folderId: createdOrUpdatedResource.internalId,
         parents: [createdOrUpdatedResource.internalId, ...parentsOfParent],
         parentId: parentsOfParent[0],
-        title: createdOrUpdatedResource.name ?? "",
+        title: createdOrUpdatedResource.name ?? "Untitled Folder",
         mimeType: MIME_TYPES.MICROSOFT.FOLDER,
         sourceUrl: createdOrUpdatedResource.webUrl ?? undefined,
       }),
@@ -681,7 +681,7 @@ export async function syncDeltaForRootNodesInDrive({
           folderId: blob.internalId,
           parents,
           parentId: parents[1] || null,
-          title: blob.name ?? "",
+          title: blob.name ?? "Untitled Folder",
           mimeType: MIME_TYPES.MICROSOFT.FOLDER,
           sourceUrl: blob.webUrl ?? undefined,
         });
@@ -884,7 +884,7 @@ async function updateDescendantsParentsInCore({
     folderId: folder.internalId,
     parents,
     parentId: parents[1] || null,
-    title: folder.name ?? "",
+    title: folder.name ?? "Untitled Folder",
     mimeType: MIME_TYPES.MICROSOFT.FOLDER,
     sourceUrl: folder.webUrl ?? undefined,
   });

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -651,11 +651,17 @@ export async function syncDeltaForRootNodesInDrive({
           blob
         );
 
+        const parents = await getParents({
+          connectorId,
+          internalId: blob.internalId,
+          startSyncTs,
+        });
+
         await upsertDataSourceFolder({
           dataSourceConfig,
           folderId: blob.internalId,
-          parents: [blob.internalId],
-          parentId: null,
+          parents,
+          parentId: parents[1] || null,
           title: blob.name ?? "",
           mimeType: MIME_TYPES.MICROSOFT.FOLDER,
           sourceUrl: blob.webUrl ?? undefined,

--- a/front/migrations/20250126_microsoft_roots_check.ts
+++ b/front/migrations/20250126_microsoft_roots_check.ts
@@ -1,0 +1,144 @@
+import type { Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
+
+import {
+  getConnectorsReplicaDbConnection,
+  getCorePrimaryDbConnection,
+} from "@app/lib/production_checks/utils";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+async function checkDataSource(
+  frontDataSource: DataSourceModel,
+  coreSequelize: Sequelize,
+  connectorsSequelize: Sequelize,
+  parentLogger: typeof Logger
+) {
+  const logger = parentLogger.child({
+    dataSourceId: frontDataSource.id,
+    connectorId: frontDataSource.connectorId,
+    name: frontDataSource.name,
+  });
+
+  logger.info("Checking data source");
+
+  // get datasource id from core
+  const rows: { id: number }[] = await coreSequelize.query(
+    `SELECT id FROM data_sources WHERE project = :projectId AND data_source_id = :dataSourceId;`,
+    {
+      replacements: {
+        projectId: frontDataSource.dustAPIProjectId,
+        dataSourceId: frontDataSource.dustAPIDataSourceId,
+      },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  if (rows.length === 0) {
+    logger.error(`Data source ${frontDataSource.id} not found in core`);
+    return;
+  }
+
+  const dataSourceId = rows[0].id;
+
+  await checkNodes(
+    frontDataSource,
+    dataSourceId,
+    coreSequelize,
+    connectorsSequelize,
+    logger
+  );
+}
+
+async function checkNodes(
+  frontDataSource: DataSourceModel,
+  dataSourceId: number,
+  coreSequelize: Sequelize,
+  connectorsSequelize: Sequelize,
+  logger: typeof Logger
+) {
+  logger.info("Processing nodes");
+
+  const rows: { id: number; internalId: string }[] =
+    await connectorsSequelize.query(
+      `SELECT id, "internalId"
+       FROM microsoft_roots
+       WHERE "connectorId" = :connectorId
+       ORDER BY id`,
+      {
+        replacements: {
+          connectorId: frontDataSource.connectorId,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+  if (rows.length === 0) {
+    logger.warn("No root nodes found");
+    return;
+  }
+
+  const rootIds = rows.map((row) => row.internalId);
+  let count = 0;
+  for (const rootId of rootIds) {
+    if (
+      !(await checkRootIsFine(rootId, rootIds, coreSequelize, dataSourceId))
+    ) {
+      logger.error(`Root ${rootId} has parents that aren't roots`);
+      count++;
+    }
+  }
+  logger.info(`Found ${count} roots with parents that aren't roots`);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+makeScript({}, async ({ execute }, logger) => {
+  const coreSequelize = getCorePrimaryDbConnection();
+  const connectorsSequelize = getConnectorsReplicaDbConnection();
+  const frontDataSources = await DataSourceModel.findAll({
+    where: { connectorProvider: "microsoft" },
+  });
+  logger.info(`Found ${frontDataSources.length} Microsoft data sources`);
+
+  for (const frontDataSource of frontDataSources) {
+    await checkDataSource(
+      frontDataSource,
+      coreSequelize,
+      connectorsSequelize,
+      logger
+    );
+  }
+});
+
+async function checkRootIsFine(
+  internalId: string,
+  rootInternalIds: string[],
+  coreSequelize: Sequelize,
+  dataSourceModelId: number
+) {
+  const rows: { node_id: string; parents: string[] }[] =
+    await coreSequelize.query(
+      `SELECT node_id, parents FROM data_sources_nodes WHERE data_source = :dataSourceModelId AND node_id = :internalId;`,
+      {
+        replacements: { dataSourceModelId, internalId },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+  if (rows.length === 0) {
+    // some root nodes are not in the core nodes table, that's fine
+    return true;
+  }
+  const rootNode = rows[0];
+
+  if (rootNode.parents.length === 1) {
+    // if the root is in nodes, and has only itself as parent, that's fine
+    return rootNode.parents[0] === rootNode.node_id;
+  }
+
+  // otherwise, one of the parents should be in the roots
+  return rootInternalIds.some((rootInternalId) =>
+    rootNode.parents.includes(rootInternalId)
+  );
+}


### PR DESCRIPTION
## Description
Part of https://github.com/dust-tt/tasks/issues/1988

Ensures the invariant that "root node <=> no parents or one of the parents is also a root node" is enforced

Here, "root" means "user selected", usually via setPermissions.

The <= implication isn't respected, some folder nodes actually were wrongly set as having no parents.

This PR fixes this and backfills.

As per the => implication, it's alreay fine:  current logic for computing parents is already sound in this respect, parents are computed via our model MicrosoftNodeResource whose elements are always stored in nodes

A check script is run to confirm that, results posted in the PR

## Risk
Usual risk level, migration relatively standard

## Deploy
- connectors
- run backfill
- run check script and update in PR
