### PR TITLE
[Notion] Upsert page / database also upserts parents

### DIFF
--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -453,6 +453,7 @@ export const notion = async ({
           {
             connectorId,
             pageId,
+            upsertParents: true,
           },
         ],
         taskQueue: QUEUE_NAME,
@@ -514,6 +515,7 @@ export const notion = async ({
             connectorId,
             databaseId,
             forceResync: !!args.forceResync,
+            upsertParents: true,
           },
         ],
         taskQueue: QUEUE_NAME,

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -20,6 +20,8 @@ import {
 import { stopNotionGarbageCollectorWorkflow } from "@connectors/connectors/notion/temporal/client";
 import { QUEUE_NAME } from "@connectors/connectors/notion/temporal/config";
 import {
+  getUpsertDatabaseWorkflowId,
+  getUpsertPageWorkflowId,
   upsertDatabaseWorkflow,
   upsertPageWorkflow,
 } from "@connectors/connectors/notion/temporal/workflows/admins";
@@ -454,7 +456,7 @@ export const notion = async ({
           },
         ],
         taskQueue: QUEUE_NAME,
-        workflowId: `notion-force-sync-upsert-page-${pageId}-connector-${connectorId}`,
+        workflowId: getUpsertPageWorkflowId(pageId, connectorId),
         searchAttributes: {
           connectorId: [connectorId],
         },
@@ -515,7 +517,7 @@ export const notion = async ({
           },
         ],
         taskQueue: QUEUE_NAME,
-        workflowId: `notion-force-sync-upsert-database-${databaseId}-connector-${connectorId}`,
+        workflowId: getUpsertDatabaseWorkflowId(databaseId, connectorId),
         searchAttributes: {
           connectorId: [connectorId],
         },

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -80,7 +80,6 @@ import { heartbeat } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import { getConnectorOrThrow } from "@connectors/lib/cli";
 
 const logger = mainLogger.child({ provider: "notion" });
 

--- a/connectors/src/connectors/notion/temporal/workflows/admins.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/admins.ts
@@ -1,4 +1,5 @@
-import { assertNever, type ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import {
   executeChild,
   ParentClosePolicy,

--- a/connectors/src/connectors/notion/temporal/workflows/admins.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/admins.ts
@@ -279,6 +279,7 @@ async function upsertParent({
             connectorId,
             databaseId: parentId,
             forceResync: false,
+            upsertParents: true,
           },
         ],
         parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,

--- a/connectors/src/connectors/notion/temporal/workflows/admins.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/admins.ts
@@ -1,5 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+
 import {
   executeChild,
   ParentClosePolicy,
@@ -289,6 +289,6 @@ async function upsertParent({
     case "unknown":
       break;
     default:
-      assertNever(parentType);
+      throw new Error(`Unknown parent type: ${parentType}`);
   }
 }

--- a/connectors/src/connectors/notion/temporal/workflows/admins.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/admins.ts
@@ -1,4 +1,4 @@
-import type { ModelId } from "@dust-tt/types";
+import { assertNever, type ModelId } from "@dust-tt/types";
 import {
   executeChild,
   ParentClosePolicy,
@@ -15,12 +15,27 @@ import {
   upsertDatabase,
 } from "@connectors/connectors/notion/temporal/workflows/upserts";
 
+export function getUpsertPageWorkflowId(
+  pageId: string,
+  connectorId: ModelId
+): string {
+  return `notion-force-sync-upsert-page-${pageId}-connector-${connectorId}`;
+}
+
+export function getUpsertDatabaseWorkflowId(
+  databaseId: string,
+  connectorId: ModelId
+): string {
+  return `notion-force-sync-upsert-database-${databaseId}-connector-${connectorId}`;
+}
+
 const {
   clearWorkflowCache,
   getDiscoveredResourcesFromCache,
   upsertDatabaseInConnectorsDb,
   deletePageOrDatabaseIfArchived,
   updateSingleDocumentParents,
+  getParentPageOrDb,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minute",
 });
@@ -29,9 +44,11 @@ const {
 export async function upsertPageWorkflow({
   connectorId,
   pageId,
+  upsertParents = false,
 }: {
   connectorId: ModelId;
   pageId: string;
+  upsertParents?: boolean;
 }) {
   const topLevelWorkflowId = workflowInfo().workflowId;
   const runTimestamp = Date.now();
@@ -39,6 +56,65 @@ export async function upsertPageWorkflow({
   const queue = new PQueue({
     concurrency: MAX_CONCURRENT_CHILD_WORKFLOWS,
   });
+
+  if (upsertParents) {
+    const parentResult = await getParentPageOrDb({
+      connectorId,
+      pageOrDbId: pageId,
+    });
+    if (!parentResult) {
+      return { skipped: true };
+    }
+
+    const { parentId, parentType } = parentResult;
+
+    // In case of infinite parents loop, the workflow execution will fail at
+    // first loop since they will have the same workflowId ("workflow execution
+    // already started"). It's acceptable behaviour: it's very rare, it may not
+    // even happen since contrarily to getParents, here we query notion directly
+    // VS our connectors DB.
+    switch (parentType) {
+      case "page":
+        await executeChild(upsertPageWorkflow, {
+          workflowId: getUpsertPageWorkflowId(parentId, connectorId),
+          searchAttributes: {
+            connectorId: [connectorId],
+          },
+          args: [
+            {
+              connectorId,
+              pageId: parentId,
+              upsertParents: true,
+            },
+          ],
+          parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
+          memo: workflowInfo().memo,
+        });
+        break;
+      case "database":
+        await executeChild(upsertDatabaseWorkflow, {
+          workflowId: getUpsertDatabaseWorkflowId(parentId, connectorId),
+          searchAttributes: {
+            connectorId: [connectorId],
+          },
+          args: [
+            {
+              connectorId,
+              databaseId: parentId,
+              forceResync: false,
+            },
+          ],
+          parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
+          memo: workflowInfo().memo,
+        });
+        break;
+      case "workspace":
+      case "unknown":
+        break;
+      default:
+        assertNever(parentType);
+    }
+  }
 
   await clearWorkflowCache({ connectorId, topLevelWorkflowId });
 


### PR DESCRIPTION
Description
---
There is now a tool in Poke to upsert a page / database from notion manually.

However, if the parent is not already upserted, the page/db would appear as orphan, which is not desirable.

This PR recursively go through parents, and upserts them

Risks
---
standard
logic to be checked
blast radius limited to single page/db upsert

Deploy
---
connectors
