### PR TITLE
[sparkle] - feat(DataTable): submenu dropdown 

### DIFF
--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -1,16 +1,39 @@
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
-import { ExternalLinkIcon, EyeIcon, PencilSquareIcon, PlusIcon, TrashIcon, useHashParam } from "@dust-tt/sparkle";
-import type { DataSourceViewContentNode, DataSourceViewType, PlanType, WorkspaceType } from "@dust-tt/types";
+import {
+  ExternalLinkIcon,
+  EyeIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  TrashIcon,
+  useHashParam,
+} from "@dust-tt/sparkle";
+import type {
+  DataSourceViewContentNode,
+  DataSourceViewType,
+  PlanType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { capitalize } from "lodash";
 import type { MouseEvent as ReactMouseEvent, RefObject } from "react";
-import React, { useCallback, useEffect, useImperativeHandle, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentUploadOrEditModal } from "@app/components/data_source/DocumentUploadOrEditModal";
 import { MultipleDocumentsUpload } from "@app/components/data_source/MultipleDocumentsUpload";
 import { TableUploadOrEditModal } from "@app/components/data_source/TableUploadOrEditModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
-import { getDisplayNameForDataSource, isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
+import { AddToSpaceDialog } from "@app/components/spaces/AddToSpaceDialog";
+import {
+  getDisplayNameForDataSource,
+  isFolder,
+  isManaged,
+  isWebsite,
+} from "@app/lib/data_sources";
 
 export type UploadOrEditContentActionKey =
   | "DocumentUploadOrEdit"
@@ -146,15 +169,15 @@ export const ContentActions = React.forwardRef<
             onClose(false);
           }}
         />
-        {/*{currentAction.contentNode && (*/}
-        {/*  <AddToSpaceDialog*/}
-        {/*    contentNode={currentAction.contentNode}*/}
-        {/*    dataSourceView={dataSourceView}*/}
-        {/*    isOpen={currentAction.action === "AddToSpaceDialog"}*/}
-        {/*    onClose={onClose}*/}
-        {/*    owner={owner}*/}
-        {/*  />*/}
-        {/*)}*/}
+        {currentAction.contentNode && (
+          <AddToSpaceDialog
+            contentNode={currentAction.contentNode}
+            dataSourceView={dataSourceView}
+            isOpen={currentAction.action === "AddToSpaceDialog"}
+            onClose={onClose}
+            owner={owner}
+          />
+        )}
       </>
     );
   }

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -1,39 +1,16 @@
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
-import {
-  ExternalLinkIcon,
-  EyeIcon,
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-  useHashParam,
-} from "@dust-tt/sparkle";
-import type {
-  DataSourceViewContentNode,
-  DataSourceViewType,
-  PlanType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import { ExternalLinkIcon, EyeIcon, PencilSquareIcon, PlusIcon, TrashIcon, useHashParam } from "@dust-tt/sparkle";
+import type { DataSourceViewContentNode, DataSourceViewType, PlanType, WorkspaceType } from "@dust-tt/types";
 import { capitalize } from "lodash";
 import type { MouseEvent as ReactMouseEvent, RefObject } from "react";
-import React, {
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useImperativeHandle, useState } from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentUploadOrEditModal } from "@app/components/data_source/DocumentUploadOrEditModal";
 import { MultipleDocumentsUpload } from "@app/components/data_source/MultipleDocumentsUpload";
 import { TableUploadOrEditModal } from "@app/components/data_source/TableUploadOrEditModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
-import { AddToSpaceDialog } from "@app/components/spaces/AddToSpaceDialog";
-import {
-  getDisplayNameForDataSource,
-  isFolder,
-  isManaged,
-  isWebsite,
-} from "@app/lib/data_sources";
+import { getDisplayNameForDataSource, isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
 
 export type UploadOrEditContentActionKey =
   | "DocumentUploadOrEdit"
@@ -169,15 +146,15 @@ export const ContentActions = React.forwardRef<
             onClose(false);
           }}
         />
