### PR TITLE
[CoreNodes] Add an exception to display Snowflake tables in "documents" `viewType`

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -17,6 +17,7 @@ import {
   Err,
   isDevelopment,
   isDustWorkspace,
+  MIME_TYPES,
   Ok,
   removeNulls,
 } from "@dust-tt/types";
@@ -183,7 +184,11 @@ function filterNodesByViewType(
   switch (viewType) {
     case "documents":
       return nodes.filter(
-        (node) => node.children_count > 0 || node.node_type !== "Table"
+        (node) =>
+          node.children_count > 0 ||
+          node.node_type !== "Table" ||
+          // TODO: replace this with either an "all" viewType or a DEFAULT_VIEWTYPE_BY_CONNECTOR_PROVIDER
+          node.mime_type === MIME_TYPES.SNOWFLAKE.TABLE
       );
     case "tables":
       return nodes.filter(

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -187,7 +187,7 @@ function filterNodesByViewType(
         (node) =>
           node.children_count > 0 ||
           node.node_type !== "Table" ||
-          // TODO: replace this with either an "all" viewType or a DEFAULT_VIEWTYPE_BY_CONNECTOR_PROVIDER
+          // TODO(nodes-core): replace this with either an "all" viewType or a DEFAULT_VIEWTYPE_BY_CONNECTOR_PROVIDER
           node.mime_type === MIME_TYPES.SNOWFLAKE.TABLE
       );
     case "tables":


### PR DESCRIPTION
## Description

- This PR aims at unlocking the ship of content-nodes -> core by not hiding the tables in Company Data, other spaces, the tree on the left.
- In the context of the project these tables were naturally hidden by the rationalization of the `viewType` filtering: leaf tables are hidden in `viewType === "documents"`.
- This PR adds an ugly exception, the two frontrunner suggestions are adding an "all" `viewType` (pending product decision) or a `DEFAULT_VIEWTYPE_BY_CONNECTOR_PROVIDER` (solves our issue in a ~satisfying way but still weird that you can see leaf documents but not leaf tables in Notion, Google Drive, Microsoft).

## Tests

## Risk

- n/a

## Deploy Plan

- Deploy front.