### PR TITLE
Ignoring logs for missing static ds nodes when cursor pagination enabled

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -94,6 +94,7 @@ export function computeNodesDiff({
       {
         connectorsContentNodesLength: connectorsContentNodes.length,
         coreContentNodesLength: coreContentNodes.length,
+        pagination,
       },
       "[CoreNodes] Different number of nodes returned by connectors and core"
     );

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -12,6 +12,7 @@ import type {
   CursorPaginationParams,
   OffsetPaginationParams,
 } from "@app/lib/api/pagination";
+import { isCursorPaginationParams } from "@app/lib/api/pagination";
 import {
   CHANNEL_MIME_TYPES,
   DATABASE_MIME_TYPES,
@@ -113,7 +114,12 @@ export function computeNodesDiff({
         ) {
           // Connectors return tables even when viewType is documents, core doesn't
           if (!(provider === "snowflake" && viewType === "documents")) {
-            missingNodes.push(connectorsNode);
+            // We expect missing nodes when cursor pagination is enabled
+            // Because core doesn't use the same sort as connectors
+            // See https://github.com/dust-tt/dust/issues/10515
+            if (!(pagination && isCursorPaginationParams(pagination))) {
+              missingNodes.push(connectorsNode);
+            }
           }
         }
       }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -89,6 +89,16 @@ export function computeNodesDiff({
   const missingNodes: DataSourceViewContentNode[] = [];
   const mismatchNodes: DataSourceViewContentNode[] = [];
 
+  if (connectorsContentNodes.length !== coreContentNodes.length) {
+    localLogger.info(
+      {
+        connectorsContentNodesLength: connectorsContentNodes.length,
+        coreContentNodesLength: coreContentNodes.length,
+      },
+      "[CoreNodes] Different number of nodes returned by connectors and core"
+    );
+  }
+
   connectorsContentNodes.forEach((connectorsNode) => {
     const coreNodes = coreContentNodes.filter(
       (coreNode) => coreNode.internalId === connectorsNode.internalId


### PR DESCRIPTION
## Description
Ignoring logs for missing static ds nodes when cursor pagination enabled
Fixes #10515 

## Tests
fetch a few nodes

## Risk
Low

## Deploy Plan
Deploy Front