### PR TITLE
[Nodes Core] Compute: has_children ES -> children_count PSQL

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3191,7 +3191,12 @@ async fn nodes_search(
 ) -> (StatusCode, Json<APIResponse>) {
     let nodes = match state
         .search_store
-        .search_nodes(payload.query, payload.filter, payload.options)
+        .search_nodes(
+            payload.query,
+            payload.filter,
+            payload.options,
+            state.store.clone(),
+        )
         .await
     {
         Ok(nodes) => nodes,

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3235,7 +3235,12 @@ async fn nodes_search_with_cursor(
 ) -> (StatusCode, Json<APIResponse>) {
     let (nodes, next_cursor) = match state
         .search_store
-        .search_nodes_with_cursor(payload.query, payload.filter, payload.cursor)
+        .search_nodes_with_cursor(
+            payload.query,
+            payload.filter,
+            payload.cursor,
+            state.store.clone(),
+        )
         .await
     {
         Ok((nodes, next_cursor)) => (nodes, next_cursor),

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -177,15 +177,15 @@ impl From<serde_json::Value> for Node {
 pub struct CoreContentNode {
     #[serde(flatten)]
     pub base: Node,
-    pub has_children: bool,
+    pub children_count: u64,
     pub parent_title: Option<String>,
 }
 
 impl CoreContentNode {
-    pub fn new(base: Node, has_children: bool, parent_title: Option<String>) -> Self {
+    pub fn new(base: Node, children_count: u64, parent_title: Option<String>) -> Self {
         CoreContentNode {
             base,
-            has_children,
+            children_count,
             parent_title,
         }
     }

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -8,13 +8,14 @@ use elasticsearch::{
     http::transport::{SingleNodeConnectionPool, TransportBuilder},
     DeleteByQueryParts, DeleteParts, Elasticsearch, IndexParts, SearchParts,
 };
-use elasticsearch_dsl::{Aggregation, BoolQuery, Query, Search};
+use elasticsearch_dsl::{Query, Search};
 use serde_json::json;
 use tracing::{error, info};
 use url::Url;
 
 use crate::{
     data_sources::node::{CoreContentNode, Node, NodeType},
+    stores::store::Store,
     utils,
 };
 
@@ -95,6 +96,7 @@ pub trait SearchStore {
         query: Option<String>,
         filter: NodesSearchFilter,
         options: Option<NodesSearchOptions>,
+        store: Box<dyn Store + Sync + Send>,
     ) -> Result<Vec<CoreContentNode>>;
 
     async fn search_nodes_with_cursor(
@@ -162,6 +164,7 @@ impl SearchStore for ElasticsearchSearchStore {
         query: Option<String>,
         filter: NodesSearchFilter,
         options: Option<NodesSearchOptions>,
+        store: Box<dyn Store + Sync + Send>,
     ) -> Result<Vec<CoreContentNode>> {
         let options = options.unwrap_or_default();
 
@@ -254,7 +257,7 @@ impl SearchStore for ElasticsearchSearchStore {
         };
 
         let compute_node_start = utils::now();
-        let result = self.compute_core_content_nodes(nodes).await;
+        let result = self.compute_core_content_nodes(nodes, store).await;
         info!(
             duration = utils::now() - compute_node_start,
             data_source_id = data_source_id,
@@ -554,7 +557,11 @@ impl ElasticsearchSearchStore {
     ///
     /// It then creates CoreContentNodes from the nodes, using the results of these queries
     /// to populate the `has_children` and `parent_title` fields
-    async fn compute_core_content_nodes(&self, nodes: Vec<Node>) -> Result<Vec<CoreContentNode>> {
+    async fn compute_core_content_nodes(
+        &self,
+        nodes: Vec<Node>,
+        store: Box<dyn Store + Sync + Send>,
+    ) -> Result<Vec<CoreContentNode>> {
         if nodes.len() as u64 > MAX_PAGE_SIZE {
             return Err(anyhow::anyhow!(
                 "Too many nodes to compute core content nodes: {} (limit is {})",
@@ -563,18 +570,16 @@ impl ElasticsearchSearchStore {
             ));
         }
 
-        // Build has_children query
-        let has_children_search = Search::new()
-            .size(0)
-            .query(Query::bool().filter(Query::terms(
-                "parent_id",
-                nodes.iter().map(|n| &n.node_id).collect::<Vec<_>>(),
-            )))
-            .aggregate(
-                "parent_nodes",
-                Aggregation::terms("parent_id").size(MAX_PAGE_SIZE),
-            );
+        // count children using store
+        let count_start = utils::now();
+        let children_count_map = store.count_nodes_children(&nodes).await?;
+        let count_duration = utils::now() - count_start;
+        info!(
+            duration = count_duration,
+            "[ElasticsearchSearchStore] Count children duration"
+        );
 
+        // Build parent titles query
         // Build parent titles query
         let parent_ids: Vec<_> = nodes.iter().filter_map(|n| n.parent_id.as_ref()).collect();
         let parent_titles_search = Search::new()
@@ -582,45 +587,12 @@ impl ElasticsearchSearchStore {
             .query(Query::bool().filter(Query::terms("node_id", parent_ids)))
             .source(vec!["node_id", "title"]);
 
-        // Execute both futures concurrently
-        let (has_children_response, parent_titles_response) = tokio::join!(
-            self.client
-                .search(SearchParts::Index(&[NODES_INDEX_NAME]))
-                .body(has_children_search)
-                .send(),
-            self.client
-                .search(SearchParts::Index(&[NODES_INDEX_NAME]))
-                .body(parent_titles_search)
-                .send()
-        );
-
-        let has_children_response = has_children_response?;
-        let parent_titles_response = parent_titles_response?;
-
-        // Process has_children results
-        let has_children_map = if has_children_response.status_code().is_success() {
-            let response_body = has_children_response.json::<serde_json::Value>().await?;
-            response_body["aggregations"]["parent_nodes"]["buckets"]
-                .as_array()
-                .map(|buckets| {
-                    buckets
-                        .iter()
-                        .filter_map(|bucket| {
-                            Some((
-                                bucket["key"].as_str()?.to_string(),
-                                bucket["doc_count"].as_u64()? > 0,
-                            ))
-                        })
-                        .collect::<HashMap<_, _>>()
-                })
-                .unwrap_or_default()
-        } else {
-            let error = has_children_response.json::<serde_json::Value>().await?;
-            return Err(anyhow::anyhow!(
-                "Failed to fetch has_children data: {}",
-                error
-            ));
-        };
+        let parent_titles_response = self
+            .client
+            .search(SearchParts::Index(&[NODES_INDEX_NAME]))
+            .body(parent_titles_search)
+            .send()
+            .await?;
 
         // Process parent titles results
         let parent_titles_map = if parent_titles_response.status_code().is_success() {
@@ -647,17 +619,14 @@ impl ElasticsearchSearchStore {
         let core_content_nodes = nodes
             .into_iter()
             .map(|node| {
-                let has_children = has_children_map
-                    .get(&node.node_id)
-                    .copied()
-                    .unwrap_or(false);
+                let children_count = children_count_map.get(&node.node_id).copied().unwrap_or(0);
                 let parent_title = node
                     .parent_id
                     .as_ref()
                     .and_then(|pid| parent_titles_map.get(pid))
                     .cloned();
 
-                CoreContentNode::new(node, has_children, parent_title)
+                CoreContentNode::new(node, children_count, parent_title)
             })
             .collect();
 

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -582,7 +582,6 @@ impl ElasticsearchSearchStore {
         );
 
         // Build parent titles query
-        // Build parent titles query
         let parent_ids: Vec<_> = nodes.iter().filter_map(|n| n.parent_id.as_ref()).collect();
         let parent_titles_search = Search::new()
             .size(parent_ids.len() as u64)

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -3624,6 +3624,59 @@ impl Store for PostgresStore {
         Ok(nodes)
     }
 
+    async fn count_nodes_children(&self, nodes: &Vec<Node>) -> Result<HashMap<String, u64>> {
+        let pool = self.pool.clone();
+        let c = pool.get().await?;
+
+        // Extract all node IDs we want to count children for and get corresponding data_source_row_ids
+        let node_ids: Vec<String> = nodes.iter().map(|n| n.node_id.clone()).collect();
+        let data_source_internal_ids: Vec<String> = nodes
+            .iter()
+            .map(|n| n.data_source_internal_id.clone())
+            .collect();
+        let r = c
+            .query(
+                "select ds.id, p.node_id FROM data_sources ds
+                JOIN UNNEST(
+                    ARRAY[$1],
+                    ARRAY[$2]
+                ) AS p(node_id, internal_id)
+                ON ds.internal_id = p.internal_id",
+                &[&node_ids, &data_source_internal_ids],
+            )
+            .await?;
+
+        let data_source_row_ids: Vec<i64> = r.iter().map(|row| row.get(0)).collect();
+        let node_ids: Vec<String> = r.iter().map(|row| row.get(1)).collect();
+
+        // using index (data_source, parents[2]), grab children count
+        let stmt = c
+            .prepare(
+                "SELECT p.node_id, COUNT(*) as child_count
+                    FROM data_sources_nodes dsn
+                    JOIN UNNEST(
+                        ARRAY[$1],
+                        ARRAY[$2]
+                    ) AS p(data_source, node_id)
+                    ON dsn.data_source = p.data_source AND dsn.parent[2] = p.node_id
+                    GROUP BY p.node_id",
+            )
+            .await?;
+        let rows = c.query(&stmt, &[&data_source_row_ids, &node_ids]).await?;
+
+        // Convert the results into a HashMap
+        let counts = rows
+            .iter()
+            .map(|row| {
+                let parent_id: String = row.get(0);
+                let count: i64 = row.get(1);
+                (parent_id, count as u64)
+            })
+            .collect::<HashMap<String, u64>>();
+
+        Ok(counts)
+    }
+
     async fn llm_cache_get(
         &self,
         project: &Project,

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -3636,11 +3636,11 @@ impl Store for PostgresStore {
             .collect();
         let r = c
             .query(
-                "select ds.id, p.node_id FROM data_sources ds
-                JOIN UNNEST(
-                    $1::text[],
-                    $2::text[]
-                ) AS p(node_id, internal_id)
+                "SELECT ds.id, p.node_id FROM data_sources ds
+                    JOIN UNNEST(
+                        $1::text[],
+                        $2::text[]
+                    ) AS p(node_id, internal_id)
                 ON ds.internal_id = p.internal_id",
                 &[&node_ids, &data_source_internal_ids],
             )

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -3638,8 +3638,8 @@ impl Store for PostgresStore {
             .query(
                 "select ds.id, p.node_id FROM data_sources ds
                 JOIN UNNEST(
-                    ARRAY[$1],
-                    ARRAY[$2]
+                    $1::text[],
+                    $2::text[]
                 ) AS p(node_id, internal_id)
                 ON ds.internal_id = p.internal_id",
                 &[&node_ids, &data_source_internal_ids],
@@ -3655,10 +3655,10 @@ impl Store for PostgresStore {
                 "SELECT p.node_id, COUNT(*) as child_count
                     FROM data_sources_nodes dsn
                     JOIN UNNEST(
-                        ARRAY[$1],
-                        ARRAY[$2]
+                        $1::bigint[],
+                        $2::text[]
                     ) AS p(data_source, node_id)
-                    ON dsn.data_source = p.data_source AND dsn.parent[2] = p.node_id
+                    ON dsn.data_source = p.data_source AND dsn.parents[2] = p.node_id
                     GROUP BY p.node_id",
             )
             .await?;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -361,6 +361,8 @@ pub trait Store {
         batch_size: i64,
     ) -> Result<Vec<(Node, i64, i64)>>;
 
+    async fn count_nodes_children(&self, nodes: &Vec<Node>) -> Result<HashMap<String, u64>>;
+
     // LLM Cache
     async fn llm_cache_get(
         &self,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -183,11 +183,11 @@ function filterNodesByViewType(
   switch (viewType) {
     case "documents":
       return nodes.filter(
-        (node) => node.has_children || node.node_type !== "Table"
+        (node) => node.children_count > 0 || node.node_type !== "Table"
       );
     case "tables":
       return nodes.filter(
-        (node) => node.has_children || node.node_type === "Table"
+        (node) => node.children_count > 0 || node.node_type === "Table"
       );
     default:
       assertNever(viewType);
@@ -200,7 +200,7 @@ function removeCatchAllFoldersIfEmpty(
   return nodes.filter(
     (node) =>
       !FOLDERS_TO_HIDE_IF_EMPTY_MIME_TYPES.includes(node.mime_type) ||
-      node.has_children
+      node.children_count > 0
   );
 }
 
@@ -282,7 +282,7 @@ async function getContentNodesForDataSourceViewFromCore(
 
   const expandable = (node: CoreAPIContentNode) =>
     !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
-    node.has_children &&
+    node.children_count > 0 &&
     // if we aren't in tables view, spreadsheets are not expandable
     !(viewType !== "tables" && SPREADSHEET_MIME_TYPES.includes(node.mime_type));
 

--- a/types/src/core/content_node.ts
+++ b/types/src/core/content_node.ts
@@ -14,6 +14,6 @@ export type CoreAPIContentNode = {
   parent_id?: string;
   parents: string[];
   source_url?: string;
-  has_children: boolean;
+  children_count: number;
   parent_title?: string;
 };


### PR DESCRIPTION
Description
---
- ES computation takes too long
- This PR tests using PSQL instead
- See PR #10367 for context
- If successful, would replace PR #10367 completely

- PR also changes has_children to children_count in core and front, which was a todo anyways and will be definitive (whereas rest of PR depends on results)

Risks
---
low, only touches nodes stuff, not too prod-y

Deploy
---
core
front
