### PR TITLE
[CoreNodes] Remove the exclusion rule on title mismatches

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -153,15 +153,6 @@ export function computeNodesDiff({
             }
             // Custom exclusion rules. The goal here is to avoid logging irrelevant differences, scoping by connector.
 
-            // Titles: until ES backfill, there is a split issue on ":" that we fixed and can ignore, see https://github.com/dust-tt/dust/issues/10281
-            if (key === "title") {
-              if (
-                connectorsNode.title.split(":")[0] === matchingCoreNode.title
-              ) {
-                return false;
-              }
-            }
-
             // For Snowflake and Zendesk we fixed how parents were computed in the core folders but not in connectors.
             // For Intercom we keep the virtual node Help Center in connectors but not in core.
             if (


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10281.
- This PR removes the exclusion rule on title mismatches.
- This rule was added because a backfill on the titles was performed in https://github.com/dust-tt/dust/pull/10487, and was only on the postgres database and did not update the ES index. 

## Tests

## Risk

- Low (shadow-read only).

## Deploy Plan

- Deploy front.