### PR TITLE
[Notion] Increase cache length for getParents

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -14,6 +14,7 @@ import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES } from "@connectors/connectors/notion/temporal/workflows";
 
 /** Compute the parents field for a notion pageOrDb See the [Design
  * Doc](https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=3d26536a4e0a464eae0c3f8f27a7af97&pm=s)
@@ -124,7 +125,7 @@ export const getParents = cacheWithRedis(
   (connectorId, pageOrDbId, seen, syncing, memoizationKey, onProgress) => {
     return `${connectorId}:${pageOrDbId}:${memoizationKey}`;
   },
-  60 * 10 * 1000
+  UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES * 60 * 1000
 );
 
 export async function updateAllParentsFields(

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -9,12 +9,12 @@ import {
   getNotionPageFromConnectorsDb,
   getPageChildrenOf,
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
+import { UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES } from "@connectors/connectors/notion/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES } from "@connectors/connectors/notion/temporal/workflows";
 
 /** Compute the parents field for a notion pageOrDb See the [Design
  * Doc](https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=3d26536a4e0a464eae0c3f8f27a7af97&pm=s)

--- a/connectors/src/connectors/notion/temporal/workflows/index.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/index.ts
@@ -29,8 +29,9 @@ const { garbageCollectBatch } = proxyActivities<typeof activities>({
   heartbeatTimeout: "5 minute",
 });
 
+export const UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES = 60;
 const { updateParentsFields } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "60 minute",
+  startToCloseTimeout: `${UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES} minutes`,
   heartbeatTimeout: "5 minute",
 });
 


### PR DESCRIPTION
Description
---
The activity updateParents can take up to 1h
But the cache expires after 10 minutes. It should last at least the duration of the activity.
Otherwise, generates slowness that can lead to
[this](https://dust4ai.slack.com/archives/C05F84CFP0E/p1739167780022469)

Risk
---
standard

Deploy
---
connectors

no need to restart workflow
