### PR TITLE
[CoreNodes] Ignore diffs due to `notion-syncing`

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -150,6 +150,14 @@ export function computeNodesDiff({
             ) {
               return false;
             }
+            // The notion-syncing is a concept only added to core and not to the parents in content nodes from connectors.
+            if (
+              ["parentInternalId", "parentInternalIds"].includes(key) &&
+              provider === "notion" &&
+              coreNode?.parentInternalIds?.includes("notion-syncing")
+            ) {
+              return false;
+            }
 
             // Special case for Google drive spreadsheets:
             // title is '{spreadsheetName} - {sheetName}' for core, but only '{sheetName}' for connectors (not always).


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10428.
- This PR adds an exclusion rule on diffs due to core having `notion-syncing` in its parents and not connectors.

## Tests


## Risk

- Low.

## Deploy Plan

- Deploy front.