### PR TITLE
[front] Add poke import/export for assistants

### DIFF
--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -119,7 +119,6 @@ export function makeColumnsForAssistants(
                 icon={ArrowDownOnSquareIcon}
                 size="xs"
                 variant="outline"
-                onClick={() => {}}
               />
             </Link>
           </>

--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -2,11 +2,13 @@ import {
   EmotionLaughIcon,
   IconButton,
   LinkWrapper,
+  PlanetIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type { LightWorkspaceType } from "@dust-tt/types";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
+import Link from "next/link";
 
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
@@ -95,18 +97,32 @@ export function makeColumnsForAssistants(
         const assistant = row.original;
 
         return (
-          <IconButton
-            icon={
-              assistant.status !== "archived" ? TrashIcon : EmotionLaughIcon
-            }
-            size="xs"
-            variant="outline"
-            onClick={async () => {
-              await (assistant.status !== "archived"
-                ? archiveAssistant(owner, reload, assistant)
-                : restoreAssistant(owner, reload, assistant));
-            }}
-          />
+          <>
+            <IconButton
+              icon={
+                assistant.status !== "archived" ? TrashIcon : EmotionLaughIcon
+              }
+              size="xs"
+              variant="outline"
+              onClick={async () => {
+                await (assistant.status !== "archived"
+                  ? archiveAssistant(owner, reload, assistant)
+                  : restoreAssistant(owner, reload, assistant));
+              }}
+            />
+            <Link
+              href={`/api/poke/workspaces/${owner.sId}/agent_configurations/${assistant.sId}/export`}
+              download={`${assistant.name}.json`}
+              target="_blank"
+            >
+              <IconButton
+                icon={PlanetIcon}
+                size="xs"
+                variant="outline"
+                onClick={() => {}}
+              />
+            </Link>
+          </>
         );
       },
     },

--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -1,8 +1,8 @@
 import {
+  ArrowDownOnSquareIcon,
   EmotionLaughIcon,
   IconButton,
   LinkWrapper,
-  PlanetIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type { LightWorkspaceType } from "@dust-tt/types";
@@ -116,7 +116,7 @@ export function makeColumnsForAssistants(
               target="_blank"
             >
               <IconButton
-                icon={PlanetIcon}
+                icon={ArrowDownOnSquareIcon}
                 size="xs"
                 variant="outline"
                 onClick={() => {}}

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -72,7 +72,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "The agent configuration is not active.",
+        message: "The agent configuration is not active, or has global scope.",
       },
     });
   }

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -1,0 +1,118 @@
+import type {
+  AgentActionConfigurationType,
+  LightAgentConfigurationType,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+
+export type ExportAgentConfigurationResponseBody = {
+  assistant: Omit<
+    LightAgentConfigurationType,
+    | "id"
+    | "versionCreatedAt"
+    | "sId"
+    | "version"
+    | "owner"
+    | "workspace"
+    | "createdAt"
+    | "versionAuthorId"
+    | "userFavorite"
+    | "requestedGroupIds"
+  > & {
+    // If empty, no actions are performed, otherwise the actions are performed.
+    actions: Omit<AgentActionConfigurationType, "id" | "sId">[];
+  };
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<ExportAgentConfigurationResponseBody>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+
+  const { aId } = req.query;
+  if (typeof aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const agentConfiguration = await getAgentConfiguration(auth, aId);
+  if (!agentConfiguration) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration you requested was not found.",
+      },
+    });
+  }
+
+  if (
+    agentConfiguration.status !== "active" ||
+    agentConfiguration.scope === "global"
+  ) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The agent configuration is not active.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      res.status(200).json({
+        assistant: {
+          name: agentConfiguration.name,
+          description: agentConfiguration.description,
+          instructions: agentConfiguration.instructions,
+          pictureUrl: agentConfiguration.pictureUrl,
+          status: agentConfiguration.status,
+          scope: agentConfiguration.scope,
+          model: agentConfiguration.model,
+          actions: agentConfiguration.actions.map((action) => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { id, sId, ...actionWithoutIds } = action;
+            return {
+              ...actionWithoutIds,
+              ...("dataSources" in action ? { dataSources: [] } : {}),
+              ...("tables" in action ? { tables: [] } : {}),
+            };
+          }),
+          templateId: agentConfiguration.templateId,
+          maxStepsPerRun: agentConfiguration.maxStepsPerRun,
+          visualizationEnabled: agentConfiguration.visualizationEnabled,
+        },
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/import.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/import.ts
@@ -1,0 +1,74 @@
+import type {
+  AgentConfigurationType,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
+import { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+
+/**
+ * @ignoreswagger
+ * Internal endpoint. Undocumented.
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<{ assistant: AgentConfigurationType }>
+  >,
+  session: SessionWithUser
+) {
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const bodyValidation = PostOrPatchAgentConfigurationRequestBodySchema.decode(
+    req.body
+  );
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+  const body = bodyValidation.right;
+
+  const result = await createOrUpgradeAgentConfiguration({
+    auth,
+    assistant: body.assistant,
+  });
+
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: result.error.message,
+      },
+    });
+  }
+
+  res.status(200).json({ assistant: result.value });
+}
+
+export default withSessionAuthentication(handler);


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1985

## Description

Add an assistant export button and possibility to reimport it in another workspace / region. Data sources references  are not exported and must be completed manually.

![Screenshot 2025-01-27 at 08 53 43](https://github.com/user-attachments/assets/1fb5faf7-f480-4b19-827b-c34496f4bbcf)

## Tests

- Export any assistant, with data sources tools
- reimport in same another workspace : correctly created
- reimport in same workspace : error message

## Risk

none

## Deploy Plan

deploy front