### PR TITLE
[CoreNodes] Ignore diff due to != case in Notion titles

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -216,6 +216,7 @@ export function computeNodesDiff({
         }
 
         // Special case for Notion titles where we sometimes get a snake_case version of the title one way or another.
+        // For instance "User test - Notes" is turned into "user_test_notes".
         if (
           key === "title" &&
           provider === "notion" &&

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -215,6 +215,20 @@ export function computeNodesDiff({
           return false;
         }
 
+        // Special case for Notion titles where we sometimes get a snake_case version of the title one way or another.
+        if (
+          key === "title" &&
+          provider === "notion" &&
+          (value.toLowerCase().replace("-", "").replaceAll(/\s+/g, "_") ==
+            matchingCoreNode.title ||
+            matchingCoreNode.title
+              .toLowerCase()
+              .replace("-", "")
+              .replaceAll(/\s+/g, "_") == value)
+        ) {
+          return false;
+        }
+
         // Special case for Google Drive spreadsheet folders: connectors
         // return a type "file" while core returns a type "folder".
         if (


### PR DESCRIPTION
## Description

- In Notion, we sometimes see a diff due to a snake_case version of the title in connectors (see [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Anotion&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZTv_0yo-ou5MgAAABhBWlR2XzA5WkFBQXZIdEVrUjQ5emlRQjAAAAAkMDE5NGYwMDItMjRmZC00MzhmLWIyZWYtNWI5N2NhZjJhMjAwAAMEfQ&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1739183125260&to_ts=1739186725260&live=true)) or the other way around (less common, [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20%40provider%3Anotion&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZTv_E39hYQb6QAAABhBWlR2X0ZLVEFBRHMxb3JoNlA3TGJRQkUAAAAkMDE5NGVmZmQtZmI2MS00ZGQzLWEwNWYtNGFlZWQwNGZhMDdjAALgzA&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1739183125260&to_ts=1739186725260&live=true)).
- Unsure as to why this happens (could be a remainder of a botched backfill), this PR suggests ignoring this diff.

## Tests

## Risk

- n/a

## Deploy Plan

- Deploy front.