### PR TITLE
[CoreNodes] Ignore type discrepancies if already identified

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -7,6 +7,11 @@ import type {
 } from "@dust-tt/types";
 import { assertNever, MIME_TYPES } from "@dust-tt/types";
 
+import {
+  CHANNEL_MIME_TYPES,
+  DATABASE_MIME_TYPES,
+  FILE_MIME_TYPES,
+} from "@app/lib/content_nodes";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type logger from "@app/logger/logger";
 
@@ -106,6 +111,19 @@ export function computeNodesDiff({
             // Special case for folder parents, the ones retrieved using getContentNodesForStaticDataSourceView do not
             // contain any parentInternalIds.
             if (provider === null && key === "parentInternalIds") {
+              return false;
+            }
+            // Ignore the type mismatch between core and connectors for mime types that were already identified.
+            if (
+              key === "type" &&
+              coreNode.mimeType &&
+              ((value === "channel" &&
+                CHANNEL_MIME_TYPES.includes(coreNode.mimeType)) ||
+                (value === "database" &&
+                  DATABASE_MIME_TYPES.includes(coreNode.mimeType)) ||
+                (value === "file" &&
+                  FILE_MIME_TYPES.includes(coreNode.mimeType)))
+            ) {
               return false;
             }
             // For Google Drive, connectors does not fill the parentInternalId at google_drive/index.ts#L324.

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -13,6 +13,7 @@ import { assertNever, MIME_TYPES } from "@dust-tt/types";
 export const CHANNEL_MIME_TYPES = [
   MIME_TYPES.GITHUB.DISCUSSIONS,
   MIME_TYPES.INTERCOM.TEAM,
+  MIME_TYPES.INTERCOM.TEAMS_FOLDER,
   MIME_TYPES.SLACK.CHANNEL,
 ] as readonly string[];
 

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -10,16 +10,20 @@ import type { ContentNode } from "@dust-tt/types";
 import { assertNever, MIME_TYPES } from "@dust-tt/types";
 
 // Mime types that should be represented with a Channel icon.
-const CHANNEL_MIME_TYPES = [
+export const CHANNEL_MIME_TYPES = [
   MIME_TYPES.GITHUB.DISCUSSIONS,
   MIME_TYPES.SLACK.CHANNEL,
 ] as readonly string[];
 
 // Mime types that should be represented with a Database icon but are not of type "table".
-const DATABASE_MIME_TYPES = [MIME_TYPES.GITHUB.ISSUES] as readonly string[];
+export const DATABASE_MIME_TYPES = [
+  MIME_TYPES.GITHUB.ISSUES,
+] as readonly string[];
 
 // Mime types that should be represented with a File icon but are not of type "document".
-const FILE_MIME_TYPES = [MIME_TYPES.WEBCRAWLER.FOLDER] as readonly string[];
+export const FILE_MIME_TYPES = [
+  MIME_TYPES.WEBCRAWLER.FOLDER,
+] as readonly string[];
 
 function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   if (node.expandable) {

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -12,6 +12,7 @@ import { assertNever, MIME_TYPES } from "@dust-tt/types";
 // Mime types that should be represented with a Channel icon.
 export const CHANNEL_MIME_TYPES = [
   MIME_TYPES.GITHUB.DISCUSSIONS,
+  MIME_TYPES.INTERCOM.TEAM,
   MIME_TYPES.SLACK.CHANNEL,
 ] as readonly string[];
 


### PR DESCRIPTION
## Description

- Currently, a large number of [logged diff](https://app.datadoghq.eu/logs?query=CoreNodes%20%40provider%3Aslack%20-%40diff.sourceUrl.connectors%3Ahttps%5C%3A%2F%2Fdrive.google.com%2Fdrive%2F%2A%20-%40internalId%3A%28microsoft%2A%20OR%20zendesk-tickets-%2A%29&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZSsK7RAy39fZAAAABhBWlNzSzhRLUFBQS1zSWdYaU1xUUZBQmMAAAAkMDE5NGFjM2UtMzQyMi00NDYwLTk3YjItOGRjYmZjMzEyODNhAAI6uw&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=host%2Casc&viz=stream&from_ts=1737978562103&to_ts=1737992962103&live=true) are due to type discrepancies, for instance on Slack channels.
- In the end state, we'll only have the node type from core (document, table, folder) and will rationalize the use of this property.
- Some of this work is already done by identifying which nodes should have a specific icon.
- This PR removes the logs that point at those already identified cases.
- This PR also adds Intercom teams to nodes represented with a Channel icon.

## Tests

## Risk

- Affects the log on the shadow read only.

## Deploy Plan

- Deploy front.