### PR TITLE
[CoreNodes] Improve log on missing nodes from core

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -203,7 +203,11 @@ export function computeNodesDiff({
   });
   if (missingInternalIds.length > 0) {
     localLogger.info(
-      { missingInternalIds },
+      {
+        missingInternalIds,
+        coreNodesCount: coreContentNodes.length,
+        maxPageSizeReached: coreContentNodes.length === 1000, // max value determined by MAX_PAGE_SIZE in search_store.rs
+      },
       "[CoreNodes] Missing nodes from core"
     );
   }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -206,7 +206,7 @@ export function computeNodesDiff({
       {
         missingInternalIds,
         coreNodesCount: coreContentNodes.length,
-        maxPageSizeReached: coreContentNodes.length === 250, // max value determined by the limit set in getContentNodesForDataSourceViewFromCore
+        maxPageSizeReached: coreContentNodes.length === 1000, // max value determined by the limit set in getContentNodesForDataSourceViewFromCore
       },
       "[CoreNodes] Missing nodes from core"
     );

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -206,7 +206,7 @@ export function computeNodesDiff({
       {
         missingInternalIds,
         coreNodesCount: coreContentNodes.length,
-        maxPageSizeReached: coreContentNodes.length === 1000, // max value determined by MAX_PAGE_SIZE in search_store.rs
+        maxPageSizeReached: coreContentNodes.length === 250, // max value determined by the limit set in getContentNodesForDataSourceViewFromCore
       },
       "[CoreNodes] Missing nodes from core"
     );

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -269,7 +269,7 @@ async function getContentNodesForDataSourceViewFromCore(
       parent_id,
       node_types: nodeTypesForViewType,
     },
-    options: { limit: 250, sort: sortForViewType },
+    options: { limit: 1000, sort: sortForViewType },
   });
 
   if (coreRes.isErr()) {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10329
- This PR aims at helping differentiate whether nodes are missing in core's response due to the limit in page size being hit or due to node actually missing.
- This PR also bumps the page size limit in front's call to core from 250 to 1000, matching the `MAX_PAGE_SIZE` in `search_store.rs`.

## Tests

## Risk

- very low

## Deploy Plan

- Deploy front.