### PR TITLE
enh: handle notion custom tags

### DIFF
--- a/connectors/src/connectors/notion/lib/constants.ts
+++ b/connectors/src/connectors/notion/lib/constants.ts
@@ -1,0 +1,4 @@
+export const NOTION_TAG_LIMITS = {
+  MAX_CUSTOM_TAGS_COUNT: 32,
+  MAX_TAG_LENGTH: 64,
+} as const;

--- a/connectors/src/connectors/notion/lib/tags.ts
+++ b/connectors/src/connectors/notion/lib/tags.ts
@@ -1,3 +1,4 @@
+import { NOTION_TAG_LIMITS } from "@connectors/connectors/notion/lib/constants";
 import type { parsePageProperties } from "@connectors/connectors/notion/lib/notion_api";
 
 export function getTagsForPage({
@@ -22,23 +23,48 @@ export function getTagsForPage({
 
   const customTags = [];
   for (const property of parsedProperties) {
+    // Handle custom __dust prefixed properties
     if (property.key.startsWith("__dust") && property.value?.length) {
       if (!Array.isArray(property.value)) {
-        customTags.push(`${property.key}:${property.value}`);
+        const tag = `${property.key}:${property.value}`;
+        if (tag.length <= NOTION_TAG_LIMITS.MAX_TAG_LENGTH) {
+          customTags.push(tag);
+        }
       } else {
         for (const v of property.value) {
-          customTags.push(`${property.key}:${v}`);
+          const tag = `${property.key}:${v}`;
+          if (tag.length <= NOTION_TAG_LIMITS.MAX_TAG_LENGTH) {
+            customTags.push(tag);
+          }
+        }
+      }
+    }
+
+    // Handle Tags property values
+    if (property.key.toLowerCase() === "tags" && property.value?.length) {
+      if (!Array.isArray(property.value)) {
+        if (property.value.length <= NOTION_TAG_LIMITS.MAX_TAG_LENGTH) {
+          customTags.push(property.value);
+        }
+      } else {
+        for (const v of property.value) {
+          if (v.length <= NOTION_TAG_LIMITS.MAX_TAG_LENGTH) {
+            customTags.push(v);
+          }
         }
       }
     }
   }
 
+  // System tags should always be included, custom tags are limited
+  const systemTags = [
+    `author:${author}`,
+    `lastEditor:${lastEditor}`,
+    `createdAt:${createdTime}`,
+    `updatedAt:${updatedTime}`,
+  ];
+
   return tags
-    .concat([
-      `author:${author}`,
-      `lastEditor:${lastEditor}`,
-      `createdAt:${createdTime}`,
-      `updatedAt:${updatedTime}`,
-    ])
-    .concat(customTags);
+    .concat(systemTags)
+    .concat(customTags.slice(0, NOTION_TAG_LIMITS.MAX_CUSTOM_TAGS_COUNT));
 }


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/2135
`dust-apply` https://dust.tt/w/0ec9852c2f/assistant/RjqYp3Gsor

We want to ingest the "tags" Notion property as custom tags on our documents.

Limit to 32 custom tags.
Ignore tags longer than 64 chars.

## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy connectors. Backfill TBD