### PR TITLE
[connectors] - feat: support Slack channel rename

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -2,7 +2,10 @@ import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
 import { JSON } from "@jsonjoy.com/util/lib/json-brand";
 import type { Request, Response } from "express";
 
-import { isChannelCreatedEvent, onChannelCreation } from "@connectors/api/webhooks/slack/created_channel";
+import {
+  isChannelCreatedEvent,
+  onChannelCreation,
+} from "@connectors/api/webhooks/slack/created_channel";
 import { botAnswerMessage } from "@connectors/connectors/slack/bot";
 import { updateSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -375,20 +375,11 @@ const _webhookSlackAPIHandler = async (
                 );
                 return res.status(200).send();
               } catch (e) {
-                if (e instanceof Error) {
-                  return apiError(req, res, {
-                    status_code: 500,
-                    api_error: {
-                      type: "internal_server_error",
-                      message: e.message,
-                    },
-                  });
-                }
                 return apiError(req, res, {
                   status_code: 500,
                   api_error: {
                     type: "internal_server_error",
-                    message: JSON.stringify(e),
+                    message: e instanceof Error ? e.message : JSON.stringify(e),
                   },
                 });
               }

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -1,11 +1,10 @@
 import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
+import { JSON } from "@jsonjoy.com/util/lib/json-brand";
 import type { Request, Response } from "express";
 
-import {
-  isChannelCreatedEvent,
-  onChannelCreation,
-} from "@connectors/api/webhooks/slack/created_channel";
+import { isChannelCreatedEvent, onChannelCreation } from "@connectors/api/webhooks/slack/created_channel";
 import { botAnswerMessage } from "@connectors/connectors/slack/bot";
+import { updateSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { getBotUserIdMemoized } from "@connectors/connectors/slack/temporal/activities";
 import {
@@ -22,8 +21,6 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 
 import { removeNulls } from "../../../../sdks/js";
-import { updateSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
-import { JSON } from "@jsonjoy.com/util/lib/json-brand";
 
 type SlackWebhookEventSubtype =
   | "message_changed"


### PR DESCRIPTION
## Description

This PR adds support for the Slack channel rename [webhook](https://api.slack.com/events/channel_rename).

**References:**
- https://github.com/dust-tt/tasks/issues/2028

## Risk

Low

## Deploy Plan

Deploy `connectors`