### PR TITLE
Poké plugin to set convo data retention

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/conversations_retention.ts
+++ b/front/lib/api/poke/plugins/workspaces/conversations_retention.ts
@@ -1,0 +1,45 @@
+import { Err, Ok } from "@dust-tt/types";
+
+import { createPlugin } from "@app/lib/api/poke/types";
+import { updateWorkspaceConversationsRetention } from "@app/lib/api/workspace";
+
+export const conversationsRetention = createPlugin(
+  {
+    id: "conversations-retention",
+    name: "Change Conversations Retention",
+    description: "Change how long conversations are retained in the workspace",
+    resourceTypes: ["workspaces"],
+    args: {
+      retentionDays: {
+        type: "number",
+        label: "Retention Days",
+        description:
+          "Number of days to retain conversations (-1 for unlimited)",
+      },
+    },
+  },
+  async (auth, resourceId, args) => {
+    const retentionDays = args.retentionDays;
+
+    if (retentionDays !== -1 && retentionDays < 1) {
+      return new Err(
+        new Error(
+          "Set -1 to remove the retention rule, or a number > 0 to set the retention rule."
+        )
+      );
+    }
+
+    const res = await updateWorkspaceConversationsRetention(
+      auth.getNonNullableWorkspace(),
+      retentionDays
+    );
+    if (res.isErr()) {
+      return res;
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Conversations retention period set to ${retentionDays === -1 ? "unlimited" : `${retentionDays} days`}.`,
+    });
+  }
+);

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -1,3 +1,4 @@
+export * from "./conversations_retention";
 export * from "./create_space";
 export * from "./disable_sso_enforcement";
 export * from "./extend_trial";

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -363,6 +363,26 @@ export async function changeWorkspaceName(
   return new Ok(undefined);
 }
 
+export async function updateWorkspaceConversationsRetention(
+  owner: LightWorkspaceType,
+  nbDays: number
+): Promise<Result<void, Error>> {
+  const [affectedCount] = await Workspace.update(
+    { conversationsRetentionDays: nbDays === -1 ? null : nbDays },
+    {
+      where: {
+        id: owner.id,
+      },
+    }
+  );
+
+  if (affectedCount === 0) {
+    return new Err(new Error("Workspace not found."));
+  }
+
+  return new Ok(undefined);
+}
+
 export async function disableSSOEnforcement(
   owner: LightWorkspaceType
 ): Promise<Result<void, Error>> {


### PR DESCRIPTION
## Description

New Poké plugin to set the conversation retention days for a workspace. 

## Tests

Tested manually.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
