### PR TITLE
fix(Confluence) - Update parents for all pages (including ones without a parent)

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -761,9 +761,6 @@ export async function confluenceUpdatePagesParentIdsActivity(
       connectorId,
       spaceId,
       lastVisitedAt: visitedAtMs,
-      parentId: {
-        [Op.not]: null,
-      },
     },
   });
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10311.
- In Confluence, the parents update pass was initially not necessary for pages just below spaces because those already had correct parents.
- This was changed with the introduction of the `hidden_syncing_content` parent in the context of KW search to prevent pages whose parents were not updated yet to appear as root elements.
- The findAll that selects pages whose parents have to be updated was not updated in consequence.
- This PR updates this call to make sure the `hidden_syncing_content` parent is replaced with the correct parents (for pages `parentId` null the parents would be the page itself and the space).
- Note: no backfill will be performed, we will wait for the sync to kick in (every 2 hours).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.