### PR TITLE
Fix Dark mode Price table Sparkle

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.400",
+  "version": "0.2.401",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.400",
+      "version": "0.2.401",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.400",
+  "version": "0.2.401",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/PriceTable.tsx
+++ b/sparkle/src/components/PriceTable.tsx
@@ -120,7 +120,7 @@ export function PriceTable({
         }}
         className={classNames(
           "s-flex s-h-full s-flex-col s-overflow-hidden s-shadow-md",
-          "dark:s-bg-structure-50-dark s-bg-white"
+          "s-bg-white dark:s-bg-structure-50-night"
         )}
       >
         {childrenWithProps}
@@ -162,7 +162,7 @@ PriceTable.Item = function ({
           : "s-gap-3 s-p-4 s-text-base",
         "s-flex s-items-start s-border-b",
         "s-border-structure-100 s-text-element-800",
-        "dark:s-border-structure-200-dark/50 dark:s-text-element-800-dark",
+        "dark:s-border-structure-200-night/50 dark:s-text-element-800-night",
         className
       )}
     >
@@ -176,7 +176,7 @@ PriceTable.Item = function ({
       <div
         className={classNames(
           variant === "xmark"
-            ? "dark:s-text-element-600-dark s-text-element-600"
+            ? "s-text-element-600 dark:s-text-element-600-night"
             : "",
           "s-overflow-hidden"
         )}
@@ -206,7 +206,7 @@ PriceTable.ActionContainer = function ({
           "s-flex s-w-full s-justify-center s-px-2",
           size === "xs" ? "s-py-2" : "s-py-4",
           position === "top"
-            ? "dark:s-border-structure-200-dark/50 s-border-b s-border-structure-100"
+            ? "s-border-b s-border-structure-100 dark:s-border-structure-200-night/50"
             : ""
         )}
       >


### PR DESCRIPTION
## Description

When we decided to handle the dark mode we changed the dark mode suffix from `-dark` to `-night` because we were already using `-dark`  for some classnames that were not dark mode related (so to avoid confusion between this suffix being our "dark" color or our "dark mode color).

Not a huge deal but needs to be fixed because currently our pricing tables on our pricing page are white https://dust.tt/home/pricing

## Tests

Locally on storybook

## Risk

Can be rolled back

## Deploy Plan

Publish Sparkle. 