### PR TITLE
Add production check to check active global front workflows (doc tracker notify, data retention)

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_front.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_front.ts
@@ -1,0 +1,45 @@
+import type { Client, WorkflowHandle } from "@temporalio/client";
+
+import type { CheckFunction } from "@app/lib/production_checks/types";
+import { getTemporalClient } from "@app/lib/temporal";
+
+const WORKFLOW_IDS = ["data-retention-workflow", "tracker-notify-workflow"];
+
+async function isWorkflowRunning(client: Client, workflowId: string) {
+  try {
+    const workflowHandle: WorkflowHandle =
+      client.workflow.getHandle(workflowId);
+    const description = await workflowHandle.describe();
+    return description.status.name === "RUNNING";
+  } catch (err) {
+    return false;
+  }
+}
+
+export const checkActiveWorkflowsForFront: CheckFunction = async (
+  _checkName,
+  logger,
+  reportSuccess,
+  reportFailure,
+  heartbeat
+) => {
+  const client = await getTemporalClient();
+
+  const missingWorkflows: string[] = [];
+  for (const workflowId of WORKFLOW_IDS) {
+    heartbeat();
+    const isRunning = await isWorkflowRunning(client, workflowId);
+    if (!isRunning) {
+      missingWorkflows.push(workflowId);
+    }
+  }
+
+  if (missingWorkflows.length > 0) {
+    reportFailure(
+      { missingWorkflows },
+      `Missing global front workflows: ${missingWorkflows.join(", ")}.`
+    );
+  } else {
+    reportSuccess({});
+  }
+};

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -2,6 +2,7 @@ import { Context } from "@temporalio/activity";
 import { v4 as uuidv4 } from "uuid";
 
 import { checkActiveWorkflows } from "@app/lib/production_checks/checks/check_active_workflows_for_connectors";
+import { checkActiveWorkflowsForFront } from "@app/lib/production_checks/checks/check_active_workflows_for_front";
 import { checkConnectorsLastSyncSuccess } from "@app/lib/production_checks/checks/check_connectors_last_sync_success";
 import { checkDataSourcesConsistency } from "@app/lib/production_checks/checks/check_data_sources_consistency";
 import { checkExtraneousWorkflows } from "@app/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors";
@@ -25,6 +26,11 @@ export const REGISTERED_CHECKS: Check[] = [
     name: "check_active_workflows_for_connector",
     check: checkActiveWorkflows,
     everyHour: 1,
+  },
+  {
+    name: "check_active_workflows_for_front",
+    check: checkActiveWorkflowsForFront,
+    everyHour: 8,
   },
   {
     name: "check_extraneous_workflows_for_paused_connectors",


### PR DESCRIPTION
## Description

This PR adds a new production check to ensure these workflows are running: 
- `"data-retention-workflow"`: workflow that runs daily to remove conversations for workspaces which have set up data retention. One for all workspaces. 
- `"tracker-notify-workflow"`: workflow that sends the tracker notifications. One for all workpaces also. 

## Tests

Non tested locally but should be straightforward. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. No need to bump the queue. 
