### PR TITLE
[Confluence] Fix: fetch space with primary key

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -219,7 +219,6 @@ export async function confluenceUpsertSpaceFolderActivity({
   const connector = await fetchConfluenceConnector(connectorId);
 
   const spaceInDb = await ConfluenceSpace.findOne({
-    attributes: ["urlSuffix"],
     where: { connectorId, spaceId },
   });
 


### PR DESCRIPTION
Description
---
Fixes issue from [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1738830099694419)
Sequelize could not update the space in the `.update` below, because the id was not fetched with the space

Risk
---
na

Deploy
---
connectors
