### PR TITLE
Add: location support when connecting bigquery

### DIFF
--- a/connectors/src/connectors/bigquery/index.ts
+++ b/connectors/src/connectors/bigquery/index.ts
@@ -4,7 +4,12 @@ import type {
   ContentNodesViewType,
   Result,
 } from "@dust-tt/types";
-import { assertNever, Err, isBigQueryCredentials, Ok } from "@dust-tt/types";
+import {
+  assertNever,
+  Err,
+  isBigQueryWithLocationCredentials,
+  Ok,
+} from "@dust-tt/types";
 
 import type { TestConnectionError } from "@connectors/connectors/bigquery/lib/bigquery_api";
 import { testConnection } from "@connectors/connectors/bigquery/lib/bigquery_api";
@@ -68,7 +73,7 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
   }): Promise<Result<string, ConnectorManagerError<CreateConnectorErrorCode>>> {
     const credentialsRes = await getCredentials({
       credentialsId: connectionId,
-      isTypeGuard: isBigQueryCredentials,
+      isTypeGuard: isBigQueryWithLocationCredentials,
       logger,
     });
     if (credentialsRes.isErr()) {
@@ -125,7 +130,7 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
 
     const newCredentialsRes = await getCredentials({
       credentialsId: connectionId,
-      isTypeGuard: isBigQueryCredentials,
+      isTypeGuard: isBigQueryWithLocationCredentials,
       logger,
     });
     if (newCredentialsRes.isErr()) {
@@ -250,7 +255,7 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
   > {
     const connectorAndCredentialsRes = await getConnectorAndCredentials({
       connectorId: this.connectorId,
-      isTypeGuard: isBigQueryCredentials,
+      isTypeGuard: isBigQueryWithLocationCredentials,
       logger,
     });
     if (connectorAndCredentialsRes.isErr()) {
@@ -319,7 +324,7 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
   }): Promise<Result<void, Error>> {
     const connectorAndCredentialsRes = await getConnectorAndCredentials({
       connectorId: this.connectorId,
-      isTypeGuard: isBigQueryCredentials,
+      isTypeGuard: isBigQueryWithLocationCredentials,
       logger,
     });
     if (connectorAndCredentialsRes.isErr()) {

--- a/connectors/src/connectors/bigquery/lib/permissions.ts
+++ b/connectors/src/connectors/bigquery/lib/permissions.ts
@@ -1,5 +1,5 @@
 import type {
-  BigQueryCredentials,
+  BigQueryCredentialsWithLocation,
   ContentNode,
   ModelId,
   Result,
@@ -34,7 +34,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
   parentInternalId,
 }: {
   connectorId: ModelId;
-  credentials: BigQueryCredentials;
+  credentials: BigQueryCredentialsWithLocation;
   parentInternalId: string | null;
 }): Promise<Result<ContentNode[], Error>> => {
   if (parentInternalId === null) {
@@ -283,7 +283,7 @@ export const saveNodesFromPermissions = async ({
 }: {
   permissions: Record<string, string>;
   connectorId: ModelId;
-  credentials: BigQueryCredentials;
+  credentials: BigQueryCredentialsWithLocation;
   logger: Logger;
 }): Promise<Result<void, Error>> => {
   for (const [internalId, permission] of Object.entries(permissions)) {

--- a/connectors/src/connectors/bigquery/temporal/activities.ts
+++ b/connectors/src/connectors/bigquery/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { isBigQueryCredentials, MIME_TYPES } from "@dust-tt/types";
+import { isBigQueryWithLocationCredentials, MIME_TYPES } from "@dust-tt/types";
 
 import {
   connectToBigQuery,
@@ -30,7 +30,7 @@ import logger from "@connectors/logger/logger";
 export async function syncBigQueryConnection(connectorId: ModelId) {
   const getConnectorAndCredentialsRes = await getConnectorAndCredentials({
     connectorId,
-    isTypeGuard: isBigQueryCredentials,
+    isTypeGuard: isBigQueryWithLocationCredentials,
     logger,
   });
   if (getConnectorAndCredentialsRes.isErr()) {

--- a/connectors/src/connectors/bigquery/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/bigquery/temporal/cast_known_errors.ts
@@ -4,73 +4,6 @@ import type {
   Next,
 } from "@temporalio/worker";
 
-import { ExternalOAuthTokenError } from "@connectors/lib/error";
-
-interface BigQueryError extends Error {
-  name: string;
-  data: {
-    nextAction: string;
-  };
-}
-
-interface BigQueryExpiredPasswordError extends BigQueryError {
-  name: "OperationFailedError";
-  data: {
-    nextAction: "PWD_CHANGE";
-  };
-}
-
-interface BigQueryAccountLockedError extends BigQueryError {
-  name: "OperationFailedError";
-  data: {
-    nextAction: "RETRY_LOGIN";
-  };
-}
-
-interface BigQueryIncorrectCredentialsError extends BigQueryError {
-  name: "OperationFailedError";
-  data: {
-    nextAction: "RETRY_LOGIN";
-  };
-}
-
-function isBigQueryError(err: unknown): err is BigQueryError {
-  return (
-    err instanceof Error &&
-    "name" in err &&
-    "data" in err &&
-    typeof err.data === "object" &&
-    err.data !== null &&
-    "nextAction" in err.data &&
-    typeof err.data.nextAction === "string"
-  );
-}
-
-function isBigQueryExpiredPasswordError(
-  err: unknown
-): err is BigQueryExpiredPasswordError {
-  return isBigQueryError(err) && err.data.nextAction === "PWD_CHANGE";
-}
-
-function isBigQueryAccountLockedError(
-  err: unknown
-): err is BigQueryAccountLockedError {
-  return (
-    isBigQueryError(err) &&
-    err.message.startsWith(
-      "Your user account has been temporarily locked due to too many failed attempts"
-    )
-  );
-}
-
-function isBigQueryIncorrectCredentialsError(
-  err: unknown
-): err is BigQueryIncorrectCredentialsError {
-  return (
-    isBigQueryError(err) &&
-    err.message.startsWith("Incorrect username or password was specified")
-  );
-}
 export class BigQueryCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -78,19 +11,7 @@ export class BigQueryCastKnownErrorsInterceptor
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">
   ): Promise<unknown> {
-    try {
-      return await next(input);
-    } catch (err: unknown) {
-      if (
-        isBigQueryExpiredPasswordError(err) ||
-        // technically, the one below could be transient;
-        // we add it here to make the user aware that getting locked out of his account blocks the connection
-        isBigQueryAccountLockedError(err) ||
-        isBigQueryIncorrectCredentialsError(err)
-      ) {
-        throw new ExternalOAuthTokenError(err);
-      }
-      throw err;
-    }
+    // Will add custom error handling as we discover them
+    return next(input);
   }
 }

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -125,6 +125,7 @@ impl Credential {
                     "auth_provider_x509_cert_url",
                     "client_x509_cert_url",
                     "universe_domain",
+                    "location",
                 ]
             }
         };

--- a/core/src/oauth/tests/functional_credentials.rs
+++ b/core/src/oauth/tests/functional_credentials.rs
@@ -151,7 +151,8 @@ async fn test_oauth_credentials_bigquery_flow_ok() {
             "token_uri": "https://oauth2.googleapis.com/token",
             "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
             "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test",
-            "universe_domain": "googleapis.com"
+            "universe_domain": "googleapis.com",
+            "location": "EU"
         }
     });
 
@@ -209,6 +210,7 @@ async fn test_oauth_credentials_bigquery_flow_ok() {
         content.get("client_email").unwrap(),
         "test@test-project.iam.gserviceaccount.com"
     );
+    assert_eq!(content.get("region").unwrap(), "EU");
 }
 
 #[tokio::test]
@@ -231,7 +233,8 @@ async fn test_oauth_credentials_bigquery_delete_ok() {
             "token_uri": "https://oauth2.googleapis.com/token",
             "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
             "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test",
-            "universe_domain": "googleapis.com"
+            "universe_domain": "googleapis.com",
+            "location": "US"
         }
     });
 

--- a/core/src/oauth/tests/functional_credentials.rs
+++ b/core/src/oauth/tests/functional_credentials.rs
@@ -210,7 +210,7 @@ async fn test_oauth_credentials_bigquery_flow_ok() {
         content.get("client_email").unwrap(),
         "test@test-project.iam.gserviceaccount.com"
     );
-    assert_eq!(content.get("region").unwrap(), "EU");
+    assert_eq!(content.get("location").unwrap(), "EU");
 }
 
 #[tokio::test]

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -1,14 +1,10 @@
 import type {
-  ConnectionCredentials,
-  CredentialsProvider,
   OAuthAPIError,
-  OauthAPIPostCredentialsResponse,
   OAuthConnectionType,
   Result,
 } from "@dust-tt/types";
 import type { OAuthProvider, OAuthUseCase } from "@dust-tt/types";
 import { Err, isValidZendeskSubdomain, OAuthAPI, Ok } from "@dust-tt/types";
-import type { LoggerInterface } from "@dust-tt/types/dist/shared/logger";
 import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
@@ -417,33 +413,4 @@ export async function finalizeConnection(
   }
 
   return new Ok(cRes.value.connection);
-}
-
-export async function postConnectionCredentials({
-  config,
-  logger,
-  provider,
-  workspaceId,
-  userId,
-  credentials,
-}: {
-  config: { url: string; apiKey: string | null };
-  logger: LoggerInterface;
-  provider: CredentialsProvider;
-  workspaceId: string;
-  userId: string;
-  credentials: ConnectionCredentials;
-}): Promise<Result<OauthAPIPostCredentialsResponse, OAuthAPIError>> {
-  const res = await new OAuthAPI(config, logger).postCredentials({
-    provider,
-    workspaceId,
-    userId,
-    credentials,
-  });
-
-  if (res.isErr()) {
-    return res;
-  }
-
-  return res;
 }

