### PR TITLE
[front] - refacto: update Chip color for "Limit reached"

### DIFF
--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -98,7 +98,7 @@ export default function ConnectorSyncingChip({
               "The website synchronization reached the maximum page limit."
             }
             className="max-w-md"
-            trigger={<Chip color="warning">Limit reached</Chip>}
+            trigger={<Chip color="amber">Limit reached</Chip>}
           />
         );
       case "webcrawling_error":


### PR DESCRIPTION
## Description

This PR changes the Chip component color from 'warning' to 'amber' to better reflect 'Limit reached' status. Having it as "warning" was really confusing as you would expect an error to have occurred.

<img width="811" alt="Screenshot 2025-02-11 at 11 44 28" src="https://github.com/user-attachments/assets/a0583bc7-e3ff-45f3-88dc-c745d7a0363e" />

## Risk

Low

## Deploy Plan

Deploy front