### PR TITLE
[connectors] Add command line to check and clean up parents

### DIFF
--- a/connectors/migrations/20250205_gdrive_clean.ts
+++ b/connectors/migrations/20250205_gdrive_clean.ts
@@ -12,7 +12,7 @@ const { FRONT_DATABASE_URI } = process.env;
 
 const BATCH_SIZE = 1000;
 
-async function checkOrphansForConnector(
+async function checkOrphansDocumentsForConnector(
   coreAPI: CoreAPI,
   connector: ConnectorResource,
   dustAPIProjectId: string,
@@ -80,6 +80,74 @@ async function checkOrphansForConnector(
   logger.info({ orphanCount }, "DONE");
 }
 
+async function checkOrphansFoldersForConnector(
+  coreAPI: CoreAPI,
+  connector: ConnectorResource,
+  dustAPIProjectId: string,
+  dustAPIDataSourceId: string,
+  execute = false,
+  nodeConcurrency: number,
+  parentLogger: typeof Logger
+) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const logger = parentLogger.child({
+    connectorId: connector.id,
+    workspaceId: dataSourceConfig.workspaceId,
+    dataSourceId: dataSourceConfig.dataSourceId,
+  });
+
+  let offset = 0;
+  let count = 0;
+  let orphanCount = 0;
+  do {
+    const coreRes = await coreAPI.getDataSourceFolders(
+      {
+        dataSourceId: dustAPIDataSourceId,
+        projectId: dustAPIProjectId,
+      },
+      {
+        limit: BATCH_SIZE,
+        offset,
+      }
+    );
+    logger.info({ offset, count }, "Fetching documents");
+
+    offset += BATCH_SIZE;
+
+    if (coreRes.isErr()) {
+      throw new Error(coreRes.error.message);
+    }
+
+    const ids = coreRes.value.folders.map((node) => node.folder_id);
+    count = ids.length;
+    const files = await GoogleDriveFiles.findAll({
+      where: {
+        dustFileId: ids,
+      },
+    });
+    const found = files.map((f) => f.dustFileId);
+    const orphans = ids.filter((id) => !found.includes(id));
+
+    logger.info({ orphans }, "Found orphan nodes");
+    orphanCount += orphans.length;
+    if (execute) {
+      await concurrentExecutor(
+        orphans,
+        async (orphan) => {
+          logger.info({ id: orphan }, "Removing orphan nodes");
+          await coreAPI.deleteDataSourceFolder({
+            dataSourceId: dustAPIDataSourceId,
+            folderId: orphan,
+            projectId: dustAPIProjectId,
+          });
+        },
+        { concurrency: nodeConcurrency }
+      );
+    }
+  } while (count === BATCH_SIZE);
+  logger.info({ orphanCount }, "DONE");
+}
+
 makeScript(
   {
     connectorConcurrency: {
@@ -134,7 +202,16 @@ makeScript(
         }
 
         logger.info({ connectorId: connector.id }, "MIGRATE");
-        await checkOrphansForConnector(
+        await checkOrphansDocumentsForConnector(
+          coreAPI,
+          connector,
+          dataSource.dustAPIProjectId,
+          dataSource.dustAPIDataSourceId,
+          execute,
+          nodeConcurrency,
+          logger
+        );
+        await checkOrphansFoldersForConnector(
           coreAPI,
           connector,
           dataSource.dustAPIProjectId,

--- a/connectors/migrations/20250205_gdrive_clean.ts
+++ b/connectors/migrations/20250205_gdrive_clean.ts
@@ -118,7 +118,10 @@ async function checkOrphansFoldersForConnector(
       throw new Error(coreRes.error.message);
     }
 
-    const ids = coreRes.value.folders.map((node) => node.folder_id);
+    const ids = coreRes.value.folders
+      .map((node) => node.folder_id)
+      .filter((id) => id !== "gdrive-sharedWithMe");
+
     count = ids.length;
     const files = await GoogleDriveFiles.findAll({
       where: {

--- a/connectors/src/lib/api/content_nodes.ts
+++ b/connectors/src/lib/api/content_nodes.ts
@@ -4,7 +4,6 @@ import type {
   Result,
 } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
-import { hash as blake3 } from "blake3";
 import { zip } from "fp-ts/lib/Array";
 import { v4 as uuidv4 } from "uuid";
 

--- a/connectors/src/lib/api/content_nodes.ts
+++ b/connectors/src/lib/api/content_nodes.ts
@@ -6,11 +6,11 @@ import type {
 import { Ok } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 import { zip } from "fp-ts/lib/Array";
+import { v4 as uuidv4 } from "uuid";
 
 import { getConnectorManager } from "@connectors/connectors";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-
 export interface ContentNodeParentIdsBlob {
   internalId: string;
   parentInternalIds: string[];
@@ -28,7 +28,7 @@ export async function getParentIdsForContentNodes(
     connectorId: connector.id,
   });
 
-  const memoizationKey = `content-node-parents-${connector.id}-${blake3(internalIds.join("-"), { length: 256 }).toString()}`;
+  const memoizationKey = uuidv4();
 
   const parentsResults = await concurrentExecutor(
     internalIds,

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -110,6 +110,7 @@ export const GoogleDriveCommandSchema = t.type({
     t.literal("garbage-collect-all"),
     t.literal("check-file"),
     t.literal("get-google-parents"),
+    t.literal("clean-invalid-parents"),
     t.literal("restart-google-webhooks"),
     t.literal("start-incremental-sync"),
     t.literal("restart-all-incremental-sync-workflows"),


### PR DESCRIPTION
## Description

- Fixed parents caching in content-nodes endpoint
- Add a check for orphan folder in 20250205_gdrive_clean
- Add a cli command to clean parent ids in connector : remove node if parent can't be found and if it's nor a root, or unset parentId if it's a root

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

