### PR TITLE
[Parents] Heartbeat during long activity

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -159,7 +159,6 @@ export async function updateAllParentsFields(
   const q = new PQueue({ concurrency: 16 });
   const promises: Promise<void>[] = [];
   for (const pageId of pageIdsToUpdate) {
-    logger.info({ pageId }, "Updating parents field for page");
     promises.push(
       q.add(async () => {
         const pageOrDbIds = await getParents(

--- a/connectors/src/connectors/notion/temporal/workflows/index.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/index.ts
@@ -30,7 +30,7 @@ const { garbageCollectBatch } = proxyActivities<typeof activities>({
   heartbeatTimeout: "5 minute",
 });
 
-export const UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES = 120;
+export const UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES = 400;
 const { updateParentsFields } = proxyActivities<typeof activities>({
   startToCloseTimeout: `${UPDATE_PARENTS_FIELDS_TIMEOUT_MINUTES} minutes`,
   heartbeatTimeout: "10 minute",


### PR DESCRIPTION
Description
---
Temporary fix for [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1739357859501129)
- heartbeat more
- increase start-to-close timeout

To unstick a notion workflow for a client with 300K pages to update in 1 go.

Follow-up: batch so that activities work on less pages

Risk
---
low

Deploy
---
connectors
restart client's notion workflow