### PR TITLE
feat: reasoning tool

### DIFF
--- a/front/components/actions/reasoning/ReasoningActionDetails.tsx
+++ b/front/components/actions/reasoning/ReasoningActionDetails.tsx
@@ -35,8 +35,7 @@ function ReasoningThinking({ action }: { action: ReasoningActionType }) {
         <ContentMessage variant="slate" size="lg">
           <Markdown
             content={thinking}
-            isStreaming={false}
-            forcedTextSize="text-sm"
+            forcedTextSize="md"
             textColor="text-muted-foreground"
             isLastMessage={false}
           />

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -248,6 +248,9 @@ export function AgentMessage({
       case "browse_params":
       case "conversation_include_file_params":
       case "github_get_pull_request_params":
+      case "reasoning_started":
+      case "reasoning_thinking":
+      case "reasoning_tokens":
         setStreamedAgentMessage((m) => {
           return updateMessageWithAction(m, event.action);
         });
@@ -306,12 +309,6 @@ export function AgentMessage({
         setLastAgentStateClassification("thinking");
         break;
       }
-
-      case "reasoning_started":
-      case "reasoning_thinking":
-      case "reasoning_tokens":
-        // TODO(REASONING TOOL): handle the events
-        break;
 
       default:
         assertNever(event);
@@ -598,7 +595,13 @@ export function AgentMessage({
 
           {agentMessage.chainOfThought?.length ? (
             <ContentMessage title="Assistant thoughts" variant="slate">
-              {agentMessage.chainOfThought}
+              <Markdown
+                content={agentMessage.chainOfThought}
+                isStreaming={false}
+                forcedTextSize="text-sm"
+                textColor="text-muted-foreground"
+                isLastMessage={false}
+              />
             </ContentMessage>
           ) : null}
         </div>

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -13,7 +13,10 @@ import type {
   TimeframeUnit,
   WorkspaceType,
 } from "@dust-tt/types";
-import { DEFAULT_MAX_STEPS_USE_PER_RUN } from "@dust-tt/types";
+import {
+  DEFAULT_MAX_STEPS_USE_PER_RUN,
+  FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG,
+} from "@dust-tt/types";
 import {
   assertNever,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
@@ -351,8 +354,8 @@ export function getDefaultReasoningActionConfiguration(): AssistantBuilderAction
     configuration: {
       // TODO(REASONING TOOL):
       // Cleanup
-      providerId: "togetherai",
-      modelId: "deepseek-ai/DeepSeek-R1",
+      providerId: FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG.providerId,
+      modelId: FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG.modelId,
       temperature: null,
       reasoningEffort: null,
     },

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -42,6 +42,7 @@ export const MODEL_PROVIDER_LOGOS: Record<ModelProvider, ComponentType> = {
   google_ai_studio: GoogleLogo,
   togetherai: PlanetIcon,
   deepseek: PlanetIcon,
+  fireworks: PlanetIcon,
 };
 
 export const USED_MODEL_CONFIGS: readonly ModelConfig[] = [

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -34,6 +34,7 @@ const prettyfiedProviderNames: { [key in ModelProviderIdType]: string } = {
   google_ai_studio: "Google",
   togetherai: "TogetherAI",
   deepseek: "Deepseek",
+  fireworks: "Fireworks",
 };
 
 const modelProviders: Record<ModelProviderIdType, string[]> =

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -15,6 +15,7 @@ import { Op, Sequelize } from "sequelize";
 
 import { browseActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/browse";
 import { dustAppRunTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/dust_app_run";
+import { reasoningActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/reasoning";
 import { tableQueryTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/tables_query";
 import { websearchActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/websearch";
 import {
@@ -121,6 +122,7 @@ async function batchRenderAgentMessages(
     agentWebsearchActions,
     agentBrowseActions,
     agentConversationIncludeFileActions,
+    agentReasoningActions,
   ] = await Promise.all([
     (async () => {
       const agentConfigurationIds: string[] = agentMessages.reduce(
@@ -151,6 +153,7 @@ async function batchRenderAgentMessages(
     (async () => browseActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () =>
       conversationIncludeFileTypesFromAgentMessageIds(agentMessageIds))(),
+    (async () => reasoningActionTypesFromAgentMessageIds(agentMessageIds))(),
   ]);
 
   // The only async part here is the content parsing, but it's "fake async" as the content parsing is not doing
@@ -172,6 +175,7 @@ async function batchRenderAgentMessages(
         agentWebsearchActions,
         agentBrowseActions,
         agentConversationIncludeFileActions,
+        agentReasoningActions,
       ]
         .flat()
         .filter((a) => a.agentMessageId === agentMessage.id)

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -16,7 +16,8 @@ type RedisUsageTagsType =
   | "message_events"
   | "retry_agent_message"
   | "update_authors"
-  | "user_message_events";
+  | "user_message_events"
+  | "reasoning_generation";
 
 export async function getRedisClient({
   origin,

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -275,6 +275,20 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
+  "assistant-v2-reason": {
+    app: {
+      appId: "hUJvIB2KDb",
+      appHash:
+        "7ba05a9b123dbf65751c73f86e1a477a77d77f0b4984f208d9f98c84713afb4b",
+    },
+    config: {
+      MODEL: {
+        // `provider_id` and `model_id` must be set by caller.
+        use_cache: false,
+        use_stream: true,
+      },
+    },
+  },
 };
 
 export type DustRegistryActionName = keyof typeof BaseDustProdActionRegistry;

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -1,5 +1,6 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import {
+  FIREWORKS_DEEPSEEK_R1_MODEL_ID,
   GEMINI_1_5_FLASH_LATEST_MODEL_ID,
   GEMINI_1_5_PRO_LATEST_MODEL_ID,
   GEMINI_2_FLASH_PREVIEW_MODEL_ID,
@@ -278,7 +279,7 @@ async function handler(
           return res.status(200).json({
             models: [
               { id: "llama-v3p1-8b-instruct" },
-              { id: "accounts/fireworks/models/deepseek-r1" },
+              { id: FIREWORKS_DEEPSEEK_R1_MODEL_ID },
             ],
           });
         case "deepseek":

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -20,6 +20,7 @@ const ModelProviderIdSchema = FlexibleEnumSchema<
   | "google_ai_studio"
   | "togetherai"
   | "deepseek"
+  | "fireworks"
 >();
 
 const ModelLLMIdSchema = FlexibleEnumSchema<
@@ -53,6 +54,7 @@ const ModelLLMIdSchema = FlexibleEnumSchema<
   | "deepseek-ai/DeepSeek-R1" // togetherai
   | "deepseek-chat" // deepseek api
   | "deepseek-reasoner" // deepseek api
+  | "accounts/fireworks/models/deepseek-r1" // fireworks
 >();
 
 const EmbeddingProviderIdSchema = FlexibleEnumSchema<"openai" | "mistral">();

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -19,6 +19,7 @@ export const MODEL_PROVIDER_IDS = [
   "google_ai_studio",
   "togetherai",
   "deepseek",
+  "fireworks",
 ] as const;
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 
@@ -137,6 +138,8 @@ export const TOGETHERAI_DEEPSEEK_R1_MODEL_ID =
   "deepseek-ai/DeepSeek-R1" as const;
 export const DEEPSEEK_CHAT_MODEL_ID = "deepseek-chat" as const;
 export const DEEPSEEK_REASONER_MODEL_ID = "deepseek-reasoner" as const;
+export const FIREWORKS_DEEPSEEK_R1_MODEL_ID =
+  "accounts/fireworks/models/deepseek-r1" as const;
 
 export const MODEL_IDS = [
   GPT_3_5_TURBO_MODEL_ID,
@@ -169,6 +172,7 @@ export const MODEL_IDS = [
   TOGETHERAI_DEEPSEEK_R1_MODEL_ID,
   DEEPSEEK_CHAT_MODEL_ID,
   DEEPSEEK_REASONER_MODEL_ID,
+  FIREWORKS_DEEPSEEK_R1_MODEL_ID,
 ] as const;
 export type ModelIdType = (typeof MODEL_IDS)[number];
 
@@ -748,6 +752,21 @@ export const DEEPSEEK_REASONER_MODEL_CONFIG: ModelConfigurationType = {
   featureFlag: "deepseek_feature",
 };
 
+export const FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "fireworks",
+  modelId: FIREWORKS_DEEPSEEK_R1_MODEL_ID,
+  displayName: "DeepSeek R1 (Fireworks)",
+  contextSize: 164_000,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 128,
+  largeModel: true,
+  description:
+    "DeepSeek's reasoning model (reasoning, 164k context, served via Fireworks).",
+  shortDescription: "DeepSeek R1 (reasoning model).",
+  isLegacy: false,
+  supportsVision: false,
+};
+
 export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
@@ -780,6 +799,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   TOGETHERAI_DEEPSEEK_R1_MODEL_CONFIG,
   DEEPSEEK_CHAT_MODEL_CONFIG,
   DEEPSEEK_REASONER_MODEL_CONFIG,
+  FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG,
 ];
 
 export type ModelConfig = (typeof SUPPORTED_MODEL_CONFIGS)[number];

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -761,10 +761,21 @@ export const FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   recommendedExhaustiveTopK: 128,
   largeModel: true,
   description:
-    "DeepSeek's reasoning model (reasoning, 164k context, served via Fireworks).",
+    "DeepSeek's reasoning model (164k context, served via Fireworks).",
   shortDescription: "DeepSeek R1 (reasoning model).",
   isLegacy: false,
   supportsVision: false,
+  delimitersConfiguration: {
+    incompleteDelimiterPatterns: [/<\/?[a-zA-Z_]*$/],
+    delimiters: [
+      {
+        openingPattern: "<think>",
+        closingPattern: "</think>",
+        classification: "chain_of_thought" as const,
+        swallow: false,
+      },
+    ],
+  },
 };
 
 export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [


### PR DESCRIPTION
## Description

Add the dust app and code to stream and handle events from the dust app into the action (DB + client).
Basic side-panel UI, with CoT streaming in a ContentMessage. 

Not covered here:
- displaying output
- thought for x seconds chip
- global deepseek-r1 agent
- auto-scroll
- streaming cursor
- assistant builder reasoning model selection


## Tests

manual

## Risk

N/A (gated)

## Deploy Plan

Deploy front

Will need to bypass the registry check (app not copied over yet)