### PR TITLE
Remove tags_array from documents/table

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -535,7 +535,7 @@ impl DataSource {
         remove_tags: Vec<String>,
     ) -> Result<Vec<String>> {
         let new_tags = store
-            .update_data_source_document_tags(
+            .update_data_source_node_tags(
                 &self.project,
                 &self.data_source_id(),
                 &document_id.to_string(),

--- a/core/src/stores/migrations/20250213_1_tags_array_prepare_remove.sql
+++ b/core/src/stores/migrations/20250213_1_tags_array_prepare_remove.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    data_sources_nodes
+ADD COLUMN IF NOT EXISTS
+    tags_array text[] NOT NULL DEFAULT array[]::text[];

--- a/core/src/stores/migrations/20250213_1_tags_array_prepare_remove.sql
+++ b/core/src/stores/migrations/20250213_1_tags_array_prepare_remove.sql
@@ -1,4 +1,7 @@
 ALTER TABLE
-    data_sources_nodes
-ADD COLUMN IF NOT EXISTS
-    tags_array text[] NOT NULL DEFAULT array[]::text[];
+    "data_sources_documents"
+ALTER COLUMN tags_array DROP NOT NULL;
+
+ALTER TABLE
+    "tables"
+ALTER COLUMN tags_array DROP NOT NULL;

--- a/core/src/stores/migrations/20250213_2_tags_array_remove.sql
+++ b/core/src/stores/migrations/20250213_2_tags_array_remove.sql
@@ -1,0 +1,7 @@
+ALTER TABLE
+    "data_sources_documents"
+DROP COLUMN IF EXISTS tags_array;
+
+ALTER TABLE
+    "tables"
+DROP COLUMN IF EXISTS tags_array;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -198,7 +198,7 @@ pub trait Store {
         data_source_id: String,
         create_params: DocumentCreateParams,
     ) -> Result<Document>;
-    async fn update_data_source_document_tags(
+    async fn update_data_source_node_tags(
         &self,
         project: &Project,
         data_source_id: &str,


### PR DESCRIPTION
## Description

Now that tags_array is replicated in data_sources_nodes, we can switch reading to it for documents and tables, and stop writing into data_sources_documents.tags_array and tables.tags-array.
A first migration is required before merging to remove the not null constraint.
Second migration to run after deploy removes the columns.

## Tests

Tested locally by resyncing connectors with docs and tables, checked and updated tags on documents.

## Risk

can be rolled back until column is removed. Need to test again before removing the old columns.

## Deploy Plan

run core/src/stores/migrations/20250213_1_tags_array_prepare_remove.sql
deploy core
run core/src/stores/migrations/20250213_2_tags_array_remove.sql

