### PR TITLE
[CoreNodes] Fix Zendesk category URLs

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -131,9 +131,9 @@ export async function syncCategory({
     folderId,
     parents,
     parentId: parentId,
-    title: categoryInDb.name,
+    title: category.name,
     mimeType: MIME_TYPES.ZENDESK.CATEGORY,
-    sourceUrl: categoryInDb.url,
+    sourceUrl: category.html_url,
     timestampMs: currentSyncDateMs,
   });
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -450,7 +450,7 @@ export async function syncZendeskCategoryActivity({
     folderId,
     parents,
     parentId,
-    title: categoryInDb.name,
+    title: fetchedCategory.name,
     mimeType: MIME_TYPES.ZENDESK.CATEGORY,
     sourceUrl: fetchedCategory.html_url,
     timestampMs: currentSyncDateMs,

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -263,6 +263,7 @@ export const ZendeskCommandSchema = t.type({
     t.literal("resync-tickets"),
     t.literal("fetch-ticket"),
     t.literal("fetch-brand"),
+    t.literal("resync-help-centers"),
   ]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10320
- This PR fixes a bug where undefined sourceUrl could be passed due to the resource not mutating on an update (it's [expected](https://sequelize.org/api/v7/classes/_sequelize_core.index.model#update) but wasn't taken in consideration in the code).
- The issue was not critical, on the 2nd sync the URL were correctly filled, but still a bug with an easy fix.
- This PR also adds a `resync-help-centers` CLI command.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Wait for the Help Centers to be resynced (<= 30 min).