### PR TITLE
feat: allow configuring anthropic beta flags in chat block config

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -319,6 +319,18 @@ impl Block for Chat {
                 if let Some(Value::String(s)) = v.get("reasoning_effort") {
                     extras["reasoning_effort"] = json!(s.clone());
                 }
+                if let Some(Value::Array(a)) = v.get("anthropic_beta_flags") {
+                    extras["anthropic_beta_flags"] = json!(a
+                        .iter()
+                        .map(|v| match v {
+                            Value::String(s) => Ok(s.clone()),
+                            _ => Err(anyhow!("Invalid `anthropic_beta_flags` in configuration for chat block `{}`: \
+                             expecting an array of strings",
+                                name
+                            ))?,
+                        })
+                        .collect::<Result<Vec<String>>>()?);
+                }
 
                 match extras.as_object().unwrap().keys().len() {
                     0 => None,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -170,6 +170,11 @@ const config = {
   getStatusPageApiToken: (): string => {
     return EnvironmentConfig.getEnvVariable("STATUS_PAGE_API_TOKEN");
   },
+  getMultiActionsAgentAnthropicBetaFlags: (): string[] | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "MULTI_ACTIONS_AGENT_ANTHROPIC_BETA_FLAGS"
+    )?.split(",");
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/2117

- remove useless `tools-2024-05-16` beta flag we were hardcoding (tools are GA)
- add ability to configure the anthropic beta flags in the Chat block config (via extras)
- add ability to set anthropic beta flags that are use for multi actions agent from env var 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Maximal blast radius potentially large

## Deploy Plan

deploy core and front
