### PR TITLE
[CoreNodes] Add cleanup script for parents in static datasources

### DIFF
--- a/front/migrations/20250203_backfill_folders_parents.ts
+++ b/front/migrations/20250203_backfill_folders_parents.ts
@@ -110,6 +110,9 @@ async function migrateFolderDataSourceParents(
         type: QueryTypes.SELECT,
       }
     )) as Node[];
+
+    logger.info(`Found ${nodes.length} nodes to process.`);
+
     if (execute) {
       await concurrentExecutor(
         nodes,
@@ -123,8 +126,6 @@ async function migrateFolderDataSourceParents(
           ),
         { concurrency: NODE_CONCURRENCY }
       );
-    } else {
-      logger.info(`Found ${nodes.length} nodes to process.`);
     }
     if (nodes.length > 0) {
       nextId = nodes[nodes.length - 1].id;

--- a/front/migrations/20250203_backfill_folders_parents.ts
+++ b/front/migrations/20250203_backfill_folders_parents.ts
@@ -124,7 +124,7 @@ async function migrateFolderDataSourceParents(
         { concurrency: NODE_CONCURRENCY }
       );
     } else {
-      logger.info(`Found ${nodes.length} to process.`);
+      logger.info(`Found ${nodes.length} nodes to process.`);
     }
     if (nodes.length > 0) {
       nextId = nodes[nodes.length - 1].id;

--- a/front/migrations/20250203_backfill_folders_parents.ts
+++ b/front/migrations/20250203_backfill_folders_parents.ts
@@ -98,7 +98,7 @@ async function migrateFolderDataSourceParents(
       `SELECT "id", "node_id", "parents", "timestamp", "document", "table"
        FROM data_sources_nodes
        WHERE data_source = :c
-         AND parents[2] IS NOT NULL
+         AND parents[2] IS NOT NULL -- leverages the index on (data_source, (parents[2]))
          AND id > :nextId
        LIMIT :batchSize`,
       {

--- a/front/migrations/20250203_backfill_folders_parents.ts
+++ b/front/migrations/20250203_backfill_folders_parents.ts
@@ -1,0 +1,168 @@
+import { concurrentExecutor, CoreAPI } from "@dust-tt/types";
+import { Op, QueryTypes } from "sequelize";
+
+import config from "@app/lib/api/config";
+import { getCoreReplicaDbConnection } from "@app/lib/production_checks/utils";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const coreSequelize = getCoreReplicaDbConnection();
+const DATASOURCE_BATCH_SIZE = 256;
+const SELECT_BATCH_SIZE = 256;
+
+const DATASOURCE_CONCURRENCY = 4;
+const NODE_CONCURRENCY = 8;
+
+async function migrateNode(
+  node: any,
+  coreAPI: CoreAPI,
+  projectId: string,
+  dataSourceId: string,
+  execute: boolean,
+  parentLogger: typeof Logger
+) {
+  const logger = parentLogger.child({
+    nodeId: node.node_id,
+    parents: node.parents,
+    created: new Date(node.created),
+  });
+  logger.info("NODE");
+  if (execute) {
+    if (node.document !== null) {
+      await coreAPI.updateDataSourceDocumentParents({
+        projectId,
+        dataSourceId,
+        documentId: node.node_id,
+        parentId: null,
+        parents: [node.node_id],
+      });
+    } else if (node.table !== null) {
+      await coreAPI.updateTableParents({
+        projectId,
+        dataSourceId,
+        tableId: node.node_id,
+        parentId: null,
+        parents: [node.node_id],
+      });
+    } else {
+      logger.warn("Node is neither a document nor a table.");
+    }
+  }
+}
+
+async function migrateFolderDataSourceParents(
+  frontDataSource: DataSourceModel,
+  coreAPI: CoreAPI,
+  execute: boolean,
+  parentLogger: typeof Logger
+) {
+  const logger = parentLogger.child({
+    project: frontDataSource.dustAPIProjectId,
+    dataSourceId: frontDataSource.dustAPIDataSourceId,
+  });
+  logger.info("MIGRATE");
+
+  const { dustAPIProjectId, dustAPIDataSourceId } = frontDataSource;
+  const coreDataSource: any = (
+    await coreSequelize.query(
+      `SELECT id
+       FROM data_sources
+       WHERE project = :p
+         AND data_source_id = :d
+       LIMIT 1`,
+      {
+        replacements: { p: dustAPIProjectId, d: dustAPIDataSourceId },
+        type: QueryTypes.SELECT,
+      }
+    )
+  )[0];
+  if (!coreDataSource) {
+    logger.warn("No core data source found for static data source.");
+    return;
+  }
+
+  let nextId = 0;
+  let nodes: any[];
+
+  do {
+    nodes = await coreSequelize.query(
+      `SELECT id, node_id, parents, timestamp
+       FROM data_sources_nodes
+       WHERE data_source = :c
+         AND parents[2] IS NOT NULL
+         AND id > :nextId
+       LIMIT :batchSize`,
+      {
+        replacements: {
+          c: coreDataSource.id,
+          batchSize: SELECT_BATCH_SIZE,
+          nextId,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+    await concurrentExecutor(
+      nodes,
+      async (node) =>
+        migrateNode(
+          node,
+          coreAPI,
+          dustAPIProjectId,
+          dustAPIDataSourceId,
+          execute,
+          logger
+        ),
+      { concurrency: NODE_CONCURRENCY }
+    );
+    if (nodes.length > 0) {
+      nextId = nodes[nodes.length - 1].id;
+    }
+  } while (nodes.length === SELECT_BATCH_SIZE);
+}
+
+async function migrateFolderDataSourcesParents(
+  nextDataSourceId: number,
+  coreAPI: CoreAPI,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  let startId = nextDataSourceId;
+  let staticDataSources;
+  do {
+    staticDataSources = await DataSourceModel.findAll({
+      where: { connectorProvider: null, id: { [Op.gt]: startId } },
+      limit: DATASOURCE_BATCH_SIZE,
+      order: [["id", "ASC"]],
+    });
+
+    await concurrentExecutor(
+      staticDataSources,
+      async (dataSource) => {
+        await migrateFolderDataSourceParents(
+          dataSource,
+          coreAPI,
+          execute,
+          logger
+        );
+      },
+      { concurrency: DATASOURCE_CONCURRENCY }
+    );
+    if (staticDataSources.length > 0) {
+      startId = staticDataSources[staticDataSources.length - 1].id;
+    }
+  } while (staticDataSources.length === DATASOURCE_BATCH_SIZE);
+}
+
+makeScript(
+  { nextDataSourceId: { type: "number", default: 0 } },
+  async ({ nextDataSourceId, execute }, logger) => {
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    await migrateFolderDataSourcesParents(
+      nextDataSourceId,
+      coreAPI,
+      execute,
+      logger
+    );
+  }
+);


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10467.

## Tests

## Risk

- Low, we potentially delete incorrect parents passed by users of the `api/v1`, but the deleted data is historical: we now enforce the validity of the parents in `api/v1` and `core`.

## Deploy Plan

- No deploy.
