### PR TITLE
[connectors] - fix(github): handle API 410

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -221,7 +221,10 @@ export async function getRepoIssuesPage(
         "transient_upstream_activity_error"
       );
     }
-
+    // Handle disabled issues case - GitHub returns 410 Gone when issues are disabled
+    if (err instanceof Error && "status" in err && err.status === 410) {
+      return [];
+    }
     throw err;
   }
 }

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -222,7 +222,11 @@ export async function getRepoIssuesPage(
       );
     }
     // Handle disabled issues case - GitHub returns 410 Gone when issues are disabled
-    if (err instanceof RequestError && err.status === 410) {
+    if (
+      err instanceof RequestError &&
+      err.status === 410 &&
+      err.message === "Issues are disabled for this repo"
+    ) {
       return [];
     }
     throw err;

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -5,7 +5,7 @@ import { createWriteStream } from "fs";
 import { mkdtemp, readdir, rm } from "fs/promises";
 import fs from "fs-extra";
 import * as reporter from "io-ts-reporters";
-import { Octokit } from "octokit";
+import { Octokit, RequestError } from "octokit";
 import { tmpdir } from "os";
 import { basename, extname, join, resolve } from "path";
 import type { Readable } from "stream";
@@ -222,7 +222,7 @@ export async function getRepoIssuesPage(
       );
     }
     // Handle disabled issues case - GitHub returns 410 Gone when issues are disabled
-    if (err instanceof Error && "status" in err && err.status === 410) {
+    if (err instanceof RequestError && err.status === 410) {
       return [];
     }
     throw err;


### PR DESCRIPTION
## Description

This PR aims at handling 410 returned by Github

**References:**
- [GitHub API docs](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue)
- [Monitors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1%20%40error.response.data.message%3A%22Issues%20are%20disabled%20for%20this%20repo%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1737880666981&to_ts=1738139866981&live=true)

## Risk

Low

## Deploy Plan

Deploy `connectors`