### PR TITLE
Improve Confluence pages `parents` definition at upsert time

### DIFF
--- a/connectors/src/connectors/confluence/lib/hierarchy.ts
+++ b/connectors/src/connectors/confluence/lib/hierarchy.ts
@@ -41,7 +41,7 @@ export async function getConfluencePageParentIds(
   connectorId: ModelId,
   page: RawConfluencePage,
   cachedHierarchy?: Record<string, string | null>
-): Promise<[string, ...string[], string]> {
+): Promise<[string, string, ...string[]]> {
   const pageIdToParentIdMap =
     cachedHierarchy ?? (await getSpaceHierarchy(connectorId, page.spaceId));
 
@@ -72,5 +72,5 @@ export async function getConfluencePageParentIds(
     ...parentIds.map((p) => makePageInternalId(p)),
     // Add the space id at the end.
     makeSpaceInternalId(page.spaceId),
-  ];
+  ] as unknown as [string, string, ...string[]]; // casting here since what we are interested in in knowing that parents[1] will be a string, no matter if it is the last element or one from the middle
 }

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -262,7 +262,7 @@ export async function markPageHasVisited({
 interface ConfluenceUpsertPageInput {
   page: NonNullable<Awaited<ReturnType<ConfluenceClient["getPageById"]>>>;
   spaceName: string;
-  parents: [string, ...string[], string];
+  parents: [string, string, ...string[]];
   confluenceConfig: ConfluenceConfiguration;
   syncType?: UpsertDataSourceDocumentParams["upsertContext"]["sync_type"];
   dataSourceConfig: DataSourceConfig;

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -461,7 +461,7 @@ export async function confluenceCheckAndUpsertPageActivity({
     return false;
   }
 
-  let parents: [string, ...string[], string];
+  let parents: [string, string, ...string[]];
   if (page.parentId) {
     // Exact parent Ids will be computed after all page imports within the space have been completed.
     parents = [

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -461,12 +461,24 @@ export async function confluenceCheckAndUpsertPageActivity({
     return false;
   }
 
+  let parents: [string, ...string[], string];
+  if (page.parentId) {
+    // Exact parent Ids will be computed after all page imports within the space have been completed.
+    parents = [
+      makePageInternalId(page.id),
+      makePageInternalId(page.parentId),
+      HiddenContentNodeParentId,
+    ];
+  } else {
+    // In this case we already have the exact parents: the page itself and the space.
+    parents = [makePageInternalId(page.id), makeSpaceInternalId(spaceId)];
+  }
+
   localLogger.info("Upserting Confluence page.");
   await upsertConfluencePageToDataSource({
     page,
     spaceName,
-    // Parent Ids will be computed after all page imports within the space have been completed.
-    parents: [makePageInternalId(page.id), HiddenContentNodeParentId],
+    parents,
     confluenceConfig,
     syncType: isBatchSync ? "batch" : "incremental",
     dataSourceConfig,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10395.
- This PR leverages the `parentId` at upsert time to:
  - Upsert the correct parents if there is no parentId (top level page).
  - Upsert at least the direct parent otherwise.
- In the latter, the page will be discoverable by query by direct parent, which replicates the current experience in connectors.
- No backfill planned since this affects the syncing state and not the end state of the data after a sync has completed.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.