### PR TITLE
Add Document Relocation Script for Cross-Region Migration

### DIFF
--- a/front/temporal/relocation/activities/destination_region/core/data_sources.ts
+++ b/front/temporal/relocation/activities/destination_region/core/data_sources.ts
@@ -1,0 +1,99 @@
+import logger from "@app/logger/logger";
+
+import config from "@app/lib/api/config";
+import {
+  CoreAPI,
+  CoreAPIDataSource,
+  dustManagedCredentials,
+} from "@dust-tt/types";
+import { RegionType } from "@app/lib/api/regions/config";
+import {
+  CreateDataSourceProjectResult,
+  DataSourceCoreIds,
+} from "@app/temporal/relocation/activities/types";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+
+export async function createDataSourceProject({
+  destRegion,
+  sourceRegionCoreDataSource,
+  workspaceId,
+}: {
+  destRegion: RegionType;
+  sourceRegionCoreDataSource: CoreAPIDataSource;
+  workspaceId: string;
+}): Promise<CreateDataSourceProjectResult> {
+  const localLogger = logger.child({
+    destRegion,
+    workspaceId,
+  });
+
+  localLogger.info("[Core] Creating data source project.");
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), localLogger);
+  const dustProject = await coreAPI.createProject();
+  if (dustProject.isErr()) {
+    localLogger.error(
+      { error: dustProject.error },
+      "[Core] Failed to create internal project for the data source."
+    );
+
+    throw new Error("Failed to create internal project for the data source.");
+  }
+
+  const dustDataSource = await coreAPI.createDataSource({
+    projectId: dustProject.value.project.project_id.toString(),
+    config: sourceRegionCoreDataSource.config,
+    credentials: dustManagedCredentials(),
+  });
+
+  if (dustDataSource.isErr()) {
+    localLogger.error(
+      { error: dustDataSource.error },
+      "[Core] Failed to create the data source."
+    );
+
+    throw new Error("Failed to create the data source.");
+  }
+
+  localLogger.info("[Core] Created project and data source.");
+
+  return {
+    dustAPIProjectId: dustProject.value.project.project_id.toString(),
+    dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
+  };
+}
+
+export async function updateDataSourceCoreIds({
+  dataSourceCoreIds,
+  destIds,
+  workspaceId,
+}: {
+  dataSourceCoreIds: DataSourceCoreIds;
+  destIds: CreateDataSourceProjectResult;
+  workspaceId: string;
+}) {
+  const localLogger = logger.child({
+    dataSourceCoreIds,
+    workspaceId,
+  });
+
+  localLogger.info("[Core] Updating data source core ids");
+
+  const dataSource = await DataSourceModel.findOne({
+    where: {
+      id: dataSourceCoreIds.id,
+    },
+  });
+
+  if (!dataSource) {
+    localLogger.error("[Core] Data source not found");
+    throw new Error("Data source not found");
+  }
+
+  await dataSource.update({
+    dustAPIDataSourceId: destIds.dustAPIDataSourceId,
+    dustAPIProjectId: destIds.dustAPIProjectId,
+  });
+
+  localLogger.info("[Core] Updated data source core ids");
+}

