### PR TITLE
[Nodes Core] Improve searchNodes API to sort and filter well

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -346,6 +346,8 @@ impl ElasticsearchSearchStore {
             ));
         }
 
+        // time the function call
+        let start = utils::now();
         // Build has_children query
         let has_children_search = Search::new()
             .size(0)
@@ -444,6 +446,10 @@ impl ElasticsearchSearchStore {
             })
             .collect();
 
+        info!(
+            duration = utils::now() - start,
+            "[ElasticsearchSearchStore] Computed core content nodes"
+        );
         Ok(core_content_nodes)
     }
 }

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -127,10 +127,10 @@ impl SearchStore for ElasticsearchSearchStore {
         let options = options.unwrap_or_default();
 
         // check that options.limit is not greater than MAX_PAGE_SIZE
-        if options.limit.unwrap_or(100) > MAX_PAGE_SIZE {
+        if options.limit.unwrap_or(MAX_PAGE_SIZE) > MAX_PAGE_SIZE {
             return Err(anyhow::anyhow!(
                 "Limit is greater than MAX_PAGE_SIZE: {} (limit is {})",
-                options.limit.unwrap_or(100),
+                options.limit.unwrap_or(MAX_PAGE_SIZE),
                 MAX_PAGE_SIZE
             ));
         }
@@ -195,7 +195,7 @@ impl SearchStore for ElasticsearchSearchStore {
         // Build and run search (sort by title if no query)
         let search = Search::new()
             .from(options.offset.unwrap_or(0))
-            .size(options.limit.unwrap_or(100))
+            .size(options.limit.unwrap_or(MAX_PAGE_SIZE))
             .query(bool_query)
             .sort(match query {
                 None => options

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -1,8 +1,10 @@
 import type {
   ContentNodesViewType,
   CoreAPIContentNode,
+  CoreAPIContentNodeType,
   CoreAPIDatasourceViewFilter,
   CoreAPIError,
+  CoreAPISortSpec,
   DataSourceViewContentNode,
   DataSourceViewType,
   PatchDataSourceViewType,
@@ -242,13 +244,29 @@ async function getContentNodesForDataSourceViewFromCore(
         ? undefined
         : ROOT_PARENT_ID);
 
+  const nodeTypesForViewType: CoreAPIContentNodeType[] =
+    viewType === "documents" ? ["Document", "Folder"] : ["Table", "Folder"];
+
+  // Always sort folders first, then sort by title.
+  const sortForViewType: CoreAPISortSpec[] =
+    viewType === "documents"
+      ? [
+          { field: "node_type", direction: "desc" },
+          { field: "title.keyword", direction: "asc" },
+        ]
+      : [
+          { field: "node_type", direction: "asc" },
+          { field: "title.keyword", direction: "asc" },
+        ];
+
   const coreRes = await coreAPI.searchNodes({
     filter: {
       data_source_views: [makeCoreDataSourceViewFilter(dataSourceView)],
       node_ids,
       parent_id,
+      node_types: nodeTypesForViewType,
     },
-    options: { limit: 250 },
+    options: { limit: 250, sort: sortForViewType },
   });
 
   if (coreRes.isErr()) {
@@ -483,7 +501,7 @@ export async function getContentNodesForDataSourceView(
       const workspace = renderLightWorkspaceType({ workspace: workspaceModel });
       if (
         (isDevelopment() || isDustWorkspace(workspace)) &&
-        showConnectorsNodes
+        !showConnectorsNodes
       ) {
         const contentNodesInView = filterAndCropContentNodesByView(
           dataSourceView,

--- a/types/src/core/content_node.ts
+++ b/types/src/core/content_node.ts
@@ -1,6 +1,6 @@
 import { ProviderVisibility } from "../front/lib/connectors_api";
 
-type CoreAPIContentNodeType = "Document" | "Table" | "Folder";
+export type CoreAPIContentNodeType = "Document" | "Table" | "Folder";
 
 export type CoreAPIContentNode = {
   data_source_id: string;

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1,6 +1,9 @@
 import { createParser } from "eventsource-parser";
 
-import { CoreAPIContentNode } from "../../core/content_node";
+import {
+  CoreAPIContentNode,
+  CoreAPIContentNodeType,
+} from "../../core/content_node";
 import {
   CoreAPIDataSource,
   CoreAPIDataSourceConfig,
@@ -170,9 +173,15 @@ export type CoreAPISearchFilter = {
   } | null;
 };
 
+export type CoreAPISortSpec = {
+  field: string;
+  direction: "asc" | "desc";
+};
+
 export type CoreAPISearchOptions = {
   limit?: number;
   offset?: number;
+  sort?: CoreAPISortSpec[];
 };
 
 export type CoreAPIDatasourceViewFilter = {
@@ -184,6 +193,7 @@ export type CoreAPINodesSearchFilter = {
   data_source_views: CoreAPIDatasourceViewFilter[];
   node_ids?: string[];
   parent_id?: string;
+  node_types?: CoreAPIContentNodeType[];
 };
 
 export class CoreAPI {


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2036 Fixes https://github.com/dust-tt/tasks/issues/2038

- Allow filtering by node type (Document, Folder, Table)
- Allow sorting by fields and directions (multiple fields to break ties)
- Changes call to searchNodes to appropriately sort by folders first and filter view correctly
- Defaults to max_page_size for number of result

Risks
---
low, not used in prod

Deploy
---
core
front
