### PR TITLE
[CoreNodes] Switch to mime-type-based icon selection for all workspaces

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -24,11 +24,7 @@ import type {
   SpaceType,
   WorkspaceType,
 } from "@dust-tt/types";
-import {
-  isDevelopment,
-  isDustWorkspace,
-  isValidContentNodesViewType,
-} from "@dust-tt/types";
+import { isValidContentNodesViewType } from "@dust-tt/types";
 import type {
   CellContext,
   ColumnDef,
@@ -390,10 +386,7 @@ export const SpaceDataSourceViewContentList = ({
     () =>
       nodes?.map((contentNode) => ({
         ...contentNode,
-        icon: getVisualForContentNode(
-          contentNode,
-          isDevelopment() || isDustWorkspace(owner)
-        ),
+        icon: getVisualForContentNode(contentNode),
         spaces: spaces.filter((space) =>
           dataSourceViews
             .filter(

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -42,6 +42,7 @@ function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   return DocumentIcon;
 }
 
+// TODO(nodes-core) clean this up to always rely on the mime type.
 export function getVisualForContentNode(node: ContentNode, useMimeType = true) {
   if (useMimeType) {
     return getVisualForContentNodeBasedOnMimeType(node);

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -42,10 +42,7 @@ function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   return DocumentIcon;
 }
 
-export function getVisualForContentNode(
-  node: ContentNode,
-  useMimeType = false
-) {
+export function getVisualForContentNode(node: ContentNode, useMimeType = true) {
   if (useMimeType) {
     return getVisualForContentNodeBasedOnMimeType(node);
   } else {


### PR DESCRIPTION
## Description

- When switching the read of content nodes for data source views from connectors to core in https://github.com/dust-tt/dust/pull/10674, the selection of the icons was not changed.
- Therefore, the selection of the icon for content node still relied on the type for workspaces other than ours, with a less rich choice since the field `type` is less rich now (only 3 types, before we had channel, database, ...).
- This PR fixes that by using the mime type by default.
- Note: for `/permissions` this will still rely on the types as the content nodes returned by `connectors` have no mime type, and `getVisualForContentNodeBasedOnType` is used as a fallback https://github.com/dust-tt/dust/blob/9cab9b4f668f8f04931915ae5434bb83c15a087c/front/lib/content_nodes.ts#L81. This is not optimal but will eventually be cleaned up by sending mime types in connectors too (will tackle in a follow up PR).

## Tests

## Risk

- n/a

## Deploy Plan

- Deploy front.