### PR TITLE
Add: bigquery permissions modal

### DIFF
--- a/connectors/migrations/db/migration_49.sql
+++ b/connectors/migrations/db/migration_49.sql
@@ -1,0 +1,8 @@
+-- Migration created on Jan 29, 2025
+CREATE TABLE IF NOT EXISTS "bigquery_configurations" (
+    "id"  SERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "connectorId" INTEGER NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+PRIMARY KEY ("id"));
+CREATE UNIQUE INDEX "bigquery_configurations_connector_id" ON "bigquery_configurations" ("connectorId");

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -1,6 +1,7 @@
 import { sendInitDbMessage } from "@dust-tt/types";
 import type { Sequelize } from "sequelize";
 
+import { BigQueryConfigurationModel } from "@connectors/lib/models/bigquery";
 import {
   ConfluenceConfiguration,
   ConfluencePage,
@@ -118,6 +119,7 @@ async function main(): Promise<void> {
   await WebCrawlerPage.sync({ alter: true });
   await WebCrawlerConfigurationHeader.sync({ alter: true });
   await SnowflakeConfigurationModel.sync({ alter: true });
+  await BigQueryConfigurationModel.sync({ alter: true });
   await RemoteDatabaseModel.sync({ alter: true });
   await RemoteSchemaModel.sync({ alter: true });
   await RemoteTableModel.sync({ alter: true });

--- a/connectors/src/api/configuration.ts
+++ b/connectors/src/api/configuration.ts
@@ -68,6 +68,7 @@ const _patchConnectorConfiguration = async (
     case "intercom":
     case "microsoft":
     case "snowflake":
+    case "bigquery":
     case "zendesk":
     case "slack": {
       throw new Error(

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -131,6 +131,7 @@ const _createConnectorAPIHandler = async (
       case "google_drive":
       case "intercom":
       case "snowflake":
+      case "bigquery":
       case "zendesk":
       case "microsoft": {
         connectorRes = await createConnector({

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -62,6 +62,9 @@ export function getConnectorManager({
       return new SnowflakeConnectorManager(connectorId);
     case "zendesk":
       return new ZendeskConnectorManager(connectorId);
+    case "bigquery":
+      //TODO(BigQuery): Implement this
+      throw new Error("BigQuery connector is not supported yet");
     default:
       assertNever(connectorProvider);
   }
@@ -118,6 +121,9 @@ export function createConnector({
       return SnowflakeConnectorManager.create(params);
     case "zendesk":
       return ZendeskConnectorManager.create(params);
+    case "bigquery":
+      //TODO(BigQuery): Implement this
+      throw new Error("BigQuery connector is not supported yet");
     default:
       assertNever(connectorProvider);
   }

--- a/connectors/src/lib/models/bigquery.ts
+++ b/connectors/src/lib/models/bigquery.ts
@@ -1,0 +1,29 @@
+import type { CreationOptional } from "sequelize";
+import { DataTypes } from "sequelize";
+
+import { sequelizeConnection } from "@connectors/resources/storage";
+import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
+
+export class BigQueryConfigurationModel extends ConnectorBaseModel<BigQueryConfigurationModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+BigQueryConfigurationModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "bigquery_configurations",
+    indexes: [{ fields: ["connectorId"], unique: true }],
+  }
+);

--- a/connectors/src/resources/connector/bigquery.ts
+++ b/connectors/src/resources/connector/bigquery.ts
@@ -1,0 +1,78 @@
+import type { ModelId } from "@dust-tt/types";
+import type { Transaction } from "sequelize";
+
+import { BigQueryConfigurationModel } from "@connectors/lib/models/bigquery";
+import {
+  RemoteDatabaseModel,
+  RemoteSchemaModel,
+  RemoteTableModel,
+} from "@connectors/lib/models/remote_databases";
+import type {
+  ConnectorProviderConfigurationType,
+  ConnectorProviderModelResourceMapping,
+  ConnectorProviderStrategy,
+  WithCreationAttributes,
+} from "@connectors/resources/connector/strategy";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+
+export class BigQueryConnectorStrategy
+  implements ConnectorProviderStrategy<"bigquery">
+{
+  async makeNew(
+    connectorId: ModelId,
+    blob: WithCreationAttributes<BigQueryConfigurationModel>,
+    transaction: Transaction
+  ): Promise<ConnectorProviderModelResourceMapping["bigquery"] | null> {
+    await BigQueryConfigurationModel.create(
+      {
+        ...blob,
+        connectorId,
+      },
+      { transaction }
+    );
+
+    return null;
+  }
+
+  async delete(
+    connector: ConnectorResource,
+    transaction: Transaction
+  ): Promise<void> {
+    await Promise.all([
+      BigQueryConfigurationModel.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+      RemoteTableModel.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+      RemoteSchemaModel.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+      RemoteDatabaseModel.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+    ]);
+  }
+
+  async fetchConfigurationsbyConnectorIds(): Promise<
+    Record<ModelId, ConnectorProviderModelResourceMapping["bigquery"]>
+  > {
+    return {};
+  }
+
+  configurationJSON(): ConnectorProviderConfigurationType {
+    return null;
+  }
+}

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -7,6 +7,7 @@ import type {
 import { assertNever } from "@dust-tt/types";
 import type { CreationAttributes, Model, Transaction } from "sequelize";
 
+import type { BigQueryConfigurationModel } from "@connectors/lib/models/bigquery";
 import type { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
 import type { GithubConnectorState } from "@connectors/lib/models/github";
 import type { GoogleDriveConfig } from "@connectors/lib/models/google_drive";
@@ -17,6 +18,7 @@ import type { SlackConfigurationModel } from "@connectors/lib/models/slack";
 import type { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
 import type { WebCrawlerConfigurationModel } from "@connectors/lib/models/webcrawler";
 import type { ZendeskConfiguration } from "@connectors/lib/models/zendesk";
+import { BigQueryConnectorStrategy } from "@connectors/resources/connector/bigquery";
 import { ConfluenceConnectorStrategy } from "@connectors/resources/connector/confluence";
 import { GithubConnectorStrategy } from "@connectors/resources/connector/github";
 import { GoogleDriveConnectorStrategy } from "@connectors/resources/connector/google_drive";
@@ -47,6 +49,7 @@ export interface ConnectorProviderModelM {
   webcrawler: WebCrawlerConfigurationModel;
   snowflake: SnowflakeConfigurationModel;
   zendesk: ZendeskConfiguration;
+  bigquery: BigQueryConfigurationModel;
 }
 
 export type ConnectorProviderModelMapping = {
@@ -81,6 +84,7 @@ export interface ConnectorProviderConfigurationTypeM {
   slack: SlackConfigurationType;
   webcrawler: WebCrawlerConfigurationType;
   zendesk: null;
+  bigquery: null;
 }
 
 export type ConnectorProviderConfigurationTypeMapping = {
@@ -141,6 +145,9 @@ export function getConnectorProviderStrategy(
 
     case "zendesk":
       return new ZendeskConnectorStrategy();
+
+    case "bigquery":
+      return new BigQueryConnectorStrategy();
 
     default:
       assertNever(type);

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -36,6 +36,8 @@ const workerFunctions: Record<WorkerType, () => Promise<void>> = {
   webcrawler: runWebCrawlerWorker,
   snowflake: runSnowflakeWorker,
   zendesk: runZendeskWorkers,
+  //TODO(BigQuery): Implement this
+  bigquery: () => Promise.resolve(),
 };
 
 const ALL_WORKERS = Object.keys(workerFunctions) as WorkerType[];

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -14,7 +14,7 @@ use super::encryption::{seal_str, unseal_str};
 pub enum CredentialProvider {
     Snowflake,
     Modjo,
-    GoogleServiceAccount,
+    Bigquery,
 }
 
 impl fmt::Display for CredentialProvider {
@@ -112,7 +112,7 @@ impl Credential {
             CredentialProvider::Modjo => {
                 vec!["api_key"]
             }
-            CredentialProvider::GoogleServiceAccount => {
+            CredentialProvider::Bigquery => {
                 vec![
                     "type",
                     "project_id",

--- a/core/src/oauth/tests/functional_credentials.rs
+++ b/core/src/oauth/tests/functional_credentials.rs
@@ -132,10 +132,10 @@ async fn test_oauth_credentials_snowflake_delete_ok() {
 }
 
 #[tokio::test]
-async fn test_oauth_credentials_google_service_account_flow_ok() {
+async fn test_oauth_credentials_bigquery_flow_ok() {
     let create_url = "/credentials".to_string();
     let create_body = json!({
-        "provider": "google_service_account",
+        "provider": "bigquery",
         "metadata": {
             "workspace_id": "PjlCyKnRu2",
             "user_id": "5dz5IMaoLW"
@@ -194,10 +194,7 @@ async fn test_oauth_credentials_google_service_account_flow_ok() {
 
     assert_eq!(retrieved_credential.credential_id, credential.credential_id);
     assert_eq!(retrieved_credential.created, credential.created);
-    assert_eq!(
-        retrieved_credential.provider.unwrap(),
-        "google_service_account"
-    );
+    assert_eq!(retrieved_credential.provider.unwrap(), "bigquery");
 
     let metadata = retrieved_credential.metadata.unwrap();
     assert_eq!(metadata.get("user_id").unwrap(), "5dz5IMaoLW");
@@ -215,10 +212,10 @@ async fn test_oauth_credentials_google_service_account_flow_ok() {
 }
 
 #[tokio::test]
-async fn test_oauth_credentials_google_service_account_delete_ok() {
+async fn test_oauth_credentials_bigquery_delete_ok() {
     let create_url = "/credentials".to_string();
     let create_body = json!({
-        "provider": "google_service_account",
+        "provider": "bigquery",
         "metadata": {
             "workspace_id": "PjlCyKnRu2",
             "user_id": "5dz5IMaoLW"
@@ -284,10 +281,10 @@ async fn test_oauth_credentials_snowflake_invalid_content() {
 }
 
 #[tokio::test]
-async fn test_oauth_credentials_google_service_account_invalid_content() {
+async fn test_oauth_credentials_bigquery_invalid_content() {
     let create_url = "/credentials".to_string();
     let create_body = json!({
-        "provider": "google_service_account",
+        "provider": "bigquery",
         "metadata": {
             "workspace_id": "PjlCyKnRu2",
             "user_id": "5dz5IMaoLW"

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -40,6 +40,7 @@ const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   webcrawler: { singular: "page", plural: "pages" },
   snowflake: { singular: "table", plural: "tables" },
   zendesk: { singular: "element", plural: "elements" },
+  bigquery: { singular: "table", plural: "tables" },
 };
 
 export const getConnectorProviderResourceName = (
@@ -296,6 +297,7 @@ export function getTableIdForContentNode(
     case "snowflake":
     case "microsoft":
     case "notion":
+    case "bigquery":
       return contentNode.internalId;
 
     case "confluence":

--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -1,0 +1,316 @@
+import {
+  BookOpenIcon,
+  Button,
+  CloudArrowLeftRightIcon,
+  Label,
+  Modal,
+  Page,
+  TextArea,
+} from "@dust-tt/sparkle";
+import type {
+  BigQueryCredentials,
+  ConnectorProvider,
+  ConnectorType,
+  DataSourceType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import {
+  BigQueryCredentialsSchema,
+  isConnectorsAPIError,
+} from "@dust-tt/types";
+import { isRight } from "fp-ts/lib/Either";
+import { formatValidationErrors } from "io-ts-reporters";
+import { useEffect, useMemo, useState } from "react";
+
+import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
+import type { PostCredentialsBody } from "@app/pages/api/w/[wId]/credentials";
+
+type CreateOrUpdateConnectionBigQueryModalProps = {
+  owner: WorkspaceType;
+  connectorProviderConfiguration: ConnectorProviderConfiguration;
+  isOpen: boolean;
+  onClose: () => void;
+  createDatasource?: ({
+    connectionId,
+    provider,
+  }: {
+    connectionId: string;
+    provider: ConnectorProvider;
+  }) => Promise<Response>;
+  onSuccess: (dataSource: DataSourceType) => void;
+  dataSourceToUpdate?: DataSourceType;
+};
+
+export function CreateOrUpdateConnectionBigQueryModal({
+  owner,
+  connectorProviderConfiguration,
+  isOpen,
+  onClose,
+  createDatasource,
+  onSuccess: _onSuccess,
+  dataSourceToUpdate,
+}: CreateOrUpdateConnectionBigQueryModalProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [credentials, setCredentials] = useState<string>("");
+
+  const credentialsState = useMemo(() => {
+    try {
+      const credentialsObject: BigQueryCredentials = JSON.parse(credentials);
+      const r = BigQueryCredentialsSchema.decode(credentialsObject);
+      if (isRight(r)) {
+        const allFieldsHaveValue = Object.values(credentialsObject).every(
+          (v) => v.length > 0
+        );
+        return {
+          credentials: credentialsObject,
+          valid: allFieldsHaveValue,
+          errorMessage: !allFieldsHaveValue
+            ? "All fields must have a value"
+            : null,
+        };
+      } else {
+        return {
+          credentials: credentialsObject,
+          valid: false,
+          errorMessage: formatValidationErrors(r.left).join(" "),
+        };
+      }
+    } catch (error) {
+      return {
+        credentials: null,
+        valid: false,
+        errorMessage: "Invalid JSON",
+      };
+    }
+  }, [credentials]);
+
+  useEffect(() => {
+    setError(credentialsState.errorMessage);
+  }, [credentialsState.errorMessage]);
+
+  if (connectorProviderConfiguration.connectorProvider !== "bigquery") {
+    // Should never happen.
+    return null;
+  }
+
+  function onSuccess(ds: DataSourceType) {
+    setCredentials("");
+    _onSuccess(ds);
+  }
+
+  const createBigQueryConnection = async () => {
+    if (!onSuccess || !createDatasource) {
+      // Should never happen.
+      throw new Error("onCreated and createDatasource are required");
+    }
+
+    setIsLoading(true);
+
+    // First we post the credentials to OAuth service.
+    const getCredentialsRes = await fetch(`/api/w/${owner.sId}/credentials`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        provider: "bigquery" as const,
+        credentials: JSON.parse(credentials) as BigQueryCredentials,
+      } as PostCredentialsBody),
+    });
+
+    if (!getCredentialsRes.ok) {
+      setError("Failed to create connection: cannot verify those credentials.");
+      setIsLoading(false);
+      return;
+    }
+
+    // Then we can try to create the connector.
+    const data = await getCredentialsRes.json();
+
+    const createDataSourceRes = await createDatasource({
+      provider: "bigquery",
+      connectionId: data.credentials.id,
+    });
+
+    if (!createDataSourceRes.ok) {
+      const err = await createDataSourceRes.json();
+      const maybeConnectorsError = "error" in err && err.error.connectors_error;
+
+      if (
+        isConnectorsAPIError(maybeConnectorsError) &&
+        maybeConnectorsError.type === "invalid_request_error"
+      ) {
+        setError(
+          `Failed to create BigQuery connection: ${maybeConnectorsError.message}`
+        );
+      } else {
+        setError(`Failed to create BigQuery connection: ${err.error.message}`);
+      }
+
+      setIsLoading(false);
+      return;
+    }
+
+    const createdManagedDataSource: {
+      dataSource: DataSourceType;
+      connector: ConnectorType;
+    } = await createDataSourceRes.json();
+
+    onSuccess(createdManagedDataSource.dataSource);
+    setIsLoading(false);
+  };
+
+  const updateBigQueryConnection = async () => {
+    if (!dataSourceToUpdate) {
+      // Should never happen.
+      throw new Error("dataSourceToUpdate is required");
+    }
+
+    setIsLoading(true);
+
+    // First we post the credentials to OAuth service.
+    const credentialsRes = await fetch(`/api/w/${owner.sId}/credentials`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        provider: "bigquery",
+        credentials: credentialsState.credentials,
+      }),
+    });
+
+    if (!credentialsRes.ok) {
+      setError("Failed to update connection: cannot verify those credentials.");
+      setIsLoading(false);
+      return;
+    }
+
+    const data = await credentialsRes.json();
+
+    const updateConnectorRes = await fetch(
+      `/api/w/${owner.sId}/data_sources/${dataSourceToUpdate.sId}/managed/update`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          connectionId: data.credentials.id,
+        }),
+      }
+    );
+
+    setIsLoading(false);
+
+    if (!updateConnectorRes.ok) {
+      const err = await updateConnectorRes.json();
+      const maybeConnectorsError = "error" in err && err.error.connectors_error;
+
+      if (
+        isConnectorsAPIError(maybeConnectorsError) &&
+        maybeConnectorsError.type === "invalid_request_error"
+      ) {
+        setError(
+          `Failed to update BigQuery connection: ${maybeConnectorsError.message}`
+        );
+      } else {
+        setError(`Failed to update BigQuery connection: ${err.error.message}`);
+      }
+
+      return;
+    }
+
+    onSuccess(dataSourceToUpdate);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="Connection Setup"
+      onClose={onClose}
+      hasChanged={false}
+      variant="side-sm"
+    >
+      <Page variant="modal">
+        <div className="w-full">
+          <Page.Vertical sizing="grow">
+            <Page.Header
+              title={`Connecting ${connectorProviderConfiguration.name}`}
+              icon={connectorProviderConfiguration.logoComponent}
+            />
+            <a
+              href={connectorProviderConfiguration.guideLink ?? ""}
+              target="_blank"
+            >
+              <Button
+                label="Read our guide"
+                size="xs"
+                variant="outline"
+                icon={BookOpenIcon}
+              />
+            </a>
+            {connectorProviderConfiguration.limitations && (
+              <div className="flex flex-col gap-y-2">
+                <div className="grow text-sm font-medium text-element-800">
+                  Limitations
+                </div>
+                <div className="text-sm font-normal text-element-700">
+                  {connectorProviderConfiguration.limitations}
+                </div>
+              </div>
+            )}
+
+            <Page.SectionHeader title="BigQuery Credentials" />
+
+            {error && (
+              <div className="w-full rounded-md bg-red-100 p-4 text-red-800">
+                {error}
+              </div>
+            )}
+
+            <div className="w-full space-y-4">
+              <Label>BigQuery Service Account JSON</Label>
+              <TextArea
+                className="min-h-[325px]"
+                name="service_account_json"
+                value={credentials}
+                placeholder="paste the content of your service account JSON here"
+                onChange={(e) => {
+                  setCredentials(e.target.value);
+                }}
+              />
+            </div>
+
+            <div className="flex justify-center pt-2">
+              <div className="flex gap-2">
+                <Button
+                  variant="highlight"
+                  size="md"
+                  icon={CloudArrowLeftRightIcon}
+                  onClick={() => {
+                    setIsLoading(true);
+                    if (dataSourceToUpdate) {
+                      void updateBigQueryConnection();
+                    } else {
+                      void createBigQueryConnection();
+                    }
+                  }}
+                  disabled={isLoading || !credentialsState.valid}
+                  label={
+                    isLoading
+                      ? "Connecting..."
+                      : dataSourceToUpdate
+                        ? "Update connection"
+                        : "Connect and select tables"
+                  }
+                />
+              </div>
+            </div>
+          </Page.Vertical>
+        </div>
+      </Page>
+    </Modal>
+  );
+}

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -82,25 +82,28 @@ export function CreateOrUpdateConnectionSnowflakeModal({
     setIsLoading(true);
 
     // First we post the credentials to OAuth service.
-    const getCredentialsRes = await fetch(`/api/w/${owner.sId}/credentials`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        provider: "snowflake",
-        credentials,
-      }),
-    });
+    const createCredentialsRes = await fetch(
+      `/api/w/${owner.sId}/credentials`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          provider: "snowflake",
+          credentials,
+        }),
+      }
+    );
 
-    if (!getCredentialsRes.ok) {
+    if (!createCredentialsRes.ok) {
       setError("Failed to create connection: cannot verify those credentials.");
       setIsLoading(false);
       return;
     }
 
     // Then we can try to create the connector.
-    const data = await getCredentialsRes.json();
+    const data = await createCredentialsRes.json();
 
     const createDataSourceRes = await createDatasource({
       provider: "snowflake",

--- a/front/components/markdown/MarkdownCitation.tsx
+++ b/front/components/markdown/MarkdownCitation.tsx
@@ -9,6 +9,7 @@ import {
   NotionLogo,
   SlackLogo,
   SnowflakeLogo,
+  TableIcon,
   ZendeskLogo,
 } from "@dust-tt/sparkle";
 import type { SVGProps } from "react";
@@ -25,6 +26,7 @@ const CITATION_ICONS = [
   "slack",
   "image",
   "snowflake",
+  "bigquery",
 ] as const;
 
 export type CitationIconType = (typeof CITATION_ICONS)[number];
@@ -44,6 +46,7 @@ export const citationIconMap: Record<
   slack: SlackLogo,
   image: ImageIcon,
   snowflake: SnowflakeLogo,
+  bigquery: TableIcon, // TODO(bigquery) replace with correct icon.
 };
 
 export interface MarkdownCitation {

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -47,6 +47,7 @@ export function getContentNodeInternalIdFromTableId(
     case "snowflake":
     case "google_drive":
     case "notion":
+    case "bigquery":
       return tableId;
 
     case "intercom":

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -1,10 +1,14 @@
 import type {
+  ConnectionCredentials,
+  CredentialsProvider,
   OAuthAPIError,
+  OauthAPIPostCredentialsResponse,
   OAuthConnectionType,
   Result,
 } from "@dust-tt/types";
 import type { OAuthProvider, OAuthUseCase } from "@dust-tt/types";
 import { Err, isValidZendeskSubdomain, OAuthAPI, Ok } from "@dust-tt/types";
+import type { LoggerInterface } from "@dust-tt/types/dist/shared/logger";
 import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
@@ -413,4 +417,33 @@ export async function finalizeConnection(
   }
 
   return new Ok(cRes.value.connection);
+}
+
+export async function postConnectionCredentials({
+  config,
+  logger,
+  provider,
+  workspaceId,
+  userId,
+  credentials,
+}: {
+  config: { url: string; apiKey: string | null };
+  logger: LoggerInterface;
+  provider: CredentialsProvider;
+  workspaceId: string;
+  userId: string;
+  credentials: ConnectionCredentials;
+}): Promise<Result<OauthAPIPostCredentialsResponse, OAuthAPIError>> {
+  const res = await new OAuthAPI(config, logger).postCredentials({
+    provider,
+    workspaceId,
+    userId,
+    credentials,
+  });
+
+  if (res.isErr()) {
+    return res;
+  }
+
+  return res;
 }

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -9,6 +9,7 @@ import {
   NotionLogo,
   SlackLogo,
   SnowflakeLogo,
+  TableIcon,
   ZendeskLogo,
 } from "@dust-tt/sparkle";
 import type {
@@ -198,6 +199,20 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     isNested: true,
     isSearchEnabled: false,
   },
+  bigquery: {
+    name: "BigQuery",
+    connectorProvider: "bigquery",
+    status: "rolling_out",
+    rollingOutFlag: "bigquery_feature",
+    hide: true,
+    description: "Query a BigQuery database.",
+    limitations: null,
+    logoComponent: TableIcon,
+    isNested: true,
+    isSearchEnabled: false,
+    guideLink: "https://docs.dust.tt/docs/bigquery-connection",
+    selectLabel: "Select tables",
+  },
 };
 
 export function getConnectorProviderLogoWithFallback(
@@ -240,6 +255,8 @@ export const isConnectorProviderAllowedForPlan = (
       return true;
     case "zendesk":
       return true;
+    case "bigquery":
+      return true;
     default:
       assertNever(provider);
   }
@@ -258,6 +275,7 @@ export const isConnectorProviderAssistantDefaultSelected = (
     case "microsoft":
     case "zendesk":
     case "snowflake":
+    case "bigquery":
       return true;
     case "webcrawler":
       return false;
@@ -279,6 +297,7 @@ export const isConnectionIdRequiredForProvider = (
     case "microsoft":
     case "zendesk":
     case "snowflake":
+    case "bigquery":
       return true;
     case "webcrawler":
       return false;

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -31,6 +31,7 @@ export function getDisplayNameForDataSource(ds: DataSourceType) {
       case "notion":
       case "zendesk":
       case "snowflake":
+      case "bigquery":
         return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
       case "webcrawler":
         return ds.name;

--- a/front/lib/document_upsert_hooks/hooks/tracker/consts.ts
+++ b/front/lib/document_upsert_hooks/hooks/tracker/consts.ts
@@ -14,6 +14,7 @@ export function isConnectorTypeTrackable(
     case "webcrawler":
     case "snowflake":
     case "zendesk":
+    case "bigquery":
       return true;
     case "slack":
       return false;

--- a/front/migrations/20241211_parents_front_migrator.ts
+++ b/front/migrations/20241211_parents_front_migrator.ts
@@ -100,6 +100,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
     );
   },
   snowflake: null,
+  bigquery: null,
   webcrawler: null,
   zendesk: null, // no migration needed!
   confluence: (parents) => parents.map(getUpdatedConfluenceId),

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -379,6 +379,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
     },
   },
   snowflake: null,
+  bigquery: null,
   webcrawler: null,
   zendesk: null,
   confluence: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -270,6 +270,7 @@ const ConnectorProvidersSchema = FlexibleEnumSchema<
   | "webcrawler"
   | "snowflake"
   | "zendesk"
+  | "bigquery"
 >();
 export type ConnectorProvider = z.infer<typeof ConnectorProvidersSchema>;
 
@@ -742,6 +743,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_github_actions"
   | "reasoning_tool_feature"
   | "deepseek_r1_global_agent_feature"
+  | "bigquery_feature"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -13,6 +13,7 @@ export const CONNECTOR_PROVIDERS = [
   "webcrawler",
   "snowflake",
   "zendesk",
+  "bigquery",
 ] as const;
 
 export const MANAGED_DS_DELETABLE: ConnectorProvider[] = [
@@ -31,6 +32,7 @@ export const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
   webcrawler: "Website",
   snowflake: "Snowflake",
   zendesk: "Zendesk",
+  bigquery: "BigQuery",
 };
 
 export const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<
@@ -53,6 +55,8 @@ export const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<
     "You cannot change the Snowflake account. Please add a new Snowflake connection instead.",
   zendesk:
     "You cannot select another Zendesk Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.",
+  bigquery:
+    "You cannot change the BigQuery project. Please add a new BigQuery connection instead.",
 };
 
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];

--- a/types/src/oauth/client/credentials.ts
+++ b/types/src/oauth/client/credentials.ts
@@ -1,41 +1,7 @@
 import { LoggerInterface } from "../../shared/logger";
 import { Result } from "../../shared/result";
-import {
-  ConnectionCredentials,
-  CredentialsProvider,
-  OauthAPIGetCredentialsResponse,
-  OauthAPIPostCredentialsResponse,
-} from "../lib";
+import { OauthAPIGetCredentialsResponse } from "../lib";
 import { OAuthAPI, OAuthAPIError } from "../oauth_api";
-
-export async function postConnectionCredentials({
-  config,
-  logger,
-  provider,
-  workspaceId,
-  userId,
-  credentials,
-}: {
-  config: { url: string; apiKey: string | null };
-  logger: LoggerInterface;
-  provider: CredentialsProvider;
-  workspaceId: string;
-  userId: string;
-  credentials: ConnectionCredentials;
-}): Promise<Result<OauthAPIPostCredentialsResponse, OAuthAPIError>> {
-  const res = await new OAuthAPI(config, logger).postCredentials({
-    provider,
-    workspaceId,
-    userId,
-    credentials,
-  });
-
-  if (res.isErr()) {
-    return res;
-  }
-
-  return res;
-}
 
 export async function getConnectionCredentials({
   config,

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -60,7 +60,11 @@ export function isValidZendeskSubdomain(s: unknown): s is string {
 
 // Credentials Providers
 
-export const CREDENTIALS_PROVIDERS = ["snowflake", "modjo"] as const;
+export const CREDENTIALS_PROVIDERS = [
+  "snowflake",
+  "modjo",
+  "bigquery",
+] as const;
 export type CredentialsProvider = (typeof CREDENTIALS_PROVIDERS)[number];
 
 export function isCredentialProvider(obj: unknown): obj is CredentialsProvider {
@@ -78,12 +82,31 @@ export const SnowflakeCredentialsSchema = t.type({
 });
 export type SnowflakeCredentials = t.TypeOf<typeof SnowflakeCredentialsSchema>;
 
+export const BigQueryCredentialsSchema = t.type({
+  type: t.string,
+  project_id: t.string,
+  private_key_id: t.string,
+  private_key: t.string,
+  client_email: t.string,
+  client_id: t.string,
+  auth_uri: t.string,
+  token_uri: t.string,
+  auth_provider_x509_cert_url: t.string,
+  client_x509_cert_url: t.string,
+  universe_domain: t.string,
+});
+
+export type BigQueryCredentials = t.TypeOf<typeof BigQueryCredentialsSchema>;
+
 export const ApiKeyCredentialsSchema = t.type({
   api_key: t.string,
 });
 export type ModjoCredentials = t.TypeOf<typeof ApiKeyCredentialsSchema>;
 
-export type ConnectionCredentials = SnowflakeCredentials | ModjoCredentials;
+export type ConnectionCredentials =
+  | SnowflakeCredentials
+  | ModjoCredentials
+  | BigQueryCredentials;
 
 export function isSnowflakeCredentials(
   credentials: ConnectionCredentials
@@ -97,14 +120,11 @@ export function isModjoCredentials(
   return "api_key" in credentials;
 }
 
-// POST Credentials
-
-export const PostSnowflakeCredentialsBodySchema = t.type({
-  provider: t.literal("snowflake"),
-  credentials: SnowflakeCredentialsSchema,
-});
-
-export const PostCredentialsBodySchema = PostSnowflakeCredentialsBodySchema;
+export function isBigQueryCredentials(
+  credentials: ConnectionCredentials
+): credentials is BigQueryCredentials {
+  return "type" in credentials && "project_id" in credentials;
+}
 
 export type OauthAPIPostCredentialsResponse = {
   credential: {

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -20,6 +20,7 @@ export const WHITELISTABLE_FEATURES = [
   "labs_github_actions",
   "reasoning_tool_feature",
   "deepseek_r1_global_agent_feature",
+  "bigquery_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

- Add the ability to create a BigQuery connexion (behind a feature flag).
- Renamed the oauth CredentialsProvider to "Bigquery" (to stay consistent with type == specific vendor + have it be "bigquery" like the ConnectorProvider).

<img width="440" alt="image" src="https://github.com/user-attachments/assets/70e4f31e-2583-471f-9c23-a189718f4efa" />

(started connector but I'd rather validate and merge one by one)

## Tests

Updated some + local testing.

## Risk

Fairly low I tried to keep the existing code the same.

## Deploy Plan

Apply migration, Deploy `oauth`, `connectors`, `front`