### PR TITLE
[Content Nodes] Faster computation of getPermissions

### DIFF
--- a/connectors/src/lib/api/content_nodes.ts
+++ b/connectors/src/lib/api/content_nodes.ts
@@ -5,12 +5,13 @@ import type {
 } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
 import { zip } from "fp-ts/lib/Array";
+import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 import { getConnectorManager } from "@connectors/connectors";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import _ from "lodash";
+
 export interface ContentNodeParentIdsBlob {
   internalId: string;
   parentInternalIds: string[];

--- a/connectors/src/lib/api/content_nodes.ts
+++ b/connectors/src/lib/api/content_nodes.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from "uuid";
 import { getConnectorManager } from "@connectors/connectors";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import _ from "lodash";
 export interface ContentNodeParentIdsBlob {
   internalId: string;
   parentInternalIds: string[];
@@ -70,9 +71,10 @@ export async function augmentContentNodesWithParentIds(
   }
 
   const nodesWithParentIds: ContentNodeWithParentIds[] = [];
+  const contentNodesMap = _.keyBy(contentNodes, "internalId");
 
   for (const { internalId, parentInternalIds } of parentsRes.value) {
-    const node = contentNodes.find((n) => n.internalId === internalId);
+    const node = contentNodesMap[internalId];
 
     if (node) {
       nodesWithParentIds.push({


### PR DESCRIPTION
Description
---
Following this
[thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1739294139364379) ; a O(n**2) loop was used, we replace it here by using a map to stay linear

Risks
---
standard

Deploy
---
connectors
