### PR TITLE
[Nodes Core] Matches gdrive expandable in core/connector nodes

### DIFF
--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -43,15 +43,6 @@ export async function isDriveObjectExpandable({
     parentId: objectId,
   };
 
-  if (viewType === "tables") {
-    // In tables view, we only show folders and spreadhsheets.
-    // A folder that only contains Documents is not expandable.
-    where.mimeType = [
-      "application/vnd.google-apps.folder",
-      "application/vnd.google-apps.spreadsheet",
-    ];
-  }
-
   return !!(await GoogleDriveFiles.findOne({
     attributes: ["id"],
     where,

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -22,7 +22,11 @@ import type {
   SpaceType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { isValidContentNodesViewType } from "@dust-tt/types";
+import {
+  isDevelopment,
+  isDustWorkspace,
+  isValidContentNodesViewType,
+} from "@dust-tt/types";
 import type {
   CellContext,
   ColumnDef,
@@ -312,7 +316,10 @@ export const SpaceDataSourceViewContentList = ({
     () =>
       nodes?.map((contentNode) => ({
         ...contentNode,
-        icon: getVisualForContentNode(contentNode),
+        icon: getVisualForContentNode(
+          contentNode,
+          isDevelopment() || isDustWorkspace(owner)
+        ),
         spaces: spaces.filter((space) =>
           dataSourceViews
             .filter(
@@ -354,6 +361,7 @@ export const SpaceDataSourceViewContentList = ({
       onSelect,
       spaces,
       dataSourceViews,
+      owner,
     ]
   );
 

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -29,7 +29,7 @@ export const FILE_MIME_TYPES = [
 ] as readonly string[];
 
 // Mime types that should be represented with a Spreadsheet icon, despite being of type "folder".
-const SPREADSHEET_MIME_TYPES = [
+export const SPREADSHEET_MIME_TYPES = [
   MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
   MIME_TYPES.MICROSOFT.SPREADSHEET,
 ] as readonly string[];


### PR DESCRIPTION
Description
--
Fixes https://github.com/dust-tt/dust/issues/10279

- In documents view, make core spreadsheets non-expandable (they were before)
- In table view, make folders with children always expandable (they weren't before)

- Also show new icons in knowledge tab for local & dust workspace

Risk
---
na

Deploy
--
connectors
front