### PR TITLE
[extension] minor ui improvements

### DIFF
--- a/extension/app/src/components/assistants/AssistantPicker.tsx
+++ b/extension/app/src/components/assistants/AssistantPicker.tsx
@@ -54,6 +54,7 @@ export function AssistantPicker({
         ) : (
           <Button
             icon={RobotIcon}
+            className="text-muted-foreground"
             variant="ghost"
             isSelect
             size={size}

--- a/extension/app/src/components/conversation/AttachFile.tsx
+++ b/extension/app/src/components/conversation/AttachFile.tsx
@@ -34,6 +34,7 @@ export const AttachFile = ({
       />
       <Button
         icon={AttachmentIcon}
+        className="text-muted-foreground"
         tooltip="Attach file"
         variant="ghost"
         size="xs"

--- a/extension/app/src/components/conversation/ConversationViewer.tsx
+++ b/extension/app/src/components/conversation/ConversationViewer.tsx
@@ -147,7 +147,7 @@ export function ConversationViewer({
   return (
     <div
       className={classNames(
-        "flex w-full max-w-4xl flex-1 flex-grow flex-col justify-start gap-2 pb-4"
+        "flex w-full flex-1 flex-grow flex-col justify-start gap-2 pb-4"
       )}
     >
       {/* Invisible span to detect when the user has scrolled to the top of the list. */}

--- a/extension/app/src/components/conversation/ConversationsListButton.tsx
+++ b/extension/app/src/components/conversation/ConversationsListButton.tsx
@@ -2,6 +2,7 @@ import type { ConversationWithoutContentPublicType } from "@dust-tt/client";
 import {
   Button,
   ChatBubbleLeftRightIcon,
+  classNames,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -88,17 +89,19 @@ const Content = () => {
       {Object.keys(conversationsByDate).map((dateLabel) => (
         <React.Fragment key={dateLabel}>
           {conversationsByDate[dateLabel as GroupLabel].length > 0 && (
-            <DropdownMenuLabel label={dateLabel} />
+            <DropdownMenuLabel
+              label={dateLabel}
+              className={classNames("text-foreground")}
+            />
           )}
           {conversationsByDate[dateLabel as GroupLabel].map((conversation) => (
             <DropdownMenuItem
               key={conversation.sId}
               label={conversation.title || "Untitled Conversation"}
-              className={
-                conversationId === conversation.sId
-                  ? "bg-primary-50"
-                  : undefined
-              }
+              className={classNames(
+                "text-sm text-muted-foreground font-normal",
+                conversationId === conversation.sId ? "bg-primary-50" : ""
+              )}
               onClick={() => {
                 navigate(`/conversations/${conversation.sId}`);
               }}

--- a/extension/app/src/components/input_bar/InputBarContainer.tsx
+++ b/extension/app/src/components/input_bar/InputBarContainer.tsx
@@ -71,7 +71,7 @@ export const InputBarContainer = ({
 
   const contentEditableClasses = classNames(
     "inline-block w-full pt-2",
-    "border-0 pr-1 pl-2 sm:pl-0 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
+    "border-0 pr-1 pl-2 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal"
   );
 

--- a/extension/app/src/pages/ConversationPage.tsx
+++ b/extension/app/src/pages/ConversationPage.tsx
@@ -69,7 +69,7 @@ export const ConversationPage = ({
             </div>
           }
         />
-        <div className="h-full w-full pt-4 mt-12">
+        <div className="h-full w-full pt-3 mt-16">
           <InputBarProvider>
             <ConversationContainer
               owner={workspace}


### PR DESCRIPTION
## Description

from: https://dust4ai.slack.com/archives/C050SM8NSPK/p1739286653710129?thread_ts=1739283951.880109&cid=C050SM8NSPK 

- No padding between header and message in conversation, could you set it to 12px? (screenshot 1)
- Could you switch icon color to muted-foreground instead of s-text-primary-950? (screenshot 2)
- On conversation list : Conversation title should be lighter (text-sm + s-text-muted-foreground + font-weight normal) and the timestamp should be darker as the navigation list component. (screenshot 3)
- It's weird that the conversation do not take the full width (screenshot 4)
- On maximal breakpoint could you do the same padding top than padding left for the placeholder and the text ? (screenshot 5)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
