### PR TITLE
Dark mode: migrate some more Sparkle components

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.385",
+  "version": "0.2.386",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.385",
+      "version": "0.2.386",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.385",
+  "version": "0.2.386",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -178,8 +178,7 @@ const variantStyles = cva("", {
     isSticky: {
       true: cn(
         "s-sticky s-top-0 s-z-10 s-border-b s-backdrop-blur-sm",
-        "s-border-border-dark/60 dark:s-border-border-dark-night/60",
-        "s-bg-muted/90 dark:s-bg-muted-night/90"
+        "s-border-border-dark/60 dark:s-border-border-dark-night/60"
       ),
     },
   },

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -26,8 +26,10 @@ export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
     <ContentBlockWrapper content={clipboardContent} className="s-my-2">
       <blockquote
         className={cn(
-          "s-w-full s-text-base s-italic s-text-foreground",
-          "s-rounded-2xl s-bg-muted-background s-py-3 s-pl-5 s-pr-12"
+          "s-w-full s-text-base s-italic",
+          "s-rounded-2xl s-py-3 s-pl-5 s-pr-12",
+          "dark:s-text-foreground-night s-text-foreground",
+          "dark:s-bg-muted-background-night s-bg-muted-background"
         )}
       >
         {children}

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -1,6 +1,8 @@
 import React, { Suspense } from "react";
 import { amber, emerald, pink, sky, slate, violet } from "tailwindcss/colors";
 
+import { cn } from "@sparkle/lib";
+
 const SyntaxHighlighter = React.lazy(
   () => import("react-syntax-highlighter/dist/esm/default-highlight")
 );
@@ -34,7 +36,7 @@ export function CodeBlock({
       display: "block",
       overflowX: "auto",
       padding: "1em",
-      color: slate[900], // Base text color
+      color: "var(--s-foreground)",
       backgroundColor: "transparent",
       fontSize: "0.875rem",
     },
@@ -107,7 +109,7 @@ export function CodeBlock({
     },
     "hljs-params": {
       // Function parameters
-      color: slate[900],
+      color: "var(--s-foreground)",
     },
     // Typography styles
     "hljs-emphasis": {
@@ -120,18 +122,27 @@ export function CodeBlock({
 
   return !inline && language ? (
     <Suspense fallback={<div />}>
-      <SyntaxHighlighter
-        wrapLongLines={wrapLongLines}
-        style={codeStyle}
-        language={languageToUse}
-        PreTag="div"
-        className="s-cursor-text"
-      >
-        {String(children).replace(/\n$/, "")}
-      </SyntaxHighlighter>
+      <div className="s-text-slate-900 dark:s-text-blue-200">
+        <SyntaxHighlighter
+          wrapLongLines={wrapLongLines}
+          style={codeStyle}
+          language={languageToUse}
+          PreTag="div"
+          className="s-cursor-text"
+        >
+          {String(children).replace(/\n$/, "")}
+        </SyntaxHighlighter>
+      </div>
     </Suspense>
   ) : (
-    <code className="s-mx-0.5 s-cursor-text s-rounded-lg s-border s-border-border-dark s-bg-muted s-px-1.5 s-py-1 s-text-amber-600">
+    <code
+      className={cn(
+        "s-mx-0.5 s-cursor-text s-rounded-lg s-border s-px-1.5 s-py-1",
+        "dark:s-border-border-dark-night s-border-border-dark",
+        "dark:s-bg-muted-night s-bg-muted",
+        "dark:s-text-amber-600-night s-text-amber-600"
+      )}
+    >
       {children}
     </code>
   );

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -49,7 +49,7 @@ function showUnsupportedDirective() {
 export function Markdown({
   content,
   isStreaming = false,
-  textColor = "s-text-foreground",
+  textColor = "s-text-foreground dark:s-text-foreground-night",
   forcedTextSize,
   isLastMessage = false,
   additionalMarkdownComponents,
@@ -189,13 +189,15 @@ export function Markdown({
         </h6>
       ),
       strong: ({ children }) => (
-        <strong className="s-font-semibold s-text-foreground">
+        <strong className="dark:s-text-foreground-night s-font-semibold s-text-foreground">
           {children}
         </strong>
       ),
       input: Input,
       blockquote: BlockquoteBlock,
-      hr: () => <div className="s-my-6 s-border-b s-border-structure-200" />,
+      hr: () => (
+        <div className="dark:s-border-structure-200-night s-my-6 s-border-b s-border-structure-200" />
+      ),
       code: CodeBlockWithExtendedSupport,
       ...additionalMarkdownComponents,
     };
@@ -248,7 +250,12 @@ function LinkBlock({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="s-break-all s-font-semibold s-text-highlight s-transition-all s-duration-200 s-ease-in-out hover:s-text-action-400 hover:s-underline active:s-text-highlight-dark"
+      className={cn(
+        "s-break-all s-font-semibold s-transition-all s-duration-200 s-ease-in-out hover:s-underline",
+        "dark:s-text-highlight-night s-text-highlight",
+        "dark:hover:s-text-action-400-night hover:s-text-action-400",
+        "dark:active:s-text-highlight-dark-night active:s-text-highlight-dark"
+      )}
     >
       {children}
     </a>
@@ -272,7 +279,9 @@ function PreBlock({ children }: { children: React.ReactNode }) {
   return (
     <pre
       className={cn(
-        "s-my-2 s-w-full s-break-all s-rounded-2xl s-border s-border-border-dark s-bg-muted-background"
+        "s-my-2 s-w-full s-break-all s-rounded-2xl s-border",
+        "dark:s-border-border-dark-night s-border-border-dark",
+        "dark:s-bg-muted-background-night s-bg-muted-background"
       )}
     >
       {validChildrenContent ? children : fallbackData || children}

--- a/sparkle/src/stories/NavigationList.stories.tsx
+++ b/sparkle/src/stories/NavigationList.stories.tsx
@@ -72,7 +72,7 @@ export const Demo = () => {
 
   return (
     <div className="s-flex s-h-[400px] s-w-full s-flex-row s-gap-12">
-      <div className="s-h-[400px] s-w-[240px] s-bg-muted">
+      <div className="s-h-[400px] s-w-[240px]">
         <NavigationList className="s-relative s-h-full s-w-full s-px-3">
           {conversationTitles.map((section, sectionIndex) => (
             <React.Fragment key={sectionIndex}>
@@ -102,7 +102,7 @@ export const Demo = () => {
           ))}
         </NavigationList>
       </div>
-      <div className="s-h-[400px] s-w-[240px] s-bg-muted">
+      <div className="s-h-[400px] s-w-[240px]">
         <NavigationList className="s-relative s-h-full s-w-full s-px-3">
           {conversationTitles.map((section, sectionIndex) => (
             <React.Fragment key={sectionIndex}>


### PR DESCRIPTION
## Description

Migrating some more Sparkle component to work with Dark mode; 

basically what we do is if we have the class: "bg-soupinou" we just add "dark:bg-soupinou-night" to make it work. 

## Tests

Locally on storybook. 

## Risk

Can be rolled back

## Deploy Plan

Publish sparkle!
