### PR TITLE
Disable Google Drive button to add a connection

### DIFF
--- a/front/components/data_source/CreateConnectionConfirmationModal.tsx
+++ b/front/components/data_source/CreateConnectionConfirmationModal.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
+import { WrenchScrewdriverIcon } from "@heroicons/react/20/solid";
 
 type CreateConnectionConfirmationModalProps = {
   connectorProviderConfiguration: ConnectorProviderConfiguration;
@@ -152,18 +153,28 @@ export function CreateConnectionConfirmationModal({
                   <Button
                     variant="highlight"
                     size="md"
-                    icon={CloudArrowLeftRightIcon}
+                    icon={
+                      connectorProviderConfiguration.connectorProvider ===
+                      "google_drive"
+                        ? WrenchScrewdriverIcon
+                        : CloudArrowLeftRightIcon
+                    }
                     onClick={() => {
                       setIsLoading(true);
                       onConfirm(extraConfig);
                     }}
-                    disabled={!isExtraConfigValid(extraConfig) || isLoading}
+                    disabled={
+                      !isExtraConfigValid(extraConfig) ||
+                      isLoading ||
+                      connectorProviderConfiguration.connectorProvider ===
+                        "google_drive"
+                    }
                     label={
                       isLoading
                         ? "Connecting..."
                         : connectorProviderConfiguration.connectorProvider ===
                             "google_drive"
-                          ? "Acknowledge and Connect"
+                          ? "Temporarily unavailable"
                           : "Connect"
                     }
                   />

--- a/front/components/data_source/CreateConnectionConfirmationModal.tsx
+++ b/front/components/data_source/CreateConnectionConfirmationModal.tsx
@@ -11,11 +11,11 @@ import {
   SheetTitle,
 } from "@dust-tt/sparkle";
 import { isValidZendeskSubdomain } from "@dust-tt/types";
+import { WrenchScrewdriverIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
-import { WrenchScrewdriverIcon } from "@heroicons/react/20/solid";
 
 type CreateConnectionConfirmationModalProps = {
   connectorProviderConfiguration: ConnectorProviderConfiguration;


### PR DESCRIPTION
## Description

- Context here: https://dust4ai.slack.com/archives/C05B529FHV1/p1739461273896949.
- This PR disables the button to add a Google Drive connector.

<img width="569" alt="Screenshot 2025-02-13 at 5 59 25 PM" src="https://github.com/user-attachments/assets/4ae5bd39-b40c-43ea-9b87-96242bbf04f7" />


## Tests

## Risk

- N/A

## Deploy Plan

- Deploy front.