### PR TITLE
Shallow file support for CSV upserts

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -67,7 +67,7 @@ import {
   makeAgentMentionsRateLimitKeyForWorkspace,
   makeMessageRateLimitKeyForWorkspace,
 } from "@app/lib/api/assistant/rate_limits";
-import { maybeUpsertFileAttachment } from "@app/lib/api/files/utils";
+import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -647,8 +647,6 @@ export async function upsertTable({
         csv: csv ?? null,
         fileId: fileId ?? null,
         truncate,
-        // TODO(spolu): remove from upsert queue
-        detectedHeaders: undefined,
         title: params.title,
         mimeType: params.mimeType,
         sourceUrl: standardizedSourceUrl,

--- a/front/lib/api/files/attachments.ts
+++ b/front/lib/api/files/attachments.ts
@@ -1,0 +1,76 @@
+import type { ConversationType } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
+
+import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
+import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
+
+// When we send the attachments at the conversation creation, we are missing the useCaseMetadata
+// Therefore, we couldn't upsert them to the conversation datasource.
+// We now update the useCaseMetadata and upsert them to the conversation datasource.
+export async function maybeUpsertFileAttachment(
+  auth: Authenticator,
+  {
+    contentFragments,
+    conversation,
+  }: {
+    contentFragments: (
+      | {
+          fileId: string;
+        }
+      | object
+    )[];
+    conversation: ConversationType;
+  }
+) {
+  const filesIds = removeNulls(
+    contentFragments.map((cf) => {
+      if ("fileId" in cf) {
+        return cf.fileId;
+      }
+    })
+  );
+
+  if (filesIds.length > 0) {
+    const fileResources = await FileResource.fetchByIds(auth, filesIds);
+    await Promise.all([
+      ...fileResources.map(async (fileResource) => {
+        if (
+          fileResource.useCase === "conversation" &&
+          !fileResource.useCaseMetadata
+        ) {
+          await fileResource.setUseCaseMetadata({
+            conversationId: conversation.sId,
+          });
+          const jitDataSource = await getOrCreateConversationDataSourceFromFile(
+            auth,
+            fileResource
+          );
+          if (!jitDataSource.isErr()) {
+            const r = await processAndUpsertToDataSource(
+              auth,
+              jitDataSource.value,
+              {
+                file: fileResource,
+              }
+            );
+            if (r.isErr()) {
+              // For now, silently log the error
+              logger.warn({
+                fileModelId: fileResource.id,
+                workspaceId: conversation.owner.sId,
+                contentType: fileResource.contentType,
+                useCase: fileResource.useCase,
+                useCaseMetadata: fileResource.useCaseMetadata,
+                message: "Failed to upsert the file.",
+                error: r.error,
+              });
+            }
+          }
+        }
+      }),
+    ]);
+  }
+}

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -481,6 +481,8 @@ export async function processAndUpsertToDataSource(
     });
   }
 
