### PR TITLE
Add validation on parents on `api/v1` endpoints that update parents

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
@@ -163,6 +163,39 @@ async function handler(
           },
         });
       }
+
+      // Enforce parents consistency: parents[0] === documentId, parents[1] === parentId (or there is no parents[1] and parentId is null).
+      if (req.body.parents.length === 0) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid parents: parents must have at least one element.`,
+          },
+        });
+      }
+      if (req.body.parents[0] !== req.query.documentId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid parents: parents[0] should be equal to document_id.`,
+          },
+        });
+      }
+      if (
+        (req.body.parents.length >= 2 || req.body.parent_id !== null) &&
+        req.body.parents[1] !== req.body.parent_id
+      ) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid parent id: parents[1] and parent_id should be equal.`,
+          },
+        });
+      }
+
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const updateRes = await coreAPI.updateDataSourceDocumentParents({
         projectId: dataSource.dustAPIProjectId,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
@@ -102,6 +102,38 @@ async function handler(
 
       const { parents, parent_id: parentId } = r.data;
 
+      // Enforce parents consistency: parents[0] === documentId, parents[1] === parentId (or there is no parents[1] and parentId is null).
+      if (parents.length === 0) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid parents: parents must have at least one element.`,
+          },
+        });
+      }
+      if (parents[0] !== tId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid parents: parents[0] should be equal to table_id.`,
+          },
+        });
+      }
+      if (
+        (parents.length >= 2 || parentId !== null) &&
+        parents[1] !== parentId
+      ) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid parent id: parents[1] and parent_id should be equal.`,
+          },
+        });
+      }
+
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const updateRes = await coreAPI.updateTableParents({
         projectId: dataSource.dustAPIProjectId,


### PR DESCRIPTION
## Description

- This PR adds the exact same validation rules on parents (`parents[0] === documentId`, `parents[1] === parentId`) in the endpoints `api/v1/.../parents` than in the endpoints for document/table upserts.
- We really don't want there to be a way to have incorrect parents in `core`.
- The endpoint `/api/v1/.../tables/[tId]/parents` is undocumented.
- We expect the endpoint `/api/v1/.../documents/[documentId]/parents` to not be used: there was ~no user who passed parents in document upserts and passing parents does not do anything as of now (therefore there is no use in updating them).
- Could cause unhandled activity errors in connectors if parents are not passed correctly, will monitor closely and fix the connectors if applicable.

## Tests

## Risk

- Could cause unhandled activity errors in connectors if the validation logic is incorrect, will monitor closely and fix the rule if applicable.

## Deploy Plan

- Deploy front.