### PR TITLE
fix(Zendesk) - handle `undefined` `label_names` for articles

### DIFF
--- a/connectors/src/@types/node-zendesk.d.ts
+++ b/connectors/src/@types/node-zendesk.d.ts
@@ -80,7 +80,7 @@ export interface ZendeskFetchedArticle {
   user_segment_id: number;
   permission_group_id: number;
   content_tag_ids: number[];
-  label_names: string[];
+  label_names?: string[];
   body: string | null;
   user_segment_ids: number[];
 }

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -124,7 +124,9 @@ export async function syncArticle({
         `SECTION: ${section.name} ${section?.description ? ` - ${section.description}` : ""}`,
       user && `USER: ${user.name} ${user?.email ? ` - ${user.email}` : ""}`,
       `SUM OF VOTES: ${article.vote_sum}`,
-      article.label_names.length ? `LABELS: ${article.label_names.join()}` : "",
+      article.label_names?.length
+        ? `LABELS: ${article.label_names.join()}`
+        : "",
     ]
       .filter(Boolean)
       .join("\n");


### PR DESCRIPTION
## Description

- We have an activity stuck [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_q=%40activityName&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZT1GDRm6gE2dwAAABhBWlQxR0R4cUFBRHdnR3FiaWlhNm5RQWUAAAAkMDE5NGY1MTgtM2NmMC00NzIwLTk5YzQtZmU4N2IxNTQ0YzM5AAAA5w&fromUser=true&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40activityName%3AsyncZendeskArticleBatchActivity%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22activityName%22%2C%22value%22%3A%22syncZendeskArticleBatchActivity%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1739278150200%2C%22to%22%3A1739279050200%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1739277584037&to_ts=1739278484037&live=true).
- The Zendesk article being synced does not contain a field `label_names`.
- Product-wise this will be handled the same way than having an empty array: we don't do anything vs we add the labels to the upserted document.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy `connectors`.