### PR TITLE
[Nodes Core] Measure latency + allow dual show

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -190,6 +190,8 @@ type SpaceDataSourceViewContentListProps = {
   plan: PlanType;
   space: SpaceType;
   systemSpace: SpaceType;
+  // TODO(20250126, nodes-core): Remove this after project end
+  showConnectorsNodes?: boolean;
 };
 
 export const SpaceDataSourceViewContentList = ({
@@ -204,6 +206,7 @@ export const SpaceDataSourceViewContentList = ({
   plan,
   space,
   systemSpace,
+  showConnectorsNodes,
 }: SpaceDataSourceViewContentListProps) => {
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
@@ -258,6 +261,8 @@ export const SpaceDataSourceViewContentList = ({
     parentId,
     pagination: isServerPagination ? pagination : undefined,
     viewType: isValidContentNodesViewType(viewType) ? viewType : "documents",
+    // TODO(20250126, nodes-core): Remove this after project end
+    showConnectorsNodes,
   });
 
   const { hasContent: hasDocuments, isNodesValidating: isDocumentsValidating } =

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -108,6 +108,7 @@ export function useDataSourceViewContentNodes({
   viewType,
   disabled = false,
   swrOptions,
+  showConnectorsNodes,
 }: {
   owner: LightWorkspaceType;
   dataSourceView?: DataSourceViewType;
@@ -117,6 +118,8 @@ export function useDataSourceViewContentNodes({
   viewType?: ContentNodesViewType;
   disabled?: boolean;
   swrOptions?: SWRConfiguration;
+  // TODO(20250126, nodes-core): Remove this after project end
+  showConnectorsNodes?: boolean;
 }): {
   isNodesError: boolean;
   isNodesLoading: boolean;
@@ -128,6 +131,10 @@ export function useDataSourceViewContentNodes({
 } {
   const params = new URLSearchParams();
   appendPaginationParams(params, pagination);
+
+  if (showConnectorsNodes) {
+    params.set("connNodes", "true");
+  }
 
   const url = dataSourceView
     ? `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes?${params}`

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -57,6 +57,9 @@ async function handler(
     });
   }
 
+  // TODO(20250126, nodes-core): Remove this after project end
+  const showConnectorsNodes = req.query.connNodes === "true";
+
   const bodyValidation = GetContentNodesOrChildrenRequestBody.decode(req.body);
   if (isLeft(bodyValidation)) {
     const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -100,7 +103,8 @@ async function handler(
       parentId,
       pagination: paginationRes.value,
       viewType,
-    }
+    },
+    showConnectorsNodes
   );
 
   if (contentNodesRes.isErr()) {

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -145,6 +145,9 @@ export default function Space({
         isAdmin={isAdmin}
         systemSpace={systemSpace}
         connector={connector}
+        // TODO(20250126, nodes-core): Remove this after project end
+        // if query param is true, show connectors nodes
+        showConnectorsNodes={router.query.connNodes === "true"}
       />
     </Page.Vertical>
   );


### PR DESCRIPTION
Description
---
- Allow seeing contentNodes by appending `&connNodes=true` in url
- log latency differences between core & connectors

Risk
---
standard

Deploy
---
front

