### PR TITLE
[Notion] Speedup parents by moving heartbeat outside getParents

### DIFF
--- a/connectors/migrations/20240802_table_parents.ts
+++ b/connectors/migrations/20240802_table_parents.ts
@@ -177,8 +177,7 @@ export async function notionTables(
       notionDatabaseId as string,
       [],
       false,
-      memo,
-      undefined
+      memo
     );
 
     await updateParents({

--- a/connectors/migrations/20241030_fix_notion_parents.ts
+++ b/connectors/migrations/20241030_fix_notion_parents.ts
@@ -125,7 +125,6 @@ async function updateParentsFieldForConnector(
             "notionPageId" in node ? node.notionPageId : node.notionDatabaseId,
             [],
             false,
-            undefined,
             undefined
           );
         } catch (e) {

--- a/connectors/migrations/20250130_recompute_notion_roots_parents.ts
+++ b/connectors/migrations/20250130_recompute_notion_roots_parents.ts
@@ -70,7 +70,6 @@ async function updateNodeParents({
     "notionPageId" in node ? node.notionPageId : node.notionDatabaseId,
     [],
     false,
-    undefined,
     undefined
   );
   const parents = parentNotionIds.map((id) => `notion-${id}`);

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -633,8 +633,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         notionId,
         [],
         false,
-        memo,
-        undefined
+        memo
       );
 
       return new Ok(parents.map((p) => nodeIdFromNotionId(p)));

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -32,8 +32,7 @@ async function _getParents(
   seen: string[],
   syncing: boolean = false,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for memoization
-  memoizationKey?: string,
-  onProgress?: () => Promise<void>
+  memoizationKey?: string
 ): Promise<string[]> {
   const parents: string[] = [pageOrDbId];
   const pageOrDb =
@@ -97,9 +96,6 @@ async function _getParents(
         );
         return parents.concat(seen);
       }
-      if (onProgress) {
-        await onProgress();
-      }
       return parents.concat(
         // parentId cannot be undefined if parentType is page or database as per
         // Notion API
@@ -110,8 +106,7 @@ async function _getParents(
           pageOrDb.parentId,
           seen,
           syncing,
-          memoizationKey,
-          onProgress
+          memoizationKey
         )
       );
     }
@@ -123,7 +118,7 @@ async function _getParents(
 export const getParents = cacheWithRedis(
   _getParents,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for memoization
-  (connectorId, pageOrDbId, seen, syncing, memoizationKey, onProgress) => {
+  (connectorId, pageOrDbId, seen, syncing, memoizationKey) => {
     return `${connectorId}:${pageOrDbId}:${memoizationKey}`;
   },
   UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES * 60 * 1000
@@ -170,8 +165,7 @@ export async function updateAllParentsFields(
           pageId,
           [],
           false,
-          memoizationKey,
-          onProgress
+          memoizationKey
         );
 
         const parents = pageOrDbIds.map((id) => nodeIdFromNotionId(id));
@@ -182,14 +176,6 @@ export async function updateAllParentsFields(
             "notionUpdateAllParentsFields: Page has no parent."
           );
         }
-
-        logger.info(
-          {
-            connectorId,
-            pageId,
-          },
-          "Updating parents field for page"
-        );
         await updateDataSourceDocumentParents({
           dataSourceConfig: dataSourceConfigFromConnector(connector),
           documentId: nodeIdFromNotionId(pageId),

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -157,7 +157,7 @@ export async function updateAllParentsFields(
   // can be desired or not depending on the use case
   const q = new PQueue({ concurrency: 16 });
   const promises: Promise<void>[] = [];
-  for (const pageId of pageIdsToUpdate) {
+  [...pageIdsToUpdate].forEach((pageId, index) => {
     promises.push(
       q.add(async () => {
         const pageOrDbIds = await getParents(
@@ -182,12 +182,13 @@ export async function updateAllParentsFields(
           parents,
           parentId: parents[1] || null,
         });
-        if (onProgress) {
+        // Call onProgress every 100 pages
+        if (onProgress && index % 100 === 0) {
           await onProgress();
         }
       })
     );
-  }
+  });
 
   await Promise.all(promises);
   return pageIdsToUpdate.size;

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -157,7 +157,7 @@ export async function updateAllParentsFields(
   // can be desired or not depending on the use case
   const q = new PQueue({ concurrency: 16 });
   const promises: Promise<void>[] = [];
-  [...pageIdsToUpdate].forEach((pageId, index) => {
+  for (const pageId of pageIdsToUpdate) {
     promises.push(
       q.add(async () => {
         const pageOrDbIds = await getParents(
@@ -182,13 +182,12 @@ export async function updateAllParentsFields(
           parents,
           parentId: parents[1] || null,
         });
-        // Call onProgress every 100 pages
-        if (onProgress && index % 100 === 0) {
+        if (onProgress) {
           await onProgress();
         }
       })
     );
-  });
+  }
 
   await Promise.all(promises);
   return pageIdsToUpdate.size;

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1795,11 +1795,9 @@ export async function renderAndUpsertPageFromCache({
           parentDb.notionDatabaseId,
           [],
           true,
-          runTimestamp.toString(),
-          async () => {
-            await heartbeat();
-          }
+          runTimestamp.toString()
         );
+        await heartbeat();
 
         const parents = parentPageOrDbIds.map((id) => `notion-${id}`);
 
@@ -2001,11 +1999,9 @@ export async function renderAndUpsertPageFromCache({
       pageId,
       [],
       true,
-      runTimestamp.toString(),
-      async () => {
-        await heartbeat();
-      }
+      runTimestamp.toString()
     );
+    await heartbeat();
 
     const parentIds = parentPageOrDbIds.map((id) => `notion-${id}`);
     if (parentIds.length === 1) {
@@ -2527,9 +2523,9 @@ export async function upsertDatabaseStructuredDataFromCache({
     databaseId,
     [],
     true,
-    runTimestamp.toString(),
-    async () => heartbeat()
+    runTimestamp.toString()
   );
+  await heartbeat();
 
   const parentIds = parentPageOrDbIds.map((id) => `notion-${id}`);
 
@@ -2695,7 +2691,6 @@ export async function updateSingleDocumentParents({
     notionDocumentId,
     [],
     false,
-    undefined,
     undefined
   );
 


### PR DESCRIPTION
Description
---
Parents is supposed to be a very fast method; even when not cached, it should take only a few ms (2 local DB calls)

heartbeating , OTOH, calls temporal's servers, so might range from tens to hundreds of ms.

The non-cached method is called appromaxitvely once per notion page on update parents. If there are many pages on the connector (e.g. 300K pages for qonto), the heartbeating can take a lot of time (edit: as discussed, that might not be true since the worker throttles the calls to the temporal server). Also, in that case we don't need to heartbeat that much

@fontanierh as you had introduced the heartbeating in parents, I assume the intent was to have ~frequent heartbeats. Having heartbeats every ~minute or so is afaict ok for the use case; From the PR, it seems ok to heartbeat before / after the getParents call, letting you check the suggestion here (which would still heartbeat much more than needed after)

Risk
---
standard

Deploy
---
connectors
