### PR TITLE
[CoreNodes] Include correct nodes in Poke diff display

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -87,6 +87,7 @@ export function computeNodesDiff({
 }) {
   const missingNodes: DataSourceViewContentNode[] = [];
   const mismatchNodes: DataSourceViewContentNode[] = [];
+  const matchingNodes: DataSourceViewContentNode[] = [];
 
   // Core and connectors follow different sorting rules,
   // so when pagination is enforced, we only want to log the number of nodes we get,
@@ -143,212 +144,215 @@ export function computeNodesDiff({
       );
     } else {
       const matchingCoreNode = matchingCoreNodes[0];
+      const entryIsInDiff = ([key, value]: [string, any]) => {
+        if (["preventSelection", "lastUpdatedAt", "permission"].includes(key)) {
+          return false;
+        }
+        // Custom exclusion rules. The goal here is to avoid logging irrelevant differences, scoping by connector.
+
+        // For Snowflake and Zendesk we fixed how parents were computed in the core folders but not in connectors.
+        // For Intercom we keep the virtual node Help Center in connectors but not in core.
+        if (
+          ["parentInternalIds", "parentInternalId"].includes(key) &&
+          provider &&
+          ["snowflake", "zendesk", "intercom"].includes(provider)
+        ) {
+          return false;
+        }
+        const coreValue =
+          matchingCoreNode[key as keyof DataSourceViewContentNode];
+
+        // Special case for folder parents, the ones retrieved using getContentNodesForStaticDataSourceView do not
+        // contain any parentInternalIds.
+        if (provider === null && key === "parentInternalIds") {
+          return false;
+        }
+        // Ignore the type mismatch between core and connectors for mime types that were already identified.
+        if (
+          key === "type" &&
+          matchingCoreNode.mimeType &&
+          ((value === "channel" &&
+            CHANNEL_MIME_TYPES.includes(matchingCoreNode.mimeType)) ||
+            (value === "database" &&
+              DATABASE_MIME_TYPES.includes(matchingCoreNode.mimeType)) ||
+            (value === "file" &&
+              FILE_MIME_TYPES.includes(matchingCoreNode.mimeType)))
+        ) {
+          return false;
+        }
+        // For Google Drive, connectors does not fill the parentInternalId at google_drive/index.ts#L324.
+        if (
+          ["parentInternalId", "parentInternalIds"].includes(key) &&
+          provider === "google_drive" &&
+          coreValue !== null &&
+          value === null
+        ) {
+          return false;
+        }
+
+        // gdrive_outside_sync is core only.
+        if (
+          "parentInternalIds" === key &&
+          provider === "google_drive" &&
+          matchingCoreNode?.parentInternalIds?.includes("gdrive_outside_sync")
+        ) {
+          return false;
+        }
+
+        // The notion-syncing is a concept only added to core and not to the parents in content nodes from connectors.
+        if (
+          ["parentInternalId", "parentInternalIds"].includes(key) &&
+          provider === "notion" &&
+          matchingCoreNode?.parentInternalIds?.includes("notion-syncing")
+        ) {
+          return false;
+        }
+
+        // Special case for Google drive spreadsheets:
+        // title is '{spreadsheetName} - {sheetName}' for core, but only '{sheetName}' for connectors (not always).
+        // The value in core is an improvement over the value in connectors, so we omit the difference.
+        if (
+          key === "title" &&
+          matchingCoreNode.mimeType ===
+            "application/vnd.google-apps.spreadsheet"
+        ) {
+          return false;
+        }
+
+        // Special case for Google Drive spreadsheet folders: connectors
+        // return a type "file" while core returns a type "folder".
+        if (
+          key === "type" &&
+          provider === "google_drive" &&
+          value === "file" &&
+          matchingCoreNode.type === "folder" &&
+          matchingCoreNode.mimeType === MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET
+        ) {
+          return false;
+        }
+
+        // Same for microsoft spreadsheet folders: connectors
+        // return a type "file" while core returns a type "folder".
+        if (
+          key === "type" &&
+          provider === "microsoft" &&
+          value === "file" &&
+          matchingCoreNode.type === "folder" &&
+          matchingCoreNode.mimeType === MIME_TYPES.MICROSOFT.SPREADSHEET
+        ) {
+          return false;
+        }
+
+        // Special case for Google Drive drives: not stored in connnectors,
+        // so parentInternalIds are empty VS [driveId]
+        if (
+          key === "parentInternalIds" &&
+          provider === "google_drive" &&
+          !value &&
+          matchingCoreNode.parentInternalIds?.length === 1 &&
+          matchingCoreNode.parentInternalIds[0] === matchingCoreNode.internalId
+        ) {
+          return false;
+        }
+
+        // Ignore sourceUrls returned by core but left empty by connectors.
+        if (key === "sourceUrl" && value === null && coreValue !== null) {
+          return false;
+        }
+        // Special case for the google drive sourceUrl: convert docs.google.com to drive.google.com/file for comparison.
+        if (key === "sourceUrl" && value && coreValue) {
+          // Remove usp=drivesdk suffix from core value for comparison
+          let cleanedCoreValue = coreValue.toString().replace(/\?.*$/, "");
+          // Convert docs.google.com to drive.google.com/file for comparison
+          if (cleanedCoreValue.startsWith("https://docs.google.com/")) {
+            const fileId = cleanedCoreValue.split("/")[5]; // Get file ID from URL
+            cleanedCoreValue = `https://drive.google.com/file/d/${fileId}/view`;
+          }
+
+          if (cleanedCoreValue === value) {
+            return false;
+          }
+        }
+
+        // Special case for the titles of Webcrawler folders: we add a trailing slash in core but not in connectors.
+        if (
+          key === "title" &&
+          provider === "webcrawler" &&
+          coreValue === `${value}/`
+        ) {
+          return false;
+        }
+        // Special case for expandable: if the core node is not expandable and the connectors one is, it means
+        // that the difference comes from the fact that the node has no children: we omit from the log.
+        if (key === "expandable" && value === true && coreValue === false) {
+          return false;
+        }
+        // Special case for expandable on Intercom collections: connectors does not allow expanding collections below the first level (there can be up to 3 levels of nesting in collections).
+        // This behavior has to be kept for /permissions, and is implemented in generic functions so cannot be changed for /content-nodes only and not /permissions.
+        // core will make them expandable if not empty no matter what.
+        // If we agree that this is the desired experience, we can ignore in the log.
+        if (
+          key === "expandable" &&
+          provider === "intercom" &&
+          matchingCoreNode.internalId.startsWith("intercom-collection") &&
+          value === false &&
+          coreValue === true
+        ) {
+          return false;
+        }
+        // Special case for Slack's providerVisibility: we only check if providerVisibility === "private" so
+        // having a falsy value in core and "public" in connectors is the same.
+        if (
+          key === "providerVisibility" &&
+          provider === "slack" &&
+          value === "public" &&
+          !coreValue
+        ) {
+          return false;
+        }
+        // Special case for Slack's permission:
+        // connectors uses "read_write" for selected nodes whereas we always set it to "read" for nodes from core.
+        if (
+          key === "permission" &&
+          provider === "slack" &&
+          value === "read_write" &&
+          coreValue === "read"
+        ) {
+          return false;
+        }
+        // Special case for Snowflake's title: we sometimes observe the internal ID database.schema.table used as
+        // the title in connectors, ignoring these occurrences.
+        if (
+          key === "title" &&
+          provider &&
+          ["snowflake", "bigquery"].includes(provider) &&
+          value.endsWith(coreValue) // value = database.schema.table, coreValue = table
+        ) {
+          return false;
+        }
+        // Special case for Notion databases titles: when empty it is filled as "Untitled Notion Database" in core
+        // whereas the connector returns an empty string.
+        if (
+          key === "title" &&
+          value.trim() === "" &&
+          coreValue === "Untitled Notion Database"
+        ) {
+          return false;
+        }
+        if (Array.isArray(value) && Array.isArray(coreValue)) {
+          return JSON.stringify(value) !== JSON.stringify(coreValue);
+        }
+        return value !== coreValue;
+      };
+
       const diff = Object.fromEntries(
         Object.entries(connectorsNode)
           .filter(([key, value]) => {
-            if (
-              ["preventSelection", "lastUpdatedAt", "permission"].includes(key)
-            ) {
-              return false;
+            const includeEntryInDiff = entryIsInDiff([key, value]);
+            if (!includeEntryInDiff) {
+              matchingNodes.push(matchingCoreNode);
             }
-            // Custom exclusion rules. The goal here is to avoid logging irrelevant differences, scoping by connector.
-
-            // For Snowflake and Zendesk we fixed how parents were computed in the core folders but not in connectors.
-            // For Intercom we keep the virtual node Help Center in connectors but not in core.
-            if (
-              ["parentInternalIds", "parentInternalId"].includes(key) &&
-              provider &&
-              ["snowflake", "zendesk", "intercom"].includes(provider)
-            ) {
-              return false;
-            }
-            const coreValue =
-              matchingCoreNode[key as keyof DataSourceViewContentNode];
-
-            // Special case for folder parents, the ones retrieved using getContentNodesForStaticDataSourceView do not
-            // contain any parentInternalIds.
-            if (provider === null && key === "parentInternalIds") {
-              return false;
-            }
-            // Ignore the type mismatch between core and connectors for mime types that were already identified.
-            if (
-              key === "type" &&
-              matchingCoreNode.mimeType &&
-              ((value === "channel" &&
-                CHANNEL_MIME_TYPES.includes(matchingCoreNode.mimeType)) ||
-                (value === "database" &&
-                  DATABASE_MIME_TYPES.includes(matchingCoreNode.mimeType)) ||
-                (value === "file" &&
-                  FILE_MIME_TYPES.includes(matchingCoreNode.mimeType)))
-            ) {
-              return false;
-            }
-            // For Google Drive, connectors does not fill the parentInternalId at google_drive/index.ts#L324.
-            if (
-              ["parentInternalId", "parentInternalIds"].includes(key) &&
-              provider === "google_drive" &&
-              coreValue !== null &&
-              value === null
-            ) {
-              return false;
-            }
-
-            // gdrive_outside_sync is core only.
-            if (
-              "parentInternalIds" === key &&
-              provider === "google_drive" &&
-              matchingCoreNode?.parentInternalIds?.includes(
-                "gdrive_outside_sync"
-              )
-            ) {
-              return false;
-            }
-
-            // The notion-syncing is a concept only added to core and not to the parents in content nodes from connectors.
-            if (
-              ["parentInternalId", "parentInternalIds"].includes(key) &&
-              provider === "notion" &&
-              matchingCoreNode?.parentInternalIds?.includes("notion-syncing")
-            ) {
-              return false;
-            }
-
-            // Special case for Google drive spreadsheets:
-            // title is '{spreadsheetName} - {sheetName}' for core, but only '{sheetName}' for connectors (not always).
-            // The value in core is an improvement over the value in connectors, so we omit the difference.
-            if (
-              key === "title" &&
-              matchingCoreNode.mimeType ===
-                "application/vnd.google-apps.spreadsheet"
-            ) {
-              return false;
-            }
-
-            // Special case for Google Drive spreadsheet folders: connectors
-            // return a type "file" while core returns a type "folder".
-            if (
-              key === "type" &&
-              provider === "google_drive" &&
-              value === "file" &&
-              matchingCoreNode.type === "folder" &&
-              matchingCoreNode.mimeType === MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET
-            ) {
-              return false;
-            }
-
-            // Same for microsoft spreadsheet folders: connectors
-            // return a type "file" while core returns a type "folder".
-            if (
-              key === "type" &&
-              provider === "microsoft" &&
-              value === "file" &&
-              matchingCoreNode.type === "folder" &&
-              matchingCoreNode.mimeType === MIME_TYPES.MICROSOFT.SPREADSHEET
-            ) {
-              return false;
-            }
-
-            // Special case for Google Drive drives: not stored in connnectors,
-            // so parentInternalIds are empty VS [driveId]
-            if (
-              key === "parentInternalIds" &&
-              provider === "google_drive" &&
-              !value &&
-              matchingCoreNode.parentInternalIds?.length === 1 &&
-              matchingCoreNode.parentInternalIds[0] ===
-                matchingCoreNode.internalId
-            ) {
-              return false;
-            }
-
-            // Ignore sourceUrls returned by core but left empty by connectors.
-            if (key === "sourceUrl" && value === null && coreValue !== null) {
-              return false;
-            }
-            // Special case for the google drive sourceUrl: convert docs.google.com to drive.google.com/file for comparison.
-            if (key === "sourceUrl" && value && coreValue) {
-              // Remove usp=drivesdk suffix from core value for comparison
-              let cleanedCoreValue = coreValue.toString().replace(/\?.*$/, "");
-              // Convert docs.google.com to drive.google.com/file for comparison
-              if (cleanedCoreValue.startsWith("https://docs.google.com/")) {
-                const fileId = cleanedCoreValue.split("/")[5]; // Get file ID from URL
-                cleanedCoreValue = `https://drive.google.com/file/d/${fileId}/view`;
-              }
-
-              if (cleanedCoreValue === value) {
-                return false;
-              }
-            }
-
-            // Special case for the titles of Webcrawler folders: we add a trailing slash in core but not in connectors.
-            if (
-              key === "title" &&
-              provider === "webcrawler" &&
-              coreValue === `${value}/`
-            ) {
-              return false;
-            }
-            // Special case for expandable: if the core node is not expandable and the connectors one is, it means
-            // that the difference comes from the fact that the node has no children: we omit from the log.
-            if (key === "expandable" && value === true && coreValue === false) {
-              return false;
-            }
-            // Special case for expandable on Intercom collections: connectors does not allow expanding collections below the first level (there can be up to 3 levels of nesting in collections).
-            // This behavior has to be kept for /permissions, and is implemented in generic functions so cannot be changed for /content-nodes only and not /permissions.
-            // core will make them expandable if not empty no matter what.
-            // If we agree that this is the desired experience, we can ignore in the log.
-            if (
-              key === "expandable" &&
-              provider === "intercom" &&
-              matchingCoreNode.internalId.startsWith("intercom-collection") &&
-              value === false &&
-              coreValue === true
-            ) {
-              return false;
-            }
-            // Special case for Slack's providerVisibility: we only check if providerVisibility === "private" so
-            // having a falsy value in core and "public" in connectors is the same.
-            if (
-              key === "providerVisibility" &&
-              provider === "slack" &&
-              value === "public" &&
-              !coreValue
-            ) {
-              return false;
-            }
-            // Special case for Slack's permission:
-            // connectors uses "read_write" for selected nodes whereas we always set it to "read" for nodes from core.
-            if (
-              key === "permission" &&
-              provider === "slack" &&
-              value === "read_write" &&
-              coreValue === "read"
-            ) {
-              return false;
-            }
-            // Special case for Snowflake's title: we sometimes observe the internal ID database.schema.table used as
-            // the title in connectors, ignoring these occurrences.
-            if (
-              key === "title" &&
-              provider &&
-              ["snowflake", "bigquery"].includes(provider) &&
-              value.endsWith(coreValue) // value = database.schema.table, coreValue = table
-            ) {
-              return false;
-            }
-            // Special case for Notion databases titles: when empty it is filled as "Untitled Notion Database" in core
-            // whereas the connector returns an empty string.
-            if (
-              key === "title" &&
-              value.trim() === "" &&
-              coreValue === "Untitled Notion Database"
-            ) {
-              return false;
-            }
-            if (Array.isArray(value) && Array.isArray(coreValue)) {
-              return JSON.stringify(value) !== JSON.stringify(coreValue);
-            }
-            return value !== coreValue;
+            return includeEntryInDiff;
           })
           .map(([key, value]) => [
             key,
@@ -406,12 +410,11 @@ export function computeNodesDiff({
       (coreNode) =>
         !connectorsContentNodes.some(
           (n) => n.internalId === coreNode.internalId
-          // Special case
-          // Notion syncing folder is not in connectors but it's in core.
-          // Connector's notion unknown folder can map to core's syncing OR unknown folder.
-          // See https://github.com/dust-tt/dust/issues/10340
-        ) && coreNode.internalId !== "notion-syncing"
+        )
     )
+    // Connector's notion-unknown folder can map to core's notion-syncing OR notion-unknown folder.
+    // See https://github.com/dust-tt/dust/issues/10340
+    .filter((coreNode) => coreNode.internalId !== "notion-syncing")
     // There is some specific code to Intercom in retrieveIntercomConversationsPermissions that hides the empty team folders + the teams folder if !hasTeamsWithReadPermission
     // TBD whether this logic will be reproduced for core, ignoring for now.
     .filter(
@@ -477,7 +480,17 @@ export function computeNodesDiff({
     extraNode.title = `[EXTRA] ${extraNode.title}`;
     return extraNode;
   });
-  return [...mismatchNodes, ...extraTitleNodes, ...missingTitleNodes];
+  const matchingTitleNodes = matchingNodes.map((node) => {
+    const matchingNode = { ...node };
+    matchingNode.title = `[OK] ${node.title}`;
+    return matchingNode;
+  });
+  return [
+    ...matchingTitleNodes,
+    ...mismatchNodes,
+    ...extraTitleNodes,
+    ...missingTitleNodes,
+  ];
 }
 
 export function getContentNodeType(node: CoreAPIContentNode): ContentNodeType {

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -88,6 +88,7 @@ export function computeNodesDiff({
   const missingNodes: DataSourceViewContentNode[] = [];
   const mismatchNodes: DataSourceViewContentNode[] = [];
   const matchingNodes: DataSourceViewContentNode[] = [];
+  const matchingNodeIds: Set<string> = new Set();
 
   // Core and connectors follow different sorting rules,
   // so when pagination is enforced, we only want to log the number of nodes we get,
@@ -349,7 +350,11 @@ export function computeNodesDiff({
         Object.entries(connectorsNode)
           .filter(([key, value]) => {
             const includeEntryInDiff = entryIsInDiff([key, value]);
-            if (!includeEntryInDiff) {
+            if (
+              !includeEntryInDiff &&
+              !matchingNodeIds.has(matchingCoreNode.internalId)
+            ) {
+              matchingNodeIds.add(matchingCoreNode.internalId);
               matchingNodes.push(matchingCoreNode);
             }
             return includeEntryInDiff;

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -340,6 +340,15 @@ export function computeNodesDiff({
         ) {
           return false;
         }
+        // Special case for Zendesk tickets sourceUrls: the sourceUrl was fixed in https://github.com/dust-tt/dust/pull/10435
+        // but not backfilled as this is a relatively low priority. It will be resynced on demand.
+        if (
+          key === "sourceUrl" &&
+          provider === "zendesk" &&
+          value.replace("/api/v2/", "/").replace(".json", "") === coreValue
+        ) {
+          return false;
+        }
         if (Array.isArray(value) && Array.isArray(coreValue)) {
           return JSON.stringify(value) !== JSON.stringify(coreValue);
         }


### PR DESCRIPTION
## Description

- This PR adds the correct nodes to the diff displayed in Poke.
- If we have a diff on a non-root node we may not get to see since we can't make our way to it (the parents won't appear if not in the diff).
- This PR aims at adding the correct nodes with an `[OK]` prefix.
- This PR also adds an exclusion rule for Zendesk tickets URLs.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.