### PR TITLE
[CoreNodes] Exclude `parentInternalId` from the diff when left unfilled for Google Drive

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -96,6 +96,15 @@ export function computeNodesDiff({
             if (provider === null && key === "parentInternalIds") {
               return false;
             }
+            // For Google Drive, connectors does not fill the parentInternalId at google_drive/index.ts#L324.
+            if (
+              ["parentInternalId"].includes(key) &&
+              provider === "google_drive" &&
+              coreValue !== null &&
+              value === null
+            ) {
+              return false;
+            }
             // Ignore sourceUrls returned by core but left empty by connectors.
             if (key === "sourceUrl" && value === null && coreValue !== null) {
               return false;


### PR DESCRIPTION
## Description

- In the content nodes returned by the Google Drive connectors, the parentInternalId is left null [here](https://github.com/dust-tt/dust/blob/b685fa2f28c24cd11d205977cfa0637321712404/connectors/src/connectors/google_drive/index.ts#L667) and [here](https://github.com/dust-tt/dust/blob/b685fa2f28c24cd11d205977cfa0637321712404/connectors/src/connectors/google_drive/index.ts#L324).
- Since `core` always has it set for non-root nodes, this difference pops up in the [log](https://app.datadoghq.eu/logs?query=CoreNodes%20-%40internalId%3Aconfluence-page-%2A%20-%40dataSourceId%3A%28dts_W10jrz0H6k70%20OR%20dts_hwB8vwIVCtwL%29&agg_m=count&agg_m_source=base&agg_q=%40provider&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZSnGLYmtmLBIgAAABhBWlNuR0xqWUFBREJaZ0lFMzM2TzFBQkkAAAAkMDE5NGE3MTgtZjY0MS00MjU1LWE3NTUtYzdmY2VkOGFmM2NkAAAoHQ&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1737797325000&to_ts=1737970125000&live=true).
- This PR adds an exclusion rule.

## Tests


## Risk

- n/a

## Deploy Plan

- Deploy front.