### PR TITLE
Add index on retrieval_document_chunk

### DIFF
--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -352,7 +352,10 @@ RetrievalDocumentChunk.init(
   {
     modelName: "retrieval_document_chunk",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["retrievalDocumentId"] }],
+    indexes: [
+      { fields: ["retrievalDocumentId"] },
+      { fields: ["workspaceId", "id"] },
+    ],
   }
 );
 

--- a/front/migrations/db/migration_166.sql
+++ b/front/migrations/db/migration_166.sql
@@ -1,0 +1,2 @@
+-- Migration created on Feb 01, 2025
+CREATE INDEX CONCURRENTLY "retrieval_document_chunks_workspace_id_id" ON "retrieval_document_chunks" ("workspaceId", "id");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The cross-region is migration on the `retrieval_document_chunks` as the query needs to hit two distinct indexes. This PR adds a new composite index.

Query to improve:
```
SELECT * FROM retrieval_document_chunks WHERE "workspaceId" = xxx ORDER BY id ASC LIMIT 2;
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Apply index in 🇺🇸 
- [x] Apply index in 🇪🇺 

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
