### PR TITLE
enh(Poke) - Improve error message for Poke user on Business plugin

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -496,7 +496,7 @@ export async function upgradeWorkspaceToBusinessPlan(
     include: ["plan"],
   });
   if (subscription) {
-    throw new Error(`Workspace already has an active subscription.`);
+    return new Err(new Error("Workspace already has an active subscription."));
   }
 
   // Check if already fully on business plan with both metadata and subscription correct.


### PR DESCRIPTION
## Description

- The PR https://github.com/dust-tt/dust/pull/10805 introduces a new Poke plugin to upgrade a workspace to Business plan.
- In this plugin when the workspace already has an active subscription we abort the operation.
- Instead of correctly showing the error to the poke user, an error is thrown.
- This PR fixes that.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy front.