### PR TITLE
[CoreNodes] Fix Zendesk root call

### DIFF
--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -76,7 +76,16 @@ async function getRootLevelContentNodes(
   const brandsInDatabase =
     await ZendeskBrandResource.fetchAllReadOnly(connectorId);
   if (isReadPermissionsOnly) {
-    return brandsInDatabase.map((brand) => brand.toContentNode(connectorId));
+    return [
+      ...brandsInDatabase
+        .filter((b) => b.ticketsPermission === "read")
+        .map((b) => b.getTicketsContentNode(connectorId, { richTitle: true })),
+      ...brandsInDatabase
+        .filter((b) => b.helpCenterPermission === "read")
+        .map((b) =>
+          b.getHelpCenterContentNode(connectorId, { richTitle: true })
+        ),
+    ];
   } else {
     const { result: brands } = await zendeskApiClient.brand.list();
     return brands.map(


### PR DESCRIPTION
## Description

- Fix the root call for Zendesk.
- We observe [logs](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Azendesk&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZSt1xTiL7XNvQAAABhBWlN0MXhvM0FBRDVrd1hJc1JfSWVRQlUAAAAkMDE5NGFkZDktNWRlNy00ZDNkLTkwMjktOGFhNjgzNDE2MzgzAAORPg&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1738065507961&to_ts=1738079907961&live=true) due to having different implementations of the root call between connectors and core.
- In connectors, there is an extra node for each Brand, which acts as a shortcut for selecting both the Help Center and the Tickets. We'll see whether we keep it that way, but in any case this node should not exist in the root call.

## Tests


## Risk

- Low, tested locally.

## Deploy Plan

- Deploy connectors.