### PR TITLE
[CoreNodes] Fix `viewType` filtering in front

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -1,7 +1,6 @@
 import type {
   ContentNodesViewType,
   CoreAPIContentNode,
-  CoreAPIContentNodeType,
   CoreAPIDatasourceViewFilter,
   CoreAPIError,
   CoreAPISortSpec,
@@ -247,9 +246,6 @@ async function getContentNodesForDataSourceViewFromCore(
         ? undefined
         : ROOT_PARENT_ID);
 
-  const nodeTypesForViewType: CoreAPIContentNodeType[] =
-    viewType === "documents" ? ["Document", "Folder"] : ["Table", "Folder"];
-
   // Always sort folders first, then sort by title.
   const sortForViewType: CoreAPISortSpec[] =
     viewType === "documents"
@@ -267,7 +263,6 @@ async function getContentNodesForDataSourceViewFromCore(
       data_source_views: [makeCoreDataSourceViewFilter(dataSourceView)],
       node_ids,
       parent_id,
-      node_types: nodeTypesForViewType,
     },
     options: { limit: 1000, sort: sortForViewType },
   });


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10403.
- The [view type filtering in front](https://github.com/dust-tt/dust/blob/6cf95f81c7d6204c5ad70f5ebf8315b7e6d0fd4e/front/lib/api/data_source_view.ts#L185) is already correct.
- This PR fixes an issues encountered when Notion pages children of databases would not be discoverable because of the pages being children of the table and the table not being returned by `core`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.