### PR TITLE
[connectors] - fix(github): error handling in `deleteIssue`

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -720,7 +720,6 @@ async function deleteIssue(
     logger.info(
       `Issue not found in DB (issueNumber: ${issueNumber}, repoId: ${repoId}, connectorId: ${connector.id}), skipping deletion`
     );
-    return;
   }
 
   const documentId = getIssueInternalId(repoId.toString(), issueNumber);
@@ -731,14 +730,16 @@ async function deleteIssue(
     logger.bindings()
   );
 
-  logger.info("Deleting GitHub issue from database.");
-  await GithubIssue.destroy({
-    where: {
-      repoId: repoId.toString(),
-      issueNumber,
-      connectorId: connector.id,
-    },
-  });
+  if (issueInDb) {
+    logger.info("Deleting GitHub issue from database.");
+    await GithubIssue.destroy({
+      where: {
+        repoId: repoId.toString(),
+        issueNumber,
+        connectorId: connector.id,
+      },
+    });
+  }
 }
 
 async function deleteDiscussion(

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -717,9 +717,10 @@ async function deleteIssue(
     },
   });
   if (!issueInDb) {
-    throw new Error(
-      `Issue not found in DB (issueNumber: ${issueNumber}, repoId: ${repoId}, connectorId: ${connector.id})`
+    logger.info(
+      `Issue not found in DB (issueNumber: ${issueNumber}, repoId: ${repoId}, connectorId: ${connector.id}), skipping deletion`
     );
+    return;
   }
 
   const documentId = getIssueInternalId(repoId.toString(), issueNumber);


### PR DESCRIPTION
## Description

This PR aims at handling error when deleting Github issues. We used to throw an error when the issue was not find in DB, we now skip it but still try to delete the associate document.

**References:**
 - https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/workflow-github-11377-issue-garbage-collect-526514610-10348/0194b2a1-b314-79b2-8aea-312e249f24e2/pending-activities
 
## Risk

Low

## Deploy Plan

- Deploy `connectors`