### PR TITLE
Properly propagate next page cursor

### DIFF
--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -520,6 +520,7 @@ export async function workspaceRelocateDataSourceCoreWorkflow({
         dataSourceCoreIds,
         destIds,
         destRegion,
+        pageCursor: null,
         sourceRegion,
         workspaceId,
       },
@@ -536,6 +537,7 @@ export async function workspaceRelocateDataSourceCoreWorkflow({
         dataSourceCoreIds,
         destIds,
         destRegion,
+        pageCursor: null,
         sourceRegion,
         workspaceId,
       },
@@ -552,6 +554,7 @@ export async function workspaceRelocateDataSourceCoreWorkflow({
         dataSourceCoreIds,
         destIds,
         destRegion,
+        pageCursor: null,
         sourceRegion,
         workspaceId,
       },
@@ -564,17 +567,19 @@ export async function workspaceRelocateDataSourceDocumentsWorkflow({
   dataSourceCoreIds,
   destIds,
   destRegion,
+  pageCursor: initialPageCursor,
   sourceRegion,
   workspaceId,
 }: RelocationWorkflowBase & {
   destIds: CreateDataSourceProjectResult;
   dataSourceCoreIds: DataSourceCoreIds;
+  pageCursor: string | null;
 }) {
   const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
   const destinationRegionActivities =
     getCoreDestinationRegionActivities(destRegion);
 
-  let pageCursor: string | null = null;
+  let pageCursor: string | null = initialPageCursor;
 
   do {
     if (workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH) {
@@ -582,6 +587,7 @@ export async function workspaceRelocateDataSourceDocumentsWorkflow({
         dataSourceCoreIds,
         destIds,
         destRegion,
+        pageCursor,
         sourceRegion,
         workspaceId,
       });
@@ -615,17 +621,19 @@ export async function workspaceRelocateDataSourceFoldersWorkflow({
   dataSourceCoreIds,
   destIds,
   destRegion,
+  pageCursor: initialPageCursor,
   sourceRegion,
   workspaceId,
 }: RelocationWorkflowBase & {
   destIds: CreateDataSourceProjectResult;
   dataSourceCoreIds: DataSourceCoreIds;
+  pageCursor: string | null;
 }) {
   const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
   const destinationRegionActivities =
     getCoreDestinationRegionActivities(destRegion);
 
-  let pageCursor: string | null = null;
+  let pageCursor: string | null = initialPageCursor;
 
   do {
     if (workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH) {
@@ -633,6 +641,7 @@ export async function workspaceRelocateDataSourceFoldersWorkflow({
         dataSourceCoreIds,
         destIds,
         destRegion,
+        pageCursor,
         sourceRegion,
         workspaceId,
       });
@@ -666,17 +675,19 @@ export async function workspaceRelocateDataSourceTablesWorkflow({
   dataSourceCoreIds,
   destIds,
   destRegion,
+  pageCursor: initialPageCursor,
   sourceRegion,
   workspaceId,
 }: RelocationWorkflowBase & {
   destIds: CreateDataSourceProjectResult;
   dataSourceCoreIds: DataSourceCoreIds;
+  pageCursor: string | null;
 }) {
   const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
   const destinationRegionActivities =
     getCoreDestinationRegionActivities(destRegion);
 
-  let pageCursor: string | null = null;
+  let pageCursor: string | null = initialPageCursor;
 
   do {
     if (workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH) {
@@ -684,6 +695,7 @@ export async function workspaceRelocateDataSourceTablesWorkflow({
         dataSourceCoreIds,
         destIds,
         destRegion,
+        pageCursor,
         sourceRegion,
         workspaceId,
       });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The initial implementation had a pagination issue where the `pageCursor` wasn't being passed to the new workflow instance during `continueAsNew`. This meant that when the workflow hit the history limit and continued as new, it would restart pagination from the beginning instead of continuing where it left off.

This fix ensures the current pagination state is properly carried over when a workflow continues as new by:
- Adding `pageCursor` to the workflow parameters
- Passing the current cursor state in the continueAsNew call

This maintains pagination progress even when a workflow needs to be continued as a new instance due to history limits.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