--- a/front/temporal/relocation/activities/destination_region/core/documents.ts
+++ b/front/temporal/relocation/activities/destination_region/core/documents.ts
@@ -1,0 +1,96 @@
+import config from "@app/lib/api/config";
+import { RegionType } from "@app/lib/api/regions/config";
+import logger from "@app/logger/logger";
+import {
+  APIRelocationBlob,
+  CORE_API_CONCURRENCY_LIMIT,
+  CoreDocumentAPIRelocationBlob,
+  CreateDataSourceProjectResult,
+} from "@app/temporal/relocation/activities/types";
+import {
+  deleteFromRelocationStorage,
+  readFromRelocationStorage,
+} from "@app/temporal/relocation/lib/file_storage/relocation";
+import {
+  concurrentExecutor,
+  CoreAPI,
+  dustManagedCredentials,
+} from "@dust-tt/types";
+
+export async function processDataSourceDocuments({
+  destIds,
+  dataPath,
+  destRegion,
+  sourceRegion,
+  sourceRegionDustFacingUrl,
+  workspaceId,
+}: {
+  destIds: CreateDataSourceProjectResult;
+  dataPath: string;
+  destRegion: RegionType;
+  sourceRegion: RegionType;
+  sourceRegionDustFacingUrl: string;
+  workspaceId: string;
+}) {
+  const localLogger = logger.child({
+    destRegion,
+    sourceRegion,
+    workspaceId,
+  });
+
+  localLogger.info("[Core] Processing data source documents");
+
+  const data =
+    await readFromRelocationStorage<CoreDocumentAPIRelocationBlob>(dataPath);
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), localLogger);
+
+  const credentials = dustManagedCredentials();
+  const destRegionDustFacingUrl = config.getClientFacingUrl();
+
+  const res = await concurrentExecutor(
+    data.blobs.documents,
+    async (d) => {
+      // If the source URL starts with the source region Dust URL, replace it with the destination region Dust URL.
+      const sourceUrl =
+        d.source_url && d.source_url.startsWith(sourceRegionDustFacingUrl)
+          ? d.source_url.replace(
+              sourceRegionDustFacingUrl,
+              destRegionDustFacingUrl
+            )
+          : d.source_url;
+
+      return coreAPI.upsertDataSourceDocument({
+        // Override the project and data source ids to the ones in the destination region.
+        projectId: destIds.dustAPIProjectId,
+        dataSourceId: destIds.dustAPIDataSourceId,
+        documentId: d.document_id,
+        timestamp: d.timestamp,
+        tags: d.tags,
+        parentId: d.parent_id,
+        parents: d.parents,
+        sourceUrl,
+        section: d.section,
+        credentials,
+        lightDocumentOutput: true,
+        title: d.title,
+        mimeType: d.mime_type,
+      });
+    },
+    { concurrency: CORE_API_CONCURRENCY_LIMIT }
+  );
+
+  const failed = res.filter((r) => r.isErr());
+  if (failed.length > 0) {
+    localLogger.error(
+      { failed },
+      "[Core] Failed to process data source documents"
+    );
+
+    throw new Error("Failed to process data source documents");
+  }
+
+  localLogger.info("[Core] Processed data source documents");
+
+  await deleteFromRelocationStorage(dataPath);
+}

