### PR TITLE
Sparkle: Add removable chip + props to search input

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.391",
+  "version": "0.2.392",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.391",
+      "version": "0.2.392",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.391",
+  "version": "0.2.392",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -2,6 +2,7 @@ import { cva } from "class-variance-authority";
 import React, { ComponentType, ReactNode } from "react";
 
 import { AnimatedText } from "@sparkle/components/";
+import { XMarkIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
 import { Icon, IconProps } from "./Icon";
@@ -31,6 +32,7 @@ type ChipProps = {
   className?: string;
   isBusy?: boolean;
   icon?: ComponentType;
+  onRemove?: () => void;
 };
 
 const sizeVariants: Record<ChipSizeType, string> = {
@@ -104,21 +106,37 @@ const chipVariants = cva("s-inline-flex s-box-border s-items-center", {
 
 const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
   (
-    { size, color, label, children, className, isBusy, icon }: ChipProps,
+    {
+      size,
+      color,
+      label,
+      children,
+      className,
+      isBusy,
+      icon,
+      onRemove,
+    }: ChipProps,
     ref
   ) => (
     <div
       className={cn(
         chipVariants({ size, background: color, text: color }),
-        className
+        className,
+        onRemove && "s-cursor-pointer"
       )}
       aria-label={label}
       ref={ref}
+      onClick={onRemove ? () => onRemove() : undefined}
     >
       {children}
       {icon && <Icon visual={icon} size={size as IconProps["size"]} />}
       {label && (
-        <span className={cn("s-pointer s-grow s-cursor-default s-truncate")}>
+        <span
+          className={cn(
+            "s-pointer s-grow s-truncate",
+            onRemove ? "s-cursor-pointer" : "s-cursor-default"
+          )}
+        >
           {isBusy ? (
             <AnimatedText variant={color}>{label}</AnimatedText>
           ) : (
@@ -126,6 +144,7 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
           )}
         </span>
       )}
+      {onRemove && <Icon visual={XMarkIcon} size={size as IconProps["size"]} />}
     </div>
   )
 );

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 
-import { Button, Icon, Input } from "@sparkle/components";
+import { Button, Icon, Input, Spinner } from "@sparkle/components";
 import { MagnifyingGlassIcon, XMarkIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
@@ -9,8 +9,10 @@ export interface SearchInputProps {
   value: string | null;
   onChange: (value: string) => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onFocus?: () => void;
   name: string;
   disabled?: boolean;
+  isLoading?: boolean;
   className?: string;
 }
 
@@ -21,8 +23,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
       value,
       onChange,
       onKeyDown,
+      onFocus,
       name,
       disabled = false,
+      isLoading = false,
       className,
     },
     ref
@@ -41,12 +45,17 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={(e) => {
             onChange(e.target.value);
           }}
+          onFocus={onFocus}
           onKeyDown={onKeyDown}
           disabled={disabled}
           ref={ref}
         />
         <div className="s-absolute s-inset-y-0 s-right-0 s-flex s-items-center s-pr-1">
-          {value ? (
+          {isLoading ? (
+            <div className="s-px-1">
+              <Spinner size="xs" />
+            </div>
+          ) : value ? (
             <Button
               icon={XMarkIcon}
               variant="ghost"

--- a/sparkle/src/stories/Chip.stories.tsx
+++ b/sparkle/src/stories/Chip.stories.tsx
@@ -58,19 +58,25 @@ export const Basic: Story = {
     size: "sm",
     color: "slate",
     isBusy: true,
+    onRemove: undefined,
   },
 };
 
 export const ThinkingChip = () => (
-  <div className="s-flex s-h-80 s-w-full s-flex-col s-items-center s-justify-center s-gap-4">
-    <Chip
-      size="sm"
-      color="slate"
-      label="
+  <Chip
+    size="sm"
+    color="slate"
+    label="
       Thinking, Searching"
-      isBusy
-    >
-      {/* <Spinner variant="dark" size="xs" /> */}
-    </Chip>
-  </div>
+    isBusy
+  />
+);
+
+export const RemovableChip = () => (
+  <Chip
+    size="sm"
+    color="slate"
+    label="Remove me"
+    onRemove={() => alert("Removed")}
+  />
 );


### PR DESCRIPTION
## Description

- `Chip` has a new `onRemove` prop that will be called onClick + adds a circle icon components. 
- `SearchInput` has new a loading state and passes the `onFocus` prop to its input if set.

## Tests

Locally on Storybook. 

## Risk

Can be rolled back. 

## Deploy Plan

Publish Sparkle
