### PR TITLE
Front: Bump Sparkle and fix tailwind border colors dark mode

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dust-tt/client": "^1.0.26",
-        "@dust-tt/sparkle": "^0.2.389",
+        "@dust-tt/sparkle": "^0.2.390",
         "@tailwindcss/forms": "^0.5.9",
         "@tiptap/extension-character-count": "^2.9.1",
         "@tiptap/extension-mention": "^2.9.1",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.389",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.389.tgz",
-      "integrity": "sha512-kG5RcozYaoZCzOt3Z6FklUcX7HngYqOUs6h04uBCUxWL/RkcrMXO7XZPmUkc3dljPGxPnZdfc5bMEuYR62TDdQ==",
+      "version": "0.2.390",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.390.tgz",
+      "integrity": "sha512-o57Q4FxaXhS4L6QWqU7PRppCzK3SxJajeUOnHnnOKogO+ROjII2xslZX7RIsghGexQrLWD133gaCNXu8b66HFg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@dust-tt/client": "^1.0.26",
-    "@dust-tt/sparkle": "^0.2.389",
+    "@dust-tt/sparkle": "^0.2.390",
     "@tailwindcss/forms": "^0.5.9",
     "@tiptap/extension-character-count": "^2.9.1",
     "@tiptap/extension-mention": "^2.9.1",

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -45,7 +45,7 @@ export function Navigation({
   }
 
   return (
-    <div className="dark:border-border-dark-night/60 flex shrink-0 overflow-x-hidden border-r border-border-dark/60">
+    <div className="flex shrink-0 overflow-x-hidden border-r border-border-dark/60 dark:border-border-dark-night/60">
       {/* Mobile sidebar */}
       <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
         <div className="fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6">

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -45,7 +45,7 @@ export function Navigation({
   }
 
   return (
-    <div className="flex shrink-0 overflow-x-hidden border-r border-border-dark/60">
+    <div className="dark:border-border-dark-night/60 flex shrink-0 overflow-x-hidden border-r border-border-dark/60">
       {/* Mobile sidebar */}
       <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
         <div className="fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.389",
+        "@dust-tt/sparkle": "0.2.390",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -160,7 +160,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",
@@ -11334,9 +11334,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.389",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.389.tgz",
-      "integrity": "sha512-kG5RcozYaoZCzOt3Z6FklUcX7HngYqOUs6h04uBCUxWL/RkcrMXO7XZPmUkc3dljPGxPnZdfc5bMEuYR62TDdQ==",
+      "version": "0.2.390",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.390.tgz",
+      "integrity": "sha512-o57Q4FxaXhS4L6QWqU7PRppCzK3SxJajeUOnHnnOKogO+ROjII2xslZX7RIsghGexQrLWD133gaCNXu8b66HFg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.389",
+    "@dust-tt/sparkle": "0.2.390",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -183,7 +183,7 @@ module.exports = {
           DEFAULT: colors.slate[100],
           night: colors.slate[900],
           dark: { DEFAULT: colors.slate[200], night: colors.slate[800] },
-          darker: { DEFAULT: colors.slate[400], night: colors.slate[6800] },
+          darker: { DEFAULT: colors.slate[400], night: colors.slate[600] },
           focus: {
             DEFAULT: colors.slate[400],
             night: colors.slate[600],

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -180,7 +180,8 @@ module.exports = {
           night: colors.emerald[500],
         },
         border: {
-          DEFAULT: { DEFAULT: colors.slate[100], night: colors.slate[900] },
+          DEFAULT: colors.slate[100],
+          night: colors.slate[900],
           dark: { DEFAULT: colors.slate[200], night: colors.slate[800] },
           darker: { DEFAULT: colors.slate[400], night: colors.slate[6800] },
           focus: {
@@ -211,7 +212,8 @@ module.exports = {
           },
         },
         muted: {
-          DEFAULT: { DEFAULT: colors.slate[100], night: colors.slate[900] },
+          DEFAULT: colors.slate[100],
+          night: colors.slate[900],
           foreground: {
             DEFAULT: colors.slate[500],
             night: colors.slate[500],


### PR DESCRIPTION
## Description

- Bump Sparkle (front and extension)
- Fix tailwind boder color config in dark mode.
- Add a missing dark mode color on `front/components/navigation/Navigation.tsx`

## Tests

Locally

## Risk

N/A

## Deploy Plan

Deploy front. 