--- a/front/temporal/relocation/activities/destination_region/core/index.ts
+++ b/front/temporal/relocation/activities/destination_region/core/index.ts
@@ -1,0 +1,2 @@
+export * from "./data_sources";
+export * from "./documents";

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -49,7 +49,7 @@ export async function writeCoreEntitiesToDestinationRegion({
   }
 
   // 3) Create users metadata in transaction.
-  for (const userMetadataChunk of blob.statements.users_metadata) {
+  for (const userMetadataChunk of blob.statements.user_metadata) {
     await frontSequelize.transaction(async (transaction) => {
       await frontSequelize.query(userMetadataChunk, { transaction });
     });

--- a/front/temporal/relocation/activities/source_region/connectors/sql.ts
+++ b/front/temporal/relocation/activities/source_region/connectors/sql.ts
@@ -15,6 +15,8 @@ export async function getAllConnectorsForWorkspace({
 }: {
   workspaceId: string;
 }) {
+  // TODO: Use the front databases to get the connectorIds.
+
   // We can use the replica db because we don't need to write to it.
   const connectorReplicaDb = getConnectorsReplicaDbConnection();
 

--- a/front/temporal/relocation/activities/source_region/core/data_sources.ts
+++ b/front/temporal/relocation/activities/source_region/core/data_sources.ts
@@ -1,0 +1,96 @@
+import config from "@app/lib/api/config";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { Op, QueryTypes } from "sequelize";
+import logger from "@app/logger/logger";
+import { CoreAPI, CoreAPIDataSource, ModelId } from "@dust-tt/types";
+import { WhereOptions } from "sequelize";
+import { DataSourceCoreIds } from "@app/temporal/relocation/activities/types";
+import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import assert from "assert";
+
+const BATCH_SIZE = 100;
+
+export async function retrieveDataSourceCoreIdsBatch({
+  lastId,
+  workspaceId,
+}: {
+  lastId?: ModelId;
+  workspaceId: string;
+}): Promise<{
+  dataSourceCoreIds: DataSourceCoreIds[];
+  hasMore: boolean;
+  lastId: ModelId;
+}> {
+  const localLogger = logger.child({
+    lastId,
+    workspaceId,
+  });
+
+  localLogger.info("[Core] Retrieving data source core ids");
+
+  const workspace = await getWorkspaceInfos(workspaceId);
+  assert(workspace, "Workspace not found.");
+
+  const whereClause: WhereOptions<DataSourceModel> = {
+    workspaceId: workspace.id,
+  };
+
+  if (lastId) {
+    whereClause.id = {
+      [Op.gt]: lastId,
+    };
+  }
+
+  const dataSources = await DataSourceModel.findAll({
+    where: whereClause,
+    order: [["id", "ASC"]],
+    limit: BATCH_SIZE,
+    raw: true,
+    type: QueryTypes.SELECT,
+  });
+
+  localLogger.info(
+    { dataSourceCount: dataSources.length },
+    "[Core] Retrieved data source core ids"
+  );
+
+  return {
+    dataSourceCoreIds: dataSources.map((ds) => ({
+      id: ds.id,
+      dustAPIDataSourceId: ds.dustAPIDataSourceId,
+      dustAPIProjectId: ds.dustAPIProjectId,
+    })),
+    hasMore: dataSources.length === BATCH_SIZE,
+    lastId: dataSources[dataSources.length - 1].id,
+  };
+}
+
+export async function getCoreDataSource({
+  dataSourceCoreIds,
+  workspaceId,
+}: {
+  dataSourceCoreIds: DataSourceCoreIds;
+  workspaceId: string;
+}): Promise<CoreAPIDataSource> {
+  const localLogger = logger.child({
+    dataSourceCoreIds,
+    workspaceId,
+  });
+
+  localLogger.info("[Core] Retrieving data source");
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), localLogger);
+
+  const dataSourceRes = await coreAPI.getDataSource({
+    projectId: dataSourceCoreIds.dustAPIProjectId,
+    dataSourceId: dataSourceCoreIds.dustAPIDataSourceId,
+  });
+
+  if (dataSourceRes.isErr()) {
+    throw new Error("Failed to retrieve data source");
+  }
+
+  const { data_source: dataSource } = dataSourceRes.value;
+
+  return dataSource;
+}

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -121,3 +121,7 @@ export async function getDataSourceDocuments({
     nextPageCursor,
   };
 }
+
+export async function getRegionDustFacingUrl() {
+  return config.getClientFacingUrl();
+}

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -13,12 +13,10 @@ import { writeToRelocationStorage } from "@app/temporal/relocation/lib/file_stor
 import config from "@app/lib/api/config";
 import {
   CORE_API_CONCURRENCY_LIMIT,
+  CORE_API_LIST_NODES_BATCH_SIZE,
   CoreDocumentAPIRelocationBlob,
   DataSourceCoreIds,
 } from "@app/temporal/relocation/activities/types";
-
-// TODO: Make this configurable.
-const BATCH_SIZE = 10;
 
 export async function getDataSourceDocuments({
   dataSourceCoreIds,
@@ -49,7 +47,7 @@ export async function getDataSourceDocuments({
   };
 
   const cursorRequest: CoreAPISearchCursorRequest = {
-    limit: BATCH_SIZE,
+    limit: CORE_API_LIST_NODES_BATCH_SIZE,
   };
 
   if (pageCursor) {

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -40,6 +40,7 @@ export async function getDataSourceDocuments({
     data_source_views: [
       {
         data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
+        // Leaving empty to get all documents.
         view_filter: [],
       },
     ],

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -1,0 +1,125 @@
+import logger from "@app/logger/logger";
+
+import { getCoreReplicaDbConnection } from "@app/lib/production_checks/utils";
+
+import { RegionType } from "@app/lib/api/regions/config";
+import {
+  concurrentExecutor,
+  CoreAPI,
+  CoreAPINodesSearchFilter,
+  CoreAPISearchCursorRequest,
+} from "@dust-tt/types";
+import { writeToRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
+import config from "@app/lib/api/config";
+import {
+  CORE_API_CONCURRENCY_LIMIT,
+  CoreDocumentAPIRelocationBlob,
+  DataSourceCoreIds,
+} from "@app/temporal/relocation/activities/types";
+
+// TODO: Make this configurable.
+const BATCH_SIZE = 10;
+
+export async function getDataSourceDocuments({
+  dataSourceCoreIds,
+  pageCursor,
+  sourceRegion,
+  workspaceId,
+}: {
+  dataSourceCoreIds: DataSourceCoreIds;
+  pageCursor: string | null;
+  sourceRegion: RegionType;
+  workspaceId: string;
+}) {
+  const localLogger = logger.child({
+    dataSourceCoreIds,
+    sourceRegion,
+  });
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), localLogger);
+
+  const filter: CoreAPINodesSearchFilter = {
+    data_source_views: [
+      {
+        data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
+        view_filter: [],
+      },
+    ],
+    node_types: ["Document"],
+  };
+
+  const cursorRequest: CoreAPISearchCursorRequest = {
+    limit: BATCH_SIZE,
+  };
+
+  if (pageCursor) {
+    cursorRequest.cursor = pageCursor;
+  }
+
+  // 1) List documents for the data source.
+  const searchResults = await coreAPI.searchNodesWithCursor({
+    filter,
+    cursor: cursorRequest,
+  });
+
+  if (searchResults.isErr()) {
+    localLogger.error(
+      { error: searchResults.error },
+      "[Core] Failed to search nodes with cursor"
+    );
+
+    throw new Error("Failed to search nodes with cursor");
+  }
+
+  const { nodes, next_page_cursor: nextPageCursor } = searchResults.value;
+
+  // 2) Get the document blobs.
+  const res = await concurrentExecutor(
+    nodes,
+    async (n) =>
+      coreAPI.getDataSourceDocumentBlob({
+        projectId: dataSourceCoreIds.dustAPIProjectId,
+        dataSourceId: dataSourceCoreIds.dustAPIDataSourceId,
+        documentId: n.node_id,
+      }),
+    { concurrency: CORE_API_CONCURRENCY_LIMIT }
+  );
+
+  const documentBlobs = res.filter((r) => r.isOk()).map((r) => r.value);
+  const failed = res.filter((r) => r.isErr());
+  if (failed.length > 0) {
+    localLogger.error(
+      { failed },
+      "[Core] Failed to get data source document blobs"
+    );
+
+    throw new Error("Failed to get data source document blobs");
+  }
+
+  const blobs: CoreDocumentAPIRelocationBlob = {
+    blobs: {
+      documents: documentBlobs,
+    },
+  };
+
+  // 3) Save the document blobs to file storage.
+  const dataPath = await writeToRelocationStorage(blobs, {
+    workspaceId,
+    type: "core",
+    operation: "data_source_document_blobs",
+  });
+
+  localLogger.info(
+    {
+      dataPath,
+      nextPageCursor,
+      nodeCount: nodes.length,
+    },
+    "[Core] Retrieved data source documents"
+  );
+
+  return {
+    dataPath,
+    nextPageCursor,
+  };
+}

--- a/front/temporal/relocation/activities/source_region/core/index.ts
+++ b/front/temporal/relocation/activities/source_region/core/index.ts
@@ -1,0 +1,2 @@
+export * from "./data_sources";
+export * from "./documents";

--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -1,6 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 import assert from "assert";
-import { Op, QueryTypes } from "sequelize";
+import { Op, QueryTypes, WhereOptions } from "sequelize";
 
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { Workspace } from "@app/lib/models/workspace";
@@ -67,7 +67,7 @@ export async function readCoreEntitiesFromSourceRegion({
   });
 
   // Fetch all associated users metadata of the workspace.
-  const usersMetadata = await UserMetadataModel.findAll({
+  const userMetadata = await UserMetadataModel.findAll({
     where: {
       userId: {
         [Op.in]: memberships.map((m) => m.userId),
@@ -98,13 +98,9 @@ export async function readCoreEntitiesFromSourceRegion({
     statements: {
       plans: generateInsertStatements("plans", plans, { onConflict: "ignore" }),
       users: generateInsertStatements("users", users, { onConflict: "ignore" }),
-      users_metadata: generateInsertStatements(
-        "users_metadata",
-        usersMetadata,
-        {
-          onConflict: "ignore",
-        }
-      ),
+      user_metadata: generateInsertStatements("user_metadata", userMetadata, {
+        onConflict: "ignore",
+      }),
       workspace: generateInsertStatements("workspaces", [workspace], {
         onConflict: "ignore",
       }),

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -1,13 +1,13 @@
 import { RegionType } from "@app/lib/api/regions/config";
 
-import { ModelId } from "@dust-tt/types";
+import { CoreAPIDocumentBlob, ModelId } from "@dust-tt/types";
 
 export interface RelocationBlob<T extends string = string> {
   statements: Record<T, string[]>;
 }
 
 export type CoreEntitiesRelocationBlob = RelocationBlob<
-  "plans" | "users_metadata" | "users" | "workspace"
+  "plans" | "user_metadata" | "users" | "workspace"
 >;
 
 export interface ReadTableChunkParams {
@@ -18,3 +18,30 @@ export interface ReadTableChunkParams {
   tableName: string;
   workspaceId: string;
 }
+
+// Core.
+
+export interface DataSourceCoreIds {
+  id: ModelId;
+  dustAPIProjectId: string;
+  dustAPIDataSourceId: string;
+}
+
+export interface CreateDataSourceProjectResult {
+  dustAPIProjectId: string;
+  dustAPIDataSourceId: string;
+}
+
+export interface APIRelocationBlob<
+  T extends string = string,
+  V extends object = object,
+> {
+  blobs: Record<T, V[]>;
+}
+
+export type CoreDocumentAPIRelocationBlob = APIRelocationBlob<
+  "documents",
+  CoreAPIDocumentBlob
+>;
+
+export const CORE_API_CONCURRENCY_LIMIT = 10;

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -19,6 +19,9 @@ export interface ReadTableChunkParams {
   workspaceId: string;
 }
 
+export const CORE_API_CONCURRENCY_LIMIT = 10;
+export const CORE_API_LIST_NODES_BATCH_SIZE = 100;
+
 // Core.
 
 export interface DataSourceCoreIds {
@@ -43,5 +46,3 @@ export type CoreDocumentAPIRelocationBlob = APIRelocationBlob<
   "documents",
   CoreAPIDocumentBlob
 >;
-
-export const CORE_API_CONCURRENCY_LIMIT = 10;

--- a/front/temporal/relocation/worker.ts
+++ b/front/temporal/relocation/worker.ts
@@ -9,6 +9,8 @@ import * as frontDestinationActivities from "@app/temporal/relocation/activities
 import * as frontSourceActivities from "@app/temporal/relocation/activities/source_region/front";
 import * as connectorsDestinationActivities from "@app/temporal/relocation/activities/destination_region/connectors/sql";
 import * as connectorsSourceActivities from "@app/temporal/relocation/activities/source_region/connectors/sql";
+import * as coreSourceActivities from "@app/temporal/relocation/activities/source_region/core";
+import * as coreDestinationActivities from "@app/temporal/relocation/activities/destination_region/core";
 import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
 import { getTemporalWorkerConnection } from "@app/temporal/relocation/temporal";
 
@@ -19,10 +21,12 @@ export async function runRelocationWorker() {
   const worker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities: {
-      ...frontDestinationActivities,
-      ...frontSourceActivities,
       ...connectorsDestinationActivities,
       ...connectorsSourceActivities,
+      ...coreDestinationActivities,
+      ...coreSourceActivities,
+      ...frontDestinationActivities,
+      ...frontSourceActivities,
     },
     taskQueue: RELOCATION_QUEUES_PER_REGION[currentRegion],
     maxConcurrentActivityTaskExecutions: 8,

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -12,7 +12,13 @@ import type * as connectorsDestinationActivities from "@app/temporal/relocation/
 import type * as frontDestinationActivities from "@app/temporal/relocation/activities/destination_region/front";
 import type * as connectorsSourceActivities from "@app/temporal/relocation/activities/source_region/connectors/sql";
 import type * as frontSourceActivities from "@app/temporal/relocation/activities/source_region/front";
+import type * as coreSourceActivities from "@app/temporal/relocation/activities/source_region/core";
+import type * as coreDestinationActivities from "@app/temporal/relocation/activities/destination_region/core";
 import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
+import {
+  CreateDataSourceProjectResult,
+  DataSourceCoreIds,
+} from "@app/temporal/relocation/activities/types";
 
 const CHUNK_SIZE = 5000;
 const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 10_000;
@@ -44,6 +50,13 @@ export async function workspaceRelocationWorkflow({
     searchAttributes: parentSearchAttributes,
     args: [{ sourceRegion, destRegion, workspaceId }],
     memo,
+  });
+
+  // 3) Relocate the core data source documents to the destination region.
+  await executeChild(workspaceRelocateCoreWorkflow, {
+    workflowId: `workspaceRelocateCoreWorkflow-${workspaceId}`,
+    searchAttributes: parentSearchAttributes,
+    args: [{ sourceRegion, destRegion, workspaceId }],
   });
 }
 
@@ -394,4 +407,170 @@ export async function workspaceRelocateConnectorsTableWorkflow({
       workspaceId,
     });
   } while (hasMoreRows);
+}
+
+/**
+ * Core relocation workflows.
+ */
+
+const getCoreSourceRegionActivities = (region: RegionType) => {
+  return proxyActivities<typeof coreSourceActivities>({
+    startToCloseTimeout: "10 minutes",
+    taskQueue: RELOCATION_QUEUES_PER_REGION[region],
+  });
+};
+
+const getCoreDestinationRegionActivities = (region: RegionType) => {
+  return proxyActivities<typeof coreDestinationActivities>({
+    startToCloseTimeout: "10 minutes",
+    taskQueue: RELOCATION_QUEUES_PER_REGION[region],
+  });
+};
+
+export async function workspaceRelocateCoreWorkflow({
+  destRegion,
+  lastProcessedId,
+  sourceRegion,
+  workspaceId,
+}: RelocationWorkflowBase & { lastProcessedId?: ModelId }) {
+  const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
+
+  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
+
+  let hasMoreRows = true;
+  let currentId: ModelId | undefined = lastProcessedId;
+
+  do {
+    if (workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH) {
+      await continueAsNew<typeof workspaceRelocateCoreWorkflow>({
+        destRegion,
+        lastProcessedId: currentId,
+        sourceRegion,
+        workspaceId,
+      });
+    }
+
+    const { dataSourceCoreIds, hasMore, lastId } =
+      await sourceRegionActivities.retrieveDataSourceCoreIdsBatch({
+        lastId: currentId,
+        workspaceId,
+      });
+
+    hasMoreRows = hasMore;
+    currentId = lastId;
+
+    for (const dsc of dataSourceCoreIds) {
+      await executeChild(workspaceRelocateDataSourceCoreWorkflow, {
+        workflowId: `workspaceRelocateDataSourceCoreWorkflow-${workspaceId}-${dsc.id}`,
+        searchAttributes: parentSearchAttributes,
+        args: [
+          {
+            dataSourceCoreIds: dsc,
+            destRegion,
+            sourceRegion,
+            workspaceId,
+          },
+        ],
+        memo,
+      });
+    }
+  } while (hasMoreRows);
+}
+
+// TODO: Below is not idempotent, we need to handle the case where the data source is already created in the destination region.
+export async function workspaceRelocateDataSourceCoreWorkflow({
+  dataSourceCoreIds,
+  destRegion,
+  sourceRegion,
+  workspaceId,
+}: RelocationWorkflowBase & { dataSourceCoreIds: DataSourceCoreIds }) {
+  const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
+
+  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
+  const destinationRegionActivities =
+    getCoreDestinationRegionActivities(destRegion);
+
+  // 1) Get the data source from the source region.
+  const sourceRegionCoreDataSource =
+    await sourceRegionActivities.getCoreDataSource({
+      dataSourceCoreIds,
+      workspaceId,
+    });
+
+  // 2) Create the project and data source in the destination region.
+  const destIds = await destinationRegionActivities.createDataSourceProject({
+    destRegion,
+    sourceRegionCoreDataSource,
+    workspaceId,
+  });
+
+  // TODO: We need to update the data source in the destination region with the new core ids.
+  // 3) Update the data source in the destination region with the new core ids.
+  await destinationRegionActivities.updateDataSourceCoreIds({
+    dataSourceCoreIds,
+    destIds,
+    workspaceId,
+  });
+
+  // 3) Relocate the data source documents to the destination region.
+  await executeChild(workspaceRelocateDataSourceDocumentsWorkflow, {
+    workflowId: `workspaceRelocateDataSourceDocumentsWorkflow-${workspaceId}-${dataSourceCoreIds.dustAPIDataSourceId}`,
+    searchAttributes: parentSearchAttributes,
+    args: [
+      {
+        dataSourceCoreIds,
+        destIds,
+        destRegion,
+        sourceRegion,
+        workspaceId,
+      },
+    ],
+  });
+}
+
+export async function workspaceRelocateDataSourceDocumentsWorkflow({
+  dataSourceCoreIds,
+  destIds,
+  destRegion,
+  sourceRegion,
+  workspaceId,
+}: RelocationWorkflowBase & {
+  destIds: CreateDataSourceProjectResult;
+  dataSourceCoreIds: DataSourceCoreIds;
+}) {
+  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
+  const destinationRegionActivities =
+    getCoreDestinationRegionActivities(destRegion);
+
+  let pageCursor: string | null = null;
+
+  do {
+    if (workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH) {
+      await continueAsNew<typeof workspaceRelocateDataSourceDocumentsWorkflow>({
+        dataSourceCoreIds,
+        destIds,
+        destRegion,
+        sourceRegion,
+        workspaceId,
+      });
+    }
+
+    const { dataPath, nextPageCursor } =
+      await sourceRegionActivities.getDataSourceDocuments({
+        pageCursor,
+        dataSourceCoreIds,
+        sourceRegion,
+        workspaceId,
+      });
+
+    await destinationRegionActivities.processDataSourceDocuments({
+      destIds,
+      dataPath,
+      destRegion,
+      sourceRegion,
+      workspaceId,
+    });
+
+    pageCursor = nextPageCursor;
+  } while (pageCursor);
 }

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -504,7 +504,6 @@ export async function workspaceRelocateDataSourceCoreWorkflow({
     workspaceId,
   });
 
-  // TODO: We need to update the data source in the destination region with the new core ids.
   // 3) Update the data source in the destination region with the new core ids.
   await destinationRegionActivities.updateDataSourceCoreIds({
     dataSourceCoreIds,

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -562,11 +562,15 @@ export async function workspaceRelocateDataSourceDocumentsWorkflow({
         workspaceId,
       });
 
+    const sourceRegionDustFacingUrl =
+      await sourceRegionActivities.getRegionDustFacingUrl();
+
     await destinationRegionActivities.processDataSourceDocuments({
       destIds,
       dataPath,
       destRegion,
       sourceRegion,
+      sourceRegionDustFacingUrl,
       workspaceId,
     });
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -945,7 +945,7 @@ export class CoreAPI {
     projectId: string;
     dataSourceId: string;
     documentId: string;
-  }): Promise<CoreAPIResponse<{ blob: CoreAPIDocumentBlob }>> {
+  }): Promise<CoreAPIResponse<CoreAPIDocumentBlob>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${projectId}/data_sources/${encodeURIComponent(
         dataSourceId


### PR DESCRIPTION
## Description
See more context around relocation system in: https://github.com/dust-tt/dust/pull/10328.

As part of our multi-region strategy, we need to relocate workspace data between regions. This PR implements the first wave of core relocation focusing on document relocation, leveraging newly introduced endpoints for efficient and reliable data transfer.

The code uses Core API endpoints exclusively to ensure reliability:
1. New cursor-based pagination endpoint for listing document nodes
2. Document blob retrieval endpoint for accurate document recreation

### Key Benefits of Core API Approach
- More reliable than accessing through front-workers
- Ensures data consistency by using official APIs

### Migration Process
1. **Workspace Data Source Discovery**
   - Query front to identify data sources
   - Retrieve Core project IDs and data source IDs

2. **Destination Setup**
   - Create project in destination region
   - Create data source in destination region
   - Update data source with new Core IDs (assumes front reindexing complete)

3. **Document Migration**
   - Paginate through all document nodes using cursor-based endpoint
   - Fetch document blobs from source region
   - Rewrite regional source URLs
   - Upsert documents in destination using new Core IDs

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
