### PR TITLE
[CoreNodes] Ignore Zendesk articles in extra core nodes

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -257,19 +257,19 @@ export function computeNodesDiff({
           (n) => n.internalId === coreNode.internalId
         )
     )
-    .map((coreNode) => coreNode.internalId);
-  if (extraCoreInternalIds.length > 0) {
     // There is some specific code to Intercom in retrieveIntercomConversationsPermissions that hides the empty team folders + the teams folder if !hasTeamsWithReadPermission
     // Reproducing this logic in core is complicated and seems over-engineered.
-    if (
-      provider !== "intercom" ||
-      extraCoreInternalIds.some((id) => !id.startsWith("intercom-team"))
-    ) {
-      localLogger.info(
-        { extraCoreInternalIds },
-        "[CoreNodes] Received extraneous core nodes"
-      );
-    }
+    .filter(
+      (coreNode) =>
+        provider !== "intercom" ||
+        !coreNode.internalId.startsWith("intercom-team")
+    )
+    .map((coreNode) => coreNode.internalId);
+  if (extraCoreInternalIds.length > 0) {
+    localLogger.info(
+      { extraCoreInternalIds },
+      "[CoreNodes] Received extraneous core nodes"
+    );
   }
 }
 

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -258,7 +258,7 @@ export function computeNodesDiff({
         )
     )
     // There is some specific code to Intercom in retrieveIntercomConversationsPermissions that hides the empty team folders + the teams folder if !hasTeamsWithReadPermission
-    // Reproducing this logic in core is complicated and seems over-engineered.
+    // TBD whether this logic will be reproduced for core, ignoring for now.
     .filter(
       (coreNode) =>
         provider !== "intercom" ||

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -264,6 +264,13 @@ export function computeNodesDiff({
         provider !== "intercom" ||
         !coreNode.internalId.startsWith("intercom-team")
     )
+    // The endpoints in the Zendesk connector do not return anything as children of a category, core does.
+    // This will be considered as an improvement, if it turns out to be a bad user experience this will be removed, ignoring for now.
+    .filter(
+      (coreNode) =>
+        provider !== "zendesk" ||
+        !coreNode.internalId.startsWith("zendesk-article")
+    )
     .map((coreNode) => coreNode.internalId);
   if (extraCoreInternalIds.length > 0) {
     localLogger.info(


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2060.
- The endpoints in the Zendesk connector do not return anything as children of a category, whereas core does.
- This can be seen as an improvement, if it turns out to be a bad user experience we'll make the categories non expandable instead.

## Tests

## Risk

- Very low.

## Deploy Plan

- Deploy front.