### PR TITLE
Add Folder Relocation Script for Cross-Region Migration

### DIFF
--- a/front/temporal/relocation/activities/destination_region/core/folders.ts
+++ b/front/temporal/relocation/activities/destination_region/core/folders.ts
@@ -1,0 +1,93 @@
+import config from "@app/lib/api/config";
+import { RegionType } from "@app/lib/api/regions/config";
+import logger from "@app/logger/logger";
+import {
+  APIRelocationBlob,
+  CORE_API_CONCURRENCY_LIMIT,
+  CoreDocumentAPIRelocationBlob,
+  CoreFolderAPIRelocationBlob,
+  CreateDataSourceProjectResult,
+} from "@app/temporal/relocation/activities/types";
+import {
+  deleteFromRelocationStorage,
+  readFromRelocationStorage,
+} from "@app/temporal/relocation/lib/file_storage/relocation";
+import {
+  concurrentExecutor,
+  CoreAPI,
+  dustManagedCredentials,
+} from "@dust-tt/types";
+
+export async function processDataSourceFolders({
+  destIds,
+  dataPath,
+  destRegion,
+  sourceRegion,
+  sourceRegionDustFacingUrl,
+  workspaceId,
+}: {
+  destIds: CreateDataSourceProjectResult;
+  dataPath: string;
+  destRegion: RegionType;
+  sourceRegion: RegionType;
+  sourceRegionDustFacingUrl: string;
+  workspaceId: string;
+}) {
+  const localLogger = logger.child({
+    destRegion,
+    sourceRegion,
+    workspaceId,
+  });
+
+  localLogger.info("[Core] Processing data source folders");
+
+  const data =
+    await readFromRelocationStorage<CoreFolderAPIRelocationBlob>(dataPath);
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), localLogger);
+
+  const credentials = dustManagedCredentials();
+  const destRegionDustFacingUrl = config.getClientFacingUrl();
+
+  const res = await concurrentExecutor(
+    data.blobs.folders,
+    async (d) => {
+      // If the source URL starts with the source region Dust URL, replace it with the destination region Dust URL.
+      const sourceUrl =
+        d.source_url && d.source_url.startsWith(sourceRegionDustFacingUrl)
+          ? d.source_url.replace(
+              sourceRegionDustFacingUrl,
+              destRegionDustFacingUrl
+            )
+          : d.source_url;
+
+      return coreAPI.upsertDataSourceFolder({
+        dataSourceId: destIds.dustAPIDataSourceId,
+        folderId: d.node_id,
+        mimeType: d.mime_type,
+        parentId: d.parent_id ?? null,
+        parents: d.parents,
+        projectId: destIds.dustAPIProjectId,
+        providerVisibility: d.provider_visibility,
+        sourceUrl,
+        timestamp: d.timestamp,
+        title: d.title,
+      });
+    },
+    { concurrency: CORE_API_CONCURRENCY_LIMIT }
+  );
+
+  const failed = res.filter((r) => r.isErr());
+  if (failed.length > 0) {
+    localLogger.error(
+      { failed },
+      "[Core] Failed to process data source folders"
+    );
+
+    throw new Error("Failed to process data source folders");
+  }
+
+  localLogger.info("[Core] Processed data source folders");
+
+  await deleteFromRelocationStorage(dataPath);
+}

--- a/front/temporal/relocation/activities/destination_region/core/index.ts
+++ b/front/temporal/relocation/activities/destination_region/core/index.ts
@@ -1,2 +1,3 @@
 export * from "./data_sources";
 export * from "./documents";
