### PR TITLE
fix(doc tracker): prevent errors on unfiltered maintained scope ds

### DIFF
--- a/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_retrieval.ts
+++ b/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_retrieval.ts
@@ -54,9 +54,12 @@ export async function callDocTrackerRetrievalAction(
     workspace_id: ownerWorkspace.sId,
     data_source_id: view.dataSourceViewId,
   }));
-  config.SEMANTIC_SEARCH.filter.parents = {
-    in_map: parentsInMap,
-  };
+
+  if (Object.keys(parentsInMap).length > 0) {
+    config.SEMANTIC_SEARCH.filter.parents = {
+      in_map: parentsInMap,
+    };
+  }
 
   config.SEMANTIC_SEARCH.target_document_tokens = targetDocumentTokens;
   config.SEMANTIC_SEARCH.top_k = topK;

--- a/front/temporal/tracker/activities.ts
+++ b/front/temporal/tracker/activities.ts
@@ -237,12 +237,15 @@ export async function trackersGenerationActivity(
       (x) => x.dustAPIDataSourceId
     );
 
-    const parentsInMap = _.mapValues(
-      _.keyBy(
-        maintainedScope,
-        (x) => maintainedDsCoreIdByDataSourceId[x.dataSourceId]
+    const parentsInMap = _.pickBy(
+      _.mapValues(
+        _.keyBy(
+          maintainedScope,
+          (x) => maintainedDsCoreIdByDataSourceId[x.dataSourceId]
+        ),
+        (x) => x.filter?.parents?.in ?? null
       ),
-      (x) => x.filter?.parents?.in ?? null
+      (x) => x !== null
     );
 
     // We retrieve content from the maintained scope based on the diff.


### PR DESCRIPTION
## Description

Fully including a datasource in the maintained scope of a tracker is producing errors, as `core` does not accept a `null` value in `parents_in_map`.

This solves the problem by not including the entry in such cases

## Tests

N/A

## Risk

N/A


## Deploy Plan

Deploy front