### PR TITLE
Move connectors to using files when upserting tables

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -14,11 +14,6 @@ import {
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
-const { DUST_FRONT_API } = process.env;
-if (!DUST_FRONT_API) {
-  throw new Error("FRONT_API not set");
-}
-
 function findMatchingChannelPatterns(
   remoteChannelName: string,
   autoReadChannelPatterns: SlackAutoReadPattern[]
@@ -105,7 +100,7 @@ export async function autoReadChannel(
         apiKey: connector.workspaceAPIKey,
       },
       logger,
-      DUST_FRONT_API
+      apiConfig.getDustFrontAPIUrl()
     );
 
     // Loop through all the matching patterns. Swallow errors and continue.

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -63,8 +63,6 @@ import {
   getUserName,
 } from "./temporal/activities";
 
-const { DUST_FRONT_API } = process.env;
-
 const MAX_FILE_SIZE_TO_UPLOAD = 10 * 1024 * 1024; // 10 MB
 
 type BotAnswerParams = {
@@ -350,10 +348,6 @@ async function answerMessage(
     userType: slackUserInfo.is_bot ? "bot" : "user",
   });
 
-  if (!DUST_FRONT_API) {
-    throw new Error("DUST_FRONT_API environment variable is not defined");
-  }
-
   if (slackUserInfo.is_bot) {
     const botName = slackUserInfo.real_name;
     requestedGroups = await slackConfig.getBotGroupIds(botName);
@@ -375,7 +369,7 @@ async function answerMessage(
       },
     },
     logger,
-    DUST_FRONT_API
+    apiConfig.getDustFrontAPIUrl()
   );
 
   // Do not await this promise, we want to continue the execution of the function in parallel.

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -730,9 +730,10 @@ export async function upsertTable({
           );
 
           const schemaHeaders = schema.map((s) => s.name);
+          const cleanedHeaders = headers.filter((h) => h !== "__dust_id");
           if (
-            schemaHeaders.length !== headers.length ||
-            !schemaHeaders.every((v, i) => v === headers[i])
+            schemaHeaders.length !== cleanedHeaders.length ||
+            !schemaHeaders.every((v, i) => v === cleanedHeaders[i])
           ) {
             logger.info(
               {


### PR DESCRIPTION
## Description

Move connectors to uploading files and then using it when upserting a table as CSV. It uploads a
file typed as `text/csv` since it is indeed a csv representation. Note that the file contentType is
not used to define the mimeType of the table which is a separate concern.

Alos move to using apiConfig instead of env vars in places.

## Tests

Tested locally

## Risk

Temporary increased load on `front` service as it pulls the file from GCS in memory instead of
receving it as a POST body. But I believe very unlikely, it's probably an improvment already.

Another risk is breaking table upserts but we're in a retriable activity section.

## Deploy Plan

- deploy `connectors`
