### PR TITLE
Fix the Zendesk ticket `sourceUrl` upserted to `core`

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -94,11 +94,12 @@ export async function syncTicket({
   // if they were never attended in the Agent Workspace their subject is not populated.
   ticket.subject ||= "No subject";
 
+  const ticketUrl = ticket.url.replace("/api/v2/", "/").replace(".json", ""); // converting the API URL into the web URL;
   if (!ticketInDb) {
     ticketInDb = await ZendeskTicketResource.makeNew({
       blob: {
         subject: ticket.subject,
-        url: ticket.url.replace("/api/v2/", "/").replace(".json", ""), // converting the API URL into the web URL
+        url: ticketUrl,
         lastUpsertedTs: new Date(currentSyncDateMs),
         ticketUpdatedAt: updatedAtDate,
         ticketId: ticket.id,
@@ -110,7 +111,7 @@ export async function syncTicket({
   } else {
     await ticketInDb.update({
       subject: ticket.subject,
-      url: ticket.url.replace("/api/v2/", "/").replace(".json", ""), // converting the API URL into the web URL
+      url: ticketUrl,
       lastUpsertedTs: new Date(currentSyncDateMs),
       ticketUpdatedAt: updatedAtDate,
       permission: "read",
@@ -224,7 +225,7 @@ ${comments
       dataSourceConfig,
       documentId,
       documentContent,
-      documentUrl: ticket.url,
+      documentUrl: ticketUrl,
       timestampMs: updatedAtDate.getTime(),
       tags: [
         ...ticket.tags,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10398.
- The value in connectors was always correct whereas the `documentUrl` upserted to core was incorrect.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Full resync the connectors where we had the issue.