### PR TITLE
[sparkle] - refacto: RadioGroupItem

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.387",
+  "version": "0.2.388",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.387",
+      "version": "0.2.388",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.387",
+  "version": "0.2.388",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -122,7 +122,7 @@ interface RadioGroupCustomItemProps
     VariantProps<typeof radioStyles> {
   iconPosition?: IconPosition;
   customItem: React.ReactNode;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const RadioGroupCustomItem = React.forwardRef<

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -113,27 +113,59 @@ const RadioGroupItem = React.forwardRef<
 
 type IconPosition = "start" | "center" | "end";
 
-interface RadioGroupCustomItemProps extends RadioGroupItemProps {
+interface RadioGroupCustomItemProps
+  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
+    VariantProps<typeof radioStyles> {
   iconPosition?: IconPosition;
+  customItem: React.ReactNode;
   children: React.ReactNode;
 }
 
 const RadioGroupCustomItem = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Item>,
   RadioGroupCustomItemProps
->(({ className, size, iconPosition = "center", children, ...props }, ref) => {
-  return (
-    <div
-      className={cn("s-flex s-flex-col", className, `s-items-${iconPosition}`)}
-    >
-      <RadioGroupItem
+>(
+  (
+    {
+      className,
+      size,
+      customItem,
+      iconPosition = "center",
+      children,
+      id,
+      ...props
+    },
+    ref
+  ) => {
+    const item = (
+      <RadioGroupPrimitive.Item
         ref={ref}
-        className={cn(radioStyles({ size }))}
+        id={id}
+        className={cn(radioStyles({ size }), className)}
         {...props}
-      />
-      {children}
-    </div>
-  );
-});
+      >
+        <RadioGroupPrimitive.Indicator
+          className={radioIndicatorStyles({ size })}
+        />
+      </RadioGroupPrimitive.Item>
+    );
+
+    return (
+      <div
+        className={cn(
+          "s-flex s-flex-col",
+          className,
+          `s-items-${iconPosition}`
+        )}
+      >
+        <div className="s-flex s-items-center s-gap-2">
+          {item}
+          {customItem}
+        </div>
+        {children}
+      </div>
+    );
+  }
+);
 
 export { RadioGroup, RadioGroupCustomItem, RadioGroupItem };

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -2,6 +2,7 @@ import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { cva, VariantProps } from "class-variance-authority";
 import * as React from "react";
 
+import { Label } from "@sparkle/components/Label";
 import { Tooltip } from "@sparkle/components/Tooltip";
 import { cn } from "@sparkle/lib/utils";
 
@@ -59,11 +60,14 @@ const RadioGroup = React.forwardRef<
 RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
 
 interface RadioGroupItemProps
-  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
+  extends Omit<
+      React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
+      "children"
+    >,
     VariantProps<typeof radioStyles> {
   tooltipMessage?: string;
-  tooltipAsChild?: boolean;
-  label?: React.ReactNode;
+  label: string;
+  labelProps?: Omit<React.ComponentPropsWithoutRef<typeof Label>, "children">;
 }
 
 const RadioGroupItem = React.forwardRef<
@@ -71,19 +75,13 @@ const RadioGroupItem = React.forwardRef<
   RadioGroupItemProps
 >(
   (
-    {
-      tooltipMessage,
-      className,
-      size,
-      tooltipAsChild = false,
-      label,
-      ...props
-    },
+    { tooltipMessage, className, size, label, labelProps, id, ...props },
     ref
   ) => {
     const item = (
       <RadioGroupPrimitive.Item
         ref={ref}
+        id={id}
         className={cn(radioStyles({ size }), className)}
         {...props}
       >
@@ -97,14 +95,15 @@ const RadioGroupItem = React.forwardRef<
       <div className="s-flex s-items-center s-gap-2">
         {tooltipMessage ? (
           <Tooltip
-            triggerAsChild={tooltipAsChild}
             trigger={item}
-            label={<span>{tooltipMessage}</span>}
+            label={<Label {...labelProps}>{label}</Label>}
           />
         ) : (
           item
         )}
-        {label}
+        <Label htmlFor={id} {...labelProps}>
+          {label}
+        </Label>
       </div>
     );
 
@@ -114,13 +113,14 @@ const RadioGroupItem = React.forwardRef<
 
 type IconPosition = "start" | "center" | "end";
 
-interface RadioGroupChoiceProps extends RadioGroupItemProps {
+interface RadioGroupCustomItemProps extends RadioGroupItemProps {
   iconPosition?: IconPosition;
+  children: React.ReactNode;
 }
 
-const RadioGroupChoice = React.forwardRef<
+const RadioGroupCustomItem = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Item>,
-  RadioGroupChoiceProps
+  RadioGroupCustomItemProps
 >(({ className, size, iconPosition = "center", children, ...props }, ref) => {
   return (
     <div
@@ -136,4 +136,4 @@ const RadioGroupChoice = React.forwardRef<
   );
 });
 
-export { RadioGroup, RadioGroupChoice, RadioGroupItem };
+export { RadioGroup, RadioGroupCustomItem, RadioGroupItem };

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -2,10 +2,10 @@ import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { cva, VariantProps } from "class-variance-authority";
 import * as React from "react";
 
+import { Icon } from "@sparkle/components/Icon";
 import { Label } from "@sparkle/components/Label";
 import { Tooltip } from "@sparkle/components/Tooltip";
 import { cn } from "@sparkle/lib/utils";
-import { Icon } from "@sparkle/components/Icon";
 
 const radioStyles = cva(
   cn(

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { Label } from "@sparkle/components/Label";
 import { Tooltip } from "@sparkle/components/Tooltip";
 import { cn } from "@sparkle/lib/utils";
+import { Icon } from "@sparkle/components/Icon";
 
 const radioStyles = cva(
   cn(
@@ -68,6 +69,7 @@ interface RadioGroupItemProps
   tooltipMessage?: string;
   label: string;
   labelProps?: Omit<React.ComponentPropsWithoutRef<typeof Label>, "children">;
+  icon?: React.ComponentType;
 }
 
 const RadioGroupItem = React.forwardRef<
@@ -75,9 +77,13 @@ const RadioGroupItem = React.forwardRef<
   RadioGroupItemProps
 >(
   (
-    { tooltipMessage, className, size, label, labelProps, id, ...props },
+    { tooltipMessage, className, icon, size, label, labelProps, id, ...props },
     ref
   ) => {
+    const renderIcon = (visual: React.ComponentType, extraClass = "") => (
+      <Icon visual={visual} size="md" className={extraClass} />
+    );
+
     const item = (
       <RadioGroupPrimitive.Item
         ref={ref}
@@ -94,13 +100,11 @@ const RadioGroupItem = React.forwardRef<
     const wrappedItem = (
       <div className="s-flex s-items-center s-gap-2">
         {tooltipMessage ? (
-          <Tooltip
-            trigger={item}
-            label={<Label {...labelProps}>{label}</Label>}
-          />
+          <Tooltip trigger={item} label={tooltipMessage} />
         ) : (
           item
         )}
+        {icon ? renderIcon(icon) : <></>}
         <Label htmlFor={id} {...labelProps}>
           {label}
         </Label>

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -103,7 +103,7 @@ export {
 } from "./Popover";
 export { Popup } from "./Popup";
 export { PriceTable } from "./PriceTable";
-export { RadioGroup, RadioGroupChoice, RadioGroupItem } from "./RadioGroup";
+export { RadioGroup, RadioGroupCustomItem, RadioGroupItem } from "./RadioGroup";
 export { RainbowEffect } from "./RainbowEffect";
 export {
   ResizableHandle,

--- a/sparkle/src/stories/RadioGroup.stories.tsx
+++ b/sparkle/src/stories/RadioGroup.stories.tsx
@@ -25,49 +25,49 @@ export const RadioGroupExample = () => {
           <RadioGroupItem
             value="option-one"
             id="option-one"
-            label={<Label htmlFor="option-one">Option One</Label>}
+            label="Option One"
           />
         </div>
         <div className="s-flex s-items-center s-space-x-2">
           <RadioGroupItem
             value="option-two"
             id="option-two"
-            label={<Label htmlFor="option-two">Option Two</Label>}
+            label="Option Two"
           />
         </div>
         <div className="s-flex s-items-center s-space-x-2">
           <RadioGroupItem
             value="option-three"
             id="option-three"
-            label={<Label htmlFor="option-two">Option Three</Label>}
+            label="Option Three"
           />
         </div>
       </RadioGroup>
       <RadioGroup defaultValue="option-one">
         <div className="s-flex s-items-center s-space-x-2">
           <RadioGroupItem
-            value="option-one"
+            value="option-four"
             id="option-four"
             size="sm"
             tooltipMessage="This is a nice tooltip message"
-            label={<Label htmlFor="option-one">Option One</Label>}
+            label="Option Four"
           />
         </div>
         <div className="s-flex s-items-center s-space-x-2">
           <RadioGroupItem
-            value="option-two"
+            value="option-five"
             id="option-five"
             size="sm"
             disabled
-            label={<Label htmlFor="option-two">Option Two</Label>}
+            label="Option Five"
           />
         </div>
         <div className="s-flex s-items-center s-space-x-2">
           <RadioGroupItem
             value="option-six"
-            id="option-three"
+            id="option-six"
             size="sm"
-            label={<Label htmlFor="option-three">Option Three</Label>}
+            label="Option Six"
           />
         </div>
       </RadioGroup>

--- a/sparkle/src/stories/RadioGroup.stories.tsx
+++ b/sparkle/src/stories/RadioGroup.stories.tsx
@@ -8,7 +8,7 @@ import {
   Label,
   LockIcon,
   RadioGroup,
-  RadioGroupChoice,
+  RadioGroupCustomItem,
   RadioGroupItem,
 } from "@sparkle/index_with_tw_base";
 
@@ -91,10 +91,10 @@ export const RadioGroupWithChildrenExample = () => {
         onValueChange={(value) => setSelectedChoice(value)}
       >
         {choices.map((choice) => (
-          <RadioGroupChoice
+          <RadioGroupCustomItem
             value={choice.id}
             iconPosition="start"
-            label={
+            customItem={
               <div className="s-flex s-items-center s-gap-2">
                 <Icon visual={LockIcon} />
                 <Label>{choice.label}</Label>
@@ -109,7 +109,7 @@ export const RadioGroupWithChildrenExample = () => {
             {choice.id === selectedChoice && (
               <span>{choice.label} is selected</span>
             )}
-          </RadioGroupChoice>
+          </RadioGroupCustomItem>
         ))}
       </RadioGroup>
     </div>

--- a/sparkle/src/stories/RadioGroup.stories.tsx
+++ b/sparkle/src/stories/RadioGroup.stories.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import {
   Button,
+  CloudArrowDownIcon,
   FolderIcon,
   Icon,
   Label,
@@ -40,6 +41,7 @@ export const RadioGroupExample = () => {
             value="option-three"
             id="option-three"
             label="Option Three"
+            icon={CloudArrowDownIcon}
           />
         </div>
       </RadioGroup>


### PR DESCRIPTION
## Description

This PR refactors the `RadioGroup` component to improve usability by:
- Simplifying the API by making label a required string prop and moving label styling into the component
- Adding proper HTML for attributes between radio inputs and labels
- Adding icon support with consistent styling
- Renaming `RadioGroupChoice` to `RadioGroupCustomItem` for better semantics

## Risk

Low, UI breaks

## Deploy Plan

- Publish alpha
- Update front
- Publish sparkle
- Deploy front
