### PR TITLE
Core: add support for parsing and validating CSV from upsert queue bucket

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1318,7 +1318,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "slug",
  "snowflake-connector-rs",
  "sqids",
  "tera",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1008,6 +1008,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37fe5b0d07f4a8260ce1e9a81413e88f459af0f2dfc55c15e96868a2f99c0f0"
+dependencies = [
+ "cfg-if",
+ "csv-core",
+ "futures",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "csv-core"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1288,7 @@ dependencies = [
  "clap",
  "cloud-storage",
  "csv",
+ "csv-async",
  "deno_core",
  "dns-lookup",
  "elasticsearch",
@@ -1303,6 +1318,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "slug",
  "snowflake-connector-rs",
  "sqids",
  "tera",
@@ -1311,10 +1327,12 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-stream",
+ "tokio-util",
  "tower-http",
  "tracing",
  "tracing-bunyan-formatter",
  "tracing-subscriber",
+ "unicode-normalization",
  "url",
  "urlencoding",
  "uuid",
@@ -4769,6 +4787,7 @@ checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -89,6 +89,7 @@ blake3 = "1.3"
 async-trait = "0.1"
 tokio = { version = "1.38", features = ["full"] }
 tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["compat"] }
 hyper = { version = "1.3.1", features = ["full"] }
 itertools = "0.10"
 futures = "0.3"
@@ -135,7 +136,9 @@ rslock = { version = "0.4.0", default-features = false, features = ["tokio-comp"
 snowflake-connector-rs = { git = "https://github.com/dust-tt/snowflake-connector-rs", rev = "5a16356" }
 gcp-bigquery-client = "0.25.1"
 axum-test = "16.0.0"
+csv-async = "1.3.0"
 csv = "1.3.0"
 tikv-jemallocator = "0.6"
 elasticsearch = "8.15.0-alpha.1"
 elasticsearch-dsl = "0.4"
+unicode-normalization = "0.1.24"

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2206,15 +2206,13 @@ async fn data_sources_delete(
 
 #[derive(serde::Deserialize)]
 struct DatabasesTablesValidateCSVContentPayload {
-    file_id: String,
+    upsert_queue_bucket_path: String,
 }
 
 async fn tables_validate_csv_content(
-    Path((project_id, data_source_id)): Path<(i64, String)>,
-    State(state): State<Arc<APIState>>,
     Json(payload): Json<DatabasesTablesValidateCSVContentPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    match LocalTable::validate_csv_content(&payload.file_id).await {
+    match LocalTable::validate_csv_content(&payload.upsert_queue_bucket_path).await {
         Ok(schema) => (
             StatusCode::OK,
             Json(APIResponse {

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -1,0 +1,323 @@
+use anyhow::{anyhow, Result};
+use cloud_storage::Object;
+use csv_async::AsyncReaderBuilder;
+use futures::stream::StreamExt;
+use lazy_static::lazy_static;
+use tokio::io::AsyncReadExt;
+
+use regex::Regex;
+use tokio_util::compat::TokioAsyncReadCompatExt;
+use unicode_normalization::UnicodeNormalization;
+
+use crate::databases::table::Row;
+
+pub struct UpsertQueueCSVContent {
+    pub upsert_queue_bucket_path: String,
+}
+
+const MAX_TABLE_COLUMNS: usize = 512;
+const MAX_COLUMN_NAME_LENGTH: usize = 1024;
+
+impl UpsertQueueCSVContent {
+    async fn get_upsert_queue_bucket() -> Result<String> {
+        match std::env::var("DUST_UPSERT_QUEUE_BUCKET") {
+            Ok(bucket) => Ok(bucket),
+            Err(_) => Err(anyhow!("DUST_UPSERT_QUEUE_BUCKET is not set")),
+        }
+    }
+
+    pub async fn parse(&self) -> Result<Vec<Row>> {
+        let bucket = Self::get_upsert_queue_bucket().await?;
+        let path = &self.upsert_queue_bucket_path;
+
+        // This is not the most efficient as we download the entire file here but we will
+        // materialize it in memory as Vec<Row> anyway so that's not a massive difference.
+        let content = Object::download(&bucket, path).await?;
+        let rdr = std::io::Cursor::new(content);
+
+        let (delimiter, rdr) = Self::find_delimiter(rdr).await?;
+        Self::csv_to_rows(rdr, delimiter).await
+    }
+
+    fn slugify(text: &str) -> String {
+        lazy_static! {
+            static ref DIACRITICS: Regex = Regex::new(r"[\u{0300}-\u{036f}]").unwrap();
+        }
+
+        let s = text
+            .nfkd() // Normalize to decomposed form
+            .collect::<String>();
+        let s = DIACRITICS.replace_all(&s, "").to_string();
+
+        // Insert _ between lowercase and uppercase/number
+        let mut with_separators = String::new();
+        let chars: Vec<char> = s.chars().collect();
+        for (i, &c) in chars.iter().enumerate() {
+            if i > 0 && c.is_uppercase() || c.is_ascii_digit() {
+                if chars[i - 1].is_lowercase() {
+                    with_separators.push('_');
+                }
+            }
+            with_separators.push(c);
+        }
+
+        with_separators
+            .to_lowercase()
+            .trim()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join("_") // Replace spaces with _
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '_' }) // Replace non-word chars
+            .collect::<String>()
+            .replace("__", "_") // Replace multiple _ with single _
+    }
+
+    pub fn sanitize_headers(headers: Vec<&str>) -> Result<Vec<String>> {
+        let mut acc = Vec::new();
+
+        for curr in headers {
+            // Special case for __dust_id which is a reserved header
+            let slug = if curr == "__dust_id" {
+                curr.to_string()
+            } else {
+                let s = Self::slugify(curr);
+                if s.is_empty() {
+                    format!("col_{}", acc.len())
+                } else {
+                    s
+                }
+            };
+
+            if slug.len() > MAX_COLUMN_NAME_LENGTH {
+                return Err(anyhow!("Column name exceeds maximum length"));
+            }
+
+            if !acc.contains(&slug) {
+                acc.push(slug);
+                continue;
+            }
+
+            // Handle conflicts by appending incrementing numbers
+            let mut conflict_resolved = false;
+            for i in 2..64 {
+                let candidate = Self::slugify(&format!("{}-{}", slug, i));
+                if !acc.contains(&candidate) {
+                    acc.push(candidate);
+                    conflict_resolved = true;
+                    break;
+                }
+            }
+
+            if !conflict_resolved {
+                return Err(anyhow!(
+                    "Failed to generate unique slugified name \
+                      for header '{}' after multiple attempts",
+                    curr
+                ));
+            }
+        }
+
+        Ok(acc)
+    }
+
+    async fn find_delimiter<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
+        mut rdr: R,
+    ) -> Result<(u8, Box<dyn tokio::io::AsyncRead + Unpin + Send>)> {
+        let mut buffer = vec![0; 16 * 1024];
+        let n = rdr.read(&mut buffer).await?;
+        buffer.truncate(n);
+
+        let candidates = b",;\t|";
+
+        let mut counts = vec![0; candidates.len()];
+        let mut in_quotes = false;
+
+        for &c in &buffer {
+            match c {
+                b'"' => in_quotes = !in_quotes,
+                _ if !in_quotes => {
+                    for (i, &candidate) in candidates.iter().enumerate() {
+                        if c == candidate {
+                            counts[i] += 1;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let (i, _) = counts
+            .iter()
+            .enumerate()
+            .max_by_key(|&(_, count)| count)
+            .ok_or_else(|| anyhow!("No delimiter found"))?;
+
+        Ok((
+            candidates[i],
+            Box::new(tokio::io::AsyncReadExt::chain(
+                std::io::Cursor::new(buffer),
+                rdr,
+            )),
+        ))
+    }
+
+    async fn csv_to_rows<R>(rdr: R, delimiter: u8) -> Result<Vec<Row>>
+    where
+        R: tokio::io::AsyncRead + Unpin + Send,
+    {
+        let mut csv = AsyncReaderBuilder::new()
+            .delimiter(delimiter)
+            .create_reader(TokioAsyncReadCompatExt::compat(rdr));
+
+        let headers = UpsertQueueCSVContent::sanitize_headers(
+            csv.headers().await?.iter().collect::<Vec<&str>>(),
+        )?;
+
+        if headers.len() > MAX_TABLE_COLUMNS {
+            Err(anyhow!("Too many columns in CSV file"))?;
+        }
+        if headers.len() == 0 {
+            Err(anyhow!("No columns in CSV file"))?;
+        }
+
+        let mut rows = Vec::new();
+
+        let mut records = csv.records();
+        let mut row_idx = 0;
+        while let Some(record) = records.next().await {
+            let record = record?;
+            let row = Row::from_csv_record(&headers, record.iter().collect::<Vec<_>>(), row_idx)?;
+            row_idx += 1;
+            rows.push(row);
+        }
+
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_find_delimiter() -> anyhow::Result<()> {
+        let csv = "a,b,c\n1,2,3\n4,5,6";
+        let (delimiter, _) =
+            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        assert_eq!(delimiter, b',');
+
+        let csv = "a;b;c\n1;2;3\n4;5;6";
+        let (delimiter, mut rdr) =
+            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        assert_eq!(delimiter, b';');
+
+        // read content of rdr to a string
+        let mut content = String::new();
+        rdr.read_to_string(&mut content).await?;
+        assert_eq!(content, csv);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sanitize_headers() -> anyhow::Result<()> {
+        let headers = vec![
+            "helloWorld",
+            "b,.,2Fkls",
+            "Æúű--cool?",
+            "a",
+            "___",
+            "__dust_id",
+            "a",
+            "",
+            "a",
+        ];
+        let sanitized = UpsertQueueCSVContent::sanitize_headers(headers)?;
+        assert_eq!(
+            sanitized,
+            vec![
+                "hello_world",
+                "b__2fkls",
+                "æuu_cool_",
+                "a",
+                "__",
+                "__dust_id",
+                "a_2",
+                "col_7",
+                "a_3"
+            ]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_csv_to_rows() -> anyhow::Result<()> {
+        let csv = "hellWorld,super-fast,c/foo,DATE\n\
+                   1,2.23,3,2025-02-14T15:06:52.380Z\n\
+                   4,hello world,6,\"Fri, 14 Feb 2025 15:10:34 GMT\"";
+        let (delimiter, rdr) =
+            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?;
+
+        assert_eq!(rows.len(), 2);
+
+        // Test first row
+        assert_eq!(rows[0].row_id, "0");
+        let value = rows[0].value.as_object().unwrap();
+        assert_eq!(value["hell_world"], 1.0);
+        assert_eq!(value["super_fast"], 2.23);
+        assert_eq!(value["c_foo"], 3.0);
+        let date = value["date"].as_object().unwrap();
+        assert_eq!(date["type"], "datetime");
+        assert_eq!(date["epoch"], 1739545612380i64);
+        assert_eq!(date["string_value"], "2025-02-14T15:06:52.380Z");
+
+        // Test second row
+        assert_eq!(rows[1].row_id, "1");
+        let value = rows[1].value.as_object().unwrap();
+        assert_eq!(value["hell_world"], 4.0);
+        assert_eq!(value["super_fast"], "hello world");
+        assert_eq!(value["c_foo"], 6.0);
+        let date = value["date"].as_object().unwrap();
+        assert_eq!(date["type"], "datetime");
+        assert_eq!(date["epoch"], 1739545834000i64);
+        assert_eq!(date["string_value"], "Fri, 14 Feb 2025 15:10:34 GMT");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_csv_errors() -> anyhow::Result<()> {
+        // Test empty CSV
+        let csv = "";
+        let (delimiter, rdr) =
+            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        assert!(UpsertQueueCSVContent::csv_to_rows(rdr, delimiter)
+            .await
+            .is_err());
+
+        // Test CSV with only headers
+        let csv = "header1,header2";
+        let (delimiter, rdr) =
+            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?;
+        assert_eq!(rows.len(), 0);
+
+        // Test CSV with too many columns (if MAX_TABLE_COLUMNS is defined)
+        let mut csv = String::new();
+        for i in 0..1000 {
+            if i > 0 {
+                csv.push(',');
+            }
+            csv.push_str(&format!("header{}", i));
+        }
+        let (delimiter, rdr) =
+            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        assert!(UpsertQueueCSVContent::csv_to_rows(rdr, delimiter)
+            .await
+            .is_err());
+
+        Ok(())
+    }
+}

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -284,6 +284,17 @@ mod tests {
         assert_eq!(date["epoch"], 1739545834000i64);
         assert_eq!(date["string_value"], "Fri, 14 Feb 2025 15:10:34 GMT");
 
+        let csv = "__dust_id,super-fast,c/foo,DATE\n\
+                   MYID1,2.23,3,2025-02-14T15:06:52.380Z\n\
+                   MYID2,hello world,6,\"Fri, 14 Feb 2025 15:10:34 GMT\"";
+        let (delimiter, rdr) =
+            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?;
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].row_id, "MYID1");
+        assert_eq!(rows[1].row_id, "MYID2");
+
         Ok(())
     }
 

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -9,7 +9,7 @@ use tracing::info;
 
 use crate::{
     data_sources::node::{Node, NodeType, ProviderVisibility},
-    databases::{database::HasValue, table_schema::TableSchema},
+    databases::{csv::UpsertQueueCSVContent, database::HasValue, table_schema::TableSchema},
     databases_store::store::DatabasesStore,
     project::Project,
     search_filter::{Filterable, SearchFilter},
@@ -587,19 +587,16 @@ impl LocalTable {
     }
 
     pub async fn validate_csv_content(upsert_queue_bucket_path: &str) -> Result<TableSchema> {
-        // let bucket = LocalTable::get_upsert_queue_bucket().await?;
-        // let stream = Object::download_streamed(&bucket, upsert_queue_bucket_path).await?;
-        // let reader = csv_async::AsyncReaderBuilder::new()
-        //     .has_headers(true)
-        //     .create_reader(stream);
-        unimplemented!("validate_csv_content")
-        // let file = File::from_id(file_id).await?;
-        // let content = file.get_content().await?;
-        // let rows = csv::Reader::from_reader(content.as_bytes())
-        //     .deserialize()
-        //     .collect::<Result<Vec<Row>, _>>()?;
-        // let schema = TableSchema::from_rows_async(rows.clone()).await?;
-        // Ok((rows, schema))
+        let rows = Arc::new(
+            UpsertQueueCSVContent {
+                upsert_queue_bucket_path: upsert_queue_bucket_path.to_string(),
+            }
+            .parse()
+            .await?,
+        );
+
+        let schema = TableSchema::from_rows_async(rows).await?;
+        Ok(schema)
     }
 }
 

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -584,6 +585,22 @@ impl LocalTable {
 
         Ok(schema)
     }
+
+    pub async fn validate_csv_content(upsert_queue_bucket_path: &str) -> Result<TableSchema> {
+        // let bucket = LocalTable::get_upsert_queue_bucket().await?;
+        // let stream = Object::download_streamed(&bucket, upsert_queue_bucket_path).await?;
+        // let reader = csv_async::AsyncReaderBuilder::new()
+        //     .has_headers(true)
+        //     .create_reader(stream);
+        unimplemented!("validate_csv_content")
+        // let file = File::from_id(file_id).await?;
+        // let content = file.get_content().await?;
+        // let rows = csv::Reader::from_reader(content.as_bytes())
+        //     .deserialize()
+        //     .collect::<Result<Vec<Row>, _>>()?;
+        // let schema = TableSchema::from_rows_async(rows.clone()).await?;
+        // Ok((rows, schema))
+    }
 }
 
 impl Filterable for Table {
@@ -609,13 +626,89 @@ impl Filterable for Table {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Row {
-    row_id: String,
-    value: Value,
+    pub row_id: String,
+    pub value: Value,
 }
 
 impl Row {
     pub fn new(row_id: String, value: Value) -> Self {
         Row { row_id, value }
+    }
+
+    /// This method implements our interpretation of CSVs into Table rows.
+    pub fn from_csv_record(
+        headers: &Vec<String>,
+        record: Vec<&str>,
+        row_idx: usize,
+    ) -> Result<Row> {
+        let mut value_map = serde_json::Map::new();
+
+        for (i, field) in record.iter().enumerate() {
+            if i >= headers.len() {
+                break;
+            }
+
+            let header = &headers[i];
+            let trimmed = field.trim();
+
+            if header == "__dust_id" {
+                continue;
+            }
+
+            let parsed_value = if trimmed.is_empty() {
+                Value::Null
+            } else if let Ok(num) = trimmed.parse::<f64>() {
+                // Numbers
+                Value::Number(serde_json::Number::from_f64(num).unwrap())
+            } else if let Ok(bool_val) = trimmed.parse::<bool>() {
+                // Booleans
+                Value::Bool(bool_val)
+            } else {
+                // Various datetime formats
+                let dt: Option<DateTime<Utc>> = [
+                    // RFC3339
+                    DateTime::parse_from_rfc3339(trimmed).map(|dt| dt.into()),
+                    // RFC2822
+                    DateTime::parse_from_rfc2822(trimmed).map(|dt| dt.into()),
+                    // Google Spreadsheet format
+                    DateTime::parse_from_str(trimmed, "%d-%b-%Y").map(|dt| dt.into()),
+                    // SQL
+                    DateTime::parse_from_str(trimmed, "%Y-%m-%d %H:%M:%S").map(|dt| dt.into()),
+                    // HTTP date
+                    DateTime::parse_from_str(trimmed, "%a, %d %b %Y %H:%M:%S GMT")
+                        .map(|dt| dt.into()),
+                ]
+                .iter()
+                .find_map(|result| result.ok());
+
+                if let Some(datetime) = dt {
+                    let mut dt_obj = serde_json::Map::new();
+                    dt_obj.insert("type".to_string(), Value::String("datetime".to_string()));
+                    dt_obj.insert(
+                        "epoch".to_string(),
+                        Value::Number(serde_json::Number::from(datetime.timestamp_millis())),
+                    );
+                    dt_obj.insert(
+                        "string_value".to_string(),
+                        Value::String(trimmed.to_string()),
+                    );
+                    Value::Object(dt_obj)
+                } else {
+                    Value::String(trimmed.to_string())
+                }
+            };
+
+            value_map.insert(header.clone(), parsed_value);
+        }
+
+        let row_id = if let Some(pos) = headers.iter().position(|h| h == "__dust_id") {
+            record.get(pos).map(|id| id.trim().to_string())
+        } else {
+            None
+        }
+        .unwrap_or_else(|| row_idx.to_string());
+
+        Ok(Row::new(row_id, Value::Object(value_map)))
     }
 
     pub fn row_id(&self) -> &str {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod data_sources {
     pub mod splitter;
 }
 pub mod databases {
+    pub mod csv;
     pub mod database;
     pub mod table;
     pub mod table_schema;


### PR DESCRIPTION
## Description

Adds support for retrieving a CSV content from the upsert queue bucket by path (to avoid leaking the workspace abstraction to `core`) and parsing it to compute the associated schema following the implementation of  `front`.

Next step is to start calling that in parallel of the rows parsing happening in `front` when receiving a table to upsert on selected workspace and compare the outputed schema with the computed headers + monitor if errors are unexpectedly raised.

## Tests

Covered by initial set of tests

## Risk

N/A not used yet

## Deploy Plan

- [x] Add `DUST_UPSERT_QUEUE_BUCKET` secret to `core`
- [ ] deploy `core`
