### PR TITLE
Remove snowflake and bigquery from default assistant sources

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -370,9 +370,11 @@ export const isConnectorProviderAssistantDefaultSelected = (
     case "intercom":
     case "microsoft":
     case "zendesk":
+      return true;
+    // As of today (07/02/2025), the default selected provider are going to be used for semantic search
+    // Remote database connectors are not available for semantic search so it makes no sense to select them by default
     case "snowflake":
     case "bigquery":
-      return true;
     case "webcrawler":
       return false;
     default:


### PR DESCRIPTION
## Description

Disable remote database as part of assistant default selection.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`, run query on front db
```
UPDATE data_sources SET "assistantDefaultSelected" = false WHERE "assistantDefaultSelected" = true AND ("connectorProvider" = 'snowflake' or "connectorProvider" = 'bigquery');
```
(there are only 20 occurrences)