### PR TITLE
[CoreNodes] Make Intercom teams node always expandable

### DIFF
--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -139,7 +139,7 @@ export async function retrieveIntercomConversationsPermissions({
         type: "channel",
         title: `All closed conversations from the past ${conversationsSlidingWindow} days`,
         sourceUrl: null,
-        expandable: false,
+        expandable: true,
         preventSelection: false,
         permission: isAllConversationsSynced ? "read" : "none",
         lastUpdatedAt: null,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10302
- In the root call, the Teams node ("All Conversations") was sometimes non-expandable, which triggers the log and is a sign that there is an opportunity to rationalize the behavior.
- This PR suggests making the node always expandable, rather that non-expandable if all teams are selected and expandable if some teams are.

## Tests

## Risk

- Very low.

## Deploy Plan

- Deploy connectors.