### PR TITLE
chore(core) - Suppress warning during compilation

### DIFF
--- a/core/src/dataset.rs
+++ b/core/src/dataset.rs
@@ -46,7 +46,7 @@ impl Dataset {
                 hasher.update(serde_json::to_string(&d)?.as_bytes());
                 Ok(())
             })
-            .collect::<Result<_>>()?;
+            .collect::<Result<()>>()?;
 
         let recomputed_hash = format!("{}", hasher.finalize().to_hex());
         assert!(recomputed_hash == hash);


### PR DESCRIPTION
## Description

- This PR suppresses the following warning, occurring during compilation:
```
warning: this function depends on never type fallback being `()`
  --> src/dataset.rs:22:5
   |
22 | /     pub fn new_from_store(
23 | |         created: u64,
24 | |         dataset_id: &str,
25 | |         hash: &str,
26 | |         data: Vec<Value>,
27 | |     ) -> Result<Self> {
   | |_____________________^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
   = help: specify the types explicitly
```
- It does so by changing the generic type in the collect call from `Result<_>` to `Result<()>`.

## Tests

## Risk

- N/A

## Deploy Plan

- Deploy core.