### PR TITLE
Add isDefaultWorkspaceConfiguration to transcripts and backfill script

### DIFF
--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -83,9 +83,11 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
   static async findByWorkspaceAndProvider({
     auth,
     provider,
+    isDefaultWorkspaceConfiguration,
   }: {
     auth: Authenticator;
     provider: LabsTranscriptsProviderType;
+    isDefaultWorkspaceConfiguration?: boolean;
   }): Promise<LabsTranscriptsConfigurationResource | null> {
     const owner = auth.workspace();
 
@@ -97,6 +99,9 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       where: {
         workspaceId: owner.id,
         provider,
+        ...(isDefaultWorkspaceConfiguration
+          ? { isDefaultWorkspaceConfiguration: true }
+          : {}),
       },
     });
 

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -16,6 +16,8 @@ export class LabsTranscriptsConfigurationModel extends WorkspaceAwareModel<LabsT
   declare provider: LabsTranscriptsProviderType;
   declare agentConfigurationId: ForeignKey<AgentConfiguration["sId"]> | null;
   declare isActive: boolean;
+
+  declare isDefaultWorkspaceConfiguration: boolean; // For default provider
   declare isDefaultFullStorage: boolean;
 
   declare userId: ForeignKey<UserModel["id"]>;
@@ -48,6 +50,11 @@ LabsTranscriptsConfigurationModel.init(
       allowNull: true,
     },
     isActive: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    isDefaultWorkspaceConfiguration: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,

--- a/front/migrations/20250214_backfill_gong_modjo_default_configurations.ts
+++ b/front/migrations/20250214_backfill_gong_modjo_default_configurations.ts
@@ -1,0 +1,71 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import { Op } from "sequelize";
+
+import { LabsTranscriptsConfigurationModel } from "@app/lib/resources/storage/models/labs_transcripts";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+async function backfillDefaultTranscriptsConfigurations(
+  workspace: LightWorkspaceType,
+  {
+    execute,
+    logger,
+  }: {
+    execute: boolean;
+    logger: Logger;
+  }
+) {
+  logger.info(
+    { workspaceId: workspace.sId, execute },
+    "Starting labs transcripts configurations backfill"
+  );
+  // Get all agent with legacy avatars
+  const labsTranscriptsConfigurations =
+    await LabsTranscriptsConfigurationModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        provider: {
+          [Op.or]: ["gong", "modjo"],
+        },
+      },
+      order: [["id", "ASC"]],
+    });
+
+  for (const transcriptsConfiguration of labsTranscriptsConfigurations) {
+    logger.info(
+      {
+        transcriptsConfiguration,
+      },
+      "Processing transcripts configuration"
+    );
+
+    if (
+      transcriptsConfiguration.connectionId ||
+      transcriptsConfiguration.credentialId
+    ) {
+      await transcriptsConfiguration.update({
+        isDefaultWorkspaceConfiguration: true,
+      });
+      logger.info(
+        {
+          transcriptsConfiguration,
+          workspaceId: workspace.sId,
+        },
+        "Updated transcripts default configuration for workspace"
+      );
+      return;
+    }
+  }
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(
+    async (workspace) =>
+      backfillDefaultTranscriptsConfigurations(workspace, {
+        execute,
+        logger,
+      }),
+    { concurrency: 10 }
+  );
+});

--- a/front/migrations/db/migration_170.sql
+++ b/front/migrations/db/migration_170.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."labs_transcripts_configurations" ADD COLUMN "isDefaultWorkspaceConfiguration" BOOLEAN NOT NULL DEFAULT false;

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -1,4 +1,5 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { isProviderWithWorkspaceConfiguration } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -10,8 +11,6 @@ import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_tr
 import { apiError } from "@app/logger/withlogging";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
 import { acceptableTranscriptProvidersCodec } from "@app/pages/api/w/[wId]/labs/transcripts";
