### PR TITLE
Do not upsert table to core if already done.

### DIFF
--- a/connectors/migrations/db/migration_50.sql
+++ b/connectors/migrations/db/migration_50.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."remote_schemas" ADD COLUMN "lastUpsertedAt" TIMESTAMP WITH TIME ZONE;
+ALTER TABLE "public"."remote_databases" ADD COLUMN "lastUpsertedAt" TIMESTAMP WITH TIME ZONE;

--- a/connectors/src/connectors/bigquery/temporal/client.ts
+++ b/connectors/src/connectors/bigquery/temporal/client.ts
@@ -45,8 +45,8 @@ export async function launchBigQuerySyncWorkflow(
       memo: {
         connectorId,
       },
-      // Every 10 minutes.
-      cronSchedule: "*/10 * * * *",
+      // Every hour.
+      cronSchedule: `${connector.id % 60} * * * *`,
     });
   } catch (err) {
     return new Err(err as Error);

--- a/connectors/src/connectors/snowflake/temporal/client.ts
+++ b/connectors/src/connectors/snowflake/temporal/client.ts
@@ -45,8 +45,8 @@ export async function launchSnowflakeSyncWorkflow(
       memo: {
         connectorId,
       },
-      // Every 10 minutes.
-      cronSchedule: "*/10 * * * *",
+      // Every hour.
+      cronSchedule: `${connector.id % 60} * * * *`,
     });
   } catch (err) {
     return new Err(err as Error);


### PR DESCRIPTION
## Description

- Do not upsert table again to core if already marked as upserted in connector.
- Cron every hour vs 10 minutes.
- Add migration for a follow up PR to do the same logic for databases and schemas.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `connectors`, run migration on US & EU