### PR TITLE
Add file content accessibility check on Google transcripts.

### DIFF
--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -260,6 +260,7 @@ export async function processTranscriptActivity(
   let transcriptTitle = "";
   let transcriptContent = "";
   let userParticipated = true;
+  let fileContentIsAccessible = true;
 
   localLogger.info(
     {},
@@ -276,6 +277,7 @@ export async function processTranscriptActivity(
       );
       transcriptTitle = googleResult.transcriptTitle;
       transcriptContent = googleResult.transcriptContent;
+      fileContentIsAccessible = googleResult.fileContentIsAccessible;
       break;
 
     case "gong":
@@ -322,6 +324,14 @@ export async function processTranscriptActivity(
 
     default:
       assertNever(transcriptsConfiguration.provider);
+  }
+
+  if (!fileContentIsAccessible) {
+    localLogger.info(
+      {},
+      "[processTranscriptActivity] File content is not accessible. Stopping."
+    );
+    return;
   }
 
   try {

--- a/front/temporal/labs/utils/google.ts
+++ b/front/temporal/labs/utils/google.ts
@@ -100,7 +100,11 @@ export async function retrieveGoogleTranscriptContent(
   transcriptsConfiguration: LabsTranscriptsConfigurationResource,
   fileId: string,
   localLogger: Logger
-): Promise<{ transcriptTitle: string; transcriptContent: string }> {
+): Promise<{
+  transcriptTitle: string;
+  transcriptContent: string;
+  fileContentIsAccessible: boolean;
+}> {
   const googleAuth = await getTranscriptsGoogleAuth(
     auth,
     transcriptsConfiguration.userId
@@ -133,15 +137,20 @@ export async function retrieveGoogleTranscriptContent(
         `Error exporting Google document. status_code: ${contentRes.status}. status_text: ${contentRes.statusText}`
       );
     }
+    const fileContentIsAccessible = true;
     const transcriptTitle = metadataRes.data.name || "Untitled";
     const transcriptContent = <string>contentRes.data;
 
-    return { transcriptTitle, transcriptContent };
+    return { transcriptTitle, transcriptContent, fileContentIsAccessible };
   } catch (error) {
     localLogger.error(
       { fileId, error },
       "Error exporting Google document. Skipping."
     );
-    return { transcriptTitle: "", transcriptContent: "" };
+    return {
+      transcriptTitle: "",
+      transcriptContent: "",
+      fileContentIsAccessible: false,
+    };
   }
 }


### PR DESCRIPTION
## Description

We've had instances of files being discovered by the transcripts processing workflow (because files were listable) but not actually accessible (file was restricted). 

Currently the transcripts processing was actually still sent, without the actual content of the trancripts (so a weird fake transcript summary was made based on the assistant's instructions and the title of the transcript only)

This should stop processing altogether whenever this happens.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
