### PR TITLE
[connectors] - feat(slack): handle deleted message

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -8,7 +8,6 @@ import {
 } from "@connectors/api/webhooks/slack/created_channel";
 import { botAnswerMessage } from "@connectors/connectors/slack/bot";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
-import { getWeekStart } from "@connectors/connectors/slack/lib/utils";
 import { getBotUserIdMemoized } from "@connectors/connectors/slack/temporal/activities";
 import {
   launchSlackGarbageCollectWorkflow,
@@ -322,10 +321,7 @@ const _webhookSlackAPIHandler = async (
               } else {
                 // If it was a non-threaded message, re-sync the week's messages
                 // here event.deleted_ts corresponds to the message timestamp
-                const messageTs = parseInt(event.deleted_ts) * 1000;
-                const weekStartTsMs = getWeekStart(
-                  new Date(messageTs)
-                ).getTime();
+                const messageTs = event.deleted_ts;
                 const results = await Promise.all(
                   slackConfigurations.map(async (c) => {
                     const slackChannel = await SlackChannel.findOne({
@@ -343,7 +339,7 @@ const _webhookSlackAPIHandler = async (
                     return launchSlackSyncOneMessageWorkflow(
                       c.connectorId,
                       channel,
-                      weekStartTsMs.toString()
+                      messageTs
                     );
                   })
                 );

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -8,6 +8,7 @@ import {
 } from "@connectors/api/webhooks/slack/created_channel";
 import { botAnswerMessage } from "@connectors/connectors/slack/bot";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
+import { getWeekStart } from "@connectors/connectors/slack/lib/utils";
 import { getBotUserIdMemoized } from "@connectors/connectors/slack/temporal/activities";
 import {
   launchSlackGarbageCollectWorkflow,
@@ -21,7 +22,6 @@ import mainLogger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
-import { getWeekStart } from "@connectors/connectors/slack/lib/utils";
 
 export interface SlackWebhookEvent<T = string> {
   bot_id?: string;
@@ -321,6 +321,7 @@ const _webhookSlackAPIHandler = async (
                 }
               } else {
                 // If it was a non-threaded message, re-sync the week's messages
+                // here event.deleted_ts corresponds to the message timestamp
                 const messageTs = parseInt(event.deleted_ts) * 1000;
                 const weekStartTsMs = getWeekStart(
                   new Date(messageTs)

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -20,6 +20,7 @@ import mainLogger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import { removeNulls } from "../../../../sdks/js";
 
 export interface SlackWebhookEvent<T = string> {
   bot_id?: string;
@@ -313,9 +314,7 @@ const _webhookSlackAPIHandler = async (
               })
             );
 
-            const activeConfigurations = validConfigurations.filter(
-              (c): c is NonNullable<typeof c> => c !== null
-            );
+            const activeConfigurations = removeNulls(validConfigurations);
 
             if (activeConfigurations.length === 0) {
               logger.info(

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -20,6 +20,7 @@ import mainLogger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+
 import { removeNulls } from "../../../../sdks/js";
 
 export interface SlackWebhookEvent<T = string> {


### PR DESCRIPTION
## Description

This PR aims at handling deleted message on Slack.

Note: this is quite tricky to test locally, the webhook's payload received on message deletion seem to match the logic but this would need to be further tested live.

**References:**
- https://github.com/dust-tt/tasks/issues/2016

## Risk

Moderated, doesn't really alter the current behaviour but might introduce bug

## Deploy Plan

- Deploy `connectors`