### PR TITLE
Fix(Microsoft) - fix Microsoft invalid token error catching

### DIFF
--- a/connectors/migrations/20250213_validate_microsoft_error_catching.ts
+++ b/connectors/migrations/20250213_validate_microsoft_error_catching.ts
@@ -1,0 +1,29 @@
+import { makeScript } from "scripts/helpers";
+
+import { getClient } from "@connectors/connectors/microsoft";
+import { isMicrosoftSignInError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+makeScript(
+  {
+    connectorId: { type: "number" },
+  },
+  async ({ execute, connectorId }, logger) => {
+    const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      throw new Error("Connector not found.");
+    }
+
+    if (execute) {
+      try {
+        await getClient(connector.connectionId);
+      } catch (error) {
+        logger.info({
+          error,
+          msg: error instanceof Error ? error.message : "error is not an Error",
+          wasErrorIdentified: isMicrosoftSignInError(error),
+        });
+      }
+    }
+  }
+);

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -6,24 +6,16 @@ import type {
 
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 
-interface MicrosoftAuthError extends Error {
-  error: string;
-  error_description: string;
-}
-
 // The SDK does not expose an error class that is rich enough for our use.
 // We'll use this function as a temporary solution for identifying an identified type of error.
-export function isMicrosoftSignInError(
-  err: unknown
-): err is MicrosoftAuthError {
+export function isMicrosoftSignInError(err: unknown): err is Error {
   return (
-    typeof err === "object" &&
-    err !== null &&
-    "error" in err &&
-    err.error === "invalid_grant" &&
-    "error_description" in err &&
-    typeof err.error_description === "string" &&
-    err.error_description.startsWith("AADSTS50173")
+    err instanceof Error &&
+    err.message.startsWith(
+      "Error retrieving access token from microsoft: code=provider_access_token_refresh_error"
+    ) &&
+    err.message.includes("invalid_grant") &&
+    err.message.includes("AADSTS50173")
   );
 }
 


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/dust/pull/10729 introduced a known error casting on a certain type of token errors for Microsoft  that can happen if the user changed their password on Microsoft.
- The function used to identify these errors was actually incorrect, the body of the error from Microsoft is actually part of the error message as a stringified JSON.
- This PR fixes that.

## Tests

- Tested using the script.

## Risk

- N/A

## Deploy Plan

- Deploy connectors.