### PR TITLE
[front] - refactor: streamline provider setup UI component

### DIFF
--- a/front/pages/w/[wId]/developers/providers.tsx
+++ b/front/pages/w/[wId]/developers/providers.tsx
@@ -1,4 +1,11 @@
-import { Button, Chip, cn, Container, Page, ShapesIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  Chip,
+  cn,
+  Container,
+  Page,
+  ShapesIcon,
+} from "@dust-tt/sparkle";
 import type { SubscriptionType, UserType, WorkspaceType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import React, { useState } from "react";
@@ -11,7 +18,11 @@ import {
 } from "@app/components/providers/ProviderSetup";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { APP_MODEL_PROVIDER_IDS, modelProviders, serviceProviders } from "@app/lib/providers";
+import {
+  APP_MODEL_PROVIDER_IDS,
+  modelProviders,
+  serviceProviders,
+} from "@app/lib/providers";
 import { useProviders } from "@app/lib/swr/apps";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
@@ -104,102 +115,98 @@ export function Providers({ owner }: { owner: WorkspaceType }) {
         />
       )}
 
-      <Container className="w-full h-full bg-background" noPadding>
+      <Container className="h-full w-full bg-background" noPadding>
         <div className="space-y-8">
-          <Page.SectionHeader
-            title="Model Providers"
-            description="Model providers available to your Dust apps."
-          />
-          <ul role="list">
-            {filteredProviders.map((provider) => (
-              <li key={provider.providerId} className="py-4">
-                <div className="items-center flex justify-between">
-                  <div className="flex flex-col gap-1.5">
-                    <div className="items-center flex">
-                      <p
-                        className={cn(
-                          "truncate text-base font-bold",
-                          configs[provider.providerId]
-                            ? "text-slate-700"
-                            : "text-slate-400"
-                        )}
-                      >
-                        {provider.name}
-                      </p>
-                      <div className="ml-2 mt-0.5 flex flex-shrink-0">
-                        <Chip
-                          size="xs"
-                          label={configs[provider.providerId] ? "enabled" : "disabled"}
-                          color={configs[provider.providerId] ?"emerald": "slate"}
-                        />
-                      </div>
-                    </div>
-                    {configs[provider.providerId] && (
-                      <p className="font-mono text-xs text-element-700">
-                        API Key:{" "}
-                        <pre>{configs[provider.providerId].redactedApiKey}</pre>
-                      </p>
-                    )}
-                  </div>
-                  <Button
-                    variant={
-                      configs[provider.providerId] ? "primary" : "outline"
-                    }
-                    label={configs[provider.providerId] ? "Edit" : "Set up"}
-                    onClick={() => {
-                      setIsModelProvider(true);
-                      setSelectedProviderId(provider.providerId);
-                    }}
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
+          <div>
+            <Page.SectionHeader
+              title="Model Providers"
+              description="Model providers available to your Dust apps."
+            />
+            <ul role="list" className="divide-y divide-structure-200 pt-4">
+              {filteredProviders.map((provider) => (
+                <ProviderListItem
+                  key={provider.providerId}
+                  name={provider.name}
+                  isEnabled={!!configs[provider.providerId]}
+                  apiKey={configs[provider.providerId]?.redactedApiKey}
+                  onAction={() => {
+                    setIsModelProvider(true);
+                    setSelectedProviderId(provider.providerId);
+                  }}
+                />
+              ))}
+            </ul>
+          </div>
 
-          <Page.SectionHeader
-            title="Service Providers"
-            description="Service providers enable your Dust Apps to query external data or write to external services."
-          />
-          <ul role="list">
-            {serviceProviders.map((provider) => (
-              <li key={provider.providerId} className="py-4">
-                <div className="items-center flex justify-between">
-                  <div className="items-center flex">
-                    <p
-                      className={cn(
-                        "truncate text-base font-bold",
-                        configs[provider.providerId]
-                          ? "text-slate-700"
-                          : "text-slate-400"
-                      )}
-                    >
-                      {provider.name}
-                    </p>
-                    <div className="ml-2 mt-0.5 flex flex-shrink-0">
-                      <Chip
-                        size="xs"
-                        label={configs[provider.providerId] ? "enabled" : "disabled"}
-                        color={configs[provider.providerId] ?"emerald": "slate"}
-                      />
-                    </div>
-                  </div>
-                  <Button
-                    variant={
-                      configs[provider.providerId] ? "primary" : "outline"
-                    }
-                    label={configs[provider.providerId] ? "Edit" : "Set up"}
-                    onClick={() => {
-                      setIsModelProvider(false);
-                      setSelectedProviderId(provider.providerId);
-                    }}
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
+          <div>
+            <Page.SectionHeader
+              title="Service Providers"
+              description="Service providers enable your Dust Apps to query external data or write to external services."
+            />
+            <ul role="list" className="divide-y divide-structure-200 pt-4">
+              {serviceProviders.map((provider) => (
+                <ProviderListItem
+                  key={provider.providerId}
+                  name={provider.name}
+                  isEnabled={!!configs[provider.providerId]}
+                  apiKey={configs[provider.providerId]?.redactedApiKey}
+                  onAction={() => {
+                    setIsModelProvider(false);
+                    setSelectedProviderId(provider.providerId);
+                  }}
+                />
+              ))}
+            </ul>
+          </div>
         </div>
       </Container>
     </>
+  );
+}
+
+function ProviderListItem({
+  name,
+  isEnabled,
+  apiKey,
+  onAction,
+}: {
+  name: string;
+  isEnabled: boolean;
+  apiKey?: string;
+  onAction: () => void;
+}) {
+  return (
+    <li className="py-4">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <p
+              className={cn(
+                "text-sm font-bold",
+                isEnabled ? "text-slate-700" : "text-slate-400"
+              )}
+            >
+              {name}
+            </p>
+            <Chip
+              size="xs"
+              label={isEnabled ? "enabled" : "disabled"}
+              color={isEnabled ? "emerald" : "slate"}
+            />
+          </div>
+          {apiKey && (
+            <p className="font-mono text-xs text-element-700">
+              API Key: <pre>{apiKey}</pre>
+            </p>
+          )}
+        </div>
+        <Button
+          variant={isEnabled ? "primary" : "outline"}
+          label={isEnabled ? "Edit" : "Set up"}
+          onClick={onAction}
+        />
+      </div>
+    </li>
   );
 }
 

--- a/front/pages/w/[wId]/developers/providers.tsx
+++ b/front/pages/w/[wId]/developers/providers.tsx
@@ -1,4 +1,4 @@
-import { Button, Page, ShapesIcon } from "@dust-tt/sparkle";
+import { Button, Chip, cn, Container, Page, ShapesIcon } from "@dust-tt/sparkle";
 import type { SubscriptionType, UserType, WorkspaceType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import React, { useState } from "react";
@@ -11,13 +11,8 @@ import {
 } from "@app/components/providers/ProviderSetup";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import {
-  APP_MODEL_PROVIDER_IDS,
-  modelProviders,
-  serviceProviders,
-} from "@app/lib/providers";
+import { APP_MODEL_PROVIDER_IDS, modelProviders, serviceProviders } from "@app/lib/providers";
 import { useProviders } from "@app/lib/swr/apps";
-import { classNames } from "@app/lib/utils";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -109,103 +104,101 @@ export function Providers({ owner }: { owner: WorkspaceType }) {
         />
       )}
 
-      <Page.SectionHeader
-        title="Model Providers"
-        description="Model providers available to your Dust apps."
-      />
-      <ul role="list" className="pt-4">
-        {filteredProviders.map((provider) => (
-          <li key={provider.providerId} className="px-2 py-4">
-            <div className="flex items-center justify-between">
-              <div className="flex flex-col gap-1.5">
-                <div className="flex items-center">
-                  <p
-                    className={classNames(
-                      "truncate text-base font-bold",
-                      configs[provider.providerId]
-                        ? "text-slate-700"
-                        : "text-slate-400"
+      <Container className="w-full h-full bg-background" noPadding>
+        <div className="space-y-8">
+          <Page.SectionHeader
+            title="Model Providers"
+            description="Model providers available to your Dust apps."
+          />
+          <ul role="list">
+            {filteredProviders.map((provider) => (
+              <li key={provider.providerId} className="py-4">
+                <div className="items-center flex justify-between">
+                  <div className="flex flex-col gap-1.5">
+                    <div className="items-center flex">
+                      <p
+                        className={cn(
+                          "truncate text-base font-bold",
+                          configs[provider.providerId]
+                            ? "text-slate-700"
+                            : "text-slate-400"
+                        )}
+                      >
+                        {provider.name}
+                      </p>
+                      <div className="ml-2 mt-0.5 flex flex-shrink-0">
+                        <Chip
+                          size="xs"
+                          label={configs[provider.providerId] ? "enabled" : "disabled"}
+                          color={configs[provider.providerId] ?"emerald": "slate"}
+                        />
+                      </div>
+                    </div>
+                    {configs[provider.providerId] && (
+                      <p className="font-mono text-xs text-element-700">
+                        API Key:{" "}
+                        <pre>{configs[provider.providerId].redactedApiKey}</pre>
+                      </p>
                     )}
-                  >
-                    {provider.name}
-                  </p>
-                  <div className="ml-2 mt-0.5 flex flex-shrink-0">
+                  </div>
+                  <Button
+                    variant={
+                      configs[provider.providerId] ? "primary" : "outline"
+                    }
+                    label={configs[provider.providerId] ? "Edit" : "Set up"}
+                    onClick={() => {
+                      setIsModelProvider(true);
+                      setSelectedProviderId(provider.providerId);
+                    }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <Page.SectionHeader
+            title="Service Providers"
+            description="Service providers enable your Dust Apps to query external data or write to external services."
+          />
+          <ul role="list">
+            {serviceProviders.map((provider) => (
+              <li key={provider.providerId} className="py-4">
+                <div className="items-center flex justify-between">
+                  <div className="items-center flex">
                     <p
-                      className={classNames(
-                        "inline-flex rounded-full px-2 text-xs font-semibold leading-5",
+                      className={cn(
+                        "truncate text-base font-bold",
                         configs[provider.providerId]
-                          ? "bg-green-100 text-green-800"
-                          : "bg-gray-100 text-gray-800"
+                          ? "text-slate-700"
+                          : "text-slate-400"
                       )}
                     >
-                      {configs[provider.providerId] ? "enabled" : "disabled"}
+                      {provider.name}
                     </p>
+                    <div className="ml-2 mt-0.5 flex flex-shrink-0">
+                      <Chip
+                        size="xs"
+                        label={configs[provider.providerId] ? "enabled" : "disabled"}
+                        color={configs[provider.providerId] ?"emerald": "slate"}
+                      />
+                    </div>
                   </div>
+                  <Button
+                    variant={
+                      configs[provider.providerId] ? "primary" : "outline"
+                    }
+                    label={configs[provider.providerId] ? "Edit" : "Set up"}
+                    onClick={() => {
+                      setIsModelProvider(false);
+                      setSelectedProviderId(provider.providerId);
+                    }}
+                  />
                 </div>
-                {configs[provider.providerId] && (
-                  <p className="font-mono text-xs text-element-700">
-                    API Key:{" "}
-                    <pre>{configs[provider.providerId].redactedApiKey}</pre>
-                  </p>
-                )}
-              </div>
-              <Button
-                variant={configs[provider.providerId] ? "primary" : "outline"}
-                label={configs[provider.providerId] ? "Edit" : "Set up"}
-                onClick={() => {
-                  setIsModelProvider(true);
-                  setSelectedProviderId(provider.providerId);
-                }}
-              />
-            </div>
-          </li>
-        ))}
-      </ul>
-
-      <Page.SectionHeader
-        title="Service Providers"
-        description="Service providers enable your Dust Apps to query external data or write to external services."
-      />
-      <ul role="list" className="pt-4">
-        {serviceProviders.map((provider) => (
-          <li key={provider.providerId} className="px-2 py-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center">
-                <p
-                  className={classNames(
-                    "truncate text-base font-bold",
-                    configs[provider.providerId]
-                      ? "text-slate-700"
-                      : "text-slate-400"
-                  )}
-                >
-                  {provider.name}
-                </p>
-                <div className="ml-2 mt-0.5 flex flex-shrink-0">
-                  <p
-                    className={classNames(
-                      "inline-flex rounded-full px-2 text-xs font-semibold leading-5",
-                      configs[provider.providerId]
-                        ? "bg-green-100 text-green-800"
-                        : "bg-gray-100 text-gray-800"
-                    )}
-                  >
-                    {configs[provider.providerId] ? "enabled" : "disabled"}
-                  </p>
-                </div>
-              </div>
-              <Button
-                variant={configs[provider.providerId] ? "ghost" : "outline"}
-                label={configs[provider.providerId] ? "Edit" : "Set up"}
-                onClick={() => {
-                  setIsModelProvider(false);
-                  setSelectedProviderId(provider.providerId);
-                }}
-              />
-            </div>
-          </li>
-        ))}
-      </ul>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Container>
     </>
   );
 }
@@ -230,7 +223,6 @@ export default function ProvidersPage({
           <Providers owner={owner} />
         </Page.Vertical>
       </Page.Vertical>
-      <div className="h-12" />
     </AppLayout>
   );
 }


### PR DESCRIPTION
## Description

This PR aims at refactoring the providers management UI to use the `Container` component and make sure style is homogenous.

![Screenshot 2025-01-29 at 17 11 44](https://github.com/user-attachments/assets/520b2a7c-4de1-4f4c-b8bf-bedfd4358229)

**References:**
 - https://github.com/dust-tt/tasks/issues/2056

## Risk

Low

## Deploy Plan

Deploy `front`