### PR TITLE
Add support for streaming for o1 models

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -741,7 +741,7 @@ impl LLM for OpenAILLM {
 
         // [o1] Hack for OpenAI `o1*` models to not use streaming.
         let model_is_o1 = self.id.as_str().starts_with("o1");
-        let (c, request_id) = if !model_is_o1 && event_sender.is_some() {
+        let (c, request_id) = if event_sender.is_some() {
             if n > 1 {
                 return Err(anyhow!(
                     "Generating multiple variations in streaming mode is not supported."
@@ -964,7 +964,7 @@ impl LLM for OpenAILLM {
                 TransformSystemMessages::Remove
             // Other reasoning models replace system messages with developer messages.
             } else if is_reasoning_model {
-                TransformSystemMessages::ReplaceWithDeveloper 
+                TransformSystemMessages::ReplaceWithDeveloper
             // Standard non-reasoning models use regular system messages.
             } else {
                 TransformSystemMessages::Keep

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -938,9 +938,7 @@ impl LLM for OpenAILLM {
     ) -> Result<LLMChatGeneration> {
         let is_reasoning_model =
             self.id.as_str().starts_with("o3") || self.id.as_str().starts_with("o1");
-        // o1 and o1-mini do not support streaming.
-        let model_supports_streaming = !self.id.as_str().starts_with("o1");
-        // o1-mini specifically does not supoport any type of system messages.
+        // o1-mini specifically does not support any type of system messages.
         let remove_system_messages = self.id.as_str().starts_with("o1-mini");
         openai_compatible_chat_completion(
             self.chat_uri()?,
@@ -960,13 +958,13 @@ impl LLM for OpenAILLM {
             top_logprobs,
             extras,
             event_sender,
-            !model_supports_streaming, // disable provider streaming
-            // Some models (o1-mini) don't support any system messages.
+            false, // don't disable provider streaming
+            // Some models (o1-mini) don't support system messages.
             if remove_system_messages {
                 TransformSystemMessages::Remove
             // Other reasoning models replace system messages with developer messages.
             } else if is_reasoning_model {
-                TransformSystemMessages::ReplaceWithDeveloper
+                TransformSystemMessages::ReplaceWithDeveloper 
             // Standard non-reasoning models use regular system messages.
             } else {
                 TransformSystemMessages::Keep

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -739,7 +739,6 @@ impl LLM for OpenAILLM {
             }
         }
 
-        // [o1] Hack for OpenAI `o1*` models to not use streaming.
         let model_is_o1 = self.id.as_str().starts_with("o1");
         let (c, request_id) = if event_sender.is_some() {
             if n > 1 {
@@ -958,8 +957,8 @@ impl LLM for OpenAILLM {
             top_logprobs,
             extras,
             event_sender,
-            false, // don't disable provider streaming
-            // Some models (o1-mini) don't support system messages.
+            false,
+            // Some models (o1-mini) don't support any system messages.
             if remove_system_messages {
                 TransformSystemMessages::Remove
             // Other reasoning models replace system messages with developer messages.


### PR DESCRIPTION
## Description

- `dust-apply https://dust.tt/w/0ec9852c2f/assistant/7ltpebguPj`
- o1 models now support streaming for API users.
- This PR removes the hack we had to circumvent this limitation.

## Tests

- Tested locally with all o1 models.

## Risk

- Use of o1 models is behind a FF.
- Quite high but well tested.

## Deploy Plan

- Deploy core.