### PR TITLE
[Mentions sorting] Use proper sort to sort mentions

### DIFF
--- a/extension/app/src/components/input_bar/editor/suggestion.ts
+++ b/extension/app/src/components/input_bar/editor/suggestion.ts
@@ -24,16 +24,13 @@ function filterAndSortSuggestions(
 ) {
   return suggestions
     .filter((item) => subFilter(lowerCaseQuery, item.label.toLowerCase()))
-    .sort((a, b) => compareForFuzzySort(lowerCaseQuery, a.label, b.label))
-    .sort((a, b) => {
-      if (a.userFavorite && !b.userFavorite) {
-        return -1;
-      } else if (!a.userFavorite && b.userFavorite) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
+    .sort((a, b) =>
+      compareForFuzzySort(
+        lowerCaseQuery,
+        a.label.toLocaleLowerCase(),
+        b.label.toLocaleLowerCase()
+      )
+    );
 }
 
 export function makeGetAssistantSuggestions() {

--- a/front/components/assistant/conversation/input_bar/editor/suggestion.ts
+++ b/front/components/assistant/conversation/input_bar/editor/suggestion.ts
@@ -25,16 +25,13 @@ function filterAndSortSuggestions(
 ) {
   return suggestions
     .filter((item) => subFilter(lowerCaseQuery, item.label.toLowerCase()))
-    .sort((a, b) => compareForFuzzySort(lowerCaseQuery, a.label, b.label))
-    .sort((a, b) => {
-      if (a.userFavorite && !b.userFavorite) {
-        return -1;
-      } else if (!a.userFavorite && b.userFavorite) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
+    .sort((a, b) =>
+      compareForFuzzySort(
+        lowerCaseQuery,
+        a.label.toLocaleLowerCase(),
+        b.label.toLocaleLowerCase()
+      )
+    );
 }
 
 export function makeGetAssistantSuggestions() {


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2111
Implementation to put favorites first was made with an issue: it broke the string fuzzy sorting

Furthermore, putting a not very relevant favorite before a very relevant favorite is questionable

This PR fixes by removing the sort by favorite

Risk
--
low, it was already borked

Deploy
---
front