### PR TITLE
enh(Confluence) - Keep space names up to date

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -232,6 +232,9 @@ export async function confluenceUpsertSpaceFolderActivity({
     mimeType: MIME_TYPES.CONFLUENCE.SPACE,
     sourceUrl: spaceInDb?.urlSuffix && `${baseUrl}/wiki${spaceInDb.urlSuffix}`,
   });
+
+  // Update the space name in db.
+  await spaceInDb?.update({ name: spaceName });
 }
 
 export async function markPageHasVisited({

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -234,7 +234,9 @@ export async function confluenceUpsertSpaceFolderActivity({
   });
 
   // Update the space name in db.
-  await spaceInDb?.update({ name: spaceName });
+  if (spaceInDb && spaceInDb.name != spaceName) {
+    await spaceInDb.update({ name: spaceName });
+  }
 }
 
 export async function markPageHasVisited({


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10525.
- Currently, folder for the Spaces are reupserted in `data_sources_folders` on every cron schedule. As a result, `core` keeps the name up-to-date.
- `connectors`' table `confluence_spaces` does not update the name of the space unless it is selected in the UI.
- This PR aims at updating the data in `connectors`' db whenever it is updated in `core`.
- No backfill will be performed, the plan is to wait for the sync to kick in (every 2 hours).

## Tests

- Tested locally, confirming the former behavior and the new one.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.