### PR TITLE
[CoreNodes] Exclude `permission` from the logged diff

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -96,7 +96,9 @@ export function computeNodesDiff({
       const diff = Object.fromEntries(
         Object.entries(connectorsNode)
           .filter(([key, value]) => {
-            if (["preventSelection", "lastUpdatedAt"].includes(key)) {
+            if (
+              ["preventSelection", "lastUpdatedAt", "permission"].includes(key)
+            ) {
               return false;
             }
             // Custom exclusion rules. The goal here is to avoid logging irrelevant differences, scoping by connector.


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10280.
- The usages of this field were checked, there actually is none (we see some code that looks like we use it but that actually writes it for the `setPermissions`).

## Tests

## Risk

- Low (only affects the log).

## Deploy Plan

- Deploy front.