### PR TITLE
enh(Microsoft) - recast "invalid_grant" errors into `ExternalOauthTokenError`

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -38,6 +38,7 @@ export class MicrosoftCastKnownErrorsInterceptor
       return await next(input);
     } catch (err: unknown) {
       // See https://learn.microsoft.com/en-us/answers/questions/1339560/sign-in-error-code-50173
+      // TODO(2025-02-12): add an error type for Microsoft client errors and catch them at strategic locations (e.g. API call to instantiate a client)
       if (isMicrosoftSignInError(err)) {
         throw new ExternalOAuthTokenError(err);
       }

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -4,6 +4,29 @@ import type {
   Next,
 } from "@temporalio/worker";
 
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
+
+interface MicrosoftAuthError extends Error {
+  error: string;
+  error_description: string;
+}
+
+// The SDK does not expose an error class that is rich enough for our use.
+// We'll use this function as a temporary solution for identifying an identified type of error.
+export function isMicrosoftSignInError(
+  err: unknown
+): err is MicrosoftAuthError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "error" in err &&
+    err.error === "invalid_grant" &&
+    "error_description" in err &&
+    typeof err.error_description === "string" &&
+    err.error_description.startsWith("AADSTS50173")
+  );
+}
+
 export class MicrosoftCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -14,10 +37,9 @@ export class MicrosoftCastKnownErrorsInterceptor
     try {
       return await next(input);
     } catch (err: unknown) {
-      // no error to intercept and cast as of yet
-      // but it will come very soon (below is to pleas the linter)
-      if (err instanceof Error) {
-        throw err;
+      // See https://learn.microsoft.com/en-us/answers/questions/1339560/sign-in-error-code-50173
+      if (isMicrosoftSignInError(err)) {
+        throw new ExternalOAuthTokenError(err);
       }
       throw err;
     }


### PR DESCRIPTION
## Description

- We have a workflow stuck [here](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/microsoft-incrementalSync-12272/d69832bb-b8a5-419f-a39c-38095631a4ae/pending-activities) with a token error (log [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZT5cvHUSnDrqQAAABhBWlQ1Y3dKNEFBQkh1dzJScERBeUtnQWIAAAAkMDE5NGY5N2MtNTljOS00NjYwLTgyYjktZWViZWU2NWRhYThmAACSgA&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1739350978000&to_ts=1739351878000&live=false)).
- This PR catches the error and rethrows it as an `ExternalOauthTokenError` for it to be visible by the user.
- The SDK does not seem to provide a class or a type for the error that is rich enough (the types exposed are `GraphClientError` and `GraphError`) for our use so we'll rely on this extensive casting and checking to identify the error.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.