### PR TITLE
[front] Fix datasource selection modal state

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -14,7 +14,7 @@ import type {
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { SetStateAction } from "react";
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
@@ -50,6 +50,12 @@ export default function AssistantBuilderDataSourceModal({
     useState<DataSourceViewSelectionConfigurations>(
       initialDataSourceConfigurations
     );
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectionConfigurations(initialDataSourceConfigurations);
+    }
+  }, [isOpen, initialDataSourceConfigurations]);
 
   useNavigationLock(true, {
     title: "Warning",

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -94,7 +94,6 @@ export default function AssistantBuilderDataSourceModal({
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
-          setSelectionConfigurations(initialDataSourceConfigurations);
           setOpen(false);
         }
       }}


### PR DESCRIPTION
## Description

When opening / changing / saving / reopening the data source selection modal in process or retrieval actions, it stays on the initial state (so not the one that was saved). It's due to the fact we reset to the initial when we close, whatever you saved or cancelled. It's safer to reset to the correct state  with an effect when opening the modal.

## Tests

locally

## Risk

none

## Deploy Plan

deploy front
