### PR TITLE
[CoreNodes] Fix exclusion rule on != nodes returned because of pagination

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -90,14 +90,17 @@ export function computeNodesDiff({
   // Core and connectors follow different sorting rules,
   // so when pagination is enforced, we only want to log the number of nodes we get,
   // and the other logs are irrelevant since we are not fetching the same nodes.
-  if (pagination && connectorsContentNodes.length !== coreContentNodes.length) {
+  if (pagination) {
     localLogger.info(
       {
         connectorsNodesCount: connectorsContentNodes.length,
         coreNodesCount: coreContentNodes.length,
         pagination,
       },
-      "[CoreNodes] Different number of nodes returned by connectors and core"
+      connectorsContentNodes.length !== pagination.limit ||
+        coreContentNodes.length !== pagination.limit
+        ? "[CoreNodes] Different number of nodes returned by connectors and core"
+        : "[CoreNodes] Different nodes were fetched due to pagination"
     );
     return [];
   }


### PR DESCRIPTION
## Description

- See log [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20-%40provider%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1739187526000&to_ts=1739191126000&live=true).
- Closes https://github.com/dust-tt/dust/issues/10662.
- The logs all turned out to come in pairs with one indicating an extraneous node and one a missing node, which seem to be due to a paginated call with != sorting order.
- To confirm this assumption, this PR fixes the exclusion rule to indicate when a diff comes from a paginated call.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy front.