### PR TITLE
Make dts id more visible in the API menu

### DIFF
--- a/front/components/ViewFolderAPIModal.tsx
+++ b/front/components/ViewFolderAPIModal.tsx
@@ -88,15 +88,24 @@ export function ViewFolderAPIModal({
         <SheetContainer>
           <div className="flex flex-col gap-6">
             <Page.P>
-              <ul className="text-gray-500">
-                <li>
-                  spaceId: <span className="font-bold">{space.sId}</span>{" "}
-                </li>
-                <li>
-                  dataSourceId:{" "}
-                  <span className="font-bold">{dataSource.sId}</span>
-                </li>
-              </ul>
+              <div className="rounded-lg bg-structure-50 p-4 shadow-sm">
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-element-700">Space ID:</span>
+                    <code className="font-mono rounded bg-white px-2 py-1 text-sm font-bold text-element-900 shadow-sm">
+                      {space.sId}
+                    </code>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-element-700">
+                      Data Source ID:
+                    </span>
+                    <code className="font-mono rounded bg-white px-2 py-1 text-sm font-bold text-element-900 shadow-sm">
+                      {dataSource.sId}
+                    </code>
+                  </div>
+                </div>
+              </div>
             </Page.P>
 
             <Page.Separator />
@@ -199,9 +208,7 @@ export function ViewFolderAPIModal({
                 For a detailed documentation of the Data source API, please
                 refer to the{" "}
                 <Link
-                  href={
-                    "https://docs.dust.tt/reference/get_api-v1-w-wid-vaults-vid-data-sources-dsid-documents-documentid"
-                  }
+                  href={"https://docs.dust.tt/reference/"}
                   className="py-1 font-bold text-action-600"
                 >
                   API Reference

--- a/front/components/app/ViewAppAPIModal.tsx
+++ b/front/components/app/ViewAppAPIModal.tsx
@@ -104,7 +104,7 @@ export function ViewAppAPIModal({
               ? "You need to run this app at least once successfully to view the endpoint"
               : "View how to run this app programmatically"
           }
-          label="API"
+          label="Use with API"
           variant="primary"
           disabled={disabled}
         />

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -269,6 +269,21 @@ export const getMenuItems = (
     }
   }
 
+  if (
+    dataSourceView.kind === "default" &&
+    dataSourceView.category === "folder"
+  ) {
+    actions.push({
+      kind: "item",
+      label: "Copy DataSource ID",
+      icon: PencilSquareIcon,
+      onClick: (e: ReactMouseEvent) => {
+        e.stopPropagation();
+        void navigator.clipboard.writeText(dataSourceView.dataSource.sId);
+      },
+    });
+  }
+
   return actions;
 };
 

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -315,7 +315,7 @@ export const SpaceResourcesList = ({
         });
         if (isFolder) {
           menuItems.push({
-            label: "API",
+            label: "Use from API",
             kind: "item",
             icon: CubeIcon,
             onClick: (e) => {


### PR DESCRIPTION
## Description

A bunch of users (and honestly myself too) are a bit lost when it comes to finding the dtsId to use a folder from the API (because in the URL it's the dtsviewId)

Making the menu a bit more visible with wording, and the ids a bit more visible with styling
<img width="445" alt="Screenshot 2025-02-14 at 12 12 37" src="https://github.com/user-attachments/assets/c38ebdad-97b5-4b56-8357-64a4c9bb62c4" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
