### PR TITLE
Prevent unreachable in `getVisualForContentNodeBasedOnMimeType` when using `connNodes`

### DIFF
--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -79,9 +79,8 @@ function getVisualForContentNodeBasedOnType(node: ContentNode) {
 
 function getVisualForContentNodeBasedOnMimeType(node: ContentNode) {
   if (!node.mimeType) {
-    throw new Error(
-      "Unreachable: getVisualForContentNodeBasedOnMimeType called on a node that does not have a mime type"
-    );
+    // Hotfix to allow using the connNodes param.
+    return getVisualForContentNodeBasedOnType(node);
   }
   if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
     if (node.providerVisibility === "private") {


### PR DESCRIPTION
## Description

- Setting the `connNodes` param to true causes a throw unreachable because of the code that was put in `getVisualForContentNodeBasedOnMimeType`.
- This PR adds a quick and dirty fix to allow using this debug feature.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.