### PR TITLE
Store a boolean when we're storing the transcripts to track usage

### DIFF
--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -246,7 +246,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     return history.get();
   }
 
-  async setStorageStatus(
+  async setStorageStatusForFileId(
     fileId: string,
     stored: boolean
   ): Promise<InferAttributes<LabsTranscriptsHistoryModel> | null> {

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -246,6 +246,24 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     return history.get();
   }
 
+  async setStorageStatus(
+    fileId: string,
+    stored: boolean
+  ): Promise<InferAttributes<LabsTranscriptsHistoryModel> | null> {
+    const history = await LabsTranscriptsHistoryModel.findOne({
+      where: {
+        configurationId: this.id,
+        fileId,
+      },
+    });
+
+    if (!history) {
+      return null;
+    }
+    await history.update({ stored });
+    return history.get();
+  }
+
   async fetchHistoryForFileId(
     fileId: LabsTranscriptsHistoryModel["fileId"]
   ): Promise<InferAttributes<LabsTranscriptsHistoryModel> | null> {

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -246,10 +246,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     return history.get();
   }
 
-  async setStorageStatusForFileId(
-    fileId: string,
-    stored: boolean
-  ): Promise<InferAttributes<LabsTranscriptsHistoryModel> | null> {
+  async setStorageStatusForFileId(fileId: string, stored: boolean) {
     const history = await LabsTranscriptsHistoryModel.findOne({
       where: {
         configurationId: this.id,
@@ -261,7 +258,6 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       return null;
     }
     await history.update({ stored });
-    return history.get();
   }
 
   async fetchHistoryForFileId(

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -100,6 +100,8 @@ export class LabsTranscriptsHistoryModel extends WorkspaceAwareModel<LabsTranscr
   declare configurationId: ForeignKey<LabsTranscriptsConfigurationModel["id"]>;
 
   declare configuration: NonAttribute<LabsTranscriptsConfigurationModel>;
+
+  declare stored?: boolean;
 }
 
 LabsTranscriptsHistoryModel.init(
@@ -125,6 +127,11 @@ LabsTranscriptsHistoryModel.init(
     conversationId: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    stored: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/front/migrations/db/migration_165.sql
+++ b/front/migrations/db/migration_165.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jan 31, 2025
+ALTER TABLE "public"."labs_transcripts_histories" ADD COLUMN "stored" BOOLEAN NOT NULL DEFAULT false;

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -288,7 +288,7 @@ export async function processTranscriptActivity(
     throw error;
   }
 
-  // labs_transcripts_full_storage FF enables storing all Gong transcripts in a single datasource view
+  // FF enables storing all Gong/Modjo transcripts in a single datasource view
   let fullStorageFF = false;
   let fullStorageDataSourceViewId = null;
 
@@ -417,6 +417,11 @@ export async function processTranscriptActivity(
         "[processTranscriptActivity] Error storing transcript to Datasource. Keep going to process."
       );
     }
+
+    await transcriptsConfiguration.setStorageStatus(
+      fileId,
+      shouldStoreTranscript
+    );
 
     localLogger.info(
       {

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -418,7 +418,7 @@ export async function processTranscriptActivity(
       );
     }
 
-    await transcriptsConfiguration.setStorageStatus(
+    await transcriptsConfiguration.setStorageStatusForFileId(
       fileId,
       shouldStoreTranscript
     );


### PR DESCRIPTION
## Description
For now we're tracking transcripts processed by assistants, but not transcripts stored. 
We need to track it to decide on prio 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Apply migration
