### PR TITLE
Upsert with file: use upsert queue bucket

### DIFF
--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -25,10 +25,7 @@ import { analyzeCSVColumns } from "@app/lib/api/csv";
 import { parseUploadRequest } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
-import type {
-  FileResource,
-  FileVersion,
-} from "@app/lib/resources/file_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 
 const UPLOAD_DELAY_AFTER_CREATION_MS = 1000 * 60 * 1; // 1 minute.

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -25,7 +25,10 @@ import { analyzeCSVColumns } from "@app/lib/api/csv";
 import { parseUploadRequest } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import type {
+  FileResource,
+  FileVersion,
+} from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 
 const UPLOAD_DELAY_AFTER_CREATION_MS = 1000 * 60 * 1; // 1 minute.
@@ -126,7 +129,10 @@ const extractTextFromFileAndUpload: ProcessingFunction = async (
         `Cannot extract text from this file type ${file.contentType}. Action: check than caller filters out unsupported file types.`
       );
     }
-    const readStream = file.getReadStream({ auth, version: "original" });
+    const readStream = file.getReadStream({
+      auth,
+      version: "original",
+    });
     const writeStream = file.getWriteStream({ auth, version: "processed" });
 
     const processedStream = await new TextExtraction(

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -309,10 +309,14 @@ const getProcessingFunction = ({
   }
 
   if (isSupportedDelimitedTextContentType(contentType)) {
-    if (useCase === "conversation" || useCase === "folder_table") {
+    if (useCase === "conversation") {
       // TODO(JIT): after JIT enablement, store raw text here too, the snippet is useless
       return extractContentAndSchemaFromDelimitedTextFiles;
-    } else if (useCase === "folder_document" || useCase === "tool_output") {
+    } else if (
+      useCase === "folder_document" ||
+      useCase === "tool_output" ||
+      useCase === "folder_table"
+    ) {
       return storeRawText;
     }
     return undefined;

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -398,13 +398,11 @@ async function getFileContent(
   // Create a stream to hold the content of the file
   const writableStream = new MemoryWritable();
 
-  let version: FileVersion = "processed";
-  if (["folder_table", "folder_document"].includes(file.useCase)) {
-    version = "upsert_queue";
-  }
-
   // Read from the processed file
-  await pipeline(file.getReadStream({ auth, version }), writableStream);
+  await pipeline(
+    file.getReadStream({ auth, version: "processed" }),
+    writableStream
+  );
 
   const content = writableStream.getContent();
 

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -29,10 +29,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import type {
-  FileResource,
-  FileVersion,
-} from "@app/lib/resources/file_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 
 const ENABLE_LLM_SNIPPETS = false;

--- a/front/lib/file_storage/config.ts
+++ b/front/lib/file_storage/config.ts
@@ -10,6 +10,9 @@ const config = {
   getGcsPrivateUploadsBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_PRIVATE_UPLOADS_BUCKET");
   },
+  getGcsUpsertQueueBucket: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_UPSERT_QUEUE_BUCKET");
+  },
 };
 
 export default config;

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -148,3 +148,6 @@ export const getPrivateUploadBucket = (options?: FileStorageOptions) =>
 
 export const getPublicUploadBucket = (options?: FileStorageOptions) =>
   getBucketInstance(config.getGcsPublicUploadBucket(), options);
+
+export const getUpsertQueueBucket = (options?: FileStorageOptions) =>
+  getBucketInstance(config.getGcsUpsertQueueBucket(), options);

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -249,9 +249,7 @@ export class FileResource extends BaseResource<FileModel> {
   // Use-case logic
 
   isUpsertUseCase(): boolean {
-    return (
-      this.useCase === "folder_document" || this.useCase === "folder_table"
-    );
+    return ["folder_document", "folder_table"].includes(this.useCase);
   }
 
   getBucketForVersion(version: FileVersion) {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -79,12 +79,7 @@ const mockFileContent = {
 
 // Mock file storage with parameterizable content
 vi.mock("@app/lib/file_storage", () => ({
-  getPrivateUploadBucket: vi.fn(() => ({
-    file: () => ({
-      createReadStream: () => Readable.from([mockFileContent.content]),
-    }),
-  })),
-  getPublicUploadBucket: vi.fn(() => ({
+  getUpsertQueueBucket: vi.fn(() => ({
     file: () => ({
       createReadStream: () => Readable.from([mockFileContent.content]),
     }),


### PR DESCRIPTION
## Description

- Stop snippetting for folder_table use-case
- Use upsert_queue bucket for folder_table and folder_document use-cases

Motivation is to leverage the upsert_queue bucket lifecycle that will delete files after 7 days.
This is in preparation of the work consisting in moving to file API for table upserts from
connectors (to avoid parsing in front and leveraging core)

For now there is no way for the user to interact with the file so it's fine to delete them over time. We likely want to prevent the user from retrieving files with these internal use-case. Will add this in a follow-up PR.

## Tests

Covered by existing tests (modified)

## Risk

Low. Table/Document upserts for folders (tested locally)

## Deploy Plan

- deploy front
