### PR TITLE
enh(Google Drive) - Increase `startToCloseTimeout` for the incremental sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -33,7 +33,7 @@ const {
 
 // Hotfix: increase timeout on incrementalSync to avoid restarting ongoing activities
 const { incrementalSync } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "120 minutes",
+  startToCloseTimeout: "180 minutes",
   heartbeatTimeout: "5 minutes",
 });
 


### PR DESCRIPTION
## Description

- The incremental sync is handled in a single activity, with a `startToCloseTimeout` of 2 hours.
- This PR bumps it to 3 hours.
- The timeout was reached (log [here](https://app.datadoghq.eu/logs?query=%22Activity%20failed%22%20%40attempt%3A%3E%3D5%20region%3Aus-central1%20%40dd.service%3Aconnectors-worker%20%40dustError.type%3Aworkflow_timeout_failure&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZUFuF3VEh-dqAAAABhBWlVGdUhES0FBQTVGazk4SC1wVzJnQUEAAAAkMDE5NTA1YjgtYTYyZC00NjFlLWI4NzgtY2U0YjkzNTY2OTFmAAACeQ&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1739556848000&to_ts=1739557748000&live=false)).
- The activity is hearbeaten.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy connectors.