### PR TITLE
[front] - deps: update sparkle to 0.2.375

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.372",
+        "@dust-tt/sparkle": "0.2.375",
         "@dust-tt/types": "file:../types",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -11331,9 +11331,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.372",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.372.tgz",
-      "integrity": "sha512-OmWGiOZqKf0sIq/d7mr2H7n0h1OTtVL9tQtu6qGAKiBMy54S54/VXHsEWT/GNRc8pNOr/rVPB5Fmw4CQrSMJcw==",
+      "version": "0.2.375",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.375.tgz",
+      "integrity": "sha512-TNCgi8bAVZWUCgLe8WVP6oPZFtpsBfdK9P/QEp5gfuvRbIg3yQbWaYcssSmLsWfPclGC5UW+LkT/pwPMSPkO0A==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.372",
+    "@dust-tt/sparkle": "0.2.375",
     "@dust-tt/types": "file:../types",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR bumps sparkle version in front, following those changes: https://github.com/dust-tt/dust/pull/10343

## Risk

Low

## Deploy Plan

- Deploy front