### PR TITLE
allow sync in dev even if region is us

### DIFF
--- a/front/lib/api/regions/config.ts
+++ b/front/lib/api/regions/config.ts
@@ -35,7 +35,10 @@ export const config = {
     };
   },
   getDustRegionSyncEnabled: (): boolean => {
-    return EnvironmentConfig.getEnvVariable("DUST_REGION") !== "us-central1";
+    return (
+      EnvironmentConfig.getEnvVariable("DUST_REGION") !== "us-central1" ||
+      isDevelopment()
+    );
   },
   getDustRegionSyncMasterUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_US_URL");


### PR DESCRIPTION
## Description

Allow syncing in dev even if DUST_REGION is set to US (as per dev setup)

## Tests

N/A

## Risk

N/A

## Deploy Plan

N/A
