### PR TITLE
[CoreNodes] Add script to recompute parents for Notion missing nodes

### DIFF
--- a/connectors/migrations/20250130_recompute_notion_roots_parents.ts
+++ b/connectors/migrations/20250130_recompute_notion_roots_parents.ts
@@ -114,7 +114,7 @@ async function updateNodeParents({
       });
     } else {
       logger.info(
-        { parents: [documentId, ...documentId], nodeId: documentId },
+        { parents: [documentId, ...parents], nodeId: documentId },
         "DRY"
       );
     }

--- a/connectors/migrations/20250130_recompute_notion_roots_parents.ts
+++ b/connectors/migrations/20250130_recompute_notion_roots_parents.ts
@@ -220,16 +220,33 @@ makeScript(
       type: "number",
       demandOption: false,
       default: 5,
-      description: "Number of connectors to process concurrently",
+      description: "Number of connectors to process concurrently.",
     },
     nodeConcurrency: {
       type: "number",
       demandOption: false,
       default: 8,
-      description: "Number of nodes to process concurrently per connector",
+      description: "Number of nodes to process concurrently per connector.",
+    },
+    extra: {
+      boolean: true,
+      description: "Recompute parents for extra nodes from core.",
+    },
+    missing: {
+      boolean: true,
+      description: "Recompute parents for missing nodes from core.",
     },
   },
-  async ({ execute, connectorConcurrency, nodeConcurrency }, logger) => {
+  async (
+    { execute, connectorConcurrency, nodeConcurrency, extra, missing },
+    logger
+  ) => {
+    if (!extra && !missing) {
+      logger.info(
+        "Nothing to compute (neither extra nor missing nodes), exiting."
+      );
+      return;
+    }
     const coreAPI = new CoreAPI(
       {
         url: EnvironmentConfig.getEnvVariable("CORE_API"),

--- a/connectors/migrations/20250130_recompute_notion_roots_parents.ts
+++ b/connectors/migrations/20250130_recompute_notion_roots_parents.ts
@@ -219,7 +219,7 @@ async function updateParentsFieldForConnector({
   });
 
   const dustAPIDataSourceId = await getDataSourceId(connector, frontSequelize);
-  logger.info({ dustAPIDataSourceId }, "DataSourceId retrieved.");
+  logger.info({ dustAPIDataSourceId }, "MIGRATE");
 
   let nodeCount = 0;
   let nextPageCursor: string | null = null;
@@ -351,7 +351,6 @@ makeScript(
     await concurrentExecutor(
       connectors,
       async (connector) => {
-        logger.info({ connectorId: connector.id }, "MIGRATE");
         await updateParentsFieldForConnector({
           coreAPI,
           frontSequelize,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10647.
- This PR extends the script `20250130_recompute_notion_roots_parents.ts`, which was used to recompute parents for nodes that were returned by `core` and not `connectors`, to do the same for nodes that are missing from `core`.

## Tests

## Risk

- Low as this only affects the shadow read for now.

## Deploy Plan

- No deploy.
