### PR TITLE
[CoreNodes] Add script to reupsert Confluence space folder

### DIFF
--- a/connectors/migrations/20250205_reupsert_confluence_space.ts
+++ b/connectors/migrations/20250205_reupsert_confluence_space.ts
@@ -44,12 +44,22 @@ makeScript(
         mimeType: MIME_TYPES.CONFLUENCE.SPACE,
         sourceUrl: `${baseUrl}/wiki${space._links.webui}`,
       });
-      await ConfluenceSpace.upsert({
-        connectorId,
-        name: space.name,
-        spaceId: spaceId.toString(),
-        urlSuffix: space._links.webui,
+      const spaceInDb = await ConfluenceSpace.findOne({
+        where: {
+          connectorId,
+          spaceId,
+        },
       });
+      if (!spaceInDb) {
+        await ConfluenceSpace.create({
+          connectorId,
+          name: space.name,
+          spaceId: spaceId,
+          urlSuffix: space._links.webui,
+        });
+      } else if (spaceInDb.name !== space.name) {
+        await spaceInDb.update({ name: space.name });
+      }
     }
   }
 );

--- a/connectors/migrations/20250205_reupsert_confluence_space.ts
+++ b/connectors/migrations/20250205_reupsert_confluence_space.ts
@@ -1,0 +1,60 @@
+import { MIME_TYPES } from "@dust-tt/types";
+import { makeScript } from "scripts/helpers";
+
+import { makeSpaceInternalId } from "@connectors/connectors/confluence/lib/internal_ids";
+import {
+  confluenceGetSpaceNameActivity,
+  fetchConfluenceConfigurationActivity,
+} from "@connectors/connectors/confluence/temporal/activities";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { ConfluenceSpace } from "@connectors/lib/models/confluence";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+makeScript(
+  {
+    connectorId: { type: "number" },
+    spaceId: { type: "number" },
+  },
+  async ({ execute, connectorId, spaceId }, logger) => {
+    const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      throw new Error("Connector not found.");
+    }
+    const confluenceConfig =
+      await fetchConfluenceConfigurationActivity(connectorId);
+    if (!confluenceConfig) {
+      throw new Error("No configuration found.");
+    }
+    const spaceName = await confluenceGetSpaceNameActivity({
+      confluenceCloudId: confluenceConfig.cloudId,
+      connectorId,
+      spaceId: spaceId.toString(),
+    });
+
+    if (!spaceName) {
+      logger.error("Space name not found.");
+      return;
+    }
+
+    logger.info({ spaceName }, "Space name");
+
+    const spaceInDb = await ConfluenceSpace.findOne({
+      attributes: ["urlSuffix"],
+      where: { connectorId, spaceId },
+    });
+    if (execute) {
+      await upsertDataSourceFolder({
+        dataSourceConfig: dataSourceConfigFromConnector(connector),
+        folderId: makeSpaceInternalId(spaceId.toString()),
+        parents: [makeSpaceInternalId(spaceId.toString())],
+        parentId: null,
+        title: spaceName,
+        mimeType: MIME_TYPES.CONFLUENCE.SPACE,
+        sourceUrl:
+          spaceInDb?.urlSuffix &&
+          `${confluenceConfig.url}/wiki${spaceInDb.urlSuffix}`,
+      });
+    }
+  }
+);

--- a/connectors/migrations/20250205_reupsert_confluence_space.ts
+++ b/connectors/migrations/20250205_reupsert_confluence_space.ts
@@ -33,10 +33,12 @@ makeScript(
     });
 
     const space = await client.getSpaceById(spaceId);
-
-    logger.info({ spaceName: space.name }, "Space name");
-
     const folderId = makeSpaceInternalId(spaceId);
+
+    logger.info(
+      { spaceId, spaceName: space.name, folderId },
+      "Upserting Confluence space."
+    );
     if (execute) {
       await upsertDataSourceFolder({
         dataSourceConfig: dataSourceConfigFromConnector(connector),

--- a/connectors/migrations/20250205_reupsert_confluence_space.ts
+++ b/connectors/migrations/20250205_reupsert_confluence_space.ts
@@ -21,16 +21,11 @@ makeScript(
     if (!connector) {
       throw new Error("Connector not found.");
     }
-    const confluenceConfig =
-      await fetchConfluenceConfigurationActivity(connectorId);
-    if (!confluenceConfig) {
-      throw new Error("No configuration found.");
-    }
 
-    const client = await getConfluenceClient({
-      cloudId: confluenceConfig.cloudId,
-      connectorId,
-    });
+    const { cloudId, url: baseUrl } =
+      await fetchConfluenceConfigurationActivity(connectorId);
+
+    const client = await getConfluenceClient({ cloudId, connectorId });
 
     const space = await client.getSpaceById(spaceId);
     const folderId = makeSpaceInternalId(spaceId);
@@ -47,7 +42,7 @@ makeScript(
         parentId: null,
         title: space.name,
         mimeType: MIME_TYPES.CONFLUENCE.SPACE,
-        sourceUrl: `${confluenceConfig.url}/wiki${space._links.webui}`,
+        sourceUrl: `${baseUrl}/wiki${space._links.webui}`,
       });
       await ConfluenceSpace.upsert({
         connectorId,


### PR DESCRIPTION
## Description

- ~This PR targets [this one entry](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Aconfluence%20-%40diff.sourceUrl.connectors%3A%2A%20%40diff.title.connectors%3A%2AIT%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZTaodC0O7CdkgAAABhBWlRhb2RvWkFBQ2M0cEhpdWllUlZBQXEAAAAkMDE5NGRhYjAtZGM2ZC00MjA4LWJkYWYtZmFmMmYwMmRjYTBkAA0LLw&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1738666818592&to_ts=1738839618592&live=true) specifically.~ Edit: we are observing discrepancies between the connectors db and core's where core is missing a Confluence space, sample [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Aconfluence%20-%40diff.parentInternalIds.core%3A__hidden_syncing_content__%20-%40missingInternalIds%3Aconfluence-page-%2A&agg_m=count&agg_m_source=base&agg_q=%40dataSourceViewId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZTbWFuc9nRBUwAAABhBWlRiV0dvQkFBRENxNUxrMjBRbjhnQWsAAAAkMDE5NGRiNTgtODg3MS00ZTEzLTljMmYtOTA3YjNmYjg0MzQyAAgbGQ&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&top_n=25&top_o=top&viz=stream&x_missing=true&from_ts=1738822750000&to_ts=1738837150000&live=true).
- It adds a script that logs the space name fetched from Confluence in dry run, and reupserts the data source folder in live run.
- This issue was supposed to be fixed for https://github.com/dust-tt/dust/pull/10545 and was fixed for every workspace except this one (which coincidentally happens to be in EU).
- Since this issue does not seem recurrent, this PR suggests addressing it manually for this one time.

## Tests

## Risk

- Low.

## Deploy Plan

- No deploy.