### PR TITLE
Add a CLI command to resync a Zendesk brand's metadata

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -223,6 +223,7 @@ export const zendesk = async ({
         brandId,
         currentSyncDateMs: Date.now(),
       });
+      return { success: true };
     }
   }
 };

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -1,10 +1,10 @@
 import type {
+  AdminResponseType,
   ZendeskCheckIsAdminResponseType,
   ZendeskCommandType,
   ZendeskCountTicketsResponseType,
   ZendeskFetchBrandResponseType,
   ZendeskFetchTicketResponseType,
-  ZendeskResyncTicketsResponseType,
 } from "@dust-tt/types";
 
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
@@ -34,9 +34,9 @@ export const zendesk = async ({
 }: ZendeskCommandType): Promise<
   | ZendeskCheckIsAdminResponseType
   | ZendeskCountTicketsResponseType
-  | ZendeskResyncTicketsResponseType
   | ZendeskFetchTicketResponseType
   | ZendeskFetchBrandResponseType
+  | AdminResponseType
 > => {
   const logger = topLogger.child({ majorCommand: "zendesk", command, args });
 

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -27,6 +27,7 @@ import {
   ZendeskConfigurationResource,
   ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
+import { syncZendeskBrandActivity } from "@connectors/connectors/zendesk/temporal/activities";
 
 export const zendesk = async ({
   command,
@@ -206,6 +207,22 @@ export const zendesk = async ({
         throw result.error;
       }
       return { success: true };
+    }
+    // Resyncs the metadata of a brand already in DB.
+    // Can be used to sync the data_sources_folders relative to the brand.
+    case "resync-brand-metadata": {
+      if (!connectorId) {
+        throw new Error(`Missing --connectorId argument`);
+      }
+      const brandId = args.brandId ? args.brandId : null;
+      if (!brandId) {
+        throw new Error(`Missing --brandId argument`);
+      }
+      await syncZendeskBrandActivity({
+        connectorId: parseInt(connectorId, 10),
+        brandId,
+        currentSyncDateMs: Date.now(),
+      });
     }
   }
 };

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -15,6 +15,7 @@ import {
   fetchZendeskTicketCount,
   getZendeskBrandSubdomain,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { syncZendeskBrandActivity } from "@connectors/connectors/zendesk/temporal/activities";
 import {
   launchZendeskSyncWorkflow,
   launchZendeskTicketReSyncWorkflow,
@@ -27,7 +28,6 @@ import {
   ZendeskConfigurationResource,
   ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
-import { syncZendeskBrandActivity } from "@connectors/connectors/zendesk/temporal/activities";
 
 export const zendesk = async ({
   command,

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -291,13 +291,6 @@ export type ZendeskCountTicketsResponseType = t.TypeOf<
   typeof ZendeskCountTicketsResponseSchema
 >;
 
-export const ZendeskResyncTicketsResponseSchema = t.type({
-  success: t.literal(true),
-});
-export type ZendeskResyncTicketsResponseType = t.TypeOf<
-  typeof ZendeskResyncTicketsResponseSchema
->;
-
 export const ZendeskFetchTicketResponseSchema = t.type({
   ticket: t.union([t.UnknownRecord, t.null]), // Zendesk type, can't be iots'd,
   isTicketOnDb: t.boolean,
@@ -473,7 +466,6 @@ export const AdminResponseSchema = t.union([
   IntercomForceResyncArticlesResponseSchema,
   ZendeskCheckIsAdminResponseSchema,
   ZendeskCountTicketsResponseSchema,
-  ZendeskResyncTicketsResponseSchema,
   ZendeskFetchTicketResponseSchema,
   ZendeskFetchBrandResponseSchema,
 ]);

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -264,6 +264,7 @@ export const ZendeskCommandSchema = t.type({
     t.literal("fetch-ticket"),
     t.literal("fetch-brand"),
     t.literal("resync-help-centers"),
+    t.literal("resync-brand-metadata"),
   ]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10362.
- This PR adds a CLI command to sync the folders and metadata of a Zendesk brand.
- The rationale behind adding it as a CLI command is the reusability in the post-CoreNodes cleanup phase.

## Tests

## Risk

- Very low.

## Deploy Plan

- Deploy connectors.