### PR TITLE
[front] - chore: improve workspace picker mobile

### DIFF
--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -9,7 +9,9 @@ import {
   SheetTrigger,
 } from "@dust-tt/sparkle";
 import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
-import React, { useContext } from "react";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { useRouter } from "next/router";
+import React, { useContext, useMemo } from "react";
 
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import {
@@ -17,6 +19,8 @@ import {
   ToggleNavigationSidebarButton,
 } from "@app/components/navigation/NavigationSidebar";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
+import WorkspacePicker from "@app/components/WorkspacePicker";
+import { useUser } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
 
 interface NavigationProps {
@@ -40,6 +44,27 @@ export function Navigation({
 }: NavigationProps) {
   const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
 
+  const router = useRouter();
+  const { user } = useUser();
+
+  const workspacePicker = useMemo(() => {
+    if (user && user.workspaces.length > 1) {
+      return (
+        <WorkspacePicker
+          user={user}
+          workspace={owner}
+          onWorkspaceUpdate={async (workspace) => {
+            const assistantRoute = `/w/${workspace.sId}/assistant/new`;
+            if (workspace.id !== owner.id) {
+              await router.push(assistantRoute).then(() => router.reload());
+            }
+          }}
+        />
+      );
+    }
+    return null;
+  }, [owner, router, user]);
+
   if (hideSidebar) {
     return null;
   }
@@ -57,14 +82,18 @@ export function Navigation({
             />
           </SheetTrigger>
         </div>
-        <SheetContent side="left" className="flex w-full max-w-xs flex-1 p-0">
-          <SheetHeader>
-            <SheetTitle className="hidden" />
+        <SheetContent side="left" className="flex w-full max-w-xs flex-1">
+          <SheetHeader className="bg-muted-background p-0">
+            <VisuallyHidden>
+              <SheetTitle className="hidden" />
+            </VisuallyHidden>
+            {workspacePicker}
           </SheetHeader>
           <NavigationSidebar
             subscription={subscription}
             owner={owner}
             subNavigation={subNavigation}
+            user={user}
           >
             {navChildren && navChildren}
           </NavigationSidebar>
@@ -78,11 +107,13 @@ export function Navigation({
           isNavigationBarOpen ? "w-80" : "w-0"
         )}
       >
-        <div className="hidden flex-1 lg:inset-y-0 lg:z-0 lg:flex lg:w-80 lg:flex-col">
+        <div className="hidden flex-1 bg-muted-background lg:inset-y-0 lg:z-0 lg:flex lg:w-80 lg:flex-col">
+          {workspacePicker}
           <NavigationSidebar
             owner={owner}
             subscription={subscription}
             subNavigation={subNavigation}
+            user={user}
           >
             {navChildren && navChildren}
           </NavigationSidebar>

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -8,7 +8,11 @@ import {
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
-import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
+import type {
+  SubscriptionType,
+  UserTypeWithWorkspaces,
+  WorkspaceType,
+} from "@dust-tt/types";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -17,9 +21,7 @@ import type { SidebarNavigation } from "@app/components/navigation/config";
 import { getTopNavigationTabs } from "@app/components/navigation/config";
 import { HelpDropdown } from "@app/components/navigation/HelpDropdown";
 import { UserMenu } from "@app/components/UserMenu";
-import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
-import { useUser } from "@app/lib/swr/user";
 
 interface NavigationSidebarProps {
   children: React.ReactNode;
@@ -27,17 +29,23 @@ interface NavigationSidebarProps {
   subNavigation?: SidebarNavigation[] | null;
   // TODO(2024-06-19 flav) Move subscription to a hook.
   subscription: SubscriptionType;
+  user: UserTypeWithWorkspaces | null;
 }
 
 export const NavigationSidebar = React.forwardRef<
   HTMLDivElement,
   NavigationSidebarProps
 >(function NavigationSidebar(
-  { owner, subscription, subNavigation, children }: NavigationSidebarProps,
+  {
+    owner,
+    subscription,
+    subNavigation,
+    children,
+    user,
+  }: NavigationSidebarProps,
   ref
 ) {
   const router = useRouter();
-  const { user } = useUser();
   const [activePath, setActivePath] = useState("");
 
   useEffect(() => {
@@ -59,19 +67,6 @@ export const NavigationSidebar = React.forwardRef<
       className="flex min-w-0 grow flex-col bg-structure-50 dark:bg-structure-50-night"
     >
       <div className="flex flex-col">
-        {user && user.workspaces.length > 1 ? (
-          <WorkspacePicker
-            user={user}
-            workspace={owner}
-            onWorkspaceUpdate={async (workspace) => {
-              const assistantRoute = `/w/${workspace.sId}/assistant/new`;
-              if (workspace.id !== owner.id) {
-                await router.push(assistantRoute).then(() => router.reload());
-              }
-            }}
-          />
-        ) : null}
-
         <AppStatusBanner />
         {subscription.endDate && (
           <SubscriptionEndBanner endDate={subscription.endDate} />

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.392",
+        "@dust-tt/sparkle": "0.2.393",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11335,9 +11335,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.392",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.392.tgz",
-      "integrity": "sha512-CFtTpX7hklEWf1lx0mftjVUF0B+6gzMLES5POLAlU1hFW88j+OnrF5WCx+O3K8rsiPWOJ2gS10N9yzjagg2Ybw==",
+      "version": "0.2.393",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.393.tgz",
+      "integrity": "sha512-o0UEJYFC451ieMBt5qHftFgMEiUk5359cvGLOsmZxIcc389us5RnHIZbJLlNq6Gxd0KHtZe0TAbPJInTeICblQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.392",
+    "@dust-tt/sparkle": "0.2.393",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",


### PR DESCRIPTION
## Description

This PR improves how we render the workspace picker on mobile. This requires to render it within the `Sheet` hence render it in the parent component of how it's rendered today.

![Screenshot 2025-02-12 at 13 53 59](https://github.com/user-attachments/assets/28aab902-9e3f-4b29-97b2-6ae2097dc5cb)

**References:**
- https://github.com/dust-tt/tasks/issues/2114

## Risk

Low

## Deploy Plan

Deploy `front`