### PR TITLE
[front] - fix: set DropdownMenu modal prop to false in FoldersHeaderMenu

### DIFF
--- a/front/components/spaces/FoldersHeaderMenu.tsx
+++ b/front/components/spaces/FoldersHeaderMenu.tsx
@@ -99,7 +99,7 @@ const AddDataDropDownButton = ({
   canWriteInSpace,
 }: AddDataDropDrownButtonProps) => {
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           size="sm"


### PR DESCRIPTION
 ## Description

This PR ensure the dropdown menu is non-modal not trapping focus.

Note: a bigger refactoring will come in this PR https://github.com/dust-tt/dust/pull/10474

**References:**
- Brings back one of the changes that was reverted from https://github.com/dust-tt/dust/pull/10470

## Risk

Low

## Deploy Plan

Deploy `front`