### PR TITLE
[CoreNodes] Add log on Notion page without a parent

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -173,6 +173,13 @@ export async function updateAllParentsFields(
         );
 
         const parents = pageOrDbIds.map((id) => `notion-${id}`);
+        if (parents.length === 1) {
+          const page = await getNotionPageFromConnectorsDb(connectorId, pageId);
+          logger.warn(
+            { parents, parentType: page?.parentType, parentId: page?.parentId },
+            "notionUpdateAllParentsFields: Page has no parent."
+          );
+        }
 
         logger.info(
           {

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2005,6 +2005,12 @@ export async function renderAndUpsertPageFromCache({
     );
 
     const parentIds = parentPageOrDbIds.map((id) => `notion-${id}`);
+    if (parentIds.length === 1) {
+      localLogger.warn(
+        { parentIds },
+        "notionRenderAndUpsertPageFromCache: Page has no parent."
+      );
+    }
 
     const content = await renderDocumentTitleAndContent({
       dataSourceConfig: dsConfig,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2006,8 +2006,9 @@ export async function renderAndUpsertPageFromCache({
 
     const parentIds = parentPageOrDbIds.map((id) => `notion-${id}`);
     if (parentIds.length === 1) {
+      const page = await getNotionPageFromConnectorsDb(connectorId, pageId);
       localLogger.warn(
-        { parentIds },
+        { parentIds, parentType: page?.parentType, parentId: page?.parentId },
         "notionRenderAndUpsertPageFromCache: Page has no parent."
       );
     }


### PR DESCRIPTION
## Description

- This PR adds a log when upserting or updating parents on a page without a parent (`parents = [pageId]`).
- This log will help tracking why certain nodes appear at the root.

## Tests

## Risk

- n/a

## Deploy Plan

- Deploy connectors.