### PR TITLE
[Notion] Allow admin to sync urls on manage page (behind FF)

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -22,6 +22,7 @@ import {
   SheetHeader,
   SheetTitle,
   Spinner,
+  TextArea,
   TrashIcon,
   useSendNotification,
 } from "@dust-tt/sparkle";
@@ -69,7 +70,10 @@ import {
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import { useSpaceDataSourceViews, useSystemSpace } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
-import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
+import {
+  useFeatureFlags,
+  useWorkspaceActiveSubscription,
+} from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
 import type { ContentNodeTreeItemStatus } from "./ContentNodeTree";
@@ -610,6 +614,10 @@ export function ConnectorPermissionsModal({
       includeParents: true,
       disabled: !canUpdatePermissions,
     });
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+  const advancedNotionManagement =
+    dataSource.connectorProvider === "notion" &&
+    featureFlags.includes("advanced_notion_management");
 
   const initialTreeSelectionModel = useMemo(
     () =>
@@ -839,7 +847,6 @@ export function ConnectorPermissionsModal({
                       CONNECTOR_CONFIGURATIONS[connector.type]?.isNested
                     }
                   />
-
                   <div className="flex justify-end gap-2 border-t pt-4">
                     <Button
                       label="Cancel"
@@ -853,6 +860,13 @@ export function ConnectorPermissionsModal({
                       onClick={save}
                     />
                   </div>
+                  {advancedNotionManagement && (
+                    <AdvancedNotionManagement
+                      owner={owner}
+                      dataSource={dataSource}
+                      sendNotification={sendNotification}
+                    />
+                  )}
                 </div>
               </SheetContainer>
             </>
@@ -973,4 +987,110 @@ export async function confirmPrivateNodesSync({
     });
   }
   return true;
+}
+
+export function AdvancedNotionManagement({
+  owner,
+  dataSource,
+  sendNotification,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  sendNotification: (notification: NotificationType) => void;
+}) {
+  const [urls, setUrls] = useState<string[]>([]);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [syncing, setSyncing] = useState(false);
+
+  const validateUrls = (urls: string[]) => {
+    if (urls.length > 10) {
+      setError("You can only enter up to 10 URLs");
+      return false;
+    }
+    if (urls.filter((url) => url.trim()).length === 0) {
+      setError("You must enter at least one URL");
+      return false;
+    }
+    if (!urls.every((url) => url.includes("notion.so") && URL.canParse(url))) {
+      setError(
+        `Invalid Notion URL format: ${
+          urls.filter(
+            (url) => !url.includes("notion.so") || !URL.canParse(url)
+          )[0]
+        }`
+      );
+      return false;
+    }
+    setError(undefined);
+    return true;
+  };
+  async function syncURLs() {
+    setSyncing(true);
+    // Remove empty strings and duplicates
+    const trimmedUrls = [...new Set(urls.filter((url) => url.trim()))];
+
+    try {
+      if (trimmedUrls.length && validateUrls(trimmedUrls)) {
+        const r = await fetch(
+          `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/notion_url_sync`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              urls: trimmedUrls,
+            }),
+          }
+        );
+
+        if (!r.ok) {
+          const error: { error: { message: string } } = await r.json();
+          throw new Error(error.error.message);
+        }
+        sendNotification({
+          type: "success",
+          title: "Sync started",
+          description: "The Notion URLs should be synced shortly.",
+        });
+      }
+    } catch (e) {
+      sendNotification({
+        type: "error",
+        title: "Error syncing Notion URLs",
+        description: "An unexpected error occurred while syncing Notion URLs.",
+      });
+      console.error(e);
+    }
+    setSyncing(false);
+  }
+
+  return (
+    <>
+      <div className="p-1 text-xl font-bold">
+        Advanced Notion Management - Manual URL sync
+      </div>
+
+      <div className="p-1">
+        Enter up to 10 Notion URLs to sync (one per line)
+      </div>
+      <TextArea
+        placeholder="https://www.notion.so/..."
+        value={urls.join("\n")}
+        onChange={(e) => {
+          setUrls(e.target.value.split("\n").map((url) => url.trim()));
+        }}
+        error={error}
+        showErrorLabel={!!error}
+      />
+      <div className="flex justify-end gap-2 border-t pt-4">
+        <Button
+          label="Sync URL(s)"
+          variant="primary"
+          onClick={syncURLs}
+          disabled={syncing}
+        />
+      </div>
+    </>
+  );
 }

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -22,7 +22,6 @@ import {
   SheetHeader,
   SheetTitle,
   Spinner,
-  TextArea,
   TrashIcon,
   useSendNotification,
 } from "@dust-tt/sparkle";
