### PR TITLE
Increasing the size of input bar on mobile 

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -62,6 +62,7 @@ const InputBarContainer = ({
   const [isExpanded, setIsExpanded] = useState(false);
   function handleExpansionToggle() {
     setIsExpanded((currentExpanded) => !currentExpanded);
+    // Focus at the end of the document when toggling expansion.
     editorService.focusEnd();
   }
 
@@ -76,6 +77,8 @@ const InputBarContainer = ({
     disableAutoFocus,
   });
 
+  // When input bar animation is requested it means the new button was clicked (removing focus from
+  // the input bar), we grab it back.
   const { animate } = useContext(InputBarContext);
   useEffect(() => {
     if (animate) {
@@ -97,14 +100,11 @@ const InputBarContainer = ({
     "inline-block w-full",
     "border-0 px-2 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal",
-    "pb-6 pt-4 sm:py-3.5"
+    "pb-6 pt-4 sm:py-3.5" // Increased padding on mobile
   );
 
-  const handleContainerClick = (e: React.MouseEvent) => {
-    // Only focus if clicking directly on the container, not on buttons or other interactive elements
-    if ((e.target as HTMLElement).id === "InputBarContainer") {
-      editorService.focusEnd();
-    }
+  const handleContainerClick = () => {
+    editorService.focusEnd();
   };
 
   return (

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -62,8 +62,6 @@ const InputBarContainer = ({
   const [isExpanded, setIsExpanded] = useState(false);
   function handleExpansionToggle() {
     setIsExpanded((currentExpanded) => !currentExpanded);
-
-    // Focus at the end of the document when toggling expansion.
     editorService.focusEnd();
   }
 
@@ -78,8 +76,6 @@ const InputBarContainer = ({
     disableAutoFocus,
   });
 
-  // When input bar animation is requested it means the new button was clicked (removing focus from
-  // the input bar), we grab it back.
   const { animate } = useContext(InputBarContext);
   useEffect(() => {
     if (animate) {
@@ -99,14 +95,23 @@ const InputBarContainer = ({
 
   const contentEditableClasses = classNames(
     "inline-block w-full",
-    "border-0 px-2 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 sm:py-3.5",
-    "whitespace-pre-wrap font-normal"
+    "border-0 px-2 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
+    "whitespace-pre-wrap font-normal",
+    "pb-6 pt-4 sm:py-3.5"
   );
+
+  const handleContainerClick = (e: React.MouseEvent) => {
+    // Only focus if clicking directly on the container, not on buttons or other interactive elements
+    if ((e.target as HTMLElement).id === "InputBarContainer") {
+      editorService.focusEnd();
+    }
+  };
 
   return (
     <div
       id="InputBarContainer"
-      className="relative flex flex-1 flex-col pt-3 sm:flex-row sm:pt-0"
+      className="relative flex flex-1 cursor-text flex-col sm:flex-row sm:pt-0"
+      onClick={handleContainerClick}
     >
       <EditorContent
         editor={editor}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -103,15 +103,10 @@ const InputBarContainer = ({
     "pb-6 pt-4 sm:py-3.5" // Increased padding on mobile
   );
 
-  const handleContainerClick = () => {
-    editorService.focusEnd();
-  };
-
   return (
     <div
       id="InputBarContainer"
       className="relative flex flex-1 cursor-text flex-col sm:flex-row sm:pt-0"
-      onClick={handleContainerClick}
     >
       <EditorContent
         editor={editor}


### PR DESCRIPTION
## Description
As we want to improve quality on mobile, I've edited the input bar to make it more affordant

**Before :** 
<img width="336" alt="image" src="https://github.com/user-attachments/assets/ed573838-e693-4994-b319-de10f1e7125d" />
<img width="343" alt="image" src="https://github.com/user-attachments/assets/b5ca5de4-024d-48a1-9117-cc187668bf6a" />

After:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/b73db9fa-4876-4814-be2c-d175e03b1207" />
<img width="340" alt="image" src="https://github.com/user-attachments/assets/05b38eb5-c313-45e6-b309-e3521924fca7" />

You can try it on front-edge
Don't hesitate to give your opinion on this one!


## Tests


## Risk


## Deploy Plan
Merge PR 
Deploy Front
