### PR TITLE
New Counter Component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.397",
+  "version": "0.2.398",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.397",
+      "version": "0.2.398",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.397",
+  "version": "0.2.398",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -3,6 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import {
+  Counter,
   Icon,
   LinkWrapper,
   LinkWrapperProps,
@@ -138,7 +139,6 @@ export interface MetaButtonProps
 const MetaButton = React.forwardRef<HTMLButtonElement, MetaButtonProps>(
   ({ className, asChild = false, children, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-
     return (
       <Comp className={className} ref={ref} {...props}>
         {children}
@@ -154,6 +154,8 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
     isLoading?: boolean;
     isPulsing?: boolean;
     tooltip?: string;
+    isCounter?: boolean;
+    counterValue?: string;
   };
 
 export type MiniButtonProps = CommonButtonProps & {
@@ -181,6 +183,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       tooltip,
       isSelect = false,
       isPulsing = false,
+      isCounter = false,
+      counterValue,
       size = "sm",
       href,
       target,
@@ -193,7 +197,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     ref
   ) => {
     const iconsSize = size === "mini" ? "sm" : size;
-
     const spinnerVariant = isLoading
       ? (variant && spinnerVariantsMapIsLoading[variant]) || "slate400"
       : (variant && spinnerVariantsMap[variant]) || "slate400";
@@ -201,7 +204,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const renderIcon = (visual: React.ComponentType, extraClass = "") => (
       <Icon visual={visual} size={iconsSize} className={extraClass} />
     );
-
     const content = (
       <>
         {isLoading ? (
@@ -211,7 +213,17 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ) : (
           icon && renderIcon(icon, "-s-mx-0.5")
         )}
-        {label}
+        <div className="s-flex s-items-center s-gap-2">
+          {label}
+          {isCounter && counterValue != null && (
+            <Counter
+              value={Number(counterValue)}
+              variant={variant || "primary"}
+              size={size === "mini" ? "xs" : size}
+              isInButton={true}
+            />
+          )}
+        </div>
         {isSelect && renderIcon(ChevronDownIcon, isLoading ? "" : "-s-mr-1")}
       </>
     );

--- a/sparkle/src/components/Counter.tsx
+++ b/sparkle/src/components/Counter.tsx
@@ -1,62 +1,118 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@sparkle/lib/utils";
 
-import type { ButtonVariantType } from "./Button";
-
 export const COUNTER_SIZES = ["xs", "sm", "md"] as const;
-type CounterSize = (typeof COUNTER_SIZES)[number];
 
-export interface CounterProps {
+const counterVariants = cva(
+  "s-inline-flex s-items-center s-justify-center s-rounded-full s-font-medium",
+  {
+    variants: {
+      size: {
+        xs: "s-h-5 s-min-w-[1.25rem] s-px-1 s-text-xs",
+        sm: "s-h-6 s-min-w-[1.5rem] s-px-1.5 s-text-sm",
+        md: "s-h-7 s-min-w-[1.75rem] s-px-2 s-text-base",
+      },
+      variant: {
+        primary: "",
+        highlight: "",
+        warning: "",
+        outline: "",
+        ghost: "",
+        "ghost-secondary": "",
+      },
+      isInButton: {
+        true: "",
+        false: "",
+      },
+    },
+    compoundVariants: [
+      {
+        isInButton: true,
+        variant: "primary",
+        className: "s-bg-primary-600/40 s-text-white",
+      },
+      {
+        isInButton: true,
+        variant: "highlight",
+        className: "s-bg-highlight-dark/50 s-text-white",
+      },
+      {
+        isInButton: true,
+        variant: "warning",
+        className: "s-bg-warning-dark/50 s-text-white",
+      },
+      {
+        isInButton: true,
+        variant: "outline",
+        className: "s-bg-slate-100 s-text-slate-900",
+      },
+      {
+        isInButton: true,
+        variant: ["ghost", "ghost-secondary"],
+        className: "s-text-primary-900 dark:s-text-primary-900-night",
+      },
+      {
+        isInButton: false,
+        variant: "primary",
+        className: "s-bg-primary-800 s-text-white",
+      },
+      {
+        isInButton: false,
+        variant: "highlight",
+        className: "s-bg-highlight s-text-white",
+      },
+      {
+        isInButton: false,
+        variant: "warning",
+        className: "s-bg-warning s-text-white",
+      },
+      {
+        isInButton: false,
+        variant: "outline",
+        className: "s-bg-slate-200 s-text-slate-900",
+      },
+      {
+        isInButton: false,
+        variant: ["ghost", "ghost-secondary"],
+        className: "s-text-primary-950 dark:s-text-primary-950-night",
+      },
+    ],
+    defaultVariants: {
+      size: "sm",
+      variant: "primary",
+      isInButton: false,
+    },
+  }
+);
+
+export interface CounterProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof counterVariants> {
   value: number;
-  className?: string;
-  size?: CounterSize;
-  variant?: ButtonVariantType;
-  isInButton?: boolean;
 }
-
-const sizeStyles: Record<CounterSize, string> = {
-  xs: "s-h-5 s-min-w-[1.25rem] s-px-1 s-text-xs",
-  sm: "s-h-6 s-min-w-[1.5rem] s-px-1.5 s-text-sm",
-  md: "s-h-7 s-min-w-[1.75rem] s-px-2 s-text-base",
-};
-
-const buttonVariantStyles: Record<ButtonVariantType, string> = {
-  primary: "s-bg-primary-600/40 s-text-white",
-  highlight: "s-bg-highlight-dark/50 s-text-white",
-  warning: "s-bg-warning-dark/50 s-text-white",
-  outline: "s-bg-slate-100 s-text-slate-900",
-  ghost: "s-text-primary-900 dark:s-text-primary-900-night",
-  "ghost-secondary": "s-text-primary-900 dark:s-text-primary-900-night",
-};
-
-const standaloneVariantStyles: Record<ButtonVariantType, string> = {
-  primary: "s-bg-primary-800 s-text-white",
-  highlight: "s-bg-highlight s-text-white",
-  warning: "s-bg-warning s-text-white",
-  outline: "s-bg-slate-200 s-text-slate-900",
-  ghost: "s-text-primary-950 dark:s-text-primary-950-night",
-  "ghost-secondary": "s-text-primary-950 dark:s-text-primary-950-night",
-};
 
 export const Counter = React.forwardRef<HTMLDivElement, CounterProps>(
   (
-    { value, className, size = "sm", variant = "primary", isInButton = false },
+    {
+      value,
+      className,
+      size = "sm",
+      variant = "primary",
+      isInButton = false,
+      ...props
+    },
     ref
   ) => {
-    const variantStyle = isInButton
-      ? buttonVariantStyles[variant]
-      : standaloneVariantStyles[variant];
-
     return (
       <div
         ref={ref}
         className={cn(
-          "s-inline-flex s-items-center s-justify-center s-rounded-full s-font-medium",
-          sizeStyles[size],
-          variantStyle,
+          counterVariants({ size, variant, isInButton }),
           className
         )}
+        {...props}
       >
         {value}
       </div>

--- a/sparkle/src/components/Counter.tsx
+++ b/sparkle/src/components/Counter.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+
+import { cn } from "@sparkle/lib/utils";
+
+import type { ButtonVariantType } from "./Button";
+
+export const COUNTER_SIZES = ["xs", "sm", "md"] as const;
+type CounterSize = (typeof COUNTER_SIZES)[number];
+
+export interface CounterProps {
+  value: number;
+  className?: string;
+  size?: CounterSize;
+  variant?: ButtonVariantType;
+  isInButton?: boolean;
+}
+
+const sizeStyles: Record<CounterSize, string> = {
+  xs: "s-h-5 s-min-w-[1.25rem] s-px-1 s-text-xs",
+  sm: "s-h-6 s-min-w-[1.5rem] s-px-1.5 s-text-sm",
+  md: "s-h-7 s-min-w-[1.75rem] s-px-2 s-text-base",
+};
+
+const buttonVariantStyles: Record<ButtonVariantType, string> = {
+  primary: "s-bg-primary-600/40 s-text-white",
+  highlight: "s-bg-highlight-dark/50 s-text-white",
+  warning: "s-bg-warning-dark/50 s-text-white",
+  outline: "s-bg-slate-100 s-text-slate-900",
+  ghost: "s-text-primary-900 dark:s-text-primary-900-night",
+  "ghost-secondary": "s-text-primary-900 dark:s-text-primary-900-night",
+};
+
+const standaloneVariantStyles: Record<ButtonVariantType, string> = {
+  primary: "s-bg-primary-800 s-text-white",
+  highlight: "s-bg-highlight s-text-white",
+  warning: "s-bg-warning s-text-white",
+  outline: "s-bg-slate-200 s-text-slate-900",
+  ghost: "s-text-primary-950 dark:s-text-primary-950-night",
+  "ghost-secondary": "s-text-primary-950 dark:s-text-primary-950-night",
+};
+
+export const Counter = React.forwardRef<HTMLDivElement, CounterProps>(
+  (
+    { value, className, size = "sm", variant = "primary", isInButton = false },
+    ref
+  ) => {
+    const variantStyle = isInButton
+      ? buttonVariantStyles[variant]
+      : standaloneVariantStyles[variant];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "s-inline-flex s-items-center s-justify-center s-rounded-full s-font-medium",
+          sizeStyles[size],
+          variantStyle,
+          className
+        )}
+      >
+        {value}
+      </div>
+    );
+  }
+);
+
+Counter.displayName = "Counter";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -37,6 +37,7 @@ export {
   ConversationMessageContent,
   ConversationMessageHeader,
 } from "./ConversationMessage";
+export { Counter } from "./Counter";
 export type { DataTableMoreButtonProps, MenuItem } from "./DataTable";
 export { DataTable } from "./DataTable";
 export {

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -1,3 +1,4 @@
+// Button.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
@@ -55,21 +56,24 @@ const meta = {
       description: "Whether the button should display a dropdown chevron",
       control: "boolean",
     },
+    isCounter: {
+      description: "Whether the button should display a counter",
+      control: "boolean",
+    },
+    counterValue: {
+      description: "Value to display in the counter (if isCounter is true)",
+      control: "text",
+      if: { arg: "isCounter", eq: true },
+    },
     tooltip: {
       description: "Optional tooltip text to display on hover",
       control: "text",
     },
   },
-  render: (args) => {
-    if (args.size === "mini" && !args.icon) {
-      args.icon = ICONS.PlusIcon;
-    }
-    return <Button {...args} />;
-  },
 } satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Button>;
 
 export const ExampleButton: Story = {
   args: {
@@ -80,8 +84,61 @@ export const ExampleButton: Story = {
     isPulsing: false,
     isSelect: false,
     disabled: false,
+    isCounter: false,
+    counterValue: "4",
   },
 };
+
+export const WithCounter: Story = {
+  args: {
+    variant: "primary",
+    label: "Notifications",
+    size: "sm",
+    isCounter: true,
+    counterValue: "4",
+  },
+};
+
+export const WithLargeCounter: Story = {
+  args: {
+    variant: "primary",
+    label: "Messages",
+    size: "sm",
+    isCounter: true,
+    counterValue: "150", // Will display as "99+"
+  },
+};
+
+export const CounterVariants = () => (
+  <div className="s-flex s-flex-col s-gap-4">
+    <div className="s-flex s-gap-4">
+      <Button variant="primary" label="Primary" isCounter counterValue="4" />
+      <Button
+        variant="highlight"
+        label="Highlight"
+        isCounter
+        counterValue="4"
+      />
+      <Button variant="warning" label="Warning" isCounter counterValue="4" />
+      <Button variant="outline" label="Outline" isCounter counterValue="4" />
+      <Button variant="ghost" label="Ghost" isCounter counterValue="4" />
+      <Button
+        variant="ghost-secondary"
+        label="Ghost Secondary"
+        isCounter
+        counterValue="4"
+      />
+    </div>
+  </div>
+);
+
+export const CounterSizes = () => (
+  <div className="s-flex s-gap-4">
+    <Button size="xs" label="Extra Small" isCounter counterValue="4" />
+    <Button size="sm" label="Small" isCounter counterValue="4" />
+    <Button size="md" label="Medium" isCounter counterValue="4" />
+  </div>
+);
 
 export const MiniButton: Story = {
   render: () => <Button size="mini" icon={PlusIcon} />,
@@ -90,7 +147,6 @@ export const MiniButton: Story = {
 const ButtonBySize = ({
   size,
 }: {
-  // Exclude 'mini' from the possible sizes since it requires special handling
   size: Exclude<React.ComponentProps<typeof Button>["size"], "mini">;
 }) => (
   <>

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -70,10 +70,16 @@ const meta = {
       control: "text",
     },
   },
+  render: (args) => {
+    if (args.size === "mini" && !args.icon) {
+      args.icon = ICONS.PlusIcon;
+    }
+    return <Button {...args} />;
+  },
 } satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof Button>;
+type Story = StoryObj<typeof meta>;
 
 export const ExampleButton: Story = {
   args: {
@@ -88,57 +94,6 @@ export const ExampleButton: Story = {
     counterValue: "4",
   },
 };
-
-export const WithCounter: Story = {
-  args: {
-    variant: "primary",
-    label: "Notifications",
-    size: "sm",
-    isCounter: true,
-    counterValue: "4",
-  },
-};
-
-export const WithLargeCounter: Story = {
-  args: {
-    variant: "primary",
-    label: "Messages",
-    size: "sm",
-    isCounter: true,
-    counterValue: "150", // Will display as "99+"
-  },
-};
-
-export const CounterVariants = () => (
-  <div className="s-flex s-flex-col s-gap-4">
-    <div className="s-flex s-gap-4">
-      <Button variant="primary" label="Primary" isCounter counterValue="4" />
-      <Button
-        variant="highlight"
-        label="Highlight"
-        isCounter
-        counterValue="4"
-      />
-      <Button variant="warning" label="Warning" isCounter counterValue="4" />
-      <Button variant="outline" label="Outline" isCounter counterValue="4" />
-      <Button variant="ghost" label="Ghost" isCounter counterValue="4" />
-      <Button
-        variant="ghost-secondary"
-        label="Ghost Secondary"
-        isCounter
-        counterValue="4"
-      />
-    </div>
-  </div>
-);
-
-export const CounterSizes = () => (
-  <div className="s-flex s-gap-4">
-    <Button size="xs" label="Extra Small" isCounter counterValue="4" />
-    <Button size="sm" label="Small" isCounter counterValue="4" />
-    <Button size="md" label="Medium" isCounter counterValue="4" />
-  </div>
-);
 
 export const MiniButton: Story = {
   render: () => <Button size="mini" icon={PlusIcon} />,

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -1,4 +1,3 @@
-// Button.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
@@ -91,7 +90,7 @@ export const ExampleButton: Story = {
     isSelect: false,
     disabled: false,
     isCounter: false,
-    counterValue: "4",
+    counterValue: "1",
   },
 };
 

--- a/sparkle/src/stories/Counter.stories.tsx
+++ b/sparkle/src/stories/Counter.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta } from "@storybook/react";
+
+import { Counter } from "../components/Counter";
+
+const meta = {
+  title: "Primitives/Counter",
+  component: Counter,
+  args: {
+    value: 4,
+    size: "sm",
+    variant: "primary",
+    isInButton: false,
+  },
+  argTypes: {
+    value: {
+      control: { type: "number" },
+    },
+    size: {
+      control: { type: "select" },
+      options: ["xs", "sm", "md"],
+    },
+    variant: {
+      control: { type: "select" },
+      options: ["primary", "highlight", "warning", "outline", "ghost"],
+    },
+    isInButton: {
+      control: "boolean",
+      description: "Whether the counter is displayed inside a button",
+    },
+  },
+} satisfies Meta<typeof Counter>;
+
+export default meta;
+
+export const Default = {
+  args: {
+    value: 4,
+    variant: "primary",
+    isInButton: false,
+  },
+};


### PR DESCRIPTION
## Description
Following this PR https://github.com/dust-tt/dust/pull/10758, we decided to create a new component called 'Counter' that displays a number inside and can be integrated into other components. Eventually, it will replace the citation mark in the citation component. It can already be integrated into buttons for label as filter needs as well as for future needs (filtering lists, etc...)
<img width="855" alt="image" src="https://github.com/user-attachments/assets/fe1043e3-aeb3-4998-a97a-a653d7d6038f" />
<img width="878" alt="image" src="https://github.com/user-attachments/assets/cfa6000e-0536-4977-8b45-0e5ee760cc1d" />


## Tests
Front-edge

## Risk
Low - UI 

## Deploy Plan
Publish Sparkle Alpha 
Front-Edge
Publish Sparkle
Update Sparkle in Front