-        {currentAction.contentNode && (
-          <AddToSpaceDialog
-            contentNode={currentAction.contentNode}
-            dataSourceView={dataSourceView}
-            isOpen={currentAction.action === "AddToSpaceDialog"}
-            onClose={onClose}
-            owner={owner}
-          />
-        )}
+        {/*{currentAction.contentNode && (*/}
+        {/*  <AddToSpaceDialog*/}
+        {/*    contentNode={currentAction.contentNode}*/}
+        {/*    dataSourceView={dataSourceView}*/}
+        {/*    isOpen={currentAction.action === "AddToSpaceDialog"}*/}
+        {/*    onClose={onClose}*/}
+        {/*    owner={owner}*/}
+        {/*  />*/}
+        {/*)}*/}
       </>
     );
   }

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.376",
+  "version": "0.2.377",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.376",
+      "version": "0.2.377",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.376",
+  "version": "0.2.377",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -22,6 +22,10 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuItemProps,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   IconButton,
   Pagination,
@@ -369,6 +373,17 @@ DataTable.Row = function Row({
   );
 };
 
+type SubMenuItem = {
+  id: string;
+  name: string;
+};
+
+interface SubmenuConfig {
+  label: string;
+  items: SubMenuItem[];
+  onSelect: (itemId: string) => void;
+}
+
 interface MoreButtonProps {
   className?: string;
   moreMenuItems?: DropdownMenuItemProps[];
@@ -376,21 +391,22 @@ interface MoreButtonProps {
     React.ComponentPropsWithoutRef<typeof DropdownMenu>,
     "modal"
   >;
+  submenus?: SubmenuConfig[];
 }
 
 DataTable.MoreButton = function MoreButton({
   className,
   moreMenuItems,
   dropdownMenuProps,
+  submenus,
 }: MoreButtonProps) {
-  if (!moreMenuItems || moreMenuItems.length === 0) {
+  if (!moreMenuItems?.length && !submenus?.length) {
     return null;
   }
 
   return (
     <DropdownMenu modal={false} {...dropdownMenuProps}>
-      <DropdownMenuTrigger // Necessary to allow clicking the dropdown in a table cell without clicking on the cell
-        // See https://github.com/radix-ui/primitives/issues/1242
+      <DropdownMenuTrigger
         onClick={(event) => {
           event.stopPropagation();
         }}
@@ -406,7 +422,7 @@ DataTable.MoreButton = function MoreButton({
 
       <DropdownMenuContent align="end">
         <DropdownMenuGroup>
-          {moreMenuItems.map((item, index) => (
+          {moreMenuItems?.map((item, index) => (
             <DropdownMenuItem
               key={index}
               {...item}
@@ -415,6 +431,25 @@ DataTable.MoreButton = function MoreButton({
                 item.onClick?.(event);
               }}
             />
+          ))}
+          {submenus?.map((submenu) => (
+            <DropdownMenuSub key={submenu.label}>
+              <DropdownMenuSubTrigger label={submenu.label} />
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent>
+                  {submenu.items.map((item) => (
+                    <DropdownMenuItem
+                      key={item.id}
+                      label={item.name}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        submenu.onSelect(item.id);
+                      }}
+                    />
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
           ))}
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -29,10 +29,18 @@ import {
   DropdownMenuTrigger,
   IconButton,
   Pagination,
+  ScrollArea,
+  ScrollBar,
   Tooltip,
 } from "@sparkle/components";
 import { useCopyToClipboard } from "@sparkle/hooks";
-import { ArrowDownIcon, ArrowUpIcon, ClipboardCheckIcon, ClipboardIcon, MoreIcon } from "@sparkle/icons";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  MoreIcon,
+} from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
@@ -414,16 +422,22 @@ DataTable.MoreButton = function MoreButton({
       <DropdownMenuSubTrigger label={item.label} />
       <DropdownMenuPortal>
         <DropdownMenuSubContent>
-          {item.items.map((subItem) => (
-            <DropdownMenuItem
-              key={subItem.id}
-              label={subItem.name}
-              onClick={(event) => {
-                event.stopPropagation();
-                item.onSelect(subItem.id);
-              }}
-            />
-          ))}
+          <ScrollArea
+            className="s-min-w-24 s-flex s-max-h-72 s-flex-col"
+            hideScrollBar
+          >
+            {item.items.map((subItem) => (
+              <DropdownMenuItem
+                key={subItem.id}
+                label={subItem.name}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  item.onSelect(subItem.id);
+                }}
+              />
+            ))}
+            <ScrollBar className="s-py-0" />
+          </ScrollArea>
         </DropdownMenuSubContent>
       </DropdownMenuPortal>
     </DropdownMenuSub>

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -32,13 +32,7 @@ import {
   Tooltip,
 } from "@sparkle/components";
 import { useCopyToClipboard } from "@sparkle/hooks";
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  ClipboardCheckIcon,
-  ClipboardIcon,
-  MoreIcon,
-} from "@sparkle/icons";
+import { ArrowDownIcon, ArrowUpIcon, ClipboardCheckIcon, ClipboardIcon, MoreIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
@@ -380,7 +374,7 @@ interface BaseMenuItem {
 
 interface RegularMenuItem
   extends BaseMenuItem,
-    Omit<DropdownMenuItemProps, "children"> {
+    Omit<DropdownMenuItemProps, "children" | "label"> {
   kind: "item";
 }
 

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -399,7 +399,7 @@ interface SubmenuMenuItem extends BaseMenuItem {
 
 export type MenuItem = RegularMenuItem | SubmenuMenuItem;
 
-interface MoreButtonProps {
+export interface DataTableMoreButtonProps {
   className?: string;
   menuItems?: MenuItem[];
   dropdownMenuProps?: Omit<
@@ -412,7 +412,7 @@ DataTable.MoreButton = function MoreButton({
   className,
   menuItems,
   dropdownMenuProps,
-}: MoreButtonProps) {
+}: DataTableMoreButtonProps) {
   if (!menuItems?.length) {
     return null;
   }

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -37,6 +37,7 @@ export {
   ConversationMessageContent,
   ConversationMessageHeader,
 } from "./ConversationMessage";
+export type { DataTableMoreButtonProps, MenuItem } from "./DataTable";
 export { DataTable } from "./DataTable";
 export {
   Dialog,

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -18,8 +18,8 @@ import {
   DropdownMenu,
   Input,
 } from "@sparkle/components/";
-import { FolderIcon } from "@sparkle/icons";
 import { MenuItem } from "@sparkle/components/DataTable";
+import { FolderIcon } from "@sparkle/icons";
 
 const meta = {
   title: "Components/DataTable",

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -40,6 +40,11 @@ type Data = {
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
   moreMenuItems?: DropdownMenuItemProps[];
+  submenus?: Array<{
+    label: string;
+    items: Array<{ id: string; name: string }>;
+    onSelect: (itemId: string) => void;
+  }>;
   dropdownMenuProps?: React.ComponentPropsWithoutRef<typeof DropdownMenu>;
   roundedAvatar?: boolean;
 };
@@ -90,17 +95,22 @@ const data: Data[] = [
     ],
   },
   {
-    name: "Very long name that should be truncated at some point to avoid overflow and make the table more readable",
+    name: "Submenu",
     usedBy: 2,
     addedBy: "Another very long user name that should be truncated",
     lastUpdated: "2023-07-09",
     size: "64kb",
     icon: FolderIcon,
-    moreMenuItems: [
+    submenus: [
       {
-        label: "Edit (disabled)",
-        onClick: () => alert("Design menu clicked"),
-        disabled: true,
+        label: "Add to Space",
+        items: [
+          { id: "space1", name: "Space 1" },
+          { id: "space2", name: "Space 2" },
+          { id: "space3", name: "Space 3" },
+          { id: "space4", name: "Space 4" },
+        ],
+        onSelect: (itemId) => console.log("Add to Space", itemId),
       },
     ],
   },
@@ -211,7 +221,10 @@ const columns: ColumnDef<Data>[] = [
     id: "actions",
     header: "",
     cell: (info) => (
-      <DataTable.MoreButton moreMenuItems={info.row.original.moreMenuItems} />
+      <DataTable.MoreButton
+        moreMenuItems={info.row.original.moreMenuItems}
+        submenus={info.row.original.submenus}
+      />
     ),
     meta: {
       className: "s-w-12 s-cursor-pointer s-text-foreground",

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -1,9 +1,5 @@
 import type { Meta } from "@storybook/react";
-import {
-  ColumnDef,
-  PaginationState,
-  SortingState,
-} from "@tanstack/react-table";
+import { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
 import React, { useMemo } from "react";
 
 import {
@@ -39,12 +35,21 @@ type Data = {
   avatarTooltipLabel?: string;
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
-  menuItems?: MenuItem[]; // Replace moreMenuItems and submenus with menuItems
-  dropdownMenuProps?: React.ComponentPropsWithoutRef<typeof DropdownMenu>;
+  menuItems?: MenuItem[];
+  dropdownMenuProps?: Omit<
+    React.ComponentPropsWithoutRef<typeof DropdownMenu>,
+    "modal"
+  >;
   roundedAvatar?: boolean;
 };
 
-const data: Data[] = [
+type TransformedData = {
+  dropdownMenuProps?: { modal: boolean };
+  menuItems?: MenuItem[];
+} & Data;
+
+
+const data: TransformedData[] = [
   {
     name: "Soupinou with tooltip on avatar",
     usedBy: 100,
@@ -154,7 +159,7 @@ const data: Data[] = [
   },
 ];
 
-const columns: ColumnDef<Data>[] = [
+const columns = useMemo<ColumnDef<TransformedData>[]>(() => [
   {
     accessorKey: "name",
     header: "Name",
@@ -233,7 +238,7 @@ const columns: ColumnDef<Data>[] = [
       className: "s-w-12 s-cursor-pointer s-text-foreground",
     },
   },
-];
+], []);
 
 // TODO: Fix 'Edit' changing the order of the rows
 export const DataTableExample = () => {
@@ -241,23 +246,20 @@ export const DataTableExample = () => {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [selectedName, setSelectedName] = React.useState("");
 
-  const tableData = data.map((item) => ({
+  const tableData = data.map(({menuItems, ...item}) => ({
     ...item,
-    dropdownMenuProps: {
-      modal: false,
-    },
-    menuItems: item.menuItems?.length
+    menuItems: menuItems?.length
       ? [
-          {
-            kind: "item" as const,
-            label: "Edit",
-            onClick: () => {
-              setSelectedName(item.name);
-              setDialogOpen(true);
-            },
+        {
+          kind: "item" as const,
+          label: "Edit",
+          onClick: () => {
+            setSelectedName(item.name);
+            setDialogOpen(true);
           },
-          ...item.menuItems,
-        ]
+        },
+        ...menuItems,
+      ]
       : undefined,
   }));
 

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -1,5 +1,9 @@
 import type { Meta } from "@storybook/react";
-import { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
+import {
+  ColumnDef,
+  PaginationState,
+  SortingState,
+} from "@tanstack/react-table";
 import React, { useMemo } from "react";
 
 import {
@@ -47,7 +51,6 @@ type TransformedData = {
   dropdownMenuProps?: { modal: boolean };
   menuItems?: MenuItem[];
 } & Data;
-
 
 const data: TransformedData[] = [
   {
@@ -159,7 +162,7 @@ const data: TransformedData[] = [
   },
 ];
 
-const columns = useMemo<ColumnDef<TransformedData>[]>(() => [
+const columns: ColumnDef<Data>[] = [
   {
     accessorKey: "name",
     header: "Name",
@@ -238,7 +241,7 @@ const columns = useMemo<ColumnDef<TransformedData>[]>(() => [
       className: "s-w-12 s-cursor-pointer s-text-foreground",
     },
   },
-], []);
+];
 
 // TODO: Fix 'Edit' changing the order of the rows
 export const DataTableExample = () => {
@@ -246,20 +249,20 @@ export const DataTableExample = () => {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [selectedName, setSelectedName] = React.useState("");
 
-  const tableData = data.map(({menuItems, ...item}) => ({
+  const tableData = data.map(({ menuItems, ...item }) => ({
     ...item,
     menuItems: menuItems?.length
       ? [
-        {
-          kind: "item" as const,
-          label: "Edit",
-          onClick: () => {
-            setSelectedName(item.name);
-            setDialogOpen(true);
+          {
+            kind: "item" as const,
+            label: "Edit",
+            onClick: () => {
+              setSelectedName(item.name);
+              setDialogOpen(true);
+            },
           },
-        },
-        ...menuItems,
-      ]
+          ...menuItems,
+        ]
       : undefined,
   }));
 

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -16,10 +16,10 @@ import {
   DialogHeader,
   DialogTitle,
   DropdownMenu,
-  DropdownMenuItemProps,
   Input,
 } from "@sparkle/components/";
 import { FolderIcon } from "@sparkle/icons";
+import { MenuItem } from "@sparkle/components/DataTable";
 
 const meta = {
   title: "Components/DataTable",
@@ -39,12 +39,7 @@ type Data = {
   avatarTooltipLabel?: string;
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
-  moreMenuItems?: DropdownMenuItemProps[];
-  submenus?: Array<{
-    label: string;
-    items: Array<{ id: string; name: string }>;
-    onSelect: (itemId: string) => void;
-  }>;
+  menuItems?: MenuItem[]; // Replace moreMenuItems and submenus with menuItems
   dropdownMenuProps?: React.ComponentPropsWithoutRef<typeof DropdownMenu>;
   roundedAvatar?: boolean;
 };
@@ -60,8 +55,9 @@ const data: Data[] = [
     avatarTooltipLabel: "Meow",
     roundedAvatar: true,
     onClick: () => alert("Soupinou clicked"),
-    moreMenuItems: [
+    menuItems: [
       {
+        kind: "item",
         label: "Edit (disabled)",
         onClick: () => alert("Soupinou clicked"),
         disabled: true,
@@ -86,8 +82,9 @@ const data: Data[] = [
     lastUpdated: "2023-07-09",
     size: "64kb",
     icon: FolderIcon,
-    moreMenuItems: [
+    menuItems: [
       {
+        kind: "item",
         label: "Edit (disabled)",
         onClick: () => alert("Design menu clicked"),
         disabled: true,
@@ -101,8 +98,9 @@ const data: Data[] = [
     lastUpdated: "2023-07-09",
     size: "64kb",
     icon: FolderIcon,
-    submenus: [
+    menuItems: [
       {
+        kind: "submenu",
         label: "Add to Space",
         items: [
           { id: "space1", name: "Space 1" },
@@ -111,6 +109,10 @@ const data: Data[] = [
           { id: "space4", name: "Space 4" },
         ],
         onSelect: (itemId) => console.log("Add to Space", itemId),
+      },
+      {
+        kind: "item",
+        label: "Test",
       },
     ],
   },
@@ -121,8 +123,9 @@ const data: Data[] = [
     lastUpdated: "2023-07-09",
     size: "64kb",
     icon: FolderIcon,
-    moreMenuItems: [
+    menuItems: [
       {
+        kind: "item",
         label: "Edit",
         onClick: () => alert("Design menu clicked"),
       },
@@ -222,8 +225,8 @@ const columns: ColumnDef<Data>[] = [
     header: "",
     cell: (info) => (
       <DataTable.MoreButton
-        moreMenuItems={info.row.original.moreMenuItems}
-        submenus={info.row.original.submenus}
+        menuItems={info.row.original.menuItems}
+        dropdownMenuProps={info.row.original.dropdownMenuProps}
       />
     ),
     meta: {
@@ -238,25 +241,25 @@ export const DataTableExample = () => {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [selectedName, setSelectedName] = React.useState("");
 
-  const tableData = data.map((item) =>
-    item.moreMenuItems
-      ? {
-          ...item,
-          dropdownMenuProps: {
-            modal: false,
-          },
-          moreMenuItems: [
-            {
-              label: "Edit",
-              onClick: () => {
-                setSelectedName(item.name);
-                setDialogOpen(true);
-              },
+  const tableData = data.map((item) => ({
+    ...item,
+    dropdownMenuProps: {
+      modal: false,
+    },
+    menuItems: item.menuItems?.length
+      ? [
+          {
+            kind: "item" as const,
+            label: "Edit",
+            onClick: () => {
+              setSelectedName(item.name);
+              setDialogOpen(true);
             },
-          ],
-        }
-      : item
-  );
+          },
+          ...item.menuItems,
+        ]
+      : undefined,
+  }));
 
   return (
     <div className="s-flex s-w-full s-max-w-4xl s-flex-col s-gap-6">


### PR DESCRIPTION
## Description

This PR aims at enabling displaying sub dropdonw menu content in the `DataTable` component.  This is to fix the following https://github.com/dust-tt/tasks/issues/2066, design checked by @pinotalexandre.

**References:**
- https://github.com/dust-tt/tasks/issues/2066

## Risk

Low, not introducing any regression

## Deploy Plan

- Publish sparkle