### PR TITLE
[CoreNodes] Fix view type filtering in `front`

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -15,7 +15,6 @@ import {
   Err,
   isDevelopment,
   isDustWorkspace,
-  MIME_TYPES,
   Ok,
   removeNulls,
 } from "@dust-tt/types";
@@ -189,13 +188,13 @@ function filterNodesByViewType(
       return nodes.filter(
         (node) =>
           node.children_count > 0 ||
-          node.node_type !== "Table" ||
-          // TODO(nodes-core): replace this with either an "all" viewType or a DEFAULT_VIEWTYPE_BY_CONNECTOR_PROVIDER
-          node.mime_type === MIME_TYPES.SNOWFLAKE.TABLE
+          ["Folder", "Document"].includes(node.node_type)
       );
     case "tables":
       return nodes.filter(
-        (node) => node.children_count > 0 || node.node_type === "Table"
+        (node) =>
+          node.children_count > 0 ||
+          ["Folder", "Table"].includes(node.node_type)
       );
     default:
       assertNever(viewType);


### PR DESCRIPTION
## Description

- Fix `viewType` filtering in `front` following changes in https://github.com/dust-tt/dust/pull/10506.
- This PR removes Snowflake-specific rule to check that the pagination works as expected (harder to test after the switch).

## Tests

## Risk

- Low (shadow-read).

## Deploy Plan

- Deploy front.