### PR TITLE
Add: support custom columns as tags and prefixes in microsoft connector

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -204,6 +204,7 @@ async function handleFileExport(
       provider: "google_drive",
       connectorId,
       parents,
+      tags: file.labels,
     });
   } else if (file.mimeType === "text/markdown") {
     const textContent = handleTextFile(res.data, maxDocumentLen);

--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -12,7 +12,11 @@ import {
   getItem,
   getParentReferenceInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
-import { typeAndPathFromInternalId } from "@connectors/connectors/microsoft/lib/utils";
+import {
+  _getListColumns,
+  getListNameFromWebUrl,
+  typeAndPathFromInternalId,
+} from "@connectors/connectors/microsoft/lib/utils";
 import { launchMicrosoftIncrementalSyncWorkflow } from "@connectors/connectors/microsoft/temporal/client";
 import { throwOnError } from "@connectors/lib/cli";
 import { terminateWorkflow } from "@connectors/lib/temporal";
@@ -97,6 +101,25 @@ export const microsoft = async ({
       };
 
       return { status: 200, content, type: typeof content };
+    }
+
+    case "list-columns": {
+      const connector = await getConnector(args);
+      if (!args.webUrl) {
+        throw new Error("Missing --webUrl argument");
+      }
+      if (!args.siteId) {
+        throw new Error("Missing --siteId argument");
+      }
+
+      const listName = getListNameFromWebUrl(args.webUrl);
+      const client = await getClient(connector.connectionId);
+      const columns = await _getListColumns({
+        client,
+        listName,
+        siteId: args.siteId,
+      });
+      return { status: 200, content: columns, type: typeof columns };
     }
 
     case "start-incremental-sync": {

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -134,8 +134,8 @@ export async function getFilesAndFolders(
 
   const endpoint =
     nodeType === "drive"
-      ? `${parentResourcePath}/root/children`
-      : `${parentResourcePath}/children`;
+      ? `${parentResourcePath}/root/children?$expand=listItem($expand=fields)`
+      : `${parentResourcePath}/children?$expand=listItem($expand=fields)`;
 
   const res = nextLink
     ? await clientApiGet(client, nextLink)
@@ -181,8 +181,9 @@ export async function getDeltaResults({
 
   const deltaPath =
     (nodeType === "folder"
-      ? itemAPIPath + "/delta"
-      : itemAPIPath + "/root/delta") + (token ? `?token=${token}` : "");
+      ? itemAPIPath + "/delta?$expand=listItem($expand=fields)"
+      : itemAPIPath + "/root/delta?$expand=listItem($expand=fields)") +
+    (token ? `&token=${token}` : "");
 
   const res = nextLink
     ? await clientApiGet(client, nextLink)

--- a/connectors/src/connectors/microsoft/lib/utils.ts
+++ b/connectors/src/connectors/microsoft/lib/utils.ts
@@ -1,3 +1,12 @@
+import { cacheWithRedis } from "@dust-tt/types";
+import type { Client } from "@microsoft/microsoft-graph-client";
+import type {
+  ColumnDefinition,
+  DriveItem,
+} from "@microsoft/microsoft-graph-types";
+
+import { clientApiGet } from "@connectors/connectors/microsoft/lib/graph_api";
+
 import type { MicrosoftNodeType } from "./types";
 import { isValidNodeType } from "./types";
 
@@ -57,3 +66,126 @@ export function getDriveInternalIdFromItemId(itemId: string) {
     itemAPIPath: `/drives/${parts[2]}`,
   });
 }
+
+async function getSiteLists(
+  client: Client,
+  siteId: string
+): Promise<microsoftgraph.List[]> {
+  const endpoint = `/sites/${siteId}/lists`;
+  const res = await clientApiGet(client, endpoint);
+  return res.value;
+}
+
+async function getSiteListByName(
+  client: Client,
+  siteId: string,
+  listName: string
+): Promise<microsoftgraph.List> {
+  const lists = await getSiteLists(client, siteId);
+  const list = lists.find((list) => list.name === listName);
+  if (!list) {
+    throw new Error(`List not found: ${listName}`);
+  }
+  return list;
+}
+
+// Parse DriveItem webUrl to get listName
+// Eg: https://casquedelumiere.sharepoint.com/sites/casquedelumiere/Shared%20Documents/folder_with_txt/simple_txt.txt => the listName is "Shared Documents"
+export const getListNameFromWebUrl = (webUrl: string) => {
+  const url = new URL(webUrl);
+  const pathParts = url.pathname.split("/");
+  const sitesIndex = pathParts.findIndex((part) => part === "sites");
+  if (sitesIndex === -1) {
+    throw new Error("Invalid webUrl format: missing sites segment");
+  }
+  const listNameEncoded = pathParts[sitesIndex + 2];
+  if (!listNameEncoded) {
+    throw new Error("Invalid webUrl format: missing list name");
+  }
+  return decodeURIComponent(listNameEncoded);
+};
+
+const isCustomColumn = (column: ColumnDefinition) => {
+  return (
+    !column.readOnly && // Not read-only
+    !column.hidden && // Not hidden
+    column.name &&
+    !column.name.startsWith("_") && // Not a system column (doesn't start with _)
+    !column.columnGroup?.startsWith("_") &&
+    ![
+      "ID",
+      "Title",
+      "Created",
+      "Modified",
+      "Author",
+      "Editor",
+      "FileLeafRef",
+      "LinkFilename",
+      "ContentType",
+      "PublishingStartDate",
+      "PublishingEndDate",
+      "PublishingExpirationDate",
+      "PublishingPageImage",
+      "PublishingPageLayout",
+      "PublishingPageImageCaption",
+      "PublishingPageImageDescription",
+    ].includes(column.name)
+  ); // Not a standard column
+};
+
+export const getCachedListColumns = cacheWithRedis(
+  _getListColumns,
+  ({ siteId, listName }) => {
+    return `${siteId}-${listName}`;
+  },
+  60 * 10 * 1000 // 10 minutes
+);
+
+export async function _getListColumns({
+  client,
+  siteId,
+  listName,
+}: {
+  client: Client;
+  siteId: string;
+  listName: string;
+}): Promise<microsoftgraph.ColumnDefinition[]> {
+  const list = await getSiteListByName(client, siteId, listName);
+
+  const endpoint = `/sites/${siteId}/lists/${list.id}/columns`;
+  const res = await clientApiGet(client, endpoint);
+  return res.value.filter(isCustomColumn);
+}
+
+// Turn the labels into a string array of formatted string such as column.displayName:value
+export const getColumnsFromListItem = async (
+  file: DriveItem,
+  client: Client
+) => {
+  const listItem = file.listItem;
+  if (
+    !listItem ||
+    !listItem.parentReference?.siteId ||
+    !listItem.webUrl ||
+    !listItem.fields
+  ) {
+    return [];
+  }
+  const listName = getListNameFromWebUrl(listItem.webUrl);
+  const columns = await getCachedListColumns({
+    client,
+    listName,
+    siteId: listItem.parentReference.siteId,
+  });
+
+  const columnsList: string[] = [];
+
+  const fields = listItem.fields as Record<string, unknown>;
+  for (const [k, v] of Object.entries(fields)) {
+    const column = columns.find((column) => column.name === k);
+    if (column) {
+      columnsList.push(`${column.displayName}:${v}`);
+    }
+  }
+  return columnsList;
+};

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -46,6 +46,7 @@ export async function handleCsvFile({
   provider,
   connectorId,
   parents,
+  tags,
 }: {
   data: ArrayBuffer;
   tableId: string;
@@ -56,6 +57,7 @@ export async function handleCsvFile({
   provider: ConnectorProvider;
   connectorId: ModelId;
   parents: string[];
+  tags: string[];
 }): Promise<Result<null, Error>> {
   if (data.byteLength > 4 * maxDocumentLen) {
     localLogger.info({}, "File too big to be chunked. Skipping");
@@ -85,6 +87,7 @@ export async function handleCsvFile({
         parentId: parents[1] || null,
         title: fileName,
         mimeType: "text/csv",
+        tags,
       })
     );
   } catch (err) {

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -326,6 +326,7 @@ export const MicrosoftCommandSchema = t.type({
   command: t.union([
     t.literal("garbage-collect-all"),
     t.literal("check-file"),
+    t.literal("list-columns"),
     t.literal("start-incremental-sync"),
     t.literal("restart-all-incremental-sync-workflows"),
     t.literal("skip-file"),


### PR DESCRIPTION
## Description

Handle custom columns from SharePoint as tags and prefixes in a similar way as google drive (get the columns list on one side, get the file custom metadata on the other and reconciliate).

## Tests

Local

## Risk

Medium, could break the MS connector.

## Deploy Plan

Deploy `connectors`