### PR TITLE
[Nodes Core] Correctly filter by viewType in front

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -476,6 +476,7 @@ impl ElasticsearchSearchStore {
         Ok(core_content_nodes)
     }
 
+    // Always add node_id as a tie-breaker
     fn build_sort(&self, sort: Option<Vec<SortSpec>>) -> Result<Vec<Sort>> {
         let mut base_sort = match sort {
             Some(sort) => {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -30,10 +30,11 @@ import {
   getContentNodeType,
   NON_EXPANDABLE_NODES_MIME_TYPES,
 } from "@app/lib/api/content_nodes";
-import type {CursorPaginationParams, OffsetPaginationParams} from "@app/lib/api/pagination";
-import {
-  isCursorPaginationParams
+import type {
+  CursorPaginationParams,
+  OffsetPaginationParams,
 } from "@app/lib/api/pagination";
+import { isCursorPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { SPREADSHEET_MIME_TYPES } from "@app/lib/content_nodes";
 import type { DustError } from "@app/lib/error";

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -134,3 +134,14 @@ export function getOffsetPaginationParams(
 
   return new Ok(queryValidation.right);
 }
+
+export interface CursorPaginationParams {
+  limit: number;
+  cursor: string;
+}
+
+export function isCursorPaginationParams(
+  pagination: CursorPaginationParams | OffsetPaginationParams
+): pagination is CursorPaginationParams {
+  return "cursor" in pagination;
+}

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -48,18 +48,18 @@ export async function getDataSourceDocuments({
     node_types: ["Document"],
   };
 
-  const cursorRequest: CoreAPISearchCursorRequest = {
+  const options: CoreAPISearchCursorRequest = {
     limit: CORE_API_LIST_NODES_BATCH_SIZE,
   };
 
   if (pageCursor) {
-    cursorRequest.cursor = pageCursor;
+    options.cursor = pageCursor;
   }
 
   // 1) List documents for the data source.
-  const searchResults = await coreAPI.searchNodesWithCursor({
+  const searchResults = await coreAPI.searchNodes({
     filter,
-    cursor: cursorRequest,
+    options,
   });
 
   if (searchResults.isErr()) {

--- a/front/temporal/relocation/activities/source_region/core/folders.ts
+++ b/front/temporal/relocation/activities/source_region/core/folders.ts
@@ -43,18 +43,18 @@ export async function getDataSourceFolders({
     node_types: ["Folder"],
   };
 
-  const cursorRequest: CoreAPISearchCursorRequest = {
+  const options: CoreAPISearchCursorRequest = {
     limit: CORE_API_LIST_NODES_BATCH_SIZE,
   };
 
   if (pageCursor) {
-    cursorRequest.cursor = pageCursor;
+    options.cursor = pageCursor;
   }
 
   // 1) List folders for the data source.
-  const searchResults = await coreAPI.searchNodesWithCursor({
+  const searchResults = await coreAPI.searchNodes({
     filter,
-    cursor: cursorRequest,
+    options,
   });
 
   if (searchResults.isErr()) {

--- a/front/temporal/relocation/activities/source_region/core/tables.ts
+++ b/front/temporal/relocation/activities/source_region/core/tables.ts
@@ -48,18 +48,18 @@ export async function getDataSourceTables({
     node_types: ["Table"],
   };
 
-  const cursorRequest: CoreAPISearchCursorRequest = {
+  const options: CoreAPISearchCursorRequest = {
     limit: CORE_API_LIST_NODES_BATCH_SIZE,
   };
 
   if (pageCursor) {
-    cursorRequest.cursor = pageCursor;
+    options.cursor = pageCursor;
   }
 
   // 1) List tables for the data source.
-  const searchResults = await coreAPI.searchNodesWithCursor({
+  const searchResults = await coreAPI.searchNodes({
     filter,
-    cursor: cursorRequest,
+    options,
   });
 
   if (searchResults.isErr()) {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -182,7 +182,7 @@ export type CoreAPISortSpec = {
 
 export type CoreAPISearchOptions = {
   limit?: number;
-  offset?: number;
+  cursor?: string;
   sort?: CoreAPISortSpec[];
 };
 
@@ -192,7 +192,7 @@ export interface CoreAPISearchCursorRequest {
   cursor?: string;
 }
 
-export interface CoreAPISearchCursorResponse {
+export interface CoreAPISearchResponse {
   nodes: CoreAPIContentNode[];
   next_page_cursor: string | null;
 }
@@ -1612,11 +1612,7 @@ export class CoreAPI {
     query?: string;
     filter: CoreAPINodesSearchFilter;
     options?: CoreAPISearchOptions;
-  }): Promise<
-    CoreAPIResponse<{
-      nodes: CoreAPIContentNode[];
-    }>
-  > {
+  }): Promise<CoreAPIResponse<CoreAPISearchResponse>> {
     const response = await this._fetchWithError(`${this._url}/nodes/search`, {
       method: "POST",
       headers: {
@@ -1628,33 +1624,6 @@ export class CoreAPI {
         options,
       }),
     });
-    return this._resultFromResponse(response);
-  }
-
-  async searchNodesWithCursor({
-    query,
-    filter,
-    cursor,
-  }: {
-    query?: string;
-    filter: CoreAPINodesSearchFilter;
-    cursor?: CoreAPISearchCursorRequest;
-  }): Promise<CoreAPIResponse<CoreAPISearchCursorResponse>> {
-    const response = await this._fetchWithError(
-      `${this._url}/nodes/search/cursor`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          query,
-          filter,
-          cursor,
-        }),
-      }
-    );
-
     return this._resultFromResponse(response);
   }
 


### PR DESCRIPTION
## Description
Fixes #10403 

Also removes the former searchWithCursor endpoint in front (it's been removed in core, since now search is always with cursor, never with offset)

## Risk
standard

## Deploy Plan
front
