### PR TITLE
Fix: missing nodes because viewType was defaulting to documents

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -85,7 +85,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -62,6 +62,8 @@ import {
 import { useSpaces } from "@app/lib/swr/spaces";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
 
+const DEFAULT_VIEW_TYPE = "all";
+
 type RowData = DataSourceViewContentNode & {
   icon: React.ComponentType;
   onClick?: () => void;
@@ -225,7 +227,7 @@ export const SpaceDataSourceViewContentList = ({
     urlPrefix: "table",
     initialPageSize: 25,
   });
-  const [viewType, setViewType] = useHashParam("viewType", "documents");
+  const [viewType, setViewType] = useHashParam("viewType", DEFAULT_VIEW_TYPE);
   const router = useRouter();
   const showSpaceUsage =
     dataSourceView.kind === "default" && isManaged(dataSourceView.dataSource);
@@ -268,7 +270,9 @@ export const SpaceDataSourceViewContentList = ({
     owner,
     parentId,
     pagination: isServerPagination ? pagination : undefined,
-    viewType: isValidContentNodesViewType(viewType) ? viewType : "documents",
+    viewType: isValidContentNodesViewType(viewType)
+      ? viewType
+      : DEFAULT_VIEW_TYPE,
     // TODO(20250126, nodes-core): Remove this after project end
     showConnectorsNodes,
   });
@@ -362,10 +366,6 @@ export const SpaceDataSourceViewContentList = ({
 
   useEffect(() => {
     if (!isTablesValidating && !isDocumentsValidating) {
-      if (isDataSourceManaged) {
-        handleViewTypeChange("documents");
-        return;
-      }
       // If the view only has content in one of the two views, we switch to that view.
       // if both view have content, or neither views have content, we default to documents.
       if (hasTables && !hasDocuments) {
@@ -373,7 +373,7 @@ export const SpaceDataSourceViewContentList = ({
       } else if (!hasTables && hasDocuments) {
         handleViewTypeChange("documents");
       } else if (!viewType) {
-        handleViewTypeChange("documents");
+        handleViewTypeChange(DEFAULT_VIEW_TYPE);
       }
     }
   }, [

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -148,7 +148,7 @@ export default function SpaceManagedDataSourcesViewsModal({
             owner={owner}
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
-            viewType="documents"
+            viewType="all"
             isRootSelectable={true}
           />
         </div>


### PR DESCRIPTION
## Description

Fix invisibile nodes in code-world because of viewType defaulting / hardcoded to documents.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`