### PR TITLE
[front] - refacto(Sheet): Modal -> Sheet 🌊 7️⃣ 

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -20,7 +20,10 @@ import {
   useSendNotification,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import type { ConversationWithoutContentType, WorkspaceType } from "@dust-tt/types";
+import type {
+  ConversationWithoutContentType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { isBuilder, isOnlyUser } from "@dust-tt/types";
 import moment from "moment";
 import type { NextRouter } from "next/router";
@@ -31,7 +34,10 @@ import { useConversationsNavigation } from "@app/components/assistant/conversati
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
-import { useConversations, useDeleteConversation } from "@app/lib/swr/conversations";
+import {
+  useConversations,
+  useDeleteConversation,
+} from "@app/lib/swr/conversations";
 import { classNames, removeDiacritics, subFilter } from "@app/lib/utils";
 
 type AssistantSidebarMenuProps = {

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -17,11 +17,10 @@ import {
   RobotIcon,
   SearchInput,
   TrashIcon,
+  useSendNotification,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
-import type { ConversationWithoutContentType } from "@dust-tt/types";
-import type { WorkspaceType } from "@dust-tt/types";
+import type { ConversationWithoutContentType, WorkspaceType } from "@dust-tt/types";
 import { isBuilder, isOnlyUser } from "@dust-tt/types";
 import moment from "moment";
 import type { NextRouter } from "next/router";
@@ -32,10 +31,7 @@ import { useConversationsNavigation } from "@app/components/assistant/conversati
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
-import {
-  useConversations,
-  useDeleteConversation,
-} from "@app/lib/swr/conversations";
+import { useConversations, useDeleteConversation } from "@app/lib/swr/conversations";
 import { classNames, removeDiacritics, subFilter } from "@app/lib/utils";
 
 type AssistantSidebarMenuProps = {
@@ -246,11 +242,11 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                     }
                   }}
                 />
-                <DropdownMenu modal={false}>
+                <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button size="sm" icon={MoreIcon} variant="outline" />
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent>
+                  <DropdownMenuContent mountPortal={false}>
                     <DropdownMenuLabel>Assistants</DropdownMenuLabel>
                     <DropdownMenuItem
                       href={`/w/${owner.sId}/builder/assistants/create`}

--- a/front/components/assistant_builder/avatar_picker/AssistantBuilderEmojiPicker.tsx
+++ b/front/components/assistant_builder/avatar_picker/AssistantBuilderEmojiPicker.tsx
@@ -6,7 +6,9 @@ import {
   EmojiPicker,
   EmotionLaughIcon,
   PaintIcon,
-  Popover,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
 } from "@dust-tt/sparkle";
 import { generateTailwindBackgroundColors } from "@dust-tt/types";
 import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
@@ -78,17 +80,15 @@ const AssistantBuilderEmojiPicker = React.forwardRef<
         size="xxl"
       />
       <div className="flex flex-row gap-2">
-        <Popover
-          popoverTriggerAsChild
-          fullWidth
-          trigger={
+        <PopoverRoot>
+          <PopoverTrigger asChild>
             <Button
               variant="outline"
               icon={EmotionLaughIcon}
               label="Pick an Emoji"
             />
-          }
-          content={
+          </PopoverTrigger>
+          <PopoverContent mountPortal={false} className="p-4" fullWidth>
             <EmojiPicker
               theme="light"
               previewPosition="none"
@@ -102,17 +102,14 @@ const AssistantBuilderEmojiPicker = React.forwardRef<
                 emojiButtonRef.current?.click();
               }}
             />
-          }
-        />
-        <Popover
-          fullWidth
-          popoverTriggerAsChild
-          trigger={
-            <div ref={colorButtonRef}>
-              <Button variant="outline" icon={PaintIcon} label="Pick a color" />
-            </div>
-          }
-          content={
+          </PopoverContent>
+        </PopoverRoot>
+
+        <PopoverRoot>
+          <PopoverTrigger asChild>
+            <Button variant="outline" icon={PaintIcon} label="Pick a color" />
+          </PopoverTrigger>
+          <PopoverContent mountPortal={false} className="p-4" fullWidth>
             <ColorPicker
               colors={
                 generateTailwindBackgroundColors() as avatarUtils.AvatarBackgroundColorType[]
@@ -126,8 +123,8 @@ const AssistantBuilderEmojiPicker = React.forwardRef<
                 colorButtonRef.current?.click();
               }}
             />
