### PR TITLE
enh(Zendesk) - Add more metadata to Zendesk ticket tags

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -205,6 +205,11 @@ export async function syncTicket({
       ticketId: ticket.id,
     });
 
+    const metadataAsTags = [];
+    for (const [key, value] of Object.entries(metadata)) {
+      metadataAsTags.push(`${key}:${value}`);
+    }
+
     const parents = ticketInDb.getParentInternalIds(connectorId);
     await upsertDataSourceDocument({
       dataSourceConfig,
@@ -216,7 +221,11 @@ export async function syncTicket({
         `title:${ticket.subject}`,
         `updatedAt:${updatedAtDate.getTime()}`,
         `createdAt:${createdAtDate.getTime()}`,
-        ...filterCustomTags(ticket.tags, logger),
+        ...metadataAsTags,
+        ...filterCustomTags(
+          [...ticket.tags, ...ticket.custom_fields.map(({ value }) => value)],
+          logger
+        ),
       ],
       parents,
       parentId: parents[1],

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -145,60 +145,21 @@ export async function syncTicket({
       "[Zendesk] Upserting ticket."
     );
 
-    const metadata = [
-      `Ticket ID: ${ticket.id}`,
-      `Subject: ${ticket.subject}`,
-      `Created At: ${createdAtDate.toISOString()}`,
-      `Updated At: ${updatedAtDate.toISOString()}`,
-      `Status: ${ticket.status}`,
-      ticket.priority ? `Priority: ${ticket.priority}` : null,
-      ticket.type ? `Type: ${ticket.type}` : null,
-      ticket.via ? `Channel: ${ticket.via.channel}` : null,
-      ticket.requester
-        ? `Requester: ${ticket.requester.name} (${ticket.requester.email})`
-        : null,
-      ticket.assignee_id ? `Assignee ID: ${ticket.assignee_id}` : "Unassigned",
-      `Organization ID: ${ticket.organization_id || "N/A"}`,
-      `Group ID: ${ticket.group_id || "N/A"}`,
-      `Tags: ${ticket.tags.length ? ticket.tags.join(", ") : "No tags"}`,
-      ticket.due_at
-        ? `Due Date: ${new Date(ticket.due_at).toISOString()}`
-        : null,
-      ticket.satisfaction_rating
-        ? `Satisfaction Rating: ${ticket.satisfaction_rating.score}`
-        : null,
-      ticket.satisfaction_rating?.comment
-        ? `Satisfaction Comment: ${ticket.satisfaction_rating.comment}`
-        : null,
-      `Has Incidents: ${ticket.has_incidents ? "Yes" : "No"}`,
-      ticket.problem_id ? `Related Problem ID: ${ticket.problem_id}` : null,
-      `Custom Fields:`,
-      ...ticket.custom_fields.map(
-        (field) => `  - Field ${field.id}: ${field.value || "N/A"}`
-      ),
-    ]
-      .filter(Boolean)
-      .join("\n");
-
-    const ticketContent = `
-${metadata}
-
-Conversation:
-${comments
-  .map((comment) => {
-    let author;
-    try {
-      author = users.find((user) => user.id === comment.author_id);
-    } catch (e) {
-      logger.warn(
-        { connectorId, e, usersType: typeof users, ...loggerArgs },
-        "[Zendesk] Error finding the author of a comment."
-      );
-      author = null;
-    }
-    return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${(comment.plain_body || comment.body).replace(/[\u2028\u2029]/g, "")}`; // removing line and paragraph separators
-  })
-  .join("\n")}
+    const ticketContent = `Conversation:\n${comments
+      .map((comment) => {
+        let author;
+        try {
+          author = users.find((user) => user.id === comment.author_id);
+        } catch (e) {
+          logger.warn(
+            { connectorId, e, usersType: typeof users, ...loggerArgs },
+            "[Zendesk] Error finding the author of a comment."
+          );
+          author = null;
+        }
+        return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${(comment.plain_body || comment.body).replace(/[\u2028\u2029]/g, "")}`; // removing line and paragraph separators
+      })
+      .join("\n")}
 `.trim();
 
     const ticketContentInMarkdown = turndownService.turndown(ticketContent);
@@ -207,12 +168,35 @@ ${comments
       dataSourceConfig,
       ticketContentInMarkdown
     );
+
+    const metadata = {
+      priority: ticket.priority,
+      ticketType: ticket.type,
+      channel: ticket.via?.channel,
+      status: ticket.status,
+      ...(ticket.group_id ? { groupId: ticket.group_id.toString() } : {}),
+      ...(ticket.organization_id
+        ? { organizationId: ticket.organization_id.toString() }
+        : {}),
+      ...(ticket.due_at
+        ? { dueDate: `${new Date(ticket.due_at).toISOString()}` }
+        : {}),
+      satisfactionRating: ticket.satisfaction_rating.score,
+      hasIncidents: ticket.has_incidents ? "Yes" : "No",
+    };
+
     const documentContent = await renderDocumentTitleAndContent({
       dataSourceConfig,
       title: ticket.subject,
       content: renderedMarkdown,
       createdAt: createdAtDate,
       updatedAt: updatedAtDate,
+      additionalPrefixes: {
+        ...metadata,
+        labels: ticket.tags.join(", ") || "none",
+        customFields:
+          ticket.custom_fields.map(({ value }) => value).join(", ") || "none",
+      },
     });
 
     const documentId = getTicketInternalId({

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -193,11 +193,9 @@ export async function syncTicket({
       updatedAt: updatedAtDate,
       additionalPrefixes: {
         ...metadata,
-        labels:
-          [
-            ...ticket.tags,
-            ...ticket.custom_fields.map(({ value }) => value),
-          ].join(", ") || "none",
+        labels: ticket.tags.join(", ") || "none",
+        customFields:
+          ticket.custom_fields.map(({ value }) => value).join(", ") || "none",
       },
     });
 
@@ -224,10 +222,8 @@ export async function syncTicket({
         `updatedAt:${updatedAtDate.getTime()}`,
         `createdAt:${createdAtDate.getTime()}`,
         ...metadataAsTags,
-        ...filterCustomTags(
-          [...ticket.tags, ...ticket.custom_fields.map(({ value }) => value)],
-          logger
-        ),
+        ...ticket.custom_fields.map(({ id, value }) => `${id}:${value}`),
+        ...filterCustomTags(ticket.tags, logger),
       ],
       parents,
       parentId: parents[1],

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -193,9 +193,11 @@ export async function syncTicket({
       updatedAt: updatedAtDate,
       additionalPrefixes: {
         ...metadata,
-        labels: ticket.tags.join(", ") || "none",
-        customFields:
-          ticket.custom_fields.map(({ value }) => value).join(", ") || "none",
+        labels:
+          [
+            ...ticket.tags,
+            ...ticket.custom_fields.map(({ value }) => value),
+          ].join(", ") || "none",
       },
     });
 


### PR DESCRIPTION
## Description

- This PR aims at aligning the metadata we pass to the chunked document prefixes and to the tags.
- It does so by adding all the metadata we already pass to the document to the tags.
- It also refactors the document rendering by using the `additionalPrefixes` argument of the function `renderDocumentTitleAndContent`.
- This PR changes slightly how the prefixes are processed, it now prevents having 2 fields in the prefixes that can grow unboudedly.
- The documentation + the notion document that inventors the tags was updated accordingly.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy connectors.
