### PR TITLE
POC dark theme internal

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -7,9 +7,15 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   EyeIcon,
   Icon,
+  ImageIcon,
   LightbulbIcon,
   LogoutIcon,
   StarIcon,
@@ -150,6 +156,30 @@ export function UserMenu({
                 icon={UserIcon}
               />
             )}
+            <DropdownMenuLabel label="Preferences (Dust only)" />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger label="Theme" icon={ImageIcon} />
+              <DropdownMenuSubContent>
+                <DropdownMenuRadioGroup>
+                  <DropdownMenuRadioItem
+                    value="light"
+                    label="Light"
+                    onClick={() => {
+                      localStorage.setItem("theme", "light");
+                      window.location.reload();
+                    }}
+                  />
+                  <DropdownMenuRadioItem
+                    value="dark"
+                    label="Dark"
+                    onClick={() => {
+                      localStorage.setItem("theme", "dark");
+                      window.location.reload();
+                    }}
+                  />
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
           </>
         )}
 

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -56,7 +56,7 @@ export const NavigationSidebar = React.forwardRef<
   return (
     <div
       ref={ref}
-      className="flex min-w-0 grow flex-col bg-structure-50 dark:bg-gray-800"
+      className="flex min-w-0 grow flex-col bg-structure-50 dark:bg-structure-50-dark"
     >
       <div className="flex flex-col">
         {user && user.workspaces.length > 1 ? (

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -54,7 +54,10 @@ export const NavigationSidebar = React.forwardRef<
   );
 
   return (
-    <div ref={ref} className="flex min-w-0 grow flex-col bg-structure-50">
+    <div
+      ref={ref}
+      className="flex min-w-0 grow flex-col bg-structure-50 dark:bg-gray-800"
+    >
       <div className="flex flex-col">
         {user && user.workspaces.length > 1 ? (
           <WorkspacePicker

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -140,56 +140,48 @@ export default function AppLayout({
         />
       </Head>
 
-      <div className={`h-full w-full ${isDarkMode ? "dark" : ""}`}>
-        <div className="flex h-full flex-row dark:bg-gray-900">
-          <Navigation
-            hideSidebar={hideSidebar}
-            isNavigationBarOpen={isNavigationBarOpen}
-            setNavigationBarOpen={setIsNavigationBarOpen}
-            owner={owner}
-            subscription={subscription}
-            navChildren={navChildren}
-            subNavigation={subNavigation}
-          />
-          <div
+      <div className={`flex h-full flex-row ${isDarkMode ? "dark" : "light"}`}>
+        <Navigation
+          hideSidebar={hideSidebar}
+          isNavigationBarOpen={isNavigationBarOpen}
+          setNavigationBarOpen={setIsNavigationBarOpen}
+          owner={owner}
+          subscription={subscription}
+          navChildren={navChildren}
+          subNavigation={subNavigation}
+        />
+        <div className="relative h-full w-full flex-1 flex-col overflow-x-hidden overflow-y-hidden dark:bg-black">
+          <main
+            id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
             className={classNames(
-              "relative h-full w-full flex-1 flex-col overflow-x-hidden overflow-y-hidden",
-              "dark:bg-gray-900 dark:text-white"
+              "flex h-full w-full flex-col items-center overflow-y-auto",
+              hasTopPadding ?? !titleChildren ? "lg:pt-8" : ""
             )}
           >
-            <main
-              id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
+            <div
               className={classNames(
-                "flex h-full w-full flex-col items-center overflow-y-auto dark:bg-gray-900",
-                hasTopPadding ?? !titleChildren ? "lg:pt-8" : ""
+                "flex w-full flex-col border-b border-primary-50 pl-12 lg:pl-0",
+                !hideSidebar
+                  ? "dark:border-structure-700/30 border-b border-structure-300/30 bg-white/80 backdrop-blur dark:bg-black/80"
+                  : "",
+                titleChildren ? "" : "lg:hidden"
               )}
             >
-              <div
-                className={classNames(
-                  "flex w-full flex-col border-b pl-12 lg:pl-0",
-                  "dark:border-gray-800",
-                  !hideSidebar
-                    ? "border-structure-300/30 bg-white/80 backdrop-blur dark:bg-gray-800/80"
-                    : "",
-                  titleChildren ? "" : "lg:hidden"
-                )}
-              >
-                <div className="h-16 grow px-6 dark:text-white">
-                  {loaded && titleChildren && titleChildren}
-                </div>
+              <div className="h-16 grow px-6">
+                {loaded && titleChildren && titleChildren}
               </div>
+            </div>
 
-              <div className="flex h-full w-full flex-col items-center overflow-y-auto px-4 dark:bg-gray-900 sm:px-8">
-                {isWideMode ? (
-                  loaded && children
-                ) : (
-                  <div className="flex w-full max-w-4xl grow flex-col dark:text-white">
-                    {loaded && children}
-                  </div>
-                )}
-              </div>
-            </main>
-          </div>
+            <div className="flex h-full w-full flex-col items-center overflow-y-auto px-4 sm:px-8">
+              {isWideMode ? (
+                loaded && children
+              ) : (
+                <div className="flex w-full max-w-4xl grow flex-col">
+                  {loaded && children}
+                </div>
+              )}
+            </div>
+          </main>
         </div>
       </div>
       <QuickStartGuide />

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -162,7 +162,7 @@ export default function AppLayout({
               className={classNames(
                 "flex w-full flex-col border-b border-primary-50 pl-12 lg:pl-0",
                 !hideSidebar
-                  ? "dark:border-structure-700/30 border-b border-structure-300/30 bg-white/80 backdrop-blur dark:bg-black/80"
+                  ? "border-b border-structure-300/30 bg-white/80 backdrop-blur dark:border-structure-300-dark/30 dark:bg-black/80"
                   : "",
                 titleChildren ? "" : "lg:hidden"
               )}

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -52,12 +52,18 @@ export default function AppLayout({
   hasTopPadding?: boolean;
 }) {
   const [loaded, setLoaded] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(false);
   const { user } = useUser();
   const { isNavigationBarOpen, setIsNavigationBarOpen } =
     useAppKeyboardShortcuts(owner);
 
   useEffect(() => {
     setLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    const theme = localStorage.getItem("theme");
+    setIsDarkMode(theme === "dark");
   }, []);
 
   useEffect(() => {
@@ -134,48 +140,56 @@ export default function AppLayout({
         />
       </Head>
 
-      <div className="light flex h-full flex-row">
-        <Navigation
-          hideSidebar={hideSidebar}
-          isNavigationBarOpen={isNavigationBarOpen}
-          setNavigationBarOpen={setIsNavigationBarOpen}
-          owner={owner}
-          subscription={subscription}
-          navChildren={navChildren}
-          subNavigation={subNavigation}
-        />
-        <div className="relative h-full w-full flex-1 flex-col overflow-x-hidden overflow-y-hidden">
-          <main
-            id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
+      <div className={`h-full w-full ${isDarkMode ? "dark" : ""}`}>
+        <div className="flex h-full flex-row dark:bg-gray-900">
+          <Navigation
+            hideSidebar={hideSidebar}
+            isNavigationBarOpen={isNavigationBarOpen}
+            setNavigationBarOpen={setIsNavigationBarOpen}
+            owner={owner}
+            subscription={subscription}
+            navChildren={navChildren}
+            subNavigation={subNavigation}
+          />
+          <div
             className={classNames(
-              "flex h-full w-full flex-col items-center overflow-y-auto",
-              hasTopPadding ?? !titleChildren ? "lg:pt-8" : ""
+              "relative h-full w-full flex-1 flex-col overflow-x-hidden overflow-y-hidden",
+              "dark:bg-gray-900 dark:text-white"
             )}
           >
-            <div
+            <main
+              id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
               className={classNames(
-                "flex w-full flex-col border-b border-primary-50 pl-12 lg:pl-0",
-                !hideSidebar
-                  ? "border-b border-structure-300/30 bg-white/80 backdrop-blur"
-                  : "",
-                titleChildren ? "" : "lg:hidden"
+                "flex h-full w-full flex-col items-center overflow-y-auto dark:bg-gray-900",
+                hasTopPadding ?? !titleChildren ? "lg:pt-8" : ""
               )}
             >
-              <div className="h-16 grow px-6">
-                {loaded && titleChildren && titleChildren}
-              </div>
-            </div>
-
-            <div className="flex h-full w-full flex-col items-center overflow-y-auto px-4 sm:px-8">
-              {isWideMode ? (
-                loaded && children
-              ) : (
-                <div className="flex w-full max-w-4xl grow flex-col">
-                  {loaded && children}
+              <div
+                className={classNames(
+                  "flex w-full flex-col border-b pl-12 lg:pl-0",
+                  "dark:border-gray-800",
+                  !hideSidebar
+                    ? "border-structure-300/30 bg-white/80 backdrop-blur dark:bg-gray-800/80"
+                    : "",
+                  titleChildren ? "" : "lg:hidden"
+                )}
+              >
+                <div className="h-16 grow px-6 dark:text-white">
+                  {loaded && titleChildren && titleChildren}
                 </div>
-              )}
-            </div>
-          </main>
+              </div>
+
+              <div className="flex h-full w-full flex-col items-center overflow-y-auto px-4 dark:bg-gray-900 sm:px-8">
+                {isWideMode ? (
+                  loaded && children
+                ) : (
+                  <div className="flex w-full max-w-4xl grow flex-col dark:text-white">
+                    {loaded && children}
+                  </div>
+                )}
+              </div>
+            </main>
+          </div>
         </div>
       </div>
       <QuickStartGuide />


### PR DESCRIPTION
## Description

POC to display a new entry in sidebar avatar menu to pick light or dark theme. It's only displayed for internal users with "show debug tools" meaning in dev mode or with existing feature flag "show_debug_tools".

I did the most simple thing I could do: 
We just set the preference on local storage and reload the page, we don't try to get info for system.
This should be improved the day we want to ship it but this is the MVP to start experimenting with dark mode locally to iterate on the components until we have a valid dark mode. 

Next steps: 
- Update components to make it usable
- Rework the toggle to display it to everyone, probably store the preference in the user-metadata over local storage
- Add option to use system preference so it automatically adapts.

<kbd>
<img width="382" alt="Screenshot 2025-01-28 at 12 47 02" src="https://github.com/user-attachments/assets/3a3846e9-cf2e-4cab-81d9-ce7f044ae969" />
</kbd>



## Tests

No tests! 

## Risk

Break the layout? 

## Deploy Plan

Deploy front!