### PR TITLE
[front] - fix(migrations): backfill retrieval

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -357,6 +357,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
       functionCallName: actionConfiguration.name,
       agentMessageId: agentMessage.agentMessageId,
       step: step,
+      workspaceId: owner.id,
     });
 
     yield {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -6,7 +6,6 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 
 export class AgentRetrievalConfiguration extends WorkspaceAwareModel<AgentRetrievalConfiguration> {
@@ -131,7 +130,7 @@ AgentRetrievalConfiguration.belongsTo(AgentConfiguration, {
 /**
  * Retrieval Action
  */
-export class AgentRetrievalAction extends BaseModel<AgentRetrievalAction> {
+export class AgentRetrievalAction extends WorkspaceAwareModel<AgentRetrievalAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;

--- a/front/migrations/20250123_backfill_retrieval.ts
+++ b/front/migrations/20250123_backfill_retrieval.ts
@@ -13,7 +13,7 @@ import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 interface TableConfig {
   model: typeof WorkspaceAwareModel<any>;
   attributes?: string[];
-  where?: (workspaceId: number) => any;
+  where: (workspaceId: number) => any;
 }
 
 const TABLES: TableConfig[] = [
@@ -60,7 +60,7 @@ async function backfillTable(
       where: {
         id: { [Op.gt]: lastSeenId },
         workspaceId: { [Op.is]: null },
-        ...(table.where?.(workspace.id) || {}),
+        ...(table.where(workspace.id) || {}),
       },
       order: [["id", "ASC"]],
       limit: batchSize,

--- a/front/migrations/20250123_backfill_retrieval.ts
+++ b/front/migrations/20250123_backfill_retrieval.ts
@@ -62,6 +62,7 @@ async function backfillTableRetrievalDocumentChunk(
       },
       attributes: ["id", "workspaceId"],
       limit: batchSize,
+      order: [["id", "ASC"]],
     });
 
     if (documents.length === 0) {

--- a/front/migrations/20250123_backfill_retrieval.ts
+++ b/front/migrations/20250123_backfill_retrieval.ts
@@ -64,7 +64,7 @@ async function backfillTableRetrievalDocumentChunk(
       limit: batchSize,
     });
 
-    if (documents.length > 0) {
+    if (documents.length === 0) {
       break;
     }
 
@@ -82,6 +82,7 @@ async function backfillTableRetrievalDocumentChunk(
         }
       );
     }
+
     lastSeenId = documents[documents.length - 1].id;
     logger.info({}, `Processed batch up to id ${lastSeenId}`);
   }

--- a/front/migrations/20250123_backfill_retrieval.ts
+++ b/front/migrations/20250123_backfill_retrieval.ts
@@ -1,7 +1,10 @@
 import type { LightWorkspaceType } from "@dust-tt/types";
 import { Op, Sequelize } from "sequelize";
 
-import { RetrievalDocument, RetrievalDocumentChunk } from "@app/lib/models/assistant/actions/retrieval";
+import {
+  RetrievalDocument,
+  RetrievalDocumentChunk,
+} from "@app/lib/models/assistant/actions/retrieval";
 import type { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";

--- a/front/migrations/20250123_backfill_retrieval.ts
+++ b/front/migrations/20250123_backfill_retrieval.ts
@@ -20,10 +20,10 @@ const TABLES: TableConfig[] = [
   {
     model: RetrievalDocument,
     attributes: ["id", "workspaceId", "dataSourceViewId"],
-    where: (workspaceId: number) => ({
+    where: (workspaceId: number, lastSeenId: number) => ({
       retrievalActionId: {
         [Op.in]: Sequelize.literal(
-          `(SELECT id FROM agent_retrieval_actions WHERE "workspaceId" = ${workspaceId})`
+          `(SELECT id FROM agent_retrieval_actions WHERE "workspaceId" = ${workspaceId}) AND id > ${lastSeenId}`
         ),
       },
     }),


### PR DESCRIPTION
## Description

This PR aims at fixing the backfill of `retrieval_documents` and `retrieval_document_chunks`. 

- For `retrieval_documents`: it uses the action instead of the data source view, as deleting a dsv will lead to having `dataSourceViewId` null
- For `retrieval_document_chunks` this aims at limiting the size of the tables before performing the join.

## Risk

Migrations -> important

## Deploy Plan

- Apply migration in US