### PR TITLE
[front] - chore: add workspaceId to AgentRetrievalAction

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -357,6 +357,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
       functionCallName: actionConfiguration.name,
       agentMessageId: agentMessage.agentMessageId,
       step: step,
+      workspaceId: owner.id,
     });
 
     yield {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -6,7 +6,6 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 
 export class AgentRetrievalConfiguration extends WorkspaceAwareModel<AgentRetrievalConfiguration> {
@@ -131,7 +130,7 @@ AgentRetrievalConfiguration.belongsTo(AgentConfiguration, {
 /**
  * Retrieval Action
  */
-export class AgentRetrievalAction extends BaseModel<AgentRetrievalAction> {
+export class AgentRetrievalAction extends WorkspaceAwareModel<AgentRetrievalAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;


### PR DESCRIPTION
## Description

This PR aims at adding "workspaceId" to `AgentRetrievalAction` when creating it.

Note: will re-run backfill migration (migration_159.sql) once deployed. 

## Risk

Low

## Deploy Plan

- Deploy `front`