### PR TITLE
[connectors] Fix google drive parent

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -26,6 +26,7 @@ import {
   driveObjectToDustType,
   getAuthObject,
   getDriveClient,
+  getDriveFileId,
   getInternalId,
   getMyDriveIdCached,
 } from "@connectors/connectors/google_drive/temporal/utils";
@@ -674,6 +675,8 @@ export async function garbageCollector(
     activity: "garbageCollector",
   });
 
+  localLogger.info("Google Drive: Starting garbage collector");
+
   const files = await GoogleDriveFiles.findAll({
     where: {
       connectorId: connectorId,
@@ -849,7 +852,7 @@ export async function markFolderAsVisited(
     driveFileId: file.id,
     name: file.name,
     mimeType: file.mimeType,
-    parentId: file.parent,
+    parentId: parents[1] ? getDriveFileId(parents[1]) : null,
     lastSeenTs: new Date(),
   });
 }


### PR DESCRIPTION
## Description

Fix parent for root folder. Take the parent from the list generated by getFileParents(), which take roots into account (return no parent higher than the selected root), and which is consistent with core.
It was previoulsy using the google drive parent, whatever the config is.

## Tests

Go from :
```
[x] drive
   [ ] folder
      [ ] files
```
To :
```
[ ] drive
   [x] folder
      [ ] files
```
And check the value of parentId of "folder"


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
