### PR TITLE
[connectors] Google drive fix and backfill

### DIFF
--- a/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
@@ -1,6 +1,9 @@
 import { makeScript } from "scripts/helpers";
 
-import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
+import {
+  GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
+  GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
+} from "@connectors/connectors/google_drive/lib/consts";
 import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
@@ -21,7 +24,9 @@ makeScript({}, async ({ execute }, logger) => {
           parents: [folderId],
           parentId: null,
           title: "Shared with me",
-          mimeType: "application/vnd.dust.googledrive.folder",
+          mimeType:
+            "application/application/vnd.dust.googledrive.shared-with_me",
+          sourceUrl: GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
         });
         logger.info(
           `Upserted folder ${folderId} for connector ${connector.id}`

--- a/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
@@ -1,9 +1,6 @@
 import { makeScript } from "scripts/helpers";
 
-import {
-  GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
-  GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
-} from "@connectors/connectors/google_drive/lib/consts";
+import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
 import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
@@ -24,8 +21,7 @@ makeScript({}, async ({ execute }, logger) => {
           parents: [folderId],
           parentId: null,
           title: "Shared with me",
-          mimeType: "application/vnd.dust.googledrive.shared-with_me",
-          sourceUrl: GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
+          mimeType: "application/vnd.dust.googledrive.folder",
         });
         logger.info(
           `Upserted folder ${folderId} for connector ${connector.id}`

--- a/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
@@ -24,8 +24,7 @@ makeScript({}, async ({ execute }, logger) => {
           parents: [folderId],
           parentId: null,
           title: "Shared with me",
-          mimeType:
-            "application/application/vnd.dust.googledrive.shared-with_me",
+          mimeType: "application/vnd.dust.googledrive.shared-with_me",
           sourceUrl: GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
         });
         logger.info(

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -5,6 +5,7 @@ import type { OAuth2Client } from "googleapis-common";
 import { GaxiosError } from "googleapis-common";
 import type { CreationAttributes } from "sequelize";
 
+import { getSourceUrlForGoogleDriveFiles } from "@connectors/connectors/google_drive";
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import {
   getMimeTypesToDownload,
@@ -510,7 +511,7 @@ async function upsertGdriveDocument(
       dataSourceConfig,
       documentId,
       documentContent: content,
-      documentUrl: file.webViewLink,
+      documentUrl: getSourceUrlForGoogleDriveFiles(file),
       timestampMs: file.updatedAtMs,
       tags,
       parents,

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -143,6 +143,15 @@ export function computeNodesDiff({
             if (key === "sourceUrl" && value === null && coreValue !== null) {
               return false;
             }
+            // Special case for the google drive sourceUrl: both are valid.
+            if (key === "sourceUrl" && value && coreValue) {
+              if (
+                value.startsWith("https://drive.google.com/file") &&
+                coreValue.toString().startsWith("https://docs.google.com/")
+              ) {
+                return false;
+              }
+            }
             // Special case for the titles of Webcrawler folders: we add a trailing slash in core but not in connectors.
             if (
               key === "title" &&

--- a/front/migrations/20250116_backfill_google_drive_source_url.ts
+++ b/front/migrations/20250116_backfill_google_drive_source_url.ts
@@ -107,7 +107,7 @@ async function backfillSpreadsheets(
          SET source_url = urls.url
          FROM (SELECT unnest(ARRAY [:nodeIds]::text[]) as node_id,
                       unnest(ARRAY [:urls]::text[])    as url) urls
-         WHERE data_sources_nodes.data_source = :dataSourceId AND data_sources_nodes.node_id = urls.node_id;`,
+         WHERE data_sources_nodes.data_source = :dataSourceId AND data_sources_nodes.node_id = urls.node_id AND source_url IS NULL;`,
         { replacements: { urls, nodeIds, dataSourceId } }
       );
       logger.info(
@@ -179,7 +179,7 @@ async function backfillFolders(
          SET source_url = urls.url
          FROM (SELECT unnest(ARRAY [:nodeIds]::text[]) as node_id,
                       unnest(ARRAY [:urls]::text[])    as url) urls
-         WHERE data_sources_nodes.data_source = :dataSourceId AND data_sources_nodes.node_id = urls.node_id;`,
+         WHERE data_sources_nodes.data_source = :dataSourceId AND data_sources_nodes.node_id = urls.node_id AND source_url IS NULL;`,
         { replacements: { urls, nodeIds, dataSourceId } }
       );
       logger.info(

--- a/front/migrations/20250116_backfill_google_drive_source_url.ts
+++ b/front/migrations/20250116_backfill_google_drive_source_url.ts
@@ -150,7 +150,7 @@ async function backfillFolders(
        FROM google_drive_files
        WHERE id > :lastId
          AND "connectorId" = :connectorId
-         AND "mimeType" = 'application/vnd.google-apps.folder'
+         AND "mimeType" = in ('application/vnd.google-apps.folder', 'application/vnd.dust.googledrive.spreadsheet')
        ORDER BY id
        LIMIT :batchSize;`,
       {


### PR DESCRIPTION
## Description

Fixes in the backfill : 
- put source url for shared-with_me
- include "application/vnd.dust.googledrive.spreadsheet" in source url backfill ( the "workbook" )
Both backfill have been executed already

Fixes the document upsert : 

Connectors return `<id>/view` , but documents were upserted with `...<id>/edit?usp=drivesdk` . Use the /view when upserting ( from `getSourceUrlForGoogleDriveFiles`)
Do we need a backfill for that ? 

## Tests

Check diff logs

## Risk


## Deploy Plan

deploy connectors
