### PR TITLE
Implement the "all" `viewType`

### DIFF
--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -1,9 +1,9 @@
-import type { ContentNode } from "@dust-tt/types";
 import type {
   ConnectorPermission,
+  ContentNode,
   WithConnectorsAPIErrorReponse,
 } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+import { assertNever, isValidContentNodesViewType } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
 import { getConnectorManager } from "@connectors/connectors";
@@ -54,13 +54,13 @@ const _getConnectorPermissions = async (
   if (
     !viewType ||
     typeof viewType !== "string" ||
-    (viewType !== "tables" && viewType !== "documents")
+    !isValidContentNodesViewType(viewType)
   ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid viewType. Required: tables | documents",
+        message: "Invalid viewType. Required: tables | documents | all",
       },
     });
   }

--- a/connectors/src/api/get_content_nodes.ts
+++ b/connectors/src/api/get_content_nodes.ts
@@ -20,7 +20,11 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 const GetContentNodesRequestBodySchema = t.type({
   includeParents: t.union([t.boolean, t.undefined]),
   internalIds: t.array(t.string),
-  viewType: t.union([t.literal("tables"), t.literal("documents")]),
+  viewType: t.union([
+    t.literal("tables"),
+    t.literal("documents"),
+    t.literal("all"),
+  ]),
 });
 type GetContentNodesRequestBody = t.TypeOf<
   typeof GetContentNodesRequestBodySchema

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -84,7 +84,7 @@ const getUseResourceHook =
       filterPermission: null,
       owner,
       parentId,
