### PR TITLE
Cleanup Zendesk garbage collection

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -183,12 +183,11 @@ export const zendesk = async ({
           connector.id
         );
 
-      const allCategoryIds =
-        await ZendeskCategoryResource.fetchByConnector(connector);
-      const categoryIds = allCategoryIds
+      const selectedCategoryIds =
+        await ZendeskCategoryResource.fetchAllReadOnly(connector.id);
+      const categoryIds = selectedCategoryIds
         .filter(
-          (c) =>
-            c.permission === "read" && !helpCenterBrandIds.includes(c.brandId) // skipping categories that will be synced through the Help Center
+          (c) => !helpCenterBrandIds.includes(c.brandId) // skipping categories that will be synced through the Help Center
         )
         .map((c) => {
           const { categoryId, brandId } = c;

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -156,7 +156,7 @@ export async function syncZendeskBrandActivity({
 
     // updating the parents for the already selected categories to add the Help Center
     const selectedCategories =
-      await ZendeskCategoryResource.fetchByBrandIdReadOnly({
+      await ZendeskCategoryResource.fetchSelectedCategoriesInBrand({
         connectorId,
         brandId,
       });
@@ -182,7 +182,7 @@ export async function syncZendeskBrandActivity({
 
     // deleting categories that were only synced because the Help Center was selected but were not explicitely selected by the user in the UI
     const categoriesNotSelected =
-      await ZendeskCategoryResource.fetchBrandUnselectedCategories({
+      await ZendeskCategoryResource.fetchUnselectedCategoriesInBrand({
         connectorId,
         brandId,
       });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -180,7 +180,7 @@ export async function syncZendeskBrandActivity({
       folderId: helpCenterNode.internalId,
     });
 
-    // deleting categories that were only synced because the Help Center was selected but were not explicitely selected by the user in the UI
+    // Delete categories that were only synced because the Help Center was selected but were not explicitly selected by the user in the UI.
     const categoriesNotSelected =
       await ZendeskCategoryResource.fetchUnselectedCategoriesInBrand({
         connectorId,
@@ -194,6 +194,30 @@ export async function syncZendeskBrandActivity({
           brandId,
           categoryId: category.categoryId,
         }),
+      });
+    }
+
+    // Update the parents for the categories that were selected to turn them into roots.
+    const selectedCategories =
+      await ZendeskCategoryResource.fetchSelectedCategoriesInBrand({
+        connectorId,
+        brandId,
+      });
+    for (const category of selectedCategories) {
+      const folderId = getCategoryInternalId({
+        connectorId,
+        brandId,
+        categoryId: category.categoryId,
+      });
+      await upsertDataSourceFolder({
+        dataSourceConfig,
+        folderId,
+        parents: [folderId],
+        parentId: null,
+        title: category.name,
+        mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+        sourceUrl: category.url,
+        timestampMs: currentSyncDateMs,
       });
     }
   }

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -207,21 +207,21 @@ export async function removeForbiddenCategoriesActivity(
       connectorId
     );
   const batchSize = 2; // we process categories 2 by 2 since each of them typically contains ~50 articles
-  const categoryIdsWithBrand = (
+  const brandAndCategoryIds = (
     await ZendeskCategoryResource.fetchReadForbiddenCategoryIds({
       connectorId,
       batchSize,
     })
   ).filter(({ brandId }) => brandsWithHelpCenterUnselected.includes(brandId));
   logger.info(
-    { ...loggerArgs, categoryCount: categoryIdsWithBrand.length },
+    { ...loggerArgs, categoryCount: brandAndCategoryIds.length },
     "[Zendesk] Removing categories with no permission."
   );
 
-  for (const ids of categoryIdsWithBrand) {
+  for (const ids of brandAndCategoryIds) {
     await deleteCategory({ connectorId, ...ids, dataSourceConfig });
   }
-  return { hasMore: categoryIdsWithBrand.length === batchSize };
+  return { hasMore: brandAndCategoryIds.length === batchSize };
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -202,12 +202,17 @@ export async function removeForbiddenCategoriesActivity(
     dataSourceId: dataSourceConfig.dataSourceId,
   };
 
+  const brandsWithHelpCenterUnselected =
+    await ZendeskBrandResource.fetchHelpCenterReadForbiddenBrandIds(
+      connectorId
+    );
   const batchSize = 2; // we process categories 2 by 2 since each of them typically contains ~50 articles
-  const categoryIdsWithBrand =
+  const categoryIdsWithBrand = (
     await ZendeskCategoryResource.fetchReadForbiddenCategoryIds({
       connectorId,
       batchSize,
-    });
+    })
+  ).filter(({ brandId }) => brandsWithHelpCenterUnselected.includes(brandId));
   logger.info(
     { ...loggerArgs, categoryCount: categoryIdsWithBrand.length },
     "[Zendesk] Removing categories with no permission."

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -40,7 +40,6 @@ const {
   removeMissingArticleBatchActivity,
   getZendeskBrandsWithHelpCenterToDeleteActivity,
   getZendeskBrandsWithTicketsToDeleteActivity,
-  deleteBrandsWithNoPermissionActivity,
   deleteCategoryBatchActivity,
   deleteTicketBatchActivity,
 } = proxyActivities<typeof gc_activities>({
@@ -447,9 +446,6 @@ export async function zendeskGarbageCollectionWorkflow({
       hasMoreTickets = hasMore;
     }
   }
-
-  // deleting the brands that have no permissions anymore
-  await deleteBrandsWithNoPermissionActivity(connectorId);
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -43,7 +43,6 @@ const {
   deleteBrandsWithNoPermissionActivity,
   deleteCategoryBatchActivity,
   deleteTicketBatchActivity,
-  removeForbiddenCategoriesActivity,
 } = proxyActivities<typeof gc_activities>({
   startToCloseTimeout: "15 minutes",
 });
@@ -423,13 +422,6 @@ export async function zendeskGarbageCollectionWorkflow({
         cursor,
       });
     } while (cursor !== null);
-  }
-
-  // deleting the categories that have no permission anymore
-  let hasMoreCategories = true;
-  while (hasMoreCategories) {
-    const { hasMore } = await removeForbiddenCategoriesActivity(connectorId);
-    hasMoreCategories = hasMore;
   }
 
   // cleaning the articles and categories of the brands that have no permission on their Help Center anymore

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -392,9 +392,7 @@ export async function zendeskCategorySyncWorkflow({
  * This workflow is responsible for deleting the following (in this order):
  * - Outdated tickets.
  * - Articles that cannot be found anymore in the Zendesk API.
- * - Categories that have no article anymore.
- * - Permissions of the Help Centers that have no category anymore (allows a cleanup at the next step).
- * - Articles of the brands that have no permission on their Help Center anymore.
+ * - Articles and categories (only those that are not selected) of the brands that have an unselected Help Center.
  * - Tickets of the brands that have no permission on tickets anymore.
  * - Brands that have no permission on tickets and Help Center anymore.
  */

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -310,20 +310,6 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return brands.map((brand) => brand.get().brandId);
   }
 
-  static async deleteBrandsWithNoPermission(
-    connectorId: number,
-    transaction?: Transaction
-  ): Promise<number> {
-    return ZendeskBrand.destroy({
-      where: {
-        connectorId,
-        helpCenterPermission: "none",
-        ticketsPermission: "none",
-      },
-      transaction,
-    });
-  }
-
   static async deleteByConnectorId(
     connectorId: number,
     transaction?: Transaction

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -300,7 +300,11 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     connectorId: number
   ): Promise<number[]> {
     const brands = await ZendeskBrand.findAll({
-      where: { connectorId, ticketsPermission: "none" },
+      where: {
+        connectorId,
+        ticketsPermission: "none",
+        helpCenterPermission: "none",
+      },
       attributes: ["brandId"],
     });
     return brands.map((brand) => brand.get().brandId);

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -266,16 +266,6 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return brands.map((brand) => brand.get().brandId);
   }
 
-  static async fetchHelpCenterReadAllowedBrands(
-    connectorId: number
-  ): Promise<ZendeskBrandResource[]> {
-    const brands = await ZendeskBrand.findAll({
-      where: { connectorId, helpCenterPermission: "read" },
-      attributes: ["brandId"],
-    });
-    return brands.map((brand) => new this(this.model, brand.get()));
-  }
-
   static async fetchTicketsAllowedBrandIds(
     connectorId: number
   ): Promise<number[]> {
@@ -291,20 +281,6 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
   ): Promise<number[]> {
     const brands = await ZendeskBrand.findAll({
       where: { connectorId, ticketsPermission: "none" },
-      attributes: ["brandId"],
-    });
-    return brands.map((brand) => brand.get().brandId);
-  }
-
-  static async fetchBrandsWithNoPermission(
-    connectorId: number
-  ): Promise<number[]> {
-    const brands = await ZendeskBrand.findAll({
-      where: {
-        connectorId,
-        ticketsPermission: "none",
-        helpCenterPermission: "none",
-      },
       attributes: ["brandId"],
     });
     return brands.map((brand) => brand.get().brandId);
@@ -431,24 +407,6 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     };
   }
 
-  static async fetchReadForbiddenCategoryIds({
-    connectorId,
-    batchSize,
-  }: {
-    connectorId: number;
-    batchSize: number;
-  }): Promise<{ categoryId: number; brandId: number }[]> {
-    const categories = await ZendeskCategory.findAll({
-      where: { connectorId, permission: "none" },
-      attributes: ["categoryId", "brandId"],
-      limit: batchSize,
-    });
-    return categories.map((category) => {
-      const { categoryId, brandId } = category.get();
-      return { categoryId, brandId };
-    });
-  }
-
   static async fetchByConnector(
     connector: ConnectorResource
   ): Promise<ZendeskCategoryResource[]> {
@@ -456,19 +414,6 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
       where: { connectorId: connector.id },
     });
     return categories.map((category) => new this(this.model, category.get()));
-  }
-
-  static async fetchIdsForConnector(
-    connectorId: number
-  ): Promise<{ categoryId: number; brandId: number }[]> {
-    const categories = await ZendeskCategory.findAll({
-      where: { connectorId },
-      attributes: ["categoryId", "brandId"],
-    });
-    return categories.map((category) => {
-      const { categoryId, brandId } = category.get();
-      return { categoryId, brandId };
-    });
   }
 
   static async fetchByCategoryId({
@@ -623,19 +568,6 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     transaction: Transaction
   ) {
     await ZendeskCategory.destroy({ where: { connectorId }, transaction });
-  }
-
-  static async revokePermissionsForBrand({
-    connectorId,
-    brandId,
-  }: {
-    connectorId: number;
-    brandId: number;
-  }) {
-    await ZendeskCategory.update(
-      { permission: "none" },
-      { where: { connectorId, brandId } }
-    );
   }
 
   async grantPermissions(): Promise<void> {

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -555,7 +555,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return categories.map((category) => new this(this.model, category.get()));
   }
 
-  static async fetchByBrandIdReadOnly({
+  static async fetchSelectedCategoriesInBrand({
     connectorId,
     brandId,
   }: {
@@ -568,7 +568,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return categories.map((category) => new this(this.model, category.get()));
   }
 
-  static async fetchBrandUnselectedCategories({
+  static async fetchUnselectedCategoriesInBrand({
     connectorId,
     brandId,
   }: {


### PR DESCRIPTION
## Description

- This PR removes obsolete operations in the garbage collection (these operations did not do anything at all).
- The activity `removeForbiddenCategoriesActivity` altogether, which was not needed for of two reasons.
  - In the GC we already loop over the Help Centers that have no permission and remove the categories that are not explicitly selected by the user.
  - In the UI it is not possible to unselect a category without unselecting the whole Help Center.
- The activity `deleteBrandsWithNoPermissionActivity` is also removed, we keep the entry in `connectors`' db with permissions "none" instead of potentially deleting them while a category remains selected underneath.
- This PR also updates the parents of categories upon unselecting the Help Center: the categories that remain selected (if any) should not have any parent (`parents = [folderId]`).

## Tests

## Risk

- n/a

## Deploy Plan

- Stop all Zendesk connectors.
- Deploy connectors.
- Resume all Zendesk connectors.