### PR TITLE
[CoreNodes] Ignore diff due to core returning "Untitled Notion Database" instead of ""

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -335,6 +335,15 @@ export function computeNodesDiff({
             ) {
               return false;
             }
+            // Special case for Notion databases titles: when empty it is filled as "Untitled Notion Database" in core
+            // whereas the connector returns an empty string.
+            if (
+              key === "title" &&
+              value.trim() === "" &&
+              coreValue === "Untitled Notion Database"
+            ) {
+              return false;
+            }
             if (Array.isArray(value) && Array.isArray(coreValue)) {
               return JSON.stringify(value) !== JSON.stringify(coreValue);
             }


### PR DESCRIPTION
## Description

- Nodes for Notion databases that do not have a title are created with a fallback title of "Untitled Notion Database" in `core`.
- In the same situation `connectors` returns an empty string.
- This PR suggests moving forward with displaying "Untitled Notion database" by ignoring the diff.
- Accepting this change is less effort than replicating the former behavior, which would require a backfill on titles (+ a micro change in the code to remove the fallback value).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.