### PR TITLE
[CoreNodes] Fix log exclusion rules on paginated calls and `notion-unknown`

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -109,7 +109,7 @@ export function computeNodesDiff({
     );
     if (matchingCoreNodes.length === 0) {
       if (
-        // Connector's notion-unknown folder can map to core's syncing OR unknown folder,
+        // Connectors' notion-unknown folder can map to core's syncing OR unknown folder,
         // it is expected that connectors can return `notion-unknown` while core returns `notion-syncing` instead.
         // See https://github.com/dust-tt/dust/issues/10340
         (connectorsNode.internalId !== "notion-unknown" ||

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -100,7 +100,7 @@ export function computeNodesDiff({
       },
       "[CoreNodes] Different number of nodes returned by connectors and core"
     );
-    return;
+    return [];
   }
 
   connectorsContentNodes.forEach((connectorsNode) => {

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -89,7 +89,11 @@ export function computeNodesDiff({
   const missingNodes: DataSourceViewContentNode[] = [];
   const mismatchNodes: DataSourceViewContentNode[] = [];
 
-  if (connectorsContentNodes.length !== coreContentNodes.length) {
+  if (
+    pagination &&
+    isCursorPaginationParams(pagination) &&
+    connectorsContentNodes.length !== coreContentNodes.length
+  ) {
     localLogger.info(
       {
         connectorsContentNodesLength: connectorsContentNodes.length,
@@ -125,12 +129,7 @@ export function computeNodesDiff({
         ) {
           // Connectors return tables even when viewType is documents, core doesn't
           if (!(provider === "snowflake" && viewType === "documents")) {
-            // We expect missing nodes when cursor pagination is enabled
-            // Because core doesn't use the same sort as connectors
-            // See https://github.com/dust-tt/dust/issues/10515
-            if (!(pagination && isCursorPaginationParams(pagination))) {
-              missingNodes.push(connectorsNode);
-            }
+            missingNodes.push(connectorsNode);
           }
         }
       }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -108,29 +108,25 @@ export function computeNodesDiff({
       (coreNode) => coreNode.internalId === connectorsNode.internalId
     );
     if (coreNodes.length === 0) {
-      // Connector's notion unknown folder can map to core's syncing OR unknown folder.
-      // See https://github.com/dust-tt/dust/issues/10340
-      // Ignore slack channels missing in core - see https://github.com/dust-tt/dust/issues/10338
       if (
+        // Connector's notion-unknown folder can map to core's syncing OR unknown folder.
+        // See https://github.com/dust-tt/dust/issues/10340
         connectorsNode.internalId !== "notion-unknown" &&
-        !connectorsNode.internalId.startsWith("slack-channel-")
-      ) {
-        if (
-          // For snowflake we ignore the missing nodes if we returned a node that is a parent.
-          // This is because connectors returns all children tables when fed with internalIds while core returns only these ids
-          // See https://github.com/dust-tt/dust/issues/10400
-          !(
-            provider === "snowflake" &&
-            coreContentNodes.some((n) =>
-              connectorsNode.internalId.startsWith(n.internalId)
-            )
+        // Ignore Slack channels missing in core - see https://github.com/dust-tt/dust/issues/10338
+        !connectorsNode.internalId.startsWith("slack-channel-") &&
+        // For Snowflake we ignore the missing nodes if we returned a node that is a parent.
+        // This is because connectors returns all children tables when fed with internalIds while core returns only these ids
+        // See https://github.com/dust-tt/dust/issues/10400
+        !(
+          provider === "snowflake" &&
+          coreContentNodes.some((n) =>
+            connectorsNode.internalId.startsWith(n.internalId)
           )
-        ) {
-          // Connectors return tables even when viewType is documents, core doesn't
-          if (!(provider === "snowflake" && viewType === "documents")) {
-            missingNodes.push(connectorsNode);
-          }
-        }
+        ) &&
+        // Connectors return tables even when viewType is documents, core doesn't
+        !(provider === "snowflake" && viewType === "documents")
+      ) {
+        missingNodes.push(connectorsNode);
       }
     } else if (coreNodes.length > 1) {
       // this one should never ever happen, it's a real red flag

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -109,9 +109,13 @@ export function computeNodesDiff({
     );
     if (matchingCoreNodes.length === 0) {
       if (
-        // Connector's notion-unknown folder can map to core's syncing OR unknown folder.
+        // Connector's notion-unknown folder can map to core's syncing OR unknown folder,
+        // it is expected that connectors can return `notion-unknown` while core returns `notion-syncing` instead.
         // See https://github.com/dust-tt/dust/issues/10340
-        connectorsNode.internalId !== "notion-unknown" &&
+        (connectorsNode.internalId !== "notion-unknown" ||
+          !coreContentNodes
+            .map((n) => n.internalId)
+            .includes("notion-syncing")) &&
         // Ignore Slack channels missing in core - see https://github.com/dust-tt/dust/issues/10338
         !connectorsNode.internalId.startsWith("slack-channel-") &&
         // For Snowflake we ignore the missing nodes if we returned a node that is a parent.


### PR DESCRIPTION
## Description

- This PR fixes the exclusion rules on the logged diff between content nodes fetches from core and from connectors.
- The exclusion rule on a `notion-unknown` missing from core was also off, the exact rule is that if we expect having a `notion-unknown` missing and getting a `notion-syncing` instead.
- For paginated calls, the node-wise diff is ignored, only the number of nodes is tracked.
- This PR also renames `coreNode(s)` into `matchingCoreNode(s)` for readability.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.