### PR TITLE
enh(Slack) - Add a CLI command `sync-channel-metadata`

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -2,8 +2,7 @@ import type {
   AdminSuccessResponseType,
   SlackCommandType,
 } from "@dust-tt/types";
-import { isSlackbotWhitelistType } from "@dust-tt/types";
-import { MIME_TYPES } from "@dust-tt/types/src";
+import { isSlackbotWhitelistType, MIME_TYPES } from "@dust-tt/types";
 
 import { updateSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
 import {

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -3,12 +3,21 @@ import type {
   SlackCommandType,
 } from "@dust-tt/types";
 import { isSlackbotWhitelistType } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types/src";
 
+import { updateSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
+import {
+  getSlackChannelSourceUrl,
+  slackChannelInternalIdFromSlackChannelId,
+} from "@connectors/connectors/slack/lib/utils";
+import { getChannel } from "@connectors/connectors/slack/temporal/activities";
 import {
   launchSlackSyncOneThreadWorkflow,
   launchSlackSyncWorkflow,
 } from "@connectors/connectors/slack/temporal/client";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { throwOnError } from "@connectors/lib/cli";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { default as topLogger } from "@connectors/logger/logger";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
@@ -212,6 +221,67 @@ export const slack = async ({
         await slackConfig.whitelistBot(botName, [groupId], whitelistType);
       }
 
+      return { success: true };
+    }
+
+    case "sync-channel-metadata": {
+      if (!args.wId) {
+        throw new Error("Missing --wId argument");
+      }
+      if (!args.channelId) {
+        throw new Error("Missing --channelId argument");
+      }
+      const connector = await ConnectorModel.findOne({
+        where: { workspaceId: `${args.wId}`, type: "slack" },
+      });
+      if (!connector) {
+        throw new Error(`Could not find connector for workspace ${args.wId}`);
+      }
+
+      const remoteChannel = await getChannel(connector.id, args.channelId);
+      if (!remoteChannel.name) {
+        throw new Error(
+          `Could not find channel name for channel ${args.channelId}`
+        );
+      }
+      const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+      const channel = await updateSlackChannelInConnectorsDb({
+        slackChannelId: args.channelId,
+        slackChannelName: remoteChannel.name,
+        connectorId: connector.id,
+      });
+
+      const slackConfiguration =
+        await SlackConfigurationResource.fetchByConnectorId(connector.id);
+      if (!slackConfiguration) {
+        throw new Error(
+          `Could not find Slack configuration for connector ${connector.id}`
+        );
+      }
+
+      if (!["read", "read_write"].includes(channel.permission)) {
+        logger.info(
+          {
+            connectorId: connector.id,
+            channelId: args.channelId,
+            channelName: remoteChannel.name,
+          },
+          "Channel is not indexed, skipping"
+        );
+        return { success: true };
+      }
+
+      await upsertDataSourceFolder({
+        dataSourceConfig,
+        folderId: slackChannelInternalIdFromSlackChannelId(args.channelId),
+        title: `#${channel.name}`,
+        parentId: null,
+        parents: [slackChannelInternalIdFromSlackChannelId(args.channelId)],
+        mimeType: MIME_TYPES.SLACK.CHANNEL,
+        sourceUrl: getSlackChannelSourceUrl(args.channelId, slackConfiguration),
+        providerVisibility: channel.private ? "private" : "public",
+      });
       return { success: true };
     }
 

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -136,6 +136,7 @@ export const SlackCommandSchema = t.type({
     t.literal("uninstall-for-unknown-team-ids"),
     t.literal("whitelist-domains"),
     t.literal("whitelist-bot"),
+    t.literal("sync-channel-metadata"),
   ]),
   args: t.record(
     t.string,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10621.
- We are observing a few nodes for Slack channels have outdated titles in core (log [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Aslack&agg_m=count&agg_m_source=base&agg_q=%40dataSourceViewId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZTgh5VUnmsT2QAAABhBWlRnaDZYekFBQm1yVlN6RXlkdGhBQUkAAAAkMDE5NGUwOGEtNTkxMi00OGQ1LWI0ZGMtYjQxMDVhZDEwYmJkAANDaw&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&top_n=25&top_o=top&viz=stream&x_missing=true&from_ts=1738822750000&to_ts=1738837150000&live=true)).
- This PR aims at adding a CLI command that will fetch the channel from Slack and resync the data in both `connectors` and `core`.
- The logic in the webhook and in the rest of the connectors was checked and is correct.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.