### PR TITLE
Fix parentId while relocating tables

### DIFF
--- a/front/temporal/relocation/activities/destination_region/core/tables.ts
+++ b/front/temporal/relocation/activities/destination_region/core/tables.ts
@@ -57,8 +57,7 @@ export async function processDataSourceTables({
 
       // There are some issues with the parents field.
       // parents[0] should be the table_id, but it's not always the case.
-      // parents[1] should be the parent_id, but it's not always the case.
-
+      // If we change the parents[0] to the table_id, then parents[1] should be the parent_id.
       let parents: string[] = [];
       let parentId: string | null = d.parent_id ?? null;
       if (d.parents.length > 0) {

--- a/front/temporal/relocation/activities/destination_region/core/tables.ts
+++ b/front/temporal/relocation/activities/destination_region/core/tables.ts
@@ -57,10 +57,14 @@ export async function processDataSourceTables({
 
       // There are some issues with the parents field.
       // parents[0] should be the table_id, but it's not always the case.
+      // parents[1] should be the parent_id, but it's not always the case.
+
       let parents: string[] = [];
+      let parentId: string | null = d.parent_id ?? null;
       if (d.parents.length > 0) {
         if (d.parents[0] !== d.table_id) {
           parents = [d.table_id, ...d.parents];
+          parentId = parents[1];
         } else {
           parents = d.parents;
         }
@@ -77,7 +81,7 @@ export async function processDataSourceTables({
         description: d.description,
         timestamp: d.timestamp,
         tags: d.tags,
-        parentId: d.parent_id ?? null,
+        parentId,
         parents,
         remoteDatabaseTableId: d.remote_database_table_id,
         remoteDatabaseSecretId: d.remote_database_secret_id,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/10460.

Core API enforces that if there is more than one parent, then `parent_id` should be equal to `parents[1]`. This PR update the in-flight hack to met those conditions.

```
Failed to upsert table - parent_id should not be null if parents[1] is defined
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
