### PR TITLE
[sparkle] - feat(SearchInput): search input with popover result

### DIFF
--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -141,7 +141,7 @@ export const SearchInputWithPopover = forwardRef<
         </PopoverTrigger>
         <PopoverContent
           className={cn(
-            "s-rounded-lg s-border s-bg-background s-shadow-md dark:s-bg-background-night",
+            "s-w-[--radix-popover-trigger-width] s-rounded-lg s-border s-bg-background s-shadow-md dark:s-bg-background-night",
             contentClassName
           )}
           sideOffset={0}

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -1,6 +1,16 @@
-import React, { forwardRef, useRef, useState } from "react";
+import React, { forwardRef } from "react";
 
-import { Button, Icon, Input, PopoverContent, PopoverRoot, PopoverTrigger, Spinner } from "@sparkle/components";
+import {
+  Button,
+  Icon,
+  Input,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  ScrollArea,
+  ScrollBar,
+  Spinner,
+} from "@sparkle/components";
 import { MagnifyingGlassIcon, XMarkIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
@@ -88,81 +98,71 @@ SearchInput.displayName = "SearchInput";
 
 export interface SearchInputWithPopoverProps extends SearchInputProps {
   children: React.ReactNode;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
   contentClassName?: string;
-  sideOffset?: number;
-  align?: "start" | "center" | "end";
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
 export const SearchInputWithPopover = forwardRef<
   HTMLInputElement,
   SearchInputWithPopoverProps
->(({ children, contentClassName, className, open, onOpenChange, value, onChange, ...searchInputProps }, ref) => {
-  const [internalOpen, setInternalOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internalOpen;
-  const handleOpenChange = isControlled ? onOpenChange : setInternalOpen;
-
-  // Merge refs to access input element
-  const setRefs = (el: HTMLInputElement | null) => {
-    inputRef.current = el;
-    if (typeof ref === "function") {
-      ref(el);
-    }
-    else if (ref) {
-      ref.current = el;
-    }
-  };
-
-  return (
-    <PopoverRoot
-      modal={false}
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (open) {
-          inputRef.current?.focus();
-        }
-        handleOpenChange?.(open);
-      }}
-    >
-      <PopoverTrigger asChild>
-        <SearchInput
-          ref={setRefs}
-          className={cn("s-w-full", className)}
-          value={value}
-          onChange={(newValue) => {
-            onChange?.(newValue);
-            if (newValue && !isOpen) {
-              handleOpenChange?.(true);
-            }
-          }}
-          {...searchInputProps}
-          aria-expanded={isOpen}
-          aria-haspopup="listbox"
-          aria-controls="search-popover-content"
-        />
-      </PopoverTrigger>
-      <PopoverContent
-        className={cn(
-          "s-w-[--radix-popover-trigger-width] s-rounded-lg s-border s-bg-background s-shadow-md dark:s-bg-background-night",
-          contentClassName
-        )}
-        sideOffset={4}
-        align="start"
-        id="search-popover-content"
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-        onInteractOutside={() => handleOpenChange?.(false)}
-      >
-        <div role="listbox" className="s-max-h-96 s-overflow-y-auto">
-          {children}
-        </div>
-      </PopoverContent>
-    </PopoverRoot>
-  );
-});
+>(
+  (
+    {
+      children,
+      contentClassName,
+      className,
+      open,
+      onOpenChange,
+      value,
+      onChange,
+      ...searchInputProps
+    },
+    ref
+  ) => {
+    return (
+      <PopoverRoot modal={false} open={open} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>
+          <SearchInput
+            ref={ref}
+            className={cn("s-w-full", className)}
+            value={value}
+            onChange={(newValue) => {
+              onChange?.(newValue);
+              if (newValue && !open) {
+                onOpenChange(true);
+              }
+            }}
+            {...searchInputProps}
+            aria-expanded={open}
+            aria-haspopup="listbox"
+            aria-controls="search-popover-content"
+          />
+        </PopoverTrigger>
+        <PopoverContent
+          className={cn(
+            "s-rounded-lg s-border s-bg-background s-shadow-md dark:s-bg-background-night",
+            contentClassName
+          )}
+          sideOffset={0}
+          align="start"
+          id="search-popover-content"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onInteractOutside={() => onOpenChange(false)}
+        >
+          <ScrollArea
+            role="listbox"
+            className="s-flex s-max-h-72 s-flex-col"
+            hideScrollBar
+          >
+            {children}
+            <ScrollBar className="py-0" />
+          </ScrollArea>
+        </PopoverContent>
+      </PopoverRoot>
+    );
+  }
+);
 
 SearchInputWithPopover.displayName = "SearchInputWithPopover";

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -1,6 +1,6 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useRef, useState } from "react";
 
-import { Button, Icon, Input, Spinner } from "@sparkle/components";
+import { Button, Icon, Input, PopoverContent, PopoverRoot, PopoverTrigger, Spinner } from "@sparkle/components";
 import { MagnifyingGlassIcon, XMarkIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
@@ -85,3 +85,84 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 );
 
 SearchInput.displayName = "SearchInput";
