### PR TITLE
[CoreNodes] Remove Webcrawler folder upserts/deletes

### DIFF
--- a/connectors/migrations/20250127_backfill_webcrawler_pages.ts
+++ b/connectors/migrations/20250127_backfill_webcrawler_pages.ts
@@ -1,0 +1,115 @@
+import { concurrentExecutor } from "@dust-tt/types";
+import { makeScript } from "scripts/helpers";
+
+import { getParentsForPage } from "@connectors/connectors/webcrawler/lib/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import {
+  deleteDataSourceFolder,
+  updateDataSourceDocumentParents,
+} from "@connectors/lib/data_sources";
+import {
+  WebCrawlerFolder,
+  WebCrawlerPage,
+} from "@connectors/lib/models/webcrawler";
+import type Logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+const CONCURRENCY = 8;
+
+async function deleteFolders(
+  connector: ConnectorResource,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const folders = await WebCrawlerFolder.findAll({
+    where: { connectorId: connector.id },
+  });
+
+  await concurrentExecutor(
+    folders,
+    async (folder) => {
+      logger.info(
+        {
+          folderId: folder.internalId,
+          folderUrl: folder.url,
+          connectorId: connector.id,
+        },
+        "DELETE"
+      );
+      if (execute) {
+        await deleteDataSourceFolder({
+          dataSourceConfig,
+          folderId: folder.internalId,
+        });
+      }
+    },
+    { concurrency: CONCURRENCY }
+  );
+}
+
+async function updatePageParents(
+  connector: ConnectorResource,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const pages = await WebCrawlerPage.findAll({
+    where: { connectorId: connector.id },
+  });
+
+  await concurrentExecutor(
+    pages,
+    async (page) => {
+      const parents = getParentsForPage(page.url, false);
+      logger.info(
+        {
+          connectorId: connector.id,
+          documentId: page.documentId,
+          pageUrl: page.url,
+          parents,
+        },
+        "UPDATE PARENTS"
+      );
+      if (execute) {
+        await updateDataSourceDocumentParents({
+          dataSourceConfig,
+          documentId: page.documentId,
+          parents,
+          parentId: parents[1] || null,
+        });
+      }
+    },
+    { concurrency: CONCURRENCY }
+  );
+}
+
+async function migrateConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  await deleteFolders(connector, execute, logger);
+  await updatePageParents(connector, execute, logger);
+}
+
+makeScript(
+  {
+    nextConnectorId: { type: "number", default: 0 },
+    connectorId: { type: "number", default: 0 },
+  },
+  async ({ execute, nextConnectorId }, logger) => {
+    logger.info({ nextConnectorId }, "Starting backfill");
+
+    const connectors = await ConnectorResource.listByType("webcrawler", {});
+
+    // sort connectors by id and start from nextConnectorId
+    const sortedConnectors = connectors
+      .sort((a, b) => a.id - b.id)
+      .filter((_, idx) => idx >= nextConnectorId);
+
+    for (const connector of sortedConnectors) {
+      await migrateConnector(connector, execute, logger);
+    }
+  }
+);

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -29,7 +29,7 @@ export function getParentsForPage(url: string, pageInItsOwnFolder: boolean) {
   }
   parents.push(
     ...getAllFoldersForUrl(url).map((f) =>
-      stableIdForUrl({ url: f, ressourceType: "folder" })
+      stableIdForUrl({ url: f, ressourceType: "file" })
     )
   );
 


### PR DESCRIPTION
## Description

- Webcrawler folders are currently upserted as `data_sources_folders`. 
- Pages with the same URLs are upserted as `data_sources_documents`, with different IDs (`stableIdForUrl` with a != `ressourceType`).
- As a result, we have non-leaf pages twice in the UI (unlike before).
- This PR removes any kind of folders from webcrawler connectors, only relying on pages as nodes of the hierarchy.

Before:
<img width="928" alt="Screenshot 2025-01-27 at 5 54 45 PM" src="https://github.com/user-attachments/assets/8c70ceb4-41b5-4e99-a520-6104ba248cfe" />

After:
<img width="928" alt="Screenshot 2025-01-27 at 5 55 26 PM" src="https://github.com/user-attachments/assets/0cd0253c-cbf9-4360-9cb3-f9476e42089a" />

## Tests

- Tested locally, backfill tested too.

## Risk

- Could potentially break our workspace, low overall.

## Deploy Plan

- Deploy connectors.