### PR TITLE
Create Business Pro plan available for workspace created via Poké

### DIFF
--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -8,17 +8,22 @@ import {
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
-import type { BillingPeriod, PlanType } from "@dust-tt/types";
+import type { BillingPeriod, PlanType, WorkspaceType } from "@dust-tt/types";
 import type { ReactNode } from "react";
 import React, { useState } from "react";
 
 import { FairUsageModal } from "@app/components/FairUsageModal";
 import {
+  BUSINESS_PLAN_COST_MONTHLY,
   getPriceWithCurrency,
   PRO_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_YEARLY,
 } from "@app/lib/client/subscription";
-import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import {
+  PRO_PLAN_LARGE_FILES_CODE,
+  PRO_PLAN_SEAT_29_CODE,
+  PRO_PLAN_SEAT_39_CODE,
+} from "@app/lib/plans/plan_codes";
 import { classNames } from "@app/lib/utils";
 
 export type PriceTableDisplay = "landing" | "subscribe";
@@ -88,6 +93,7 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
 ];
 
 export function ProPriceTable({
+  owner,
   size,
   plan,
   onClick,
@@ -95,6 +101,7 @@ export function ProPriceTable({
   display,
   billingPeriod = "monthly",
 }: {
+  owner?: WorkspaceType;
   size: "sm" | "xs";
   plan?: PlanType;
   onClick?: () => void;
@@ -175,10 +182,20 @@ export function ProPriceTable({
 
   const biggerButtonSize = size === "xs" ? "sm" : "md";
 
-  const price =
+  let price =
     billingPeriod === "monthly"
       ? getPriceWithCurrency(PRO_PLAN_COST_MONTHLY)
       : getPriceWithCurrency(PRO_PLAN_COST_YEARLY);
+
+  const isBusiness = owner?.metadata?.isBusiness ?? false;
+  if (isBusiness) {
+    price = getPriceWithCurrency(BUSINESS_PLAN_COST_MONTHLY);
+  }
+
+  const isProPlanCode =
+    plan?.code === PRO_PLAN_SEAT_29_CODE ||
+    plan?.code === PRO_PLAN_LARGE_FILES_CODE ||
+    plan?.code === PRO_PLAN_SEAT_39_CODE;
 
   return (
     <>
@@ -194,7 +211,7 @@ export function ProPriceTable({
         size={size}
         magnified={false}
       >
-        {onClick && (!plan || plan.code !== PRO_PLAN_SEAT_29_CODE) && (
+        {onClick && (!plan || !isProPlanCode) && (
           <PriceTable.ActionContainer position="top">
             <Button
               variant="highlight"

--- a/front/components/plans/ProPlansTable.tsx
+++ b/front/components/plans/ProPlansTable.tsx
@@ -1,5 +1,5 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@dust-tt/sparkle";
-import type { BillingPeriod, PlanType } from "@dust-tt/types";
+import type { BillingPeriod, PlanType, WorkspaceType } from "@dust-tt/types";
 import React from "react";
 
 import type { PriceTableDisplay } from "@app/components/plans/PlansTables";
@@ -7,18 +7,34 @@ import { ProPriceTable } from "@app/components/plans/PlansTables";
 import { classNames } from "@app/lib/utils";
 
 export function ProPlansTable({
+  owner,
   size = "sm",
   className = "",
   plan,
   display,
   setBillingPeriod,
 }: {
+  owner: WorkspaceType;
   size?: "sm" | "xs";
   className?: string;
   plan?: PlanType;
   display: PriceTableDisplay;
   setBillingPeriod: (billingPeriod: BillingPeriod) => void;
 }) {
+  const isBusiness = owner.metadata?.isBusiness ?? false;
+
+  if (isBusiness) {
+    return (
+      <ProPriceTable
+        owner={owner}
+        display={display}
+        size={size}
+        plan={plan}
+        billingPeriod="monthly"
+      />
+    );
+  }
+
   return (
     <div className={classNames("w-full sm:px-0", className)}>
       <Tabs
@@ -32,6 +48,7 @@ export function ProPlansTable({
         <div className="mt-8">
           <TabsContent value="monthly">
             <ProPriceTable
+              owner={owner}
               display={display}
               size={size}
               plan={plan}
@@ -40,6 +57,7 @@ export function ProPlansTable({
           </TabsContent>
           <TabsContent value="yearly">
             <ProPriceTable
+              owner={owner}
               display={display}
               size={size}
               plan={plan}

--- a/front/lib/api/poke/plugins/global/create_workspace.ts
+++ b/front/lib/api/poke/plugins/global/create_workspace.ts
@@ -30,6 +30,11 @@ export const createWorkspacePlugin = createPlugin(
         label: "Enable Auto Join",
         description: "Enable auto join for the domain",
       },
+      isBusiness: {
+        type: "boolean",
+        label: "Is Business",
+        description: "Is the workspace a business workspace (Pro plan 39€)",
+      },
     },
   },
   async (auth, _, args) => {
@@ -49,6 +54,7 @@ export const createWorkspacePlugin = createPlugin(
       email,
       name,
       isVerified: enableAutoJoin,
+      isBusiness: args.isBusiness,
     });
 
     const newWorkspaceAuth = await Authenticator.internalAdminForWorkspace(

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -4,6 +4,7 @@
 // not on the Stripe dashboard.
 export const PRO_PLAN_COST_MONTHLY = 29;
 export const PRO_PLAN_COST_YEARLY = 27;
+export const BUSINESS_PLAN_COST_MONTHLY = 39;
 
 export const getPriceWithCurrency = (price: number): string => {
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -15,6 +15,7 @@ export async function createWorkspace(session: SessionWithUser) {
     email: externalUser.email,
     name: externalUser.nickname,
     isVerified: externalUser.email_verified,
+    isBusiness: false,
   });
 }
 
@@ -22,10 +23,12 @@ export async function createWorkspaceInternal({
   email,
   name,
   isVerified,
+  isBusiness,
 }: {
   email: string;
   name: string;
   isVerified: boolean;
+  isBusiness: boolean;
 }) {
   const [, emailDomain] = email.split("@");
 
@@ -36,6 +39,9 @@ export async function createWorkspaceInternal({
   const workspace = await Workspace.create({
     sId: generateRandomModelSId(),
     name,
+    metadata: {
+      isBusiness,
+    },
   });
 
   const lightWorkspace = renderLightWorkspaceType({ workspace });

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -9,6 +9,7 @@ export const TRIAL_PLAN_CODE = "TRIAL_PLAN_CODE";
 // Current pro plans:
 export const PRO_PLAN_SEAT_29_CODE = "PRO_PLAN_SEAT_29";
 export const PRO_PLAN_LARGE_FILES_CODE = "PRO_PLAN_LARGE_FILES";
+export const PRO_PLAN_SEAT_39_CODE = "PRO_PLAN_SEAT_39";
 
 /**
  * ENT_PLAN_FAKE is not subscribable and is only used to display the Enterprise plan in the UI (hence it's not stored on the db).

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -2,7 +2,10 @@ import { isDevelopment } from "@dust-tt/types";
 import type { Attributes } from "sequelize";
 
 import { Plan } from "@app/lib/models/plan";
-import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import {
+  PRO_PLAN_SEAT_29_CODE,
+  PRO_PLAN_SEAT_39_CODE,
+} from "@app/lib/plans/plan_codes";
 
 export type PlanAttributes = Omit<
   Attributes<Plan>,
@@ -34,6 +37,27 @@ if (isDevelopment()) {
     maxMessagesTimeframe: "lifetime",
     maxUsersInWorkspace: 1000,
     maxVaultsInWorkspace: 1,
+    isSlackbotAllowed: true,
+    isManagedSlackAllowed: true,
+    isManagedConfluenceAllowed: true,
+    isManagedNotionAllowed: true,
+    isManagedGoogleDriveAllowed: true,
+    isManagedGithubAllowed: true,
+    isManagedIntercomAllowed: true,
+    isManagedWebCrawlerAllowed: true,
+    maxDataSourcesCount: -1,
+    maxDataSourcesDocumentsCount: -1,
+    maxDataSourcesDocumentsSizeMb: 2,
+    trialPeriodDays: 14,
+    canUseProduct: true,
+  });
+  PRO_PLANS_DATA.push({
+    code: PRO_PLAN_SEAT_39_CODE,
+    name: "Pro Business",
+    maxMessages: -1,
+    maxMessagesTimeframe: "lifetime",
+    maxUsersInWorkspace: 1000,
+    maxVaultsInWorkspace: 5,
     isSlackbotAllowed: true,
     isManagedSlackAllowed: true,
     isManagedConfluenceAllowed: true,

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -209,10 +209,11 @@ export default function Subscribe({
               </Page.Vertical>
               <Page.Horizontal sizing="grow">
                 <ProPlansTable
+                  owner={owner}
                   size="xs"
                   display="subscribe"
                   setBillingPeriod={setBillingPeriod}
-                ></ProPlansTable>
+                />
               </Page.Horizontal>
             </Page.Horizontal>
           ) : (
@@ -231,10 +232,11 @@ export default function Subscribe({
               </Page.Vertical>
               <Page.Vertical sizing="grow">
                 <ProPlansTable
+                  owner={owner}
                   size="xs"
                   display="subscribe"
                   setBillingPeriod={setBillingPeriod}
-                ></ProPlansTable>
+                />
               </Page.Vertical>
             </Page.Horizontal>
           )}

--- a/front/scripts/dev/create_test_workspaces.ts
+++ b/front/scripts/dev/create_test_workspaces.ts
@@ -60,6 +60,7 @@ async function createTestWorkspaces(
       email: user.email,
       name: name,
       isVerified: true,
+      isBusiness: false,
     });
 
     logger.info(`Workspace ${name} created.`);


### PR DESCRIPTION
## Description

This PRs introduces a new business plan. 
When creating a workspace from poké, we have a new checkbox "Is Business" that will redirect the user to the new business plan when they go to the stripe checkout session. This plan has less restrictions then the pro plan and is more expensive. 

To redirect to the valid plan; we set a flag on the workspace metadata.

## Tests

Tested locally. 

## Risk

Break checkout session. 

## Deploy Plan

- [x] Create new Stripe product in dev and prod environment. 
- [x] Create new plan on local & prod db. 
- [ ] Deploy front.  
