### PR TITLE
[Tables API] Fix requirement of mimeType

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -120,7 +120,7 @@ import { apiError } from "@app/logger/withlogging";
  *                 description: 'Reserved for internal use, should not be set. ID of the direct parent to associate with the table'
  *               mime_type:
  *                 type: string
- *                 description: Mime type of the table
+ *                 description: INTERNAL: Mime type of the table. Should not be set.
  *     responses:
  *       200:
  *         description: The table

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2278,7 +2278,7 @@ export const UpsertDatabaseTableRequestSchema = z.object({
   remote_database_table_id: z.string().nullable().optional(),
   remote_database_secret_id: z.string().nullable().optional(),
   title: z.string(),
-  mime_type: z.string(),
+  mime_type: z.string().nullable().optional(),
   source_url: z.string().nullable().optional(),
 });
 


### PR DESCRIPTION
Description
---
Closes https://github.com/dust-tt/tasks/issues/2097

Mimetype was both required by type system, and forbidden by our API, because

The logic decided by former issue #8758 and PR #9877 , to allow a user mimetype and validate it, was not respected.

Given the nature of the table endpoint, it's better that we
- keep the decision of a required mimetype from system key;
- keep setting us ourselves when it's a user--as such preventing the user from setting the mimetype.

This PR does this, by letting the field optional in types.

Risk
---
standard

Deploy
---
front
