### PR TITLE
Upg: show empty selected remote databases nodes + handle multi-region tables better

### DIFF
--- a/connectors/src/connectors/bigquery/temporal/activities.ts
+++ b/connectors/src/connectors/bigquery/temporal/activities.ts
@@ -2,13 +2,10 @@ import type { ModelId } from "@dust-tt/types";
 import { isBigQueryWithLocationCredentials, MIME_TYPES } from "@dust-tt/types";
 
 import {
-  connectToBigQuery,
-  fetchDatasets,
-  fetchTables,
+  fetchTree,
   isConnectionReadonly,
 } from "@connectors/connectors/bigquery/lib/bigquery_api";
 import { sync } from "@connectors/lib/remote_databases/activities";
-import type { RemoteDBTable } from "@connectors/lib/remote_databases/utils";
 import { getConnectorAndCredentials } from "@connectors/lib/remote_databases/utils";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
@@ -27,33 +24,17 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
 
   const { credentials, connector } = getConnectorAndCredentialsRes.value;
 
-  const connection = connectToBigQuery(credentials);
-
   // BigQuery is read-only as we force the readonly scope when creating the client.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- BigQuery is read-only but leaving the call in case of copy-pasting later.
   const readonlyConnectionCheck = isConnectionReadonly();
 
-  const datasetRes = await fetchDatasets({ credentials, connection });
-  if (datasetRes.isErr()) {
-    throw datasetRes.error;
+  const treeRes = await fetchTree({ credentials });
+  if (treeRes.isErr()) {
+    throw treeRes.error;
   }
-  const datasets = datasetRes.value;
+  const tree = treeRes.value;
 
-  const liveTables: RemoteDBTable[] = [];
-  for (const dataset of datasets) {
-    const tablesOnBigQueryRes = await fetchTables({
-      credentials,
-      datasetName: dataset.name,
-      connection,
-    });
-    if (tablesOnBigQueryRes.isErr()) {
-      throw tablesOnBigQueryRes.error;
-    }
-
-    liveTables.push(...tablesOnBigQueryRes.value);
-  }
-
-  await sync({ liveTables, mimeTypes: MIME_TYPES.BIGQUERY, connector });
+  await sync({ remoteDBTree: tree, mimeTypes: MIME_TYPES.BIGQUERY, connector });
 
   await syncSucceeded(connectorId);
 }

--- a/connectors/src/lib/remote_databases/utils.ts
+++ b/connectors/src/lib/remote_databases/utils.ts
@@ -31,6 +31,14 @@ export const remoteDBTableCodec = t.type({
 });
 export type RemoteDBTable = t.TypeOf<typeof remoteDBTableCodec>;
 
+export type RemoteDBTree = {
+  databases: (RemoteDBDatabase & {
+    schemas: (RemoteDBSchema & {
+      tables: RemoteDBTable[];
+    })[];
+  })[];
+};
+
 export const parseSchemaInternalId = (
   schemaInternalId: string
 ): RemoteDBSchema => {
@@ -43,6 +51,17 @@ export const parseSchemaInternalId = (
     name: schemaName,
     database_name: dbName,
   };
+};
+
+export const parseTableInternalId = (
+  tableInternalId: string
+): RemoteDBTable => {
+  const [dbName, schemaName, tableName] = tableInternalId.split(".");
+  if (!dbName || !schemaName || !tableName) {
+    throw new Error(`Invalid table internalId: ${tableInternalId}`);
+  }
+
+  return { name: tableName, database_name: dbName, schema_name: schemaName };
 };
 
 // Helper functions to get connector and credentials

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.test.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.test.ts
@@ -113,7 +113,11 @@ describe("POST /api/w/[wId]/credentials/check_bigquery_locations", () => {
         locations: {
           us: ["dataset1.table1", "dataset1.table2"],
           eu: ["dataset2.table3"],
-          "eu-central1": ["dataset3.table4", "dataset4.table5"],
+          "eu-central1": [
+            "dataset2.table3",
+            "dataset3.table4",
+            "dataset4.table5",
+          ],
         },
       });
     }


### PR DESCRIPTION
## Description

- Allow dataset from multi-regions to be used when a subset region is selected.
- Show full hierarchy of nodes based on permissions, not only the ones leading to an actual table.

## Tests

Updated and local

## Risk

Low

## Deploy Plan

Deploy `connectors` and `front`