### PR TITLE
Add Poke DataSource plugin to check Zendesk Tickets

### DIFF
--- a/connectors/migrations/20250110_investigate_zendesk_hc.ts
+++ b/connectors/migrations/20250110_investigate_zendesk_hc.ts
@@ -43,6 +43,9 @@ makeScript({}, async ({ execute }, logger) => {
         accessToken,
         subdomain,
       });
+      if (!brandSubdomain) {
+        throw new Error("Brand not found.");
+      }
 
       let couldFetchCategories;
       try {

--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -44,6 +44,10 @@ const whitelistedCommands = [
     majorCommand: "connectors",
     command: "clear-error",
   },
+  {
+    majorCommand: "zendesk",
+    command: "fetch-ticket",
+  },
 ];
 
 const _adminAPIHandler = async (

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -100,6 +100,9 @@ export const zendesk = async ({
         subdomain,
         accessToken,
       });
+      if (!brandSubdomain) {
+        throw new Error(`Brand ${brandId} not found in Zendesk.`);
+      }
 
       const ticketCount = await fetchZendeskTicketCount({
         brandSubdomain,
@@ -135,6 +138,12 @@ export const zendesk = async ({
       if (!ticketId) {
         throw new Error(`Missing --ticketId argument`);
       }
+      const ticketOnDb = await ZendeskTicketResource.fetchByTicketId({
+        connectorId: connector.id,
+        brandId,
+        ticketId,
+      });
+
       const { accessToken, subdomain } =
         await getZendeskSubdomainAndAccessToken(connector.connectionId);
       const brandSubdomain = await getZendeskBrandSubdomain({
@@ -143,17 +152,19 @@ export const zendesk = async ({
         subdomain,
         accessToken,
       });
+      if (!brandSubdomain) {
+        return {
+          ticket: null,
+          isTicketOnDb: ticketOnDb !== null,
+        };
+      }
 
       const ticket = await fetchZendeskTicket({
         accessToken,
         ticketId,
         brandSubdomain,
       });
-      const ticketOnDb = await ZendeskTicketResource.fetchByTicketId({
-        connectorId: connector.id,
-        brandId,
-        ticketId,
-      });
+
       return {
         ticket: ticket as { [key: string]: unknown } | null,
         isTicketOnDb: ticketOnDb !== null,

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -135,9 +135,20 @@ export const zendesk = async ({
         await getZendeskSubdomainAndAccessToken(connector.connectionId);
 
       if (args.ticketUrl) {
-        const { brandSubdomain, ticketId } = extractMetadataFromDocumentUrl(
-          args.ticketUrl
-        );
+        let brandSubdomain, ticketId;
+        try {
+          const {
+            brandSubdomain: extractedSubdomain,
+            ticketId: extractedTicketId,
+          } = extractMetadataFromDocumentUrl(args.ticketUrl);
+          brandSubdomain = extractedSubdomain;
+          ticketId = extractedTicketId;
+        } catch (e) {
+          return {
+            ticket: null,
+            isTicketOnDb: false,
+          };
+        }
         const ticket = await fetchZendeskTicket({
           accessToken,
           ticketId,

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -41,19 +41,35 @@ export const zendesk = async ({
 > => {
   const logger = topLogger.child({ majorCommand: "zendesk", command, args });
 
-  const connectorId = args.connectorId ? args.connectorId.toString() : null;
-  const connector = connectorId
-    ? await ConnectorResource.fetchById(connectorId)
-    : null;
-  if (connector && connector.type !== "zendesk") {
+  let connector;
+  if (args.wId && args.dsId) {
+    connector = await ConnectorResource.findByDataSource({
+      workspaceId: args.wId,
+      dataSourceId: args.dsId,
+    });
+    if (!connector) {
+      throw new Error(
+        `Connector not found for workspace ${args.wId} and data source ${args.dsId}.`
+      );
+    }
+  } else if (args.connectorId) {
+    connector = await ConnectorResource.fetchById(args.connectorId);
+    if (!connector) {
+      throw new Error(`Connector ${args.connectorId} not found.`);
+    }
+  } else {
+    throw new Error(
+      "Either the workspace and dataSource IDs or the connector ID are required."
+    );
+  }
+  const connectorId = connector.id;
+
+  if (connector.type !== "zendesk") {
     throw new Error(`Connector ${args.connectorId} is not of type zendesk`);
   }
 
   switch (command) {
     case "check-is-admin": {
-      if (!connector) {
-        throw new Error(`Connector ${connectorId} not found`);
-      }
       const user = await fetchZendeskCurrentUser(
         await getZendeskSubdomainAndAccessToken(connector.connectionId)
       );
@@ -65,9 +81,6 @@ export const zendesk = async ({
       };
     }
     case "count-tickets": {
-      if (!connector) {
-        throw new Error(`Connector ${connectorId} not found`);
-      }
       const brandId = args.brandId ? Number(args.brandId) : null;
       if (!brandId) {
         throw new Error(`Missing --brandId argument`);
@@ -101,9 +114,6 @@ export const zendesk = async ({
       return { ticketCount };
     }
     case "resync-tickets": {
-      if (!connector) {
-        throw new Error(`Connector ${connectorId} not found`);
-      }
       const result = await launchZendeskTicketReSyncWorkflow(connector, {
         forceResync: args.forceResync === "true",
       });
@@ -117,9 +127,6 @@ export const zendesk = async ({
       return { success: true };
     }
     case "fetch-ticket": {
-      if (!connector) {
-        throw new Error(`Connector ${connectorId} not found`);
-      }
       const brandId = args.brandId ? Number(args.brandId) : null;
       if (!brandId) {
         throw new Error(`Missing --brandId argument`);
@@ -153,9 +160,6 @@ export const zendesk = async ({
       };
     }
     case "fetch-brand": {
-      if (!connector) {
-        throw new Error(`Connector ${connectorId} not found`);
-      }
       const brandId = args.brandId ? args.brandId : null;
       if (!brandId) {
         throw new Error(`Missing --brandId argument`);
@@ -175,9 +179,6 @@ export const zendesk = async ({
       };
     }
     case "resync-help-centers": {
-      if (!connector) {
-        throw new Error(`Connector ${connectorId} not found`);
-      }
       const helpCenterBrandIds =
         await ZendeskBrandResource.fetchHelpCenterReadAllowedBrandIds(
           connector.id
@@ -210,15 +211,12 @@ export const zendesk = async ({
     // Resyncs the metadata of a brand already in DB.
     // Can be used to sync the data_sources_folders relative to the brand.
     case "resync-brand-metadata": {
-      if (!connectorId) {
-        throw new Error(`Missing --connectorId argument`);
-      }
       const brandId = args.brandId ? args.brandId : null;
       if (!brandId) {
         throw new Error(`Missing --brandId argument`);
       }
       await syncZendeskBrandActivity({
-        connectorId: parseInt(connectorId, 10),
+        connectorId: connectorId,
         brandId,
         currentSyncDateMs: Date.now(),
       });

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -31,7 +31,7 @@ export function extractMetadataFromDocumentUrl(ticketUrl: string): {
 } {
   // Format: https://${subdomain}.zendesk.com/tickets/${ticketId}.
   const match = ticketUrl.match(
-    /^https:\/\/([^.]+)\.zendesk\.com\/tickets\/(\d+)/
+    /^https:\/\/([^.]+)\.zendesk\.com\/tickets\/#?(\d+)/
   );
   if (!match || !match[1] || !match[2]) {
     throw new Error(`Invalid ticket URL: ${ticketUrl}`);

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -21,6 +21,27 @@ import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const turndownService = new TurndownService();
 
+function apiUrlToDocumentUrl(apiUrl: string): string {
+  return apiUrl.replace("/api/v2/", "/").replace(".json", "");
+}
+
+export function extractMetadataFromDocumentUrl(ticketUrl: string): {
+  brandSubdomain: string;
+  ticketId: number;
+} {
+  // Format: https://${subdomain}.zendesk.com/tickets/${ticketId}.
+  const match = ticketUrl.match(
+    /^https:\/\/([^.]+)\.zendesk\.com\/tickets\/(\d+)/
+  );
+  if (!match || !match[1] || !match[2]) {
+    throw new Error(`Invalid ticket URL: ${ticketUrl}`);
+  }
+  return {
+    brandSubdomain: match[1],
+    ticketId: parseInt(match[2], 10),
+  };
+}
+
 /**
  * Deletes a ticket from the db and the data sources.
  */
@@ -95,7 +116,7 @@ export async function syncTicket({
   // if they were never attended in the Agent Workspace their subject is not populated.
   ticket.subject ||= "No subject";
 
-  const ticketUrl = ticket.url.replace("/api/v2/", "/").replace(".json", ""); // converting the API URL into the web URL;
+  const ticketUrl = apiUrlToDocumentUrl(ticket.url);
   if (!ticketInDb) {
     ticketInDb = await ZendeskTicketResource.makeNew({
       blob: {

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -74,7 +74,7 @@ export async function getZendeskBrandSubdomain({
   brandId: number;
   subdomain: string;
   accessToken: string;
-}): Promise<string> {
+}): Promise<string | null> {
   const brandInDb = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -84,7 +84,7 @@ export async function getZendeskBrandSubdomain({
   }
   const brand = await fetchZendeskBrand({ subdomain, accessToken, brandId });
   if (!brand) {
-    throw new Error(`Brand ${brandId} not found in Zendesk.`);
+    return null;
   }
   return brand.subdomain;
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -354,6 +354,10 @@ export async function syncZendeskCategoryBatchActivity({
     accessToken,
     subdomain,
   });
+  if (!brandSubdomain) {
+    throw new Error(`Brand ${brandId} not found in Zendesk.`);
+  }
+
   const brandInDb = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -444,6 +448,9 @@ export async function syncZendeskCategoryActivity({
     subdomain,
     brandId,
   });
+  if (!brandSubdomain) {
+    throw new Error(`Brand ${brandId} not found in Zendesk.`);
+  }
 
   // if the category is not on Zendesk anymore, we remove its permissions
   const fetchedCategory = await fetchZendeskCategory({
@@ -627,6 +634,9 @@ export async function syncZendeskTicketBatchActivity({
     accessToken,
     subdomain,
   });
+  if (!brandSubdomain) {
+    throw new Error(`Brand ${brandId} not found in Zendesk.`);
+  }
 
   const startTime =
     Math.floor(currentSyncDateMs / 1000) -

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -155,6 +155,9 @@ export async function removeMissingArticleBatchActivity({
     accessToken,
     subdomain,
   });
+  if (!brandSubdomain) {
+    throw new Error(`Brand ${brandId} not found in Zendesk.`);
+  }
 
   // not deleting in batch for now, assuming we won't have that many articles to delete at once
   await concurrentExecutor(

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -227,6 +227,9 @@ export async function syncZendeskTicketUpdateBatchActivity({
     subdomain,
     accessToken,
   });
+  if (!brandSubdomain) {
+    throw new Error(`Brand ${brandId} not found in Zendesk.`);
+  }
 
   const { tickets, hasMore, nextLink } = await fetchZendeskTickets(
     accessToken,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -210,6 +210,19 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return blob && new this(this.model, blob.get());
   }
 
+  static async fetchByBrandSubdomain({
+    connectorId,
+    subdomain,
+  }: {
+    connectorId: number;
+    subdomain: string;
+  }): Promise<ZendeskBrandResource | null> {
+    const blob = await ZendeskBrand.findOne({
+      where: { connectorId, subdomain },
+    });
+    return blob && new this(this.model, blob.get());
+  }
+
   static async fetchByBrandIds({
     connectorId,
     brandIds,

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -723,12 +723,11 @@ async function handleCheckOrFindNotionUrl(
   return res.json();
 }
 
-async function handleCheckZendeskTicket(args: {
-  brandId: number;
-  ticketId: number;
-  wId: string;
-  dsId: string;
-}): Promise<ZendeskFetchTicketResponseType | null> {
+async function handleCheckZendeskTicket(
+  args:
+    | { brandId: number; ticketId: number; wId: string; dsId: string }
+    | { ticketUrl: string; wId: string; dsId: string }
+): Promise<ZendeskFetchTicketResponseType | null> {
   const res = await fetch(`/api/poke/admin`, {
     method: "POST",
     headers: {
@@ -959,15 +958,19 @@ function ZendeskTicketCheck({
 }) {
   const [brandId, setBrandId] = useState<number | null>(null);
   const [ticketId, setTicketId] = useState<number | null>(null);
+  const [ticketUrl, setTicketUrl] = useState<string | null>(null);
+
   const [ticketDetails, setTicketDetails] =
     useState<ZendeskFetchTicketResponseType | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+
+  const [idsIsLoading, setIdsIsLoading] = useState(false);
+  const [urlIsLoading, setUrlIsLoading] = useState(false);
 
   return (
     <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-gray-600">
       <div className="ml-2 flex items-center gap-2">
-        <div>Brand ID / Ticket ID</div>
-        <div className="ml-6 flex max-w-md grow items-center gap-4">
+        <div className="w-32">Brand / Ticket IDs</div>
+        <div className="flex max-w-md grow items-center gap-4">
           <div className="flex-1">
             <Input
               type="number"
@@ -988,12 +991,12 @@ function ZendeskTicketCheck({
         </div>
         <Button
           variant="outline"
-          icon={isLoading ? Spinner : MagnifyingGlassIcon}
-          label={isLoading ? undefined : "Check"}
-          disabled={!ticketId || !brandId || isLoading}
+          icon={idsIsLoading ? Spinner : MagnifyingGlassIcon}
+          label={idsIsLoading ? undefined : "Check"}
+          disabled={!ticketId || !brandId || idsIsLoading}
           onClick={async () => {
             if (brandId && ticketId) {
-              setIsLoading(true);
+              setIdsIsLoading(true);
               setTicketDetails(
                 await handleCheckZendeskTicket({
                   brandId,
@@ -1002,7 +1005,37 @@ function ZendeskTicketCheck({
                   dsId,
                 })
               );
-              setIsLoading(false);
+              setIdsIsLoading(false);
+            }
+          }}
+        />
+      </div>
+      <div className="ml-2 mt-4 flex items-center gap-2">
+        <div className="w-32">Ticket URL</div>
+        <div className="max-w-md flex-1 grow items-center gap-4">
+          <Input
+            type="text"
+            placeholder="Ticket URL"
+            onChange={(e) => setTicketUrl(e.target.value)}
+            value={ticketUrl ?? ""}
+          />
+        </div>
+        <Button
+          variant="outline"
+          icon={urlIsLoading ? Spinner : MagnifyingGlassIcon}
+          label={urlIsLoading ? undefined : "Check"}
+          disabled={!ticketUrl || urlIsLoading}
+          onClick={async () => {
+            if (ticketUrl) {
+              setUrlIsLoading(true);
+              setTicketDetails(
+                await handleCheckZendeskTicket({
+                  ticketUrl,
+                  wId: owner.sId,
+                  dsId,
+                })
+              );
+              setUrlIsLoading(false);
             }
           }}
         />

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -11,6 +11,7 @@ import {
   EyeIcon,
   Input,
   LockIcon,
+  MagnifyingGlassIcon,
   SliderToggle,
   TableIcon,
 } from "@dust-tt/sparkle";
@@ -962,9 +963,9 @@ function ZendeskTicketCheck({
 
   return (
     <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-gray-600">
-      <div className="flex items-center gap-2">
+      <div className="ml-2 flex items-center gap-2">
         <div>Brand ID / Ticket ID</div>
-        <div className="flex max-w-md grow items-center gap-4">
+        <div className="ml-6 flex max-w-md grow items-center gap-4">
           <div className="flex-1">
             <Input
               type="number"
@@ -985,6 +986,7 @@ function ZendeskTicketCheck({
         </div>
         <Button
           variant="outline"
+          icon={MagnifyingGlassIcon}
           label="Check"
           disabled={!ticketId || !brandId}
           onClick={async () => {
@@ -1004,15 +1006,7 @@ function ZendeskTicketCheck({
       <div className="text-gray-800">
         {ticketDetails && (
           <div className="flex flex-col gap-2 rounded-md border pt-2 text-lg">
-            {ticketDetails.ticket && (
-              <div>
-                <span className="font-bold">Details:</span>{" "}
-                <span>
-                  <JsonViewer value={ticketDetails.ticket} rootName={false} />
-                </span>
-              </div>
-            )}
-            <div className="mb-4 mt-2 flex justify-center gap-2">
+            <div className="mb-4 ml-4 mt-2 flex gap-2">
               <Chip
                 label={ticketDetails.ticket ? "Found" : "Not Found"}
                 color={ticketDetails.ticket ? "emerald" : "warning"}
@@ -1022,6 +1016,12 @@ function ZendeskTicketCheck({
                 color={ticketDetails.isTicketOnDb ? "purple" : "warning"}
               />
             </div>
+            {ticketDetails.ticket && (
+              <div className="ml-4 pt-2 text-xs text-element-700">
+                <div className="mb-1 font-bold">Details</div>
+                <JsonViewer value={ticketDetails.ticket} rootName={false} />
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -1012,12 +1012,12 @@ function ZendeskTicketCheck({
           <div className="flex flex-col gap-2 rounded-md border pt-2 text-lg">
             <div className="mb-4 ml-4 mt-2 flex gap-2">
               <Chip
-                label={ticketDetails.ticket ? "Found" : "Not Found"}
-                color={ticketDetails.ticket ? "emerald" : "warning"}
+                label={ticketDetails.isTicketOnDb ? "Synced" : "Not synced"}
+                color={ticketDetails.isTicketOnDb ? "purple" : "pink"}
               />
               <Chip
-                label={ticketDetails.isTicketOnDb ? "Synced" : "Not synced"}
-                color={ticketDetails.isTicketOnDb ? "purple" : "warning"}
+                label={ticketDetails.ticket ? "Found" : "Not Found"}
+                color={ticketDetails.ticket ? "emerald" : "warning"}
               />
             </div>
             {ticketDetails.ticket && (

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -13,6 +13,7 @@ import {
   LockIcon,
   MagnifyingGlassIcon,
   SliderToggle,
+  Spinner,
   TableIcon,
 } from "@dust-tt/sparkle";
 import type {
@@ -960,6 +961,7 @@ function ZendeskTicketCheck({
   const [ticketId, setTicketId] = useState<number | null>(null);
   const [ticketDetails, setTicketDetails] =
     useState<ZendeskFetchTicketResponseType | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   return (
     <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-gray-600">
@@ -986,11 +988,12 @@ function ZendeskTicketCheck({
         </div>
         <Button
           variant="outline"
-          icon={MagnifyingGlassIcon}
-          label="Check"
-          disabled={!ticketId || !brandId}
+          icon={isLoading ? Spinner : MagnifyingGlassIcon}
+          label={isLoading ? undefined : "Check"}
+          disabled={!ticketId || !brandId || isLoading}
           onClick={async () => {
             if (brandId && ticketId) {
+              setIsLoading(true);
               setTicketDetails(
                 await handleCheckZendeskTicket({
                   brandId,
@@ -999,6 +1002,7 @@ function ZendeskTicketCheck({
                   dsId,
                 })
               );
+              setIsLoading(false);
             }
           }}
         />

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   ContextItem,
   DocumentTextIcon,
   DropdownMenu,
@@ -1003,24 +1004,24 @@ function ZendeskTicketCheck({
       <div className="text-gray-800 dark:text-gray-200">
         {ticketDetails && (
           <div className="flex flex-col gap-2 rounded-md border pt-2 text-lg">
-            <span
-              className={classNames(
-                "font-bold",
-                ticketDetails.isTicketOnDb ? "text-emerald-800" : "text-red-800"
-              )}
-            >
-              {ticketDetails.isTicketOnDb
-                ? "Ticket synced"
-                : "Ticket not synced"}
-            </span>
-            {
+            {ticketDetails.ticket && (
               <div>
                 <span className="font-bold">Details:</span>{" "}
                 <span>
                   <JsonViewer value={ticketDetails.ticket} rootName={false} />
                 </span>
               </div>
-            }
+            )}
+            <div className="mb-4 mt-2 flex justify-center gap-2">
+              <Chip
+                label={ticketDetails.ticket ? "Found" : "Not Found"}
+                color={ticketDetails.ticket ? "emerald" : "warning"}
+              />
+              <Chip
+                label={ticketDetails.isTicketOnDb ? "Synced" : "Not synced"}
+                color={ticketDetails.isTicketOnDb ? "purple" : "warning"}
+              />
+            </div>
           </div>
         )}
       </div>

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -962,20 +962,25 @@ function ZendeskTicketCheck({
   return (
     <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-gray-600 dark:text-gray-400">
       <div className="flex items-center gap-2">
-        <div>Notion URL</div>
-        <div className="grow">
-          <Input
-            type="number"
-            placeholder="Brand ID"
-            onChange={(e) => setBrandId(parseInt(e.target.value, 10))}
-            value={brandId?.toString()}
-          />
-          <Input
-            type="number"
-            placeholder="Ticket ID"
-            onChange={(e) => setTicketId(parseInt(e.target.value, 10))}
-            value={ticketId?.toString()}
-          />
+        <div>Brand ID / Ticket ID</div>
+        <div className="flex max-w-md grow items-center gap-4">
+          <div className="flex-1">
+            <Input
+              type="number"
+              placeholder="Brand ID"
+              onChange={(e) => setBrandId(parseInt(e.target.value, 10))}
+              value={brandId?.toString()}
+            />
+          </div>
+          <div className="text-center text-gray-600">/</div>
+          <div className="flex-1">
+            <Input
+              type="number"
+              placeholder="Ticket ID"
+              onChange={(e) => setTicketId(parseInt(e.target.value, 10))}
+              value={ticketId?.toString()}
+            />
+          </div>
         </div>
         <Button
           variant="outline"

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -15,6 +15,7 @@ import {
   SliderToggle,
   Spinner,
   TableIcon,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import type {
   ConnectorType,
@@ -1044,13 +1045,35 @@ function ZendeskTicketCheck({
         {ticketDetails && (
           <div className="flex flex-col gap-2 rounded-md border pt-2 text-lg">
             <div className="mb-4 ml-4 mt-2 flex gap-2">
-              <Chip
-                label={ticketDetails.isTicketOnDb ? "Synced" : "Not synced"}
-                color={ticketDetails.isTicketOnDb ? "purple" : "pink"}
+              <Tooltip
+                label={
+                  ticketDetails.isTicketOnDb
+                    ? "The ticket is synced with Dust."
+                    : "The ticket is not synced with Dust."
+                }
+                className="max-w-md"
+                trigger={
+                  <Chip
+                    label={ticketDetails.isTicketOnDb ? "Synced" : "Not synced"}
+                    color={ticketDetails.isTicketOnDb ? "purple" : "pink"}
+                  />
+                }
               />
-              <Chip
-                label={ticketDetails.ticket ? "Found" : "Not Found"}
-                color={ticketDetails.ticket ? "emerald" : "warning"}
+              <Tooltip
+                label={
+                  ticketDetails.ticket
+                    ? "The ticket can be found on Zendesk."
+                    : ticketUrl
+                      ? "The URL is malformed or does not lead to an existing ticket."
+                      : "The ticket or the brand was not found."
+                }
+                className="max-w-md"
+                trigger={
+                  <Chip
+                    label={ticketDetails.ticket ? "Found" : "Not Found"}
+                    color={ticketDetails.ticket ? "emerald" : "warning"}
+                  />
+                }
               />
             </div>
             {ticketDetails.ticket && (

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -961,7 +961,7 @@ function ZendeskTicketCheck({
     useState<ZendeskFetchTicketResponseType | null>(null);
 
   return (
-    <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-gray-600 dark:text-gray-400">
+    <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-gray-600">
       <div className="flex items-center gap-2">
         <div>Brand ID / Ticket ID</div>
         <div className="flex max-w-md grow items-center gap-4">
@@ -1001,7 +1001,7 @@ function ZendeskTicketCheck({
           }}
         />
       </div>
-      <div className="text-gray-800 dark:text-gray-200">
+      <div className="text-gray-800">
         {ticketDetails && (
           <div className="flex flex-col gap-2 rounded-md border pt-2 text-lg">
             {ticketDetails.ticket && (

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -1015,7 +1015,7 @@ function ZendeskTicketCheck({
         <div className="max-w-md flex-1 grow items-center gap-4">
           <Input
             type="text"
-            placeholder="Ticket URL"
+            placeholder="https://{subdomain}.zendesk.com/tickets/{ticket_id}"
             onChange={(e) => setTicketUrl(e.target.value)}
             value={ticketUrl ?? ""}
           />

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -277,6 +277,8 @@ export const ZendeskCommandSchema = t.type({
     t.literal("resync-brand-metadata"),
   ]),
   args: t.type({
+    wId: t.union([t.string, t.undefined]),
+    dsId: t.union([t.string, t.undefined]),
     connectorId: t.union([t.number, t.undefined]),
     brandId: t.union([t.number, t.undefined]),
     query: t.union([t.string, t.undefined]),

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -284,6 +284,7 @@ export const ZendeskCommandSchema = t.type({
     query: t.union([t.string, t.undefined]),
     forceResync: t.union([t.literal("true"), t.undefined]),
     ticketId: t.union([t.number, t.undefined]),
+    ticketUrl: t.union([t.string, t.undefined]),
   }),
 });
 export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;


### PR DESCRIPTION
## Description

- This PR adds a Poke plugin to check whether a Zendesk ticket is synced and/or found on Zendesk.
- This PR also allows using a workspace + dataSource in zendesk admin CLI commands.

![Screenshot 2025-02-16 at 1 40 36 AM](https://github.com/user-attachments/assets/ed9a0ada-f8e3-4675-b1c1-cef6327969be)

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Deploy front.