### PR TITLE
[connectors] - fix(intercom): logging in `intercomTeamFullSyncWorkflow`

### DIFF
--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -500,18 +500,19 @@ export async function syncTeamOnlyActivity({
       lastUpsertedTs: new Date(currentSyncMs),
     });
   } catch (error) {
-    const e = error as Error;
     logger.error(
       {
-        error: e,
-        errorMessage: e.message || "Unknown error",
-        errorStack: e.stack,
+        error: error instanceof Error ? error : JSON.stringify(error),
+        ...(error instanceof Error && {
+          errorMessage: error.message || "Unknown error",
+          errorStack: error.stack,
+        }),
         teamId,
         ...loggerArgs,
       },
       "[Intercom] Failed to fetch team"
     );
-    throw e;
+    throw error;
   }
 
   // Also make sure a datasource folder node is created for the team


### PR DESCRIPTION
## Description

This PR aims at fixing error handling in `intercomTeamFullSyncWorkflow`.

**References:**
- [Monitors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1%20%40activityName%3AsyncTeamOnlyActivity&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1738169930516&to_ts=1738184330516&live=true)

## Risk

Low

## Deploy Plan

Deploy `connectors`