### PR TITLE
Agent ds tags

### DIFF
--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -18,6 +18,10 @@ export class AgentDataSourceConfiguration extends WorkspaceAwareModel<AgentDataS
   declare parentsIn: string[] | null;
   declare parentsNotIn: string[] | null;
 
+  declare tagsQuery: "fixed" | "auto" | null;
+  declare tagsIn: string[] | null;
+  declare tagsNotIn: string[] | null;
+
   declare dataSourceId: ForeignKey<DataSourceModel["id"]>;
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
 
@@ -53,6 +57,18 @@ AgentDataSourceConfiguration.init(
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
     },
+    tagsQuery: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    tagsIn: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+    },
+    tagsNotIn: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+    },
   },
   {
     modelName: "agent_data_source_configuration",
@@ -65,11 +81,32 @@ AgentDataSourceConfiguration.init(
     sequelize: frontSequelize,
     hooks: {
       beforeValidate: (dataSourceConfig: AgentDataSourceConfiguration) => {
+        // Checking parents.
         if (
           (dataSourceConfig.parentsIn === null) !==
           (dataSourceConfig.parentsNotIn === null)
         ) {
           throw new Error("Parents must be both set or both null");
+        }
+        // Checking tags.
+        if (dataSourceConfig.tagsQuery === "fixed") {
+          if (
+            !dataSourceConfig.tagsIn?.length &&
+            !dataSourceConfig.tagsNotIn?.length
+          ) {
+            throw new Error(
+              "TagsIn/notIn can't be both empty if tagsQuery is fixed"
+            );
+          }
+        } else {
+          if (
+            dataSourceConfig.tagsIn !== null ||
+            dataSourceConfig.tagsNotIn !== null
+          ) {
+            throw new Error(
+              "TagsIn/notIn must be null if tagsQuery is auto or null"
+            );
+          }
         }
       },
     },

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -18,7 +18,7 @@ export class AgentDataSourceConfiguration extends WorkspaceAwareModel<AgentDataS
   declare parentsIn: string[] | null;
   declare parentsNotIn: string[] | null;
 
-  declare tagsQuery: "fixed" | "auto" | null;
+  declare tagsMode: "custom" | "auto" | null;
   declare tagsIn: string[] | null;
   declare tagsNotIn: string[] | null;
 
@@ -57,7 +57,7 @@ AgentDataSourceConfiguration.init(
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
     },
-    tagsQuery: {
+    tagsMode: {
       type: DataTypes.STRING,
       allowNull: true,
     },
@@ -80,31 +80,28 @@ AgentDataSourceConfiguration.init(
     ],
     sequelize: frontSequelize,
     hooks: {
-      beforeValidate: (dataSourceConfig: AgentDataSourceConfiguration) => {
+      beforeValidate: (dsConfig: AgentDataSourceConfiguration) => {
         // Checking parents.
         if (
-          (dataSourceConfig.parentsIn === null) !==
-          (dataSourceConfig.parentsNotIn === null)
+          (dsConfig.parentsIn === null) !==
+          (dsConfig.parentsNotIn === null)
         ) {
           throw new Error("Parents must be both set or both null");
         }
         // Checking tags.
-        if (dataSourceConfig.tagsQuery === "fixed") {
-          if (
-            !dataSourceConfig.tagsIn?.length &&
-            !dataSourceConfig.tagsNotIn?.length
-          ) {
+        if ((dsConfig.tagsIn === null) !== (dsConfig.tagsNotIn === null)) {
+          throw new Error("Tags must be both set or both null");
+        }
+        if (dsConfig.tagsMode === "custom") {
+          if (!dsConfig.tagsIn?.length && !dsConfig.tagsNotIn?.length) {
             throw new Error(
-              "TagsIn/notIn can't be both empty if tagsQuery is fixed"
+              "TagsIn/notIn can't be both empty if tagsMode is custom"
             );
           }
         } else {
-          if (
-            dataSourceConfig.tagsIn !== null ||
-            dataSourceConfig.tagsNotIn !== null
-          ) {
+          if (dsConfig.tagsIn !== null || dsConfig.tagsNotIn !== null) {
             throw new Error(
-              "TagsIn/notIn must be null if tagsQuery is auto or null"
+              "TagsIn/notIn must be null if tagsMode is auto or null"
             );
           }
         }

--- a/front/migrations/db/migration_167.sql
+++ b/front/migrations/db/migration_167.sql
@@ -1,0 +1,5 @@
+
+-- Migration created on Jan 30, 2025
+ALTER TABLE "public"."agent_data_source_configurations" ADD COLUMN "tagsMode" VARCHAR(255);
+ALTER TABLE "public"."agent_data_source_configurations" ADD COLUMN "tagsIn" VARCHAR(255)[];
+ALTER TABLE "public"."agent_data_source_configurations" ADD COLUMN "tagsNotIn" VARCHAR(255)[];


### PR DESCRIPTION
## Description

This PR updates the model `AgentDataSourceConfiguration` to add new fields to store the tag filtering config. 
The logic to use those will be handled in a different PR. 


The filters go as is: 
- `tagsQuery = null` then tagsIn/tagNotIn must be both null too and there is no filtering.
- `tagsQuery = auto` then tagsIn/tagNotIn must be both null too and there will be dynamic filtering.
- `tagsQuery = fixed` then tagsIn/tagNotIn must be both arrays will at least one item in one of them, and fixed filtering on the desired tag(s).

## Tests

No tests. 

## Risk

All new fields are nullable so should not be risky. 

## Deploy Plan

Run migration on front db, deploy front. 
