### PR TITLE
Fix: allow selecting for bigquery in AB

### DIFF
--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -84,7 +84,6 @@ const STRUCTURED_DATA_SOURCES: ConnectorProvider[] = [
   "google_drive",
   "notion",
   "microsoft",
-  "snowflake",
 ];
 
 export function supportsDocumentsData(ds: DataSource): boolean {
@@ -94,6 +93,7 @@ export function supportsDocumentsData(ds: DataSource): boolean {
 export function supportsStructuredData(ds: DataSource): boolean {
   return Boolean(
     isFolder(ds) ||
+      isRemoteDatabase(ds) ||
       (ds.connectorProvider &&
         STRUCTURED_DATA_SOURCES.includes(ds.connectorProvider))
   );


### PR DESCRIPTION
## Description

Bigquery was not eligible as a structured data provider in AB.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`