### PR TITLE
fix(remote-db) - Fix query to check for existing schemas

### DIFF
--- a/connectors/src/connectors/bigquery/lib/permissions.ts
+++ b/connectors/src/connectors/bigquery/lib/permissions.ts
@@ -314,7 +314,7 @@ export const saveNodesFromPermissions = async ({
           const existingSchema = await RemoteSchemaModel.findOne({
             where: {
               connectorId,
-              internalId,
+              internalId: [database, dataset.name].join("."),
             },
           });
           if (!existingSchema) {

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -322,7 +322,7 @@ export const saveNodesFromPermissions = async ({
           const existingSchema = await RemoteSchemaModel.findOne({
             where: {
               connectorId,
-              internalId,
+              internalId: [database, schema.name].join("."),
             },
           });
           if (!existingSchema) {


### PR DESCRIPTION
## Description

- The current implementation for remote database connectors (Snowflake, BigQuery) incorrectly fetches the schema when setting permissions on a database.
- This issue causes `UniqueConstraintError: Validation error`.
- This PR fixes that.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.