### PR TITLE
[front] - fix(website): check for duplicate name at creation

### DIFF
--- a/front/components/spaces/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/SpaceWebsiteModal.tsx
@@ -157,12 +157,14 @@ export default function SpaceWebsiteModal({
     }
   }, [isOpen, dataSourceView, webCrawlerConfiguration]);
 
-  const { mutateRegardlessOfQueryParams: mutateSpaceDataSourceViews } =
-    useSpaceDataSourceViews({
-      workspaceId: owner.sId,
-      spaceId: space.sId,
-      category: WEBSITE_CAT,
-    });
+  const {
+    spaceDataSourceViews,
+    mutateRegardlessOfQueryParams: mutateSpaceDataSourceViews,
+  } = useSpaceDataSourceViews({
+    workspaceId: owner.sId,
+    spaceId: space.sId,
+    category: WEBSITE_CAT,
+  });
 
   const frequencyDisplayText: Record<CrawlingFrequency, string> = {
     never: "Never",
@@ -206,6 +208,15 @@ export default function SpaceWebsiteModal({
         nameError = "Please provide a name.";
       } else if (dataSourceNameRes.isErr()) {
         nameError = dataSourceNameRes.error;
+      } else {
+        const nameExists = spaceDataSourceViews.some(
+          (view) =>
+            view.dataSource.name.toLowerCase() ===
+              dataSourceName.toLowerCase() && view.sId !== dataSourceView?.sId
+        );
+        if (nameExists) {
+          nameError = "A website with this name already exists";
+        }
       }
     }
 


### PR DESCRIPTION
## Description

This PR aims at checking whether a website with the same name already exists when creating a website. If it does, it will add an error label to the name input field.

**References:**
- https://github.com/dust-tt/tasks/issues/2003

## Risk

Low

## Deploy Plan

Deploy `front`