### PR TITLE
enh(GitHub) - Truncate tags passed to document prefix

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1,5 +1,6 @@
 import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
 import { assertNever, MIME_TYPES } from "@dust-tt/types";
+import { safeSubstring } from "@dust-tt/types/src";
 import { Context } from "@temporalio/activity";
 import { hash as blake3 } from "blake3";
 import { promises as fs } from "fs";
@@ -61,7 +62,6 @@ import type { Logger } from "@connectors/logger/logger";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import { safeSubstring } from "@dust-tt/types/src";
 
 export async function githubGetReposResultPageActivity(
   connectorId: ModelId,

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1,6 +1,5 @@
 import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
-import { assertNever, MIME_TYPES } from "@dust-tt/types";
-import { safeSubstring } from "@dust-tt/types/src";
+import { assertNever, MIME_TYPES, safeSubstring } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import { hash as blake3 } from "blake3";
 import { promises as fs } from "fs";

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -61,6 +61,7 @@ import type { Logger } from "@connectors/logger/logger";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import { safeSubstring } from "@dust-tt/types/src";
 
 export async function githubGetReposResultPageActivity(
   connectorId: ModelId,
@@ -154,7 +155,7 @@ async function renderIssue(
     updatedAt: issue.updatedAt,
     author: renderGithubUser(issue.creator),
     additionalPrefixes: {
-      labels: issue.labels.join(", "),
+      labels: safeSubstring(issue.labels.join(", "), 0, 128), // We truncate the labels to avoid having a prefix too large.
       isPullRequest: issue.isPullRequest.toString(),
     },
     content: await renderMarkdownSection(dataSourceConfig, issue.body ?? "", {


### PR DESCRIPTION
## Description

- Context here: https://dust4ai.slack.com/archives/C05F84CFP0E/p1739430882633759
- More tags were added to GitHub PR here https://github.com/dust-tt/dust/pull/10683
- Some PRs with lots of labels caused the section prefix to be too large (prefixes accrue to more than half `max_chunk_size`).
- This PR truncates the concatenation of the tags added to the prefix of the main section, keeping the tags indexed in ES and in `data_sources_nodes` preserved.
- As for the stuck entries in the upsert queue, I'll terminate the workflows and use the CLI to reupserts the missing data. AFAICT the GCS objects will get cleaned up after a week.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy connectors.