### PR TITLE
Fix description handling in table upsert through API with fileAPI

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -489,6 +489,7 @@ export async function upsertTable({
       )
     );
   }
+
   // parents and parentId must comply to the invariant parents[1] === parentId
   if (
     (tableParents.length >= 2 || tableParentId !== null) &&
@@ -501,7 +502,6 @@ export async function upsertTable({
       )
     );
   }
-
   let standardizedSourceUrl: string | null = null;
   if (sourceUrl) {
     const { valid: isSourceUrlValid, standardized } = validateUrl(sourceUrl);

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -218,6 +218,7 @@ const upsertDocumentToDatasource: ProcessingFunction = async ({
   }
   const { title: upsertTitle, ...restArgs } = upsertArgs ?? {};
   const upsertDocumentRes = await upsertDocument({
+    // Beware, most values here are default values that are overrided by the ...restArgs below.
     document_id: documentId,
     source_url: sourceUrl,
     text: content,
@@ -257,16 +258,14 @@ const upsertTableToDatasource: ProcessingFunction = async ({
   if (upsertArgs && "tableId" in upsertArgs) {
     tableId = upsertArgs.tableId ?? tableId;
   }
-  let description = "Table uploaded from file";
-  if (upsertArgs && "description" in upsertArgs && !upsertArgs.description) {
-    description = upsertArgs.description;
-  }
   const { title: upsertTitle, ...restArgs } = upsertArgs ?? {};
 
   const upsertTableRes = await upsertTable({
+    // Beware, most values here are default values that are overrided by the ...restArgs below,
+    // including description.
     tableId,
     name: slugify(file.fileName),
-    description,
+    description: "Table uploaded from file",
     truncate: true,
     csv: content,
     tags: [`title:${file.fileName}`, `fileId:${file.sId}`],
@@ -306,17 +305,7 @@ type ProcessingFunction = ({
   file: FileResource;
   content: string;
   dataSource: DataSourceResource;
-  upsertArgs?:
-    | Pick<UpsertDocumentArgs, "document_id" | "title" | "tags">
-    | Pick<
-        UpsertTableArgs,
-        | "name"
-        | "title"
-        | "description"
-        | "tableId"
-        | "tags"
-        | "useAppForHeaderDetection"
-      >;
+  upsertArgs?: UpsertDocumentArgs | UpsertTableArgs;
 }) => Promise<Result<undefined, Error>>;
 
 const getProcessingFunction = ({
@@ -432,17 +421,7 @@ export async function processAndUpsertToDataSource(
   }: {
     file: FileResource;
     optionalContent?: string;
-    upsertArgs?:
-      | Pick<UpsertDocumentArgs, "document_id" | "title" | "tags">
-      | Pick<
-          UpsertTableArgs,
-          | "name"
-          | "title"
-          | "description"
-          | "tableId"
-          | "tags"
-          | "useAppForHeaderDetection"
-        >;
+    upsertArgs?: UpsertDocumentArgs | UpsertTableArgs;
   }
 ): Promise<
   Result<

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -257,11 +257,16 @@ const upsertTableToDatasource: ProcessingFunction = async ({
   if (upsertArgs && "tableId" in upsertArgs) {
     tableId = upsertArgs.tableId ?? tableId;
   }
+  let description = "Table uploaded from file";
+  if (upsertArgs && "description" in upsertArgs && !upsertArgs.description) {
+    description = upsertArgs.description;
+  }
   const { title: upsertTitle, ...restArgs } = upsertArgs ?? {};
+
   const upsertTableRes = await upsertTable({
     tableId,
     name: slugify(file.fileName),
-    description: "Table uploaded from file",
+    description,
     truncate: true,
     csv: content,
     tags: [`title:${file.fileName}`, `fileId:${file.sId}`],

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -122,7 +122,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
   itInTransaction(
     "successfully upserts file to data source with the right arguments",
     async (t) => {
-      const { req, res, workspace, globalGroup, auth } =
+      const { req, res, workspace, globalGroup, user } =
         await createPrivateApiMockRequest({
           method: "POST",
         });
@@ -134,7 +134,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
         space,
         t
       );
-      const file = await FileFactory.create(auth, {
+      const file = await FileFactory.create(workspace, user, {
         contentType: "text/csv",
         fileName: "test.csv",
         fileSize: 100,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -40,7 +40,7 @@ const CORE_FAKE_RESPONSE = {
 
 // Mock environment config
 vi.mock("@dust-tt/types", async (importOriginal) => {
-  const mod = await importOriginal();
+  const mod = (await importOriginal()) as Record<string, any>;
   return {
     ...mod,
     EnvironmentConfig: {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -134,13 +134,8 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
         space,
         t
       );
-      const file = await FileFactory.create(workspace, user, {
-        contentType: "text/csv",
-        fileName: "test.csv",
-        fileSize: 100,
-        status: "ready",
+      const file = await FileFactory.csv(workspace, user, {
         useCase: "folder_table",
-        content: "foo,bar,baz\n1,2,3\n4,5,6",
       });
 
       req.query.dsId = dataSourceView.dataSource.sId;
@@ -198,9 +193,6 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData()).toEqual({
-        file: file.toPublicJSON(auth),
-      });
     }
   );
 });

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -198,7 +198,6 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
-      console.log(res._getJSONData());
       expect(res._getJSONData()).toEqual({
         file: file.toPublicJSON(auth),
       });

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -1,0 +1,207 @@
+import { Readable } from "stream";
+import { describe, expect, vi } from "vitest";
+
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./files";
+
+const CORE_FAKE_RESPONSE = {
+  response: {
+    table: {
+      project: { project_id: 47 },
+      data_source_id:
+        "21ab3a9994350d8bbd3f76e4c5d233696d6793b271f19407d60d7db825a16381",
+      data_source_internal_id:
+        "7f93516e45f485f18f889040ed13764a418acf422c34f4f0d3e9474ccccb5386",
+      created: 1738254966701,
+      table_id: "test-table",
+      name: "Test Table",
+      description: "Test Description",
+      timestamp: 1738254966701,
+      tags: [],
+      title: "Test Title",
+      mime_type: "text/csv",
+      provider_visibility: null,
+      parent_id: null,
+      parents: ["test-table"],
+      source_url: null,
+      schema: null,
+      schema_stale_at: null,
+      remote_database_table_id: null,
+      remote_database_secret_id: null,
+    },
+  },
+};
+
+// Mock environment config
+vi.mock("@dust-tt/types", async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    EnvironmentConfig: {
+      ...mod.EnvironmentConfig,
+      getEnvVariable: vi.fn((key: string) => {
+        switch (key) {
+          case "DUST_PRIVATE_UPLOADS_BUCKET":
+            return "test-private-bucket";
+          case "DUST_UPLOAD_BUCKET":
+            return "test-public-bucket";
+          default:
+            return process.env[key];
+        }
+      }),
+    },
+  };
+});
+
+vi.mock(import("@app/lib/api/config"), (() => ({
+  default: {
+    getCoreAPIConfig: vi.fn().mockReturnValue({
+      url: "http://localhost:9999",
+      apiKey: "foo",
+    }),
+    getClientFacingUrl: vi.fn().mockReturnValue("http://localhost:3000"),
+  },
+})) as any);
+
+// Create a mock content setter
+const mockFileContent = {
+  content: "default content", // Default content
+  setContent: (newContent: string) => {
+    mockFileContent.content = newContent;
+  },
+};
+
+// Mock file storage with parameterizable content
+vi.mock("@app/lib/file_storage", () => ({
+  getPrivateUploadBucket: vi.fn(() => ({
+    file: () => ({
+      createReadStream: () => Readable.from([mockFileContent.content]),
+    }),
+  })),
+  getPublicUploadBucket: vi.fn(() => ({
+    file: () => ({
+      createReadStream: () => Readable.from([mockFileContent.content]),
+    }),
+  })),
+}));
+
+describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
+  itInTransaction("returns 404 when file not found", async (t) => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const space = await SpaceFactory.global(workspace, t);
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      space,
+      t
+    );
+
+    req.query.dsId = dataSourceView.dataSource.sId;
+    req.body = {
+      fileId: "non-existent",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(JSON.parse(res._getData())).toEqual({
+      error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  });
+
+  itInTransaction(
+    "successfully upserts file to data source with the right arguments",
+    async (t) => {
+      const { req, res, workspace, globalGroup, auth } =
+        await createPrivateApiMockRequest({
+          method: "POST",
+        });
+      const space = await SpaceFactory.global(workspace, t);
+      await GroupSpaceFactory.associate(space, globalGroup);
+
+      const dataSourceView = await DataSourceViewFactory.folder(
+        workspace,
+        space,
+        t
+      );
+      const file = await FileFactory.create(auth, {
+        contentType: "text/csv",
+        fileName: "test.csv",
+        fileSize: 100,
+        status: "ready",
+        useCase: "folder_table",
+        content: "foo,bar,baz\n1,2,3\n4,5,6",
+      });
+
+      req.query.dsId = dataSourceView.dataSource.sId;
+      req.body = {
+        fileId: file.sId,
+        upsertArgs: {
+          tableId: "test-table",
+          name: "Test Table",
+          title: "Test Title",
+          description: "Test Description",
+          tags: ["test"],
+          useAppForHeaderDetection: true,
+        },
+      };
+
+      // Set specific content for this test
+      mockFileContent.setContent("foo,bar,baz\n1,2,3\n4,5,6");
+
+      // First fetch is to create the table
+      global.fetch = vi.fn().mockImplementation(async (url, init) => {
+        const req = JSON.parse(init.body);
+        if ((url as string).endsWith("/tables")) {
+          expect(req.table_id).toBe("test-table");
+          expect(req.name).toBe("Test Table");
+          expect(req.description).toBe("Test Description");
+          return Promise.resolve(
+            new Response(JSON.stringify(CORE_FAKE_RESPONSE), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            })
+          );
+          //
+        }
+
+        if ((url as string).endsWith("/rows")) {
+          expect(req.rows[0].row_id).toBe("0");
+          expect(req.rows[0].value.bar).toBe(2);
+          expect(req.rows[1].value.foo).toBe(4);
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                response: {
+                  success: true,
+                },
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              }
+            )
+          );
+        }
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      console.log(res._getJSONData());
+      expect(res._getJSONData()).toEqual({
+        file: file.toPublicJSON(auth),
+      });
+    }
+  );
+});

--- a/front/tests/utils/DataSourceViewFactory.ts
+++ b/front/tests/utils/DataSourceViewFactory.ts
@@ -1,13 +1,13 @@
+import type { WorkspaceType } from "@dust-tt/types";
 import { faker } from "@faker-js/faker";
 import type { Transaction } from "sequelize";
 
-import type { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 
 export class DataSourceViewFactory {
   static async folder(
-    workspace: Workspace,
+    workspace: WorkspaceType,
     space: SpaceResource,
     t: Transaction
   ) {

--- a/front/tests/utils/FeatureFlagFactory.ts
+++ b/front/tests/utils/FeatureFlagFactory.ts
@@ -1,10 +1,12 @@
-import type { WhitelistableFeature } from "@dust-tt/types";
+import type { WhitelistableFeature, WorkspaceType } from "@dust-tt/types";
 
 import { FeatureFlag } from "@app/lib/models/feature_flag";
-import type { Workspace } from "@app/lib/models/workspace";
 
 export class FeatureFlagFactory {
-  static async basic(featureName: WhitelistableFeature, workspace: Workspace) {
+  static async basic(
+    featureName: WhitelistableFeature,
+    workspace: WorkspaceType
+  ) {
     return FeatureFlag.create({
       name: featureName,
       workspaceId: workspace.id,

--- a/front/tests/utils/FileFactory.ts
+++ b/front/tests/utils/FileFactory.ts
@@ -31,7 +31,6 @@ export class FileFactory {
       useCase: FileUseCase;
       useCaseMetadata?: FileUseCaseMetadata | null;
       snippet?: string | null;
-      content?: string | null; // Content to store in GCS
     }
   ) {
     const file = await FileResource.makeNew({
@@ -52,5 +51,32 @@ export class FileFactory {
     }
 
     return file;
+  }
+
+  static csv(
+    workspace: WorkspaceType,
+    user: UserResource,
+    {
+      useCase,
+      useCaseMetadata,
+      fileName,
+      status,
+      fileSize,
+    }: {
+      useCase: FileUseCase;
+      useCaseMetadata?: FileUseCaseMetadata;
+      fileName?: string;
+      fileSize?: number;
+      status?: FileStatus;
+    }
+  ) {
+    return this.create(workspace, user, {
+      contentType: "text/csv",
+      fileName: fileName ?? "file.csv",
+      fileSize: fileSize ?? 100,
+      status: status ?? "ready",
+      useCase,
+      useCaseMetadata,
+    });
   }
 }

--- a/front/tests/utils/FileFactory.ts
+++ b/front/tests/utils/FileFactory.ts
@@ -1,0 +1,54 @@
+import type {
+  FileStatus,
+  FileUseCase,
+  FileUseCaseMetadata,
+  SupportedFileContentType,
+} from "@dust-tt/types";
+
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+
+export class FileFactory {
+  // We don't support passing a content as GCS has to be mocked in test so the content part can be
+  // injected by mocking the GCS client.
+  static async create(
+    auth: Authenticator,
+    {
+      contentType,
+      fileName,
+      fileSize,
+      status,
+      useCase,
+      useCaseMetadata = null,
+      snippet = null,
+    }: {
+      contentType: SupportedFileContentType;
+      fileName: string;
+      fileSize: number;
+      status: FileStatus;
+      useCase: FileUseCase;
+      useCaseMetadata?: FileUseCaseMetadata | null;
+      snippet?: string | null;
+      content?: string | null; // Content to store in GCS
+    }
+  ) {
+    const file = await FileResource.makeNew({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      userId: auth.getNonNullableUser().id,
+      contentType,
+      fileName,
+      fileSize,
+      useCase,
+      useCaseMetadata,
+      snippet,
+    });
+
+    if (status === "ready") {
+      await file.markAsReady();
+    } else if (status === "failed") {
+      await file.markAsFailed();
+    }
+
+    return file;
+  }
+}

--- a/front/tests/utils/FileFactory.ts
+++ b/front/tests/utils/FileFactory.ts
@@ -3,16 +3,18 @@ import type {
   FileUseCase,
   FileUseCaseMetadata,
   SupportedFileContentType,
+  WorkspaceType,
 } from "@dust-tt/types";
 
-import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 
 export class FileFactory {
   // We don't support passing a content as GCS has to be mocked in test so the content part can be
   // injected by mocking the GCS client.
   static async create(
-    auth: Authenticator,
+    workspace: WorkspaceType,
+    user: UserResource,
     {
       contentType,
       fileName,
@@ -33,8 +35,8 @@ export class FileFactory {
     }
   ) {
     const file = await FileResource.makeNew({
-      workspaceId: auth.getNonNullableWorkspace().id,
-      userId: auth.getNonNullableUser().id,
+      workspaceId: workspace.id,
+      userId: user.id,
       contentType,
       fileName,
       fileSize,

--- a/front/tests/utils/GroupFactory.ts
+++ b/front/tests/utils/GroupFactory.ts
@@ -1,11 +1,9 @@
-import type { Workspace } from "@app/lib/models/workspace";
+import type { WorkspaceType } from "@dust-tt/types";
+
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
 
 export class GroupFactory {
-  static async defaults(workspace: Workspace) {
-    return GroupResource.makeDefaultsForWorkspace(
-      renderLightWorkspaceType({ workspace })
-    );
+  static async defaults(workspace: WorkspaceType) {
+    return GroupResource.makeDefaultsForWorkspace(workspace);
   }
 }

--- a/front/tests/utils/MembershipFactory.ts
+++ b/front/tests/utils/MembershipFactory.ts
@@ -1,18 +1,16 @@
-import type { MembershipRoleType } from "@dust-tt/types";
+import type { MembershipRoleType, WorkspaceType } from "@dust-tt/types";
 
-import type { Workspace } from "@app/lib/models/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
 
 export class MembershipFactory {
   static async associate(
-    workspace: Workspace,
+    workspace: WorkspaceType,
     user: UserResource,
     role: MembershipRoleType
   ) {
     return MembershipResource.createMembership({
-      workspace: renderLightWorkspaceType({ workspace }),
+      workspace,
       user,
       role,
     });

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -1,11 +1,11 @@
+import type { WorkspaceType } from "@dust-tt/types";
 import { faker } from "@faker-js/faker";
 import type { Transaction } from "sequelize";
 
-import type { Workspace } from "@app/lib/models/workspace";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 
 export class SpaceFactory {
-  static async global(workspace: Workspace, t: Transaction) {
+  static async global(workspace: WorkspaceType, t: Transaction) {
     return SpaceResource.makeNew(
       {
         name: "space " + faker.string.alphanumeric(8),
@@ -17,7 +17,7 @@ export class SpaceFactory {
     );
   }
 
-  static async system(workspace: Workspace, t: Transaction) {
+  static async system(workspace: WorkspaceType, t: Transaction) {
     return SpaceResource.makeNew(
       {
         name: "space " + faker.string.alphanumeric(8),
@@ -29,7 +29,7 @@ export class SpaceFactory {
     );
   }
 
-  static async regular(workspace: Workspace, t: Transaction) {
+  static async regular(workspace: WorkspaceType, t: Transaction) {
     return SpaceResource.makeNew(
       {
         name: "space " + faker.string.alphanumeric(8),

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -2,13 +2,15 @@ import { faker } from "@faker-js/faker";
 
 import { Workspace } from "@app/lib/models/workspace";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 
 export class WorkspaceFactory {
   static async basic() {
-    return Workspace.create({
+    const workspace = await Workspace.create({
       sId: generateRandomModelSId(),
       name: faker.company.name(),
       description: faker.company.catchPhrase(),
     });
+    return renderLightWorkspaceType({ workspace });
   }
 }

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,3 +1,4 @@
+import type { WorkspaceType } from "@dust-tt/types";
 import { faker } from "@faker-js/faker";
 
 import { Workspace } from "@app/lib/models/workspace";
@@ -5,12 +6,15 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 
 export class WorkspaceFactory {
-  static async basic() {
+  static async basic(): Promise<WorkspaceType> {
     const workspace = await Workspace.create({
       sId: generateRandomModelSId(),
       name: faker.company.name(),
       description: faker.company.catchPhrase(),
     });
-    return renderLightWorkspaceType({ workspace });
+    return {
+      ...renderLightWorkspaceType({ workspace }),
+      ssoEnforced: workspace.ssoEnforced,
+    };
   }
 }

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -17,7 +17,7 @@ vi.mock(import("../../lib/auth"), async (importOriginal) => {
   };
 });
 
-import { getSession } from "../../lib/auth";
+import { Authenticator, getSession } from "../../lib/auth";
 
 /**
  * Creates a mock request with authentication for testing private API endpoints.
@@ -36,6 +36,7 @@ import { getSession } from "../../lib/auth";
  *   - user: Created test user
  *   - membership: Created workspace membership
  *   - globalGroup: Created global group for the workspace
+ *   - auth: an admin Authenticator for the test user
  */
 export const createPrivateApiMockRequest = async ({
   method = "GET",
@@ -53,6 +54,13 @@ export const createPrivateApiMockRequest = async ({
   const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
 
   const membership = await MembershipFactory.associate(workspace, user, role);
+  const auth = new Authenticator({
+    workspace,
+    user,
+    role: "admin",
+    groups: [globalGroup],
+    subscription: null,
+  });
 
   // Mock the getSession function to return the user without going through the auth0 session
   vi.mocked(getSession).mockReturnValue(
@@ -73,5 +81,14 @@ export const createPrivateApiMockRequest = async ({
     headers: {},
   });
 
-  return { req, res, workspace, user, membership, globalGroup, systemGroup };
+  return {
+    req,
+    res,
+    workspace,
+    user,
+    membership,
+    globalGroup,
+    systemGroup,
+    auth,
+  };
 };

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -17,7 +17,7 @@ vi.mock(import("../../lib/auth"), async (importOriginal) => {
   };
 });
 
-import { Authenticator, getSession } from "../../lib/auth";
+import { getSession } from "../../lib/auth";
 
 /**
  * Creates a mock request with authentication for testing private API endpoints.
@@ -54,13 +54,6 @@ export const createPrivateApiMockRequest = async ({
   const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
 
   const membership = await MembershipFactory.associate(workspace, user, role);
-  const auth = new Authenticator({
-    workspace,
-    user,
-    role: "admin",
-    groups: [globalGroup],
-    subscription: null,
-  });
 
   // Mock the getSession function to return the user without going through the auth0 session
   vi.mocked(getSession).mockReturnValue(
@@ -89,6 +82,5 @@ export const createPrivateApiMockRequest = async ({
     membership,
     globalGroup,
     systemGroup,
-    auth,
   };
 };

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -36,7 +36,6 @@ import { getSession } from "../../lib/auth";
  *   - user: Created test user
  *   - membership: Created workspace membership
  *   - globalGroup: Created global group for the workspace
- *   - auth: an admin Authenticator for the test user
  */
 export const createPrivateApiMockRequest = async ({
   method = "GET",


### PR DESCRIPTION
## Description

- Added comment to make it clearer that ...restArgs is hard to grasp
- Simplified types to make things a bit clearer

## Tests

Introduced one e2e test for fileAPI + upsert on private API.
Moved to relying on WorkspaceType instead of Workspace in tests.

## Risk

N/A

## Deploy Plan

- deploy `front`