### PR TITLE
Dark mode: Bump Sparkle & fixes for sidebar

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -69,6 +69,8 @@ export function UserMenu({
     [owner, sendNotification, user, featureFlags]
   );
 
+  const theme = localStorage.getItem("theme") || "light";
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger>
@@ -160,7 +162,7 @@ export function UserMenu({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger label="Theme" icon={ImageIcon} />
               <DropdownMenuSubContent>
-                <DropdownMenuRadioGroup>
+                <DropdownMenuRadioGroup value={theme}>
                   <DropdownMenuRadioItem
                     value="light"
                     label="Light"

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -252,7 +252,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                   <DropdownMenuTrigger asChild>
                     <Button size="sm" icon={MoreIcon} variant="outline" />
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent mountPortal={false}>
+                  <DropdownMenuContent>
                     <DropdownMenuLabel>Assistants</DropdownMenuLabel>
                     <DropdownMenuItem
                       href={`/w/${owner.sId}/builder/assistants/create`}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.400",
+        "@dust-tt/sparkle": "0.2.401",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11336,9 +11336,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.400",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.400.tgz",
-      "integrity": "sha512-s5ZA7fxRN/K0MWcOss45lXzdwwmk61WeVW3GqLbMUv+zsOSbJ8ouN0Xgjw/AaIsqd3gv4ORgRCHsyqJel9A/nw==",
+      "version": "0.2.401",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.401.tgz",
+      "integrity": "sha512-a0FvO+ielIf7op0rupJ1TbXZUonBmqqJzliaJRgdIp+7MMFeeXrbD+ytTC88qfkt0zRRau42Jr7Zu5o/RT7u6Q==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.400",
+    "@dust-tt/sparkle": "0.2.401",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",


### PR DESCRIPTION
## Description

- Bump Sparkle to get the valid Price Tables in dark mode. 
- Adds missing value param on the dark mode drop down (to display the dot icon).
- Remove `mountPortal={false}` from `AssistantSidebarMenu` to fix this issue: 

<img width="441" alt="Screenshot 2025-02-15 at 13 29 39" src="https://github.com/user-attachments/assets/c6f8ad0f-de89-4cf7-93cc-d03339f27169" />

(for some reasons we can see this issue on prod dark mode but not light one, while on local I have it in both)


## Tests

Locally.

## Risk

Can be rolled back

## Deploy Plan

Deploy front!
