### PR TITLE
[Notion] Poke plugin to sync / delete notion URLs

### DIFF
--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -20,7 +20,22 @@ const whitelistedCommands = [
     majorCommand: "notion",
     command: "find-url",
   },
-  { majorCommand: "slack", command: "whitelist-bot" },
+  {
+    majorCommand: "notion",
+    command: "delete-url",
+  },
+  {
+    majorCommand: "notion",
+    command: "upsert-page",
+  },
+  {
+    majorCommand: "notion",
+    command: "upsert-database",
+  },
+  {
+    majorCommand: "slack",
+    command: "whitelist-bot",
+  },
   {
     majorCommand: "connectors",
     command: "set-error",

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -38,7 +38,7 @@ import { getOrphanedCount, getParents, hasChildren } from "./lib/parents";
 
 const logger = mainLogger.child({ provider: "notion" });
 
-function nodeIdFromNotionId(notionId: string) {
+export function nodeIdFromNotionId(notionId: string) {
   return `notion-${notionId}`;
 }
 

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -15,6 +15,7 @@ import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { nodeIdFromNotionId } from "@connectors/connectors/notion";
 
 /** Compute the parents field for a notion pageOrDb See the [Design
  * Doc](https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=3d26536a4e0a464eae0c3f8f27a7af97&pm=s)
@@ -173,7 +174,7 @@ export async function updateAllParentsFields(
           onProgress
         );
 
-        const parents = pageOrDbIds.map((id) => `notion-${id}`);
+        const parents = pageOrDbIds.map((id) => nodeIdFromNotionId(id));
         if (parents.length === 1) {
           const page = await getNotionPageFromConnectorsDb(connectorId, pageId);
           logger.warn(
@@ -191,7 +192,7 @@ export async function updateAllParentsFields(
         );
         await updateDataSourceDocumentParents({
           dataSourceConfig: dataSourceConfigFromConnector(connector),
-          documentId: `notion-${pageId}`,
+          documentId: nodeIdFromNotionId(pageId),
           parents,
           parentId: parents[1] || null,
         });

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -79,6 +79,7 @@ import { heartbeat } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import { nodeIdFromNotionId } from "@connectors/connectors/notion";
 
 const logger = mainLogger.child({ provider: "notion" });
 
@@ -2703,19 +2704,19 @@ export async function updateSingleDocumentParents({
     "Parents for document"
   );
 
-  const parents = parentsNotionIds.map((id) => `notion-${id}`);
+  const parents = parentsNotionIds.map((id) => nodeIdFromNotionId(id));
 
   if (documentType === "page") {
     await updateDataSourceDocumentParents({
       dataSourceConfig,
-      documentId: `notion-${notionDocumentId}`,
+      documentId: nodeIdFromNotionId(notionDocumentId),
       parents,
       parentId: parents[1] || null,
     });
   } else if (documentType === "database") {
     await updateDataSourceTableParents({
       dataSourceConfig,
-      tableId: `notion-${notionDocumentId}`,
+      tableId: nodeIdFromNotionId(notionDocumentId),
       parents,
       parentId: parents[1] || null,
     });

--- a/connectors/src/connectors/notion/temporal/workflows/admins.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/admins.ts
@@ -20,6 +20,7 @@ const {
   getDiscoveredResourcesFromCache,
   upsertDatabaseInConnectorsDb,
   deletePageOrDatabaseIfArchived,
+  updateSingleDocumentParents,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minute",
 });
@@ -100,6 +101,12 @@ export async function upsertPageWorkflow({
     objectId: pageId,
     objectType: "page",
     loggerArgs,
+  });
+
+  await updateSingleDocumentParents({
+    connectorId,
+    notionDocumentId: pageId,
+    documentType: "page",
   });
 
   return { skipped };
@@ -184,5 +191,11 @@ export async function upsertDatabaseWorkflow({
     objectId: databaseId,
     objectType: "database",
     loggerArgs,
+  });
+
+  await updateSingleDocumentParents({
+    connectorId,
+    notionDocumentId: databaseId,
+    documentType: "database",
   });
 }

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -54,6 +54,8 @@ export function PluginForm({ disabled, manifest, onSubmit }: PluginFormProps) {
     return Object.fromEntries(
       Object.entries(manifest.args).map(([key, arg]) => {
         switch (arg.type) {
+          case "text":
+            return [key, ""];
           case "string":
             return [key, ""];
           case "number":
@@ -107,7 +109,8 @@ export function PluginForm({ disabled, manifest, onSubmit }: PluginFormProps) {
                   <PokeFormLabel>{arg.label}</PokeFormLabel>
                   <PokeFormControl>
                     <>
-                      {arg.type === "string" && <PokeFormTextArea {...field} />}
+                      {arg.type === "text" && <PokeFormTextArea {...field} />}
+                      {arg.type === "string" && <PokeFormInput {...field} />}
                       {arg.type === "number" && (
                         <PokeFormInput
                           type="number"

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -16,6 +16,7 @@ import {
   PokeFormItem,
   PokeFormLabel,
   PokeFormMessage,
+  PokeFormTextArea,
 } from "@app/components/poke/shadcn/ui/form";
 import {
   PokeSelect,
@@ -106,7 +107,7 @@ export function PluginForm({ disabled, manifest, onSubmit }: PluginFormProps) {
                   <PokeFormLabel>{arg.label}</PokeFormLabel>
                   <PokeFormControl>
                     <>
-                      {arg.type === "string" && <PokeFormInput {...field} />}
+                      {arg.type === "string" && <PokeFormTextArea {...field} />}
                       {arg.type === "number" && (
                         <PokeFormInput
                           type="number"

--- a/front/components/poke/shadcn/ui/form.tsx
+++ b/front/components/poke/shadcn/ui/form.tsx
@@ -161,6 +161,23 @@ FormMessage.displayName = "FormMessage";
 
 // Override the default input component to add border and background styles.
 const FormInput = React.forwardRef<
+  HTMLInputElement,
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, "value"> & {
+    value?: React.ComponentProps<typeof Input>["value"];
+  }
+>(({ className, value, ...props }, ref) => {
+  return (
+    <Input
+      ref={ref}
+      className={cn("border-2 border-border-dark bg-white", className)}
+      value={value}
+      {...props}
+    />
+  );
+});
+FormInput.displayName = "FormInput";
+
+const FormTextArea = React.forwardRef<
   HTMLTextAreaElement,
   Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "value"> & {
     value?: React.ComponentProps<typeof TextArea>["value"];
@@ -177,7 +194,7 @@ const FormInput = React.forwardRef<
     </div>
   );
 });
-FormInput.displayName = "FormInput";
+FormTextArea.displayName = "FormTextArea";
 
 export {
   Form as PokeForm,
@@ -188,4 +205,5 @@ export {
   FormItem as PokeFormItem,
   FormLabel as PokeFormLabel,
   FormMessage as PokeFormMessage,
+  FormTextArea as PokeFormTextArea,
 };

--- a/front/components/poke/shadcn/ui/form.tsx
+++ b/front/components/poke/shadcn/ui/form.tsx
@@ -1,4 +1,4 @@
-import { Input, Label } from "@dust-tt/sparkle";
+import { Input, Label, TextArea } from "@dust-tt/sparkle";
 import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
@@ -161,18 +161,20 @@ FormMessage.displayName = "FormMessage";
 
 // Override the default input component to add border and background styles.
 const FormInput = React.forwardRef<
-  HTMLInputElement,
-  Omit<React.InputHTMLAttributes<HTMLInputElement>, "value"> & {
-    value?: React.ComponentProps<typeof Input>["value"];
+  HTMLTextAreaElement,
+  Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "value"> & {
+    value?: React.ComponentProps<typeof TextArea>["value"];
   }
 >(({ className, value, ...props }, ref) => {
   return (
-    <Input
-      ref={ref}
-      className={cn("border-2 border-border-dark bg-white", className)}
-      value={value}
-      {...props}
-    />
+    <div ref={ref as React.RefObject<HTMLDivElement>}>
+      <TextArea
+        className={cn("border-2 border-border-dark bg-white", className)}
+        value={value ?? undefined}
+        minRows={2}
+        {...props}
+      />
+    </div>
   );
 });
 FormInput.displayName = "FormInput";

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -1,4 +1,4 @@
 export * from "./garbage_collect_google_drive_document";
 export * from "./mark_connector_as_error";
-export * from "./operations";
 export * from "./notion_url_sync";
+export * from "./operations";

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -1,3 +1,4 @@
 export * from "./garbage_collect_google_drive_document";
 export * from "./mark_connector_as_error";
 export * from "./operations";
+export * from "./notion_url_sync";

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -169,7 +169,7 @@ export const notionUrlSyncPlugin = createPlugin(
             db: { [key: string]: unknown } | null;
           };
 
-          if (page || db) {
+          if ((page && !page.in_trash) || (db && !db.in_trash)) {
             return new Err(
               new Error(
                 `URL ${url} still available on Notion, should not be deleted.`

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -72,7 +72,7 @@ export const notionUrlSyncPlugin = createPlugin(
         async (url) => {
           const findUrlRes = await connectorsAPI.admin({
             majorCommand: "notion",
-            command: "find-url",
+            command: "check-url",
             args: {
               wId: auth.getNonNullableWorkspace().sId,
               dsId: dataSource.sId,
@@ -92,7 +92,7 @@ export const notionUrlSyncPlugin = createPlugin(
           }
 
           const { page, db } = decoded.right;
-
+          console.log({ page, db });
           if (page) {
             const upsertPageRes = await connectorsAPI.admin({
               majorCommand: "notion",
@@ -100,7 +100,7 @@ export const notionUrlSyncPlugin = createPlugin(
               args: {
                 wId: auth.getNonNullableWorkspace().sId,
                 dsId: dataSource.sId,
-                pageId: page.notionPageId as string,
+                pageId: page.id as string,
               },
             });
 
@@ -108,7 +108,7 @@ export const notionUrlSyncPlugin = createPlugin(
               return new Err(new Error(upsertPageRes.error.message));
             }
 
-            return new Ok(`Upserted page ${page.notionPageId} for url ${url}`);
+            return new Ok(`Upserted page ${page.id} for url ${url}`);
           } else if (db) {
             const upsertDbRes = await connectorsAPI.admin({
               majorCommand: "notion",
@@ -116,7 +116,7 @@ export const notionUrlSyncPlugin = createPlugin(
               args: {
                 wId: auth.getNonNullableWorkspace().sId,
                 dsId: dataSource.sId,
-                databaseId: db.notionDatabaseId as string,
+                databaseId: db.id as string,
               },
             });
 
@@ -124,9 +124,7 @@ export const notionUrlSyncPlugin = createPlugin(
               return new Err(new Error(upsertDbRes.error.message));
             }
 
-            return new Ok(
-              `Upserted database ${db.notionDatabaseId} for url ${url}`
-            );
+            return new Ok(`Upserted database ${db.id} for url ${url}`);
           } else {
             return new Err(
               new Error(`No page or database found for url ${url}`)

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -31,7 +31,7 @@ export const notionUrlSyncPlugin = createPlugin(
         values: NOTION_OPERATIONS,
       },
       urls: {
-        type: "string",
+        type: "text",
         label: "URLs",
         description:
           "List of URLs to sync or delete, separated by a comma (,) or newline",

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -31,7 +31,8 @@ export const notionUrlSyncPlugin = createPlugin(
       urls: {
         type: "string",
         label: "URLs",
-        description: "List of URLs to sync or delete, separated by a comma (,)",
+        description:
+          "List of URLs to sync or delete, separated by a comma (,) or newline",
       },
     },
   },
@@ -56,7 +57,7 @@ export const notionUrlSyncPlugin = createPlugin(
 
     const { operation, urls } = args;
 
-    const urlsArray = urls.split(",").map((url) => url.trim());
+    const urlsArray = urls.split(/[\n,]/).map((url) => url.trim());
 
     const connectorsAPI = new ConnectorsAPI(
       config.getConnectorsAPIConfig(),

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -1,4 +1,3 @@
-import type { AdminCommandType } from "@dust-tt/types";
 import {
   concurrentExecutor,
   ConnectorsAPI,

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -1,0 +1,201 @@
+import type { AdminCommandType } from "@dust-tt/types";
+import {
+  concurrentExecutor,
+  ConnectorsAPI,
+  Err,
+  NotionFindUrlResponseSchema,
+  Ok,
+} from "@dust-tt/types";
+
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+import { isLeft } from "fp-ts/lib/Either";
+
+const NOTION_OPERATIONS = ["Sync urls", "Delete urls"] as const;
+
+export const notionUrlSyncPlugin = createPlugin(
+  {
+    id: "notion-url-sync",
+    name: "Notion URLs sync/delete",
+    description: "Sync or delete a Notion URL to Dust",
+    resourceTypes: ["data_sources"],
+    args: {
+      operation: {
+        type: "enum",
+        label: "Operation",
+        description: "Select operation to perform",
+        values: NOTION_OPERATIONS,
+      },
+      urls: {
+        type: "string",
+        label: "URLs",
+        description: "List of URLs to sync or delete, separated by a comma (,)",
+      },
+    },
+  },
+  async (auth, dataSourceId, args) => {
+    if (!dataSourceId) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    if (dataSource.connectorProvider !== "notion") {
+      return new Err(new Error("Data source is not Notion."));
+    }
+
+    const { connectorId } = dataSource;
+    if (!connectorId) {
+      return new Err(new Error("No connector on datasource."));
+    }
+
+    const { operation, urls } = args;
+
+    const urlsArray = urls.split(",").map((url) => url.trim());
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    if (operation === "Sync urls") {
+      const notionCommand: AdminCommandType = {
+        majorCommand: "notion",
+        command: "find-url",
+        args: {
+          wId: auth.getNonNullableWorkspace().sId,
+          dsId: dataSource.sId,
+        },
+      };
+
+      const res = await concurrentExecutor(
+        urlsArray,
+        async (url) => {
+          const findUrlRes = await connectorsAPI.admin({
+            ...notionCommand,
+            args: {
+              ...notionCommand.args,
+              url,
+            },
+          });
+
+          if (findUrlRes.isErr()) {
+            return new Err(new Error(findUrlRes.error.message));
+          }
+
+          const decoded = NotionFindUrlResponseSchema.decode(findUrlRes.value);
+          if (isLeft(decoded)) {
+            return new Err(new Error("Invalid response from Notion"));
+          }
+
+          const { page, db } = decoded.right;
+
+          if (page) {
+            const upsertPageRes = await connectorsAPI.admin({
+              majorCommand: "notion",
+              command: "upsert-page",
+              args: {
+                wId: auth.getNonNullableWorkspace().sId,
+                dsId: dataSource.sId,
+                pageId: page.notionPageId as string,
+              },
+            });
+
+            if (upsertPageRes.isErr()) {
+              return new Err(new Error(upsertPageRes.error.message));
+            }
+
+            return new Ok(`Upserted page ${page.notionPageId} for url ${url}`);
+          } else if (db) {
+            const upsertDbRes = await connectorsAPI.admin({
+              majorCommand: "notion",
+              command: "upsert-database",
+              args: {
+                wId: auth.getNonNullableWorkspace().sId,
+                dsId: dataSource.sId,
+                databaseId: db.notionDatabaseId as string,
+              },
+            });
+
+            if (upsertDbRes.isErr()) {
+              return new Err(new Error(upsertDbRes.error.message));
+            }
+
+            return new Ok(
+              `Upserted database ${db.notionDatabaseId} for url ${url}`
+            );
+          } else {
+            return new Err(
+              new Error(`No page or database found for url ${url}`)
+            );
+          }
+        },
+        { concurrency: 8 }
+      );
+
+      if (res.some((r) => r.isErr())) {
+        return new Err(
+          new Error(
+            res.map((r) => (r.isErr() ? r.error.message : r.value)).join("\n")
+          )
+        );
+      }
+
+      return new Ok({
+        display: "text",
+        value: `Synced ${urlsArray.length} URLs from Notion.`,
+      });
+    } else if (operation === "Delete urls") {
+      const notionCommand: AdminCommandType = {
+        majorCommand: "notion",
+        command: "delete-url",
+        args: {
+          wId: auth.getNonNullableWorkspace().sId,
+          dsId: dataSource.sId,
+        },
+      };
+
+      const res = await concurrentExecutor(
+        urlsArray,
+        async (url) => {
+          const res = await connectorsAPI.admin({
+            ...notionCommand,
+            args: {
+              ...notionCommand.args,
+              url,
+            },
+          });
+
+          if (res.isErr()) {
+            return new Err(
+              new Error(`Could not delete url ${url}: ${res.error.message}`)
+            );
+          }
+
+          return new Ok(`Deleted url ${url}`);
+        },
+        { concurrency: 8 }
+      );
+
+      if (res.some((r) => r.isErr())) {
+        return new Err(
+          new Error(
+            res.map((r) => (r.isErr() ? r.error.message : r.value)).join("\n")
+          )
+        );
+      }
+
+      return new Ok({
+        display: "text",
+        value: `Deleted ${urlsArray.length} URLs from Notion.`,
+      });
+    } else {
+      return new Err(new Error("Invalid operation"));
+    }
+  }
+);

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -59,7 +59,21 @@ export const notionUrlSyncPlugin = createPlugin(
 
     const { operation, urls } = args;
 
-    const urlsArray = urls.split(/[\n,]/).map((url) => url.trim());
+    const urlsArray = urls
+      .split(/[\n,]/g)
+      .map((url) => url.trim())
+      .filter((url) => url.length > 0);
+
+    // check urls are valid
+    if (urlsArray.some((url) => !URL.canParse(url))) {
+      return new Err(
+        new Error(
+          `Invalid URLs: ${urlsArray
+            .filter((url) => !URL.canParse(url))
+            .join(", ")}`
+        )
+      );
+    }
 
     const connectorsAPI = new ConnectorsAPI(
       config.getConnectorsAPIConfig(),

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -106,7 +106,6 @@ export const notionUrlSyncPlugin = createPlugin(
           }
 
           const { page, db } = decoded.right;
-          console.log({ page, db });
           if (page) {
             const upsertPageRes = await connectorsAPI.admin({
               majorCommand: "notion",

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -13,13 +13,15 @@ type InferArgType<
   V = never,
 > = T extends "string"
   ? string
-  : T extends "number"
-    ? number
-    : T extends "boolean"
-      ? boolean
-      : T extends "enum"
-        ? V
-        : never;
+  : T extends "text"
+    ? string
+    : T extends "number"
+      ? number
+      : T extends "boolean"
+        ? boolean
+        : T extends "enum"
+          ? V
+          : never;
 
 type InferPluginArgs<T extends PluginArgs> = {
   [K in keyof T]: InferArgType<

--- a/types/src/front/lib/poke/plugins.ts
+++ b/types/src/front/lib/poke/plugins.ts
@@ -24,6 +24,11 @@ interface NumberArgDefinition extends BaseArgDefinition {
   values?: never;
 }
 
+interface TextArgDefinition extends BaseArgDefinition {
+  type: "text";
+  values?: never;
+}
+
 interface BooleanArgDefinition extends BaseArgDefinition {
   type: "boolean";
   values?: never;
@@ -32,6 +37,7 @@ interface BooleanArgDefinition extends BaseArgDefinition {
 export type PluginArgDefinition =
   | EnumArgDefinition
   | StringArgDefinition
+  | TextArgDefinition
   | NumberArgDefinition
   | BooleanArgDefinition;
 
@@ -63,6 +69,9 @@ export function createIoTsCodecFromArgs(
 
   for (const [key, arg] of Object.entries(args)) {
     switch (arg.type) {
+      case "text":
+        codecProps[key] = t.string;
+        break;
       case "string":
         codecProps[key] = t.string;
         break;


### PR DESCRIPTION
Description
---
Needed to fix https://github.com/dust-tt/tasks/issues/2099 and https://github.com/dust-tt/tasks/issues/2098

Also:
- adds a textarea to poke plugin form
- updates parents after single page / db upsertion (otherwise parents are wrong)
- deletes pages either unreachable, or trashed

![image](https://github.com/user-attachments/assets/8821b679-c667-4cc8-87a8-893349692d41)
![image](https://github.com/user-attachments/assets/cb8fc9fb-1735-427e-ba5c-314404fa414c)


Risk
---
standard

Deploy
---
connectors
front
