### PR TITLE
Rename use-cases around upserts

### DIFF
--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -87,7 +87,7 @@ export const DocumentUploadOrEditModal = ({
   });
   const fileUploaderService = useFileUploaderService({
     owner,
-    useCase: "folder_document",
+    useCase: "upsert_document",
   });
 
   const [editionStatus, setEditionStatus] = useState({

--- a/front/components/data_source/MultipleDocumentsUpload.tsx
+++ b/front/components/data_source/MultipleDocumentsUpload.tsx
@@ -63,7 +63,7 @@ export const MultipleDocumentsUpload = ({
   // Used for creating files, with text extraction post-processing
   const fileUploaderService = useFileUploaderService({
     owner,
-    useCase: "folder_document",
+    useCase: "upsert_document",
   });
 
   const doUpsertFileAsDataSourceEntry = useUpsertFileAsDatasourceEntry(

--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -85,7 +85,7 @@ export const TableUploadOrEditModal = ({
   // Get the processed file content from the file API
   const fileUploaderService = useFileUploaderService({
     owner,
-    useCase: "folder_table",
+    useCase: "upsert_table",
   });
   const [fileId, setFileId] = useState<string | null>(null);
   const doUpsertFileAsDataSourceEntry = useUpsertFileAsDatasourceEntry(

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -218,8 +218,8 @@ const getProcessingFunction = ({
     if (
       [
         "conversation",
-        "folder_document",
-        "folder_table",
+        "upsert_document",
+        "upsert_table",
         "tool_output",
       ].includes(useCase)
     ) {
@@ -234,7 +234,7 @@ const getProcessingFunction = ({
     case "application/vnd.ms-powerpoint":
     case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
     case "application/pdf":
-      if (useCase === "conversation" || useCase === "folder_document") {
+      if (["conversation", "upsert_document"].includes(useCase)) {
         return extractTextFromFileAndUpload;
       }
       break;
@@ -270,9 +270,7 @@ const getProcessingFunction = ({
     case "text/x-perl":
     case "text/x-perl-script":
       if (
-        useCase === "conversation" ||
-        useCase === "folder_document" ||
-        useCase === "tool_output"
+        ["conversation", "upsert_document", "tool_output"].includes(useCase)
       ) {
         return storeRawText;
       }

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -320,13 +320,9 @@ const getProcessingFunction = ({
 
   // Use isSupportedDelimitedTextContentType() everywhere to have a common source of truth
   if (isSupportedDelimitedTextContentType(contentType)) {
-    if (
-      useCase === "conversation" ||
-      useCase === "tool_output" ||
-      useCase === "folder_table"
-    ) {
+    if (["conversation", "tool_output", "upsert_table"].includes(useCase)) {
       return upsertTableToDatasource;
-    } else if (useCase === "folder_document") {
+    } else if (useCase === "upsert_document") {
       return upsertDocumentToDatasource;
     } else {
       return undefined;
@@ -335,9 +331,7 @@ const getProcessingFunction = ({
 
   if (
     isSupportedPlainTextContentType(contentType) &&
-    (useCase === "conversation" ||
-      useCase === "tool_output" ||
-      useCase === "folder_document")
+    ["conversation", "tool_output", "upsert_document"].includes(useCase)
   ) {
     return upsertDocumentToDatasource;
   }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -245,7 +245,7 @@ export class FileResource extends BaseResource<FileModel> {
   // Use-case logic
 
   isUpsertUseCase(): boolean {
-    return ["folder_document", "folder_table"].includes(this.useCase);
+    return ["upsert_document", "upsert_table"].includes(this.useCase);
   }
 
   getBucketForVersion(version: FileVersion) {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -168,7 +168,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
         t
       );
       const file = await FileFactory.csv(workspace, user, {
-        useCase: "folder_table",
+        useCase: "upsert_table",
       });
 
       req.query.dsId = dataSourceView.dataSource.sId;

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
@@ -56,7 +56,7 @@ async function handler(
   }
 
   // Only folder document and table upserts are supported on this endpoint.
-  if (!["folder_document", "folder_table"].includes(file.useCase)) {
+  if (!["upsert_document", "upsert_table"].includes(file.useCase)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -28,8 +28,8 @@ const FileUploadUrlRequestSchema = t.type({
   useCase: t.union([
     t.literal("conversation"),
     t.literal("avatar"),
-    t.literal("folder_document"),
-    t.literal("folder_table"),
+    t.literal("upsert_document"),
+    t.literal("upsert_table"),
   ]),
   useCaseMetadata: t.union([t.undefined, t.type({ conversationId: t.string })]),
 });

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2397,7 +2397,7 @@ const FileTypeStatusSchema = FlexibleEnumSchema<
 >();
 
 const FileTypeUseCaseSchema = FlexibleEnumSchema<
-  "conversation" | "avatar" | "tool_output" | "folder_document" | "folder_table"
+  "conversation" | "avatar" | "tool_output" | "upsert_document" | "upsert_table"
 >();
 
 export const FileTypeSchema = z.object({

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -9,8 +9,8 @@ export type FileUseCase =
   | "conversation"
   | "avatar"
   | "tool_output"
-  | "folder_document"
-  | "folder_table";
+  | "upsert_document"
+  | "upsert_table";
 
 export type FileUseCaseMetadata = {
   conversationId: string;


### PR DESCRIPTION
## Description

Rename `folder_table` and `folder_document` to `upsert_table` and `upsert_document` respectively to
use beyond folder (for connectors)

## Tests

Covered by existing tests

## Risk

Low

## Deploy Plan

- Deploy `front`
