### PR TITLE
Add cursor-based pagination endpoint for nodes search

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -35,8 +35,7 @@ use dust::{
     blocks::block::BlockType,
     data_sources::{
         data_source::{self, Section},
-        node::Node,
-        node::ProviderVisibility,
+        node::{Node, ProviderVisibility},
         qdrant::QdrantClients,
     },
     databases::{
@@ -51,7 +50,8 @@ use dust::{
     run,
     search_filter::{Filterable, SearchFilter},
     search_stores::search_store::{
-        ElasticsearchSearchStore, NodesSearchFilter, NodesSearchOptions, SearchStore,
+        ElasticsearchSearchStore, NodesSearchCursorRequest, NodesSearchFilter, NodesSearchOptions,
+        SearchStore,
     },
     sqlite_workers::client::{self, HEARTBEAT_INTERVAL_MS},
     stores::{
@@ -3217,6 +3217,46 @@ async fn nodes_search(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NodesSearchWithCursorPayload {
+    query: Option<String>,
+    filter: NodesSearchFilter,
+    cursor: Option<NodesSearchCursorRequest>,
+}
+
+async fn nodes_search_with_cursor(
+    State(state): State<Arc<APIState>>,
+    Json(payload): Json<NodesSearchWithCursorPayload>,
+) -> (StatusCode, Json<APIResponse>) {
+    let (nodes, next_cursor) = match state
+        .search_store
+        .search_nodes_with_cursor(payload.query, payload.filter, payload.cursor)
+        .await
+    {
+        Ok((nodes, next_cursor)) => (nodes, next_cursor),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_server_error",
+                "Failed to search nodes",
+                Some(e),
+            )
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(APIResponse {
+            error: None,
+            response: Some(json!({
+                "nodes": nodes,
+                "next_page_cursor": next_cursor,
+            })),
+        }),
+    )
+}
+
+#[derive(serde::Deserialize)]
 struct DatabaseQueryRunPayload {
     query: String,
     tables: Vec<(i64, String, String)>,
@@ -3700,6 +3740,7 @@ fn main() {
 
         //Search
         .route("/nodes/search", post(nodes_search))
+        .route("/nodes/search/cursor", post(nodes_search_with_cursor))
 
         // Misc
         .route("/tokenize", post(tokenize))

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -185,6 +185,17 @@ export type CoreAPISearchOptions = {
   sort?: CoreAPISortSpec[];
 };
 
+export interface CoreAPISearchCursorRequest {
+  sort?: CoreAPISortSpec[];
+  limit?: number;
+  cursor?: string;
+}
+
+export interface CoreAPISearchCursorResponse {
+  nodes: CoreAPIContentNode[];
+  next_page_cursor: string | null;
+}
+
 export type CoreAPIDatasourceViewFilter = {
   data_source_id: string;
   view_filter: string[];
@@ -196,6 +207,22 @@ export type CoreAPINodesSearchFilter = {
   parent_id?: string;
   node_types?: CoreAPIContentNodeType[];
 };
+
+export interface CoreAPIUpsertDataSourceDocumentPayload {
+  projectId: string;
+  dataSourceId: string;
+  documentId: string;
+  timestamp?: number | null;
+  tags: string[];
+  parentId: string | null;
+  parents: string[];
+  sourceUrl?: string | null;
+  section: CoreAPIDataSourceDocumentSection;
+  credentials: CredentialsType;
+  lightDocumentOutput?: boolean;
+  title: string;
+  mimeType: string;
+}
 
 export class CoreAPI {
   _url: string;
@@ -872,21 +899,7 @@ export class CoreAPI {
     lightDocumentOutput = false,
     title,
     mimeType,
-  }: {
-    projectId: string;
-    dataSourceId: string;
-    documentId: string;
-    timestamp?: number | null;
-    tags: string[];
-    parentId: string | null;
-    parents: string[];
-    sourceUrl?: string | null;
-    section: CoreAPIDataSourceDocumentSection;
-    credentials: CredentialsType;
-    lightDocumentOutput?: boolean;
-    title: string;
-    mimeType: string;
-  }): Promise<
+  }: CoreAPIUpsertDataSourceDocumentPayload): Promise<
     CoreAPIResponse<{
       document:
         | CoreAPIDocument
@@ -1590,6 +1603,33 @@ export class CoreAPI {
         options,
       }),
     });
+    return this._resultFromResponse(response);
+  }
+
+  async searchNodesWithCursor({
+    query,
+    filter,
+    cursor,
+  }: {
+    query?: string;
+    filter: CoreAPINodesSearchFilter;
+    cursor?: CoreAPISearchCursorRequest;
+  }): Promise<CoreAPIResponse<CoreAPISearchCursorResponse>> {
+    const response = await this._fetchWithError(
+      `${this._url}/nodes/search/cursor`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query,
+          filter,
+          cursor,
+        }),
+      }
+    );
+
     return this._resultFromResponse(response);
   }
 


### PR DESCRIPTION
## Description
The current `/nodes/search` endpoint uses offset-based pagination which has significant limitations:
1. Deep pagination becomes increasingly inefficient as the offset grows because Elasticsearch must calculate and skip over all previous results
2. Limited to max 10k (from + size < 10k) results.

This is particularly problematic when we need to retrieve ALL nodes of a specific type from a data source, which is required for operations like workspace relocation where we need to process all documents/tables/folders.

## Solution
Add a new `/nodes/search/cursor` endpoint that implements cursor-based pagination using Elasticsearch's `search_after` parameter ([documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html)). This approach:
1. Uses `node_id` as a unique sort key to ensure stable ordering
2. Returns a cursor that can be used to fetch the next page
4. Performs consistently regardless of how deep into the result set we paginate

The new endpoint supports the same filtering capabilities as the existing one but replaces the offset/limit mechanism with a cursor-based approach.

## Why a new endpoint?
Rather than modifying the existing endpoint, we're introducing a new one for several reasons:
1. **Backward Compatibility**: Many parts of the application rely on the current offset-based pagination. A new endpoint allows for gradual migration without breaking existing functionality.
2. **Clear Contract**: The new endpoint makes it explicit that it uses cursor-based pagination, with a different set of parameters and response format.

**We will deprecate existing endpoint to always use the new one**

## Implementation
- Added `search_nodes_with_cursor` to the `SearchStore` trait
- Implemented cursor-based pagination using Elasticsearch's `search_after`
- Used base64 encoding for cursors to make them URL-safe
- Maintained all existing filtering capabilities
- Added TypeScript types and API methods

## Usage Example
```typescript
// First page
const firstPage = await api.searchNodesWithCursor({
  filter: {
    data_source_views: [{
      data_source_id: "ds_123",
      view_filter: []
    }],
    node_types: ["Document"]
  },
  cursor: {
    limit: 100
  }
});

// Next pages
while (firstPage.next_page_cursor) {
  const nextPage = await api.searchNodesWithCursor({
    filter: {/* same filter */},
    cursor: {
      limit: 100,
      cursor: firstPage.next_page_cursor
    }
  });
  // Process results...
}
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