@@ -58,6 +57,7 @@ import { CreateOrUpdateConnectionBigQueryModal } from "@app/components/data_sour
 import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
+import { AdvancedNotionManagement } from "@app/components/spaces/AdvancedNotionManagement";
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
 import {
   CONNECTOR_CONFIGURATIONS,
@@ -987,110 +987,4 @@ export async function confirmPrivateNodesSync({
     });
   }
   return true;
-}
-
-export function AdvancedNotionManagement({
-  owner,
-  dataSource,
-  sendNotification,
-}: {
-  owner: WorkspaceType;
-  dataSource: DataSourceType;
-  sendNotification: (notification: NotificationType) => void;
-}) {
-  const [urls, setUrls] = useState<string[]>([]);
-  const [error, setError] = useState<string | undefined>(undefined);
-  const [syncing, setSyncing] = useState(false);
-
-  const validateUrls = (urls: string[]) => {
-    if (urls.length > 10) {
-      setError("You can only enter up to 10 URLs");
-      return false;
-    }
-    if (urls.filter((url) => url.trim()).length === 0) {
-      setError("You must enter at least one URL");
-      return false;
-    }
-    if (!urls.every((url) => url.includes("notion.so") && URL.canParse(url))) {
-      setError(
-        `Invalid Notion URL format: ${
-          urls.filter(
-            (url) => !url.includes("notion.so") || !URL.canParse(url)
-          )[0]
-        }`
-      );
-      return false;
-    }
-    setError(undefined);
-    return true;
-  };
-  async function syncURLs() {
-    setSyncing(true);
-    // Remove empty strings and duplicates
-    const trimmedUrls = [...new Set(urls.filter((url) => url.trim()))];
-
-    try {
-      if (trimmedUrls.length && validateUrls(trimmedUrls)) {
-        const r = await fetch(
-          `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/notion_url_sync`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              urls: trimmedUrls,
-            }),
-          }
-        );
-
-        if (!r.ok) {
-          const error: { error: { message: string } } = await r.json();
-          throw new Error(error.error.message);
-        }
-        sendNotification({
-          type: "success",
-          title: "Sync started",
-          description: "The Notion URLs should be synced shortly.",
-        });
-      }
-    } catch (e) {
-      sendNotification({
-        type: "error",
-        title: "Error syncing Notion URLs",
-        description: "An unexpected error occurred while syncing Notion URLs.",
-      });
-      console.error(e);
-    }
-    setSyncing(false);
-  }
-
-  return (
-    <>
-      <div className="p-1 text-xl font-bold">
-        Advanced Notion Management - Manual URL sync
-      </div>
-
-      <div className="p-1">
-        Enter up to 10 Notion URLs to sync (one per line)
-      </div>
-      <TextArea
-        placeholder="https://www.notion.so/..."
-        value={urls.join("\n")}
-        onChange={(e) => {
-          setUrls(e.target.value.split("\n").map((url) => url.trim()));
-        }}
-        error={error}
-        showErrorLabel={!!error}
-      />
-      <div className="flex justify-end gap-2 border-t pt-4">
-        <Button
-          label="Sync URL(s)"
-          variant="primary"
-          onClick={syncURLs}
-          disabled={syncing}
-        />
-      </div>
-    </>
-  );
 }

