### PR TITLE
[CoreNodes] Add backfill script for node titles

### DIFF
--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -42,6 +42,7 @@ function logInconsistencies(nodes: Node[], logger: typeof Logger) {
     nodes
       .filter(
         (n) =>
+          n.tags_array.title &&
           n.title !== n.tags_array.title.split(":")[0] &&
           n.title !== n.tags_array.title
       )
@@ -63,7 +64,7 @@ async function processNodes({
   coreSequelize: Sequelize;
 }) {
   const nodes = allNodes.filter(
-    (n) => n.title === n.tags_array.title.split(":")[0]
+    (n) => n.tags_array.title && n.title === n.tags_array.title.split(":")[0]
   );
   if (nodes.length === 0) {
     return;

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -51,7 +51,11 @@ function logInconsistencies(nodes: Node[], logger: typeof Logger) {
       .filter((n) => {
         const titleFromTag = getTitleFromTags(n);
         /// Log only the diff that is not what was identified where the title in data_sources_nodes is the cropped version of titleFromTag.
-        return titleFromTag && n.title !== titleFromTag.split(":")[0];
+        return (
+          titleFromTag &&
+          n.title !== titleFromTag &&
+          n.title !== titleFromTag.split(":")[0]
+        );
       })
       .map((n) => [
         n.node_id,

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -51,7 +51,9 @@ function logInconsistencies(nodes: Node[], logger: typeof Logger) {
         { tagTitle: n.tags_array.title, nodeTitle: n.title },
       ])
   );
-  logger.info({ diff }, "Title inconsistencies.");
+  if (Object.keys(diff).length > 0) {
+    logger.info({ diff }, "Title inconsistencies.");
+  }
 }
 
 async function processNodes({

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -233,7 +233,7 @@ makeScript(
       return;
     }
     const coreSequelize = getCorePrimaryDbConnection();
-    const staticDataSources = await DataSourceModel.findAll({
+    const dataSources = await DataSourceModel.findAll({
       where: {
         connectorProvider: provider,
         id: { [Op.gt]: nextDataSourceId },
@@ -241,7 +241,7 @@ makeScript(
       order: [["id", "ASC"]],
     });
 
-    for (const dataSource of staticDataSources) {
+    for (const dataSource of dataSources) {
       await migrateDataSource(dataSource, coreSequelize, execute, logger);
     }
   }

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -50,7 +50,7 @@ function logInconsistencies(nodes: Node[], logger: typeof Logger) {
     nodes
       .filter((n) => {
         const titleFromTag = getTitleFromTags(n);
-        return titleFromTag && n.title === titleFromTag;
+        return titleFromTag && n.title !== titleFromTag;
       })
       .map((n) => [
         n.node_id,

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -60,14 +60,17 @@ async function processNodes({
   allNodes,
   coreDataSourceId,
   coreSequelize,
+  logger,
 }: {
   allNodes: Node[];
   coreDataSourceId: number;
   coreSequelize: Sequelize;
+  logger: typeof Logger;
 }) {
   const nodes = allNodes.filter(
     (n) => n.tags_array.title && n.title === n.tags_array.title.split(":")[0]
   );
+  logger.info(`Found ${nodes.length} nodes to process.`);
   if (nodes.length === 0) {
     return;
   }
@@ -125,7 +128,6 @@ async function migrateDocuments({
       }
     )) as Node[];
 
-    logger.info(`Found ${nodes.length} documents to process.`);
     logInconsistencies(nodes, logger);
 
     if (execute) {
@@ -133,6 +135,7 @@ async function migrateDocuments({
         allNodes: nodes,
         coreSequelize,
         coreDataSourceId,
+        logger,
       });
     }
     nextId = nodes[nodes.length - 1]?.node_id;
@@ -171,7 +174,6 @@ async function migrateTables({
       }
     )) as Node[];
 
-    logger.info(`Found ${nodes.length} tables to process.`);
     logInconsistencies(nodes, logger);
 
     if (execute) {
@@ -179,6 +181,7 @@ async function migrateTables({
         allNodes: nodes,
         coreSequelize,
         coreDataSourceId,
+        logger,
       });
     }
     nextId = nodes[nodes.length - 1]?.node_id;

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -7,7 +7,7 @@ import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import type Logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
-const SELECT_BATCH_SIZE = 256;
+const SELECT_BATCH_SIZE = 512;
 
 type Node = {
   node_id: string;

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -1,0 +1,247 @@
+import { concurrentExecutor } from "@dust-tt/types";
+import type { Sequelize } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
+
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const DATASOURCE_BATCH_SIZE = 256;
+const SELECT_BATCH_SIZE = 256;
+
+const DATASOURCE_CONCURRENCY = 4;
+
+type Node = {
+  node_id: string;
+  tags_array: Record<string, string>;
+  timestamp: number;
+  title: string;
+};
+
+async function getCoreDataSourceId(
+  frontDataSource: DataSourceModel,
+  coreSequelize: Sequelize
+): Promise<number | null> {
+  const { dustAPIProjectId, dustAPIDataSourceId } = frontDataSource;
+  const coreDataSource: any = (
+    await coreSequelize.query(
+      `SELECT id
+       FROM data_sources
+       WHERE project = :dustAPIProjectId
+         AND data_source_id = :dustAPIDataSourceId
+       LIMIT 1`,
+      {
+        replacements: { dustAPIProjectId, dustAPIDataSourceId },
+        type: QueryTypes.SELECT,
+      }
+    )
+  )[0];
+  return coreDataSource?.id || null;
+}
+
+function logInconsistencies(nodes: Node[], logger: typeof Logger) {
+  const diff = Object.fromEntries(
+    nodes
+      .filter(
+        (n) =>
+          n.title !== n.tags_array.title.split(":")[0] &&
+          n.title !== n.tags_array.title
+      )
+      .map((n) => [
+        n.node_id,
+        { tagTitle: n.tags_array.title, nodeTitle: n.title },
+      ])
+  );
+  logger.info({ diff }, "Title inconsistencies.");
+}
+
+async function processNodes({
+  allNodes,
+  coreDataSourceId,
+  coreSequelize,
+}: {
+  allNodes: Node[];
+  coreDataSourceId: number;
+  coreSequelize: Sequelize;
+}) {
+  const nodes = allNodes.filter(
+    (n) => n.title === n.tags_array.title.split(":")[0]
+  );
+  if (nodes.length === 0) {
+    return;
+  }
+  // Replacing the titles with the ones in the tags.
+  const titles = nodes.map((n) => n.tags_array.title);
+
+  await coreSequelize.query(
+    `UPDATE data_sources_nodes dsn
+     SET title = unnested.title
+     FROM (
+              SELECT UNNEST(ARRAY [:nodeIds]::text[]) AS node_id,
+                     UNNEST(ARRAY [:titles]::text[])  AS title
+          ) unnested
+     WHERE dsn.data_source = :coreDataSourceId
+       AND dsn.node_id = unnested.node_id;`,
+    {
+      replacements: {
+        nodeIds: nodes.map((n) => n.node_id),
+        titles,
+        coreDataSourceId,
+      },
+    }
+  );
+}
+
+async function migrateDocuments({
+  coreDataSourceId,
+  coreSequelize,
+  execute,
+  logger,
+}: {
+  coreDataSourceId: number;
+  coreSequelize: Sequelize;
+  execute: boolean;
+  logger: typeof Logger;
+}) {
+  let nextId = "";
+  let nodes: Node[];
+
+  do {
+    nodes = (await coreSequelize.query(
+      `SELECT dsn.node_id, dsn.timestamp, dsn.title, dsd.tags_array
+       FROM data_sources_nodes dsn
+            JOIN data_sources_documents dsd ON dsd.id = dsn.document
+       WHERE dsn.data_source = :coreDataSourceId
+         AND dsn.node_id > :nextId
+       LIMIT :batchSize`,
+      {
+        replacements: {
+          coreDataSourceId,
+          batchSize: SELECT_BATCH_SIZE,
+          nextId,
+        },
+        type: QueryTypes.SELECT,
+      }
+    )) as Node[];
+
+    logger.info(`Found ${nodes.length} documents to process.`);
+    logInconsistencies(nodes, logger);
+
+    if (execute) {
+      await processNodes({
+        allNodes: nodes,
+        coreSequelize,
+        coreDataSourceId,
+      });
+    }
+    nextId = nodes[nodes.length - 1]?.node_id;
+  } while (nodes.length === SELECT_BATCH_SIZE);
+}
+
+async function migrateTables({
+  coreDataSourceId,
+  coreSequelize,
+  execute,
+  logger,
+}: {
+  coreDataSourceId: number;
+  coreSequelize: Sequelize;
+  execute: boolean;
+  logger: typeof Logger;
+}) {
+  let nextId = "";
+  let nodes: Node[];
+
+  do {
+    nodes = (await coreSequelize.query(
+      `SELECT dsn.node_id, dsn.timestamp, dsn.title, t.tags_array
+       FROM data_sources_nodes dsn
+            JOIN tables t ON t.id = dsn.table
+       WHERE dsn.data_source = :coreDataSourceId
+         AND dsn.node_id > :nextId
+       LIMIT :batchSize`,
+      {
+        replacements: {
+          coreDataSourceId,
+          batchSize: SELECT_BATCH_SIZE,
+          nextId,
+        },
+        type: QueryTypes.SELECT,
+      }
+    )) as Node[];
+
+    logger.info(`Found ${nodes.length} tables to process.`);
+    logInconsistencies(nodes, logger);
+
+    if (execute) {
+      await processNodes({
+        allNodes: nodes,
+        coreSequelize,
+        coreDataSourceId,
+      });
+    }
+    nextId = nodes[nodes.length - 1]?.node_id;
+  } while (nodes.length === SELECT_BATCH_SIZE);
+}
+
+async function migrateDataSource(
+  frontDataSource: DataSourceModel,
+  coreSequelize: Sequelize,
+  execute: boolean,
+  parentLogger: typeof Logger
+) {
+  const logger = parentLogger.child({
+    project: frontDataSource.dustAPIProjectId,
+    dataSourceId: frontDataSource.dustAPIDataSourceId,
+  });
+  logger.info("MIGRATE");
+
+  const coreDataSourceId = await getCoreDataSourceId(
+    frontDataSource,
+    coreSequelize
+  );
+  if (!coreDataSourceId) {
+    logger.error("No core datasource found.");
+    return;
+  }
+
+  await migrateDocuments({ coreDataSourceId, coreSequelize, execute, logger });
+  await migrateTables({ coreDataSourceId, coreSequelize, execute, logger });
+}
+
+async function migrateDataSources(
+  nextDataSourceId: number,
+  coreSequelize: Sequelize,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  let startId = nextDataSourceId;
+  let staticDataSources;
+  do {
+    staticDataSources = await DataSourceModel.findAll({
+      where: { connectorProvider: null, id: { [Op.gt]: startId } },
+      limit: DATASOURCE_BATCH_SIZE,
+      order: [["id", "ASC"]],
+    });
+
+    await concurrentExecutor(
+      staticDataSources,
+      async (dataSource) => {
+        await migrateDataSource(dataSource, coreSequelize, execute, logger);
+      },
+      { concurrency: DATASOURCE_CONCURRENCY }
+    );
+    if (staticDataSources.length > 0) {
+      startId = staticDataSources[staticDataSources.length - 1].id;
+    }
+  } while (staticDataSources.length === DATASOURCE_BATCH_SIZE); // early exit on the first incomplete batch
+}
+
+makeScript(
+  { nextDataSourceId: { type: "number", default: 0 } },
+  async ({ nextDataSourceId, execute }, logger) => {
+    const coreSequelize = getCorePrimaryDbConnection();
+    await migrateDataSources(nextDataSourceId, coreSequelize, execute, logger);
+  }
+);

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -50,7 +50,7 @@ function logInconsistencies(nodes: Node[], logger: typeof Logger) {
     nodes
       .filter((n) => {
         const titleFromTag = getTitleFromTags(n);
-        return titleFromTag && n.title !== titleFromTag;
+        return titleFromTag && n.title !== titleFromTag.split(":")[0];
       })
       .map((n) => [
         n.node_id,
@@ -79,7 +79,7 @@ async function processNodes({
 }) {
   const nodes = allNodes.filter((n) => {
     const titleFromTag = getTitleFromTags(n);
-    return titleFromTag && titleFromTag !== n.title;
+    return titleFromTag && n.title === titleFromTag.split(":")[0];
   });
   if (nodes.length === 0) {
     return;

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -50,6 +50,7 @@ function logInconsistencies(nodes: Node[], logger: typeof Logger) {
     nodes
       .filter((n) => {
         const titleFromTag = getTitleFromTags(n);
+        /// Log only the diff that is not what was identified where the title in data_sources_nodes is the cropped version of titleFromTag.
         return titleFromTag && n.title !== titleFromTag.split(":")[0];
       })
       .map((n) => [
@@ -79,6 +80,7 @@ async function processNodes({
 }) {
   const nodes = allNodes.filter((n) => {
     const titleFromTag = getTitleFromTags(n);
+    /// Keep only the diff that was identified where the title in data_sources_nodes is the cropped version of titleFromTag.
     return titleFromTag && n.title === titleFromTag.split(":")[0];
   });
   if (nodes.length === 0) {

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -59,6 +59,8 @@ function logInconsistencies(nodes: Node[], logger: typeof Logger) {
   );
   if (Object.keys(diff).length > 0) {
     logger.info({ diff }, "Title inconsistencies.");
+  } else {
+    logger.info("No title inconsistency.");
   }
 }
 
@@ -79,10 +81,10 @@ async function processNodes({
     const titleFromTag = getTitleFromTags(n);
     return titleFromTag && titleFromTag !== n.title;
   });
-  logger.info(`Found ${nodes.length} nodes to process.`);
   if (nodes.length === 0) {
     return;
   }
+  logger.info(`Found ${nodes.length} nodes to process.`);
   // Replacing the titles with the ones in the tags.
   const titles = nodes.map(getTitleFromTags);
 

--- a/front/migrations/20250203_backfill_nodes_titles.ts
+++ b/front/migrations/20250203_backfill_nodes_titles.ts
@@ -16,9 +16,9 @@ type Node = {
   title: string;
 };
 
-function getTitleFromTags(tags: string[]): string | null {
+function getTitleFromTags(node: Node): string | null {
   return (
-    tags
+    node.tags_array
       .filter((tag) => tag.startsWith("title:"))
       .map((n) => n.split("title:").slice(1).join(""))[0] || null
   );
@@ -49,12 +49,12 @@ function logInconsistencies(nodes: Node[], logger: typeof Logger) {
   const diff = Object.fromEntries(
     nodes
       .filter((n) => {
-        const titleFromTag = getTitleFromTags(n.tags_array);
+        const titleFromTag = getTitleFromTags(n);
         return titleFromTag && n.title === titleFromTag;
       })
       .map((n) => [
         n.node_id,
-        { tagTitle: getTitleFromTags(n.tags_array), nodeTitle: n.title },
+        { tagTitle: getTitleFromTags(n), nodeTitle: n.title },
       ])
   );
   if (Object.keys(diff).length > 0) {
@@ -76,7 +76,7 @@ async function processNodes({
   logger: typeof Logger;
 }) {
   const nodes = allNodes.filter((n) => {
-    const titleFromTag = getTitleFromTags(n.tags_array);
+    const titleFromTag = getTitleFromTags(n);
     return titleFromTag && titleFromTag !== n.title;
   });
   logger.info(`Found ${nodes.length} nodes to process.`);
@@ -84,7 +84,7 @@ async function processNodes({
     return;
   }
   // Replacing the titles with the ones in the tags.
-  const titles = nodes.map((n) => getTitleFromTags(n.tags_array));
+  const titles = nodes.map(getTitleFromTags);
 
   if (execute) {
     await coreSequelize.query(


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/dust/issues/10281.

## Tests

## Risk

- Low, titles in `data_sources_nodes` only used for shadow reading.

## Deploy Plan

- No deploy
