### PR TITLE
[front] - fix: streamline folder document upload

### DIFF
--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -1,9 +1,26 @@
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
-import { ExternalLinkIcon, EyeIcon, PencilSquareIcon, PlusIcon, TrashIcon, useHashParam } from "@dust-tt/sparkle";
-import type { DataSourceViewContentNode, DataSourceViewType, PlanType, WorkspaceType } from "@dust-tt/types";
+import {
+  ExternalLinkIcon,
+  EyeIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  TrashIcon,
+  useHashParam,
+} from "@dust-tt/sparkle";
+import type {
+  DataSourceViewContentNode,
+  DataSourceViewType,
+  PlanType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { capitalize } from "lodash";
 import type { MouseEvent as ReactMouseEvent, RefObject } from "react";
-import React, { useCallback, useEffect, useImperativeHandle, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentUploadOrEditModal } from "@app/components/data_source/DocumentUploadOrEditModal";
@@ -11,7 +28,12 @@ import { MultipleDocumentsUpload } from "@app/components/data_source/MultipleDoc
 import { TableUploadOrEditModal } from "@app/components/data_source/TableUploadOrEditModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { AddToSpaceDialog } from "@app/components/spaces/AddToSpaceDialog";
-import { getDisplayNameForDataSource, isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
+import {
+  getDisplayNameForDataSource,
+  isFolder,
+  isManaged,
+  isWebsite,
+} from "@app/lib/data_sources";
 
 export type UploadOrEditContentActionKey =
   | "DocumentUploadOrEdit"

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -25,7 +25,6 @@ import React, {
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentUploadOrEditModal } from "@app/components/data_source/DocumentUploadOrEditModal";
 import { MultipleDocumentsUpload } from "@app/components/data_source/MultipleDocumentsUpload";
-import { TableUploadOrEditModal } from "@app/components/data_source/TableUploadOrEditModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { AddToSpaceDialog } from "@app/components/spaces/AddToSpaceDialog";
 import {
@@ -34,6 +33,7 @@ import {
   isManaged,
   isWebsite,
 } from "@app/lib/data_sources";
+import { TableUploadOrEditModal } from "@app/components/data_source/TableUploadOrEditModal";
 
 export type UploadOrEditContentActionKey =
   | "DocumentUploadOrEdit"
@@ -137,11 +137,8 @@ export const ContentActions = React.forwardRef<
 
     return (
       <>
-        {currentAction.action === "TableUploadOrEdit" ? (
-          <TableUploadOrEditModal {...modalProps} />
-        ) : (
-          <DocumentUploadOrEditModal {...modalProps} />
-        )}
+        <TableUploadOrEditModal {...modalProps} />
+        <DocumentUploadOrEditModal {...modalProps} />
         <MultipleDocumentsUpload
           dataSourceView={dataSourceView}
           isOpen={currentAction.action === "MultipleDocumentsUpload"}

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -1,39 +1,17 @@
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
-import {
-  ExternalLinkIcon,
-  EyeIcon,
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-  useHashParam,
-} from "@dust-tt/sparkle";
-import type {
-  DataSourceViewContentNode,
-  DataSourceViewType,
-  PlanType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import { ExternalLinkIcon, EyeIcon, PencilSquareIcon, PlusIcon, TrashIcon, useHashParam } from "@dust-tt/sparkle";
+import type { DataSourceViewContentNode, DataSourceViewType, PlanType, WorkspaceType } from "@dust-tt/types";
 import { capitalize } from "lodash";
 import type { MouseEvent as ReactMouseEvent, RefObject } from "react";
-import React, {
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useImperativeHandle, useState } from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentUploadOrEditModal } from "@app/components/data_source/DocumentUploadOrEditModal";
 import { MultipleDocumentsUpload } from "@app/components/data_source/MultipleDocumentsUpload";
+import { TableUploadOrEditModal } from "@app/components/data_source/TableUploadOrEditModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { AddToSpaceDialog } from "@app/components/spaces/AddToSpaceDialog";
-import {
-  getDisplayNameForDataSource,
-  isFolder,
-  isManaged,
-  isWebsite,
-} from "@app/lib/data_sources";
-import { TableUploadOrEditModal } from "@app/components/data_source/TableUploadOrEditModal";
+import { getDisplayNameForDataSource, isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
 
 export type UploadOrEditContentActionKey =
   | "DocumentUploadOrEdit"

--- a/front/components/spaces/FoldersHeaderMenu.tsx
+++ b/front/components/spaces/FoldersHeaderMenu.tsx
@@ -99,7 +99,7 @@ const AddDataDropDownButton = ({
   canWriteInSpace,
 }: AddDataDropDrownButtonProps) => {
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           size="sm"


### PR DESCRIPTION
## Description

This PR aims at fixing the trapped focus when opening the table/document modal from a folder, using the dropdown. By setting `modal={false}` we make sure that the focus doesn't get trapped.

Ideally we would have each `DropdownMenu.item` to be a trigger of the modal to open, but this requires to also modify the way we use content actions. Will do in a next PR

**References:**
- https://github.com/dust-tt/tasks/issues/2074

## Risk

Low

## Deploy Plan

Deploy `front`