### PR TITLE
[CoreNodes] Fix titles on nodes that were upserted without a title

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -263,7 +263,8 @@ async function getContentNodesForDataSourceViewFromCore(
       return {
         internalId: node.node_id,
         parentInternalId: node.parent_id ?? null,
-        title: node.title,
+        // TODO(2025-01-27 aubin): remove this once the handling of nodes without a title has been improved in the api/v1
+        title: node.title === "Untitled document" ? node.node_id : node.title,
         sourceUrl: node.source_url ?? null,
         permission: "read",
         lastUpdatedAt: node.timestamp,


### PR DESCRIPTION
## Description

- Currently, `api/v1` has a [fallback value](https://github.com/dust-tt/dust/blob/ec2bccb9c6fef273973dd806c529c5e0c9d2a4c4/front/pages/api/v1/w/%5BwId%5D/spaces/%5BspaceId%5D/data_sources/%5BdsId%5D/documents/%5BdocumentId%5D/index.ts#L541) when the title is missing.
- The current behavior is that in `getContentNodesForStaticDataSourceView` front has a special handling of titles for documents that uses the tags and relies on the `document_id` as a fallback.
- To replicate the current behavior, we implement the same fallback value for nodes fetched from `core`, awaiting a better handling in `api/v1` (which will require a backfill).

## Tests

- n/a

## Risk

- Low, only the Dust workspace is affected.

## Deploy Plan

- Deploy front.