### PR TITLE
[CoreNodes] Fix Google Drive parents migration script

### DIFF
--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -34,6 +34,12 @@ async function migrateNode({
   let newParents = coreNode.parents;
   let newParentId: string | null = null;
   try {
+    if (
+      coreNode.table !== null &&
+      !coreNode.node_id.startsWith("google-spreadsheet")
+    ) {
+      logger.warn("Sheet that does not start with google-spreadsheet.");
+    }
     const uniqueIds = [
       ...new Set(
         // Google Drive node IDs can start either with gdrive- (files and folders) or with google-spreadsheet (sheets).

--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -36,12 +36,14 @@ async function migrateNode({
   try {
     const uniqueIds = [
       ...new Set(
-        [coreNode.node_id, ...coreNode.parents].map((x) =>
-          x.replace("gdrive-", "")
+        [coreNode.node_id, ...coreNode.parents].map((id) =>
+          id.startsWith("google-spreadsheet") ? id : id.replace("gdrive-", "")
         )
       ),
     ];
-    newParents = uniqueIds.map((id) => `gdrive-${id}`);
+    newParents = uniqueIds.map((id) =>
+      id.startsWith("google-spreadsheet") ? id : `gdrive-${id}`
+    );
     newParentId = newParents[1] || null;
   } catch (e) {
     logger.error(

--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -99,7 +99,15 @@ async function migrateNode({
             parentId: newParentId,
           });
         } else {
-          throw new Error("Unreachable: folder with incorrect parents.");
+          logger.error(
+            {
+              nodeId: coreNode.node_id,
+              fromParents: coreNode.parents,
+              toParents: newParents,
+            },
+            "Folder with incorrect parents."
+          );
+          return;
         }
         if (updateRes.isErr()) {
           logger.error(

--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -35,7 +35,7 @@ async function migrateNode({
   let newParentId: string | null = null;
   try {
     const uniqueIds = [
-      new Set(
+      ...new Set(
         [coreNode.node_id, ...coreNode.parents].map((x) =>
           x.replace("gdrive-", "")
         )

--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -36,6 +36,7 @@ async function migrateNode({
   try {
     const uniqueIds = [
       ...new Set(
+        // Google Drive node IDs can start either with gdrive- (files and folders) or with google-spreadsheet (sheets).
         [coreNode.node_id, ...coreNode.parents].map((id) =>
           id.startsWith("google-spreadsheet") ? id : id.replace("gdrive-", "")
         )


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/dust/pull/10442 introduces a migration script that aims at fixing the parents of Google Drive nodes.
- This script does not handle node IDs of sheets correctly: these IDs start with `google-spreadsheet` and should not be prepended with a `gdrive`.

## Tests

## Risk

- Can always be fixed in a nth attempt.

## Deploy Plan

- No deploy.
