### PR TITLE
enh(Google Drive) - skip skipped files and folders in parents incremental update

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -605,6 +605,7 @@ async function recurseUpdateParents(
     where: {
       connectorId: connector.id,
       parentId: file.driveFileId,
+      skipReason: null,
     },
   });
 

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -535,13 +535,18 @@ export async function incrementalSync(
             },
             "Folder moved"
           );
-
-          await recurseUpdateParents(
-            connector,
-            localFolder,
-            parents,
-            localLogger
-          );
+          if (localFolder.skipReason) {
+            localLogger.info(
+              `Google Drive folder skipped with skip reason ${localFolder.skipReason}`
+            );
+          } else {
+            await recurseUpdateParents(
+              connector,
+              localFolder,
+              parents,
+              localLogger
+            );
+          }
         }
 
         if (!localFolder) {


### PR DESCRIPTION
## Description

- In Google Drive's incremental sync, we update the parents for folders that were moved with their descendants.
- The parents update does not check the `skipReason` of the files.
- We have an activity stuck on a parents update because the table to update was missing in core. The upsert of the table failed with the error `Failed to parse CSV: Column name is too long (over 1024 characters).`, therefore marking it as paused would be the call but it does not unblock the activity as of now.
- This PR adds this check.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.