### PR TITLE
Fix Notion unknown parent of unknown

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -614,6 +614,11 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
   }): Promise<Result<string[], Error>> {
     const notionId = notionIdFromNodeId(internalId);
 
+    // The two nodes unknonwn and syncing are special folders always found at the root (no parent).
+    if (notionId === "unknown" || notionId === "syncing") {
+      return new Ok([internalId]);
+    }
+
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       logger.error({ connectorId: this.connectorId }, "Connector not found");


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10309.
- See log [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Anotion&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZSurHbvz4YpbAAAABhBWlN1ckg4a0FBQW1qM1NYdzdJeU93RmoAAAAkMDE5NGFlYWUtMTA3NC00MDBhLTk4YTktMjQwZDZmNGM3MzhhAALTtQ&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1738085288107&to_ts=1738088888107&live=true).
- This will go away anyway in the switch but the fix costs ~nothing.

## Tests

## Risk

- very low

## Deploy Plan

- Deploy connectors.