--- a/front/components/spaces/AdvancedNotionManagement.tsx
+++ b/front/components/spaces/AdvancedNotionManagement.tsx
@@ -1,5 +1,6 @@
-import { NotificationType, TextArea, Button } from "@dust-tt/sparkle";
-import { WorkspaceType, DataSourceType } from "@dust-tt/types";
+import type { NotificationType } from "@dust-tt/sparkle";
+import { Button, TextArea } from "@dust-tt/sparkle";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import { useState } from "react";
 
 export function AdvancedNotionManagement({

--- a/front/components/spaces/AdvancedNotionManagement.tsx
+++ b/front/components/spaces/AdvancedNotionManagement.tsx
@@ -1,0 +1,108 @@
+import { NotificationType, TextArea, Button } from "@dust-tt/sparkle";
+import { WorkspaceType, DataSourceType } from "@dust-tt/types";
+import { useState } from "react";
+
+export function AdvancedNotionManagement({
+  owner,
+  dataSource,
+  sendNotification,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  sendNotification: (notification: NotificationType) => void;
+}) {
+  const [urls, setUrls] = useState<string[]>([]);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [syncing, setSyncing] = useState(false);
+
+  const validateUrls = (urls: string[]) => {
+    if (urls.length > 10) {
+      setError("You can only enter up to 10 URLs");
+      return false;
+    }
+    if (urls.filter((url) => url.trim()).length === 0) {
+      setError("You must enter at least one URL");
+      return false;
+    }
+    if (!urls.every((url) => url.includes("notion.so") && URL.canParse(url))) {
+      setError(
+        `Invalid Notion URL format: ${
+          urls.filter(
+            (url) => !url.includes("notion.so") || !URL.canParse(url)
+          )[0]
+        }`
+      );
+      return false;
+    }
+    setError(undefined);
+    return true;
+  };
+  async function syncURLs() {
+    setSyncing(true);
+    // Remove empty strings and duplicates
+    const trimmedUrls = [...new Set(urls.filter((url) => url.trim()))];
+
+    try {
+      if (trimmedUrls.length && validateUrls(trimmedUrls)) {
+        const r = await fetch(
+          `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/notion_url_sync`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              urls: trimmedUrls,
+            }),
+          }
+        );
+
+        if (!r.ok) {
+          const error: { error: { message: string } } = await r.json();
+          throw new Error(error.error.message);
+        }
+        sendNotification({
+          type: "success",
+          title: "Sync started",
+          description: "The Notion URLs should be synced shortly.",
+        });
+      }
+    } catch (e) {
+      sendNotification({
+        type: "error",
+        title: "Error syncing Notion URLs",
+        description: "An unexpected error occurred while syncing Notion URLs.",
+      });
+    }
+    setSyncing(false);
+  }
+
+  return (
+    <>
+      <div className="p-1 text-xl font-bold">
+        Advanced Notion Management - Manual URL sync
+      </div>
+
+      <div className="p-1">
+        Enter up to 10 Notion URLs to sync (one per line)
+      </div>
+      <TextArea
+        placeholder="https://www.notion.so/..."
+        value={urls.join("\n")}
+        onChange={(e) => {
+          setUrls(e.target.value.split("\n").map((url) => url.trim()));
+        }}
+        error={error}
+        showErrorLabel={!!error}
+      />
+      <div className="flex justify-end gap-2 border-t pt-4">
+        <Button
+          label="Sync URL(s)"
+          variant="primary"
+          onClick={syncURLs}
+          disabled={syncing}
+        />
+      </div>
+    </>
+  );
+}

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -1,14 +1,16 @@
 import {
   concurrentExecutor,
   ConnectorsAPI,
+  DataSourceType,
   Err,
   NotionFindUrlResponseSchema,
   Ok,
+  Result,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 
 import config from "@app/lib/api/config";
-import { createPlugin } from "@app/lib/api/poke/types";
+import { createPlugin, PluginResponse } from "@app/lib/api/poke/types";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 
@@ -75,158 +77,193 @@ export const notionUrlSyncPlugin = createPlugin(
       );
     }
 
