### PR TITLE
Sparklize Dust apps

### DIFF
--- a/front/components/app/DatasetPicker.tsx
+++ b/front/components/app/DatasetPicker.tsx
@@ -50,6 +50,7 @@ export default function DatasetPicker({
         <Button
           href={createDatasetUrl}
           label={isDatasetsLoading ? "Loading..." : "Create dataset"}
+          size="xs"
         />
       ) : (
         <DropdownMenu>
@@ -59,6 +60,7 @@ export default function DatasetPicker({
               variant="outline"
               disabled={readOnly}
               label={dataset ? dataset : "Select dataset"}
+              size="xs"
             />
           </DropdownMenuTrigger>
 

--- a/front/components/app/ModelPicker.tsx
+++ b/front/components/app/ModelPicker.tsx
@@ -85,6 +85,7 @@ export default function ModelPicker({
           <Button
             href={`/w/${owner.sId}/developers/providers`}
             label={isProvidersLoading ? "Loading..." : "Setup provider"}
+            size="xs"
           />
         ) : (
           <div className="inline-flex items-center rounded-md border border-white px-3 py-1 text-sm font-normal text-gray-300">

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -152,18 +152,20 @@ export default function NewBlock({
           >
             <div className="grid max-w-md grid-cols-12 items-center">
               <div className="col-span-4 sm:col-span-3">
-                <div className="flex text-base font-medium text-gray-900">
+                <div className="dark:text-gray-900-night flex text-base font-medium text-gray-900">
                   <div
                     className={cn(
                       "mr-1 rounded-md px-1 py-0.5 text-sm font-bold",
-                      block.type === "input" ? "bg-orange-200" : "bg-gray-200"
+                      block.type === "input"
+                        ? "dark:bg-orange-200-night bg-orange-200"
+                        : "dark:bg-gray-200-night bg-gray-200"
                     )}
                   >
                     {block.type}
                   </div>
                 </div>
               </div>
-              <div className="col-span-8 pr-2 text-sm text-gray-700 sm:col-span-9 sm:pl-6">
+              <div className="dark:text-gray-700-night col-span-8 pr-2 text-sm text-gray-700 sm:col-span-9 sm:pl-6">
                 <strong>{block.name}</strong>
                 <br />
                 <p className="text-sm">{block.description}</p>

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   PlusIcon,
+  ScrollArea,
 } from "@dust-tt/sparkle";
 import type { BlockType, SpecificationType } from "@dust-tt/types";
 
@@ -145,34 +146,38 @@ export default function NewBlock({
       <DropdownMenuContent
         className={classNames("my-2 block w-max", small ? "-right-16" : "")}
       >
-        {blocks.map((block) => (
-          <DropdownMenuItem
-            key={block.type}
-            onClick={() => onClick(block.type)}
-          >
-            <div className="grid max-w-md grid-cols-12 items-center">
-              <div className="col-span-4 sm:col-span-3">
-                <div className="dark:text-gray-900-night flex text-base font-medium text-gray-900">
-                  <div
-                    className={cn(
-                      "mr-1 rounded-md px-1 py-0.5 text-sm font-bold",
-                      block.type === "input"
-                        ? "dark:bg-orange-200-night bg-orange-200"
-                        : "dark:bg-gray-200-night bg-gray-200"
-                    )}
-                  >
-                    {block.type}
+        <ScrollArea className="h-[400px]">
+          <div className="p-1">
+            {blocks.map((block) => (
+              <DropdownMenuItem
+                key={block.type}
+                onClick={() => onClick(block.type)}
+              >
+                <div className="grid max-w-md grid-cols-12 items-center">
+                  <div className="col-span-4 sm:col-span-3">
+                    <div className="dark:text-gray-900-night flex text-base font-medium text-gray-900">
+                      <div
+                        className={cn(
+                          "mr-1 rounded-md px-1 py-0.5 text-sm font-bold",
+                          block.type === "input"
+                            ? "dark:bg-orange-200-night bg-orange-200"
+                            : "dark:bg-gray-200-night bg-gray-200"
+                        )}
+                      >
+                        {block.type}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="dark:text-gray-700-night col-span-8 pr-2 text-sm text-gray-700 sm:col-span-9 sm:pl-6">
+                    <strong>{block.name}</strong>
+                    <br />
+                    <p className="text-sm">{block.description}</p>
                   </div>
                 </div>
-              </div>
-              <div className="dark:text-gray-700-night col-span-8 pr-2 text-sm text-gray-700 sm:col-span-9 sm:pl-6">
-                <strong>{block.name}</strong>
-                <br />
-                <p className="text-sm">{block.description}</p>
-              </div>
-            </div>
-          </DropdownMenuItem>
-        ))}
+              </DropdownMenuItem>
+            ))}
+          </div>
+        </ScrollArea>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -3,6 +3,8 @@ import {
   Button,
   ChevronDownIcon,
   ChevronUpIcon,
+  Chip,
+  Input,
   Spinner,
   Square3Stack3DIcon,
   TrashIcon,
@@ -91,101 +93,74 @@ export default function Block({
   });
 
   return (
-    <div className="">
+    <div>
       <div
         className={classNames(
           block.indent == 1 ? "ml-8" : "ml-0",
-          "border-material-300 group flex flex-auto flex-col rounded-lg border px-4 pb-3 pt-1"
+          "border-slate-300 dark:border-slate-700",
+          "flex flex-col rounded-lg border px-4 py-4"
         )}
       >
-        <div className="flex flex-row items-center">
-          <div className="mr-2 flex-initial">
-            <div className="">
-              <span className="rounded-md bg-gray-200 px-1 py-0.5 text-sm font-medium">
-                {block.type}
-              </span>
-            </div>
-          </div>
-
-          <div className="flex flex-auto pr-2 font-bold text-gray-700">
-            <input
-              type="text"
+        <div className="flex w-full flex-row items-start justify-between">
+          <div className="flex flex-row items-start gap-2">
+            <Chip label={block.type} color="slate" />
+            <Input
               placeholder="BLOCK_NAME"
-              className={classNames(
-                "block w-full rounded-md px-1 py-1 uppercase placeholder-gray-200",
-                readOnly
-                  ? "border-white ring-0 focus:border-white focus:ring-0"
-                  : nameError != ""
-                    ? "border-orange-400 focus:border-orange-400 focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-              )}
               readOnly={readOnly}
               value={block.name}
+              messageStatus={nameError != "" ? "error" : undefined}
+              message={nameError}
               onChange={(e) => handleNameChange(e.target.value.toUpperCase())}
             />
           </div>
 
-          <div
-            className={classNames(
-              readOnly || !canUseCache
-                ? "hidden"
-                : "ml-1 mr-2 flex flex-initial flex-row space-x-1"
-            )}
-          >
-            {block.config && block.config.use_cache ? (
+          <div className="flex flex-row items-start gap-1">
+            {!readOnly && canUseCache && (
               <Button
-                tooltip="Results are cached (faster)"
+                tooltip={
+                  block.config && block.config.use_cache
+                    ? "Results are cached (faster)"
+                    : "Results are computed at each run"
+                }
                 variant="ghost-secondary"
                 size="mini"
-                icon={Square3Stack3DIcon}
-                onClick={() => {
-                  handleUseCacheChange(false);
-                }}
-              />
-            ) : (
-              <Button
-                tooltip="Results are computed at each run"
-                variant="ghost-secondary"
-                size="mini"
-                icon={ArrowPathIcon}
-                onClick={() => {
-                  handleUseCacheChange(true);
-                }}
+                icon={
+                  block.config && block.config.use_cache
+                    ? Square3Stack3DIcon
+                    : ArrowPathIcon
+                }
+                onClick={() => handleUseCacheChange(!block.config?.use_cache)}
               />
             )}
-          </div>
 
-          <div
-            className={classNames(
-              readOnly
-                ? "hidden"
-                : "flex flex-initial flex-row items-center space-x-1"
+            {!readOnly && (
+              <>
+                <NewBlock
+                  disabled={readOnly}
+                  onClick={onBlockNew}
+                  spec={spec}
+                  small={true}
+                />
+                <Button
+                  variant="ghost-secondary"
+                  icon={ChevronUpIcon}
+                  onClick={onBlockUp}
+                  size="mini"
+                />
+                <Button
+                  variant="ghost-secondary"
+                  icon={ChevronDownIcon}
+                  onClick={onBlockDown}
+                  size="mini"
+                />
+                <Button
+                  variant="ghost-secondary"
+                  icon={TrashIcon}
+                  onClick={onBlockDelete}
+                  size="mini"
+                />
+              </>
             )}
-          >
-            <NewBlock
-              disabled={readOnly}
-              onClick={onBlockNew}
-              spec={spec}
-              small={true}
-            />
-            <Button
-              variant="ghost-secondary"
-              icon={ChevronUpIcon}
-              onClick={onBlockUp}
-              size="mini"
-            />
-            <Button
-              variant="ghost-secondary"
-              icon={ChevronDownIcon}
-              onClick={onBlockDown}
-              size="mini"
-            />
-            <Button
-              variant="ghost-secondary"
-              icon={TrashIcon}
-              onClick={onBlockDelete}
-              size="mini"
-            />
           </div>
         </div>
         <div className="flex">{children}</div>
@@ -195,14 +170,24 @@ export default function Block({
         {status &&
         status.status == "running" &&
         !["map", "reduce", "end"].includes(block.type) ? (
-          <div className="flex flex-row items-center text-sm text-gray-400">
+          <div
+            className={classNames(
+              "flex flex-row items-center text-sm",
+              "dark:text-gray-400-night text-gray-400"
+            )}
+          >
             <div className="ml-2 mr-2">
               <Spinner size="xs" variant="color" />
             </div>
             {` ${status.success_count} successes ${status.error_count} errors`}
           </div>
         ) : running && !(status && status.status != "running") ? (
-          <div className="flex flex-row items-center text-sm text-gray-400">
+          <div
+            className={classNames(
+              "flex flex-row items-center text-sm",
+              "dark:text-gray-400-night text-gray-400"
+            )}
+          >
             <div role="status">
               <div className="ml-2 mr-2">
                 <Spinner size="xs" variant="color" />

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -101,9 +101,9 @@ export default function Block({
           "flex flex-col rounded-lg border px-4 py-4"
         )}
       >
-        <div className="flex w-full flex-row items-start justify-between">
+        <div className="flex w-full flex-row items-start justify-between pb-2">
           <div className="flex flex-row items-start gap-2">
-            <Chip label={block.type} color="slate" />
+            <Chip label={block.type} color="slate" size="sm" />
             <Input
               placeholder="BLOCK_NAME"
               readOnly={readOnly}

--- a/front/components/app/blocks/Browser.tsx
+++ b/front/components/app/blocks/Browser.tsx
@@ -179,7 +179,7 @@ export default function Browser({
         <Collapsible defaultOpen={false}>
           <Collapsible.Button label="Advanced" />
           <Collapsible.Panel>
-            <div className="flex flex-row items-center space-x-4">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
               <div className="flex items-center space-x-2">
                 <Label className="whitespace-nowrap">Error as output</Label>
                 <Checkbox

--- a/front/components/app/blocks/Browser.tsx
+++ b/front/components/app/blocks/Browser.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, ChevronRightIcon } from "@dust-tt/sparkle";
+import { Button, Checkbox, Collapsible, Input, Label } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
@@ -6,12 +6,10 @@ import type {
   SpecificationType,
 } from "@dust-tt/types";
 import type { BlockType, RunType } from "@dust-tt/types";
-import Link from "next/link";
-import { useState } from "react";
 
 import { filterServiceProviders } from "@app/lib/providers";
 import { useProviders } from "@app/lib/swr/apps";
-import { classNames, shallowBlockClone } from "@app/lib/utils";
+import { shallowBlockClone } from "@app/lib/utils";
 
 import Block from "./Block";
 
@@ -119,8 +117,6 @@ export default function Browser({
     onBlockUpdate(b);
   };
 
-  const [advancedExpanded, setAdvancedExpanded] = useState(false);
-
   return (
     <Block
       owner={owner}
@@ -139,184 +135,96 @@ export default function Browser({
       onBlockDown={onBlockDown}
       onBlockNew={onBlockNew}
     >
-      <div className="mx-4 flex w-full flex-col">
-        <div className="flex flex-col text-sm font-medium leading-8 text-gray-500">
-          {advancedExpanded ? (
-            <div
-              onClick={() => setAdvancedExpanded(false)}
-              className="-ml-5 flex w-24 flex-initial cursor-pointer items-center font-bold"
-            >
-              <span>
-                <ChevronDownIcon className="mr-1 mt-0.5 h-4 w-4" />
-              </span>
-              advanced
-            </div>
-          ) : (
-            <div
-              onClick={() => setAdvancedExpanded(true)}
-              className="-ml-5 flex w-24 flex-initial cursor-pointer items-center font-bold"
-            >
-              <span>
-                <ChevronRightIcon className="mr-1 mt-0.5 h-4 w-4" />
-              </span>
-              advanced
-            </div>
-          )}
-          {advancedExpanded ? (
-            <div className="flex flex-col">
-              <div className="flex flex-col xl:flex-row xl:space-x-2">
-                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                  <div className="flex flex-initial">error as output:</div>
-                  <div className="flex flex-initial font-normal">
-                    <input
-                      type="checkbox"
-                      className={classNames(
-                        "ml-1 mr-4 h-4 w-4 rounded border-gray-300 bg-gray-100 text-action-600 focus:ring-2 focus:ring-white",
-                        readOnly ? "" : "cursor-pointer"
-                      )}
-                      checked={block.config.error_as_output}
-                      onClick={(e) => {
-                        if (readOnly) {
-                          e.preventDefault();
-                        }
-                      }}
-                      onChange={(e) => {
-                        handleErrorAsOutputChange(e.target.checked);
-                      }}
-                    />
-                  </div>
-                </div>
-                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                  <div className="flex flex-initial">timeout:</div>
-                  <div className="flex flex-initial font-normal">
-                    <input
-                      type="text"
-                      className={classNames(
-                        "block w-16 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                        readOnly
-                          ? "border-white ring-0 focus:border-white focus:ring-0"
-                          : "border-white focus:border-gray-300 focus:ring-0"
-                      )}
-                      spellCheck={false}
-                      readOnly={readOnly}
-                      value={block.spec.timeout}
-                      onChange={(e) => handleTimeoutChange(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                  <div className="flex flex-initial">wait until:</div>
-                  <div className="flex flex-initial font-normal">
-                    <input
-                      type="text"
-                      className={classNames(
-                        "block w-32 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                        readOnly
-                          ? "border-white ring-0 focus:border-white focus:ring-0"
-                          : "border-white focus:border-gray-300 focus:ring-0"
-                      )}
-                      spellCheck={false}
-                      readOnly={readOnly}
-                      value={block.spec.wait_until}
-                      onChange={(e) => handleWaitUntilChange(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <div className="flex flex-1 flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                  <div className="flex flex-initial">wait for:</div>
-                  <div className="flex flex-1 font-normal">
-                    <input
-                      type="text"
-                      placeholder=""
-                      className={classNames(
-                        "block w-32 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                        readOnly
-                          ? "border-white ring-0 focus:border-white focus:ring-0"
-                          : "border-white focus:border-gray-300 focus:ring-0"
-                      )}
-                      spellCheck={false}
-                      readOnly={readOnly}
-                      value={block.spec.wait_for}
-                      onChange={(e) => handleWaitForChange(e.target.value)}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          ) : null}
-        </div>
-
-        <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-          <div className="flex flex-initial flex-row items-center space-x-1">
-            <div className="flex flex-initial items-center">
-              URL (with scheme):
-            </div>
-            {!isProvidersLoading && !browserlessAPIProvider && !readOnly ? (
+      <div className="flex w-full flex-col gap-4 pt-2 text-sm">
+        <div className="flex w-full flex-col gap-2">
+          <div className="flex flex-row items-center gap-2">
+            <Label>URL (with scheme)</Label>
+            {!isProvidersLoading && !browserlessAPIProvider && !readOnly && (
               <div className="px-2">
-                {isAdmin ? (
-                  <Link
-                    href={`/w/${owner.sId}/developers/providers`}
-                    className={classNames(
-                      "inline-flex items-center rounded-md py-1 text-sm font-normal",
-                      "border px-3",
-                      readOnly
-                        ? "border-white text-gray-300"
-                        : "border-orange-400 text-gray-700",
-                      "focus:outline-none focus:ring-0"
-                    )}
-                  >
-                    Setup Browserless API
-                  </Link>
-                ) : (
-                  <div
-                    className={classNames(
-                      "inline-flex items-center rounded-md py-1 text-sm font-normal",
-                      "border px-3",
-                      "border-white text-gray-300"
-                    )}
-                  >
-                    Browserless API not available
-                  </div>
-                )}
+                <Button
+                  href={`/w/${owner.sId}/developers/providers`}
+                  variant="warning"
+                  label={
+                    isAdmin
+                      ? "Setup Browserless API"
+                      : "Browserless API not available"
+                  }
+                  readOnly={!isAdmin}
+                  size="xs"
+                />
               </div>
-            ) : null}
+            )}
           </div>
-          <div className="flex w-full font-normal">
-            <input
-              type="text"
-              placeholder=""
-              className={classNames(
-                "font-mono block w-full resize-none bg-slate-100 px-1 py-1 text-[13px] font-normal",
-                readOnly
-                  ? "border-white ring-0 focus:border-white focus:ring-0"
-                  : "border-white focus:border-white focus:ring-0"
-              )}
-              spellCheck={false}
-              readOnly={readOnly}
-              value={block.spec.url}
-              onChange={(e) => handleUrlChange(e.target.value)}
-            />
-          </div>
-
-          <div className="flex flex-initial flex-row items-center space-x-1">
-            <div className="flex flex-initial items-center">CSS selector:</div>
-          </div>
-          <div className="flex w-full font-normal">
-            <input
-              type="text"
-              placeholder=""
-              className={classNames(
-                "font-mono block w-full resize-none bg-slate-100 px-1 py-1 text-[13px] font-normal",
-                readOnly
-                  ? "border-white ring-0 focus:border-white focus:ring-0"
-                  : "border-white focus:border-white focus:ring-0"
-              )}
-              readOnly={readOnly}
-              value={block.spec.selector}
-              onChange={(e) => handleSelectorChange(e.target.value)}
-            />
-          </div>
+          <Input
+            type="text"
+            placeholder=""
+            spellCheck={false}
+            readOnly={readOnly}
+            value={block.spec.url}
+            onChange={(e) => handleUrlChange(e.target.value)}
+          />
         </div>
+
+        <div className="flex w-full flex-col gap-2">
+          <Label>CSS selector</Label>
+          <Input
+            type="text"
+            placeholder=""
+            readOnly={readOnly}
+            value={block.spec.selector}
+            onChange={(e) => handleSelectorChange(e.target.value)}
+          />
+        </div>
+
+        <Collapsible defaultOpen={false}>
+          <Collapsible.Button label="Advanced" />
+          <Collapsible.Panel>
+            <div className="flex flex-row items-center space-x-4">
+              <div className="flex items-center space-x-2">
+                <Label className="whitespace-nowrap">Error as output</Label>
+                <Checkbox
+                  checked={block.config.error_as_output}
+                  onChange={(checked) => handleErrorAsOutputChange(!!checked)}
+                  disabled={readOnly}
+                />
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <Label className="whitespace-nowrap">Timeout</Label>
+                <Input
+                  type="text"
+                  readOnly={readOnly}
+                  spellCheck={false}
+                  value={block.spec.timeout}
+                  onChange={(e) => handleTimeoutChange(e.target.value)}
+                />
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <Label className="whitespace-nowrap">Wait until</Label>
+                <Input
+                  type="text"
+                  spellCheck={false}
+                  readOnly={readOnly}
+                  value={block.spec.wait_until}
+                  onChange={(e) => handleWaitUntilChange(e.target.value)}
+                />
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <Label className="whitespace-nowrap">Wait for</Label>
+                <Input
+                  type="text"
+                  placeholder=""
+                  spellCheck={false}
+                  readOnly={readOnly}
+                  value={block.spec.wait_for}
+                  onChange={(e) => handleWaitForChange(e.target.value)}
+                />
+              </div>
+            </div>
+          </Collapsible.Panel>
+        </Collapsible>
       </div>
     </Block>
   );

--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -1,6 +1,12 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { ChevronDownIcon, ChevronRightIcon, XMarkIcon } from "@dust-tt/sparkle";
+import {
+  Checkbox,
+  Collapsible,
+  Input,
+  Label,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
 import type { AppType } from "@dust-tt/types";
@@ -147,8 +153,6 @@ export default function Chat({
     onBlockUpdate(b);
   };
 
-  const [advancedExpanded, setAdvancedExpanded] = useState(false);
-  const [functionsExpanded, setFunctionsExpanded] = useState(false);
   const [newStop, setNewStop] = useState("");
 
   const config =
@@ -161,6 +165,8 @@ export default function Chat({
   if (typeof block.config.temperature === "number") {
     temperature = block.config.temperature.toString();
   }
+
+  const theme = localStorage.getItem("theme");
 
   return (
     <Block
@@ -180,10 +186,10 @@ export default function Chat({
       onBlockDown={onBlockDown}
       onBlockNew={onBlockNew}
     >
-      <div className="mx-4 flex w-full flex-col">
-        <div className="flex flex-col xl:flex-row xl:space-x-2">
-          <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="mr-1 flex flex-initial">model:</div>
+      <div className="flex w-full flex-col gap-2">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <div className="flex items-center space-x-2">
+            <Label className="whitespace-nowrap">Model</Label>
             <ModelPicker
               owner={owner}
               readOnly={readOnly}
@@ -202,43 +208,25 @@ export default function Chat({
               chatOnly={true}
             />
           </div>
-          <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">temperature:</div>
-            <div className="flex flex-initial font-normal">
-              <input
-                type="text"
-                className={classNames(
-                  "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                  readOnly
-                    ? "border-white ring-0 focus:border-white focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
-                readOnly={readOnly}
-                value={temperature}
-                onChange={(e) => handleTemperatureChange(e.target.value)}
-              />
-            </div>
+          <div className="flex items-center space-x-2">
+            <Label className="whitespace-nowrap">Temperature</Label>
+            <Input
+              readOnly={readOnly}
+              value={temperature}
+              onChange={(e) => handleTemperatureChange(e.target.value)}
+            />
           </div>
-          <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">max tokens:</div>
-            <div className="flex flex-initial font-normal">
-              <input
-                type="text"
-                className={classNames(
-                  "block w-12 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                  readOnly
-                    ? "border-white ring-0 focus:border-white focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
-                spellCheck={false}
-                readOnly={readOnly}
-                value={block.spec.max_tokens || ""}
-                onChange={(e) => handleMaxTokensChange(e.target.value)}
-              />
-            </div>
+          <div className="flex items-center space-x-2">
+            <Label className="whitespace-nowrap">Max tokens</Label>
+            <Input
+              spellCheck={false}
+              readOnly={readOnly}
+              value={block.spec.max_tokens || ""}
+              onChange={(e) => handleMaxTokensChange(e.target.value)}
+            />
           </div>
-          <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">stop:</div>
+          <div className="flex items-center space-x-2">
+            <Label className="whitespace-nowrap">Stop</Label>
             <div className="flex w-full font-normal">
               <div
                 className={classNames(
@@ -264,18 +252,11 @@ export default function Chat({
                   )}
                 </div>
                 {readOnly ? null : (
-                  <input
+                  <Input
                     type="text"
                     placeholder="add stop"
                     value={newStop}
                     onChange={(e) => setNewStop(e.target.value)}
-                    className={classNames(
-                      "ml-1 flex w-20 flex-1 rounded-md px-1 py-1 text-sm font-normal ring-0",
-                      "placeholder-gray-300",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-gray-300 focus:border-gray-300 focus:border-gray-500 focus:ring-0"
-                    )}
                     readOnly={readOnly}
                     onBlur={(e) => {
                       if (e.target.value.trim().length > 0) {
@@ -302,217 +283,127 @@ export default function Chat({
             </div>
           </div>
         </div>
-
-        <div className="flex flex-col text-sm font-medium leading-8 text-gray-500">
-          {advancedExpanded ? (
-            <div
-              onClick={() => setAdvancedExpanded(false)}
-              className="-ml-5 flex w-24 flex-initial cursor-pointer items-center font-bold"
-            >
-              <span>
-                <ChevronDownIcon className="mr-1 mt-0.5 h-4 w-4" />
-              </span>
-              advanced
-            </div>
-          ) : (
-            <div
-              onClick={() => setAdvancedExpanded(true)}
-              className="-ml-5 flex w-24 flex-initial cursor-pointer items-center font-bold"
-            >
-              <span>
-                <ChevronRightIcon className="mr-1 mt-0.5 h-4 w-4" />
-              </span>
-              advanced
-            </div>
-          )}
-          {advancedExpanded ? (
-            <div className="flex flex-col xl:flex-row xl:space-x-2">
-              <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                <div className="flex flex-initial">frequency_penalty:</div>
-                <div className="flex flex-initial font-normal">
-                  <input
-                    type="text"
-                    className={classNames(
-                      "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
-                    spellCheck={false}
-                    readOnly={readOnly}
-                    value={block.spec.frequency_penalty}
-                    onChange={(e) =>
-                      handleFrequencyPenaltyChange(e.target.value)
-                    }
-                  />
+        <div>
+          <Collapsible>
+            <Collapsible.Button label="Advanced" />
+            <Collapsible.Panel>
+              <div className="flex flex-row gap-2">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                  <div className="flex items-center space-x-2">
+                    <Label>frequency_penalty</Label>
+                    <Input
+                      type="number"
+                      spellCheck={false}
+                      readOnly={readOnly}
+                      value={block.spec.frequency_penalty}
+                      onChange={(e) =>
+                        handleFrequencyPenaltyChange(e.target.value)
+                      }
+                    />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Label>presence_penalty</Label>
+                    <Input
+                      type="number"
+                      spellCheck={false}
+                      readOnly={readOnly}
+                      value={block.spec.presence_penalty}
+                      onChange={(e) =>
+                        handlePresencePenaltyChange(e.target.value)
+                      }
+                    />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Label>top_p</Label>
+                    <Input
+                      type="number"
+                      spellCheck={false}
+                      readOnly={readOnly}
+                      value={block.spec.top_p}
+                      onChange={(e) => handleTopPChange(e.target.value)}
+                    />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Label>top_logprobs</Label>
+                    <Input
+                      type="number"
+                      readOnly={readOnly}
+                      value={block.spec.top_logprobs}
+                      onChange={(e) =>
+                        handleTopLogprobsChange(parseInt(e.target.value))
+                      }
+                    />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Label>logprobs</Label>
+                    <Checkbox
+                      checked={block.spec.logprobs}
+                      onChange={(checked) => handleLogprobsChange(!!checked)}
+                    />
+                  </div>
                 </div>
               </div>
-              <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                <div className="flex flex-initial">presence_penalty:</div>
-                <div className="flex flex-initial font-normal">
-                  <input
-                    type="text"
-                    className={classNames(
-                      "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
-                    spellCheck={false}
-                    readOnly={readOnly}
-                    value={block.spec.presence_penalty}
-                    onChange={(e) =>
-                      handlePresencePenaltyChange(e.target.value)
-                    }
-                  />
-                </div>
-              </div>
-              <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                <div className="flex flex-initial">top_p:</div>
-                <div className="flex flex-initial font-normal">
-                  <input
-                    type="text"
-                    className={classNames(
-                      "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
-                    spellCheck={false}
-                    readOnly={readOnly}
-                    value={block.spec.top_p}
-                    onChange={(e) => handleTopPChange(e.target.value)}
-                  />
-                </div>
-              </div>
-              <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                <div className="flex flex-initial">top_logprobs:</div>
-                <div className="flex flex-initial font-normal">
-                  <input
-                    type="number"
-                    className={classNames(
-                      "block w-12 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
-                    readOnly={readOnly}
-                    value={block.spec.top_logprobs}
-                    onChange={(e) =>
-                      handleTopLogprobsChange(parseInt(e.target.value))
-                    }
-                  />
-                </div>
-              </div>
-              <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                <div className="flex flex-initial">logprobs:</div>
-                <div className="flex flex-initial font-normal">
-                  <input
-                    type="checkbox"
-                    checked={block.spec.logprobs}
-                    onChange={(e) => handleLogprobsChange(e.target.checked)}
-                  />
-                </div>
-              </div>
-            </div>
-          ) : null}
+            </Collapsible.Panel>
+          </Collapsible>
         </div>
 
-        <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-          <div className="flex flex-initial items-center">instructions:</div>
+        <div className="flex flex-col gap-2 text-sm">
+          <Label>Instructions</Label>
           <div className="flex w-full font-normal">
             <div className="w-full leading-5">
-              <div
-                className={classNames("border border-slate-100 bg-slate-100")}
+              <CodeEditor
+                data-color-mode={theme === "dark" ? "dark" : "light"}
+                readOnly={readOnly}
+                value={block.spec.instructions}
+                language="jinja2"
+                placeholder=""
+                onChange={(e) => handleInstructionsChange(e.target.value)}
+                padding={3}
+                minHeight={80}
+                className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
                 style={{
-                  minHeight: "48px",
+                  color: "rgb(55 65 81)",
+                  fontSize: 13,
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
                 }}
-              >
-                <CodeEditor
-                  data-color-mode="light"
-                  readOnly={readOnly}
-                  value={block.spec.instructions}
-                  language="jinja2"
-                  placeholder=""
-                  onChange={(e) => handleInstructionsChange(e.target.value)}
-                  padding={3}
-                  style={{
-                    color: "rgb(55 65 81)",
-                    fontSize: 13,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
+              />
             </div>
           </div>
         </div>
 
-        <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-          <div className="flex flex-initial items-center">messages :</div>
+        <div className="flex flex-col gap-2 text-sm">
+          <Label>Messages</Label>
           <div className="flex w-full font-normal">
             <div className="w-full leading-4">
-              <div
-                className={classNames(
-                  "border bg-slate-100",
-                  "border-slate-100"
-                )}
-              >
-                <CodeEditor
-                  data-color-mode="light"
-                  readOnly={readOnly}
-                  value={block.spec.messages_code}
-                  language="js"
-                  placeholder=""
-                  onChange={(e) => handleMessagesCodeChange(e.target.value)}
-                  padding={15}
-                  style={{
-                    fontSize: 12,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
+              <CodeEditor
+                data-color-mode={theme === "dark" ? "dark" : "light"}
+                readOnly={readOnly}
+                value={block.spec.messages_code}
+                language="js"
+                placeholder=""
+                onChange={(e) => handleMessagesCodeChange(e.target.value)}
+                padding={15}
+                minHeight={80}
+                className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
+                style={{
+                  fontSize: 12,
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                }}
+              />
             </div>
           </div>
         </div>
-
-        <div className="flex flex-col text-sm font-medium leading-8 text-gray-500">
-          {functionsExpanded ? (
-            <div
-              onClick={() => setFunctionsExpanded(false)}
-              className="-ml-5 flex w-24 flex-initial cursor-pointer items-center font-bold"
-            >
-              <span>
-                <ChevronDownIcon className="mr-1 mt-0.5 h-4 w-4" />
-              </span>
-              functions
-            </div>
-          ) : (
-            <div
-              onClick={() => setFunctionsExpanded(true)}
-              className="-ml-5 flex w-24 flex-initial cursor-pointer items-center font-bold"
-            >
-              <span>
-                <ChevronRightIcon className="mr-1 mt-0.5 h-4 w-4" />
-              </span>
-              functions
-            </div>
-          )}
-          {functionsExpanded ? (
-            <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-              <div className="flex w-full font-normal">
-                <div className="w-full leading-4">
-                  <div
-                    className={classNames(
-                      "border bg-slate-100",
-                      "border-slate-100"
-                    )}
-                  >
+        <div>
+          <Collapsible>
+            <Collapsible.Button label="Functions" />
+            <Collapsible.Panel>
+              <div className="flex flex-col gap-2 text-sm">
+                <div className="flex w-full font-normal">
+                  <div className="w-full leading-4">
                     <CodeEditor
-                      data-color-mode="light"
+                      data-color-mode={theme === "dark" ? "dark" : "light"}
                       readOnly={readOnly}
                       value={block.spec.functions_code}
                       language="js"
@@ -521,36 +412,31 @@ export default function Chat({
                         handleFunctionsCodeChange(e.target.value)
                       }
                       padding={15}
+                      minHeight={80}
+                      className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
                       style={{
                         fontSize: 12,
                         fontFamily:
                           "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                        backgroundColor: "rgb(241 245 249)",
                       }}
                     />
                   </div>
                 </div>
-              </div>
-              <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                <div className="flex flex-initial">function_call:</div>
-                <div className="flex flex-initial font-normal">
-                  <input
-                    type="text"
-                    className={classNames(
-                      "block w-48 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
-                    spellCheck={false}
-                    readOnly={readOnly}
-                    value={block.config.function_call}
-                    onChange={(e) => handleFunctionCallChange(e.target.value)}
-                  />
+                <div className="flex flex-row items-center gap-2 text-sm">
+                  <Label>function_call:</Label>
+                  <div className="flex flex-initial font-normal">
+                    <Input
+                      type="text"
+                      spellCheck={false}
+                      readOnly={readOnly}
+                      value={block.config.function_call}
+                      onChange={(e) => handleFunctionCallChange(e.target.value)}
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          ) : null}
+            </Collapsible.Panel>
+          </Collapsible>
         </div>
       </div>
     </Block>

--- a/front/components/app/blocks/Code.tsx
+++ b/front/components/app/blocks/Code.tsx
@@ -1,5 +1,6 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
+import { Label } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
@@ -9,7 +10,7 @@ import type {
 import type { BlockType, RunType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 
-import { classNames, shallowBlockClone } from "@app/lib/utils";
+import { shallowBlockClone } from "@app/lib/utils";
 
 import Block from "./Block";
 
@@ -55,6 +56,8 @@ export default function Code({
     onBlockUpdate(b);
   };
 
+  const theme = localStorage.getItem("theme");
+
   return (
     <Block
       owner={owner}
@@ -73,38 +76,27 @@ export default function Code({
       onBlockNew={onBlockNew}
       canUseCache={false}
     >
-      <div className="mx-4 flex w-full flex-col">
-        <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-          <div className="flex flex-initial items-center">code :</div>
+      <div className="flex w-full flex-col pt-2">
+        <div className="flex flex-col gap-2 text-sm">
+          <Label>Code</Label>
           <div className="flex w-full font-normal">
-            <div className="w-full leading-4">
-              <div
-                className={classNames(
-                  "border bg-slate-100",
-                  "border-slate-100"
-                )}
+            <div className="w-full">
+              <CodeEditor
+                data-color-mode={theme === "dark" ? "dark" : "light"}
+                readOnly={readOnly}
+                value={block.spec.code}
+                language="js"
+                placeholder=""
+                onChange={(e) => handleCodeChange(e.target.value)}
+                padding={15}
+                minHeight={80}
+                className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
                 style={{
-                  minHeight: "80px",
+                  fontSize: 12,
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
                 }}
-              >
-                <CodeEditor
-                  data-color-mode="light"
-                  readOnly={readOnly}
-                  value={block.spec.code}
-                  language="js"
-                  placeholder=""
-                  onChange={(e) => handleCodeChange(e.target.value)}
-                  padding={15}
-                  minHeight={78}
-                  className="bg-slate-100"
-                  style={{
-                    fontSize: 12,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
+              />
             </div>
           </div>
         </div>

--- a/front/components/app/blocks/Curl.tsx
+++ b/front/components/app/blocks/Curl.tsx
@@ -6,6 +6,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Input,
+  Label,
 } from "@dust-tt/sparkle";
 import type {
   AppType,
@@ -18,7 +20,7 @@ import type {
 import dynamic from "next/dynamic";
 import { useEffect } from "react";
 
-import { classNames, shallowBlockClone } from "@app/lib/utils";
+import { shallowBlockClone } from "@app/lib/utils";
 
 import Block from "./Block";
 
@@ -105,6 +107,8 @@ export default function Curl({
     }
   });
 
+  const theme = localStorage.getItem("theme");
+
   return (
     <Block
       owner={owner}
@@ -123,9 +127,9 @@ export default function Curl({
       onBlockDown={onBlockDown}
       onBlockNew={onBlockNew}
     >
-      <div className="mx-4 flex w-full flex-col">
-        <div className="mt-1 flex flex-row space-x-2">
-          <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+      <div className="flex w-full flex-col gap-4 pt-2">
+        <div className="flex flex-row gap-2">
+          <div className="flex flex-row items-center space-x-1 text-sm">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -150,32 +154,25 @@ export default function Curl({
               )}
             </DropdownMenu>
           </div>
-          <div className="flex w-full flex-1 flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+          <div className="flex w-full flex-1 flex-row items-center gap-2 text-sm font-medium">
             <div className="flex flex-1 font-normal">
               <div className="flex flex-1 rounded-md">
-                <span
-                  className={classNames(
-                    readOnly ? "cursor-default" : "cursor-pointer",
-                    "inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 px-1 text-sm text-gray-500"
-                  )}
+                <Button
+                  variant="ghost-secondary"
+                  size="sm"
+                  disabled={readOnly}
+                  className="rounded-l-md rounded-r-none border border-r-0"
                   onClick={() => {
                     if (!readOnly) {
-                      if (block.spec.scheme == "https") {
-                        handleSchemeChange("http");
-                      } else {
-                        handleSchemeChange("https");
-                      }
+                      handleSchemeChange(
+                        block.spec.scheme === "https" ? "http" : "https"
+                      );
                     }
                   }}
-                >
-                  {block.spec.scheme}://
-                </span>
-                <input
-                  type="text"
-                  className={classNames(
-                    "block flex-1 rounded-none rounded-r-md py-1 pl-1 text-sm font-normal",
-                    "border-gray-300 focus:border-gray-300 focus:ring-0"
-                  )}
+                  label={`${block.spec.scheme}://`}
+                />
+                <Input
+                  className="h-full flex-1 rounded-l-none"
                   readOnly={readOnly}
                   value={block.spec.url}
                   onChange={(e) => handleUrlChange(e.target.value)}
@@ -184,61 +181,47 @@ export default function Curl({
             </div>
           </div>
         </div>
-        <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-          <div className="flex flex-initial items-center">headers :</div>
+        <div className="flex flex-col gap-2 text-sm">
+          <Label>Headers</Label>
           <div className="flex w-full font-normal">
-            <div className="w-full leading-4">
-              <div
-                className={classNames(
-                  "border bg-slate-100",
-                  "border-slate-100"
-                )}
-              >
-                <CodeEditor
-                  data-color-mode="light"
-                  readOnly={readOnly}
-                  value={block.spec.headers_code}
-                  language="js"
-                  placeholder=""
-                  onChange={(e) => handleHeadersCodeChange(e.target.value)}
-                  padding={15}
-                  style={{
-                    fontSize: 12,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
+            <div className="w-full">
+              <CodeEditor
+                data-color-mode="light"
+                readOnly={readOnly}
+                value={block.spec.headers_code}
+                language="js"
+                placeholder=""
+                onChange={(e) => handleHeadersCodeChange(e.target.value)}
+                padding={15}
+                className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
+                style={{
+                  fontSize: 12,
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                }}
+              />
             </div>
           </div>
         </div>
-        <div className="flex flex-col text-sm font-medium leading-8 text-gray-500">
-          <div className="flex flex-initial items-center">body :</div>
+        <div className="flex flex-col gap-2 text-sm">
+          <Label>Body</Label>
           <div className="flex w-full font-normal">
-            <div className="w-full leading-4">
-              <div
-                className={classNames(
-                  "border bg-slate-100",
-                  "border-slate-100"
-                )}
-              >
-                <CodeEditor
-                  data-color-mode="light"
-                  readOnly={readOnly}
-                  value={block.spec.body_code}
-                  language="js"
-                  placeholder=""
-                  onChange={(e) => handleBodyCodeChange(e.target.value)}
-                  padding={15}
-                  style={{
-                    fontSize: 12,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
+            <div className="w-full">
+              <CodeEditor
+                data-color-mode={theme === "dark" ? "dark" : "light"}
+                readOnly={readOnly}
+                value={block.spec.body_code}
+                language="js"
+                placeholder=""
+                onChange={(e) => handleBodyCodeChange(e.target.value)}
+                padding={15}
+                className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
+                style={{
+                  fontSize: 12,
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                }}
+              />
             </div>
           </div>
         </div>

--- a/front/components/app/blocks/Data.tsx
+++ b/front/components/app/blocks/Data.tsx
@@ -1,4 +1,4 @@
-import { Button, PencilSquareIcon } from "@dust-tt/sparkle";
+import { Button, Label, PencilSquareIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
@@ -67,9 +67,9 @@ export default function Data({
       onBlockNew={onBlockNew}
       canUseCache={false}
     >
-      <div className="mx-4 flex flex-col sm:flex-row sm:space-x-2">
-        <div className="flex flex-row items-center space-x-2 text-sm font-medium leading-8 text-gray-700">
-          <div className="flex flex-initial">dataset:</div>
+      <div className="flex flex-col sm:flex-row">
+        <div className="flex flex-row items-center text-sm font-medium leading-8 text-gray-700">
+          <Label>Dataset</Label>
           {block.spec.dataset_id && block.spec.hash ? (
             <div className="flex items-center">
               {block.spec.dataset_id}

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -1,6 +1,6 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { XMarkIcon } from "@dust-tt/sparkle";
+import { Checkbox, Chip, Collapsible, Input, Label } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
@@ -8,12 +8,11 @@ import type {
   SpecificationType,
 } from "@dust-tt/types";
 import type { BlockType, RunType } from "@dust-tt/types";
-import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 
 import DataSourcePicker from "@app/components/data_source/DataSourcePicker";
-import { classNames, shallowBlockClone } from "@app/lib/utils";
+import { shallowBlockClone } from "@app/lib/utils";
 
 import Block from "./Block";
 
@@ -55,7 +54,6 @@ export default function DataSource({
 }>) {
   const [newTagsIn, setNewTagsIn] = useState("");
   const [newTagsNot, setNewTagsNot] = useState("");
-  const [filtersExpanded, setFiltersExpanded] = useState(false);
 
   const handleAddTagsIn = (tag: string) => {
     const b = shallowBlockClone(block);
@@ -189,6 +187,8 @@ export default function DataSource({
     onBlockUpdate(b);
   };
 
+  const theme = localStorage.getItem("theme");
+
   return (
     <Block
       owner={owner}
@@ -207,10 +207,10 @@ export default function DataSource({
       onBlockDown={onBlockDown}
       onBlockNew={onBlockNew}
     >
-      <div className="mx-4 flex w-full flex-col">
-        <div className="flex flex-col xl:flex-row xl:space-x-2">
-          <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="mr-1 flex flex-initial">Data Source:</div>
+      <div className="flex w-full flex-col gap-2">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <div className="flex items-center space-x-2">
+            <Label>Data Source</Label>
             <DataSourcePicker
               owner={owner}
               readOnly={readOnly}
@@ -221,269 +221,186 @@ export default function DataSource({
               }}
             />
           </div>
-          <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">top k:</div>
+          <div className="flex items-center space-x-2">
+            <Label>Top K</Label>
             <div className="flex flex-initial font-normal">
-              <input
+              <Input
                 type="text"
-                className={classNames(
-                  "block w-12 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                  readOnly
-                    ? "border-white ring-0 focus:border-white focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
                 readOnly={readOnly}
                 value={block.config.top_k}
                 onChange={(e) => handleTopKChange(e.target.value)}
               />
             </div>
           </div>
-          <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">full text:</div>
+          <div className="flex items-center space-x-2">
+            <Label>Full Text</Label>
             <div className="flex flex-initial font-normal">
-              <input
-                type="checkbox"
-                className={classNames(
-                  "ml-1 mr-4 h-4 w-4 rounded border-gray-300 bg-gray-100 text-action-600 focus:ring-2 focus:ring-white",
-                  readOnly ? "" : "cursor-pointer"
-                )}
+              <Checkbox
                 checked={block.spec.full_text || false}
-                onClick={(e) => {
-                  if (readOnly) {
-                    e.preventDefault();
-                  }
-                }}
-                onChange={(e) => {
-                  handleFullTextChange(e.target.checked);
+                onChange={(checked) => handleFullTextChange(!!checked)}
+                disabled={readOnly}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col space-y-1">
+          <Label>Query</Label>
+          <div className="flex w-full font-normal">
+            <div className="w-full leading-5">
+              <CodeEditor
+                data-color-mode={theme === "dark" ? "dark" : "light"}
+                readOnly={readOnly}
+                value={block.spec.query}
+                language="jinja2"
+                placeholder=""
+                onChange={(e) => handleQueryChange(e.target.value)}
+                padding={3}
+                minHeight={80}
+                className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
+                style={{
+                  color: "rgb(55 65 81)",
+                  fontSize: 13,
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
                 }}
               />
             </div>
           </div>
         </div>
 
-        <div className="flex flex-col text-sm font-medium leading-8 text-gray-500">
-          {filtersExpanded ? (
-            <div
-              onClick={() => setFiltersExpanded(false)}
-              className="-ml-5 flex w-24 flex-initial cursor-pointer items-center font-bold"
-            >
-              <span>
-                <ChevronDownIcon className="mr-1 mt-0.5 h-4 w-4" />
-              </span>
-              filters
-            </div>
-          ) : (
-            <div
-              onClick={() => setFiltersExpanded(true)}
-              className="-ml-5 flex w-24 flex-initial cursor-pointer items-center font-bold"
-            >
-              <span>
-                <ChevronRightIcon className="mr-1 mt-0.5 h-4 w-4" />
-              </span>
-              filters
-            </div>
-          )}
-          {filtersExpanded ? (
-            <div className="flex flex-col space-y-1">
-              <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-                <div className="flex w-full font-normal">
-                  <div className="w-full leading-4">
-                    <div
-                      className={classNames(
-                        "border bg-slate-100",
-                        "border-slate-100"
-                      )}
-                    >
-                      <CodeEditor
-                        data-color-mode="light"
-                        readOnly={readOnly}
-                        value={block.spec.filter_code}
-                        language="js"
-                        placeholder=""
-                        onChange={(e) => handleFilterCodeChange(e.target.value)}
-                        padding={15}
-                        style={{
-                          fontSize: 12,
-                          fontFamily:
-                            "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                          backgroundColor: "rgb(241 245 249)",
-                        }}
-                      />
-                    </div>
-                  </div>
+        <div className="w-full">
+          <Collapsible>
+            <Collapsible.Button label="Filters" />
+            <Collapsible.Panel>
+              <div className="flex w-full flex-col gap-2">
+                <div className="flex w-full flex-col gap-2">
+                  <CodeEditor
+                    data-color-mode={theme === "dark" ? "dark" : "light"}
+                    readOnly={readOnly}
+                    value={block.spec.filter_code}
+                    language="js"
+                    placeholder=""
+                    onChange={(e) => handleFilterCodeChange(e.target.value)}
+                    padding={15}
+                    minHeight={80}
+                    className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
+                    style={{
+                      fontSize: 12,
+                      fontFamily:
+                        "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                    }}
+                  />
                 </div>
-              </div>
 
-              <div className="flex flex-col xl:flex-row xl:space-x-2">
-                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                  <div className="flex flex-initial">tags.in:</div>
-                  <div className="flex w-full font-normal">
-                    <div
-                      className={classNames(
-                        "flex flex-row items-center text-sm font-normal"
-                      )}
-                    >
-                      <div className="flex flex-row items-center space-x-1">
-                        {(block.config.filter?.tags?.in || []).map(
-                          (tag: string, i: number) => (
-                            <div
-                              key={i}
-                              className="flex rounded-md bg-slate-100 px-1"
-                            >
-                              {tag}
-                              <span
-                                onClick={() => handleRemoveTagsIn(i)}
-                                className="ml-1 flex cursor-pointer items-center"
-                              >
-                                <XMarkIcon />
-                              </span>
-                            </div>
-                          )
+                <div className="flex flex-col gap-2">
+                  <div className="flex flex-initial flex-row items-center gap-2">
+                    <Label>tags.in</Label>
+                    <div className="flex w-full">
+                      <div className="flex flex-row items-center gap-1">
+                        {!readOnly && (
+                          <Input
+                            type="text"
+                            placeholder="add tag"
+                            value={newTagsIn}
+                            onChange={(e) => setNewTagsIn(e.target.value)}
+                            readOnly={readOnly}
+                            onBlur={(e) => {
+                              if (e.target.value.trim().length > 0) {
+                                handleAddTagsIn(e.target.value);
+                                e.preventDefault();
+                              }
+                            }}
+                            onKeyDown={(e) => {
+                              const tag = e.currentTarget.value;
+                              if (
+                                (e.key === "Tab" || e.key == "Enter") &&
+                                tag.trim().length > 0
+                              ) {
+                                handleAddTagsIn(tag);
+                                e.preventDefault();
+                              }
+                              if (
+                                e.key === "Backspace" &&
+                                newTagsIn.length === 0
+                              ) {
+                                handleRemoveTagsIn();
+                              }
+                            }}
+                          />
                         )}
-                      </div>
-                      {readOnly ? null : (
-                        <input
-                          type="text"
-                          placeholder="add tag"
-                          value={newTagsIn}
-                          onChange={(e) => setNewTagsIn(e.target.value)}
-                          className={classNames(
-                            "ml-1 flex w-20 flex-1 rounded-md px-1 py-1 text-sm font-normal ring-0",
-                            "placeholder-gray-300",
-                            readOnly
-                              ? "border-white ring-0 focus:border-white focus:ring-0"
-                              : "border-gray-300 focus:border-gray-500 focus:ring-0"
+                        <div className="flex flex-row gap-1">
+                          {(block.config.filter?.tags?.in || []).map(
+                            (tag: string, i: number) => (
+                              <Chip
+                                key={i}
+                                label={tag}
+                                onRemove={() => handleRemoveTagsIn(i)}
+                                color="slate"
+                              />
+                            )
                           )}
-                          readOnly={readOnly}
-                          onBlur={(e) => {
-                            if (e.target.value.trim().length > 0) {
-                              handleAddTagsIn(e.target.value);
-                              e.preventDefault();
-                            }
-                          }}
-                          onKeyDown={(e) => {
-                            const tag = e.currentTarget.value;
-                            if (
-                              (e.key === "Tab" || e.key == "Enter") &&
-                              tag.trim().length > 0
-                            ) {
-                              handleAddTagsIn(tag);
-                              e.preventDefault();
-                            }
-                            if (
-                              e.key === "Backspace" &&
-                              newTagsIn.length === 0
-                            ) {
-                              handleRemoveTagsIn();
-                            }
-                          }}
-                        />
-                      )}
+                        </div>
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                  <div className="flex flex-initial">tags.not:</div>
-                  <div className="flex w-full font-normal">
-                    <div
-                      className={classNames(
-                        "flex flex-row items-center text-sm font-normal"
-                      )}
-                    >
-                      <div className="flex flex-row items-center space-x-1">
-                        {(block.config.filter?.tags?.not || []).map(
-                          (tag: string, i: number) => (
-                            <div
-                              key={i}
-                              className="flex rounded-md bg-slate-100 px-1"
-                            >
-                              {tag}
-                              <span
-                                onClick={() => handleRemoveTagsNot(i)}
-                                className="ml-1 flex cursor-pointer items-center"
-                              >
-                                <XMarkIcon />
-                              </span>
-                            </div>
-                          )
+                  <div className="flex flex-initial flex-row items-center gap-2">
+                    <Label>tags.not</Label>
+                    <div className="flex w-full">
+                      <div className="flex flex-row items-center gap-1">
+                        {!readOnly && (
+                          <Input
+                            type="text"
+                            placeholder="add tag"
+                            value={newTagsNot}
+                            onChange={(e) => setNewTagsNot(e.target.value)}
+                            readOnly={readOnly}
+                            onBlur={(e) => {
+                              if (e.target.value.trim().length > 0) {
+                                handleAddTagsNot(e.target.value);
+                                e.preventDefault();
+                              }
+                            }}
+                            onKeyDown={(e) => {
+                              const tag = e.currentTarget.value;
+                              if (
+                                (e.key === "Tab" || e.key == "Enter") &&
+                                tag.trim().length > 0
+                              ) {
+                                handleAddTagsNot(tag);
+                                e.preventDefault();
+                              }
+                              if (
+                                e.key === "Backspace" &&
+                                newTagsNot.length === 0
+                              ) {
+                                handleRemoveTagsNot();
+                              }
+                            }}
+                          />
                         )}
+                        <div className="flex flex-row items-center">
+                          <div className="flex flex-row gap-1">
+                            {(block.config.filter?.tags?.not || []).map(
+                              (tag: string, i: number) => (
+                                <Chip
+                                  key={i}
+                                  label={tag}
+                                  onRemove={() => handleRemoveTagsNot(i)}
+                                  color="slate"
+                                />
+                              )
+                            )}
+                          </div>
+                        </div>
                       </div>
-                      {readOnly ? null : (
-                        <input
-                          type="text"
-                          placeholder="add tag"
-                          value={newTagsNot}
-                          onChange={(e) => setNewTagsNot(e.target.value)}
-                          className={classNames(
-                            "ml-1 flex w-20 flex-1 rounded-md px-1 py-1 text-sm font-normal ring-0",
-                            "placeholder-gray-300",
-                            readOnly
-                              ? "border-white ring-0 focus:border-white focus:ring-0"
-                              : "border-gray-300 focus:border-gray-500 focus:ring-0"
-                          )}
-                          readOnly={readOnly}
-                          onBlur={(e) => {
-                            if (e.target.value.trim().length > 0) {
-                              handleAddTagsNot(e.target.value);
-                              e.preventDefault();
-                            }
-                          }}
-                          onKeyDown={(e) => {
-                            const tag = e.currentTarget.value;
-                            if (
-                              (e.key === "Tab" || e.key == "Enter") &&
-                              tag.trim().length > 0
-                            ) {
-                              handleAddTagsNot(tag);
-                              e.preventDefault();
-                            }
-                            if (
-                              e.key === "Backspace" &&
-                              newTagsNot.length === 0
-                            ) {
-                              handleRemoveTagsNot();
-                            }
-                          }}
-                        />
-                      )}
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          ) : null}
-        </div>
-
-        <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-          <div className="flex flex-initial items-center">query:</div>
-          <div className="flex w-full font-normal">
-            <div className="w-full leading-5">
-              <div
-                className={classNames("border border-slate-100 bg-slate-100")}
-                style={{
-                  minHeight: "48px",
-                }}
-              >
-                <CodeEditor
-                  data-color-mode="light"
-                  readOnly={readOnly}
-                  value={block.spec.query}
-                  language="jinja2"
-                  placeholder=""
-                  onChange={(e) => handleQueryChange(e.target.value)}
-                  padding={3}
-                  style={{
-                    color: "rgb(55 65 81)",
-                    fontSize: 13,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
-            </div>
-          </div>
+            </Collapsible.Panel>
+          </Collapsible>
         </div>
       </div>
     </Block>

--- a/front/components/app/blocks/Database.tsx
+++ b/front/components/app/blocks/Database.tsx
@@ -1,6 +1,6 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { Button, PlusIcon, XMarkIcon } from "@dust-tt/sparkle";
+import { Button, Label, PlusIcon, XMarkIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
@@ -89,9 +89,7 @@ export function TablesManager({
 
   return (
     <div className="pb-2">
-      <div className="mr-1 flex pt-1 text-sm font-medium text-gray-700">
-        Table:
-      </div>
+      <Label>Table</Label>
       {block.config.tables?.map((table: TableConfig, index: number) => (
         <div key={index}>
           <div className="flex flex-col items-center xl:flex-row">
@@ -153,7 +151,10 @@ export function TablesManager({
               <div>
                 <Button
                   onClick={() => removeTable(index)}
-                  className="text-slate-400 hover:text-muted-foreground"
+                  className={classNames(
+                    "text-slate-400 dark:text-slate-400",
+                    "hover:text-muted-foreground dark:hover:text-muted-foreground"
+                  )}
                   icon={XMarkIcon}
                   size="xs"
                   variant="secondary"
@@ -213,6 +214,7 @@ export default function Database({
   onBlockDown: () => void;
   onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
 }>) {
+  const theme = localStorage.getItem("theme");
   return (
     <Block
       owner={owner}
@@ -241,39 +243,29 @@ export default function Database({
         />
 
         <div>
-          <div className="flex pb-2 text-sm font-medium text-gray-700">
-            query:
-          </div>
-          <div className="flex w-full font-normal">
-            <div className="w-full leading-5">
-              <div
-                className={classNames("border border-slate-100 bg-slate-100")}
-                style={{
-                  minHeight: "48px",
-                }}
-              >
-                <CodeEditor
-                  data-color-mode="light"
-                  readOnly={readOnly}
-                  value={block.spec.query}
-                  language="jinja2"
-                  placeholder=""
-                  onChange={(e) => {
-                    const b = shallowBlockClone(block);
-                    b.spec.query = e.target.value;
-                    onBlockUpdate(b);
-                  }}
-                  padding={3}
-                  style={{
-                    color: "rgb(55 65 81)",
-                    fontSize: 13,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
-            </div>
+          <Label>Query</Label>
+          <div className="w-full font-normal">
+            <CodeEditor
+              data-color-mode={theme === "dark" ? "dark" : "light"}
+              readOnly={readOnly}
+              value={block.spec.query}
+              language="jinja2"
+              placeholder=""
+              onChange={(e) => {
+                const b = shallowBlockClone(block);
+                b.spec.query = e.target.value;
+                onBlockUpdate(b);
+              }}
+              padding={3}
+              minHeight={80}
+              className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
+              style={{
+                color: "rgb(55 65 81)",
+                fontSize: 13,
+                fontFamily:
+                  "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+              }}
+            />
           </div>
         </div>
       </div>

--- a/front/components/app/blocks/Input.tsx
+++ b/front/components/app/blocks/Input.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   EyeIcon,
+  Label,
   PencilSquareIcon,
   Sheet,
   SheetContainer,
@@ -128,7 +129,7 @@ export default function Input({
           <div>
             {!((!block.config || !block.config.dataset) && readOnly) ? (
               <div className="flex flex-row items-center space-x-2 text-sm font-medium leading-8 text-gray-700">
-                Dataset:&nbsp;
+                <Label>Dataset</Label>
                 <DatasetPicker
                   owner={owner}
                   app={app}

--- a/front/components/app/blocks/LLM.tsx
+++ b/front/components/app/blocks/LLM.tsx
@@ -1,5 +1,6 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
+import { Input, Label } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
@@ -151,6 +152,8 @@ export default function LLM({
 
   const [newStop, setNewStop] = useState("");
 
+  const theme = localStorage.getItem("theme");
+
   return (
     <Block
       owner={owner}
@@ -172,7 +175,7 @@ export default function LLM({
       <div className="mx-4 flex w-full flex-col">
         <div className="flex flex-col xl:flex-row xl:space-x-2">
           <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="mr-1 flex flex-initial">model:</div>
+            <Label>Model</Label>
             <ModelPicker
               owner={owner}
               readOnly={readOnly}
@@ -189,16 +192,10 @@ export default function LLM({
             />
           </div>
           <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">temperature:</div>
+            <Label>Temperature</Label>
             <div className="flex flex-initial font-normal">
-              <input
+              <Input
                 type="text"
-                className={classNames(
-                  "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                  readOnly
-                    ? "border-white ring-0 focus:border-white focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
                 readOnly={readOnly}
                 value={block.spec.temperature}
                 onChange={(e) => handleTemperatureChange(e.target.value)}
@@ -208,14 +205,8 @@ export default function LLM({
           <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
             <div className="flex flex-initial">max tokens:</div>
             <div className="flex flex-initial font-normal">
-              <input
+              <Input
                 type="text"
-                className={classNames(
-                  "block w-12 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                  readOnly
-                    ? "border-white ring-0 focus:border-white focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
                 spellCheck={false}
                 readOnly={readOnly}
                 value={block.spec.max_tokens}
@@ -224,7 +215,7 @@ export default function LLM({
             </div>
           </div>
           <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">stop:</div>
+            <Label>Stop</Label>
             <div className="flex w-full font-normal">
               <div
                 className={classNames(
@@ -244,18 +235,11 @@ export default function LLM({
                   )}
                 </div>
                 {readOnly ? null : (
-                  <input
+                  <Input
                     type="text"
                     placeholder="add"
                     value={newStop}
                     onChange={(e) => setNewStop(e.target.value)}
-                    className={classNames(
-                      "ml-1 flex w-20 flex-1 rounded-md px-1 py-1 text-sm font-normal ring-0",
-                      "placeholder-gray-300",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
                     readOnly={readOnly}
                     onBlur={(e) => {
                       if (e.target.value.trim().length > 0) {
@@ -292,7 +276,7 @@ export default function LLM({
               <span>
                 <ChevronDownIcon className="mr-1 mt-0.5 h-4 w-4" />
               </span>
-              advanced
+              Advanced
             </div>
           ) : (
             <div
@@ -302,7 +286,7 @@ export default function LLM({
               <span>
                 <ChevronRightIcon className="mr-1 mt-0.5 h-4 w-4" />
               </span>
-              advanced
+              Advanced
             </div>
           )}
           {advancedExpanded ? (
@@ -310,14 +294,8 @@ export default function LLM({
               <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
                 <div className="flex flex-initial">frequency_penalty:</div>
                 <div className="flex flex-initial font-normal">
-                  <input
+                  <Input
                     type="text"
-                    className={classNames(
-                      "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
                     spellCheck={false}
                     readOnly={readOnly}
                     value={block.spec.frequency_penalty}
@@ -330,14 +308,8 @@ export default function LLM({
               <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
                 <div className="flex flex-initial">presence_penalty:</div>
                 <div className="flex flex-initial font-normal">
-                  <input
+                  <Input
                     type="text"
-                    className={classNames(
-                      "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
                     spellCheck={false}
                     readOnly={readOnly}
                     value={block.spec.presence_penalty}
@@ -350,14 +322,8 @@ export default function LLM({
               <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
                 <div className="flex flex-initial">top_p:</div>
                 <div className="flex flex-initial font-normal">
-                  <input
+                  <Input
                     type="text"
-                    className={classNames(
-                      "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
                     spellCheck={false}
                     readOnly={readOnly}
                     value={block.spec.top_p}
@@ -368,14 +334,8 @@ export default function LLM({
               <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
                 <div className="flex flex-initial">top_logprobs:</div>
                 <div className="flex flex-initial font-normal">
-                  <input
+                  <Input
                     type="text"
-                    className={classNames(
-                      "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                      readOnly
-                        ? "border-white ring-0 focus:border-white focus:ring-0"
-                        : "border-white focus:border-gray-300 focus:ring-0"
-                    )}
                     spellCheck={false}
                     readOnly={readOnly}
                     value={block.spec.top_logprobs}
@@ -459,14 +419,8 @@ export default function LLM({
                 <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
                   <div className="flex flex-initial">count:</div>
                   <div className="flex flex-initial font-normal">
-                    <input
+                    <Input
                       type="text"
-                      className={classNames(
-                        "block w-8 flex-1 px-1 py-1 text-sm font-normal",
-                        readOnly
-                          ? "border-white ring-0 focus:border-white focus:ring-0"
-                          : "border-white focus:border-gray-300 focus:ring-0"
-                      )}
                       spellCheck={false}
                       readOnly={readOnly}
                       value={block.spec.few_shot_count}
@@ -483,29 +437,24 @@ export default function LLM({
           <div className="flex flex-initial items-center">prompt:</div>
           <div className="flex w-full font-normal">
             <div className="w-full leading-5">
-              <div
-                className={classNames("border border-slate-100 bg-slate-100")}
+              <CodeEditor
+                data-color-mode={theme === "dark" ? "dark" : "light"}
+                readOnly={readOnly}
+                value={block.spec.prompt}
+                language="jinja2"
+                placeholder=""
+                onChange={(e) => handlePromptChange(e.target.value)}
+                padding={3}
+                minHeight={80}
+                className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
                 style={{
-                  minHeight: "48px",
+                  color: "rgb(55 65 81)",
+                  fontSize: 13,
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                  backgroundColor: "rgb(241 245 249)",
                 }}
-              >
-                <CodeEditor
-                  data-color-mode="light"
-                  readOnly={readOnly}
-                  value={block.spec.prompt}
-                  language="jinja2"
-                  placeholder=""
-                  onChange={(e) => handlePromptChange(e.target.value)}
-                  padding={3}
-                  style={{
-                    color: "rgb(55 65 81)",
-                    fontSize: 13,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
+              />
             </div>
           </div>
         </div>

--- a/front/components/app/blocks/MapReduce.tsx
+++ b/front/components/app/blocks/MapReduce.tsx
@@ -1,3 +1,4 @@
+import { Input, Label } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
@@ -6,7 +7,7 @@ import type {
 } from "@dust-tt/types";
 import type { BlockType, RunType } from "@dust-tt/types";
 
-import { classNames, shallowBlockClone } from "@app/lib/utils";
+import { shallowBlockClone } from "@app/lib/utils";
 
 import Block from "./Block";
 
@@ -74,16 +75,10 @@ export function Map({
       <div className="mx-4 flex w-full flex-col">
         <div className="flex flex-col lg:flex-row lg:space-x-4">
           <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">from:</div>
+            <Label>From</Label>
             <div className="flex flex-initial font-normal">
-              <input
+              <Input
                 type="text"
-                className={classNames(
-                  "block w-48 flex-1 rounded-md px-1 py-1 text-sm font-bold uppercase text-gray-700",
-                  readOnly
-                    ? "border-white ring-0 focus:border-white focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
                 readOnly={readOnly}
                 value={block.spec.from}
                 onChange={(e) => handleFromChange(e.target.value)}
@@ -91,16 +86,10 @@ export function Map({
             </div>
           </div>
           <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">repeat:</div>
+            <Label>Repeat</Label>
             <div className="flex flex-initial font-normal">
-              <input
+              <Input
                 type="text"
-                className={classNames(
-                  "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                  readOnly
-                    ? "border-white ring-0 focus:border-white focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
                 spellCheck={false}
                 readOnly={readOnly}
                 value={block.spec.repeat}

--- a/front/components/app/blocks/Search.tsx
+++ b/front/components/app/blocks/Search.tsx
@@ -4,6 +4,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Input,
+  Label,
 } from "@dust-tt/sparkle";
 import type {
   AppType,
@@ -113,7 +115,7 @@ export default function Search({
       onBlockDown={onBlockDown}
       onBlockNew={onBlockNew}
     >
-      <div className="mx-4 flex w-full flex-col">
+      <div className="flex w-full flex-col gap-4">
         <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
           <div className="flex flex-initial">provider:</div>
           {/* Owner has zero search providers */}
@@ -164,45 +166,26 @@ export default function Search({
             </DropdownMenu>
           )}
         </div>
-        <div className="flex flex-col xl:flex-row xl:space-x-2">
-          <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="flex flex-initial">num:</div>
-            <div className="flex flex-initial font-normal">
-              <input
-                type="text"
-                className={classNames(
-                  "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                  readOnly
-                    ? "border-white ring-0 focus:border-white focus:ring-0"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
-                readOnly={readOnly}
-                value={block.spec.num}
-                onChange={(e) => handleNumChange(e.target.value)}
-              />
-            </div>
-          </div>
+        <div className="flex flex-col gap-2">
+          <Label>Num</Label>
+          <Input
+            type="text"
+            placeholder=""
+            readOnly={readOnly}
+            value={block.spec.num}
+            onChange={(e) => handleNumChange(e.target.value)}
+          />
         </div>
-        <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
-          <div className="flex flex-initial flex-row items-center space-x-1">
-            <div className="flex flex-initial items-center">query:</div>
-          </div>
+        <div className="flex flex-col gap-2">
+          <Label>Query</Label>
 
-          <div className="flex w-full font-normal">
-            <input
-              type="text"
-              placeholder=""
-              className={classNames(
-                "font-mono block w-full resize-none bg-slate-100 px-1 py-1 text-[13px] font-normal",
-                readOnly
-                  ? "border-white ring-0 focus:border-white focus:ring-0"
-                  : "border-white focus:border-white focus:ring-0"
-              )}
-              readOnly={readOnly}
-              value={block.spec.query}
-              onChange={(e) => handleQueryChange(e.target.value)}
-            />
-          </div>
+          <Input
+            type="text"
+            placeholder=""
+            readOnly={readOnly}
+            value={block.spec.query}
+            onChange={(e) => handleQueryChange(e.target.value)}
+          />
         </div>
       </div>
     </Block>


### PR DESCRIPTION
## Description

Starting to migrate Dust apps components to Sparkle + Dark mode. 
Unless we want a very big PR, we need to live for a few days with different designs for the blocks. I _think_ that's okay but let me know if not!

It's clearly not perfect I'm sure I could have improved even more the html tree but using sparkle is already making things better 💅🏻 


<img width="941" alt="Screenshot 2025-02-14 at 20 39 37" src="https://github.com/user-attachments/assets/f9b5ded9-43c0-4fdc-8c18-5f1eaf84a6d2" />


<img width="933" alt="Screenshot 2025-02-14 at 20 40 19" src="https://github.com/user-attachments/assets/319bf9d6-6888-4828-a066-51960234a90c" />


## Tests

Locally.

## Risk

Break something in the Dust app display, can be rolled back.

## Deploy Plan

Deploy front.