### PR TITLE
Sparkle: Fix export of StarStrokeIcon

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.373",
+  "version": "0.2.374",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.373",
+      "version": "0.2.374",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.373",
+  "version": "0.2.374",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/icons/solid/index.ts
+++ b/sparkle/src/icons/solid/index.ts
@@ -102,7 +102,7 @@ export { default as SparklesIcon } from "./Sparkles";
 export { default as SquareIcon } from "./Square";
 export { default as Square3Stack3DIcon } from "./Square3Stack3D";
 export { default as StarIcon } from "./Star";
-export { default as StarStrokeIconIcon } from "./StarStrokeIcon";
+export { default as StarStrokeIcon } from "./StarStrokeIcon";
 export { default as StopIcon } from "./Stop";
 export { default as StopSignIcon } from "./StopSign";
 export { default as TableIcon } from "./Table";


### PR DESCRIPTION
## Description

Fixing what I think is  a typo from https://github.com/dust-tt/dust/pull/10239/files#diff-ba66bf1686d69dda010bfa78fd8dd88eb99b4f64dc28ad49813b549da24c9351

## Tests

None

## Risk

None

## Deploy Plan

Publish Sparkle
