### PR TITLE
Sparkle: Fix backgound color bg-muted-night

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.389",
+  "version": "0.2.390",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.389",
+      "version": "0.2.390",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.389",
+  "version": "0.2.390",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -366,7 +366,7 @@ DataTable.Row = function Row({
         "s-group/dt s-border-b s-transition-colors s-duration-300 s-ease-out",
         "s-border-separator dark:s-border-separator-night",
         onClick
-          ? "dark:hover:s-bg-muted-night s-cursor-pointer hover:s-bg-muted"
+          ? "s-cursor-pointer hover:s-bg-muted dark:hover:s-bg-muted-night"
           : "",
         widthClassName,
         className

--- a/sparkle/src/components/LoadingBlock.tsx
+++ b/sparkle/src/components/LoadingBlock.tsx
@@ -10,7 +10,7 @@ function LoadingBlock({
     <div
       className={cn(
         "s-animate-opacity-pulse s-rounded-md",
-        "dark:s-bg-muted-night s-bg-muted",
+        "s-bg-muted dark:s-bg-muted-night",
         className
       )}
       {...props}

--- a/sparkle/src/components/Resizable.tsx
+++ b/sparkle/src/components/Resizable.tsx
@@ -41,7 +41,7 @@ const ResizableHandle = ({
       "data-[panel-group-direction=vertical]:after:s--translate-y-1/2",
       "data-[panel-group-direction=vertical]:after:s-translate-x-0",
       "[&[data-panel-group-direction=vertical]>div]:s-rotate-90",
-      "dark:s-bg-border-night s-bg-border",
+      "s-bg-border dark:s-bg-border-night",
       className
     )}
     {...props}
@@ -50,7 +50,7 @@ const ResizableHandle = ({
       <div
         className={cn(
           "s-z-10 s-flex s-h-4 s-w-3 s-items-center s-justify-center s-rounded-sm s-border",
-          "dark:s-bg-border-night s-bg-border"
+          "s-bg-border dark:s-bg-border-night"
         )}
       >
         <Icon visual={GrabIcon} size="xs" />

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -56,12 +56,22 @@ const sheetVariants = cva(
   {
     variants: {
       side: {
-        top: "s-inset-x-0 s-top-0 s-border-b data-[state=closed]:s-slide-out-to-top data-[state=open]:s-slide-in-from-top",
-        bottom:
-          "s-inset-x-0 s-bottom-0 s-border-t data-[state=closed]:s-slide-out-to-bottom data-[state=open]:s-slide-in-from-bottom",
-        left: "s-inset-y-0 s-left-0 s-border-r data-[state=closed]:s-slide-out-to-left data-[state=open]:s-slide-in-from-left",
-        right:
-          "s-inset-y-0 s-right-0 s-border-l data-[state=closed]:s-slide-out-to-right data-[state=open]:s-slide-in-from-right",
+        top: cn(
+          "s-inset-x-0 s-top-0 data-[state=closed]:s-slide-out-to-top data-[state=open]:s-slide-in-from-top",
+          "s-border-b dark:s-border-border-night s-border-border"
+        ),
+        bottom: cn(
+          "s-inset-x-0 s-bottom-0 data-[state=closed]:s-slide-out-to-bottom data-[state=open]:s-slide-in-from-bottom",
+          "s-border-t dark:s-border-border-night s-border-border"
+        ),
+        left: cn(
+          "s-inset-y-0 s-left-0 data-[state=closed]:s-slide-out-to-left data-[state=open]:s-slide-in-from-left",
+          "s-border-r dark:s-border-border-night s-border-border"
+        ),
+        right: cn(
+          "s-inset-y-0 s-right-0 data-[state=closed]:s-slide-out-to-right data-[state=open]:s-slide-in-from-right",
+          "s-border-l dark:s-border-border-night s-border-border"
+        ),
       },
       size: sizeClasses,
     },
@@ -159,7 +169,7 @@ const SheetFooter = ({
   <div
     className={cn(
       "s-flex s-flex-none s-flex-row s-gap-2 s-border-t s-px-3 s-py-3",
-      "dark:s-border-border-night s-border-border",
+      "s-border-border dark:s-border-border-night",
       className
     )}
     {...props}

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -139,7 +139,7 @@ export function CodeBlock({
       className={cn(
         "s-mx-0.5 s-cursor-text s-rounded-lg s-border s-px-1.5 s-py-1",
         "s-border-border-dark dark:s-border-border-dark-night",
-        "dark:s-bg-muted-night s-bg-muted",
+        "s-bg-muted dark:s-bg-muted-night",
         "dark:s-text-amber-600-night s-text-amber-600"
       )}
     >

--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -223,9 +223,16 @@ module.exports = {
           night: colors.emerald[500],
         },
         border: {
-          DEFAULT: { DEFAULT: colors.slate[100], night: colors.slate[900] },
-          dark: { DEFAULT: colors.slate[200], night: colors.slate[800] },
-          darker: { DEFAULT: colors.slate[400], night: colors.slate[600] },
+          DEFAULT: colors.slate[100],
+          night: colors.slate[900],
+          dark: {
+            DEFAULT: colors.slate[200],
+            night: colors.slate[800],
+          },
+          darker: {
+            DEFAULT: colors.slate[400],
+            night: colors.slate[600],
+          },
           focus: {
             DEFAULT: colors.blue[400],
             night: colors.slate[600],
@@ -255,7 +262,8 @@ module.exports = {
           },
         },
         muted: {
-          DEFAULT: { DEFAULT: "#F6F8FB", night: colors.slate[900] },
+          DEFAULT: "#F6F8FB",
+          night: colors.slate[900],
           foreground: {
             DEFAULT: colors.slate[500],
             night: colors.slate[400],


### PR DESCRIPTION
## Description

Fixing the `s-bg-muted-night` color on sparkle and use it on the Sheet component to fix the border colors on Dark mode. 
I'll also fix the config on front color (on the PR that bumps Sparkle)

## Tests

Locally on Sparkle. 

## Risk

Can be rolled back. 

## Deploy Plan

Publish Sparkle. 