-          }
-        />
+          </PopoverContent>
+        </PopoverRoot>
       </div>
     </div>
   );

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -4,10 +4,15 @@ import {
   ExclamationCircleIcon,
   Icon,
   Input,
-  Modal,
   Page,
   ScrollArea,
   SearchInput,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
   SliderToggle,
   useSendNotification,
   XMarkIcon,
@@ -208,112 +213,125 @@ export function CreateOrEditSpaceModal({
   }, [doDelete, handleClose, owner.sId, router, space]);
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={handleClose}
-      title={space ? `Edit ${space.name}` : "Create a Space"}
-      saveLabel={space ? "Save" : "Create"}
-      variant="side-md"
-      hasChanged={
-        !!spaceName &&
-        (!isRestricted || (isRestricted && deduplicatedMembers.length > 0))
-      }
-      isSaving={isSaving}
-      className="flex overflow-visible" // overflow-visible is needed to avoid clipping the delete button
-      onSave={onSave}
-    >
-      <Page.Vertical gap="md" sizing="grow">
-        <div className="flex w-full flex-col gap-y-4 overflow-y-hidden px-1">
-          <div className="mb-4 flex w-full flex-col gap-y-2 pt-2">
-            <Page.SectionHeader title="Name" />
-            <Input
-              placeholder="Space's name"
-              value={spaceName}
-              name="spaceName"
-              onChange={(e) => setSpaceName(e.target.value)}
-            />
-            {!space && (
-              <div className="flex gap-1 text-xs text-element-700">
-                <Icon visual={ExclamationCircleIcon} size="xs" />
-                <span>Space name must be unique</span>
-              </div>
-            )}
-          </div>
-          <div className="flex w-full flex-col gap-y-2 border-t pt-2">
-            <div className="flex w-full items-center justify-between overflow-visible">
-              <Page.SectionHeader title="Restricted Access" />
-              <SliderToggle
-                selected={isRestricted}
-                onClick={() => setIsRestricted(!isRestricted)}
+    <Sheet open={isOpen} onOpenChange={handleClose}>
+      <SheetContent trapFocusScope={false} size="lg">
+        <SheetHeader>
+          <SheetTitle>
+            {space ? `Edit ${space.name}` : "Create a Space"}
+          </SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <div className="flex w-full flex-col gap-y-4">
+            <div className="mb-4 flex w-full flex-col gap-y-2">
+              <Page.SectionHeader title="Name" />
+              <Input
+                placeholder="Space's name"
+                value={spaceName}
+                name="spaceName"
+                onChange={(e) => setSpaceName(e.target.value)}
               />
-            </div>
-            <div className="text-sm font-normal text-element-700">
-              {isRestricted ? (
-                <p>Restricted access is active.</p>
-              ) : (
-                <p>
-                  Restricted access is disabled. The space is accessible to
-                  everyone in the workspace.
-                </p>
+              {!space && (
+                <div className="flex gap-1 text-xs text-element-700">
+                  <Icon visual={ExclamationCircleIcon} size="xs" />
+                  <span>Space name must be unique</span>
+                </div>
               )}
             </div>
-          </div>
-          {isRestricted && (
-            <>
-              <div className="flex flex-row justify-end gap-2">
-                <SearchMembersPopover
-                  owner={owner}
-                  selectedMembers={deduplicatedMembers}
-                  onMembersUpdated={setSelectedMembers}
+
+            <div className="flex w-full flex-col gap-y-2 border-t pt-2">
+              <div className="flex w-full items-center justify-between overflow-visible">
+                <Page.SectionHeader title="Restricted Access" />
+                <SliderToggle
+                  selected={isRestricted}
+                  onClick={() => setIsRestricted(!isRestricted)}
                 />
-                {membersCount >= MIN_MEMBERS_FOR_BATCH_OPTION && (
-                  <BatchAddMembersPopover
+              </div>
+              <div className="text-sm font-normal text-element-700">
+                {isRestricted ? (
+                  <p>Restricted access is active.</p>
+                ) : (
+                  <p>
+                    Restricted access is disabled. The space is accessible to
+                    everyone in the workspace.
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {isRestricted && (
+              <>
+                <div className="flex flex-row justify-end gap-2">
+                  <SearchMembersPopover
                     owner={owner}
                     selectedMembers={deduplicatedMembers}
                     onMembersUpdated={setSelectedMembers}
                   />
-                )}
-              </div>
-              <SearchInput
-                name="search"
-                placeholder="Search (email)"
-                value={searchSelectedMembers}
-                onChange={(s) => {
-                  setSearchSelectedMembers(s);
-                }}
-              />
-              <ScrollArea className="h-full">
-                <MembersTable
-                  onMembersUpdated={setSelectedMembers}
-                  selectedMembers={deduplicatedMembers}
-                  searchSelectedMembers={searchSelectedMembers}
+                  {membersCount >= MIN_MEMBERS_FOR_BATCH_OPTION && (
+                    <BatchAddMembersPopover
+                      owner={owner}
+                      selectedMembers={deduplicatedMembers}
+                      onMembersUpdated={setSelectedMembers}
+                    />
+                  )}
+                </div>
+                <SearchInput
+                  name="search"
+                  placeholder="Search (email)"
+                  value={searchSelectedMembers}
+                  onChange={(s) => {
+                    setSearchSelectedMembers(s);
+                  }}
                 />
-              </ScrollArea>
-            </>
-          )}
-          {isAdmin && space && space.kind === "regular" && (
-            <>
-              <ConfirmDeleteSpaceDialog
-                space={space}
-                handleDelete={onDelete}
-                isOpen={showDeleteConfirmDialog}
-                isDeleting={isDeleting}
-                onClose={() => setShowDeleteConfirmDialog(false)}
-              />
-              <div className="flex w-full justify-end">
-                <Button
-                  size="sm"
-                  label="Delete Space"
-                  variant="warning"
-                  className="mr-2"
-                  onClick={() => setShowDeleteConfirmDialog(true)}
+                <ScrollArea className="h-full">
+                  <MembersTable
+                    onMembersUpdated={setSelectedMembers}
+                    selectedMembers={deduplicatedMembers}
+                    searchSelectedMembers={searchSelectedMembers}
+                  />
+                </ScrollArea>
+              </>
+            )}
+
+            {isAdmin && space && space.kind === "regular" && (
+              <>
+                <ConfirmDeleteSpaceDialog
+                  space={space}
+                  handleDelete={onDelete}
+                  isOpen={showDeleteConfirmDialog}
+                  isDeleting={isDeleting}
+                  onClose={() => setShowDeleteConfirmDialog(false)}
                 />
-              </div>
-            </>
-          )}
-        </div>
-      </Page.Vertical>
-    </Modal>
+                <div className="flex w-full justify-end">
+                  <Button
+                    size="sm"
+                    label="Delete Space"
+                    variant="warning"
+                    onClick={() => setShowDeleteConfirmDialog(true)}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: isSaving ? "Saving..." : space ? "Save" : "Create",
+            onClick: onSave,
+            disabled:
+              !(
+                !!spaceName &&
+                (!isRestricted ||
+                  (isRestricted && deduplicatedMembers.length > 0))
+              ) || isSaving,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
   );
 }
 

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   DataTable,
   Input,
+  Label,
   Page,
   ScrollArea,
   SearchInput,
@@ -249,16 +250,14 @@ export function CreateOrEditSpaceModal({
                   onClick={() => setIsRestricted(!isRestricted)}
                 />
               </div>
-              <div className="text-sm font-normal text-element-700">
-                {isRestricted ? (
-                  <p>Restricted access is active.</p>
-                ) : (
-                  <p>
-                    Restricted access is disabled. The space is accessible to
-                    everyone in the workspace.
-                  </p>
-                )}
-              </div>
+              {isRestricted ? (
+                <Label>Restricted access is active.</Label>
+              ) : (
+                <Label>
+                  Restricted access is disabled. The space is accessible to
+                  everyone in the workspace.
+                </Label>
+              )}
             </div>
 
             {isRestricted && (

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -1,8 +1,6 @@
 import {
   Button,
   DataTable,
-  ExclamationCircleIcon,
-  Icon,
   Input,
   Page,
   ScrollArea,
@@ -224,17 +222,22 @@ export function CreateOrEditSpaceModal({
           <div className="flex w-full flex-col gap-y-4">
             <div className="mb-4 flex w-full flex-col gap-y-2">
               <Page.SectionHeader title="Name" />
-              <Input
-                placeholder="Space's name"
-                value={spaceName}
-                name="spaceName"
-                onChange={(e) => setSpaceName(e.target.value)}
-              />
-              {!space && (
-                <div className="flex gap-1 text-xs text-element-700">
-                  <Icon visual={ExclamationCircleIcon} size="xs" />
-                  <span>Space name must be unique</span>
-                </div>
+              {!space ? (
+                <Input
+                  placeholder="Space's name"
+                  value={spaceName}
+                  name="spaceName"
+                  message="Space name must be unique"
+                  messageStatus="info"
+                  onChange={(e) => setSpaceName(e.target.value)}
+                />
+              ) : (
+                <Input
+                  placeholder="Space's name"
+                  value={spaceName}
+                  name="spaceName"
+                  onChange={(e) => setSpaceName(e.target.value)}
+                />
               )}
             </div>
 

--- a/front/components/spaces/SearchMembersPopover.tsx
+++ b/front/components/spaces/SearchMembersPopover.tsx
@@ -87,7 +87,7 @@ export function SearchMembersPopover({
       <PopoverTrigger asChild>
         <Button label="Add members" icon={UserIcon} size="sm" />
       </PopoverTrigger>
-      <PopoverContent className="mr-2 p-4">
+      <PopoverContent mountPortal={false} className="mr-2 p-4">
         <SearchInput
           name="search"
           placeholder="Search members (email)"

--- a/front/components/spaces/SpaceCreateAppModal.tsx
+++ b/front/components/spaces/SpaceCreateAppModal.tsx
@@ -1,8 +1,13 @@
 import {
   ExclamationCircleIcon,
   Input,
-  Modal,
   Page,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
   TextArea,
   useSendNotification,
 } from "@dust-tt/sparkle";
@@ -106,21 +111,22 @@ export const SpaceCreateAppModal = ({
   };
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={() => {
-        setIsOpen(false);
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setIsOpen(false);
+        }
       }}
-      onSave={onSave}
-      hasChanged={name !== null || description !== null}
-      title="Create a new App"
-      variant="side-sm"
     >
-      <Page variant="modal">
-        <div className="w-full">
-          <Page.Vertical sizing="grow">
-            <Page.SectionHeader title="Name" />
-            <div className="w-full">
+      <SheetContent size="lg">
+        <SheetHeader>
+          <SheetTitle>Create a new App</SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <div className="flex flex-col gap-4">
+            <div>
+              <Page.SectionHeader title="Name" />
               <Input
                 placeholder="app_name"
                 name="name"
@@ -139,10 +145,9 @@ export const SpaceCreateAppModal = ({
                 alphanumeric, - or _ characters.
               </p>
             </div>
-
             <Page.Separator />
-            <Page.SectionHeader title="Description" />
-            <div className="w-full">
+            <div>
+              <Page.SectionHeader title="Description" />
               <TextArea
                 placeholder="This description guides assistants in understanding how to use
                 your app effectively and determines its relevance in responding to user inquiries."
@@ -157,9 +162,20 @@ export const SpaceCreateAppModal = ({
                 showErrorLabel
               />
             </div>
-          </Page.Vertical>
-        </div>
-      </Page>
-    </Modal>
+          </div>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "Save",
+            onClick: onSave,
+            disabled: !(name !== null || description !== null),
+          }}
+        />
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -425,7 +425,6 @@ export const SpaceDataSourceViewContentList = ({
       })) || [],
     [
       nodes,
-      owner,
       spaces,
       canReadInSpace,
       canWriteInSpace,

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -1,4 +1,11 @@
-import { Modal } from "@dust-tt/sparkle";
+import {
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
 import type {
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
@@ -129,30 +136,47 @@ export default function SpaceManagedDataSourcesViewsModal({
   );
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={() => {
-        onSave(selectionConfigurations);
-        onClose();
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
       }}
-      hasChanged={hasChanged}
-      variant="side-md"
-      title={`Add connected data to space "${space.name}"`}
     >
-      <div className="w-full pt-12">
-        <div className="overflow-x-auto">
-          <DataSourceViewsSelector
-            useCase="spaceDatasourceManagement"
-            dataSourceViews={systemSpaceDataSourceViews}
-            owner={owner}
-            selectionConfigurations={selectionConfigurations}
-            setSelectionConfigurations={setSelectionConfigurationsCallback}
-            viewType="all"
-            isRootSelectable={true}
-          />
-        </div>
-      </div>
-    </Modal>
+      <SheetContent size="lg">
+        <SheetHeader>
+          <SheetTitle>Add connected data to space "{space.name}"</SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <div className="overflow-x-auto">
+            <DataSourceViewsSelector
+              useCase="spaceDatasourceManagement"
+              dataSourceViews={systemSpaceDataSourceViews}
+              owner={owner}
+              selectionConfigurations={selectionConfigurations}
+              setSelectionConfigurations={setSelectionConfigurationsCallback}
+              viewType="all"
+              isRootSelectable={true}
+            />
+          </div>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Save",
+            onClick: () => {
+              onSave(selectionConfigurations);
+              onClose();
+            },
+            disabled: !hasChanged,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/front/hooks/useChangeMembersRoles.ts
+++ b/front/hooks/useChangeMembersRoles.ts
@@ -4,7 +4,7 @@ import type {
   RoleType,
   UserTypeWithWorkspaces,
 } from "@dust-tt/types";
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 
 import { useMembers, useSearchMembers } from "@app/lib/swr/memberships";
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.393",
+        "@dust-tt/sparkle": "0.2.395",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11336,9 +11336,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.393",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.393.tgz",
-      "integrity": "sha512-o0UEJYFC451ieMBt5qHftFgMEiUk5359cvGLOsmZxIcc389us5RnHIZbJLlNq6Gxd0KHtZe0TAbPJInTeICblQ==",
+      "version": "0.2.395",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.395.tgz",
+      "integrity": "sha512-Grxv0ajrVIWfl3FT81uSc0otSvBmMKB0zA5Fo4WWOb9hg993VMerrrvn7IWRapyCdcG/WB7oltJYHGgoYa+FiQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.393",
+    "@dust-tt/sparkle": "0.2.395",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -57,13 +57,13 @@ import {
   LabsTranscriptsConfigurationModel,
   LabsTranscriptsHistoryModel,
 } from "@app/lib/resources/storage/models/labs_transcripts";
+import { PlatformActionsConfigurationModel } from "@app/lib/resources/storage/models/platform_actions";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { deleteAllConversations } from "@app/temporal/scrub_workspace/activities";
-import { PlatformActionsConfigurationModel } from "@app/lib/resources/storage/models/platform_actions";
 
 const hardDeleteLogger = logger.child({ activity: "hard-delete" });
 


### PR DESCRIPTION
## Description

This PR continues the efforts on migrating from `Modal` to `Sheet`.

 It also fixes a bunch of front end bugs in which `Popover` and `Dropdown` where triggered but clicking on an element would actually click underneath it. This was caused by components being rendered in a portal and hence mounted outside the expected parent component.

**References:**
- https://github.com/dust-tt/tasks/issues/2156

## Risk

Low

## Deploy Plan

Deploy `front`
