### PR TITLE
[connectors] Add command to upsert parents

### DIFF
--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -112,6 +112,7 @@ export const GoogleDriveCommandSchema = t.type({
     t.literal("check-file"),
     t.literal("get-google-parents"),
     t.literal("clean-invalid-parents"),
+    t.literal("update-core-parents"),
     t.literal("restart-google-webhooks"),
     t.literal("start-incremental-sync"),
     t.literal("restart-all-incremental-sync-workflows"),


### PR DESCRIPTION
## Description

This adds a cli command that will update parents in core for an individual file, in case we have discrepancies.

```
./admin/cli.sh google_drive update-core-parents --wId k6uf57NMIi --connectorId 11  --fileId gdrive-1KJuiFKCotgCiisTBfePB-hwYN-k20_0C58NEZIyjGhE
```

## Tests


## Risk

## Deploy Plan