--- a/front/lib/swr/bigquery.ts
+++ b/front/lib/swr/bigquery.ts
@@ -1,0 +1,42 @@
+import type {
+  CheckBigQueryCredentials,
+  LightWorkspaceType,
+} from "@dust-tt/types";
+import { useMemo } from "react";
+
+import { fetcherWithBody, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PostCheckBigQueryLocationsResponseBody } from "@app/pages/api/w/[wId]/credentials/check_bigquery_locations";
+
+export function useBigQueryLocations({
+  owner,
+  credentials,
+}: {
+  owner: LightWorkspaceType;
+  credentials?: CheckBigQueryCredentials | null;
+}) {
+  const url = `/api/w/${owner.sId}/credentials/check_bigquery_locations`;
+  const fetchKey = useMemo(() => {
+    return JSON.stringify({
+      url,
+      body: credentials,
+    }); // Serialize with body to ensure uniqueness.
+  }, [url, credentials]);
+
+  const { data, error, mutate } = useSWRWithDefaults<
+    string,
+    PostCheckBigQueryLocationsResponseBody
+  >(fetchKey, async () => {
+    if (!url) {
+      return undefined;
+    }
+
+    return fetcherWithBody([url, { credentials }, "POST"]);
+  });
+
+  return {
+    locations: useMemo(() => (data ? data.locations : []), [data]),
+    isLocationsLoading: !error && !data,
+    isLocationsError: !!error,
+    mutateLocations: mutate,
+  };
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,6 +9,7 @@
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "0.2.376",
         "@dust-tt/types": "file:../types",
+        "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
         "@hookform/resolvers": "^3.3.4",
@@ -12516,9 +12517,124 @@
         "node": ">=14.2.0"
       }
     },
