### PR TITLE
[Knowledge - Spreadsheets] Message when user clicks 'raw content'

### DIFF
--- a/front/components/DataSourceViewDocumentModal.tsx
+++ b/front/components/DataSourceViewDocumentModal.tsx
@@ -72,12 +72,21 @@ export default function DataSourceViewDocumentModal({
               )}
               {!isDocumentLoading && isDocumentError && (
                 <div className="flex flex-col gap-2 py-8">
-                  <Label className="text-warning-500">
-                    Unable to retrieve document.
-                  </Label>
                   <span className="text-sm text-element-700">
-                    We were not able to synchronize this document. Please
-                    contact support@dust.tt for assistance.
+                    This document has no raw content available
+                    <ul className="list-disc pl-4">
+                      <li>
+                        if the document is a spreadsheet, this is expected.
+                        Spreasheets do not expose raw contents. They are made
+                        available in Dust via the `Table Query` action in
+                        assistants.
+                      </li>
+                      <li>
+                        Otherwise, this is unexpected. Please contact
+                        support@dust.tt for assistance on synchronizing the
+                        document.
+                      </li>
+                    </ul>
                   </span>
                 </div>
               )}

--- a/front/components/DataSourceViewDocumentModal.tsx
+++ b/front/components/DataSourceViewDocumentModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Label,
   Sheet,
   SheetContainer,
   SheetContent,


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2105

Clicking "view raw content" on a spreadsheet was leading to an error
message, see issue

This PR is a temporary fix, since in the knowledge tab and in this
modal, it's not possible to know whether the item is a table or
not---connectors' content nodes do not provide the information.

When the nodes core project is shipped, this distinction can be made
and we can remove "View raw contents" for spreadsheets.

Risk
---
none

Deploy
---
front