### PR TITLE
File API: move to sId for string id instead of id

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -846,7 +846,7 @@ async function makeContentFragments(
         allContentFragments.push({
           title: fileName,
           url: fileRes.value.publicUrl,
-          fileId: fileRes.value.id,
+          fileId: fileRes.value.sId,
           context: null,
         });
       }
@@ -926,7 +926,7 @@ async function makeContentFragments(
   allContentFragments.push({
     title: `Thread content from #${channel.channel.name}`,
     url: url,
-    fileId: fileRes.value.id,
+    fileId: fileRes.value.sId,
     context: null,
   });
 

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -254,7 +254,7 @@ export function useFileUploaderService({
 
         return new Ok({
           ...fileBlob,
-          fileId: file.id,
+          fileId: file.sId,
           isUploading: false,
           preview: isSupportedImageContentType(fileBlob.contentType)
             ? `${fileUploaded.downloadUrl}?action=view`

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -265,8 +265,7 @@ const upsertTableToDatasource: ProcessingFunction = async (
     });
   }
 
-  // Note from seb : it would be better to merge useCase and useCaseMetadata to be able to specify
-  // what each use case is able to do / requires via typing.
+  // Note from seb : it would be better to merge useCase and useCaseMetadata to be able to specify what each use case is able to do / requires via typing.
   if (file.useCaseMetadata) {
     await file.setUseCaseMetadata({
       ...file.useCaseMetadata,
@@ -284,8 +283,7 @@ const upsertExcelToDatasource: ProcessingFunction = async (
   auth,
   { file, content, dataSource, upsertArgs }
 ) => {
-  // Excel files are processed in a special way, we need to extract the content of each worksheet
-  // and upsert it as a separate table.
+  // Excel files are processed in a special way, we need to extract the content of each worksheet and upsert it as a separate table.
   let worksheetName: string | undefined;
   let worksheetContent: string | undefined;
 
@@ -350,7 +348,7 @@ type ProcessingFunction = (
     dataSource: DataSourceResource;
     upsertArgs?: UpsertDocumentArgs | UpsertTableArgs;
   }
-) => Promise<Result<{ snippet: string | null }, Error>>;
+) => Promise<Result<undefined, Error>>;
 
 const getProcessingFunction = ({
   contentType,
@@ -440,7 +438,7 @@ const maybeApplyProcessing: ProcessingFunction = async (
     );
   }
 
-  return new Ok({ snippet: null });
+  return new Ok(undefined);
 };
 
 export async function processAndUpsertToDataSource(

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -265,7 +265,8 @@ const upsertTableToDatasource: ProcessingFunction = async (
     });
   }
 
-  // Note from seb : it would be better to merge useCase and useCaseMetadata to be able to specify what each use case is able to do / requires via typing.
+  // Note from seb : it would be better to merge useCase and useCaseMetadata to be able to specify
+  // what each use case is able to do / requires via typing.
   if (file.useCaseMetadata) {
     await file.setUseCaseMetadata({
       ...file.useCaseMetadata,
@@ -283,7 +284,8 @@ const upsertExcelToDatasource: ProcessingFunction = async (
   auth,
   { file, content, dataSource, upsertArgs }
 ) => {
-  // Excel files are processed in a special way, we need to extract the content of each worksheet and upsert it as a separate table.
+  // Excel files are processed in a special way, we need to extract the content of each worksheet
+  // and upsert it as a separate table.
   let worksheetName: string | undefined;
   let worksheetContent: string | undefined;
 
@@ -348,7 +350,7 @@ type ProcessingFunction = (
     dataSource: DataSourceResource;
     upsertArgs?: UpsertDocumentArgs | UpsertTableArgs;
   }
-) => Promise<Result<undefined, Error>>;
+) => Promise<Result<{ snippet: string | null }, Error>>;
 
 const getProcessingFunction = ({
   contentType,
@@ -438,7 +440,7 @@ const maybeApplyProcessing: ProcessingFunction = async (
     );
   }
 
-  return new Ok(undefined);
+  return new Ok({ snippet: null });
 };
 
 export async function processAndUpsertToDataSource(

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -301,10 +301,12 @@ export class FileResource extends BaseResource<FileModel> {
 
   toJSON(auth: Authenticator): FileType {
     const blob: FileType = {
+      // TODO(spolu): move this to ModelId
+      id: this.sId,
+      sId: this.sId,
       contentType: this.contentType,
       fileName: this.fileName,
       fileSize: this.fileSize,
-      id: this.sId,
       status: this.status,
       useCase: this.useCase,
     };
@@ -331,10 +333,12 @@ export class FileResource extends BaseResource<FileModel> {
 
   toPublicJSON(auth: Authenticator): FileType {
     const blob: FileType = {
+      // TODO(spolu): move this to ModelId
+      id: this.sId,
+      sId: this.sId,
       contentType: this.contentType,
       fileName: this.fileName,
       fileSize: this.fileSize,
-      id: this.sId,
       status: this.status,
       useCase: this.useCase,
     };

--- a/front/pages/api/v1/w/[wId]/files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.test.ts
@@ -42,6 +42,7 @@ describe("POST /api/w/[wId]/files", () => {
     expect(data.file.contentType).toBe("text/csv");
     expect(data.file.fileName).toBe("test.csv");
     expect(data.file.uploadUrl).toContain("http://localhost:9999");
+    expect(data.file.sId).toBeDefined();
   });
 
   itInTransaction(

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2383,11 +2383,13 @@ const FileTypeUseCaseSchema = FlexibleEnumSchema<
 >();
 
 export const FileTypeSchema = z.object({
+  // TODO(spolu): move this to ModelIdSchema
+  id: z.string(),
+  sId: z.string(),
   contentType: z.string(),
   downloadUrl: z.string().optional(),
   fileName: z.string(),
   fileSize: z.number(),
-  id: z.string(),
   status: FileTypeStatusSchema,
   uploadUrl: z.string().optional(),
   publicUrl: z.string().optional(),

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -24,6 +24,8 @@ export interface FileType {
   downloadUrl?: string;
   fileName: string;
   fileSize: number;
+  sId: string;
+  // TODO(spolu): move this to being the ModelId
   id: string;
   status: FileStatus;
   uploadUrl?: string;


### PR DESCRIPTION
## Description

Add `sId` to FileResource toJSON functions as well as internal and external types.
Move to using sId for our internal usages (connectors, extension)

Next step will consist in auditing public API usage, migrate existing external users and move
file.id to be the model id. We will have to fix the extension post sdk version cut + wait for another cut of the extension as well.

## Tests

Add a test for presence of sId in the public API

## Risk

Breaking slack bot and extension but low

## Deploy Plan

- deploy `front`
- deploy `connectors`
- publish sdk