### PR TITLE
Fix wording in Assistant builder button

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -687,7 +687,7 @@ function NewActionModal({
             onClick: onCloseLocal,
           }}
           rightButtonProps={{
-            label: "Send",
+            label: "Save",
             onClick: onModalSave,
           }}
         />


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2161.
- This PR fixes the wording on the bottom right button of the Action screen in the Assistant builder.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.