+
+export interface SearchInputWithPopoverProps extends SearchInputProps {
+  children: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  contentClassName?: string;
+  sideOffset?: number;
+  align?: "start" | "center" | "end";
+}
+
+export const SearchInputWithPopover = forwardRef<
+  HTMLInputElement,
+  SearchInputWithPopoverProps
+>(({ children, contentClassName, className, open, onOpenChange, value, onChange, ...searchInputProps }, ref) => {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internalOpen;
+  const handleOpenChange = isControlled ? onOpenChange : setInternalOpen;
+
+  // Merge refs to access input element
+  const setRefs = (el: HTMLInputElement | null) => {
+    inputRef.current = el;
+    if (typeof ref === "function") {
+      ref(el);
+    }
+    else if (ref) {
+      ref.current = el;
+    }
+  };
+
+  return (
+    <PopoverRoot
+      modal={false}
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (open) {
+          inputRef.current?.focus();
+        }
+        handleOpenChange?.(open);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <SearchInput
+          ref={setRefs}
+          className={cn("s-w-full", className)}
+          value={value}
+          onChange={(newValue) => {
+            onChange?.(newValue);
+            if (newValue && !isOpen) {
+              handleOpenChange?.(true);
+            }
+          }}
+          {...searchInputProps}
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-controls="search-popover-content"
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        className={cn(
+          "s-w-[--radix-popover-trigger-width] s-rounded-lg s-border s-bg-background s-shadow-md dark:s-bg-background-night",
+          contentClassName
+        )}
+        sideOffset={4}
+        align="start"
+        id="search-popover-content"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        onInteractOutside={() => handleOpenChange?.(false)}
+      >
+        <div role="listbox" className="s-max-h-96 s-overflow-y-auto">
+          {children}
+        </div>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+});
+
+SearchInputWithPopover.displayName = "SearchInputWithPopover";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -110,7 +110,7 @@ export {
   ResizablePanelGroup,
 } from "./Resizable";
 export { ScrollArea, ScrollBar } from "./ScrollArea";
-export { SearchInput, SearchInputWithDropdown, SearchInputWithPopover } from "./SearchInput";
+export { SearchInput, SearchInputWithPopover } from "./SearchInput";
 export { Separator } from "./Separator";
 export {
   Sheet,

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -110,7 +110,7 @@ export {
   ResizablePanelGroup,
 } from "./Resizable";
 export { ScrollArea, ScrollBar } from "./ScrollArea";
-export { SearchInput } from "./SearchInput";
+export { SearchInput, SearchInputWithDropdown, SearchInputWithPopover } from "./SearchInput";
 export { Separator } from "./Separator";
 export {
   Sheet,

--- a/sparkle/src/stories/SearchInput.stories.tsx
+++ b/sparkle/src/stories/SearchInput.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import React from "react";
+import React, { useState } from "react";
 
-import { SearchInput } from "../index_with_tw_base";
+import { SearchInput, SearchInputWithPopover } from "../index_with_tw_base";
 
 const meta = {
   title: "Components/SearchInput",
@@ -67,3 +67,44 @@ export const ExampleSearchInput: Story = {
     );
   },
 };
+
+export function SearchInputWithPopoverScrollableExample() {
+  const [value, setValue] = useState("");
+  const [open, setOpen] = useState(false);
+  const items = Array.from({ length: 50 }).map((_, i) => `Item ${i + 1}`);
+
+  const filteredItems = items.filter((item) =>
+    item.toLowerCase().includes(value.toLowerCase())
+  );
+
+  return (
+    <SearchInputWithPopover
+      name="search"
+      placeholder="Type to search..."
+      value={value}
+      onChange={setValue}
+      open={open}
+      onOpenChange={setOpen}
+    >
+      {filteredItems.length > 0 ? (
+        filteredItems.map((item) => (
+          <div
+            key={item}
+            role="option"
+            className="s-cursor-pointer s-py-2 hover:s-bg-primary-100 dark:hover:s-bg-primary-100-night"
+            onClick={() => {
+              setValue(item);
+              setOpen(false);
+            }}
+          >
+            {item}
+          </div>
+        ))
+      ) : (
+        <div className="s-px-4 s-py-2 s-text-muted-foreground">
+          No results found
+        </div>
+      )}
+    </SearchInputWithPopover>
+  );
+}


### PR DESCRIPTION
## Description

This PR aims at creating a new sparkle component which builds on top of the existing `SearchInput` to display the filtered content on a `Popover`.

<img width="562" alt="Screenshot 2025-02-15 at 14 26 09" src="https://github.com/user-attachments/assets/7c885f0c-895a-4f6c-837f-fdfeed468979" />

## Risk

Low

## Deploy Plan

- Publish `sparkle`
- Deploy `front`