-      viewType: "documents",
+      viewType: "all",
     });
 
 export async function handleUpdatePermissions(
@@ -601,7 +601,7 @@ export function ConnectorPermissionsModal({
       filterPermission: "read",
       owner,
       parentId: null,
-      viewType: "documents",
+      viewType: "all",
       includeParents: true,
       disabled: !canUpdatePermissions,
     });

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -86,8 +86,10 @@ export function DataSourceViewPermissionTree({
       emptyComponent={
         viewType === "tables" ? (
           <Tree.Empty label="No tables" />
-        ) : (
+        ) : viewType === "documents" ? (
           <Tree.Empty label="No documents" />
+        ) : (
+          <Tree.Empty label="No data" />
         )
       }
     />

--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -494,7 +494,7 @@ function DataSourceViewSelectedNodes({
               setDataSourceViewToDisplay(dataSourceView);
               setDocumentToDisplay(documentId);
             }}
-            viewType="documents"
+            viewType="all"
           />
         </Tree.Item>
       ))}

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -5,6 +5,7 @@ import type {
   SpaceType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import type { SetStateAction } from "react";
 import { useCallback, useContext, useMemo, useState } from "react";
 
@@ -58,15 +59,22 @@ export default function AssistantBuilderDataSourceModal({
     [setSelectionConfigurations]
   );
 
-  const supportedDataSourceViewsForViewType = useMemo(
-    () =>
-      viewType === "documents"
-        ? dataSourceViews.filter((dsv) => supportsDocumentsData(dsv.dataSource))
-        : dataSourceViews.filter((dsv) =>
-            supportsStructuredData(dsv.dataSource)
-          ),
-    [dataSourceViews, viewType]
-  );
+  const supportedDataSourceViewsForViewType = useMemo(() => {
+    switch (viewType) {
+      case "all":
+        return dataSourceViews;
+      case "tables":
+        return dataSourceViews.filter((dsv) =>
+          supportsStructuredData(dsv.dataSource)
+        );
+      case "documents":
+        return dataSourceViews.filter((dsv) =>
+          supportsDocumentsData(dsv.dataSource)
+        );
+      default:
+        assertNever(viewType);
+    }
+  }, [dataSourceViews, viewType]);
 
   return (
     <Modal

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -27,7 +27,7 @@ const getUseResourceHook =
       filterPermission: "write",
       owner,
       parentId,
-      viewType: "documents",
+      viewType: "all",
     });
 
 interface SlackIntegrationProps {

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -169,14 +169,14 @@ function SpaceBreadCrumbs({
     owner,
     dataSourceView: parentId ? dataSourceView : undefined,
     internalIds: parentId ? [parentId] : [],
-    viewType: "documents",
+    viewType: "all",
   });
 
   const { nodes: folders } = useDataSourceViewContentNodes({
     dataSourceView: currentFolder ? dataSourceView : undefined,
     internalIds: currentFolder?.parentInternalIds ?? [],
     owner,
-    viewType: "documents",
+    viewType: "all",
   });
 
   const items = useMemo(() => {

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -85,7 +85,7 @@ export default function SpaceManagedDataSourcesViewsModal({
   const initialConfigurations = useMultipleDataSourceViewsContentNodes({
     dataSourceViewsAndInternalIds,
     owner,
-    viewType: "documents",
+    viewType: "all",
   });
   const [selectionConfigurations, setSelectionConfigurations] =
     useState<DataSourceViewSelectionConfigurations>({});

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -455,7 +455,7 @@ const SpaceDataSourceViewItem = ({
     dataSourceView: item,
     owner,
     parentId: node?.internalId,
-    viewType: "documents",
+    viewType: "all",
     disabled: !isExpanded,
     swrOptions: {
       revalidateOnFocus: false,
@@ -471,7 +471,7 @@ const SpaceDataSourceViewItem = ({
     dataSourceView: item,
     owner,
     internalIds: [router.query.parentId as string],
-    viewType: "documents",
+    viewType: "all",
     disabled: !router.asPath.startsWith(basePath) || !router.query.parentId,
   });
 

--- a/front/components/trackers/TrackerBuilderDataSourceModal.tsx
+++ b/front/components/trackers/TrackerBuilderDataSourceModal.tsx
@@ -15,6 +15,7 @@ import type {
   SpaceType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import type { SetStateAction } from "react";
 import { useCallback, useMemo, useState } from "react";
 
@@ -55,15 +56,22 @@ export default function TrackerBuilderDataSourceModal({
     [setSelectionConfigurations]
   );
 
-  const supportedDataSourceViewsForViewType = useMemo(
-    () =>
-      viewType === "documents"
-        ? dataSourceViews.filter((dsv) => supportsDocumentsData(dsv.dataSource))
-        : dataSourceViews.filter((dsv) =>
-            supportsStructuredData(dsv.dataSource)
-          ),
-    [dataSourceViews, viewType]
-  );
+  const supportedDataSourceViewsForViewType = useMemo(() => {
+    switch (viewType) {
+      case "all":
+        return dataSourceViews;
+      case "tables":
+        return dataSourceViews.filter((dsv) =>
+          supportsStructuredData(dsv.dataSource)
+        );
+      case "documents":
+        return dataSourceViews.filter((dsv) =>
+          supportsDocumentsData(dsv.dataSource)
+        );
+      default:
+        assertNever(viewType);
+    }
+  }, [dataSourceViews, viewType]);
 
   return (
     <Sheet>

--- a/front/components/trackers/TrackerDataSourceSelectedTree.tsx
+++ b/front/components/trackers/TrackerDataSourceSelectedTree.tsx
@@ -76,7 +76,7 @@ export const TrackerDataSourceSelectedTree = ({
                     setDataSourceViewToDisplay(dsConfig.dataSourceView);
                     setDocumentToDisplay(documentId);
                   }}
-                  viewType={"documents"}
+                  viewType={"all"}
                 />
               )}
               {dsConfig.selectedResources.map((node) => {
@@ -135,7 +135,7 @@ export const TrackerDataSourceSelectedTree = ({
                         setDataSourceViewToDisplay(dsConfig.dataSourceView);
                         setDocumentToDisplay(documentId);
                       }}
-                      viewType={"documents"}
+                      viewType={"all"}
                     />
                   </Tree.Item>
                 );

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -1,6 +1,5 @@
 import type {
   ConnectorProvider,
-  ContentNodesViewType,
   ContentNodeType,
   CoreAPIContentNode,
   DataSourceViewContentNode,
@@ -75,14 +74,12 @@ export function computeNodesDiff({
   coreContentNodes,
   pagination,
   provider,
-  viewType,
   localLogger,
 }: {
   connectorsContentNodes: DataSourceViewContentNode[];
   coreContentNodes: DataSourceViewContentNode[];
   provider: ConnectorProvider | null;
   pagination: OffsetPaginationParams | CursorPaginationParams | undefined;
-  viewType: ContentNodesViewType;
   localLogger: typeof logger;
 }) {
   const missingNodes: DataSourceViewContentNode[] = [];
@@ -128,9 +125,7 @@ export function computeNodesDiff({
           coreContentNodes.some((n) =>
             connectorsNode.internalId.startsWith(n.internalId)
           )
-        ) &&
-        // Connectors return tables even when viewType is documents, core doesn't
-        !(provider === "snowflake" && viewType === "documents")
+        )
       ) {
         missingNodes.push(connectorsNode);
       }

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -200,6 +200,8 @@ function filterNodesByViewType(
           node.children_count > 0 ||
           ["Folder", "Table"].includes(node.node_type)
       );
+    case "all":
+      return nodes;
     default:
       assertNever(viewType);
   }
@@ -525,7 +527,6 @@ export async function getContentNodesForDataSourceView(
       coreContentNodes: coreContentNodesRes.value.nodes,
       provider: dataSourceView.dataSource.connectorProvider,
       pagination: params.pagination,
-      viewType: params.viewType,
       localLogger,
     });
 

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -356,7 +356,7 @@ async function getContentNodesForStaticDataSourceView(
     });
   }
 
-  if (viewType === "documents") {
+  if (viewType === "documents" || viewType === "all") {
     if (isCursorPaginationParams(paginationParams)) {
       throw new Error(
         "Cursor pagination is not supported for static data sources. Note: this code path should be deleted at the end of the project nodes core (2025-02-03)."

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -15,7 +15,6 @@ import {
   Err,
   isDevelopment,
   isDustWorkspace,
-  MIME_TYPES,
   Ok,
   removeNulls,
 } from "@dust-tt/types";
@@ -190,9 +189,7 @@ function filterNodesByViewType(
       return nodes.filter(
         (node) =>
           node.children_count > 0 ||
-          ["Folder", "Document"].includes(node.node_type) ||
-          node.mime_type === MIME_TYPES.BIGQUERY.TABLE ||
-          node.mime_type === MIME_TYPES.SNOWFLAKE.TABLE
+          ["Folder", "Document"].includes(node.node_type)
       );
     case "tables":
       return nodes.filter(

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -297,8 +297,11 @@ async function getContentNodesForDataSourceViewFromCore(
   const expandable = (node: CoreAPIContentNode) =>
     !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
     node.children_count > 0 &&
-    // if we aren't in tables view, spreadsheets are not expandable
-    !(viewType !== "tables" && SPREADSHEET_MIME_TYPES.includes(node.mime_type));
+    // if we aren't in tables/all view, spreadsheets are not expandable
+    !(
+      !["tables", "all"].includes(viewType) &&
+      SPREADSHEET_MIME_TYPES.includes(node.mime_type)
+    );
 
   return new Ok({
     nodes: resultNodes.map((node) => {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -5,7 +5,11 @@ import type {
   DataSourceType,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
-import { assertNever, ConnectorsAPI } from "@dust-tt/types";
+import {
+  assertNever,
+  ConnectorsAPI,
+  isValidContentNodesViewType,
+} from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -249,13 +253,13 @@ export async function getManagedDataSourcePermissionsHandler(
   if (
     !viewType ||
     typeof viewType !== "string" ||
-    (viewType !== "tables" && viewType !== "documents")
+    !isValidContentNodesViewType(viewType)
   ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid viewType. Required: tables | documents",
+        message: "Invalid viewType. Required: tables | documents | all",
       },
     });
   }

--- a/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
@@ -91,7 +91,7 @@ export default function DataSourceViewPage({
             )}
             setSelectionConfigurations={() => {}}
             useContentNodes={useContentNodes}
-            viewType="documents"
+            viewType="all"
             isRootSelectable={true}
           />
         </div>

--- a/types/src/connectors/content_nodes.ts
+++ b/types/src/connectors/content_nodes.ts
@@ -1,10 +1,12 @@
 import * as t from "io-ts";
 
-// When viewing ContentNodes for a connector, we have 2 view types: tables and documents.
-// "tables" view is only useful for Notion and Google Drive connectors in "read" permissions mode.
-// It allows to pick tables in the Assistant Builder.
-// "documents" view is useful for all connectors and all permissions modes (allows to pick documents in the Assistant Builder
-// and view the permission tree).
+// When viewing ContentNodes, we have 3 view types: "tables", "documents" and "all".
+// - The "tables" view allows picking tables in the Extract and TableQuery tools,
+// which applies to Notion, Google Drive, Microsoft, Snowflake and BigQuery connectors.
+// - The "documents" view allows picking documents in the Search tool,
+// which is useful for all connectors except Snowflake and BigQuery.
+// - The "all" view shows all nodes, which is used in the Knowledge tab for displaying content node trees.
+// More precisely, the "tables" (resp. "documents") view hides leaves that are documents (resp. tables).
 
 // Define a codec for ContentNodesViewType using io-ts.
 export const ContentNodesViewTypeCodec = t.union([

--- a/types/src/connectors/content_nodes.ts
+++ b/types/src/connectors/content_nodes.ts
@@ -10,6 +10,7 @@ import * as t from "io-ts";
 export const ContentNodesViewTypeCodec = t.union([
   t.literal("tables"),
   t.literal("documents"),
+  t.literal("all"),
 ]);
 
 export type ContentNodesViewType = t.TypeOf<typeof ContentNodesViewTypeCodec>;
@@ -17,5 +18,5 @@ export type ContentNodesViewType = t.TypeOf<typeof ContentNodesViewTypeCodec>;
 export function isValidContentNodesViewType(
   value: unknown
 ): value is ContentNodesViewType {
-  return value === "documents" || value === "tables";
+  return value === "documents" || value === "tables" || value === "all";
 }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2070.
- This PR implements the "all" `viewType` in an effort to rationalize how content nodes are filtered.
- The filtering on `viewType` happens in front, we call `core` again if we are missing nodes.
- Nothing to change in connectors: the only case where the `viewType` is actually checked compare it to "tables.

## Tests

- Tested locally with nodes from core and from connectors (disabled the `isDevelopment() || isDustWorkspace(workspace)`).

## Risk

- Could incorrectly hide or show nodes in content node trees.

## Deploy Plan

- Deploy front.