### PR TITLE
Fix parents field on table in-flight

### DIFF
--- a/front/temporal/relocation/activities/destination_region/core/tables.ts
+++ b/front/temporal/relocation/activities/destination_region/core/tables.ts
@@ -55,6 +55,19 @@ export async function processDataSourceTables({
             )
           : d.source_url;
 
+      // There are some issues with the parents field.
+      // parents[0] should be the table_id, but it's not always the case.
+      let parents: string[] = [];
+      if (d.parents.length > 0) {
+        if (d.parents[0] !== d.table_id) {
+          parents = [d.table_id, ...d.parents];
+        } else {
+          parents = d.parents;
+        }
+      } else {
+        parents = [d.table_id];
+      }
+
       // 1) Upsert the table.
       const upsertRes = await coreAPI.upsertTable({
         projectId: destIds.dustAPIProjectId,
@@ -65,7 +78,7 @@ export async function processDataSourceTables({
         timestamp: d.timestamp,
         tags: d.tags,
         parentId: d.parent_id ?? null,
-        parents: d.parents,
+        parents,
         remoteDatabaseTableId: d.remote_database_table_id,
         remoteDatabaseSecretId: d.remote_database_secret_id,
         title: d.title,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While relocating tables across region using the Core API, we got a lot of `Failed to upsert table - parents[0] and table_id should be equal`. Looking closely at those tables, indeed the parent field is prefixed with `gdrive-` but the `node_id` isn't. They all look to have been created more or less at the same time.

cc @aubin-tchoi @philipperolet you might want to investigate but for now, proceeding with this in-flight fix to resume relocation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