+  // TODO(spolu): [CSV-FILE] move content extraction to the processing function so that we don't
+  // extract content for tables and instead submit with fileId
   const content = optionalContent
     ? optionalContent
     : await getFileContent(auth, file);

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -234,24 +234,26 @@ const upsertTableToDatasource: ProcessingFunction = async (
   const { title: upsertTitle, ...restArgs } = upsertArgs ?? {};
 
   const upsertTableRes = await upsertTable({
-    // Beware, most values here are default values that are overrided by the ...restArgs below,
-    // including description.
-    tableId,
-    name: slugify(file.fileName),
-    description: "Table uploaded from file",
-    truncate: true,
-    csv: content.trim(),
-    tags: [`title:${file.fileName}`, `fileId:${file.sId}`],
-    parents: [tableId],
-    async: false,
-    dataSource,
     auth,
-    title: upsertTitle ?? file.fileName,
-    mimeType: file.contentType,
-    sourceUrl: file.getPrivateUrl(auth),
+    params: {
+      // Beware, most values here are default values that are overrided by the ...restArgs below,
+      // including description.
+      tableId,
+      name: slugify(file.fileName),
+      description: "Table uploaded from file",
+      truncate: true,
+      csv: content.trim(),
+      tags: [`title:${file.fileName}`, `fileId:${file.sId}`],
+      parents: [tableId],
+      async: false,
+      title: upsertTitle ?? file.fileName,
+      mimeType: file.contentType,
+      sourceUrl: file.getPrivateUrl(auth),
 
-    // Used to override defaults, for manual file uploads where some fields are user-defined.
-    ...restArgs,
+      // Used to override defaults, for manual file uploads where some fields are user-defined.
+      ...restArgs,
+    },
+    dataSource,
   });
 
   if (upsertTableRes.isErr()) {

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -194,7 +194,7 @@ const upsertDocumentToDatasource: ProcessingFunction = async (
   }
   const { title: upsertTitle, ...restArgs } = upsertArgs ?? {};
   const upsertDocumentRes = await upsertDocument({
-    // Beware, most values here are default values that are overrided by the ...restArgs below.
+    // Beware, most values here are default values that are overridden by the ...restArgs below.
     document_id: documentId,
     source_url: sourceUrl,
     text: content,
@@ -236,7 +236,7 @@ const upsertTableToDatasource: ProcessingFunction = async (
   const upsertTableRes = await upsertTable({
     auth,
     params: {
-      // Beware, most values here are default values that are overrided by the ...restArgs below,
+      // Beware, most values here are default values that are overridden by the ...restArgs below,
       // including description.
       tableId,
       name: slugify(file.fileName),

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -136,7 +136,6 @@ export async function upsertTableFromCsv({
   csv,
   fileId,
   truncate,
-  detectedHeaders,
   title,
   mimeType,
   sourceUrl,
@@ -153,7 +152,6 @@ export async function upsertTableFromCsv({
   csv: string | null;
   fileId: string | null;
   truncate: boolean;
-  detectedHeaders?: DetectedHeadersType;
   title: string;
   mimeType: string;
   sourceUrl: string | null;
@@ -202,7 +200,6 @@ export async function upsertTableFromCsv({
     ? await rowsFromCsv({
         auth,
         csv,
-        detectedHeaders,
       })
     : null;
 
@@ -363,17 +360,10 @@ export async function upsertTableFromCsv({
 export async function rowsFromCsv({
   auth,
   csv,
-  detectedHeaders,
 }: {
   auth: Authenticator;
   csv: string;
-  detectedHeaders?: DetectedHeadersType;
-}): Promise<
-  Result<
-    { detectedHeaders: DetectedHeadersType; rows: CoreAPIRow[] },
-    CsvParsingError
-  >
-> {
+}): Promise<Result<{ rows: CoreAPIRow[] }, CsvParsingError>> {
   const now = performance.now();
   const delimiter = await guessDelimiter(csv);
   if (!delimiter) {
@@ -387,9 +377,7 @@ export async function rowsFromCsv({
   const valuesByCol: Record<string, string[]> = Object.create(null);
   let header, rowIndex;
   try {
-    const headerRes = detectedHeaders
-      ? new Ok(detectedHeaders)
-      : await detectHeaders(csv, delimiter);
+    const headerRes = await detectHeaders(csv, delimiter);
 
     if (headerRes.isErr()) {
       return headerRes;

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -185,6 +185,14 @@ export async function upsertTableFromCsv({
       });
     }
 
+    if (file.useCase !== "upsert_table") {
+      return new Err({
+        type: "invalid_request_error",
+        message:
+          "The file provided has not the expected `upsert_table` use-case",
+      });
+    }
+
     const content = await getFileContent(auth, file);
     if (!content) {
       return new Err({

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -17,10 +17,11 @@ import { CsvError, parse } from "csv-parse";
 import { DateTime } from "luxon";
 
 import config from "@app/lib/api/config";
+import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
+import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
-
-import type { DataSourceResource } from "../resources/data_source_resource";
 
 const MAX_TABLE_COLUMNS = 512;
 const MAX_COLUMN_NAME_LENGTH = 1024;
@@ -44,7 +45,7 @@ type InputValidationError = {
 };
 
 type NotFoundError = {
-  type: "table_not_found";
+  type: "table_not_found" | "file_not_found";
   message: string;
 };
 
@@ -133,6 +134,7 @@ export async function upsertTableFromCsv({
   tableParentId,
   tableParents,
   csv,
+  fileId,
   truncate,
   detectedHeaders,
   title,
@@ -149,37 +151,51 @@ export async function upsertTableFromCsv({
   tableParentId: string | null;
   tableParents: string[];
   csv: string | null;
+  fileId: string | null;
   truncate: boolean;
   detectedHeaders?: DetectedHeadersType;
   title: string;
   mimeType: string;
   sourceUrl: string | null;
 }): Promise<Result<{ table: CoreAPITable }, TableOperationError>> {
-  const owner = auth.workspace();
-
-  if (!owner) {
-    logger.error(
-      {
-        type: "internal_server_error",
-        message: "Failed to get workspace.",
-      },
-      "Failed to get workspace."
-    );
-    return new Err({
-      type: "internal_server_error",
-      coreAPIError: {
-        code: "workspace_not_found",
-        message: "Failed to get workspace.",
-      },
-      message: "Failed to get workspace.",
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   if (tableParentId && tableParents && tableParents[1] !== tableParentId) {
     return new Err({
       type: "invalid_request_error",
       message: "Invalid request body, parents[1] and parent_id should be equal",
     });
+  }
+
+  // TODO(spolu): [CSV-FILE] add ability to core to take a GCS file path directly
+  if (fileId) {
+    const file = await FileResource.fetchById(auth, fileId);
+    if (!file) {
+      return new Err({
+        type: "not_found_error",
+        notFoundError: {
+          type: "file_not_found",
+          message:
+            "The file associated with the fileId you provided was not found",
+        },
+      });
+    }
+    if (file.status !== "ready") {
+      return new Err({
+        type: "invalid_request_error",
+        message: "The file provided is not ready",
+      });
+    }
+
+    const content = await getFileContent(auth, file);
+    if (!content) {
+      return new Err({
+        type: "invalid_request_error",
+        message: "The file provided is empty",
+      });
+    }
+
+    csv = content;
   }
 
   const csvRowsRes = csv

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -46,6 +46,7 @@ export const EnqueueUpsertTable = t.type({
   tableParentId: t.union([t.string, t.undefined, t.null]),
   tableParents: t.union([t.array(t.string), t.undefined, t.null]),
   csv: t.union([t.string, t.null]),
+  fileId: t.union([t.string, t.null]),
   truncate: t.boolean,
   detectedHeaders: t.union([DetectedHeaders, t.undefined]),
   title: t.string,

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -30,11 +30,6 @@ export const EnqueueUpsertDocument = t.type({
   mimeType: t.string,
 });
 
-const DetectedHeaders = t.type({
-  header: t.array(t.string),
-  rowIndex: t.number,
-});
-
 export const EnqueueUpsertTable = t.type({
   workspaceId: t.string,
   dataSourceId: t.string,
@@ -46,9 +41,9 @@ export const EnqueueUpsertTable = t.type({
   tableParentId: t.union([t.string, t.undefined, t.null]),
   tableParents: t.union([t.array(t.string), t.undefined, t.null]),
   csv: t.union([t.string, t.null]),
-  fileId: t.union([t.string, t.null]),
+  // TODO(spolu): [CSV-FILE] Remove undefined once deployed
+  fileId: t.union([t.string, t.null, t.undefined]),
   truncate: t.boolean,
-  detectedHeaders: t.union([DetectedHeaders, t.undefined]),
   title: t.string,
   mimeType: t.string,
   sourceUrl: t.union([t.string, t.undefined, t.null]),

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -1,7 +1,9 @@
+import { Readable } from "stream";
 import { describe, vi } from "vitest";
 import { expect } from "vitest";
 
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import {
   createPublicApiMockRequest,
   createPublicApiSystemOnlyAuthenticationTests,
@@ -52,6 +54,23 @@ vi.mock(import("@app/lib/api/config"), (() => ({
     }),
   },
 })) as any);
+
+// Create a mock content setter
+const mockFileContent = {
+  content: "default content", // Default content
+  setContent: (newContent: string) => {
+    mockFileContent.content = newContent;
+  },
+};
+
+// Mock file storage with parameterizable content
+vi.mock("@app/lib/file_storage", () => ({
+  getUpsertQueueBucket: vi.fn(() => ({
+    file: () => ({
+      createReadStream: () => Readable.from([mockFileContent.content]),
+    }),
+  })),
+}));
 
 describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv", () => {
   itInTransaction("returns when called with a valid CSV", async (t) => {
@@ -124,4 +143,131 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual(CORE_FAKE_RESPONSE.response);
   });
+
+  itInTransaction("succesfully upserts a CSV received as file", async (t) => {
+    const { req, res, workspace, globalGroup } =
+      await createPublicApiMockRequest({
+        systemKey: true,
+        method: "POST",
+      });
+
+    const space = await SpaceFactory.global(workspace, t);
+    await GroupSpaceFactory.associate(space, globalGroup);
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      space,
+      t
+    );
+
+    const file = await FileFactory.csv(workspace, null, {
+      useCase: "upsert_table",
+    });
+
+    // Set specific content for this test
+    mockFileContent.setContent("foo,bar,baz\n1,2,3\n4,5,6");
+
+    req.query.spaceId = space.sId;
+    req.query.dsId = dataSourceView.dataSource.sId;
+
+    req.body = {
+      name: "footable",
+      truncate: true,
+      title: "Wonderful table",
+      mimeType: "text/csv",
+      description: "desc",
+      fileId: file.sId,
+      tableId: "fooTable-1",
+    };
+
+    // First fetch is to create the table
+    global.fetch = vi.fn().mockImplementation(async (url, init) => {
+      const req = JSON.parse(init.body);
+
+      if ((url as string).endsWith("/tables")) {
+        expect(req.table_id).toBe("fooTable-1");
+        expect(req.name).toBe("footable");
+        expect(req.parents[0]).toBe("fooTable-1");
+        expect(req.source_url).toBeNull();
+        return Promise.resolve(
+          new Response(JSON.stringify(CORE_FAKE_RESPONSE), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      }
+
+      if ((url as string).endsWith("/rows")) {
+        expect(req.rows[0].row_id).toBe("0");
+        expect(req.rows[0].value.bar).toBe(2);
+        expect(req.rows[1].value.foo).toBe(4);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              response: {
+                success: true,
+              },
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        );
+      }
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  itInTransaction(
+    "errors if the file provided has the wrong use-case",
+    async (t) => {
+      const { req, res, workspace, globalGroup } =
+        await createPublicApiMockRequest({
+          systemKey: true,
+          method: "POST",
+        });
+
+      const space = await SpaceFactory.global(workspace, t);
+      await GroupSpaceFactory.associate(space, globalGroup);
+      const dataSourceView = await DataSourceViewFactory.folder(
+        workspace,
+        space,
+        t
+      );
+
+      const file = await FileFactory.csv(workspace, null, {
+        useCase: "avatar",
+      });
+
+      // Set specific content for this test
+      mockFileContent.setContent("foo,bar,baz\n1,2,3\n4,5,6");
+
+      req.query.spaceId = space.sId;
+      req.query.dsId = dataSourceView.dataSource.sId;
+
+      req.body = {
+        name: "footable",
+        truncate: true,
+        title: "Wonderful table",
+        mimeType: "text/csv",
+        description: "desc",
+        fileId: file.sId,
+        tableId: "fooTable-1",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          message:
+            "Invalid request body: The file provided has not the expected `upsert_table` use-case",
+          type: "invalid_request_error",
+        },
+      });
+    }
+  );
 });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -121,6 +121,14 @@ async function handler(
 
       if (upsertRes.isErr()) {
         switch (upsertRes.error.code) {
+          case "invalid_csv_and_file":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: upsertRes.error.message,
+              },
+            });
           case "missing_csv":
             return apiError(req, res, {
               status_code: 400,
@@ -153,11 +161,19 @@ async function handler(
                 message: upsertRes.error.message,
               },
             });
-          case "resource_not_found":
+          case "table_not_found":
             return apiError(req, res, {
               status_code: 404,
               api_error: {
                 type: "table_not_found",
+                message: upsertRes.error.message,
+              },
+            });
+          case "file_not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "file_not_found",
                 message: upsertRes.error.message,
               },
             });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -9,7 +9,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { handleDataSourceTableCSVUpsert } from "@app/lib/api/data_sources";
+import { upsertTable } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -113,7 +113,7 @@ async function handler(
           },
         });
       }
-      const upsertRes = await handleDataSourceTableCSVUpsert({
+      const upsertRes = await upsertTable({
         auth,
         params: r.data,
         dataSource,
@@ -122,13 +122,9 @@ async function handler(
       if (upsertRes.isErr()) {
         switch (upsertRes.error.code) {
           case "invalid_csv_and_file":
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message: upsertRes.error.message,
-              },
-            });
+          case "invalid_parents":
+          case "invalid_parent_id":
+          case "invalid_url":
           case "missing_csv":
             return apiError(req, res, {
               status_code: 400,
@@ -142,14 +138,6 @@ async function handler(
               status_code: 500,
               api_error: {
                 type: "data_source_error",
-                message: upsertRes.error.message,
-              },
-            });
-          case "invalid_parent_id":
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
                 message: upsertRes.error.message,
               },
             });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITable, WithAPIErrorResponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import {
   assertNever,
   PatchDataSourceTableRequestBodySchema,
@@ -25,7 +25,7 @@ export const config = {
 };
 
 export type PatchTableResponseBody = {
-  table?: CoreAPITable;
+  table?: { table_id: string };
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -100,11 +100,13 @@ async function handler(
       }
 
       const upsertRes = await upsertTable({
-        ...bodyValidation.right,
-        tableId,
-        async: bodyValidation.right.async ?? false,
-        dataSource,
         auth,
+        params: {
+          ...bodyValidation.right,
+          tableId,
+          async: bodyValidation.right.async ?? false,
+        },
+        dataSource,
       });
 
       if (upsertRes.isErr()) {

--- a/front/temporal/upsert_tables/activities.ts
+++ b/front/temporal/upsert_tables/activities.ts
@@ -89,7 +89,6 @@ export async function upsertTableActivity(
     csv: upsertQueueItem.csv,
     fileId: upsertQueueItem.fileId,
     truncate: upsertQueueItem.truncate,
-    detectedHeaders: upsertQueueItem.detectedHeaders,
     title: upsertQueueItem.title,
     mimeType: upsertQueueItem.mimeType,
     sourceUrl: upsertQueueItem.sourceUrl ?? null,

--- a/front/temporal/upsert_tables/activities.ts
+++ b/front/temporal/upsert_tables/activities.ts
@@ -87,6 +87,7 @@ export async function upsertTableActivity(
     tableParentId: upsertQueueItem.tableParentId || null,
     tableParents: upsertQueueItem.tableParents || [],
     csv: upsertQueueItem.csv,
+    fileId: upsertQueueItem.fileId,
     truncate: upsertQueueItem.truncate,
     detectedHeaders: upsertQueueItem.detectedHeaders,
     title: upsertQueueItem.title,

--- a/front/temporal/upsert_tables/activities.ts
+++ b/front/temporal/upsert_tables/activities.ts
@@ -87,7 +87,7 @@ export async function upsertTableActivity(
     tableParentId: upsertQueueItem.tableParentId || null,
     tableParents: upsertQueueItem.tableParents || [],
     csv: upsertQueueItem.csv,
-    fileId: upsertQueueItem.fileId,
+    fileId: upsertQueueItem.fileId ?? null,
     truncate: upsertQueueItem.truncate,
     title: upsertQueueItem.title,
     mimeType: upsertQueueItem.mimeType,

--- a/front/tests/utils/FileFactory.ts
+++ b/front/tests/utils/FileFactory.ts
@@ -14,7 +14,7 @@ export class FileFactory {
   // injected by mocking the GCS client.
   static async create(
     workspace: WorkspaceType,
-    user: UserResource,
+    user: UserResource | null,
     {
       contentType,
       fileName,
@@ -35,7 +35,7 @@ export class FileFactory {
   ) {
     const file = await FileResource.makeNew({
       workspaceId: workspace.id,
-      userId: user.id,
+      userId: user?.id || null,
       contentType,
       fileName,
       fileSize,
@@ -55,7 +55,7 @@ export class FileFactory {
 
   static csv(
     workspace: WorkspaceType,
-    user: UserResource,
+    user: UserResource | null,
     {
       useCase,
       useCaseMetadata,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2219,6 +2219,7 @@ export const UpsertTableFromCsvRequestSchema = z.object({
   sourceUrl: z.string().nullable().optional(),
   tableId: z.string(),
   csv: z.string().optional(),
+  fileId: z.string().optional(),
 });
 
 export type UpsertTableFromCsvRequestType = z.infer<


### PR DESCRIPTION
## Description

Adds support for Files when upserting CSVs. If a file is provided, its content is still currently
retrieved in the endpoint implementation in front. Goal is to move connectors to this new interface
and remove support for inlined CSV content before starting the optimization work of handling all CSV
content operations in core.

This PR also removed duplicated implementaion of upsertTable :o

## Tests

- Adds a test for the file-based flow

## Risk

- Mostly connectors upsert tables which can be retried in case of problems.

## Deploy Plan

- deploy `front`
