### PR TITLE
[CoreNodes] Ignore diff due to URI encoding in `sourceUrls`

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -283,6 +283,11 @@ export function computeNodesDiff({
         ) {
           return false;
         }
+
+        // Ignore diff in the sourceUrl due to URI encoding.
+        if (key === "sourceUrl" && coreValue === encodeURI(value)) {
+          return false;
+        }
         // Special case for expandable: if the core node is not expandable and the connectors one is, it means
         // that the difference comes from the fact that the node has no children: we omit from the log.
         if (key === "expandable" && value === true && coreValue === false) {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10651.
- See log [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Agithub&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZTvUarCH6laQwAAABhBWlR2VWJ3dUFBRE5aM2FZbWFnOVZnQksAAAAkMDE5NGVmNTItYjljNy00MzZhLTk0ZmQtNGU0NTdlMWJhMzYzAALLQg&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1738930976000&to_ts=1738945376000&live=true).
- In GitHub nodes, `connectors` does not URI-encode the source URLs, whereas `core` does.
- This PR aims at ignoring the diff caused by this to reduce noise.

## Tests

## Risk

- n/a.

## Deploy Plan

- Deploy front.