### PR TITLE
Add: batch add for members in space, fix pagination

### DIFF
--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -85,7 +85,7 @@ export function InviteEmailModal({
     const existingMembersResponses = await Promise.all(
       inviteEmailsList.map(async (email) => {
         const response = await fetch(
-          `/api/w/${owner.sId}/members/search?searchTerm=${encodeURIComponent(email)}&orderBy=name`
+          `/api/w/${owner.sId}/members/search?searchTerm=${encodeURIComponent(email)}`
         );
         if (!response.ok) {
           throw new Error("Failed to fetch member information");

--- a/front/components/spaces/BatchAddMembersPopover.tsx
+++ b/front/components/spaces/BatchAddMembersPopover.tsx
@@ -35,7 +35,7 @@ export function BatchAddMembersPopover({
   const { members, isMembersLoading } = useMembersByEmails({
     workspaceId: owner.sId,
     emails,
-    disabled: !doSave,
+    disabled: !isOpen || !doSave,
   });
 
   const isListValid = emails?.length && !error;

--- a/front/components/spaces/BatchAddMembersPopover.tsx
+++ b/front/components/spaces/BatchAddMembersPopover.tsx
@@ -1,0 +1,136 @@
+import { removeNulls } from "@dust-tt/client";
+import {
+  Button,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  TextArea,
+  UserGroupIcon,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import type { LightWorkspaceType, UserType } from "@dust-tt/types";
+import React, { useCallback, useEffect, useState } from "react";
+
+import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
+import { useMembersByEmails } from "@app/lib/swr/memberships";
+import { isEmailValid } from "@app/lib/utils";
+
+interface BatchAddMembersPopoverProps {
+  owner: LightWorkspaceType;
+  selectedMembers: UserType[];
+  onMembersUpdated: (members: UserType[]) => void;
+}
+
+export function BatchAddMembersPopover({
+  owner,
+  selectedMembers,
+  onMembersUpdated,
+}: BatchAddMembersPopoverProps) {
+  const sendNotification = useSendNotification();
+  const [isOpen, setIsOpen] = useState(false);
+  const [content, setContent] = useState("");
+  const [error, setError] = useState<string>();
+  const [emails, setEmails] = useState<string[]>([]);
+  const [doSave, setDoSave] = useState(false);
+  const { members, isMembersLoading } = useMembersByEmails({
+    workspaceId: owner.sId,
+    emails,
+    disabled: !doSave,
+  });
+
+  const isListValid = emails?.length && !error;
+  const buttonLabel = isListValid ? `Add ${emails.length} members` : "...";
+
+  const onTextAreaChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setContent(e.target.value);
+      const emails = removeNulls(
+        e.target.value
+          .split("\n")
+          .map((email) => email.trim())
+          .filter((email) => isEmailValid(email))
+      );
+      setEmails(emails);
+      setError(
+        emails.length > MAX_SEARCH_EMAILS
+          ? `Too many emails provided. Maximum is ${MAX_SEARCH_EMAILS}.`
+          : undefined
+      );
+    },
+    []
+  );
+
+  const buttonOnClick = useCallback(() => {
+    if (isListValid) {
+      setDoSave(true);
+    }
+  }, [isListValid]);
+
+  useEffect(() => {
+    if (doSave && members.length > 0) {
+      sendNotification({
+        type: "success",
+        title: "Batch add members",
+        description:
+          members.length > 1
+            ? `${members.length} members were successfully added to this space.`
+            : `${members.length} member was successfully added to this space.`,
+      });
+
+      // Check the diff between emails and members
+      const missingEmails = emails.filter(
+        (email) => !members.some((m) => m.email === email)
+      );
+
+      if (missingEmails.length > 0) {
+        sendNotification({
+          type: "error",
+          title: "Some emails were not added",
+          description: `The following emails were not added: ${missingEmails.join(", ")}`,
+        });
+      }
+
+      onMembersUpdated(selectedMembers.concat(members));
+      setIsOpen(false);
+      setDoSave(false);
+      setContent("");
+      setEmails([]);
+      setError(undefined);
+    }
+  }, [
+    doSave,
+    emails,
+    members,
+    onMembersUpdated,
+    selectedMembers,
+    sendNotification,
+  ]);
+
+  return (
+    <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button label="Batch add" icon={UserGroupIcon} size="sm" />
+      </PopoverTrigger>
+      <PopoverContent className="mr-2 p-4">
+        <div className="text-sm font-normal text-element-700">
+          Enter the list of emails, one per line, max {MAX_SEARCH_EMAILS} per
+          batch.
+        </div>
+        <TextArea
+          onChange={onTextAreaChange}
+          value={content}
+          disabled={isMembersLoading}
+        ></TextArea>
+        {error && <div className="text-xs text-warning-500">{error}</div>}
+        <div className="mt-3 flex flex-row justify-end gap-2">
+          <Button
+            label={buttonLabel}
+            onClick={buttonOnClick}
+            disabled={!isListValid || isMembersLoading}
+            isLoading={isMembersLoading}
+          />
+        </div>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -13,12 +13,12 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type { LightWorkspaceType, SpaceType, UserType } from "@dust-tt/types";
-import { isDevelopment } from "@dust-tt/types";
 import type {
   CellContext,
   PaginationState,
   SortingState,
 } from "@tanstack/react-table";
+import _ from "lodash";
 import { useRouter } from "next/router";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -34,7 +34,7 @@ import {
   useUpdateSpace,
 } from "@app/lib/swr/spaces";
 
-const MIN_MEMBERS_FOR_BATCH_OPTION = isDevelopment() ? 2 : 50;
+const MIN_MEMBERS_FOR_BATCH_OPTION = 50;
 
 type RowData = {
   icon: string;
@@ -86,12 +86,10 @@ export function CreateOrEditSpaceModal({
   const [searchSelectedMembers, setSearchSelectedMembers] =
     useState<string>("");
 
-  const deduplicatedMembers = useMemo(() => {
-    return selectedMembers.filter(
-      (member, index, self) =>
-        index === self.findIndex((t) => t.sId === member.sId)
-    );
-  }, [selectedMembers]);
+  const deduplicatedMembers = useMemo(
+    () => _.uniqBy(selectedMembers, "sId"),
+    [selectedMembers]
+  );
 
   const doCreate = useCreateSpace({ owner });
   const doUpdate = useUpdateSpace({ owner });

--- a/front/components/spaces/SearchMembersPopover.tsx
+++ b/front/components/spaces/SearchMembersPopover.tsx
@@ -83,56 +83,54 @@ export function SearchMembersPopover({
   const hasMore = totalMembersCount > allMembers.length;
 
   return (
-    <div className="flex flex-col items-end gap-2">
-      <PopoverRoot>
-        <PopoverTrigger asChild>
-          <Button label="Add members" icon={UserIcon} size="sm" />
-        </PopoverTrigger>
-        <PopoverContent className="mr-2 p-4">
-          <SearchInput
-            name="search"
-            placeholder="Search members (email)"
-            value={searchTerm}
-            onChange={(e) => {
-              setSearchTerm(e);
-            }}
-          />
-          <ScrollArea className="mt-2 flex max-h-[300px] flex-col">
-            <div className="space-y-1">
-              {filteredMembers.map((member) => (
-                <div
-                  key={member.sId}
-                  className="flex cursor-pointer flex-col items-start hover:opacity-80"
-                  onClick={addMember(member)}
-                >
-                  <div className="my-1 flex items-center gap-2">
-                    <Avatar size="sm" visual={member.image || ""} />
-                    <div>
-                      <div className="text-sm">{member.fullName}</div>
-                      <div className="text-xs text-element-700">
-                        {member.email}
-                      </div>
+    <PopoverRoot>
+      <PopoverTrigger asChild>
+        <Button label="Add members" icon={UserIcon} size="sm" />
+      </PopoverTrigger>
+      <PopoverContent className="mr-2 p-4">
+        <SearchInput
+          name="search"
+          placeholder="Search members (email)"
+          value={searchTerm}
+          onChange={(e) => {
+            setSearchTerm(e);
+          }}
+        />
+        <ScrollArea className="mt-2 flex max-h-[300px] flex-col">
+          <div className="space-y-1">
+            {filteredMembers.map((member) => (
+              <div
+                key={member.sId}
+                className="flex cursor-pointer flex-col items-start hover:opacity-80"
+                onClick={addMember(member)}
+              >
+                <div className="my-1 flex items-center gap-2">
+                  <Avatar size="sm" visual={member.image || ""} />
+                  <div>
+                    <div className="text-sm">{member.fullName}</div>
+                    <div className="text-xs text-element-700">
+                      {member.email}
                     </div>
                   </div>
-                  <Separator />
                 </div>
-              ))}
-            </div>
-            <InfiniteScroll
-              nextPage={loadNextPage}
-              hasMore={hasMore}
-              isValidating={isLoading}
-              isLoading={isLoading}
-            >
-              {isLoading && (
-                <div className="py-2 text-center text-sm text-element-700">
-                  Loading more members...
-                </div>
-              )}
-            </InfiniteScroll>
-          </ScrollArea>
-        </PopoverContent>
-      </PopoverRoot>
-    </div>
+                <Separator />
+              </div>
+            ))}
+          </div>
+          <InfiniteScroll
+            nextPage={loadNextPage}
+            hasMore={hasMore}
+            isValidating={isLoading}
+            isLoading={isLoading}
+          >
+            {isLoading && (
+              <div className="py-2 text-center text-sm text-element-700">
+                Loading more members...
+              </div>
+            )}
+          </InfiniteScroll>
+        </ScrollArea>
+      </PopoverContent>
+    </PopoverRoot>
   );
 }

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -179,7 +179,10 @@ async function warnPostDeletion(
   switch (dataSourceProvider) {
     case "github":
       // get admin emails
-      const { members } = await getMembers(auth, { roles: ["admin"] });
+      const { members } = await getMembers(auth, {
+        roles: ["admin"],
+        activeOnly: true,
+      });
       const adminEmails = members.map((u) => u.email);
       // send email to admins
       for (const email of adminEmails) {

--- a/front/lib/memberships.ts
+++ b/front/lib/memberships.ts
@@ -1,0 +1,1 @@
+export const MAX_SEARCH_EMAILS = 100;

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -1,5 +1,5 @@
 import type { MembershipRoleType } from "@dust-tt/types";
-import type { CreationOptional, ForeignKey } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -15,6 +15,7 @@ export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   declare endAt: Date | null;
 
   declare userId: ForeignKey<UserModel["id"]>;
+  declare user: NonAttribute<UserModel>;
 }
 MembershipModel.init(
   {
@@ -55,4 +56,5 @@ UserModel.hasMany(MembershipModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
+
 MembershipModel.belongsTo(UserModel);

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -1,4 +1,5 @@
 import type {
+  LightWorkspaceType,
   ModelId,
   Result,
   UserProviderType,
@@ -6,12 +7,20 @@ import type {
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+
+export interface SearchMembersPaginationParams {
+  orderColumn: "name";
+  orderDirection: "asc" | "desc";
+  offset: number;
+  limit: number;
+}
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -218,6 +227,70 @@ export class UserResource extends BaseResource<UserModel> {
       lastName: this.lastName,
       fullName: this.fullName(),
       image: this.imageUrl,
+    };
+  }
+
+  static async listUserWithExactEmails(
+    owner: LightWorkspaceType,
+    emails: string[]
+  ): Promise<UserResource[]> {
+    const users = await UserModel.findAll({
+      include: [
+        {
+          model: MembershipModel,
+          as: "memberships",
+          where: {
+            workspaceId: owner.id,
+            startAt: { [Op.lte]: new Date() },
+            endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }] },
+          },
+          required: true,
+        },
+      ],
+      where: {
+        email: emails,
+      },
+    });
+
+    return users.map((user) => new UserResource(UserModel, user.get()));
+  }
+
+  static async listUsersWithEmailPredicat(
+    owner: LightWorkspaceType,
+    options: {
+      email?: string;
+    },
+    paginationParams: SearchMembersPaginationParams
+  ): Promise<{ users: UserResource[]; total: number }> {
+    const userWhereClause: any = {};
+    if (options.email) {
+      userWhereClause.email = {
+        [Op.iLike]: `%${options.email}%`,
+      };
+    }
+
+    const { count, rows: users } = await UserModel.findAndCountAll({
+      where: userWhereClause,
+      include: [
+        {
+          model: MembershipModel,
+          as: "memberships",
+          where: {
+            workspaceId: owner.id,
+            startAt: { [Op.lte]: new Date() },
+            endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }] },
+          },
+          required: true,
+        },
+      ],
+      order: [[paginationParams.orderColumn, paginationParams.orderDirection]],
+      limit: paginationParams.limit,
+      offset: paginationParams.offset,
+    });
+
+    return {
+      users: users.map((u) => new UserResource(UserModel, u.get())),
+      total: count,
     };
   }
 }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -2,7 +2,6 @@ import type { LightWorkspaceType } from "@dust-tt/types";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
-import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
@@ -126,10 +125,6 @@ export function useMembersByEmails({
 
   if (emails.length === 0) {
     disabled = true;
-  }
-
-  if (emails.length > MAX_SEARCH_EMAILS && !disabled) {
-    throw new Error("Too many emails provided.");
   }
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -17,3 +17,17 @@ export const setQueryParam = (
     { shallow: true }
   );
 };
+
+export const parseQueryString = (url: string) => {
+  // Remove everything before the query string
+  const queryString = url.split("?")[1] || "";
+  const searchParams = new URLSearchParams(queryString);
+
+  // Convert to plain object
+  const params: Record<string, string> = {};
+  searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+
+  return params;
+};

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -54,6 +54,7 @@
         "hot-shots": "^10.0.0",
         "io-ts": "^2.2.20",
         "io-ts-reporters": "^2.0.1",
+        "io-ts-types": "^0.5.19",
         "jsonwebtoken": "^9.0.0",
         "jszip": "^3.10.1",
         "jwks-rsa": "^3.1.0",
@@ -26458,6 +26459,17 @@
         "io-ts": "^2.2.16"
       }
     },
+    "node_modules/io-ts-types": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.19.tgz",
+      "integrity": "sha512-kQOYYDZG5vKre+INIDZbLeDJe+oM+4zLpUkjXyTMyUfoCpjJNyi29ZLkuEAwcPufaYo3yu/BsemZtbdD+NtRfQ==",
+      "peerDependencies": {
+        "fp-ts": "^2.0.0",
+        "io-ts": "^2.0.0",
+        "monocle-ts": "^2.0.0",
+        "newtype-ts": "^0.3.2"
+      }
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -29073,6 +29085,15 @@
         "node": "*"
       }
     },
+    "node_modules/monocle-ts": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
+      "integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
+      "peer": true,
+      "peerDependencies": {
+        "fp-ts": "^2.5.0"
+      }
+    },
     "node_modules/moo-color": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
@@ -29157,6 +29178,16 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "license": "MIT"
+    },
+    "node_modules/newtype-ts": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
+      "integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==",
+      "peer": true,
+      "peerDependencies": {
+        "fp-ts": "^2.0.0",
+        "monocle-ts": "^2.0.0"
+      }
     },
     "node_modules/next": {
       "version": "14.2.23",

--- a/front/package.json
+++ b/front/package.json
@@ -68,6 +68,7 @@
     "hot-shots": "^10.0.0",
     "io-ts": "^2.2.20",
     "io-ts-reporters": "^2.0.1",
+    "io-ts-types": "^0.5.19",
     "jsonwebtoken": "^9.0.0",
     "jszip": "^3.10.1",
     "jwks-rsa": "^3.1.0",

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -382,7 +382,10 @@ async function handler(
               "Couldn't get owner or subscription from `auth`."
             );
           }
-          const { members } = await getMembers(auth, { roles: ["admin"] });
+          const { members } = await getMembers(auth, {
+            roles: ["admin"],
+            activeOnly: true,
+          });
           const adminEmails = members.map((u) => u.email);
           const customerEmail = invoice.customer_email;
           if (customerEmail && !adminEmails.includes(customerEmail)) {
@@ -515,7 +518,10 @@ async function handler(
             }
 
             // then email admins
-            const { members } = await getMembers(auth, { roles: ["admin"] });
+            const { members } = await getMembers(auth, {
+              roles: ["admin"],
+              activeOnly: true,
+            });
             const adminEmails = members.map((u) => u.email);
             if (adminEmails.length === 0) {
               return apiError(req, res, {

--- a/front/pages/api/w/[wId]/members/index.test.ts
+++ b/front/pages/api/w/[wId]/members/index.test.ts
@@ -8,7 +8,7 @@ import { membershipFactory } from "@app/tests/utils/MembershipFactory";
 import { userFactory } from "@app/tests/utils/UserFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
 
-import handler from "./index";
+import handler, { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "./index";
 
 describe("GET /api/w/[wId]/members", () => {
   itInTransaction("returns all members for admin", async () => {
@@ -123,7 +123,7 @@ describe("GET /api/w/[wId]/members", () => {
 
     // Create 55 members (more than default limit of 50)
     const users = await Promise.all(
-      Array(54) // +1 from createPrivateApiMockRequest
+      Array(DEFAULT_PAGE_LIMIT + 4) // +1 from createPrivateApiMockRequest
         .fill(null)
         .map(() => userFactory().basic().create())
     );
@@ -138,8 +138,8 @@ describe("GET /api/w/[wId]/members", () => {
 
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
-    expect(data.total).toBe(55);
-    expect(data.members).toHaveLength(50); // Default limit
+    expect(data.total).toBe(DEFAULT_PAGE_LIMIT + 5);
+    expect(data.members).toHaveLength(DEFAULT_PAGE_LIMIT); // Default limit
     expect(data.nextPageUrl).toBeDefined();
   });
 
@@ -153,7 +153,7 @@ describe("GET /api/w/[wId]/members", () => {
 
       // Create 200 members (more than max limit of 150)
       const users = await Promise.all(
-        Array(199) // +1 from createPrivateApiMockRequest
+        Array(MAX_PAGE_LIMIT + 49) // +1 from createPrivateApiMockRequest
           .fill(null)
           .map(() => userFactory().basic().create())
       );
@@ -171,8 +171,8 @@ describe("GET /api/w/[wId]/members", () => {
 
       expect(res._getStatusCode()).toBe(200);
       const data = res._getJSONData();
-      expect(data.total).toBe(200);
-      expect(data.members).toHaveLength(50); // Should fall back to default limit
+      expect(data.total).toBe(MAX_PAGE_LIMIT + 50);
+      expect(data.members).toHaveLength(DEFAULT_PAGE_LIMIT); // Should fall back to default limit
       expect(data.nextPageUrl).toBeDefined();
     }
   );

--- a/front/pages/api/w/[wId]/members/index.test.ts
+++ b/front/pages/api/w/[wId]/members/index.test.ts
@@ -1,0 +1,337 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { describe, expect } from "vitest";
+
+import { parseQueryString } from "@app/lib/utils/router";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { membershipFactory } from "@app/tests/utils/MembershipFactory";
+import { userFactory } from "@app/tests/utils/UserFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./index";
+
+describe("GET /api/w/[wId]/members", () => {
+  itInTransaction("returns all members for admin", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Create additional members
+    const users = await Promise.all([
+      userFactory().basic().create(),
+      userFactory().basic().create(),
+      userFactory().basic().create(),
+    ]);
+
+    await Promise.all(
+      users.map((user) =>
+        membershipFactory().associate(workspace, user, "user").create()
+      )
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.total).toBe(4); // 3 created users + 1 from createPrivateApiMockRequest
+    expect(data.members).toHaveLength(4);
+    expect(data.members[0]).toHaveProperty("id");
+    expect(data.members[0]).toHaveProperty("email");
+    expect(data.nextPageUrl).toBeUndefined();
+  });
+
+  itInTransaction("returns 403 for non-admin users", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can see memberships or modify it.",
+      },
+    });
+  });
+
+  itInTransaction(
+    "returns only admin members for builder with admin role query",
+    async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "builder",
+      });
+
+      // Create additional members with different roles
+      const users = await Promise.all([
+        userFactory().basic().create(),
+        userFactory().basic().create(),
+        userFactory().basic().create(),
+      ]);
+
+      await Promise.all([
+        membershipFactory().associate(workspace, users[0], "admin").create(),
+        membershipFactory().associate(workspace, users[1], "admin").create(),
+        membershipFactory().associate(workspace, users[2], "user").create(),
+      ]);
+
+      // Add admin role query parameter
+      req.query.role = "admin";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.members).toHaveLength(2); // Only admin users
+      expect(data.total).toBe(2);
+      expect(data.nextPageUrl).toBeUndefined();
+      data.members.forEach((member: any) => {
+        expect(member.workspaces[0].role).toBe("admin");
+      });
+    }
+  );
+
+  itInTransaction("returns 405 for non-GET methods", async () => {
+    for (const method of ["POST", "PUT", "DELETE"] as const) {
+      const { req, res } = await createPrivateApiMockRequest({
+        method,
+        role: "admin",
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+    }
+  });
+
+  itInTransaction("handles pagination with default parameters", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Create 55 members (more than default limit of 50)
+    const users = await Promise.all(
+      Array(54) // +1 from createPrivateApiMockRequest
+        .fill(null)
+        .map(() => userFactory().basic().create())
+    );
+
+    await Promise.all(
+      users.map((user) =>
+        membershipFactory().associate(workspace, user, "user").create()
+      )
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.total).toBe(55);
+    expect(data.members).toHaveLength(50); // Default limit
+    expect(data.nextPageUrl).toBeDefined();
+  });
+
+  itInTransaction(
+    "falls back to default limit if requested limit exceeds maximum",
+    async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      // Create 200 members (more than max limit of 150)
+      const users = await Promise.all(
+        Array(199) // +1 from createPrivateApiMockRequest
+          .fill(null)
+          .map(() => userFactory().basic().create())
+      );
+
+      await Promise.all(
+        users.map((user) =>
+          membershipFactory().associate(workspace, user, "user").create()
+        )
+      );
+
+      // Request more than max allowed limit
+      req.query.limit = "200";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.total).toBe(200);
+      expect(data.members).toHaveLength(50); // Should fall back to default limit
+      expect(data.nextPageUrl).toBeDefined();
+    }
+  );
+
+  itInTransaction("handles custom pagination parameters", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Create 10 members
+    const users = [];
+
+    for (let i = 0; i < 9; i++) {
+      const createdAt = new Date(new Date().getTime() - (i + 1) * 1000);
+      const user = await userFactory().withCreatedAt(createdAt).create();
+      await membershipFactory()
+        .associateWithCreatedAt(workspace, user, "user", createdAt)
+        .create();
+      users.push(user);
+    }
+
+    // Set custom pagination parameters
+    req.query.limit = "5";
+    req.query.orderColumn = "createdAt";
+    req.query.orderDirection = "desc";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.total).toBe(10);
+    expect(data.members).toHaveLength(5);
+    expect(data.nextPageUrl).toBeDefined();
+    // Check that members are ordered by createdAt in descending order
+    const memberCreatedAts = data.members.map((m: any) => m.createdAt);
+    for (let i = 0; i < memberCreatedAts.length - 1; i++) {
+      expect(memberCreatedAts[i]).toBeGreaterThanOrEqual(
+        memberCreatedAts[i + 1]
+      );
+    }
+  });
+
+  itInTransaction("returns correct first and second pages", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Create 15 members
+    const users = [];
+    for (let i = 0; i < 15; i++) {
+      // Todo: we have to set the same date to both because pagination is done on membership createdAt
+      // but we return users with their createdAt
+      const createdAt = new Date(new Date().getTime() - (i + 1) * 1000);
+      const user = await userFactory().withCreatedAt(createdAt).create();
+      await membershipFactory()
+        .associateWithCreatedAt(workspace, user, "user", createdAt)
+        .create();
+
+      users.push(user);
+    }
+
+    // Get first page
+    req.query.limit = "10";
+    req.query.orderColumn = "createdAt";
+    req.query.orderDirection = "desc";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const firstPageData = res._getJSONData();
+
+    expect(firstPageData.total).toBe(16); // 15 created + 1 admin
+    expect(firstPageData.members).toHaveLength(10);
+    expect(firstPageData.nextPageUrl).toBeDefined();
+
+    const { req: req2, res: res2 } = createMocks<
+      NextApiRequest,
+      NextApiResponse
+    >({
+      method: "GET",
+      query: parseQueryString(firstPageData.nextPageUrl),
+      headers: {},
+    });
+
+    await handler(req2, res2);
+
+    expect(res2._getStatusCode()).toBe(200);
+    const secondPageData = res2._getJSONData();
+
+    expect(secondPageData.total).toBe(16);
+    expect(secondPageData.members).toHaveLength(6);
+
+    // Verify no overlap between pages
+    const firstPageIds = new Set(firstPageData.members.map((m: any) => m.id));
+    const secondPageIds = new Set(secondPageData.members.map((m: any) => m.id));
+    const intersection = [...firstPageIds].filter((id) =>
+      secondPageIds.has(id)
+    );
+    expect(intersection).toHaveLength(0);
+
+    // Verify ordering
+    const allMembers = [...firstPageData.members, ...secondPageData.members];
+    for (let i = 0; i < allMembers.length - 1; i++) {
+      expect(allMembers[i].createdAt).toBeGreaterThanOrEqual(
+        allMembers[i + 1].createdAt
+      );
+    }
+  });
+
+  itInTransaction(
+    "returns 200 for invalid pagination limit and fallback",
+    async () => {
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      // Test invalid limit
+      req.query.limit = "-1";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().members).toHaveLength(1);
+    }
+  );
+
+  itInTransaction(
+    "returns 200 for invalid pagination orderColumn and use ",
+    async () => {
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      // Test invalid order column
+      req.query.limit = "10";
+      req.query.orderColumn = "invalidColumn";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().members).toHaveLength(1);
+    }
+  );
+
+  itInTransaction("returns 200 for empty lastValue", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    req.query.lastValue = "";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().members).toHaveLength(1);
+  });
+});

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -14,6 +14,7 @@ import type { MembershipsPaginationParams } from "@app/lib/resources/membership_
 import { apiError } from "@app/logger/withlogging";
 
 export const DEFAULT_PAGE_LIMIT = 50;
+export const MAX_PAGE_LIMIT = 150;
 
 export type GetMembersResponseBody = {
   members: UserTypeWithWorkspaces[];
@@ -25,7 +26,7 @@ const MembersPaginationCodec = t.type({
   limit: withFallback(
     t.refinement(
       NumberFromString,
-      (n): n is number => n >= 0 && n <= 150,
+      (n): n is number => n >= 0 && n <= MAX_PAGE_LIMIT,
       `LimitWithRange`
     ),
     DEFAULT_PAGE_LIMIT

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect } from "vitest";
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { membershipFactory } from "@app/tests/utils/MembershipFactory";
+import { userFactory } from "@app/tests/utils/UserFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./search";
+
+describe("GET /api/w/[wId]/members/search", () => {
+  itInTransaction("returns 403 for non-admin users", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can search memberships.",
+      },
+    });
+  });
+
+  itInTransaction("returns 405 for non-GET methods", async () => {
+    for (const method of ["POST", "PUT", "DELETE"] as const) {
+      const { req, res } = await createPrivateApiMockRequest({
+        method,
+        role: "admin",
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+    }
+  });
+
+  itInTransaction("handles search by term", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Create users with specific names for search
+    const users = await Promise.all([
+      userFactory().basic().create(),
+      userFactory().basic().create(),
+      userFactory().basic().create(),
+    ]);
+
+    await Promise.all(
+      users.map((user) =>
+        membershipFactory().associate(workspace, user, "user").create()
+      )
+    );
+
+    req.query.searchTerm = users[0].email;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.total).toBe(1);
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0].id).toBe(users[0].id);
+  });
+
+  itInTransaction("handles search by emails", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const users = await Promise.all([
+      userFactory().basic().create(),
+      userFactory().basic().create(),
+      userFactory().basic().create(),
+    ]);
+
+    await Promise.all(
+      users.map((user) =>
+        membershipFactory().associate(workspace, user, "user").create()
+      )
+    );
+
+    req.query.searchEmails = users[0].email + "," + users[1].email;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.total).toBe(2);
+    expect(data.members).toHaveLength(2);
+    expect(data.members.map((m: any) => m.email)).toContain(users[0].email);
+    expect(data.members.map((m: any) => m.email)).toContain(users[1].email);
+  });
+
+  itInTransaction("returns 400 when too many emails provided", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Create a string with more than MAX_SEARCH_EMAILS emails
+    const tooManyEmails = Array(51)
+      .fill(null)
+      .map((_, i) => `user${i}@example.com`)
+      .join(",");
+
+    req.query.searchEmails = tooManyEmails;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Too many emails provided. Maximum is 100.",
+      },
+    });
+  });
+
+  itInTransaction("handles pagination with search results", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Create 29 (+1 from createPrivateApiMockRequest) users with similar names
+    const users = await Promise.all(
+      Array(29)
+        .fill(null)
+        .map(() => userFactory().basic().create())
+    );
+
+    await Promise.all(
+      users.map((user) =>
+        membershipFactory().associate(workspace, user, "user").create()
+      )
+    );
+
+    req.query.limit = "20";
+    req.query.offset = "0";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.total).toBe(30);
+    expect(data.members).toHaveLength(20);
+  });
+
+  itInTransaction("handles empty search results", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    req.query.searchTerm = "NonexistentUser";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.total).toBe(0);
+    expect(data.members).toHaveLength(0);
+  });
+});

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "vitest";
 
