### PR TITLE
enh(Confluence) - Add an `update-parents` CLI command

### DIFF
--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -149,6 +149,7 @@ export const confluence = async ({
       if (!args.connectorId) {
         throw new Error("Missing --connectorId argument");
       }
+      // Not passing a spaceId means that all spaces have to be checked out here.
       if (!args.spaceId) {
         const spaces = await ConfluenceSpace.findAll({
           attributes: ["spaceId"],

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -17,10 +17,10 @@ import {
   confluenceUpsertPagesWithFullParentsWorkflow,
   confluenceUpsertPageWithFullParentsWorkflow,
 } from "@connectors/connectors/confluence/temporal/workflows";
+import { ConfluenceSpace } from "@connectors/lib/models/confluence";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { ConfluenceSpace } from "@connectors/lib/models/confluence";
 
 export const confluence = async ({
   command,

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -150,9 +150,6 @@ export const confluence = async ({
         throw new Error("Missing --connectorId argument");
       }
       if (!args.spaceId) {
-        throw new Error("Missing --spaceId argument");
-      }
-      if (args.spaceId === "all") {
         const spaces = await ConfluenceSpace.findAll({
           attributes: ["spaceId"],
           where: { connectorId: args.connectorId },

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -763,7 +763,7 @@ export async function confluenceGetTopLevelPageIdsActivity({
 export async function confluenceUpdatePagesParentIdsActivity(
   connectorId: ModelId,
   spaceId: string,
-  visitedAtMs: number
+  visitedAtMs: number | null
 ) {
   const connector = await fetchConfluenceConnector(connectorId);
 
@@ -772,7 +772,7 @@ export async function confluenceUpdatePagesParentIdsActivity(
     where: {
       connectorId,
       spaceId,
-      lastVisitedAt: visitedAtMs,
+      ...(visitedAtMs ? { lastVisitedAt: visitedAtMs } : {}),
     },
   });
 

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -34,10 +34,12 @@ export const ConfluenceCommandSchema = t.type({
     t.literal("me"),
     t.literal("upsert-page"),
     t.literal("upsert-pages"),
+    t.literal("update-parents"),
   ]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
     pageId: t.union([t.number, t.undefined]),
+    spaceId: t.union([t.string, t.undefined]),
     file: t.union([t.string, t.undefined]),
     keyInFile: t.union([t.string, t.undefined]),
   }),


### PR DESCRIPTION
## Description

- In the context of https://github.com/dust-tt/tasks/issues/2077, we have observed invalid states in core's table `data_sources_nodes` for Confluence pages: we have pages that do not have a parent (not even the space).
- There is no code path that allows for this in the connector, therefore we only need to fix the existing entries in db.
- This PR adds a CLI command `update-parents` that recomputes the parent hierarchy for a space or for all spaces of a connector and updates the parents in core (qdrant, postgres and ES), with the same code than the connector.

## Tests

## Risk

- Low, the same code than the connector is used.

## Deploy Plan

- Deploy connectors.
