### PR TITLE
Front: Add front endpoint & swr to fetch tags from core

### DIFF
--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -1,4 +1,10 @@
-import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
+import type {
+  DataSourceType,
+  LightWorkspaceType,
+  TagResult,
+  TagSearchParams,
+  TagSearchResponse,
+} from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
@@ -24,4 +30,25 @@ export function useDataSourceUsage({
     isUsageError: error,
     mutate,
   };
+}
+
+export function useTagSearch({ owner }: { owner: LightWorkspaceType }) {
+  const searchTags = async (params: TagSearchParams): Promise<TagResult[]> => {
+    const res = await fetch(`/api/w/${owner.sId}/data_sources/tags`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(params),
+    });
+
+    if (!res.ok) {
+      throw new Error("Failed to search tags");
+    }
+
+    const data = (await res.json()) as TagSearchResponse;
+    return data.tags;
+  };
+
+  return { searchTags };
 }

--- a/front/pages/api/w/[wId]/data_sources/tags.ts
+++ b/front/pages/api/w/[wId]/data_sources/tags.ts
@@ -1,0 +1,97 @@
+import { CoreAPI } from "@dust-tt/types";
+import { isLeft } from "fp-ts/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import apiConfig from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+export const PostTagSearchBodySchema = t.type({
+  query: t.string,
+  queryType: t.string,
+  dataSources: t.array(t.string),
+});
+
+export type PostTagSearchBody = t.TypeOf<typeof PostTagSearchBodySchema>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  auth: Authenticator
+) {
+  const user = auth.getNonNullableUser();
+  if (!user || !auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "data_source_auth_error",
+        message: "You are not authorized to fetch tags.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const flags = await getFeatureFlags(owner);
+
+  if (!flags.includes("tags_filters")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message: "The feature is not enabled for this workspace.",
+      },
+    });
+  }
+
+  const { method } = req;
+
+  if (method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const bodyValidation = PostTagSearchBodySchema.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const { query, queryType, dataSources } = bodyValidation.right;
+
+  const coreAPI = new CoreAPI(apiConfig.getCoreAPIConfig(), logger);
+  const result = await coreAPI.searchTags({
+    query,
+    queryType,
+    dataSources,
+  });
+
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to search tags",
+      },
+    });
+  }
+  return res.status(200).json(result.value.response);
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -782,6 +782,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_github_actions"
   | "deepseek_r1_global_agent_feature"
   | "bigquery_feature"
+  | "tags_filters"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -75,3 +75,19 @@ export function isDataSourceNameValid(name: string): Result<void, string> {
 
   return new Ok(undefined);
 }
+
+export type TagResult = {
+  tag: string;
+  match_count: number;
+  data_sources: string[];
+};
+
+export type TagSearchResponse = {
+  tags: TagResult[];
+};
+
+export type TagSearchParams = {
+  query: string;
+  queryType: string;
+  dataSources: string[];
+};

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -192,9 +192,20 @@ export interface CoreAPISearchCursorRequest {
   cursor?: string;
 }
 
-export interface CoreAPISearchResponse {
+export interface CoreAPISearchNodesResponse {
   nodes: CoreAPIContentNode[];
   next_page_cursor: string | null;
+}
+
+export interface CoreAPISearchTagsResponse {
+  error: string | null;
+  response: {
+    tags: {
+      tag: string;
+      match_count: number;
+      data_sources: string[];
+    }[];
+  };
 }
 
 export type CoreAPIDatasourceViewFilter = {
@@ -1612,7 +1623,7 @@ export class CoreAPI {
     query?: string;
     filter: CoreAPINodesSearchFilter;
     options?: CoreAPISearchOptions;
-  }): Promise<CoreAPIResponse<CoreAPISearchResponse>> {
+  }): Promise<CoreAPIResponse<CoreAPISearchNodesResponse>> {
     const response = await this._fetchWithError(`${this._url}/nodes/search`, {
       method: "POST",
       headers: {
@@ -1622,6 +1633,29 @@ export class CoreAPI {
         query,
         filter,
         options,
+      }),
+    });
+    return this._resultFromResponse(response);
+  }
+
+  async searchTags({
+    query,
+    queryType,
+    dataSources,
+  }: {
+    query: string;
+    queryType: string;
+    dataSources: string[];
+  }): Promise<CoreAPIResponse<CoreAPISearchTagsResponse>> {
+    const response = await this._fetchWithError(`${this._url}/tags/search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query,
+        query_type: queryType,
+        data_sources: dataSources,
       }),
     });
     return this._resultFromResponse(response);

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -19,6 +19,7 @@ export const WHITELISTABLE_FEATURES = [
   "labs_github_actions",
   "deepseek_r1_global_agent_feature",
   "bigquery_feature",
+  "tags_filters",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

This PR adds: 
- New feature flag for tags_filter
- New function in front `coreApi` to fetch tags.
- New front api route to fetch tags (`POST /w/[wId]/data_sources/tags`)
- SWR function to call this new endpoint from a React component. 


Note: The new Core API route is blocked on https://github.com/dust-tt/dust/pull/10441 and the request params will most likely change and not look like what I currently have now (`PostTagSearchBodySchema`). 

But we can still merge this to continue working on the UI. 

## Tests

Tested locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 