### PR TITLE
[DataSourceViews] Prevent updating parents for "default" dsvs

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -9,7 +9,7 @@ import type {
   Result,
   UserType,
 } from "@dust-tt/types";
-import { formatUserFullName, Ok, removeNulls } from "@dust-tt/types";
+import { Err, formatUserFullName, Ok, removeNulls } from "@dust-tt/types";
 import assert from "assert";
 import type {
   Attributes,
@@ -517,6 +517,12 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     parentsToRemove: string[] = []
   ): Promise<Result<undefined, Error>> {
     const currentParents = this.parentsIn || [];
+
+    if (this.kind === "default") {
+      return new Err(
+        new Error("Cannot update parents for default data source view")
+      );
+    }
 
     // add new parents
     const newParents = [...new Set(currentParents), ...new Set(parentsToAdd)];

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -520,7 +520,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
     if (this.kind === "default") {
       return new Err(
-        new Error("Cannot update parents for default data source view")
+        new Error("`parentsIn` cannot be set for default data source view")
       );
     }
 
@@ -540,6 +540,12 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   async setParents(
     parentsIn: string[] | null
   ): Promise<Result<undefined, Error>> {
+    if (this.kind === "default") {
+      return new Err(
+        new Error("`parentsIn` cannot be set for default data source view")
+      );
+    }
+
     await this.update({ parentsIn });
     return new Ok(undefined);
   }


### PR DESCRIPTION
Description
---
Part of fixing [this](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1739015965949919?thread_ts=1738940774.053339&cid=C050A0S2Z7F)

"default" datasource views, used by connection admin, should always have `parentsIn` set to null

For unknown reasons, this wasn't true for our workspace's google drive and microsoft, but true for all the rest

This PR is as such enforcing an existing invariant, as can be seen [here](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiItLXNlbGVjdCAqIGZyb20gZGF0YV9zb3VyY2Vfdmlld3Mgd2hlcmUgXCJkYXRhU291cmNlSWRcIiA9IDI2MDtcbnNlbGVjdCAqIGZyb20gZGF0YV9zb3VyY2Vfdmlld3Mgd2hlcmUga2luZCA9ICdkZWZhdWx0JyBhbmQgXCJwYXJlbnRzSW5cIiBpcyBub3QgbnVsbDsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo0fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUuY29sdW1uX3dpZHRocyI6W251bGwsbnVsbCw3MDBdfX0=)

Risk
---
check that "default" is only used for connection admin purposes, otherwise this may break something else

Deploy
---
front
