### PR TITLE
Core: Supports Filter tags is_in_map and is_not_map

### DIFF
--- a/core/src/search_filter.rs
+++ b/core/src/search_filter.rs
@@ -11,18 +11,21 @@ pub trait Filterable {
 }
 
 /// A filter to apply to the search query based on `tags`. All documents returned must have at least
-/// one tag in `is_in` and none of the tags in `is_not`.
+/// one tag in `is_in` and none of the tags in `is_not`. The `is_in_map` field allows to
+/// specify tags per data_source_id.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TagsFilter {
     #[serde(rename = "in")]
     pub is_in: Option<Vec<String>>,
+    #[serde(rename = "in_map")]
+    pub is_in_map: Option<HashMap<String, Vec<String>>>,
     #[serde(rename = "not")]
     pub is_not: Option<Vec<String>>,
 }
 
 /// A filter to apply to the search query based on document parents. All documents returned must have at least
 /// one parent in `is_in` and none of their parents in `is_not`. The `is_in_map` field allows to
-/// sepecify parents per data_source_id.
+/// specify parents per data_source_id.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ParentsFilter {
     #[serde(rename = "in")]
@@ -100,6 +103,24 @@ impl SearchFilter {
                             None => self_tags.is_in = Some(is_in.clone()),
                             Some(ref mut self_is_in) => {
                                 self_is_in.extend(is_in.clone());
+                            }
+                        },
+                    }
+                    match &tags.is_in_map {
+                        None => (),
+                        Some(ref is_in_map) => match &mut self_tags.is_in_map {
+                            None => self_tags.is_in_map = Some(is_in_map.clone()),
+                            Some(ref mut self_is_in_map) => {
+                                for (k, v) in is_in_map.iter() {
+                                    match self_is_in_map.get_mut(k) {
+                                        None => {
+                                            self_is_in_map.insert(k.clone(), v.clone());
+                                        }
+                                        Some(ref mut self_v) => {
+                                            self_v.extend(v.clone());
+                                        }
+                                    }
+                                }
                             }
                         },
                     }
@@ -236,9 +257,43 @@ impl SearchFilter {
     // We postprocess `parents.is_in_map` if it is set to augment or set `parents.is_in` based on
     // the current `data_source_id`` and set `parents.is_in_map` to `None` since this is a virtual
     // filter that we never want to send to qdrant.
+    // We do the same for `tags.is_in_map`.
     pub fn postprocess_for_data_source(&self, data_source_id: &str) -> SearchFilter {
         let filter = SearchFilter {
-            tags: self.tags.clone(),
+            tags: match &self.tags {
+                Some(tags) => {
+                    let mut is_in: Option<Vec<String>> = None;
+
+                    match &tags.is_in {
+                        Some(v) => {
+                            is_in = Some(v.clone());
+                        }
+                        None => (),
+                    }
+
+                    match &tags.is_in_map {
+                        Some(h) => match h.get(data_source_id) {
+                            Some(v) => match &mut is_in {
+                                Some(is_in) => {
+                                    is_in.extend(v.clone());
+                                }
+                                None => {
+                                    is_in = Some(v.clone());
+                                }
+                            },
+                            None => (),
+                        },
+                        None => (),
+                    }
+
+                    Some(TagsFilter {
+                        is_in,
+                        is_in_map: None,
+                        is_not: tags.is_not.clone(),
+                    })
+                }
+                None => None,
+            },
             parents: match &self.parents {
                 Some(parents) => {
                     let mut is_in: Option<Vec<String>> = None;
@@ -281,12 +336,27 @@ impl SearchFilter {
     pub fn ensure_postprocessed(&self) -> Result<()> {
         match &self.parents {
             Some(parents) => match &parents.is_in_map {
-                Some(_) => Err(anyhow!(
-                    "SearchFilter must be postprocessed before being used"
-                )),
-                None => Ok(()),
+                Some(_) => {
+                    return Err(anyhow!(
+                        "SearchFilter must be postprocessed before being used (parents.is_in_map)"
+                    ))
+                }
+                None => (),
             },
-            None => Ok(()),
+            None => (),
         }
+        match &self.tags {
+            Some(tags) => match &tags.is_in_map {
+                Some(_) => {
+                    return Err(anyhow!(
+                        "SearchFilter must be postprocessed before being used (tags.is_in_map)"
+                    ))
+                }
+                None => (),
+            },
+            None => (),
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/2048

We need to support `is_in_map` on TagsFilter as we do for ParentsFilter.
Edit: And `is_not_map`!


## Tests

No test added. 
Tested a retrieval locally, still working. 

## Risk

Should not be super risky, can be rolled back. 

## Deploy Plan

Deploy core. 
