### PR TITLE
enh(Slack bot) - Improve handling of `ExternalOAuthTokenError`s

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -108,6 +108,13 @@ export async function botAnswerMessage(
   }
   const { slackConfig, connector } = connectorRes.value;
 
+  // If we do not have a valid token, we won't be able to post the message anyway.
+  if (connector.isPaused() && connector.errorType === "oauth_token_revoked") {
+    return new Err(
+      new Error("Connector is paused due to an oauth_token_revoked error.")
+    );
+  }
+
   try {
     const res = await answerMessage(
       message,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -25,6 +25,7 @@ import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
 import removeMarkdown from "remove-markdown";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
+
 import {
   makeErrorBlock,
   makeMessageUpdateBlocksAndText,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -25,8 +25,6 @@ import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
 import removeMarkdown from "remove-markdown";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
-
-import { getConnectorManager } from "@connectors/connectors";
 import {
   makeErrorBlock,
   makeMessageUpdateBlocksAndText,
@@ -134,19 +132,6 @@ export async function botAnswerMessage(
     if (e instanceof ExternalOAuthTokenError) {
       // Mark the connector as errored so that the user is notified in the Connection Admin UI.
       await syncFailed(connector.id, "oauth_token_revoked");
-      // Pause the connector.
-      const connectorManager = getConnectorManager({
-        connectorId: connector.id,
-        connectorProvider: connector.type,
-      });
-      if (connectorManager) {
-        await connectorManager.pause();
-      } else {
-        logger.error(
-          { connectorId: connector.id },
-          `Connector manager not found for connector`
-        );
-      }
       return new Err(
         new Error("Invalid Slack auth, the bot cannot answer the message.")
       );

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -132,11 +132,11 @@ export async function botAnswerMessage(
     const slackClient = await getSlackClient(connector.id);
     await slackClient.chat.postMessage({
       channel: slackChannel,
-      text: "An unexpected error occured. Our team has been notified",
+      text: "An unexpected error occurred. Our team has been notified",
       thread_ts: slackMessageTs,
     });
 
-    return new Err(new Error("An unexpected error occured"));
+    return new Err(new Error("An unexpected error occurred"));
   }
 }
 

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -126,9 +126,21 @@ export async function botAnswerMessage(
     if (e instanceof ExternalOAuthTokenError) {
       // Mark the connector as errored so that the user is notified in the Connection Admin UI.
       await syncFailed(connector.id, "oauth_token_revoked");
-      return new Err(
-        new Error("Invalid Slack auth, the bot cannot answer the message.")
-      );
+      try {
+        const slackClient = await getSlackClient(connector.id);
+        await slackClient.chat.postMessage({
+          channel: slackChannel,
+          text: "Authorization error, please re-authenticate Slack in Connection Admin.",
+          thread_ts: slackMessageTs,
+        });
+
+        return new Ok(undefined);
+      } catch (e) {
+        if (e instanceof ExternalOAuthTokenError) {
+          return new Ok(undefined);
+        }
+        return new Err(new Error("Could not post message occurred"));
+      }
     }
     logger.error(
       {

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -123,6 +123,14 @@ export async function botAnswerMessage(
 
     return new Ok(undefined);
   } catch (e) {
+    logger.error(
+      {
+        error: e,
+        connectorId: connector.id,
+        slackTeamId,
+      },
+      "Unexpected exception answering to Slack Chat Bot message"
+    );
     if (e instanceof ExternalOAuthTokenError) {
       // Mark the connector as errored so that the user is notified in the Connection Admin UI.
       await syncFailed(connector.id, "oauth_token_revoked");
@@ -136,14 +144,6 @@ export async function botAnswerMessage(
 
       return new Ok(undefined);
     }
-    logger.error(
-      {
-        error: e,
-        connectorId: connector.id,
-        slackTeamId,
-      },
-      "Unexpected exception answering to Slack Chat Bot message"
-    );
     const slackClient = await getSlackClient(connector.id);
     await slackClient.chat.postMessage({
       channel: slackChannel,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -126,6 +126,7 @@ export async function botAnswerMessage(
     if (e instanceof ExternalOAuthTokenError) {
       // Mark the connector as errored so that the user is notified in the Connection Admin UI.
       await syncFailed(connector.id, "oauth_token_revoked");
+      // Send a custom message for the user to be informed about it.
       const slackClient = await getSlackClient(connector.id);
       await slackClient.chat.postMessage({
         channel: slackChannel,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -110,13 +110,6 @@ export async function botAnswerMessage(
   }
   const { slackConfig, connector } = connectorRes.value;
 
-  // If we do not have a valid token, we won't be able to post the message anyway.
-  if (connector.isPaused() && connector.errorType === "oauth_token_revoked") {
-    return new Err(
-      new Error("Connector is paused due to an oauth_token_revoked error.")
-    );
-  }
-
   try {
     const res = await answerMessage(
       message,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -126,21 +126,14 @@ export async function botAnswerMessage(
     if (e instanceof ExternalOAuthTokenError) {
       // Mark the connector as errored so that the user is notified in the Connection Admin UI.
       await syncFailed(connector.id, "oauth_token_revoked");
-      try {
-        const slackClient = await getSlackClient(connector.id);
-        await slackClient.chat.postMessage({
-          channel: slackChannel,
-          text: "Authorization error, please re-authenticate Slack in Connection Admin.",
-          thread_ts: slackMessageTs,
-        });
+      const slackClient = await getSlackClient(connector.id);
+      await slackClient.chat.postMessage({
+        channel: slackChannel,
+        text: "Authorization error, please re-authenticate Slack in Connection Admin.",
+        thread_ts: slackMessageTs,
+      });
 
-        return new Ok(undefined);
-      } catch (e) {
-        if (e instanceof ExternalOAuthTokenError) {
-          return new Ok(undefined);
-        }
-        return new Err(new Error("Could not post message occurred"));
-      }
+      return new Ok(undefined);
     }
     logger.error(
       {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2191.
- This PR improves error handling of `ExternalOAuthTokenError`s in the Slack bot in two ways:
  - When trying to answer a message while the connector is errored with an `oauth_token_revoked`, it stops right away. ~Rationale: we won't be able to post the message anyway.~ Edit: in some case () we can and send want to send a custom message then.
  - When getting an `ExternalOAuthTokenError`, we mark the connector as errored with an `oauth_token_revoked` for the user to see it in the UI. It's the same code than https://github.com/dust-tt/dust/blob/b6a124a90e78579aa6d88bda6a9bf058614a15f7/connectors/src/lib/temporal_monitoring.ts#L141, which is in the `ActivityInboundLogInterceptor`.
- This PR assumes that the OAuth scopes on our app are in sync with what is required by the code, otherwise reauthenticating does not do anything (but does not do any harm).

## Tests

- Not tested yet, TBC

## Risk

- Low.

## Deploy Plan

- Deploy connectors.