### PR TITLE
Retrieval: Do not apply tagging filter if both are empty

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -259,7 +259,7 @@ export function applyDataSourceFilters(
       const tagsNot =
         ds.filter.tags === "auto" ? globalTagsNot : ds.filter.tags.not;
 
-      if (tagsIn && tagsNot) {
+      if (tagsIn && tagsNot && (tagsIn.length > 0 || tagsNot.length > 0)) {
         config.DATASOURCE.filter.tags.in_map[
           dsView.dataSource.dustAPIDataSourceId
         ] = tagsIn;


### PR DESCRIPTION
## Description

Do not apply tagging filter if both are empty. Cannot be the case for manual filtering but could be for auto. 

## Tests

Locally.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