+    "node_modules/@google-cloud/bigquery": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-7.9.1.tgz",
+      "integrity": "sha512-ZkcRMpBoFLxIh6TiQBywA22yT3c2j0f07AHWEMjtYqMQzZQbFrpxuJU2COp3tyjZ91ZIGHe4gY7/dGZL88cltg==",
+      "dependencies": {
+        "@google-cloud/common": "^5.0.0",
+        "@google-cloud/paginator": "^5.0.2",
+        "@google-cloud/precise-date": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.1",
+        "big.js": "^6.0.0",
+        "duplexify": "^4.0.0",
+        "extend": "^3.0.2",
+        "is": "^3.3.0",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/common": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
+      "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
+      "dependencies": {
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.1",
+        "duplexify": "^4.1.1",
+        "extend": "^3.0.2",
+        "google-auth-library": "^9.0.0",
+        "html-entities": "^2.5.2",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "arrify": "^2.0.0",
@@ -12528,9 +12644,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-4.0.0.tgz",
+      "integrity": "sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@google-cloud/projectify": {
       "version": "4.0.0",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
@@ -12538,7 +12661,6 @@
     },
     "node_modules/@google-cloud/promisify": {
       "version": "4.0.0",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -20828,6 +20950,18 @@
       "version": "2.2.3",
       "license": "Apache-2.0"
     },
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
       "license": "MIT",
@@ -25038,6 +25172,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/google-p12-pem": {
       "version": "4.0.1",
       "license": "MIT",
@@ -26274,7 +26416,6 @@
     },
     "node_modules/html-entities": {
       "version": "2.5.2",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -26585,6 +26726,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "optional": true
+    },
+    "node_modules/is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "1.0.4",

--- a/front/package.json
+++ b/front/package.json
@@ -23,6 +23,7 @@
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "0.2.376",
     "@dust-tt/types": "file:../types",
+    "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",
     "@hookform/resolvers": "^3.3.4",

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.test.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.test.ts
@@ -1,0 +1,197 @@
+import { BigQuery } from "@google-cloud/bigquery";
+import { describe, expect, vi } from "vitest";
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./check_bigquery_locations";
+
+vi.mock("@google-cloud/bigquery");
+
+// Mock the getSession function to return the user without going through the auth0 session
+vi.mock(import("../../../../../lib/auth"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    getSession: vi.fn().mockReturnValue({
+      user: {
+        sub: "test-user",
+      },
+    }),
+  };
+});
+
+const MOCK_CREDENTIALS = {
+  type: "service_account",
+  project_id: "test-project",
+  private_key_id: "test-key-id",
+  private_key: "test-private-key",
+  client_email: "test@test-project.iam.gserviceaccount.com",
+  client_id: "test-client-id",
+  auth_uri: "https://accounts.google.com/o/oauth2/auth",
+  token_uri: "https://oauth2.googleapis.com/token",
+  auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
+  client_x509_cert_url:
+    "https://www.googleapis.com/robot/v1/metadata/x509/test",
+  universe_domain: "googleapis.com",
+};
+
+describe("POST /api/w/[wId]/credentials/check_bigquery_locations", () => {
+  itInTransaction(
+    "returns locations with tables when called with valid credentials",
+    async () => {
+      const mockDatasets = [
+        {
+          id: "dataset1",
+          location: "us-central1",
+          getTables: vi.fn().mockResolvedValue([
+            [
+              {
+                id: "table1",
+                location: "US",
+              },
+              {
+                id: "table2",
+                location: "US-central1",
+              },
+              {
+                id: "table3",
+                location: "US-central2",
+              },
+              {
+                id: "table4",
+                location: "US-central3-a",
+              },
+            ],
+          ]),
+        },
+        {
+          id: "dataset2",
+          location: "EU",
+          getTables: vi.fn().mockResolvedValue([
+            [
+              {
+                id: "table3",
+                location: "EU",
+              },
+            ],
+          ]),
+        },
+      ];
+
+      vi.mocked(BigQuery).mockImplementation(
+        () =>
+          ({
+            getDatasets: vi.fn().mockResolvedValue([mockDatasets]),
+          }) as any
+      );
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      req.body = {
+        credentials: MOCK_CREDENTIALS,
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        locations: {
+          us: [
+            "dataset1.table1",
+            "dataset1.table2",
+            "dataset1.table3",
+            "dataset1.table4",
+          ],
+          "us-central1": ["dataset1.table2"],
+          "us-central2": ["dataset1.table3"],
+          "us-central3-a": ["dataset1.table4"],
+          eu: ["dataset2.table3"],
+        },
+      });
+    }
+  );
+
+  itInTransaction(
+    "returns 400 when called with invalid credentials",
+    async () => {
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      req.body = {
+        credentials: {
+          invalid: "credentials",
+        },
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    }
+  );
+
+  itInTransaction(
+    "returns 400 when BigQuery client throws an error",
+    async () => {
+      vi.mocked(BigQuery).mockImplementation(
+        () =>
+          ({
+            getDatasets: vi.fn().mockRejectedValue(new Error("BigQuery error")),
+          }) as any
+      );
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      req.body = {
+        credentials: MOCK_CREDENTIALS,
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(JSON.parse(res._getData())).toMatchObject({
+        error: {
+          message: "Failed to check BigQuery locations: BigQuery error",
+        },
+      });
+    }
+  );
+
+  itInTransaction("returns 405 when called with invalid method", async () => {
+    const { req, res } = await createPrivateApiMockRequest();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  itInTransaction("returns 403 when user is not workspace admin", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    req.body = {
+      credentials: MOCK_CREDENTIALS,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(JSON.parse(res._getData())).toMatchObject({
+      error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can check BigQuery locations.",
+      },
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
@@ -1,0 +1,134 @@
+import type { APIErrorType, WithAPIErrorResponse } from "@dust-tt/types";
+import { CheckBigQueryCredentialsSchema } from "@dust-tt/types";
+import { BigQuery } from "@google-cloud/bigquery";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+const PostCheckBigQueryRegionsRequestBodySchema = t.type({
+  credentials: CheckBigQueryCredentialsSchema,
+});
+
+export type PostCheckBigQueryLocationsResponseBody = {
+  locations: Record<string, string[]>;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostCheckBigQueryLocationsResponseBody>
+  >,
+  auth: Authenticator
+) {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "invalid_request_error" as APIErrorType,
+        message: "Method not allowed",
+      },
+    });
+  }
+
+  // Check if the user is an admin
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can check BigQuery locations.",
+      },
+    });
+  }
+
+  const bodyValidation = PostCheckBigQueryRegionsRequestBodySchema.decode(
+    req.body
+  );
+
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error" as APIErrorType,
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const credentialsValidation = CheckBigQueryCredentialsSchema.decode(
+    bodyValidation.right.credentials
+  );
+
+  if (isLeft(credentialsValidation)) {
+    const pathError = reporter.formatValidationErrors(
+      credentialsValidation.left
+    );
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error" as APIErrorType,
+        message: `Invalid credentials: ${pathError}`,
+      },
+    });
+  }
+
+  const credentials = credentialsValidation.right;
+
+  try {
+    const bigquery = new BigQuery({
+      credentials,
+      scopes: ["https://www.googleapis.com/auth/bigquery.readonly"],
+    });
+
+    // Get all datasets
+    const [datasets] = await bigquery.getDatasets();
+
+    // Initialize locations map
+    const allLocations: Record<string, string[]> = {};
+
+    // Process each dataset and its tables
+    for (const dataset of datasets) {
+      const [tables] = await dataset.getTables();
+
+      for (const table of tables) {
+        const locationRaw = table.location?.toLowerCase();
+        if (locationRaw) {
+          const locations = locationRaw.includes("-")
+            ? [locationRaw.split("-")[0], locationRaw]
+            : [locationRaw];
+
+          for (const location of locations) {
+            if (!allLocations[location]) {
+              allLocations[location] = [];
+            }
+
+            const tableId = `${dataset.id}.${table.id}`;
+            allLocations[location].push(tableId);
+          }
+        }
+      }
+    }
+
+    return res.status(200).json({
+      locations: allLocations,
+    });
+  } catch (err) {
+    const error = err as Error;
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error" as APIErrorType,
+        message: `Failed to check BigQuery locations: ${error.message}`,
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -82,7 +82,7 @@ export const SnowflakeCredentialsSchema = t.type({
 });
 export type SnowflakeCredentials = t.TypeOf<typeof SnowflakeCredentialsSchema>;
 
-export const BigQueryCredentialsSchema = t.type({
+export const CheckBigQueryCredentialsSchema = t.type({
   type: t.string,
   project_id: t.string,
   private_key_id: t.string,
@@ -96,7 +96,28 @@ export const BigQueryCredentialsSchema = t.type({
   universe_domain: t.string,
 });
 
-export type BigQueryCredentials = t.TypeOf<typeof BigQueryCredentialsSchema>;
+export type CheckBigQueryCredentials = t.TypeOf<
+  typeof CheckBigQueryCredentialsSchema
+>;
+
+export const BigQueryCredentialsWithLocationSchema = t.type({
+  type: t.string,
+  project_id: t.string,
+  private_key_id: t.string,
+  private_key: t.string,
+  client_email: t.string,
+  client_id: t.string,
+  auth_uri: t.string,
+  token_uri: t.string,
+  auth_provider_x509_cert_url: t.string,
+  client_x509_cert_url: t.string,
+  universe_domain: t.string,
+  location: t.string,
+});
+
+export type BigQueryCredentialsWithLocation = t.TypeOf<
+  typeof BigQueryCredentialsWithLocationSchema
+>;
 
 export const ApiKeyCredentialsSchema = t.type({
   api_key: t.string,
@@ -106,7 +127,7 @@ export type ModjoCredentials = t.TypeOf<typeof ApiKeyCredentialsSchema>;
 export type ConnectionCredentials =
   | SnowflakeCredentials
   | ModjoCredentials
-  | BigQueryCredentials;
+  | BigQueryCredentialsWithLocation;
 
 export function isSnowflakeCredentials(
   credentials: ConnectionCredentials
@@ -120,10 +141,14 @@ export function isModjoCredentials(
   return "api_key" in credentials;
 }
 
-export function isBigQueryCredentials(
+export function isBigQueryWithLocationCredentials(
   credentials: ConnectionCredentials
-): credentials is BigQueryCredentials {
-  return "type" in credentials && "project_id" in credentials;
+): credentials is BigQueryCredentialsWithLocation {
+  return (
+    "type" in credentials &&
+    "project_id" in credentials &&
+    "location" in credentials
+  );
 }
 
 export type OauthAPIPostCredentialsResponse = {

--- a/types/src/oauth/oauth_api.ts
+++ b/types/src/oauth/oauth_api.ts
@@ -170,6 +170,7 @@ export class OAuthAPI {
     });
     return this._resultFromResponse(response);
   }
+
   async getCredentials({
     credentialsId,
   }: {


### PR DESCRIPTION
## Description

Add location selection (if needed) when connecting to BigQuery as it's not possible to do join between regions.
Store the location in the credentials to make it easy to retrieve from core.

## Tests

Tested locally + added tests and updated tests.

## Risk

Low as we are only touching the bigquery part.

## Deploy Plan

Deploy `connectors`, `oauth`, `front`