### PR TITLE
[.github] - fix(deploy: correct dockerfile path in cloud-build script

### DIFF
--- a/.github/actions/build-image/cloud-build.sh
+++ b/.github/actions/build-image/cloud-build.sh
@@ -31,7 +31,7 @@ if [ -z "$IMAGE_NAME" ] || [ -z "$REGION" ] || [ -z "$PROJECT_ID" ]; then
     exit 1
 fi
 
-DOCKERFILE_PATH="dockerfiles/${IMAGE_NAME}.Dockerfile"
+DOCKERFILE_PATH="./dockerfiles/${IMAGE_NAME}.Dockerfile"
 
 if [ ! -f "$DOCKERFILE_PATH" ]; then
     echo "Error: Dockerfile $DOCKERFILE_PATH does not exist"


### PR DESCRIPTION
## Description

This PR adds leading "./" in `cloud-build.sh` to ensure the Dockerfile path is resolved correctly within the script.

## Risk

None

## Deploy Plan

N/A
