### PR TITLE
[CoreNodes] Add exclusion rule for Notion database nodes

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -441,6 +441,17 @@ export function computeNodesDiff({
             n.internalId.startsWith(coreNode.internalId)
           )
         )
+    )
+    // The documents upserted for Notion databases are children of the table node and are not returned by connectors.
+    // core's behavior is considered to be an improvement, as it allows selecting the document alone without the table and its children pages.
+    .filter(
+      (coreNode) =>
+        !(
+          provider === "notion" &&
+          coreNode.internalId.startsWith("notion-database-") &&
+          coreNode.parentInternalId?.replace("notion-", "") ===
+            coreNode.internalId.replace("notion-database-", "")
+        )
     );
   if (extraCoreNodes.length > 0) {
     localLogger.info(


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2076 (does not handle all logs).
- This PR excludes from the diff extra core nodes coming from the fact that connectors does not return a node for the document of a Notion database (as a child of the table node for the same database, the document has an ID that starts in `notion-database-`).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.