### PR TITLE
[CoreNodes] Ignore missing nodes from core due Snowflake's root call specificities

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -230,7 +230,16 @@ export function computeNodesDiff({
       }
     }
   });
-  if (missingInternalIds.length > 0) {
+  if (
+    missingInternalIds.length > 0 &&
+    // Snowflake's root call returns all the selected databases, schemas and tables even if non-root.
+    !(
+      provider === "snowflake" &&
+      missingInternalIds.every((id) =>
+        coreContentNodes.some((n) => n.parentInternalIds?.includes(id))
+      )
+    )
+  ) {
     localLogger.info(
       {
         missingInternalIds,


### PR DESCRIPTION
## Description

- Snowflake's [root call](https://github.com/dust-tt/dust/blob/ffc69ed644c6ddb20f37c1553ed0adb107c37054/connectors/src/connectors/snowflake/lib/permissions.ts#L134) returns the tables and schemas selected, even if their parent is selected as well.
- This PR aims at ignoring discrepancies due to this.

## Tests

## Risk

- Only affects the log.

## Deploy Plan

- Deploy front.