### PR TITLE
[core] Fix the SQL query for document upserts 

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1868,7 +1868,7 @@ impl Store for PostgresStore {
                 "INSERT INTO data_sources_documents \
                    (id, data_source, created, document_id, timestamp, tags_array, \
                     hash, text_size, chunk_count, status) \
-                   VALUES (DEFAULT, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
+                   VALUES (DEFAULT, $1, $2, $3, $4, $5, $6, $7, $8, $9) \
                    RETURNING id, created",
             )
             .await?;


### PR DESCRIPTION
## Description

- The query for document upserts was partly updated in https://github.com/dust-tt/dust/pull/10085
- This PR adds the missing part (invalid number of parameters).

## Tests

n/a

## Risk

- n/a

## Deploy Plan

- Deploy core
- Scale back front-worker (was temporarily scaled down)