### PR TITLE
[front] - refactor: `AgentProcess` models to use `WorkspaceAwareModel`

### DIFF
--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -9,9 +9,9 @@ import { DataTypes } from "sequelize";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 
-export class AgentProcessConfiguration extends BaseModel<AgentProcessConfiguration> {
+export class AgentProcessConfiguration extends WorkspaceAwareModel<AgentProcessConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -116,7 +116,7 @@ AgentProcessConfiguration.belongsTo(AgentConfiguration, {
 /**
  * Process Action
  */
-export class AgentProcessAction extends BaseModel<AgentProcessAction> {
+export class AgentProcessAction extends WorkspaceAwareModel<AgentProcessAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;


### PR DESCRIPTION
## Description

This PR aims at updating `AgentProcessConfiguration` and `AgentProcessAction` to use `WorkspaceAwareModel` instead of `BaseModel`.

## Risk

Low, migrations were already ran

## Deploy Plan

- Deploy `front`
- Rerun `migration_159.sql` 
- Run `migration_160.sql`
