### PR TITLE
Bump Sparkle to get Search input + fix border ContentMessage

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.401",
+  "version": "0.2.402",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.401",
+      "version": "0.2.402",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.401",
+  "version": "0.2.402",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -30,7 +30,7 @@ const contentMessageVariants = cva(
         emerald: "s-bg-emerald-100 dark:s-bg-emerald-100-night",
         amber: "s-bg-amber-100 dark:s-bg-amber-100-night",
         slate:
-          "s-bg-muted-background dark:s-bg-muted-background-night s-border s-border-border",
+          "s-bg-muted-background dark:s-bg-muted-background-night s-border s-border-border dark:s-border-border-night",
         purple: "s-bg-purple-100 dark:s-bg-purple-100-night",
         warning: "s-bg-warning-100 dark:s-bg-warning-100-night",
         sky: "s-bg-sky-100 dark:s-bg-sky-100-night",


### PR DESCRIPTION
## Description

SearchInput was added here: https://github.com/dust-tt/dust/pull/10823/files
-> But was missing the Sparkle bump. 

+ Fix a border issue on ContentMessage!

## Tests

Locally on storybook.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish Sparkle