### PR TITLE
fix(Confluence CLI) - prevent type issue on `spaceId`

### DIFF
--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -169,7 +169,7 @@ export const confluence = async ({
       } else {
         await confluenceUpdatePagesParentIdsActivity(
           args.connectorId,
-          args.spaceId,
+          args.spaceId.toString(),
           null
         );
       }

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -40,7 +40,7 @@ export const ConfluenceCommandSchema = t.type({
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
     pageId: t.union([t.number, t.undefined]),
-    spaceId: t.union([t.string, t.undefined]),
+    spaceId: t.union([t.number, t.undefined]),
     file: t.union([t.string, t.undefined]),
     keyInFile: t.union([t.string, t.undefined]),
   }),


### PR DESCRIPTION
## Description

- Very much akin to `https://github.com/dust-tt/dust/pull/9387`.
- We have a type issue due to `minimist` parsing the `spaceIds` passed in command line as numbers due to them looking like numbers.
- This PR exposes a `number` type to `minimist` and then converts it to a string in the CLI code.

## Tests

## Risk

- n/a.

## Deploy Plan

- Deploy connectors.