+export * from "./folders";

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -6,8 +6,10 @@ import { RegionType } from "@app/lib/api/regions/config";
 import {
   concurrentExecutor,
   CoreAPI,
+  CoreAPIDocumentBlob,
   CoreAPINodesSearchFilter,
   CoreAPISearchCursorRequest,
+  Ok,
 } from "@dust-tt/types";
 import { writeToRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
 import config from "@app/lib/api/config";
@@ -84,7 +86,9 @@ export async function getDataSourceDocuments({
     { concurrency: CORE_API_CONCURRENCY_LIMIT }
   );
 
-  const documentBlobs = res.filter((r) => r.isOk()).map((r) => r.value);
+  const documentBlobs = res
+    .filter((r): r is Ok<CoreAPIDocumentBlob> => r.isOk())
+    .map((r) => r.value);
   const failed = res.filter((r) => r.isErr());
   if (failed.length > 0) {
     localLogger.error(

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -105,7 +105,7 @@ export async function getDataSourceDocuments({
   const dataPath = await writeToRelocationStorage(blobs, {
     workspaceId,
     type: "core",
-    operation: "data_source_document_blobs",
+    operation: "data_source_documents_blobs",
   });
 
   localLogger.info(

--- a/front/temporal/relocation/activities/source_region/core/folders.ts
+++ b/front/temporal/relocation/activities/source_region/core/folders.ts
@@ -33,6 +33,8 @@ export async function getDataSourceFolders({
     sourceRegion,
   });
 
+  localLogger.info("[Core] Retrieving data source folders");
+
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), localLogger);
 
   const filter: CoreAPINodesSearchFilter = {

--- a/front/temporal/relocation/activities/source_region/core/folders.ts
+++ b/front/temporal/relocation/activities/source_region/core/folders.ts
@@ -1,0 +1,100 @@
+import { writeToRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
+
+import {
+  CORE_API_LIST_NODES_BATCH_SIZE,
+  CoreFolderAPIRelocationBlob,
+} from "@app/temporal/relocation/activities/types";
+
+import {
+  CoreAPI,
+  CoreAPINodesSearchFilter,
+  CoreAPISearchCursorRequest,
+} from "@dust-tt/types";
+
+import { RegionType } from "@app/lib/api/regions/config";
+import logger from "@app/logger/logger";
+
+import { DataSourceCoreIds } from "@app/temporal/relocation/activities/types";
+import config from "@app/lib/api/config";
+
+export async function getDataSourceFolders({
+  dataSourceCoreIds,
+  pageCursor,
+  sourceRegion,
+  workspaceId,
+}: {
+  dataSourceCoreIds: DataSourceCoreIds;
+  pageCursor: string | null;
+  sourceRegion: RegionType;
+  workspaceId: string;
+}) {
+  const localLogger = logger.child({
+    dataSourceCoreIds,
+    sourceRegion,
+  });
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), localLogger);
+
+  const filter: CoreAPINodesSearchFilter = {
+    data_source_views: [
+      {
+        data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
+        // Leaving empty to get all folders.
+        view_filter: [],
+      },
+    ],
+    node_types: ["Folder"],
+  };
+
+  const cursorRequest: CoreAPISearchCursorRequest = {
+    limit: CORE_API_LIST_NODES_BATCH_SIZE,
+  };
+
+  if (pageCursor) {
+    cursorRequest.cursor = pageCursor;
+  }
+
+  // 1) List folders for the data source.
+  const searchResults = await coreAPI.searchNodesWithCursor({
+    filter,
+    cursor: cursorRequest,
+  });
+
+  if (searchResults.isErr()) {
+    localLogger.error(
+      { error: searchResults.error },
+      "[Core] Failed to search nodes with cursor"
+    );
+
+    throw new Error("Failed to search nodes with cursor");
+  }
+
+  const { nodes, next_page_cursor: nextPageCursor } = searchResults.value;
+
+  const blobs: CoreFolderAPIRelocationBlob = {
+    blobs: {
+      folders: nodes,
+    },
+  };
+
+  // 3) Save the folders blobs to file storage.
+  const dataPath = await writeToRelocationStorage(blobs, {
+    workspaceId,
+    type: "core",
+    operation: "data_source_folders_blobs",
+  });
+
+  localLogger.info(
+    {
+      dataPath,
+      nextPageCursor,
+      nodeCount: nodes.length,
+    },
+    "[Core] Retrieved data source folders"
+  );
+
+  return {
+    dataPath,
+    nextPageCursor,
+  };
+}

--- a/front/temporal/relocation/activities/source_region/core/index.ts
+++ b/front/temporal/relocation/activities/source_region/core/index.ts
@@ -1,2 +1,3 @@
 export * from "./data_sources";
 export * from "./documents";
+export * from "./folders";

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -1,6 +1,10 @@
 import { RegionType } from "@app/lib/api/regions/config";
 
-import { CoreAPIDocumentBlob, ModelId } from "@dust-tt/types";
+import {
+  CoreAPIContentNode,
+  CoreAPIDocumentBlob,
+  ModelId,
+} from "@dust-tt/types";
 
 export interface RelocationBlob<T extends string = string> {
   statements: Record<T, string[]>;
@@ -45,4 +49,9 @@ export interface APIRelocationBlob<
 export type CoreDocumentAPIRelocationBlob = APIRelocationBlob<
   "documents",
   CoreAPIDocumentBlob
+>;
+
+export type CoreFolderAPIRelocationBlob = APIRelocationBlob<
+  "folders",
+  CoreAPIContentNode
 >;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Following the document and relocation wave (https://github.com/dust-tt/dust/pull/10385), this PR implements the folder relocation wave of our multi-region migration strategy.

Like previous waves, this script uses Core API endpoints for reliability, but with special attention to folder hierarchy:

### Migration Process
1. **Folder Discovery**
   - Uses cursor-based pagination with `node_type: ["Folder"]`
   - Lists all folders for a given data source

2. **Folder Recreation**
   - Create folders in destination region
   - Folders are stupid simples and can be re-created from the DataSourceNodes (no other information is needed).
   
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