-    const connectorsAPI = new ConnectorsAPI(
-      config.getConnectorsAPIConfig(),
-      logger
-    );
-
     if (operation === "Sync urls") {
-      const res = await concurrentExecutor(
+      return await syncNotionUrls({
         urlsArray,
-        async (url) => {
-          const findUrlRes = await connectorsAPI.admin({
-            majorCommand: "notion",
-            command: "check-url",
-            args: {
-              wId: auth.getNonNullableWorkspace().sId,
-              dsId: dataSource.sId,
-              url,
-            },
-          });
-
-          if (findUrlRes.isErr()) {
-            return new Err(new Error(findUrlRes.error.message));
-          }
-
-          const decoded = NotionFindUrlResponseSchema.decode(findUrlRes.value);
-          if (isLeft(decoded)) {
-            return new Err(
-              new Error("Unreachable: Invalid response from dust API")
-            );
-          }
-
-          const { page, db } = decoded.right;
-          if (page) {
-            const upsertPageRes = await connectorsAPI.admin({
-              majorCommand: "notion",
-              command: "upsert-page",
-              args: {
-                wId: auth.getNonNullableWorkspace().sId,
-                dsId: dataSource.sId,
-                pageId: page.id as string,
-              },
-            });
-
-            if (upsertPageRes.isErr()) {
-              return new Err(new Error(upsertPageRes.error.message));
-            }
-
-            return new Ok(`Upserted page ${page.id} for url ${url}`);
-          } else if (db) {
-            const upsertDbRes = await connectorsAPI.admin({
-              majorCommand: "notion",
-              command: "upsert-database",
-              args: {
-                wId: auth.getNonNullableWorkspace().sId,
-                dsId: dataSource.sId,
-                databaseId: db.id as string,
-              },
-            });
-
-            if (upsertDbRes.isErr()) {
-              return new Err(new Error(upsertDbRes.error.message));
-            }
-
-            return new Ok(`Upserted database ${db.id} for url ${url}`);
-          } else {
-            return new Err(
-              new Error(`No page or database found for url ${url}`)
-            );
-          }
-        },
-        { concurrency: 8 }
-      );
-
-      if (res.some((r) => r.isErr())) {
-        return new Err(
-          new Error(
-            res.map((r) => (r.isErr() ? r.error.message : r.value)).join("\n")
-          )
-        );
-      }
-
-      return new Ok({
-        display: "text",
-        value: `Synced ${urlsArray.length} URLs from Notion.`,
+        dataSourceId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       });
     } else if (operation === "Delete urls") {
-      const res = await concurrentExecutor(
+      return await deleteUrls({
         urlsArray,
-        async (url) => {
-          const checkUrlRes = await connectorsAPI.admin({
-            majorCommand: "notion",
-            command: "check-url",
-            args: {
-              wId: auth.getNonNullableWorkspace().sId,
-              dsId: dataSource.sId,
-              url,
-            },
-          });
-
-          if (checkUrlRes.isErr()) {
-            return new Err(new Error(checkUrlRes.error.message));
-          }
-
-          const { page, db } = checkUrlRes.value as {
-            page: { [key: string]: unknown } | null;
-            db: { [key: string]: unknown } | null;
-          };
-
-          if ((page && !page.in_trash) || (db && !db.in_trash)) {
-            return new Err(
-              new Error(
-                `URL ${url} still available on Notion, should not be deleted.`
-              )
-            );
-          }
-
-          const deleteUrlRes = await connectorsAPI.admin({
-            majorCommand: "notion",
-            command: "delete-url",
-            args: {
-              wId: auth.getNonNullableWorkspace().sId,
-              dsId: dataSource.sId,
-              url,
-            },
-          });
-
-          if (deleteUrlRes.isErr()) {
-            return new Err(
-              new Error(
-                `Could not delete url ${url}: ${deleteUrlRes.error.message}`
-              )
-            );
-          }
-
-          return new Ok(`Deleted url ${url}`);
-        },
-        { concurrency: 8 }
-      );
-
-      if (res.some((r) => r.isErr())) {
-        return new Err(
-          new Error(
-            res.map((r) => (r.isErr() ? r.error.message : r.value)).join("\n")
-          )
-        );
-      }
-
-      return new Ok({
-        display: "text",
-        value: `Deleted ${urlsArray.length} URLs from Notion.`,
+        dataSourceId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       });
     } else {
       return new Err(new Error("Invalid operation"));
     }
   }
 );
+
+export async function syncNotionUrls({
+  urlsArray,
+  dataSourceId,
+  workspaceId,
+}: {
+  urlsArray: string[];
+  dataSourceId: string;
+  workspaceId: string;
+}): Promise<Result<PluginResponse, Error>> {
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  const res = await concurrentExecutor(
+    urlsArray,
+    async (url) => {
+      const checkUrlRes = await connectorsAPI.admin({
+        majorCommand: "notion",
+        command: "check-url",
+        args: {
+          wId: workspaceId,
+          dsId: dataSourceId,
+          url,
+        },
+      });
+
+      if (checkUrlRes.isErr()) {
+        return new Err(new Error(checkUrlRes.error.message));
+      }
+
+      const decoded = NotionFindUrlResponseSchema.decode(checkUrlRes.value);
+      if (isLeft(decoded)) {
+        return new Err(
+          new Error("Unreachable: Invalid response from dust API")
+        );
+      }
+
+      const { page, db } = decoded.right;
+      if (page) {
+        const upsertPageRes = await connectorsAPI.admin({
+          majorCommand: "notion",
+          command: "upsert-page",
+          args: {
+            wId: workspaceId,
+            dsId: dataSourceId,
+            pageId: page.id as string,
+          },
+        });
+
+        if (upsertPageRes.isErr()) {
+          return new Err(new Error(upsertPageRes.error.message));
+        }
+
+        return new Ok(`Upserted page ${page.id} for url ${url}`);
+      } else if (db) {
+        const upsertDbRes = await connectorsAPI.admin({
+          majorCommand: "notion",
+          command: "upsert-database",
+          args: {
+            wId: workspaceId,
+            dsId: dataSourceId,
+            databaseId: db.id as string,
+          },
+        });
+
+        if (upsertDbRes.isErr()) {
+          return new Err(new Error(upsertDbRes.error.message));
+        }
+
+        return new Ok(`Upserted database ${db.id} for url ${url}`);
+      } else {
+        return new Err(new Error(`No page or database found for url ${url}`));
+      }
+    },
+    { concurrency: 8 }
+  );
+
+  if (res.some((r) => r.isErr())) {
+    return new Err(
+      new Error(
+        res.map((r) => (r.isErr() ? r.error.message : r.value)).join("\n")
+      )
+    );
+  }
+
+  return new Ok({
+    display: "text",
+    value: `Synced ${urlsArray.length} URLs from Notion.`,
+  });
+}
+
+export async function deleteUrls({
+  urlsArray,
+  dataSourceId,
+  workspaceId,
+}: {
+  urlsArray: string[];
+  dataSourceId: string;
+  workspaceId: string;
+}): Promise<Result<PluginResponse, Error>> {
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  const res = await concurrentExecutor(
+    urlsArray,
+    async (url) => {
+      const checkUrlRes = await connectorsAPI.admin({
+        majorCommand: "notion",
+        command: "check-url",
+        args: {
+          wId: workspaceId,
+          dsId: dataSourceId,
+          url,
+        },
+      });
+
+      if (checkUrlRes.isErr()) {
+        return new Err(new Error(checkUrlRes.error.message));
+      }
+
+      const { page, db } = checkUrlRes.value as {
+        page: { [key: string]: unknown } | null;
+        db: { [key: string]: unknown } | null;
+      };
+
+      if ((page && !page.in_trash) || (db && !db.in_trash)) {
+        return new Err(
+          new Error(
+            `URL ${url} still available on Notion, should not be deleted.`
+          )
+        );
+      }
+
+      const deleteUrlRes = await connectorsAPI.admin({
+        majorCommand: "notion",
+        command: "delete-url",
+        args: {
+          wId: workspaceId,
+          dsId: dataSourceId,
+          url,
+        },
+      });
+
+      if (deleteUrlRes.isErr()) {
+        return new Err(
+          new Error(
+            `Could not delete url ${url}: ${deleteUrlRes.error.message}`
+          )
+        );
+      }
+
+      return new Ok(`Deleted url ${url}`);
+    },
+    { concurrency: 8 }
+  );
+
+  if (res.some((r) => r.isErr())) {
+    return new Err(
+      new Error(
+        res.map((r) => (r.isErr() ? r.error.message : r.value)).join("\n")
+      )
+    );
+  }
+
+  return new Ok({
+    display: "text",
+    value: `Deleted ${urlsArray.length} URLs from Notion.`,
+  });
+}

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -1,16 +1,16 @@
+import type { Result } from "@dust-tt/types";
 import {
   concurrentExecutor,
   ConnectorsAPI,
-  DataSourceType,
   Err,
   NotionFindUrlResponseSchema,
   Ok,
-  Result,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 
 import config from "@app/lib/api/config";
-import { createPlugin, PluginResponse } from "@app/lib/api/poke/types";
+import type { PluginResponse } from "@app/lib/api/poke/types";
+import { createPlugin } from "@app/lib/api/poke/types";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 
@@ -78,13 +78,13 @@ export const notionUrlSyncPlugin = createPlugin(
     }
 
     if (operation === "Sync urls") {
-      return await syncNotionUrls({
+      return syncNotionUrls({
         urlsArray,
         dataSourceId,
         workspaceId: auth.getNonNullableWorkspace().sId,
       });
     } else if (operation === "Delete urls") {
-      return await deleteUrls({
+      return deleteUrls({
         urlsArray,
         dataSourceId,
         workspaceId: auth.getNonNullableWorkspace().sId,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
@@ -1,0 +1,119 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { getFeatureFlags, type Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { apiError } from "@app/logger/withlogging";
+import * as z from "zod";
+import { fromError } from "zod-validation-error";
+import { syncNotionUrls } from "@app/lib/api/poke/plugins/data_sources/notion_url_sync";
+type PostNotionSyncResponseBody = { success: true } | { error: string };
+
+// zod type for payload
+const PostNotionSyncPayload = z.object({
+  urls: z.array(z.string()),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostNotionSyncResponseBody | void>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const { dsId } = req.query;
+  if (typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  // fetchById enforces through auth the authorization (workspace here mainly).
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
+  // endpoint protected by feature flag
+  if (
+    !dataSource ||
+    !(await getFeatureFlags(owner)).includes("advanced_notion_management")
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  if (!dataSource.connectorId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "data_source_not_managed",
+        message: "The data source you requested is not managed.",
+      },
+    });
+  }
+
+  if (!dataSource.canAdministrate(auth) || !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can sync Notion URLs.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation = PostNotionSyncPayload.safeParse(req.body);
+
+      if (bodyValidation.error) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: fromError(bodyValidation.error).toString(),
+          },
+        });
+      }
+
+      const { urls } = bodyValidation.data;
+
+      const result = await syncNotionUrls({
+        urlsArray: urls,
+        dataSourceId: dsId,
+        workspaceId: owner.sId,
+      });
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      res.status(200).json({ success: true });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
@@ -5,7 +5,7 @@ import { fromError } from "zod-validation-error";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { syncNotionUrls } from "@app/lib/api/poke/plugins/data_sources/notion_url_sync";
-import type {Authenticator} from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
@@ -1,13 +1,14 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getFeatureFlags, type Authenticator } from "@app/lib/auth";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { apiError } from "@app/logger/withlogging";
 import * as z from "zod";
 import { fromError } from "zod-validation-error";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { syncNotionUrls } from "@app/lib/api/poke/plugins/data_sources/notion_url_sync";
+import type {Authenticator} from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { apiError } from "@app/logger/withlogging";
 type PostNotionSyncResponseBody = { success: true } | { error: string };
 
 // zod type for payload

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -793,6 +793,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "bigquery_feature"
   | "tags_filters"
   | "salesforce_feature"
+  | "advanced_notion_management"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -21,6 +21,7 @@ export const WHITELISTABLE_FEATURES = [
   "bigquery_feature",
   "tags_filters",
   "salesforce_feature",
+  "advanced_notion_management",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2173

- provide interface in connection management of notion to sync urls
- create endpoint to do so
- refactors poke sync urls so it can be used by endpoint

![image](https://github.com/user-attachments/assets/4f475aac-f08a-4ab1-bf6d-53eec769fd21)

Risks
---
standard

Deploy
---
front
