### PR TITLE
[CoreNodes] Implement viewType filtering for documents

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -179,7 +179,9 @@ function filterNodesByViewType(
 ) {
   switch (viewType) {
     case "documents":
-      return nodes;
+      return nodes.filter(
+        (node) => node.has_children || node.node_type !== "Table"
+      );
     case "tables":
       return nodes.filter(
         (node) => node.has_children || node.node_type === "Table"


### PR DESCRIPTION
## Description

- The `viewType` filtering was implemented in https://github.com/dust-tt/dust/pull/10218 for Tables but not for documents.
- This PR implements the filtering for documents.
- The logic of how the `viewType` is used varies between connectors, the ones concerned by this change are: Google Drive, Microsoft and Notion + static folders.
  - Google Drive relies on the `viewType` to 1. compute the expandable property, which was rationalized by using core's `has_children` and 2. correctly retrieve sheets in `viewType === Tables`, which is a no-op since core does not make a difference between sheets and files (abstracted into nodes).
  - Notion upserts databases as both tables and documents.
  - Microsoft is very similar to Google Drive (fetches sheets if `viewType === "tables"`, uses it to compute `expandable`).
  - Folders: https://dust4ai.slack.com/archives/C050SM8NSPK/p1737999132773899 (`getContentNodesForStaticDataSourceView` uses either `getDataSourceDocuments` or `getTables` depending on the `viewType`, which most likely should be propagated to the search endpoint so not handled in this PR but in an upcoming one).

## Tests

## Risk

- Low, will be monitored using the log.

## Deploy Plan

- Deploy front.