### PR TITLE
Fix: duplicate tableName in a datasource

### DIFF
--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -156,7 +156,7 @@ export async function sync({
       upsertDataSourceRemoteTable({
         dataSourceConfig,
         tableId: tableInternalId,
-        tableName: tableName,
+        tableName: tableInternalId,
         remoteDatabaseTableId: tableInternalId,
         remoteDatabaseSecretId: connector.connectionId,
         tableDescription: "",


### PR DESCRIPTION
## Description

Fix using the table name from the db as the name of the table in core (it must be unique accross the whole datasource) and use the fully qualified internal table id.

## Tests

Local

## Risk

Low, slightly changed the behavior in the previous PR which introduced the bug.

## Deploy Plan

Deploy `connectors`