### PR TITLE
Add: labels as tags for google drive

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
-import { assertNever, MIME_TYPES, safeSubstring } from "@dust-tt/types";
+import { assertNever, MIME_TYPES } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import { hash as blake3 } from "blake3";
 import { promises as fs } from "fs";
@@ -154,7 +154,7 @@ async function renderIssue(
     updatedAt: issue.updatedAt,
     author: renderGithubUser(issue.creator),
     additionalPrefixes: {
-      labels: safeSubstring(issue.labels.join(", "), 0, 128), // We truncate the labels to avoid having a prefix too large.
+      labels: issue.labels.join(", "),
       isPullRequest: issue.isPullRequest.toString(),
     },
     content: await renderMarkdownSection(dataSourceConfig, issue.body ?? "", {

--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -18,6 +18,7 @@ import {
 } from "@connectors/connectors/google_drive/temporal/client";
 import { MIME_TYPES_TO_EXPORT } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
+  _getLabels,
   getAuthObject,
   getDriveClient,
   getDriveFileId,
@@ -82,6 +83,12 @@ export const google_drive = async ({
         );
       }
       return { success: true };
+    }
+    case "list-labels": {
+      const connector = await getConnector(args);
+      const authCredentials = await getAuthObject(connector.connectionId);
+      const labels = await _getLabels(authCredentials);
+      return { status: 200, content: labels, type: typeof labels };
     }
     case "check-file": {
       const connector = await getConnector(args);

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -476,6 +476,9 @@ async function upsertGdriveDocument(
     createdAt: file.createdAtMs ? new Date(file.createdAtMs) : undefined,
     lastEditor: file.lastEditor ? file.lastEditor.displayName : undefined,
     content: documentContent,
+    additionalPrefixes: {
+      labels: file.labels.join(", "),
+    },
   });
 
   if (documentContent === undefined) {
@@ -490,10 +493,12 @@ async function upsertGdriveDocument(
   if (file.createdAtMs) {
     tags.push(`createdAt:${file.createdAtMs}`);
   }
-  if (file.lastEditor) {
+  if (file.lastEditor?.displayName) {
     tags.push(`lastEditor:${file.lastEditor.displayName}`);
   }
   tags.push(`mimeType:${file.mimeType}`);
+
+  tags.push(...file.labels);
 
   const documentLen = documentContent ? sectionLength(documentContent) : 0;
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -550,6 +550,7 @@ export async function renderMarkdownSection(
 }
 
 const MAX_AUTHOR_CHAR_LENGTH = 48;
+const MAX_ADDITIONAL_PREFIXES_LENGTH = 128;
 // Will render the document based on title, optional createdAt and updatedAt and a structured
 // content. The title, createdAt and updatedAt will be presented in a standardized way across
 // connectors. The title should not include any `\n`.
@@ -605,7 +606,7 @@ export async function renderDocumentTitleAndContent({
   }
   if (additionalPrefixes) {
     for (const [key, value] of Object.entries(additionalPrefixes)) {
-      metaPrefix += `$${key}: ${value}\n`;
+      metaPrefix += `$${key}: ${safeSubstring(value, 0, MAX_ADDITIONAL_PREFIXES_LENGTH)}\n`;
     }
   }
   if (metaPrefix) {
@@ -826,6 +827,7 @@ export async function upsertDataSourceTableFromCsv({
   title,
   mimeType,
   sourceUrl,
+  tags,
 }: {
   dataSourceConfig: DataSourceConfig;
   tableId: string;
@@ -839,6 +841,7 @@ export async function upsertDataSourceTableFromCsv({
   title: string;
   mimeType: string;
   sourceUrl?: string;
+  tags?: string[];
 }) {
   const localLogger = logger.child({ ...loggerArgs, tableId, tableName });
   const statsDTags = [
@@ -877,7 +880,7 @@ export async function upsertDataSourceTableFromCsv({
     title,
     mimeType,
     timestamp: null,
-    tags: null,
+    tags: tags ?? null,
     sourceUrl: sourceUrl ?? null,
   };
   const dustRequestConfig: AxiosRequestConfig = {

--- a/connectors/src/types/google_drive.ts
+++ b/connectors/src/types/google_drive.ts
@@ -16,6 +16,7 @@ export type GoogleDriveObjectType = {
   webViewLink?: string;
   driveId: string;
   isInSharedDrive: boolean;
+  labels: string[];
 };
 
 export type GoogleDriveFolderType = {
@@ -42,4 +43,5 @@ export const FILE_ATTRIBUTES_TO_FETCH = [
   "size",
   "trashed",
   "webViewLink",
+  "labelInfo",
 ] as const;

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -81,6 +81,7 @@ const PROVIDER_STRATEGIES: Record<
           : [
               "https://www.googleapis.com/auth/drive.metadata.readonly",
               "https://www.googleapis.com/auth/drive.readonly",
+              "https://www.googleapis.com/auth/drive.labels.readonly",
             ];
       const qs = querystring.stringify({
         response_type: "code",

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -119,6 +119,7 @@ export const GoogleDriveCommandSchema = t.type({
     t.literal("skip-file"),
     t.literal("register-webhook"),
     t.literal("register-all-webhooks"),
+    t.literal("list-labels"),
   ]),
   args: t.record(
     t.string,


### PR DESCRIPTION
## Description

Labels are fetched and turned into tags (and prefixes) for google drive docs & tables.

## Tests

Local

## Risk

Medium, could break google drive connector.

## Deploy Plan

Deploy `connectors`
Deploy `front`
Note that it needs a re-auth to provide an additional scope to fetch the labels.