### PR TITLE
[CoreNodes] Align Intercom's behavior regarding expandable with core

### DIFF
--- a/connectors/src/connectors/intercom/lib/permissions.ts
+++ b/connectors/src/connectors/intercom/lib/permissions.ts
@@ -82,7 +82,7 @@ export async function retrieveSelectedNodes({
       type: "channel",
       title: "Conversations",
       sourceUrl: null,
-      expandable: false,
+      expandable: true,
       permission: "read",
       lastUpdatedAt: null,
     });

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -225,6 +225,16 @@ export function computeNodesDiff({
             if (key === "expandable" && value === true && coreValue === false) {
               return false;
             }
+            // Special case for expandable in Intercom: connectors set it depending on the context whereas core sets it to true if it has at least 1 child.
+            // We opt for using core's logic as the new ground truth.
+            if (
+              key === "expandable" &&
+              provider === "intercom" &&
+              value === false &&
+              coreValue === true
+            ) {
+              return false;
+            }
             // Special case for Slack's providerVisibility: we only check if providerVisibility === "private" so
             // having a falsy value in core and "public" in connectors is the same.
             if (

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -225,16 +225,6 @@ export function computeNodesDiff({
             if (key === "expandable" && value === true && coreValue === false) {
               return false;
             }
-            // Special case for expandable in Intercom: connectors set it depending on the context whereas core sets it to true if it has at least 1 child.
-            // We opt for using core's logic as the new ground truth.
-            if (
-              key === "expandable" &&
-              provider === "intercom" &&
-              value === false &&
-              coreValue === true
-            ) {
-              return false;
-            }
             // Special case for Slack's providerVisibility: we only check if providerVisibility === "private" so
             // having a falsy value in core and "public" in connectors is the same.
             if (


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10432.
- This PR suggests using core's logic as the new baseline: we set `expandable` to true iff the node has children and is not in `NON_EXPANDABLE_NODES_MIME_TYPES` and changes `connectors` accordingly.

## Tests


## Risk

- Very low.

## Deploy Plan

- Deploy connectors.