### PR TITLE
Tags filter auto UI + rework design

### DIFF
--- a/front/components/assistant_builder/tags/TagSearchInput.tsx
+++ b/front/components/assistant_builder/tags/TagSearchInput.tsx
@@ -21,6 +21,7 @@ export interface TagSearchProps {
   onTagRemove: (tag: DataSourceTag) => void;
   tagChipColor?: "slate" | "red";
   isLoading: boolean;
+  disabled?: boolean;
 }
 
 export const TagSearchInput = ({
@@ -32,6 +33,7 @@ export const TagSearchInput = ({
   onTagRemove,
   tagChipColor = "slate",
   isLoading,
+  disabled = false,
 }: TagSearchProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -73,6 +75,7 @@ export const TagSearchInput = ({
           placeholder="Search labels..."
           className="w-full"
           isLoading={isLoading}
+          disabled={disabled}
         />
         <DropdownMenu
           open={

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -34,8 +34,10 @@ export type DataSourceViewSelectionConfiguration = {
   dataSourceView: DataSourceViewType;
   selectedResources: DataSourceViewContentNode[];
   isSelectAll: boolean;
-  tagsFilter: { in: string[]; not: string[] } | "auto" | null;
+  tagsFilter: TagsFilter;
 };
+
+export type TagsFilter = { in: string[]; not: string[] } | "auto" | null;
 
 export function defaultSelectionConfiguration(
   dataSourceView: DataSourceViewType


### PR DESCRIPTION
## Description

Adds the auto UI + redesign the Popover. 

<img width="607" alt="Screenshot 2025-02-13 at 15 21 32" src="https://github.com/user-attachments/assets/7db88b02-1134-4319-91f6-4297ec3d8723" />

Since we overrides the tags when auto is enable, I added a little backup to let them restore if needed. 

## Tests

Locally.

## Risk

Can be rolled back, but it's still behind a feature flag.

## Deploy Plan

Deploy front. 
