### PR TITLE
Authorize upsert_table use-case on public API if system key

### DIFF
--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -51,14 +51,17 @@ async function handler(
     });
   }
 
-  if (!isPublicySupportedUseCase(file.useCase)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The file use case is not supported by the API.",
-      },
-    });
+  if (!auth.isSystemKey()) {
+    // Limit use-case if not a system key.
+    if (!isPublicySupportedUseCase(file.useCase)) {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The file use case is not supported by the API.",
+        },
+      });
+    }
   }
 
   switch (req.method) {

--- a/front/pages/api/v1/w/[wId]/files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.test.ts
@@ -45,7 +45,7 @@ describe("POST /api/w/[wId]/files", () => {
   });
 
   itInTransaction(
-    "refuses non public use-case without system API key",
+    "refuses non public use-case without a system API key",
     async () => {
       const { req, res } = await createPublicApiMockRequest({
         method: "POST",
@@ -61,6 +61,47 @@ describe("POST /api/w/[wId]/files", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(400);
+    }
+  );
+
+  itInTransaction("refuses invalid use-cases", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+
+    req.body = {
+      contentType: "text/csv",
+      fileName: "test.csv",
+      fileSize: 1024,
+      useCase: "random",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  itInTransaction(
+    "accepts non public use-case with a system API key",
+    async () => {
+      const { req, res } = await createPublicApiMockRequest({
+        method: "POST",
+        systemKey: true,
+      });
+
+      req.body = {
+        contentType: "text/csv",
+        fileName: "test.csv",
+        fileSize: 1024,
+        useCase: "upsert_table",
+      };
+
+      await handler(req, res);
+
+      console.log(res._getJSONData());
+
+      expect(res._getStatusCode()).toBe(200);
     }
   );
 });

--- a/front/pages/api/v1/w/[wId]/files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.test.ts
@@ -99,8 +99,6 @@ describe("POST /api/w/[wId]/files", () => {
 
       await handler(req, res);
 
-      console.log(res._getJSONData());
-
       expect(res._getStatusCode()).toBe(200);
     }
   );

--- a/front/pages/api/v1/w/[wId]/files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, vi } from "vitest";
+
+import {
+  createPublicApiAuthenticationTests,
+  createPublicApiMockRequest,
+} from "@app/tests/utils/generic_public_api_tests";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./index";
+
+describe(
+  "public api authentication tests",
+  createPublicApiAuthenticationTests(handler)
+);
+
+vi.mock(import("@app/lib/api/config"), (() => ({
+  default: {
+    getClientFacingUrl: vi.fn().mockReturnValue("http://localhost:9999"),
+  },
+})) as any);
+
+describe("POST /api/w/[wId]/files", () => {
+  itInTransaction("creates file upload URL successfully", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    req.body = {
+      contentType: "text/csv",
+      fileName: "test.csv",
+      fileSize: 1024,
+      useCase: "conversation",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.file).toBeDefined();
+    expect(data.file.uploadUrl).toBeDefined();
+    expect(data.file.status).toBe("created");
+    expect(data.file.contentType).toBe("text/csv");
+    expect(data.file.fileName).toBe("test.csv");
+    expect(data.file.uploadUrl).toContain("http://localhost:9999");
+  });
+
+  itInTransaction(
+    "refuses non public use-case without system API key",
+    async () => {
+      const { req, res } = await createPublicApiMockRequest({
+        method: "POST",
+      });
+
+      req.body = {
+        contentType: "text/csv",
+        fileName: "test.csv",
+        fileSize: 1024,
+        useCase: "upsert_table",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    }
+  );
+});

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -3,6 +3,7 @@ import { FileUploadUrlRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import {
   ensureFileSize,
+  isPublicySupportedUseCase,
   isSupportedFileContentType,
   rateLimiter,
 } from "@dust-tt/types";
@@ -119,6 +120,17 @@ async function handler(
             api_error: {
               type: "rate_limit_error",
               message: "You have reached the rate limit for this workspace.",
+            },
+          });
+        }
+
+        // Limit use-case if not a system key.
+        if (!isPublicySupportedUseCase(useCase)) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "The file use case is not supported by the API.",
             },
           });
         }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2381,7 +2381,7 @@ export const FileUploadUrlRequestSchema = z.object({
   contentType: SupportedFileContentFragmentTypeSchema,
   fileName: z.string().max(256, "File name must be less than 256 characters"),
   fileSize: z.number(),
-  useCase: z.literal("conversation"),
+  useCase: z.union([z.literal("conversation"), z.literal("upsert_table")]),
   useCaseMetadata: z
     .object({
       conversationId: z.string(),


### PR DESCRIPTION
## Description

Authorize `upsert_table` file creation and upload on the public API if called by a system key.

## Tests

Added a test

## Risk

Very low

## Deploy Plan

- Deploy `front`
