### PR TITLE
[CoreNodes] Backfill Slack channels `providerVisibility` in core

### DIFF
--- a/connectors/migrations/20250128_backfill_provider_visibility.ts
+++ b/connectors/migrations/20250128_backfill_provider_visibility.ts
@@ -1,0 +1,56 @@
+import { MIME_TYPES } from "@dust-tt/types";
+import { makeScript } from "scripts/helpers";
+import { Op } from "sequelize";
+
+import { slackChannelInternalIdFromSlackChannelId } from "@connectors/connectors/slack/lib/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { SlackChannel } from "@connectors/lib/models/slack";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+const FOLDER_CONCURRENCY = 16;
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("slack", {});
+
+  for (const connector of connectors) {
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    const connectorId = connector.id;
+
+    const channels = await SlackChannel.findAll({
+      where: {
+        connectorId: connectorId,
+        permission: { [Op.or]: ["read", "read_write"] },
+      },
+    });
+
+    if (execute) {
+      await concurrentExecutor(
+        channels,
+        async (channel) => {
+          const internalId = slackChannelInternalIdFromSlackChannelId(
+            channel.slackChannelId
+          );
+          await upsertDataSourceFolder({
+            dataSourceConfig,
+            folderId: internalId,
+            title: `#${channel.slackChannelName}`,
+            parentId: null,
+            parents: [internalId],
+            mimeType: MIME_TYPES.SLACK.CHANNEL,
+            providerVisibility: channel.private ? "private" : "public",
+          });
+        },
+        { concurrency: FOLDER_CONCURRENCY }
+      );
+      logger.info(
+        `Upserted ${channels.length} channels for connector ${connector.id}`
+      );
+    } else {
+      logger.info(
+        `Found ${channels.length} channels for connector ${connector.id}`
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Description

- Close https://github.com/dust-tt/dust/issues/10286.
- The `providerVisibility` was actually never backfilled.
- The backfill script uses `api/v1` here to update the postgres db and the index.

## Tests

## Risk

- Low.

## Deploy Plan

- Run the script.