### PR TITLE
Do not upsert schemas and databases to core if already done

### DIFF
--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -312,6 +312,7 @@ export const batch = async ({
         "google_drive",
         "snowflake",
         "zendesk",
+        "bigquery",
       ];
       if (!PROVIDERS_ALLOWING_RESTART.includes(args.provider)) {
         throw new Error(

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -9,6 +9,7 @@ type AllowedPermissions = "selected" | "unselected" | "inherited";
 export class RemoteDatabaseModel extends ConnectorBaseModel<RemoteDatabaseModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare lastUpsertedAt: CreationOptional<Date> | null;
 
   declare internalId: string;
   declare name: string;
@@ -49,6 +50,7 @@ RemoteDatabaseModel.init(
 export class RemoteSchemaModel extends ConnectorBaseModel<RemoteSchemaModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare lastUpsertedAt: CreationOptional<Date> | null;
 
   declare internalId: string;
   declare name: string;


### PR DESCRIPTION
## Description

Apply the same logic for schemas and databases : trust the connectors state to reflect the core state.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `connectors`, restart connectors for snowflake and bigquery