### PR TITLE
[front] - fix(csv): standardize error type for CSV parsing issues

### DIFF
--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -22,7 +22,7 @@ type GeneralWorkflowErrorType =
   | "unhandled_internal_activity_error"
   | "workflow_timeout_failure";
 
-type TablesErrorType = "invalid_headers" | "file_too_large";
+type TablesErrorType = "invalid_headers" | "file_too_large" | "invalid_csv";
 
 // Combine both general and provider-specific error types.
 type WorkflowErrorType = GeneralWorkflowErrorType | ProviderErrorType;

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -1,7 +1,4 @@
-import type {
-  DataSourceSearchQuery,
-  DataSourceSearchResponseType,
-} from "@dust-tt/client";
+import type { DataSourceSearchQuery, DataSourceSearchResponseType } from "@dust-tt/client";
 import type {
   AdminCommandType,
   ConnectorProvider,
@@ -675,7 +672,7 @@ export async function handleDataSourceTableCSVUpsert({
       code:
         | "missing_csv"
         | "data_source_error"
-        | "invalid_rows"
+        | "invalid_csv"
         | "resource_not_found"
         | "invalid_parent_id"
         | "internal_error";
@@ -710,7 +707,7 @@ export async function handleDataSourceTableCSVUpsert({
     if (csvRowsRes?.isErr()) {
       return new Err({
         name: "dust_error",
-        code: "invalid_rows",
+        code: "invalid_csv",
         message: "Failed to parse CSV: " + csvRowsRes.error.message,
       });
     }
@@ -785,7 +782,7 @@ export async function handleDataSourceTableCSVUpsert({
       if ("csvParsingError" in tableRes.error) {
         return new Err({
           name: "dust_error",
-          code: "internal_error",
+          code: "invalid_csv",
           message:
             "Failed to parse CSV: " + tableRes.error.csvParsingError.message,
         });

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -1,4 +1,7 @@
-import type { DataSourceSearchQuery, DataSourceSearchResponseType } from "@dust-tt/client";
+import type {
+  DataSourceSearchQuery,
+  DataSourceSearchResponseType,
+} from "@dust-tt/client";
 import type {
   AdminCommandType,
   ConnectorProvider,

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -376,18 +376,19 @@ export async function rowsFromCsv({
     });
   }
 
-  const headerRes = detectedHeaders
-    ? new Ok(detectedHeaders)
-    : await detectHeaders(auth, csv, delimiter, useAppForHeaderDetection);
-
-  if (headerRes.isErr()) {
-    return headerRes;
-  }
-  const { header, rowIndex } = headerRes.value;
-
   // this differs with = {} in that it prevent errors when header values clash with object properties such as toString, constructor, ..
   const valuesByCol: Record<string, string[]> = Object.create(null);
+  let header, rowIndex;
   try {
+    const headerRes = detectedHeaders
+      ? new Ok(detectedHeaders)
+      : await detectHeaders(auth, csv, delimiter, useAppForHeaderDetection);
+
+    if (headerRes.isErr()) {
+      return headerRes;
+    }
+    ({ header, rowIndex } = headerRes.value);
+
     const parser = parse(csv, { delimiter });
     let i = 0;
     for await (const anyRecord of parser) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -145,7 +145,7 @@ async function handler(
                 message: upsertRes.error.message,
               },
             });
-          case "invalid_rows":
+          case "invalid_csv":
             return apiError(req, res, {
               status_code: 400,
               api_error: {


### PR DESCRIPTION
## Description

This PR is a second attempt to handle gracefully CSV errors to return 400s instead of 500s.

## Risk

Low

## Deploy Plan

- Deploy `front`
- Deploy `connectors`