### PR TITLE
[CoreNodes] Fix the log on paginated calls

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -97,8 +97,7 @@ export function computeNodesDiff({
         coreNodesCount: coreContentNodes.length,
         pagination,
       },
-      connectorsContentNodes.length !== pagination.limit ||
-        coreContentNodes.length !== pagination.limit
+      connectorsContentNodes.length !== coreContentNodes.length
         ? "[CoreNodes] Different number of nodes returned by connectors and core"
         : "[CoreNodes] Different nodes were fetched due to pagination"
     );


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/10663.
- The rule was incorrect; the number of nodes returned can be != from the pagination limit if there isn't enough nodes in total, example where we actually have 0 node [here](https://app.datadoghq.eu/logs?query=CoreNodes%20-%22Latency%20between%20connectors%20and%20core%22%20-%40provider%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZTw3BvYM6_HDwAAABhBWlR3M0M5VkFBQjFHVmQwLU9KWkJBQWUAAAAkMDE5NGYwZGMtNGJmMS00MTllLThjMWUtODlhNmM1NTcyNGJmAAAsSg&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1739204240000&to_ts=1739207840000&live=true).

## Tests

- n/a.

## Risk

- n/a.

## Deploy Plan

- Deploy front.