### PR TITLE
[Nodes Core] Optimize children count by storing

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2229,11 +2229,7 @@ async fn tables_upsert(
         )
         .await
     {
-        Ok(table) => match state
-            .search_store
-            .index_node(Node::from(table.clone()))
-            .await
-        {
+        Ok((table, node)) => match state.search_store.index_node(node).await {
             Ok(_) => (
                 StatusCode::OK,
                 Json(APIResponse {
@@ -2943,11 +2939,7 @@ async fn folders_upsert(
             "Failed to upsert folder",
             Some(e),
         ),
-        Ok(folder) => match state
-            .search_store
-            .index_node(Node::from(folder.clone()))
-            .await
-        {
+        Ok((folder, node)) => match state.search_store.index_node(node).await {
             Ok(_) => (
                 StatusCode::OK,
                 Json(APIResponse {
@@ -3098,7 +3090,13 @@ async fn folders_delete(
             .store
             .delete_data_source_folder(&project, &data_source_id, &folder_id)
             .await?;
-        state.search_store.delete_node(Node::from(folder)).await?;
+        state
+            .search_store
+            .delete_node(&Node::compute_unique_id(
+                &folder.data_source_internal_id(),
+                &folder_id,
+            ))
+            .await?;
         Ok(())
     }
     .await;

--- a/core/src/data_sources/folder.rs
+++ b/core/src/data_sources/folder.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::node::{Node, NodeType, ProviderVisibility};
+use super::node::ProviderVisibility;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Folder {
@@ -72,23 +72,5 @@ impl Folder {
     }
     pub fn provider_visibility(&self) -> &Option<ProviderVisibility> {
         &self.provider_visibility
-    }
-}
-
-impl From<Folder> for Node {
-    fn from(folder: Folder) -> Node {
-        Node::new(
-            &folder.data_source_id,
-            &folder.data_source_internal_id,
-            &folder.folder_id,
-            NodeType::Folder,
-            folder.timestamp,
-            &folder.title,
-            &folder.mime_type,
-            folder.provider_visibility,
-            folder.parent_id,
-            folder.parents,
-            folder.source_url,
-        )
     }
 }

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -89,6 +89,7 @@ pub struct Node {
     pub parent_id: Option<String>,
     pub parents: Vec<String>,
     pub source_url: Option<String>,
+    pub children_count: u64,
 }
 
 impl Node {
@@ -104,6 +105,7 @@ impl Node {
         parent_id: Option<String>,
         parents: Vec<String>,
         source_url: Option<String>,
+        children_count: u64,
     ) -> Self {
         Node {
             data_source_id: data_source_id.to_string(),
@@ -117,6 +119,7 @@ impl Node {
             parent_id: parent_id.clone(),
             parents,
             source_url,
+            children_count,
         }
     }
 
@@ -145,6 +148,10 @@ impl Node {
         &self.parents
     }
 
+    pub fn children_count(&self) -> u64 {
+        self.children_count
+    }
+
     // Consumes self into a Folder.
     pub fn into_folder(self) -> Folder {
         Folder::new(
@@ -161,9 +168,12 @@ impl Node {
         )
     }
 
-    // Computes a globally unique id for the node.
+    pub fn compute_unique_id(data_source_internal_id: &str, node_id: &str) -> String {
+        format!("{}__{}", data_source_internal_id, node_id)
+    }
+
     pub fn unique_id(&self) -> String {
-        format!("{}__{}", self.data_source_internal_id, self.node_id)
+        Self::compute_unique_id(&self.data_source_internal_id, &self.node_id)
     }
 }
 
@@ -177,16 +187,11 @@ impl From<serde_json::Value> for Node {
 pub struct CoreContentNode {
     #[serde(flatten)]
     pub base: Node,
-    pub has_children: bool,
     pub parent_title: Option<String>,
 }
 
 impl CoreContentNode {
-    pub fn new(base: Node, has_children: bool, parent_title: Option<String>) -> Self {
-        CoreContentNode {
-            base,
-            has_children,
-            parent_title,
-        }
+    pub fn new(base: Node, parent_title: Option<String>) -> Self {
+        CoreContentNode { base, parent_title }
     }
 }

--- a/core/src/search_stores/migrations/20250129_add_children_count.http
+++ b/core/src/search_stores/migrations/20250129_add_children_count.http
@@ -1,0 +1,9 @@
+PUT core.data_sources_nodes/_mapping
+{
+  "properties": {
+    "children_count": {
+      "type": "integer",
+      "required": true
+    }
+  }
+}

--- a/core/src/stores/migrations/20250129_nodes_add_children_count.sql
+++ b/core/src/stores/migrations/20250129_nodes_add_children_count.sql
@@ -1,0 +1,3 @@
+-- migration created on 2025-01-29
+ALTER TABLE data_sources_nodes ADD COLUMN children_count INTEGER NOT NULL DEFAULT 0;
+

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -182,7 +182,7 @@ pub trait Store {
         data_source_id: &str,
         document_id: &str,
         version_hash: &Option<String>,
-    ) -> Result<Option<Document>>;
+    ) -> Result<Option<(Document, Node)>>;
     async fn find_data_source_document_ids(
         &self,
         project: &Project,
@@ -197,7 +197,7 @@ pub trait Store {
         project: &Project,
         data_source_id: String,
         create_params: DocumentCreateParams,
-    ) -> Result<Document>;
+    ) -> Result<(Document, Node)>;
     async fn update_data_source_document_tags(
         &self,
         project: &Project,
@@ -279,7 +279,7 @@ pub trait Store {
         project: Project,
         data_source_id: String,
         upsert_params: TableUpsertParams,
-    ) -> Result<Table>;
+    ) -> Result<(Table, Node)>;
     async fn update_data_source_table_schema(
         &self,
         project: &Project,
@@ -326,7 +326,7 @@ pub trait Store {
         project: Project,
         data_source_id: String,
         upsert_params: FolderUpsertParams,
-    ) -> Result<Folder>;
+    ) -> Result<(Folder, Node)>;
     async fn load_data_source_folder(
         &self,
         project: &Project,
@@ -604,6 +604,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
        provider_visibility          TEXT,
        parents                      TEXT[] NOT NULL,
        source_url                   TEXT,
+       children_count               INTEGER,
        document                     BIGINT,
        \"table\"                    BIGINT,
        folder                       BIGINT,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -183,11 +183,11 @@ function filterNodesByViewType(
   switch (viewType) {
     case "documents":
       return nodes.filter(
-        (node) => node.has_children || node.node_type !== "Table"
+        (node) => node.children_count > 0 || node.node_type !== "Table"
       );
     case "tables":
       return nodes.filter(
-        (node) => node.has_children || node.node_type === "Table"
+        (node) => node.children_count > 0 || node.node_type === "Table"
       );
     default:
       assertNever(viewType);
@@ -200,7 +200,7 @@ function removeCatchAllFoldersIfEmpty(
   return nodes.filter(
     (node) =>
       !FOLDERS_TO_HIDE_IF_EMPTY_MIME_TYPES.includes(node.mime_type) ||
-      node.has_children
+      node.children_count > 0
   );
 }
 
@@ -282,7 +282,7 @@ async function getContentNodesForDataSourceViewFromCore(
 
   const expandable = (node: CoreAPIContentNode) =>
     !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
-    node.has_children &&
+    node.children_count > 0 &&
     // if we aren't in tables view, spreadsheets are not expandable
     !(viewType !== "tables" && SPREADSHEET_MIME_TYPES.includes(node.mime_type));
 

--- a/types/src/core/content_node.ts
+++ b/types/src/core/content_node.ts
@@ -14,6 +14,6 @@ export type CoreAPIContentNode = {
   parent_id?: string;
   parents: string[];
   source_url?: string;
-  has_children: boolean;
+  children_count: number;
   parent_title?: string;
 };


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2037 (hopefully)

Logs show the [nodes computation](https://app.datadoghq.eu/logs?query=%28%22%5BCoreNodes%5D%20Latency%22%20%40coreLatency%3A%3E200%29%20OR%20%28%22%5BElasticsearchSearchStore%5D%22%20%40duration%3A%3E200%29&agg_m=%40diff&agg_m_source=base&agg_q=%40provider&agg_q_source=base&agg_t=pc75&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1738078296173&to_ts=1738079196173) which is where has_children is computed is slow

This PR fixes by adding a field so there is no runtime computation
- add `children_count` column to node data model
- add it to the ES mapping
- change the Node struct to reflect (column not settable though, only computed)
- at each node update (upsert, parents update, delete) update the parent count
- backfill psql
- backfill ES (scroll & update query?)

This should make core calls very fast.

Risks
---
low (still unused)

Deploy
---
- add filed in ES/PSQL (not required)
- deploy core
- deploy front
- backfill ES / PSQL
- make fields required

