### PR TITLE
Add endpoint to retrieve document upsert blob

### DIFF
--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -1,4 +1,4 @@
-import { ProviderVisibility } from "..";
+import { ProviderVisibility } from "../front/lib/connectors_api";
 
 export type QdrantCluster = "cluster-0";
 export const DEFAULT_QDRANT_CLUSTER: QdrantCluster = "cluster-0";

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -1,3 +1,5 @@
+import { ProviderVisibility } from "..";
+
 export type QdrantCluster = "cluster-0";
 export const DEFAULT_QDRANT_CLUSTER: QdrantCluster = "cluster-0";
 
@@ -66,6 +68,19 @@ export type CoreAPIDocument = {
   title: string | null;
   mime_type: string | null;
   text?: string | null;
+};
+
+export type CoreAPIDocumentBlob = {
+  document_id: string;
+  timestamp: number;
+  tags: string[];
+  parent_id: string | null;
+  parents: string[];
+  source_url: string | null;
+  section: CoreAPIDataSourceDocumentSection;
+  title: string;
+  mime_type: string;
+  provider_visibility: ProviderVisibility | null;
 };
 
 export type CoreAPILightDocument = {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -9,6 +9,7 @@ import {
   CoreAPIDataSourceConfig,
   CoreAPIDataSourceDocumentSection,
   CoreAPIDocument,
+  CoreAPIDocumentBlob,
   CoreAPIDocumentVersion,
   CoreAPIFolder,
   CoreAPILightDocument,
@@ -917,6 +918,30 @@ export class CoreAPI {
           title: title,
           mime_type: mimeType,
         }),
+      }
+    );
+
+    return this._resultFromResponse(response);
+  }
+
+  async getDataSourceDocumentBlob({
+    projectId,
+    dataSourceId,
+    documentId,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+    documentId: string;
+  }): Promise<CoreAPIResponse<{ blob: CoreAPIDocumentBlob }>> {
+    const response = await this._fetchWithError(
+      `${this._url}/projects/${projectId}/data_sources/${encodeURIComponent(
+        dataSourceId
+      )}/documents/${encodeURIComponent(documentId)}/blob`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
       }
     );
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See relocation system context [here](https://github.com/dust-tt/dust/pull/10341).

As part of the data source relocation work, we need to move documents between regions. To ensure data consistency and avoid duplicating complex logic, we want to leverage the Core API for both fetching and upserting documents.

This PR adds a new endpoint in Core that returns a document blob containing all the fields required to upsert a document through the API. 

The blob matches the API's upsert payload schema, making it possible to:
1. Fetch a document from the source region using this new endpoint
2. Upsert it in the destination region using the existing API endpoint

This approach:
- Avoids duplicating document retrieval/formatting logic in the relocation worker
- Prevents direct DB access from the worker
- Ensures consistency by using the same code path used by the API
- Makes the relocation process more robust by relying on stable API contracts
- Reduces risks of data inconsistency during relocation

## Usage
The relocation worker will:
1. Call `GET /projects/{project_id}/data_sources/{ds_id}/documents/{doc_id}/api_blob` on source region's Core 
2. Use the returned blob to call `POST /api/v1/w/{wId}/data_sources/{dsId}/documents/{documentId}` on destination region's API

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
