### PR TITLE
[CoreNodes] Fix log exclusion rule on folder parents

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -93,7 +93,7 @@ export function computeNodesDiff({
             const coreValue = coreNode[key as keyof DataSourceViewContentNode];
             // Special case for folder parents, the ones retrieved using getContentNodesForStaticDataSourceView do not
             // contain any parentInternalIds.
-            if (provider === null && key === "parentInternalIds" && !value) {
+            if (provider === null && key === "parentInternalIds") {
               return false;
             }
             // Ignore sourceUrls returned by core but left empty by connectors.


### PR DESCRIPTION
## Description

- The rule that excludes diffs on the `parentInternalIds` for folders failed to do its job as seen [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%40extraCoreInternalIds%3Anotion-unknown%20-%40provider%3Asnowflake%20-%40internalId%3A%28slack-channel-%2A%20OR%20intercom-team-4233-4352447%20OR%20intercom-team-%2A%20OR%20notion-%2A%29%20-%40diff.parentInternalId.core%3Agdrive-%2A%20-%40provider%3Agoogle_drive%20-%40diff.title.connectors%3Adust-dbt&agg_m=count&agg_m_source=base&agg_q=%40provider&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZSmzcs_Q0LzIQAAABhBWlNtemRGVEFBQU1lSFVjRVgtb1lRQlgAAAAkMDE5NGE2ZjMtYWU2ZC00Yjc4LWIzZWItN2RjMGMyNGUyYjdkAAur5g&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=host%2Casc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1737952085744&to_ts=1737966485744&live=true) for instance.
- This PR fixes that (see [here](https://github.com/dust-tt/dust/blob/a1e4abda0bf7aefe70c6f2afead2a8cf93ddd74d/front/lib/api/data_source_view.ts#L320), it's actually not a falsy value).

## Tests

## Risk

- n/a

## Deploy Plan

- Deploy front