### PR TITLE
Clarify legacy bits in string ID generation

### DIFF
--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -12,11 +12,12 @@ const sqids = new Sqids({
   minLength: RESOURCE_S_ID_MIN_LENGTH,
 });
 
-// Static shard key until we implement sharding.
-const SHARD_KEY = 1;
-
-// Static region for now.
-const REGION = 1; // US.
+// /!\ These legacy bits are part of the ID encoding scheme and must be preserved to maintain
+// backwards compatibility with existing string IDs in the database.
+// They were originally used for sharding and region information but are no longer functionally
+// needed after migration to cross-region architecture.
+const LEGACY_SHARD_BIT = 1;
+const LEGACY_REGION_BIT = 1; // Previously indicated US region.
 
 const RESOURCES_PREFIX = {
   file: "fil",
@@ -46,15 +47,13 @@ export function makeSId(
     workspaceId: ModelId;
   }
 ): string {
-  const idsToEncode = [REGION, SHARD_KEY, workspaceId, id];
+  const idsToEncode = [LEGACY_REGION_BIT, LEGACY_SHARD_BIT, workspaceId, id];
 
   return `${RESOURCES_PREFIX[resourceName]}_${sqids.encode(idsToEncode)}`;
 }
 
 function getIdsFromSId(sId: string): Result<
   {
-    region: number;
-    shardKey: number;
     workspaceId: ModelId;
     resourceId: ModelId;
   },
@@ -77,9 +76,9 @@ function getIdsFromSId(sId: string): Result<
       return new Err(new Error("Invalid decoded string Id length"));
     }
 
-    const [region, shardKey, workspaceId, resourceId] = ids;
+    const [, , workspaceId, resourceId] = ids;
 
-    return new Ok({ region, shardKey, workspaceId, resourceId });
+    return new Ok({ workspaceId, resourceId });
   } catch (error) {
     return new Err(
       error instanceof Error ? error : new Error("Failed to decode string Id")

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -12,8 +12,8 @@ const sqids = new Sqids({
   minLength: RESOURCE_S_ID_MIN_LENGTH,
 });
 
-// /!\ These legacy bits are part of the ID encoding scheme and must be preserved to maintain
-// backwards compatibility with existing string IDs in the database.
+// WARNING: These legacy bits are part of the ID encoding scheme and must be preserved to maintain
+// backwards compatibility with existing string IDs.
 // They were originally used for sharding and region information but are no longer functionally
 // needed after migration to cross-region architecture.
 const LEGACY_SHARD_BIT = 1;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Our string ID (sId) generation system includes bits for region and shard key information. These were originally designed to support our sharding strategy and regional deployment. However, with our expansion to Europe and the need for customer relocation between regions, this approach proved problematic as it would require changing customer sIds during relocation.

## Changes
This PR improves code clarity by:
- Renaming variables to clearly indicate their legacy status
- Adding detailed comments explaining why these bits are deprecated but must be preserved
- No functional changes - all existing sIds remain unchanged

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
None - this is a non-functional change focused on code clarity.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
