### PR TITLE
Augment maintenance page to redirect to new region

### DIFF
--- a/front/lib/api/regions/config.ts
+++ b/front/lib/api/regions/config.ts
@@ -3,7 +3,7 @@ import { EnvironmentConfig, isDevelopment } from "@dust-tt/types";
 export const SUPPORTED_REGIONS = ["europe-west1", "us-central1"] as const;
 export type RegionType = (typeof SUPPORTED_REGIONS)[number];
 
-interface RegionInfo {
+export interface RegionInfo {
   name: RegionType;
   url: string;
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -427,9 +427,13 @@ export async function disableSSOEnforcement(
   return new Ok(undefined);
 }
 
+interface WorkspaceMetadata {
+  maintenance?: "relocation" | "relocation-done";
+}
+
 export async function updateWorkspaceMetadata(
   owner: LightWorkspaceType,
-  metadata: Record<string, boolean | string | number | object>
+  metadata: WorkspaceMetadata
 ): Promise<Result<void, Error>> {
   const previousMetadata = owner.metadata || {};
   const newMetadata = { ...previousMetadata, ...metadata };
@@ -452,7 +456,13 @@ export async function updateWorkspaceMetadata(
 export async function setWorkspaceRelocating(
   owner: LightWorkspaceType
 ): Promise<Result<void, Error>> {
-  return updateWorkspaceMetadata(owner, { maintenance: "relocation" });
+  return updateWorkspaceMetadata(owner, { maintenance: "relocation-done" });
+}
+
+export async function setWorkspaceRelocated(
+  owner: LightWorkspaceType
+): Promise<Result<void, Error>> {
+  return updateWorkspaceMetadata(owner, { maintenance: "relocation-done" });
 }
 
 export async function updateExtensionConfiguration(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -456,7 +456,7 @@ export async function updateWorkspaceMetadata(
 export async function setWorkspaceRelocating(
   owner: LightWorkspaceType
 ): Promise<Result<void, Error>> {
-  return updateWorkspaceMetadata(owner, { maintenance: "relocation-done" });
+  return updateWorkspaceMetadata(owner, { maintenance: "relocation" });
 }
 
 export async function setWorkspaceRelocated(

--- a/front/pages/maintenance.tsx
+++ b/front/pages/maintenance.tsx
@@ -3,72 +3,103 @@ import { isString } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 
+import type { RegionInfo } from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/regions/config";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   requireUserPrivilege: "none",
 })<{
   code: string;
+  otherRegion: RegionInfo;
 }>(async (context) => {
   return {
     props: {
       code: isString(context.query.code) ? context.query.code : "",
+      otherRegion: config.getOtherRegionInfo(),
     },
   };
 });
 
 const defaultErrorMessageClassName = "text-base font-normal text-slate-100";
 
-function getErrorMessage(code: string) {
+interface MaintenancePageInfo {
+  title: string;
+  message: React.ReactNode;
+  buttonLabel: string;
+  buttonUrl: string;
+}
+
+function getMaintenancePageInfo(
+  code: string,
+  otherRegion: RegionInfo
+): MaintenancePageInfo {
   switch (code) {
     case "relocation":
-      return (
-        <>
-          <Page.Header
-            title={
-              <span className="text-white">Service Relocation in Progress</span>
-            }
-          />
+      return {
+        title: "Service Relocation in Progress",
+        message: (
+          <>
+            <p className={defaultErrorMessageClassName}>
+              Your account is currently being relocated to a new region. During
+              this planned migration, you won't be able to access our
+              application. This temporary interruption ensures a smooth
+              transition of your organization's data.
+            </p>
+            <h4 className="text-xl font-bold text-white">What's happening?</h4>
+            <p className={defaultErrorMessageClassName}>
+              As discussed with your team, we're moving your account to a
+              different regional infrastructure. All your data, settings, and
+              configurations will remain exactly as they were. We'll notify your
+              team once the relocation is complete and your access is restored.
+            </p>
+          </>
+        ),
+        buttonLabel: "Back to homepage",
+        buttonUrl: "/",
+      };
+
+    case "relocation-done":
+      return {
+        title: "Service Relocation Complete",
+        message: (
           <p className={defaultErrorMessageClassName}>
-            Your account is currently being relocated to a new region. During
-            this planned migration, you won't be able to access our application.
-            This temporary interruption ensures a smooth transition of your
-            organization's data.
+            Your account has been successfully relocated to a new region. You
+            can now access our application.
           </p>
-          <h4 className="text-xl font-bold text-white">What's happening?</h4>
-          <p className={defaultErrorMessageClassName}>
-            As discussed with your team, we're moving your account to a
-            different regional infrastructure. All your data, settings, and
-            configurations will remain exactly as they were. We'll notify your
-            team once the relocation is complete and your access is restored.
-          </p>
-        </>
-      );
+        ),
+        buttonLabel: `Continue to ${otherRegion.name}`,
+        buttonUrl: `${otherRegion.url}/`,
+      };
+
     default:
-      return (
-        <>
-          <Page.Header
-            title={<span className="text-white">Under Maintenance</span>}
-          />
-          <p className={defaultErrorMessageClassName}>
-            We're currently performing maintenance on this workspace.
-            <br />
-            Please check back in a few minutes.
-          </p>
-          <p className="text-sm font-normal italic text-slate-300">
-            If this persists for an extended period,
-            <br />
-            please contact us at support@dust.tt
-          </p>{" "}
-        </>
-      );
+      return {
+        title: "Under Maintenance",
+        message: (
+          <>
+            <p className={defaultErrorMessageClassName}>
+              We're currently performing maintenance on this workspace.
+              <br />
+              Please check back in a few minutes.
+            </p>
+            <p className="text-sm font-normal italic text-slate-300">
+              If this persists for an extended period,
+              <br />
+              please contact us at support@dust.tt
+            </p>
+          </>
+        ),
+        buttonLabel: "Back to homepage",
+        buttonUrl: "/",
+      };
   }
 }
 
 export default function MaintenancePage({
   code,
+  otherRegion,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const errorMessage = getErrorMessage(code);
+  const maintenancePageInfo = getMaintenancePageInfo(code, otherRegion);
 
   return (
     <>
@@ -78,10 +109,21 @@ export default function MaintenancePage({
           <div className="flex flex-col items-center gap-6 text-center">
             <Icon visual={LogoSquareColorLogo} size="lg" />
             <div className="mx-20 flex flex-col items-center gap-6">
-              {errorMessage}
+              <Page.Header
+                title={
+                  <span className="text-white">
+                    {maintenancePageInfo.title}
+                  </span>
+                }
+              />
+              {maintenancePageInfo.message}
             </div>
-            <Link href="/">
-              <Button variant="primary" label="Back to homepage" size="sm" />
+            <Link href={maintenancePageInfo.buttonUrl}>
+              <Button
+                variant="outline"
+                label={maintenancePageInfo.buttonLabel}
+                size="sm"
+              />
             </Link>
           </div>
         </div>

--- a/front/scripts/relocate_workspace.ts
+++ b/front/scripts/relocate_workspace.ts
@@ -1,10 +1,18 @@
 import { pauseAllManagedDataSources } from "@app/lib/api/data_sources";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { config, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
-import { setWorkspaceRelocating } from "@app/lib/api/workspace";
+import {
+  setWorkspaceRelocated,
+  setWorkspaceRelocating,
+} from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { makeScript } from "@app/scripts/helpers";
 import { launchWorkspaceRelocationWorkflow } from "@app/temporal/relocation/client";
+
+const mode = {
+  relocation: "relocation",
+  relocationDone: "relocation-done",
+};
 
 makeScript(
   {
@@ -23,8 +31,16 @@ makeScript(
       choices: SUPPORTED_REGIONS,
       demandOption: true,
     },
+    mode: {
+      type: "string",
+      choices: Object.values(mode),
+      default: mode.relocation,
+    },
   },
-  async ({ destinationRegion, sourceRegion, workspaceId, execute }, logger) => {
+  async (
+    { destinationRegion, sourceRegion, workspaceId, mode, execute },
+    logger
+  ) => {
     const currentRegion = config.getCurrentRegion();
     if (sourceRegion !== currentRegion) {
       logger.error(
@@ -44,30 +60,50 @@ makeScript(
     logger.info("Start relocating workspace");
 
     if (execute) {
-      // 1) Set the workspace as relocating.
-      const updateRes = await setWorkspaceRelocating(owner);
-      if (updateRes.isErr()) {
-        logger.error(
-          `Failed to set workspace as relocating: ${updateRes.error.message}`
-        );
-        return;
-      }
+      switch (mode) {
+        case "relocation":
+          // 1) Set the workspace as relocating.
+          const workspaceRelocatingRes = await setWorkspaceRelocating(owner);
+          if (workspaceRelocatingRes.isErr()) {
+            logger.error(
+              `Failed to set workspace as relocating: ${workspaceRelocatingRes.error.message}`
+            );
+            return;
+          }
 
-      // 2) Pause all connectors using the connectors API.
-      const pauseRes = await pauseAllManagedDataSources(auth, {
-        markAsError: true,
-      });
-      if (pauseRes.isErr()) {
-        logger.error(`Failed to pause connectors: ${pauseRes.error.message}`);
-        return;
-      }
+          // 2) Pause all connectors using the connectors API.
+          const pauseRes = await pauseAllManagedDataSources(auth, {
+            markAsError: true,
+          });
+          if (pauseRes.isErr()) {
+            logger.error(
+              `Failed to pause connectors: ${pauseRes.error.message}`
+            );
+            return;
+          }
 
-      // 3) Launch the relocation workflow.
-      await launchWorkspaceRelocationWorkflow({
-        workspaceId: owner.sId,
-        sourceRegion,
-        destRegion: destinationRegion as RegionType,
-      });
+          // 3) Launch the relocation workflow.
+          await launchWorkspaceRelocationWorkflow({
+            workspaceId: owner.sId,
+            sourceRegion,
+            destRegion: destinationRegion as RegionType,
+          });
+          break;
+
+        case "relocation-done":
+          // 1) Set the workspace as relocated.
+          const workspaceRelocatedRes = await setWorkspaceRelocated(owner);
+          if (workspaceRelocatedRes.isErr()) {
+            logger.error(
+              `Failed to set workspace as relocated: ${workspaceRelocatedRes.error.message}`
+            );
+            return;
+          }
+          break;
+
+        default:
+          throw new Error(`Invalid mode: ${mode}`);
+      }
     }
   }
 );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Once a cross-region relocation is done, we won't delete data in the source region until a few days, but still, we want to ensure all users are redirected to the new region where there data was migrated.

This PR augments the workspace's metadata to handle the `relocation-done` case, which offers a CTA to head to the new region of the workspace.

The relocate workspace script has also been updated to accommodate for this change.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
