### PR TITLE
[core] Remove duplicate code

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -494,7 +494,7 @@ impl DataSource {
         parents: Vec<String>,
     ) -> Result<()> {
         store
-            .update_data_source_document_parents(
+            .update_data_source_node_parents(
                 &self.project,
                 &self.data_source_id(),
                 &document_id.to_string(),

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -262,7 +262,7 @@ impl Table {
         parents: Vec<String>,
     ) -> Result<()> {
         store
-            .update_data_source_table_parents(
+            .update_data_source_node_parents(
                 &self.project,
                 &self.data_source_id,
                 &&self.table_id,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -206,13 +206,6 @@ pub trait Store {
         add_tags: &Vec<String>,
         remove_tags: &Vec<String>,
     ) -> Result<Vec<String>>;
-    async fn update_data_source_document_parents(
-        &self,
-        project: &Project,
-        data_source_id: &str,
-        document_id: &str,
-        parents: &Vec<String>,
-    ) -> Result<()>;
     async fn update_data_source_document_chunk_count(
         &self,
         project: &Project,
@@ -287,13 +280,6 @@ pub trait Store {
         table_id: &str,
         schema: &TableSchema,
     ) -> Result<()>;
-    async fn update_data_source_table_parents(
-        &self,
-        project: &Project,
-        data_source_id: &str,
-        table_id: &str,
-        parents: &Vec<String>,
-    ) -> Result<()>;
     async fn invalidate_data_source_table_schema(
         &self,
         project: &Project,
@@ -360,6 +346,13 @@ pub trait Store {
         id_cursor: i64,
         batch_size: i64,
     ) -> Result<Vec<(Node, i64, i64)>>;
+    async fn update_data_source_node_parents(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        document_id: &str,
+        parents: &Vec<String>,
+    ) -> Result<()>;
 
     async fn count_nodes_children(&self, nodes: &Vec<Node>) -> Result<HashMap<String, u64>>;
 


### PR DESCRIPTION
## Description

Updating parents for tables and documents is now the same code (since parents are now in the smae table), so removing the duplicate code.

## Tests

Update parents for tables and documents

## Risk

none

## Deploy Plan

deploy core