### PR TITLE
Fix: id type for bigquery config

### DIFF
--- a/connectors/migrations/db/migration_49.sql
+++ b/connectors/migrations/db/migration_49.sql
@@ -1,6 +1,6 @@
 -- Migration created on Jan 29, 2025
 CREATE TABLE IF NOT EXISTS "bigquery_configurations" (
-    "id"  SERIAL,
+    "id"  BIGSERIAL,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "connectorId" INTEGER NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,


### PR DESCRIPTION
## Description

Fix id to bigint.

## Tests

Local

## Risk

Low

## Deploy Plan

Merge, Run migration