### PR TITLE
Fix parameters for JSONB field

### DIFF
--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -8,6 +8,7 @@ import type {
   CoreEntitiesRelocationBlob,
   RelocationBlob,
 } from "@app/temporal/relocation/activities/types";
+import { isArrayOfPlainObjects } from "@app/temporal/relocation/activities/types";
 import {
   deleteFromRelocationStorage,
   readFromRelocationStorage,
@@ -116,7 +117,10 @@ export async function processFrontTableChunk({
     for (const { sql, params } of statements) {
       await frontSequelize.transaction(async (transaction) =>
         frontSequelize.query(sql, {
-          bind: params,
+          // TODO(2025-01-31): Remove this once current batch of data is processed.
+          bind: params.map((p) =>
+            isArrayOfPlainObjects(p) ? JSON.stringify(p) : p
+          ),
           type: QueryTypes.INSERT,
           transaction,
         })

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -4,6 +4,7 @@ import type {
   CoreAPITableBlob,
   ModelId,
 } from "@dust-tt/types";
+import { isPlainObject } from "lodash";
 
 import type { RegionType } from "@app/lib/api/regions/config";
 
@@ -61,3 +62,9 @@ export type CoreTableAPIRelocationBlob = APIRelocationBlob<
   "tables",
   CoreAPITableBlob
 >;
+
+export function isArrayOfPlainObjects(value: unknown) {
+  return (
+    Array.isArray(value) && value.every((element) => isPlainObject(element))
+  );
+}

--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -1,3 +1,5 @@
+import { isArrayOfPlainObjects } from "@app/temporal/relocation/activities/types";
+
 const DEFAULT_CHUNK_SIZE = 250;
 
 export function generateParameterizedInsertStatements(
@@ -29,7 +31,13 @@ export function generateParameterizedInsertStatements(
       const rowPlaceholders: string[] = [];
       for (const col of columns) {
         rowPlaceholders.push(`$${paramIndex++}`);
-        params.push(row[col]);
+
+        // Array of plain objects are serialized to JSON strings.
+        const serialized = isArrayOfPlainObjects(row[col])
+          ? JSON.stringify(row[col])
+          : row[col];
+
+        params.push(serialized);
       }
       placeholders.push(`(${rowPlaceholders.join(",")})`);
     }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While running a relocation in production, we notice some serialization errors:

```
detail":"Expected \":\", but found \",\".","where":"JSON data, line 1: ..
```

Indeed, using `binds` to pass parameters does not work well with array of plain objects. This PR fixes it:
- by ensuring that all paramters are properly sanitized before being saved in GCS
- to temporarily unblock the current workflow, also sanitize in the region if not already done (this will be removed afterward). 

Also tested for array of primitives types and regular plain object, those two types don't need any stringify.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested locally, was able to reproduce issue and this fix actually solve the issue.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
