### PR TITLE
poke: add audit log for operations on connectors

### DIFF
--- a/front/lib/api/poke/plugins/data_sources/operations.ts
+++ b/front/lib/api/poke/plugins/data_sources/operations.ts
@@ -3,7 +3,7 @@ import { assertNever, ConnectorsAPI, Err, Ok } from "@dust-tt/types";
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import logger from "@app/logger/logger";
+import logger, { auditLog } from "@app/logger/logger";
 
 const OPERATIONS = ["STOP", "PAUSE", "UNPAUSE", "RESUME", "SYNC"] as const;
 
@@ -63,7 +63,14 @@ export const connectorOperationsPlugin = createPlugin(
 
     const { op } = args;
 
-    logger.info(`Executing ${op} on connectorId=${connectorId}.`);
+    auditLog(
+      {
+        connectorId,
+        op,
+        who: auth.user(),
+      },
+      "Executing operation on connector"
+    );
     const res = await doOperation(op, connectorId.toString());
     if (res.isErr()) {
       return new Err(new Error(res.error.message));

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -606,12 +606,15 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       });
     }
 
-    auditLog("Membership role updated", {
-      userId: user.id,
-      workspaceId: workspace.id,
-      previousRole,
-      newRole,
-    });
+    auditLog(
+      {
+        userId: user.id,
+        workspaceId: workspace.id,
+        previousRole,
+        newRole,
+      },
+      "Membership role updated"
+    );
     return new Ok({ previousRole, newRole });
   }
 

--- a/front/logger/logger.ts
+++ b/front/logger/logger.ts
@@ -50,8 +50,8 @@ export default logger;
 export type { Logger } from "pino";
 
 export function auditLog(
-  message: string,
   data: Record<string, unknown>,
+  message: string,
   auditLogger = logger
 ) {
   auditLogger.info({ ...data, audit: true }, message);


### PR DESCRIPTION
## Description

- Adds a call to `auditLog` when running an operation on poke.
- Fix the log structure (no variable in strings)
- invert the auditLog signature to align with logger.info/...

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `front`
