### PR TITLE
[Audit log] Create ability to audit log, log kept 6 months

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -23,7 +23,7 @@ import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import logger from "@app/logger/logger";
+import logger, { auditLog } from "@app/logger/logger";
 
 type GetMembershipsOptions = RequireAtLeastOne<{
   users: UserResource[];
@@ -606,6 +606,12 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       });
     }
 
+    auditLog("Membership role updated", {
+      userId: user.id,
+      workspaceId: workspace.id,
+      previousRole,
+      newRole,
+    });
     return new Ok({ previousRole, newRole });
   }
 

--- a/front/logger/logger.ts
+++ b/front/logger/logger.ts
@@ -48,3 +48,11 @@ const logger = pino(pinoOptions);
 
 export default logger;
 export type { Logger } from "pino";
+
+export function auditLog(
+  message: string,
+  data: Record<string, unknown>,
+  auditLogger = logger
+) {
+  auditLogger.info({ ...data, audit: true }, message);
+}


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2092

Create an auditLog function, logging on a specific datadog index (not in main) when used, kept for 6 months

Use it to log membership changes

Thread on slack [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1738849071827609)

Risks
---
low, cost is capped since max 1M logs/day (1/50th of what we currently log)

Deploy
---
front