### PR TITLE
Improve Google Drive backfill script

### DIFF
--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -198,8 +198,6 @@ async function migrateDataSource({
       }
     )) as Node[];
 
-    logger.info({ nextId, rowCount: rows.length }, "BATCH");
-
     if (rows.length === 0) {
       break;
     }

--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -15,6 +15,7 @@ const NODE_CONCURRENCY = 16;
 
 interface Node {
   parents: string[];
+  data_source: number;
   node_id: string;
   source_url: string;
   timestamp: number;
@@ -78,14 +79,7 @@ async function migrateNode({
     newParents.every((x, i) => x === coreNode.parents[i]) &&
     coreNode.parents.every((x, i) => x === newParents[i])
   ) {
-    logger.info(
-      {
-        documentId: coreNode.node_id,
-        fromParents: coreNode.parents,
-        toParents: newParents,
-      },
-      `SKIP document (parents are already correct)`
-    );
+    localLogger.info(`SKIP document (parents are already correct)`);
     return new Ok(undefined);
   }
 
@@ -124,38 +118,15 @@ async function migrateNode({
           });
         }
         if (updateRes.isErr()) {
-          logger.error(
-            {
-              nodeId: coreNode.node_id,
-              fromParents: coreNode.parents,
-              toParents: newParents,
-              toParentId: newParentId,
-            },
-            `Error while updating parents`
-          );
+          localLogger.error(`Error while updating parents`);
           throw new Error(updateRes.error.message);
         }
       },
       { retries: 10 }
     )({});
-
-    logger.info(
-      {
-        nodeId: coreNode.node_id,
-        fromParents: coreNode.parents,
-        toParents: newParents,
-      },
-      `LIVE`
-    );
+    localLogger.info(`LIVE`);
   } else {
-    logger.info(
-      {
-        nodeId: coreNode.node_id,
-        fromParents: coreNode.parents,
-        toParents: newParents,
-      },
-      `DRY`
-    );
+    localLogger.info(`DRY`);
   }
 
   return new Ok(undefined);

--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -118,7 +118,7 @@ async function migrateNode({
           throw new Error(updateRes.error.message);
         }
       },
-      { retries: 10 }
+      { retries: 3 }
     )({});
     localLogger.info(`LIVE`);
   } else {

--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -183,6 +183,7 @@ async function migrateDataSource({
            SELECT 1
            FROM UNNEST(parents) p
            WHERE p NOT LIKE 'gdrive-%'
+             AND p NOT LIKE 'google-spreadsheet-%'
        )
        ORDER BY node_id
        LIMIT :batchSize`,

--- a/front/migrations/20250131_fix_google_drive_parents.ts
+++ b/front/migrations/20250131_fix_google_drive_parents.ts
@@ -79,6 +79,11 @@ async function migrateNode({
     return new Ok(undefined);
   }
 
+  if (coreNode.node_id != newParents[0]) {
+    localLogger.error("Invalid node_id");
+    return;
+  }
+
   if (execute) {
     await withRetries(
       async () => {


### PR DESCRIPTION
## Description

- The backfill script fixed in https://github.com/dust-tt/dust/pull/10548 failed due to the fact that some nodes have an incorrect node_id (not starting with `gdrive-`) with the error that `parents[0]` has to be equal to the `node_id`.
- This PR also logs the `data_source` to help debugging these nodes in the future.
- It also lowers the number of retries from 10 to 3 (no reason to go to 10 really) and optimizes the initial select by ignoring spreadsheets that are ok.

## Tests

## Risk

- n/a

## Deploy Plan

- No deploy.