### PR TITLE
[CoreNodes] Ignore diff in titles for BigQuery tables

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -330,7 +330,7 @@ export function computeNodesDiff({
             // the title in connectors, ignoring these occurrences.
             if (
               key === "title" &&
-              provider === "snowflake" &&
+              ["snowflake", "bigquery"].includes(provider) &&
               value.endsWith(coreValue) // value = database.schema.table, coreValue = table
             ) {
               return false;

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -330,6 +330,7 @@ export function computeNodesDiff({
             // the title in connectors, ignoring these occurrences.
             if (
               key === "title" &&
+              provider &&
               ["snowflake", "bigquery"].includes(provider) &&
               value.endsWith(coreValue) // value = database.schema.table, coreValue = table
             ) {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10611.
- See log [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Abigquery&agg_m=count&agg_m_source=base&agg_q=%40dataSourceViewId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZTfjm4-1zFjJQAAABhBWlRmam5UbUFBQm9hZXdjMG5rTjhnQmkAAAAkMDE5NGRmOTQtYTFkNC00ZjQyLWE3YzEtZGQyYmQ2ZTljZDE1AAkGiQ&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&top_n=25&top_o=top&viz=stream&x_missing=true&from_ts=1738822750000&to_ts=1738837150000&live=true).
- For BigQuery tables, core returns the table name as the node title, whereas `connectors` returns the `internalId`, which is of the form `db.schema.table`.
- This PR suggests ignoring the diff, assuming that the desired end state is core's behavior.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.