### PR TITLE
[CoreNodes] Fix Webcrawler folder names

### DIFF
--- a/connectors/migrations/20250127_backfill_webcrawler_folder_titles.ts
+++ b/connectors/migrations/20250127_backfill_webcrawler_folder_titles.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert";
+
+import { concurrentExecutor, MIME_TYPES } from "@dust-tt/types";
+import _ from "lodash";
+import { makeScript } from "scripts/helpers";
+
+import { getDisplayNameForFolder } from "@connectors/connectors/webcrawler/lib/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { WebCrawlerFolder } from "@connectors/lib/models/webcrawler";
+import type Logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+async function migrateConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  parentLogger: typeof Logger
+) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const connectorId = connector.id;
+  const logger = parentLogger.child({ connectorId });
+
+  logger.info("MIGRATE");
+
+  const folders = await WebCrawlerFolder.findAll({
+    where: { connectorId },
+  });
+
+  const foldersByUrl = _.keyBy(folders, "url");
+
+  const getParents = (folder: WebCrawlerFolder): string[] => {
+    assert(
+      folder.parentUrl === null || foldersByUrl[folder.parentUrl],
+      "Parent folder not found"
+    );
+    const parentFolder = folder.parentUrl
+      ? foldersByUrl[folder.parentUrl]
+      : null;
+    return [
+      folder.internalId,
+      ...(parentFolder ? getParents(parentFolder) : []),
+    ];
+  };
+  await concurrentExecutor(
+    folders,
+    async (folder) => {
+      logger.info({
+        folderId: folder.internalId,
+        folderUrl: folder.url,
+      });
+      if (execute) {
+        const parents = getParents(folder);
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId: folder.internalId,
+          timestampMs: folder.updatedAt.getTime(),
+          parents,
+          parentId: parents[1] || null,
+          title: getDisplayNameForFolder(folder),
+          mimeType: MIME_TYPES.WEBCRAWLER.FOLDER,
+        });
+      }
+    },
+    { concurrency: 8 }
+  );
+}
+
+makeScript(
+  {
+    nextConnectorId: { type: "number", default: 0 },
+    connectorId: { type: "number", default: 0 },
+  },
+  async ({ execute, nextConnectorId }, logger) => {
+    logger.info({ nextConnectorId }, "Starting backfill");
+
+    const connectors = await ConnectorResource.listByType("webcrawler", {});
+
+    // sort connectors by id and start from nextConnectorId
+    const sortedConnectors = connectors
+      .sort((a, b) => a.id - b.id)
+      .filter((_, idx) => idx >= nextConnectorId);
+
+    for (const connector of sortedConnectors) {
+      await migrateConnector(connector, execute, logger);
+    }
+  }
+);

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -14,6 +14,7 @@ import turndown from "turndown";
 
 import {
   getAllFoldersForUrl,
+  getDisplayNameForFolder,
   getFolderForUrl,
   getIpAddressForUrl,
   getParentsForPage,
@@ -291,7 +292,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
             timestampMs: webCrawlerFolder.updatedAt.getTime(),
             parents,
             parentId: parents[1] || null,
-            title: folder,
+            title: getDisplayNameForFolder(webCrawlerFolder),
             mimeType: MIME_TYPES.WEBCRAWLER.FOLDER,
             sourceUrl: webCrawlerFolder.url,
           });


### PR DESCRIPTION
## Description

- We observe discrepancies in the content node titles between core and connectors (example [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%40extraCoreInternalIds%3Anotion-unknown%20-%40provider%3Asnowflake%20-%40internalId%3A%28slack-channel-%2A%20OR%20intercom-team-4233-4352447%20OR%20intercom-team-%2A%20OR%20notion-%2A%29%20-%40diff.parentInternalId.core%3Agdrive-%2A%20-%40provider%3Agoogle_drive%20-%40diff.title.connectors%3Adust-dbt%20%40provider%3Awebcrawler&agg_m=count&agg_m_source=base&agg_q=%40provider&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZSm9rOScErafwAAABhBWlNtOXJkWEFBQVdjZnZkZzR1c1R3RDQAAAAkMDE5NGE2ZjctYjBiOC00ZTQxLThlOWQtOTM4OTEwOTc0YjZhAAKoEw&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1737952085744&to_ts=1737966485744&live=true)).
- The title passed returned by connectors is indeed different from the one passed in `upsertDataSourcefolder`.
- This PR addresses that.

## Tests

## Risk

- n/a

## Deploy Plan

- Deploy connectors.
- Run backfill script.