### PR TITLE
[Poke - templates] Fix sync "pull template" button

### DIFF
--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -6,7 +6,6 @@ import Link from "next/link";
 import React, { useState } from "react";
 
 import { PokeButton } from "@app/components/poke/shadcn/ui/button";
-import { config } from "@app/lib/api/regions/config";
 import { usePokeAssistantTemplates, usePokePullTemplates } from "@app/poke/swr";
 
 export interface TemplatesDisplayType {
@@ -85,7 +84,11 @@ export function makeColumnsForTemplates() {
   ];
 }
 
-export function TemplatesDataTable() {
+export function TemplatesDataTable({
+  dustRegionSyncEnabled,
+}: {
+  dustRegionSyncEnabled: boolean;
+}) {
   const { assistantTemplates, isAssistantTemplatesLoading } =
     usePokeAssistantTemplates();
   const { doPull, isPulling } = usePokePullTemplates();
@@ -98,7 +101,7 @@ export function TemplatesDataTable() {
     <div className="border-material-200 my-4 flex w-full flex-col gap-2 rounded-lg border p-4">
       <div className="flex w-full items-center justify-between gap-3">
         <h2 className="text-md flex-grow pb-4 font-bold">Templates:</h2>
-        {config.getDustRegionSyncEnabled() && (
+        {dustRegionSyncEnabled && (
           <PokeButton
             aria-label="Pull templates"
             variant="outline"

--- a/front/pages/poke/templates/index.tsx
+++ b/front/pages/poke/templates/index.tsx
@@ -2,20 +2,28 @@ import type { ReactElement } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { TemplatesDataTable } from "@app/components/poke/templates/TemplatesDataTable";
+import { config } from "@app/lib/api/regions/config";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withSuperUserAuthRequirements<object>(
   async () => {
+    const dustRegionSyncEnabled = config.getDustRegionSyncEnabled();
     return {
-      props: {},
+      props: {
+        dustRegionSyncEnabled,
+      },
     };
   }
 );
 
-export default function ListTemplates() {
+export default function ListTemplates({
+  dustRegionSyncEnabled,
+}: {
+  dustRegionSyncEnabled: boolean;
+}) {
   return (
     <div className="mx-auto h-full flex-grow flex-col items-center justify-center p-8 pt-8">
-      <TemplatesDataTable />
+      <TemplatesDataTable dustRegionSyncEnabled={dustRegionSyncEnabled} />
     </div>
   );
 }


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2124

getting the region env variable from the browser didn't work

This PR is fetching the required boolean via server side props

Risk
--
low

Deploy
---
front
