### PR TITLE
[Conversations] Display error when agent not found

### DIFF
--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -7,6 +7,7 @@ import { apiError } from "@app/logger/withlogging";
 const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
   conversation_access_restricted: 403,
   conversation_not_found: 404,
+  conversation_with_unavailable_agent: 403,
 };
 
 export function apiErrorForConversation(

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -265,7 +265,8 @@ export interface ConversationParticipantsType {
 
 export type ConversationErrorType =
   | "conversation_not_found"
-  | "conversation_access_restricted";
+  | "conversation_access_restricted"
+  | "conversation_with_unavailable_agent";
 
 export class ConversationError extends Error {
   readonly type: ConversationErrorType;


### PR DESCRIPTION
Description
---
Fixes monitor with e.g. [Qonto]()

When an agent is not available anymore (here because a feature flag was turned off), the conversation cannot be rendered.

This PR displays a nice message instead of blowing up the app, and prevents unhandled api errors for the eng runner

Risk
---
low, it matches exactly previous cases of failure

Deploy
---
front
