### PR TITLE
Add: support for excel files at upload

### DIFF
--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -77,13 +77,12 @@ async function getJITActions(
           id: -1,
           name: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
           sId: generateRandomModelSId(),
-          tables: filesUsableAsTableQuery.flatMap(
-            (f) =>
-              f.generatedTables?.map((tableId) => ({
-                workspaceId: auth.getNonNullableWorkspace().sId,
-                dataSourceViewId: dataSourceView.sId,
-                tableId: tableId,
-              })) ?? []
+          tables: filesUsableAsTableQuery.flatMap((f) =>
+            f.generatedTables.map((tableId) => ({
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              dataSourceViewId: dataSourceView.sId,
+              tableId: tableId,
+            }))
           ),
         };
         actions.push(action);

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -77,11 +77,14 @@ async function getJITActions(
           id: -1,
           name: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
           sId: generateRandomModelSId(),
-          tables: filesUsableAsTableQuery.map((f) => ({
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            dataSourceViewId: dataSourceView.sId,
-            tableId: f.fileId,
-          })),
+          tables: filesUsableAsTableQuery.flatMap(
+            (f) =>
+              f.generatedTables?.map((tableId) => ({
+                workspaceId: auth.getNonNullableWorkspace().sId,
+                dataSourceViewId: dataSourceView.sId,
+                tableId: tableId,
+              })) ?? []
+          ),
         };
         actions.push(action);
       }

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -78,7 +78,11 @@ export function listFiles(
           snippet: m.snippet,
           // Backward compatibility: we fallback to the fileId if no generated tables are mentionned but the file is queryable.
           generatedTables:
-            m.generatedTables ?? (isQueryable ? [m.fileId] : null),
+            m.generatedTables.length > 0
+              ? m.generatedTables
+              : isQueryable
+                ? [m.fileId]
+                : [],
           contentFragmentVersion: m.contentFragmentVersion,
           isIncludable,
           isQueryable,
@@ -102,7 +106,7 @@ export function listFiles(
           title: f.title,
           snippet: f.snippet,
           // For simplicity later, we always set the generatedTables to the fileId if the file is queryable for agent generated files.
-          generatedTables: isQueryable ? [f.fileId] : null,
+          generatedTables: isQueryable ? [f.fileId] : [],
           contentFragmentVersion: "latest",
           isIncludable,
           isQueryable,

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -76,6 +76,9 @@ export function listFiles(
           title: m.title,
           contentType: m.contentType,
           snippet: m.snippet,
+          // Backward compatibility: we fallback to the fileId if no generated tables are mentionned but the file is queryable.
+          generatedTables:
+            m.generatedTables ?? (isQueryable ? [m.fileId] : null),
           contentFragmentVersion: m.contentFragmentVersion,
           isIncludable,
           isQueryable,
@@ -98,6 +101,8 @@ export function listFiles(
           contentType: f.contentType,
           title: f.title,
           snippet: f.snippet,
+          // For simplicity later, we always set the generatedTables to the fileId if the file is queryable for agent generated files.
+          generatedTables: isQueryable ? [f.fileId] : null,
           contentFragmentVersion: "latest",
           isIncludable,
           isQueryable,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -454,6 +454,12 @@ export interface UpsertTableArgs {
   sourceUrl?: string | null;
 }
 
+export function isUpsertTableArgs(
+  args: UpsertTableArgs | UpsertDocumentArgs | undefined
+): args is UpsertTableArgs {
+  return args !== undefined && "tableId" in args;
+}
+
 export async function upsertTable({
   tableId,
   name,

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -220,7 +220,7 @@ const getProcessingFunction = ({
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
       contentType === "application/vnd.ms-excel"
     ) {
-      // We use tika to extract from excel files, it will turn into a htlml table
+      // We use tika to extract from excel files, it will turn into a html table
       // We will upsert from the html table later
       return extractTextFromFileAndUpload;
     } else if (

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -216,6 +216,14 @@ const getProcessingFunction = ({
 
   if (isSupportedDelimitedTextContentType(contentType)) {
     if (
+      contentType ===
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+      contentType === "application/vnd.ms-excel"
+    ) {
+      // We use tika to extract from excel files, it will turn into a htlml table
+      // We will upsert from the html table later
+      return extractTextFromFileAndUpload;
+    } else if (
       [
         "conversation",
         "upsert_document",

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -291,6 +291,16 @@ const upsertTableToDatasource: ProcessingFunction = async ({
     });
   }
 
+  if (file.useCaseMetadata) {
+    await file.setUseCaseMetadata({
+      ...file.useCaseMetadata,
+      generatedTables: [
+        ...(file.useCaseMetadata.generatedTables ?? []),
+        tableId,
+      ],
+    });
+  }
+
   return new Ok(undefined);
 };
 

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -291,6 +291,7 @@ const upsertTableToDatasource: ProcessingFunction = async ({
     });
   }
 
+  // Note from seb : it would be better to merge useCase and useCaseMetadata to be able to specify what each use case is able to do / requires via typing.
   if (file.useCaseMetadata) {
     await file.setUseCaseMetadata({
       ...file.useCaseMetadata,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -233,14 +233,14 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
 
     let fileSid: string | null = null;
     let snippet: string | null = null;
-    let generatedTables: string[] | null = null;
+    let generatedTables: string[] = [];
 
     if (this.fileId) {
       const file = await FileResource.fetchByModelId(this.fileId);
       if (file) {
         fileSid = file.sId;
         snippet = file.snippet;
-        generatedTables = file.useCaseMetadata?.generatedTables ?? null;
+        generatedTables = file.useCaseMetadata?.generatedTables ?? [];
       }
     }
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -233,17 +233,22 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
 
     let fileSid: string | null = null;
     let snippet: string | null = null;
+    let generatedTables: string[] | null = null;
 
     if (this.fileId) {
       const file = await FileResource.fetchByModelId(this.fileId);
-      fileSid = file?.sId ?? null;
-      snippet = file?.snippet ?? null;
+      if (file) {
+        fileSid = file.sId;
+        snippet = file.snippet;
+        generatedTables = file.useCaseMetadata?.generatedTables ?? null;
+      }
     }
 
     return {
       id: message.id,
       fileId: fileSid,
       snippet: snippet,
+      generatedTables: generatedTables,
       sId: message.sId,
       created: message.createdAt.getTime(),
       type: "content_fragment",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -24968,14 +24968,16 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
-      "version": "7.1.7",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "devOptional": true,
-      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -107,6 +107,10 @@ export const supportedOtherFileFormats = {
     ".ppt",
     ".pptx",
   ],
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+    ".xlsx",
+  ],
+  "application/vnd.ms-excel": [".xls"],
   "application/pdf": [".pdf"],
   "text/comma-separated-values": [".csv"],
   "text/csv": [".csv"],

--- a/types/src/front/assistant/actions/conversation/list_files.ts
+++ b/types/src/front/assistant/actions/conversation/list_files.ts
@@ -11,7 +11,7 @@ export type ConversationFileType = {
   contentType: SupportedContentFragmentType;
   contentFragmentVersion: ContentFragmentVersion;
   snippet: string | null;
-  generatedTables: string[] | null;
+  generatedTables: string[];
   isIncludable: boolean;
   isSearchable: boolean;
   isQueryable: boolean;

--- a/types/src/front/assistant/actions/conversation/list_files.ts
+++ b/types/src/front/assistant/actions/conversation/list_files.ts
@@ -11,6 +11,7 @@ export type ConversationFileType = {
   contentType: SupportedContentFragmentType;
   contentFragmentVersion: ContentFragmentVersion;
   snippet: string | null;
+  generatedTables: string[] | null;
   isIncludable: boolean;
   isSearchable: boolean;
   isQueryable: boolean;

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -20,6 +20,7 @@ export type ContentFragmentType = {
   sId: string;
   fileId: string | null;
   snippet: string | null;
+  generatedTables: string[] | null;
   created: number;
   type: "content_fragment";
   visibility: MessageVisibility;

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -20,7 +20,7 @@ export type ContentFragmentType = {
   sId: string;
   fileId: string | null;
   snippet: string | null;
-  generatedTables: string[] | null;
+  generatedTables: string[];
   created: number;
   type: "content_fragment";
   visibility: MessageVisibility;

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -16,6 +16,7 @@ export type FileUseCase =
 
 export type FileUseCaseMetadata = {
   conversationId: string;
+  generatedTables?: string[];
 };
 
 export interface FileType {

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -3,6 +3,8 @@ import { removeNulls } from "../shared/utils/general";
 
 const uniq = <T>(arr: T[]): T[] => Array.from(new Set(arr));
 
+export const TABLE_PREFIX = "TABLE:";
+
 export type FileStatus = "created" | "failed" | "ready";
 
 export type FileUseCase =
@@ -90,6 +92,11 @@ const FILE_FORMATS = {
   "text/comma-separated-values": { cat: "delimited", exts: [".csv"] },
   "text/tsv": { cat: "delimited", exts: [".tsv"] },
   "text/tab-separated-values": { cat: "delimited", exts: [".tsv"] },
+  "application/vnd.ms-excel": { cat: "delimited", exts: [".xls"] },
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
+    cat: "delimited",
+    exts: [".xlsx"],
+  },
 
   // Data
   "text/plain": { cat: "data", exts: [".txt", ".log", ".cfg", ".conf"] },

--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -133,13 +133,17 @@ export class TextExtraction {
 
     if (config) {
       const { transformer, selector } = config;
-      if (transformer === "document") {
-        const prefix = pagePrefixesPerMimeType[contentType];
-        return transformStream(responseStream, prefix, selector);
-      } else if (transformer === "csv") {
-        return transformStreamToCSV(responseStream, selector);
+      switch (transformer) {
+        case "document": {
+          const prefix = pagePrefixesPerMimeType[contentType];
+          return transformStream(responseStream, prefix, selector);
+        }
+        case "csv": {
+          return transformStreamToCSV(responseStream, selector);
+        }
+        default:
+          assertNever(transformer);
       }
-      assertNever(transformer);
     }
 
     return responseStream;

--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -7,11 +7,13 @@ import * as reporter from "io-ts-reporters";
 import { Readable } from "stream";
 
 import { Err, Ok, Result } from "../result";
+import { assertNever } from "../utils/assert_never";
 import {
   readableStreamToReadable,
   RequestInitWithDuplex,
 } from "../utils/streams";
 import { transformStream } from "./transform";
+import { transformStreamToCSV } from "./transformToCSV";
 
 // Define the codec for the response.
 const TikaResponseCodec = t.type({
@@ -41,6 +43,8 @@ const supportedContentTypes = [
   "application/vnd.ms-powerpoint",
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
 ] as const;
 
 type SupportedContentTypes = (typeof supportedContentTypes)[number];
@@ -48,19 +52,36 @@ type SupportedContentTypes = (typeof supportedContentTypes)[number];
 type ContentTypeConfig = {
   [key in SupportedContentTypes]?: {
     handler: "html" | "text";
-    pageSelector?: string;
+    transformer: "document" | "csv";
+    selector: string;
   };
 };
 
 const contentTypeConfig: ContentTypeConfig = {
-  "application/pdf": { handler: "html", pageSelector: "page" },
+  "application/pdf": {
+    handler: "html",
+    selector: "page",
+    transformer: "document",
+  },
   "application/vnd.ms-powerpoint": {
     handler: "html",
-    pageSelector: "slide-content",
+    selector: "slide-content",
+    transformer: "document",
   },
   "application/vnd.openxmlformats-officedocument.presentationml.presentation": {
     handler: "html",
-    pageSelector: "slide-content",
+    selector: "slide-content",
+    transformer: "document",
+  },
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
+    handler: "html",
+    selector: "h1",
+    transformer: "csv",
+  },
+  "application/vnd.ms-excel": {
+    handler: "html",
+    selector: "h1",
+    transformer: "csv",
   },
 };
 
@@ -108,14 +129,20 @@ export class TextExtraction {
 
     const responseStream = readableStreamToReadable(response.body);
 
-    const pageSelector = contentTypeConfig[contentType]?.pageSelector;
-    if (pageSelector) {
-      // If we have a page selector, we need to parse the stream and return another stream.
-      const prefix = pagePrefixesPerMimeType[contentType];
-      return transformStream(responseStream, prefix, pageSelector);
-    } else {
-      return responseStream;
+    const config = contentTypeConfig[contentType];
+
+    if (config) {
+      const { transformer, selector } = config;
+      if (transformer === "document") {
+        const prefix = pagePrefixesPerMimeType[contentType];
+        return transformStream(responseStream, prefix, selector);
+      } else if (transformer === "csv") {
+        return transformStreamToCSV(responseStream, selector);
+      }
+      assertNever(transformer);
     }
+
+    return responseStream;
   }
 
   // Query the Tika server and return the response data.
@@ -166,7 +193,7 @@ export class TextExtraction {
     const contentType = response["Content-Type"];
 
     const pageSelector =
-      contentTypeConfig[contentType as SupportedContentTypes]?.pageSelector;
+      contentTypeConfig[contentType as SupportedContentTypes]?.selector;
     if (pageSelector) {
       return this.processContentBySelector(response, pageSelector);
     }

--- a/types/src/shared/text_extraction/transformToCSV.ts
+++ b/types/src/shared/text_extraction/transformToCSV.ts
@@ -64,7 +64,7 @@ export function transformStreamToCSV(
 
       onclosetag(name) {
         const lastTag = state.tags.pop();
-        if (name != lastTag) {
+        if (name !== lastTag) {
           throw new Error("Invalid tag order");
         } else {
           if (lastTag === "tr") {

--- a/types/src/shared/text_extraction/transformToCSV.ts
+++ b/types/src/shared/text_extraction/transformToCSV.ts
@@ -71,7 +71,8 @@ export function transformStreamToCSV(
           throw new Error("Invalid tag order");
         } else {
           if (lastTag === HTML_TAGS.ROW) {
-            htmlParsingTransform.push(stringify(state.currentRow));
+            const csv = stringify([state.currentRow]);
+            htmlParsingTransform.push(csv);
             state.currentRow = [];
           }
         }

--- a/types/src/shared/text_extraction/transformToCSV.ts
+++ b/types/src/shared/text_extraction/transformToCSV.ts
@@ -1,0 +1,140 @@
+import { stringify } from "csv-stringify/sync";
+import { Parser } from "htmlparser2";
+import { Readable, Transform } from "stream";
+
+import { TABLE_PREFIX } from "../../front/files";
+
+interface ParserState {
+  tags: string[];
+  currentRow: string[];
+  currentTable: string[][];
+}
+
+/**
+ * A Transform stream that processes HTML data from a Readable stream, extracts text from tables
+ * and converts it to CSV format. It handles two specific cases:
+ * 1. Text within elements matching the selector, which gets prefixed with TABLE_PREFIX
+ * 2. Content within table cells (<td>), which gets converted to CSV format
+ *
+ * @param input - A Node.js Readable stream containing HTML
+ * @param selector - A tag name to match for direct text extraction (prefixed with TABLE_PREFIX)
+ * @returns A new Readable stream that emits the processed text in CSV format
+ *
+ * How it works:
+ * 1. We create a single HTML parser (Parser) instance that listens to events:
+ *    - onopentag: Tracks the current tag stack
+ *    - ontext:
+ *      * If inside selector-matched element: adds text with TABLE_PREFIX
+ *      * If inside <td>: collects text for current row
+ *    - onclosetag: When a </tr> is encountered, converts the collected row to CSV
+ *    - onerror: Destroys the transform if a parsing error occurs
+ *
+ * 2. We wrap this parser in a Node Transform stream to:
+ *    - pipe HTML input into it
+ *    - process data chunks through the parser
+ *    - handle proper stream cleanup in flush
+ */
+export function transformStreamToCSV(
+  input: Readable,
+  selector: string
+): Readable {
+  // Track parser state.
+  const state: ParserState = {
+    tags: [],
+    currentRow: [],
+    currentTable: [],
+  };
+
+  // Create a single parser instance for the entire stream.
+  const parser = new Parser(
+    {
+      onopentag(name) {
+        state.tags.push(name);
+      },
+
+      ontext(text) {
+        const currentTag = state.tags[state.tags.length - 1];
+
+        if (currentTag === selector) {
+          htmlParsingTransform.push(`${TABLE_PREFIX}${text}\n`);
+        } else if (currentTag === "td") {
+          state.currentRow.push(text);
+        }
+      },
+
+      onclosetag(name) {
+        const lastTag = state.tags.pop();
+        if (name != lastTag) {
+          throw new Error("Invalid tag order");
+        } else {
+          if (lastTag === "tr") {
+            state.currentRow = [];
+            state.currentTable.push(state.currentRow);
+          }
+          if (lastTag === "table") {
+            htmlParsingTransform.push(stringify(state.currentTable));
+            state.currentTable = [];
+          }
+        }
+      },
+
+      onerror(err) {
+        // If we encounter a parser error, destroy the transform with that error.
+        htmlParsingTransform.destroy(err);
+      },
+    },
+    { decodeEntities: true } // Instruct parser to decode HTML entities like &amp.
+  );
+
+  // Create transform stream.
+  const htmlParsingTransform = new Transform({
+    objectMode: true,
+
+    transform(chunk: Buffer, _encoding, callback) {
+      try {
+        parser.write(chunk.toString());
+        callback();
+      } catch (error) {
+        if (error instanceof Error) {
+          callback(error);
+        } else {
+          callback(
+            new Error(
+              typeof error === "string"
+                ? error
+                : "Unknown error in htmlParsingTransform.transform()"
+            )
+          );
+        }
+      }
+    },
+
+    flush(callback) {
+      try {
+        // Signal to the parser that we're done (end of the HTML input).
+        parser.end();
+
+        callback();
+      } catch (error) {
+        if (error instanceof Error) {
+          callback(error);
+        } else {
+          callback(
+            new Error(
+              typeof error === "string"
+                ? error
+                : "Unknown error in htmlParsingTransform.flush()"
+            )
+          );
+        }
+      }
+    },
+  });
+
+  // Handle errors on both streams.
+  input.on("error", (error) => htmlParsingTransform.destroy(error));
+  htmlParsingTransform.on("error", (error) => input.destroy(error));
+
+  // Pipe the input HTML stream through our transform and return the result
+  return input.pipe(htmlParsingTransform);
+}


### PR DESCRIPTION
## Description

- Added a new parser to build a "csv" out of the tikka output from excel files (html table(s)). Because excel file can contains multiple sheets, the output is one file with multiple csv content in it.
  - @flvndvd can you double check I implemented it right ?
- Added support to extract the content from the previous file and upsert a table for each found csv content.
- Store the generated tables in `generatedTables: string[]` on the `useCaseMetadata` of the file.
- Use the generateTables property in the table query jit action.

## Tests

Local

## Risk

Medium as it should not change anything presented to the model for the previous use cases of file uploads.

## Deploy Plan

Deploy `front`