### PR TITLE
[sparkle] - fix: `useHashParam` hook 

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.374",
+  "version": "0.2.375",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.374",
+      "version": "0.2.375",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.374",
+  "version": "0.2.375",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/hooks/useHashParams.ts
+++ b/sparkle/src/hooks/useHashParams.ts
@@ -28,6 +28,7 @@ const setHashParam = (
   shouldReplaceState: boolean
 ) => {
   if (typeof window !== "undefined") {
+    const { pathname, search } = window.location;
     const [prefix, searchParams] = getHashSearchParams(window.location);
 
     if (typeof value === "undefined" || value === "") {
@@ -36,10 +37,12 @@ const setHashParam = (
       searchParams.set(key, value);
     }
 
-    const search = searchParams.toString();
-    const hash = search ? `${prefix}?${search}` : prefix;
+    const hashSearch = searchParams.toString();
+    const hash = hashSearch ? `${prefix}?${hashSearch}` : prefix;
+    const newUrl = `${pathname}${search}#${hash}`;
+
     if (shouldReplaceState && "replaceState" in history) {
-      history.replaceState(null, "", `#${hash}`);
+      history.replaceState(null, "", newUrl);
     } else {
       window.location.hash = hash;
     }


### PR DESCRIPTION
## Description

This PR aims at fixing the `useHashParams` hook. We use to reset the entire url. We now split the search terms and the pathname and only override the search terms.

**References:**
- https://github.com/dust-tt/tasks/issues/2040

## Risk

Breaking modals

## Deploy Plan

- Publish sparkle
- Bump sparkle version in front