-
-const PROVIDERS_WITH_WORKSPACE_CONFIGURATIONS = ["gong", "modjo"];
 
 export const GetDefaultTranscriptsConfigurationBodySchema = t.type({
   provider: acceptableTranscriptProvidersCodec,
@@ -68,11 +67,7 @@ async function handler(
       }
 
       // Whitelist providers that allow workspace-wide configuration.
-      if (
-        !PROVIDERS_WITH_WORKSPACE_CONFIGURATIONS.includes(
-          transcriptsConfiguration.provider
-        )
-      ) {
+      if (!isProviderWithWorkspaceConfiguration(provider)) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -58,6 +58,7 @@ async function handler(
         await LabsTranscriptsConfigurationResource.findByWorkspaceAndProvider({
           auth,
           provider,
+          isDefaultWorkspaceConfiguration: true,
         });
 
       if (!transcriptsConfiguration) {

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -169,6 +169,23 @@ async function handler(
         }
       }
 
+      let isDefaultWorkspaceConfiguration = false;
+
+      if (isCredentialProvider(provider)) {
+        const currentDefaultConfiguration =
+          await LabsTranscriptsConfigurationResource.findByWorkspaceAndProvider(
+            {
+              auth,
+              provider,
+              isDefaultWorkspaceConfiguration: true,
+            }
+          );
+
+        isDefaultWorkspaceConfiguration =
+          currentDefaultConfiguration === null ||
+          currentDefaultConfiguration === undefined;
+      }
+
       const transcriptsConfigurationPostResource =
         await LabsTranscriptsConfigurationResource.makeNew({
           userId: user.id,
@@ -176,6 +193,7 @@ async function handler(
           provider,
           connectionId: connectionId ?? null,
           credentialId: credentialId ?? null,
+          isDefaultWorkspaceConfiguration,
         });
 
       return res

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -1,5 +1,9 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
-import { isCredentialProvider, OAuthAPI } from "@dust-tt/types";
+import {
+  isCredentialProvider,
+  isProviderWithWorkspaceConfiguration,
+  OAuthAPI,
+} from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -171,7 +175,7 @@ async function handler(
 
       let isDefaultWorkspaceConfiguration = false;
 
-      if (isCredentialProvider(provider)) {
+      if (isProviderWithWorkspaceConfiguration(provider)) {
         const currentDefaultConfiguration =
           await LabsTranscriptsConfigurationResource.findByWorkspaceAndProvider(
             {

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -61,6 +61,14 @@ export function isValidZendeskSubdomain(s: unknown): s is string {
 
 // Credentials Providers
 
+export const PROVIDERS_WITH_WORKSPACE_CONFIGURATIONS = [
+  "gong",
+  "modjo",
+] as const;
+
+export type ProvidersWithWorkspaceConfigurations =
+  (typeof PROVIDERS_WITH_WORKSPACE_CONFIGURATIONS)[number];
+
 export const CREDENTIALS_PROVIDERS = [
   "snowflake",
   "modjo",
@@ -70,6 +78,14 @@ export type CredentialsProvider = (typeof CREDENTIALS_PROVIDERS)[number];
 
 export function isCredentialProvider(obj: unknown): obj is CredentialsProvider {
   return CREDENTIALS_PROVIDERS.includes(obj as CredentialsProvider);
+}
+
+export function isProviderWithWorkspaceConfiguration(
+  obj: unknown
+): obj is ProvidersWithWorkspaceConfigurations {
+  return PROVIDERS_WITH_WORKSPACE_CONFIGURATIONS.includes(
+    obj as ProvidersWithWorkspaceConfigurations
+  );
 }
 
 // Credentials


### PR DESCRIPTION
## Description

- Add isDefaultWorkspaceConfiguration to LabsTranscriptConfiguration
- This is for providers that use a default config
- Allows people to change their default config (api key or else) because for now they cant as it falls back to the config of the next user
- The goal of this is for the person that setup the original global transcripts config (gong, modjo) for the workspace to disconnect and reconnect with new creds

Backfill script to consider all "first" modjo/gong connection of each workspace as the default one.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run migration 170
Then run 20250214_backfill_gong_modjo_default_configurations.ts
