### PR TITLE
[CoreNodes] Ignore inconsistencies in Snowflake tables title between `core` and `connectors`

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -176,6 +176,15 @@ export function computeNodesDiff({
             ) {
               return false;
             }
+            // Special case for Snowflake's title: we sometimes observe the internal ID database.schema.table used as
+            // the title in connectors, ignoring these occurrences.
+            if (
+              key === "title" &&
+              provider === "snowflake" &&
+              value.endsWith(coreValue) // value = database.schema.table, coreValue = table
+            ) {
+              return false;
+            }
             if (Array.isArray(value) && Array.isArray(coreValue)) {
               return JSON.stringify(value) !== JSON.stringify(coreValue);
             }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10335.
- In logs such as [this one](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Asnowflake&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZSycBmRmQk82gAAABhBWlN5Y0I0VEFBQXVGRHVkN29Iam5nQ3kAAAAkMDE5NGIyNzAtN2NiZC00YmY1LWIzNmItZTk3NTdkNjk2ZjE2AAKYhw&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1738097766821&to_ts=1738101366821&live=true), we observe that connectors returns the internal ID (database.schema.table) for the title instead of the table name like core.
- This PR makes the assumption that the desired result is the table name, and proceeds to ignore these discrepancies in the log.

## Tests

## Risk

- Low

## Deploy Plan

- Deploy front.