### PR TITLE
[Embeddings] Mistral: Limit splits_chunk size to 32

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -948,8 +948,17 @@ impl DataSource {
             .collect::<Vec<_>>();
 
         // Chunk splits into a vectors of 128 chunks (Vec<Vec<String>>)
+
+        // if provider is mistral, we can only go to 32-size chunked splits
+        // because mistral does not accept more than 16k tokens per batch request
+        // (with 512 tokens per split)
+        let chunk_size = match embedder_config.provider_id {
+            ProviderID::Mistral => 32,
+            _ => 128,
+        };
+
         let chunked_splits = splits_to_embbed
-            .chunks(128)
+            .chunks(chunk_size)
             .map(|chunk| chunk.to_vec())
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
Description
---

Mistral errs with that:
```
Failed to upsert document (error: DataSource chunk embedding error:
Error querying `mistral:mistral-embed`: error=Too many retries (1):
[model_error(retryable=,
request_id=c5827b6823e8fa1d7f096b1e5d94c057true)] "Too many tokens in
batch. Max is 16384 got 33635")
```
see [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1739183235555579)

Risk
---
standard

Deploy
---
core
