### PR TITLE
Optimize the remote database sync and add heartbeat

### DIFF
--- a/connectors/src/connectors/bigquery/temporal/workflows.ts
+++ b/connectors/src/connectors/bigquery/temporal/workflows.ts
@@ -5,7 +5,7 @@ import type * as activities from "@connectors/connectors/bigquery/temporal/activ
 import { resyncSignal } from "@connectors/connectors/bigquery/temporal/signals";
 
 const { syncBigQueryConnection } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "5 minute",
+  startToCloseTimeout: "10 minute",
 });
 
 export async function bigquerySyncWorkflow({

--- a/connectors/src/connectors/snowflake/temporal/workflows.ts
+++ b/connectors/src/connectors/snowflake/temporal/workflows.ts
@@ -5,7 +5,7 @@ import type * as activities from "@connectors/connectors/snowflake/temporal/acti
 import { resyncSignal } from "@connectors/connectors/snowflake/temporal/signals";
 
 const { syncSnowflakeConnection } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "30 minutes",
+  startToCloseTimeout: "10 minutes",
 });
 
 export async function snowflakeSyncWorkflow({


### PR DESCRIPTION
## Description

Optimize the sync activity to only upsert databases and schema once to core (previously, it would do it on every discovered tables).

So previously, number of upsert to core would be ~#tables * 3.
Now, number of upserts to core would be #tables + #schemas + #databases.

One of our customers has thousands of tables so it should be fairly impactful.

Also, added heartbeat, more logs and set to 10 minutes start to close.

Next optimization step would be to trust that if we have it marked as upserted in connector it means that core has it (but schema and databases do not have the column yet)

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `connectors`