### PR TITLE
Fix snowflake missing and extra nodes

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectorProvider,
+  ContentNodesViewType,
   ContentNodeType,
   CoreAPIContentNode,
   DataSourceViewContentNode,
@@ -69,11 +70,13 @@ export function computeNodesDiff({
   connectorsContentNodes,
   coreContentNodes,
   provider,
+  viewType,
   localLogger,
 }: {
   connectorsContentNodes: DataSourceViewContentNode[];
   coreContentNodes: DataSourceViewContentNode[];
   provider: ConnectorProvider | null;
+  viewType: ContentNodesViewType;
   localLogger: typeof logger;
 }) {
   const missingNodes: DataSourceViewContentNode[] = [];
@@ -102,7 +105,10 @@ export function computeNodesDiff({
             )
           )
         ) {
-          missingNodes.push(connectorsNode);
+          // Connectors return tables even when viewType is documents, core doesn't
+          if (!(provider === "snowflake" && viewType === "documents")) {
+            missingNodes.push(connectorsNode);
+          }
         }
       }
     } else if (coreNodes.length > 1) {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -462,9 +462,11 @@ export async function getContentNodesForDataSourceView(
     dataSourceViewId: dataSourceView.sId,
     provider: dataSourceView.dataSource.connectorProvider,
     viewType: params.viewType,
-    isRootCall: !params.parentId && !params.internalIds,
+    isRootCall:
+      !params.parentId && !params.internalIds && !dataSourceView.parentsIn,
     parentId: params.parentId,
     internalIds: params.internalIds,
+    parentsIn: dataSourceView.parentsIn,
   });
 
   const coreStart = new Date();

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -497,6 +497,7 @@ export async function getContentNodesForDataSourceView(
       connectorsContentNodes: contentNodesResult.nodes,
       coreContentNodes: coreContentNodesRes.value.nodes,
       provider: dataSourceView.dataSource.connectorProvider,
+      viewType: params.viewType,
       localLogger,
     });
 

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -466,7 +466,7 @@ export async function getContentNodesForDataSourceView(
       !params.parentId && !params.internalIds && !dataSourceView.parentsIn,
     parentId: params.parentId,
     internalIds: params.internalIds,
-    parentsIn: dataSourceView.parentsIn,
+    parentsIn: dataSourceView.parentsIn || undefined,
   });
 
   const coreStart = new Date();


### PR DESCRIPTION
## Description
- parentsIn leads to a nodes query with internalIds set -> not a root call
- modified log in computeNodesDiff to also log parentsIn
- Fixes #10400  

## Tests
- Fetch a few nodes locally

## Risk
Low

## Deploy Plan
Deploy front
