### PR TITLE
[Notion] CLI command to delete URL

### DIFF
--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -3,6 +3,7 @@ import type {
   ModelId,
   NotionCheckUrlResponseType,
   NotionCommandType,
+  NotionDeleteUrlResponseType,
   NotionFindUrlResponseType,
   NotionMeResponseType,
   NotionSearchPagesResponseType,
@@ -11,7 +12,11 @@ import type {
 import { Client, isFullDatabase, isFullPage } from "@notionhq/client";
 import { Op } from "sequelize";
 
-import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
+import {
+  deleteDatabase,
+  deletePage,
+  getNotionAccessToken,
+} from "@connectors/connectors/notion/temporal/activities";
 import { stopNotionGarbageCollectorWorkflow } from "@connectors/connectors/notion/temporal/client";
 import { QUEUE_NAME } from "@connectors/connectors/notion/temporal/config";
 import {
@@ -26,6 +31,7 @@ import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 import { getParsedDatabase, retrievePage } from "./notion_api";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 
 const logger = mainLogger.child({ provider: "notion" });
 
@@ -141,6 +147,51 @@ export async function findNotionUrl({
   return { page: null, db: null };
 }
 
+export async function deleteNotionUrl({
+  connector,
+  url,
+}: {
+  connector: ConnectorModel;
+  url: string;
+}) {
+  const pageOrDbId = pageOrDbIdFromUrl(url);
+
+  const dataSourceConfig = await dataSourceConfigFromConnector(connector);
+
+  const page = await NotionPage.findOne({
+    where: {
+      notionPageId: pageOrDbId,
+      connectorId: connector.id,
+    },
+  });
+  if (page) {
+    await deletePage({
+      connectorId: connector.id,
+      dataSourceConfig,
+      pageId: page.notionPageId,
+      logger,
+    });
+  }
+
+  const db = await NotionDatabase.findOne({
+    where: {
+      notionDatabaseId: pageOrDbId,
+      connectorId: connector.id,
+    },
+  });
+
+  if (db) {
+    await deleteDatabase({
+      connectorId: connector.id,
+      dataSourceConfig,
+      databaseId: db.notionDatabaseId,
+      logger,
+    });
+  }
+
+  return { deletedPage: !!page, deletedDb: !!db };
+}
+
 export async function checkNotionUrl({
   connectorId,
   connectionId,
@@ -219,6 +270,7 @@ export const notion = async ({
   | NotionUpsertResponseType
   | NotionSearchPagesResponseType
   | NotionCheckUrlResponseType
+  | NotionDeleteUrlResponseType
   | NotionMeResponseType
 > => {
   const logger = topLogger.child({ majorCommand: "notion", command, args });
@@ -545,6 +597,30 @@ export const notion = async ({
 
       const r = await findNotionUrl({
         connectorId: connector.id,
+        url,
+      });
+
+      return r;
+    }
+
+    // WARNING: This is meant to be used on pages deleted from Notion but not
+    // yet from Dust Since garbage collection can be long, we allow manually
+    // deleting pages from Dust before it finishes It is not meant to be used on
+    // pages that are still synced in Notion
+    case "delete-url": {
+      const { url, wId, dsId } = args;
+
+      if (!url) {
+        throw new Error("Missing --url argument");
+      }
+
+      const connector = await getConnectorOrThrow({
+        dataSourceId: dsId,
+        workspaceId: wId,
+      });
+
+      const r = await deleteNotionUrl({
+        connector,
         url,
       });
 

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -23,6 +23,7 @@ import {
   upsertDatabaseWorkflow,
   upsertPageWorkflow,
 } from "@connectors/connectors/notion/temporal/workflows/admins";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getConnectorOrThrow } from "@connectors/lib/cli";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import { getTemporalClient } from "@connectors/lib/temporal";
@@ -31,7 +32,6 @@ import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 import { getParsedDatabase, retrievePage } from "./notion_api";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 
 const logger = mainLogger.child({ provider: "notion" });
 

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -92,6 +92,7 @@ export const NotionCommandSchema = t.type({
     t.literal("search-pages"),
     t.literal("check-url"),
     t.literal("find-url"),
+    t.literal("delete-url"),
     t.literal("me"),
     t.literal("stop-all-garbage-collectors"),
     t.literal("update-parents-fields"),
@@ -418,6 +419,15 @@ export const NotionCheckUrlResponseSchema = t.type({
 
 export type NotionCheckUrlResponseType = t.TypeOf<
   typeof NotionCheckUrlResponseSchema
+>;
+
+export const NotionDeleteUrlResponseSchema = t.type({
+  deletedPage: t.boolean,
+  deletedDb: t.boolean,
+});
+
+export type NotionDeleteUrlResponseType = t.TypeOf<
+  typeof NotionDeleteUrlResponseSchema
 >;
 
 export const NotionFindUrlResponseSchema = t.type({

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -475,6 +475,7 @@ export const AdminResponseSchema = t.union([
   IntercomCheckTeamsResponseSchema,
   IntercomFetchConversationResponseSchema,
   NotionCheckUrlResponseSchema,
+  NotionDeleteUrlResponseSchema,
   NotionMeResponseSchema,
   NotionSearchPagesResponseSchema,
   NotionUpsertResponseSchema,


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2098

Allows deleting notion pages or databases from Dust

Required for instance when the GC takes too long and client wants to make sure pages are removed immediately

Note: this should be used on pages already deleted from Notion, as per comment

Risk
---
misuse

Deploy
---
connectors
