### PR TITLE
Use BISERIAL instead of SERIAL in migration

### DIFF
--- a/front/migrations/db/migration_162.sql
+++ b/front/migrations/db/migration_162.sql
@@ -1,6 +1,6 @@
 -- Migration created on Jan 27, 2025
 CREATE TABLE IF NOT EXISTS "agent_reasoning_configurations" (
-    "id" SERIAL,
+    "id" BIGSERIAL,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "sId" VARCHAR(255) NOT NULL,
@@ -20,7 +20,7 @@ CREATE INDEX CONCURRENTLY "agent_reasoning_configurations_agent_configuration_id
 CREATE INDEX CONCURRENTLY "agent_reasoning_configurations_workspace_id" ON "agent_reasoning_configurations" ("workspaceId");
 
 CREATE TABLE IF NOT EXISTS "agent_reasoning_actions" (
-    "id" SERIAL,
+    "id" BIGSERIAL,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "runId" VARCHAR(255),

--- a/front/migrations/db/migration_162.sql
+++ b/front/migrations/db/migration_162.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS "agent_reasoning_configurations" (
     "modelId" VARCHAR(255) NOT NULL,
     "temperature" FLOAT,
     "reasoningEffort" VARCHAR(255),
-    "agentConfigurationId" INTEGER NOT NULL REFERENCES "agent_configurations" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    "agentConfigurationId" BIGINT NOT NULL REFERENCES "agent_configurations" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
     "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     PRIMARY KEY ("id")
 );
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS "agent_reasoning_actions" (
     "functionCallId" VARCHAR(255),
     "functionCallName" VARCHAR(255),
     "step" INTEGER NOT NULL,
-    "agentMessageId" INTEGER NOT NULL REFERENCES "agent_messages" ("id") ON DELETE NO ACTION ON UPDATE CASCADE,
+    "agentMessageId" BIGINT NOT NULL REFERENCES "agent_messages" ("id") ON DELETE NO ACTION ON UPDATE CASCADE,
     "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     PRIMARY KEY ("id")
 );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the migration introduced in https://github.com/dust-tt/dust/pull/10256. Every Primary Keys in production should use `BIGSERIAL` and **NOT** `SERIAL`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Run the migration in EU
- [ ] Re Run migration in US (yours @fontanierh)