### PR TITLE
enh(LaTeX rendering) - iterate on prompt

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -141,7 +141,9 @@ export async function constructPromptMultiActions(
   }
 
   additionalInstructions +=
-    "\nWhen generating latex formulas, solely rely on the $$ escape sequence, single $ latex sequences are not supported.\n";
+    "\nWhen generating latex formulas, ALWAYS rely on the $$ escape sequence, single $ latex sequences are not supported." +
+    "\nEvery latex formula should be inside double dollars $$ blocks." +
+    "\nParentheses cannot be used to enclose mathematical formulas: BAD: \\( \\Delta \\), GOOD: $$ \\Delta $$.\n";
 
   let prompt = `${context}\n${instructions}`;
   if (additionalInstructions) {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2140.
- GPT models seem to rely a lot on parentheses to enclose mathematical formulas.
- This PR adjusts the meta prompt to advise against this.

Not a rigorous demonstration but before:
<img width="912" alt="Screenshot 2025-02-12 at 6 43 31 PM" src="https://github.com/user-attachments/assets/6402bcf1-67f7-48d8-8477-146ff6da238b" />

After
<img width="912" alt="Screenshot 2025-02-12 at 6 43 44 PM" src="https://github.com/user-attachments/assets/31cabb66-7d37-4e95-80fc-3482eb5ecf8c" />

Also tested with 3.5 sonnet.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.