### PR TITLE
[.github] - fix(deploy): remove explicit platform and cache settings in depo

### DIFF
--- a/.github/actions/build-image/cloudbuild.yaml
+++ b/.github/actions/build-image/cloudbuild.yaml
@@ -27,10 +27,6 @@ steps:
       depot build \
         --project 3vz0lnf16v \
         --provenance=false \
-        --platform linux/amd64 \
-        --cache-from type=gha,scope=${_IMAGE_NAME} \
-        --cache-to type=gha,mode=max,scope=${_IMAGE_NAME} \
-        --build-context platform=linux/amd64 \
         --progress=plain \
         -t ${_REGION}-docker.pkg.dev/${_PROJECT_ID}/dust-images/${_IMAGE_NAME}:${SHORT_SHA}-test \
         -f ${_DOCKERFILE_PATH} \


### PR DESCRIPTION
## Description

This PR ditches some depot build settings. Surprisingly they seemed to work when triggering depot build locally, they are probably not supported by "Cloud Build" though.

## Risk

None

## Deploy Plan

N/A