### PR TITLE
[Notion] Move updateParents to a workflow, process by batches

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -126,7 +126,8 @@ export const getParents = cacheWithRedis(
   (connectorId, pageOrDbId, seen, syncing, memoizationKey, onProgress) => {
     return `${connectorId}:${pageOrDbId}:${memoizationKey}`;
   },
-  UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES * 60 * 1000
+  // parents should be stable over the maximum time if memoized (almost a day).
+  23 * 60 * 60 * 1000
 );
 
 export async function updateAllParentsFields(

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -10,7 +10,6 @@ import {
   getNotionPageFromConnectorsDb,
   getPageChildrenOf,
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
-import { UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES } from "@connectors/connectors/notion/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1133,7 +1133,6 @@ async function getResourcesNotSeenInGarbageCollectionRunBatch(
   return JSON.parse(batch) as GCResource[];
 }
 
-
 const PARENTS_UPDATE_BATCH_SIZE = 10000;
 
 export async function updateParentsFields(

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1133,7 +1133,7 @@ async function getResourcesNotSeenInGarbageCollectionRunBatch(
   return JSON.parse(batch) as GCResource[];
 }
 
-const PARENTS_UPDATE_BATCH_SIZE = 10;
+const PARENTS_UPDATE_BATCH_SIZE = 250;
 
 export async function updateParentsFields({
   connectorId,

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,4 +1,4 @@
-const WORKFLOW_VERSION = 43;
+const WORKFLOW_VERSION = 44;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;
 export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${WORKFLOW_VERSION}`;
 


### PR DESCRIPTION
Description
---
Call to updateAllParents is too long for some clients because too many pages to update (300K, more than 2 hours)

This makes parents update into a workflow, processing them by batches---as such stabler since finer grained activities.


Risks
---
standard high: good local tests + multiple reviewers

Deploy
---
Procedure to avoid non-deterministic errors on workflow changes
