### PR TITLE
[front] - deps: upgrade @dust-tt/sparkle to version 0.2.400

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.398",
+        "@dust-tt/sparkle": "0.2.400",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11336,9 +11336,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.398",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.398.tgz",
-      "integrity": "sha512-KCZrJa4uvJnMdvlqPqhfJWXEo0WnpQWQ5TxZh38CKduNhqloNNhiEG8oHP4T1DAPou9DWJ85H9TS1DKmSAnhRQ==",
+      "version": "0.2.400",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.400.tgz",
+      "integrity": "sha512-s5ZA7fxRN/K0MWcOss45lXzdwwmk61WeVW3GqLbMUv+zsOSbJ8ouN0Xgjw/AaIsqd3gv4ORgRCHsyqJel9A/nw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.398",
+    "@dust-tt/sparkle": "0.2.400",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",


### PR DESCRIPTION
## Description

This PR bumps sparkle in front which fixes https://github.com/dust-tt/tasks/issues/2193

## Risk

Low

## Deploy Plan

Deploy `front`