+import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { membershipFactory } from "@app/tests/utils/MembershipFactory";
 import { userFactory } from "@app/tests/utils/UserFactory";
@@ -112,7 +113,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     });
 
     // Create a string with more than MAX_SEARCH_EMAILS emails
-    const tooManyEmails = Array(51)
+    const tooManyEmails = Array(MAX_SEARCH_EMAILS + 1)
       .fill(null)
       .map((_, i) => `user${i}@example.com`)
       .join(",");
@@ -125,7 +126,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",
-        message: "Too many emails provided. Maximum is 100.",
+        message: `Too many emails provided. Maximum is ${MAX_SEARCH_EMAILS}.`,
       },
     });
   });

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -73,11 +73,8 @@ async function handler(
       }
 
       const query = queryRes.right;
-
-      if (
-        query.searchEmails?.length &&
-        query.searchEmails.length > MAX_SEARCH_EMAILS
-      ) {
+      const emails = query.searchEmails?.split(",");
+      if (emails?.length && emails.length > MAX_SEARCH_EMAILS) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -91,7 +88,7 @@ async function handler(
         auth,
         {
           searchTerm: query.searchTerm,
-          searchEmails: query.searchEmails?.split(","),
+          searchEmails: emails,
         },
         query
       );

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -50,7 +50,10 @@ export async function sendDataDeletionEmail({
     if (!ws) {
       throw new Error("No workspace found");
     }
-    const { members: admins } = await getMembers(auth, { roles: ["admin"] });
+    const { members: admins } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
     for (const a of admins) {
       await sendAdminDataDeletionEmail({
         email: a.email,

--- a/front/tests/utils/MembershipFactory.ts
+++ b/front/tests/utils/MembershipFactory.ts
@@ -21,6 +21,22 @@ class MembershipFactory extends Factory<MembershipModel> {
       workspaceId: workspace.id,
     });
   }
+
+  associateWithCreatedAt(
+    workspace: Workspace,
+    user: UserModel,
+    role: MembershipRoleType,
+    createdAt: Date
+  ) {
+    return this.params({
+      role,
+      startAt: createdAt,
+      createdAt: createdAt,
+      endAt: null,
+      userId: user.id,
+      workspaceId: workspace.id,
+    });
+  }
 }
 
 export const membershipFactory = () => {

--- a/front/tests/utils/UserFactory.ts
+++ b/front/tests/utils/UserFactory.ts
@@ -25,6 +25,22 @@ class UserFactory extends Factory<UserModel> {
       lastName: faker.person.lastName(),
     });
   }
+
+  withCreatedAt(createdAt: Date) {
+    return this.params({
+      sId: generateRandomModelSId(),
+      auth0Sub: faker.string.uuid(),
+      provider: "google",
+      providerId: faker.string.uuid(),
+
+      username: faker.internet.displayName(),
+      email: faker.internet.email(),
+      name: faker.person.fullName(),
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+      createdAt,
+    });
+  }
 }
 
 export const userFactory = () => {

--- a/front/tests/utils/factories.ts
+++ b/front/tests/utils/factories.ts
@@ -16,18 +16,6 @@ export abstract class Factory<M extends Model> {
     return this;
   }
 
-  async createList(
-    count: number,
-    params: Partial<InferCreationAttributes<M>>
-  ): Promise<M[]> {
-    const models: M[] = [];
-    for (let i = 0; i < count; i++) {
-      const model = await this.create(params);
-      models.push(model);
-    }
-    return models;
-  }
-
   async create(params?: Partial<InferCreationAttributes<M>>): Promise<M> {
     return this.make({ ...this.attrs, ...params });
   }


### PR DESCRIPTION
## Description

Add ability to batch add members to a space.
Discovered that pagination was a bit of a mess (offset vs were, loose typing..), fixed everything on my path but left to stop expanding scope at some point.
Also, we were sending emails to inactive admins.

## Tests

Added for `/members/` and `/members/search` endpoints.

## Risk

Medium, could break some emails flow (i doubt it).

## Deploy Plan

Deploy `front`, enjoy