### PR TITLE
Dark mode in Context + handle platform and providers white logos

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -59,6 +59,7 @@ import { RequestDataSourceModal } from "@app/components/data_source/RequestDataS
 import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import { AdvancedNotionManagement } from "@app/components/spaces/AdvancedNotionManagement";
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import {
   CONNECTOR_CONFIGURATIONS,
   isConnectorPermissionsEditable,
@@ -225,6 +226,7 @@ function DataSourceEditionModal({
   onEditPermissionsClick,
   owner,
 }: DataSourceEditionModalProps) {
+  const { isDark } = useTheme();
   const [extraConfig, setExtraConfig] = useState<Record<string, string>>({});
   const { user } = useUser();
 
@@ -268,7 +270,10 @@ function DataSourceEditionModal({
       <>
         <div className="mt-4 flex flex-col">
           <div className="flex items-center gap-2">
-            <Icon visual={connectorConfiguration.logoComponent} size="md" />
+            <Icon
+              visual={connectorConfiguration.getLogoComponent(isDark)}
+              size="md"
+            />
             <Page.SectionHeader
               title={`${connectorConfiguration.name} data & permissions`}
             />
@@ -422,6 +427,7 @@ function DataSourceDeletionModal({
   onClose,
   owner,
 }: DataSourceDeletionModalProps) {
+  const { isDark } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const sendNotification = useSendNotification();
   const { user } = useUser();
@@ -475,7 +481,10 @@ function DataSourceDeletionModal({
       <>
         <div className="mt-4 flex flex-col">
           <div className="flex items-center gap-2">
-            <Icon visual={connectorConfiguration.logoComponent} size="md" />
+            <Icon
+              visual={connectorConfiguration.getLogoComponent(isDark)}
+              size="md"
+            />
             <Page.SectionHeader
               title={`Deleting ${connectorConfiguration.name} connection`}
             />

--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -49,6 +49,7 @@ import { useMemo, useState } from "react";
 
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { DataSourceViewPermissionTree } from "@app/components/DataSourceViewPermissionTree";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getContentNodeInternalIdFromTableId } from "@app/lib/api/content_nodes";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
@@ -355,6 +356,7 @@ function DataSourceViewsSection({
   dataSourceConfigurations,
   viewType,
 }: DataSourceViewsSectionProps) {
+  const { isDark } = useTheme();
   const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
     null
   );
@@ -383,10 +385,10 @@ function DataSourceViewsSection({
 
           if (dataSourceView) {
             const { dataSource } = dataSourceView;
-            dsLogo = getConnectorProviderLogoWithFallback(
-              dataSource.connectorProvider,
-              FolderIcon
-            );
+            dsLogo = getConnectorProviderLogoWithFallback({
+              provider: dataSource.connectorProvider,
+              isDark,
+            });
             dataSourceName = getDisplayNameForDataSource(dataSource);
           }
 

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -2,7 +2,6 @@ import {
   BracesIcon,
   Button,
   ExternalLinkIcon,
-  FolderIcon,
   IconButton,
   Tree,
 } from "@dust-tt/sparkle";
@@ -19,6 +18,7 @@ import { DataSourceTagsFilterDropdown } from "@app/components/assistant_builder/
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { DataSourceViewPermissionTree } from "@app/components/DataSourceViewPermissionTree";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewSelectionConfigurationByImportance } from "@app/lib/connectors";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
@@ -44,6 +44,7 @@ export default function DataSourceSelectionSection({
   owner,
   viewType,
 }: DataSourceSelectionSectionProps) {
+  const { isDark } = useTheme();
   const { dataSourceViews } = useContext(AssistantBuilderContext);
   const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
     null
@@ -94,10 +95,10 @@ export default function DataSourceSelectionSection({
             {orderDatasourceViewSelectionConfigurationByImportance(
               Object.values(dataSourceConfigurations)
             ).map((dsConfig) => {
-              const LogoComponent = getConnectorProviderLogoWithFallback(
-                dsConfig.dataSourceView.dataSource.connectorProvider,
-                FolderIcon
-              );
+              const LogoComponent = getConnectorProviderLogoWithFallback({
+                provider: dsConfig.dataSourceView.dataSource.connectorProvider,
+                isDark,
+              });
 
               return (
                 <Tree.Item

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -48,7 +48,8 @@ import React, {
 } from "react";
 
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
-import { MODEL_PROVIDER_LOGOS } from "@app/components/providers/types";
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { ParagraphExtension } from "@app/components/text_editor/extensions";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import {
@@ -401,6 +402,7 @@ interface ModelListProps {
 }
 
 function ModelList({ modelConfigs, onClick }: ModelListProps) {
+  const { isDark } = useTheme();
   const handleClick = (modelConfig: ModelConfigurationType) => {
     onClick({
       modelId: modelConfig.modelId,
@@ -414,7 +416,7 @@ function ModelList({ modelConfigs, onClick }: ModelListProps) {
       {modelConfigs.map((modelConfig) => (
         <DropdownMenuItem
           key={modelConfig.modelId}
-          icon={MODEL_PROVIDER_LOGOS[modelConfig.providerId]}
+          icon={getModelProviderLogo(modelConfig.providerId, isDark)}
           description={modelConfig.shortDescription}
           label={modelConfig.displayName}
           onClick={() => handleClick(modelConfig)}

--- a/front/components/data_source/CreateConnectionConfirmationModal.tsx
+++ b/front/components/data_source/CreateConnectionConfirmationModal.tsx
@@ -15,6 +15,7 @@ import { WrenchScrewdriverIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 
 type CreateConnectionConfirmationModalProps = {
@@ -30,6 +31,7 @@ export function CreateConnectionConfirmationModal({
   onClose,
   onConfirm,
 }: CreateConnectionConfirmationModalProps) {
+  const { isDark } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const [extraConfig, setExtraConfig] = useState<Record<string, string>>({});
 
@@ -70,7 +72,7 @@ export function CreateConnectionConfirmationModal({
             <Page.Vertical gap="lg" align="stretch">
               <Page.Header
                 title={`Connecting ${connectorProviderConfiguration.name}`}
-                icon={connectorProviderConfiguration.logoComponent}
+                icon={connectorProviderConfiguration.getLogoComponent(isDark)}
               />
               <Button
                 label="Read our guide"

--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -34,6 +34,7 @@ import { isRight } from "fp-ts/lib/Either";
 import { formatValidationErrors } from "io-ts-reporters";
 import React, { useEffect, useMemo, useState } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 import { useBigQueryLocations } from "@app/lib/swr/bigquery";
 import type { PostCredentialsBody } from "@app/pages/api/w/[wId]/credentials";
@@ -63,6 +64,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
   onSuccess: _onSuccess,
   dataSourceToUpdate,
 }: CreateOrUpdateConnectionBigQueryModalProps) {
+  const { isDark } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [credentials, setCredentials] = useState<string>("");
@@ -284,7 +286,9 @@ export function CreateOrUpdateConnectionBigQueryModal({
         <SheetHeader>
           <SheetTitle className="flex items-center gap-2">
             <span className="[&>svg]:h-6 [&>svg]:w-6">
-              <Icon visual={connectorProviderConfiguration.logoComponent} />
+              <Icon
+                visual={connectorProviderConfiguration.getLogoComponent(isDark)}
+              />
             </span>
             Connecting {connectorProviderConfiguration.name}
           </SheetTitle>

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -22,6 +22,7 @@ import type {
 import { isConnectorsAPIError } from "@dust-tt/types";
 import { useState } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 
 type CreateOrUpdateConnectionSnowflakeModalProps = {
@@ -49,6 +50,7 @@ export function CreateOrUpdateConnectionSnowflakeModal({
   onSuccess: _onSuccess,
   dataSourceToUpdate,
 }: CreateOrUpdateConnectionSnowflakeModalProps) {
+  const { isDark } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [credentials, setCredentials] = useState<SnowflakeCredentials>({
@@ -214,7 +216,9 @@ export function CreateOrUpdateConnectionSnowflakeModal({
         <SheetHeader>
           <SheetTitle className="flex items-center gap-2">
             <span className="[&>svg]:h-6 [&>svg]:w-6">
-              <Icon visual={connectorProviderConfiguration.logoComponent} />
+              <Icon
+                visual={connectorProviderConfiguration.getLogoComponent(isDark)}
+              />
             </span>
             Connecting {connectorProviderConfiguration.name}
           </SheetTitle>

--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -19,6 +19,7 @@ import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
 import * as _ from "lodash";
 import { useEffect, useState } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
 import { sendRequestDataSourceEmail } from "@app/lib/email";
@@ -33,6 +34,7 @@ export function RequestDataSourceModal({
   dataSources,
   owner,
 }: RequestDataSourceModal) {
+  const { isDark } = useTheme();
   const [selectedDataSource, setSelectedDataSource] =
     useState<DataSourceType | null>(null);
 
@@ -125,9 +127,10 @@ export function RequestDataSourceModal({
                           label={getDisplayNameForDataSource(
                             selectedDataSource
                           )}
-                          icon={getConnectorProviderLogoWithFallback(
-                            selectedDataSource.connectorProvider
-                          )}
+                          icon={getConnectorProviderLogoWithFallback({
+                            provider: selectedDataSource.connectorProvider,
+                            isDark,
+                          })}
                         />
                       ) : (
                         <Button
@@ -146,9 +149,10 @@ export function RequestDataSourceModal({
                               key={dataSource.sId}
                               label={getDisplayNameForDataSource(dataSource)}
                               onClick={() => setSelectedDataSource(dataSource)}
-                              icon={getConnectorProviderLogoWithFallback(
-                                dataSource.connectorProvider
-                              )}
+                              icon={getConnectorProviderLogoWithFallback({
+                                provider: dataSource.connectorProvider,
+                                isDark,
+                              })}
                             />
                           )
                       )}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -27,6 +27,7 @@ import type {
   TreeSelectionModelUpdater,
 } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import {
@@ -331,12 +332,13 @@ export function DataSourceViewSelector({
   defaultCollapsed = true,
   useCase,
 }: DataSourceViewSelectorProps) {
+  const { isDark } = useTheme();
   const dataSourceView = selectionConfiguration.dataSourceView;
 
-  const LogoComponent = getConnectorProviderLogoWithFallback(
-    dataSourceView.dataSource.connectorProvider,
-    FolderIcon
-  );
+  const LogoComponent = getConnectorProviderLogoWithFallback({
+    provider: dataSourceView.dataSource.connectorProvider,
+    isDark,
+  });
 
   const internalIds = selectionConfiguration.selectedResources.map(
     (r) => r.internalId

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -1,8 +1,10 @@
 import {
   AnthropicLogo,
+  AnthropicWhiteLogo,
   GoogleLogo,
   MistralLogo,
   OpenaiLogo,
+  OpenaiWhiteLogo,
   PlanetIcon,
 } from "@dust-tt/sparkle";
 import type { ModelConfig, SUPPORTED_MODEL_CONFIGS } from "@dust-tt/types";
@@ -32,16 +34,47 @@ import type { ComponentType } from "react";
 
 type ModelProvider = (typeof SUPPORTED_MODEL_CONFIGS)[number]["providerId"];
 
-export const MODEL_PROVIDER_LOGOS: Record<ModelProvider, ComponentType> = {
-  openai: OpenaiLogo,
-  anthropic: AnthropicLogo,
-  mistral: MistralLogo,
-  google_ai_studio: GoogleLogo,
-  togetherai: PlanetIcon,
-  deepseek: PlanetIcon,
-  fireworks: PlanetIcon,
+type ModelProviderLogos = Record<
+  ModelProvider,
+  {
+    light: ComponentType;
+    dark?: ComponentType;
+  }
+>;
+
+const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
+  openai: {
+    light: OpenaiLogo,
+    dark: OpenaiWhiteLogo,
+  },
+  anthropic: {
+    light: AnthropicLogo,
+    dark: AnthropicWhiteLogo,
+  },
+  mistral: {
+    light: MistralLogo,
+  },
+  google_ai_studio: {
+    light: GoogleLogo,
+  },
+  togetherai: {
+    light: PlanetIcon,
+  },
+  deepseek: {
+    light: PlanetIcon,
+  },
+  fireworks: {
+    light: PlanetIcon,
+  },
 };
 
+export const getModelProviderLogo = (
+  provider: ModelProvider,
+  isDark: boolean
+) => {
+  const logos = MODEL_PROVIDER_LOGOS[provider];
+  return isDark && logos.dark ? logos.dark : logos.light;
+};
 export const USED_MODEL_CONFIGS: readonly ModelConfig[] = [
   GPT_4O_MODEL_CONFIG,
   GPT_4O_MINI_MODEL_CONFIG,

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -38,6 +38,7 @@ import { useCallback, useState } from "react";
 import { CreateConnectionConfirmationModal } from "@app/components/data_source/CreateConnectionConfirmationModal";
 import { CreateOrUpdateConnectionBigQueryModal } from "@app/components/data_source/CreateOrUpdateConnectionBigQueryModal";
 import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import {
   CONNECTOR_CONFIGURATIONS,
   getConnectorProviderLogoWithFallback,
@@ -117,6 +118,7 @@ export const AddConnectionMenu = ({
   });
 
   const router = useRouter();
+  const { isDark } = useTheme();
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const { systemSpace } = useSystemSpace({ workspaceId: owner.sId });
 
@@ -489,7 +491,10 @@ export const AddConnectionMenu = ({
               <DropdownMenuItem
                 key={i.connectorProvider}
                 label={CONNECTOR_CONFIGURATIONS[i.connectorProvider].name}
-                icon={getConnectorProviderLogoWithFallback(i.connectorProvider)}
+                icon={getConnectorProviderLogoWithFallback({
+                  provider: i.connectorProvider,
+                  isDark,
+                })}
                 onClick={() => {
                   handleConnectionClick(i);
                 }}

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -6,7 +6,6 @@ import {
   Cog6ToothIcon,
   CubeIcon,
   DataTable,
-  FolderIcon,
   PencilSquareIcon,
   SearchInput,
   Spinner,
@@ -37,6 +36,7 @@ import { AddConnectionMenu } from "@app/components/spaces/AddConnectionMenu";
 import { EditSpaceManagedDataSourcesViews } from "@app/components/spaces/EditSpaceManagedDatasourcesViews";
 import { EditSpaceStaticDatasourcesViews } from "@app/components/spaces/EditSpaceStaticDatasourcesViews";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { ViewFolderAPIModal } from "@app/components/ViewFolderAPIModal";
 import {
   getConnectorProviderLogoWithFallback,
@@ -246,6 +246,7 @@ export const SpaceResourcesList = ({
   onSelect,
   integrations,
 }: SpaceResourcesListProps) => {
+  const { isDark } = useTheme();
   const [assistantName, setAssistantName] = useState<string | null>(null);
   const { sId: assistantSId } = useAgentConfigurationSIdLookup({
     workspaceId: owner.sId,
@@ -341,7 +342,7 @@ export const SpaceResourcesList = ({
       return {
         dataSourceView,
         label: getDataSourceNameFromView(dataSourceView),
-        icon: getConnectorProviderLogoWithFallback(provider, FolderIcon),
+        icon: getConnectorProviderLogoWithFallback({ provider, isDark }),
         workspaceId: owner.sId,
         isAdmin,
         isLoading: provider ? isLoadingByProvider[provider] : false,

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -23,6 +23,7 @@ import { useRouter } from "next/router";
 import type { ComponentType, ReactElement } from "react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
@@ -447,6 +448,7 @@ const SpaceDataSourceViewItem = ({
   space: SpaceType;
   node?: DataSourceViewContentNode;
 }): ReactElement => {
+  const { isDark } = useTheme();
   const { setNavigationSelection } = usePersistedNavigationSelection();
   const router = useRouter();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -491,10 +493,10 @@ const SpaceDataSourceViewItem = ({
 
   const LogoComponent = node
     ? getVisualForContentNode(node)
-    : getConnectorProviderLogoWithFallback(
-        item.dataSource.connectorProvider,
-        FolderIcon
-      );
+    : getConnectorProviderLogoWithFallback({
+        provider: item.dataSource.connectorProvider,
+        isDark,
+      });
 
   const dataSourceViewPath = node
     ? `${basePath}?parentId=${node?.internalId}`

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -8,6 +8,7 @@ import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/con
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import { Navigation } from "@app/components/navigation/Navigation";
 import { QuickStartGuide } from "@app/components/QuickStartGuide";
+import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
 import { useUser } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
@@ -61,27 +62,6 @@ export default function AppLayout({
   }, []);
 
   useEffect(() => {
-    const theme = localStorage.getItem("theme");
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-
-    const setDarkMode = (isDark: boolean) => {
-      document.body.classList.toggle("dark", isDark);
-      document.body.classList.toggle("s-dark", isDark);
-    };
-
-    const handleSystemChange = (e: MediaQueryListEvent) => {
-      if (theme === "system") {
-        setDarkMode(e.matches);
-      }
-    };
-
-    setDarkMode(theme === "dark" || (theme === "system" && mediaQuery.matches));
-
-    mediaQuery.addEventListener("change", handleSystemChange);
-    return () => mediaQuery.removeEventListener("change", handleSystemChange);
-  }, []);
-
-  useEffect(() => {
     if (typeof window !== "undefined" && user?.sId) {
       // Identify the user with GTM
       window.dataLayer = window.dataLayer || [];
@@ -101,7 +81,7 @@ export default function AppLayout({
   }, [user?.email, user?.fullName, user?.sId]);
 
   return (
-    <>
+    <ThemeProvider>
       <Head>
         <title>{pageTitle ? pageTitle : `Dust - ${owner.name}`}</title>
         <link rel="shortcut icon" href="/static/favicon.png" />
@@ -209,6 +189,6 @@ export default function AppLayout({
               })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
             `}
       </Script>
-    </>
+    </ThemeProvider>
   );
 }

--- a/front/components/sparkle/ThemeContext.tsx
+++ b/front/components/sparkle/ThemeContext.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "dark" | "light" | "system";
+
+interface ThemeContextType {
+  theme: Theme;
+  isDark: boolean;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme") as Theme;
+    if (savedTheme) {
+      setTheme(savedTheme);
+    }
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const updateTheme = () => {
+      const nextIsDark =
+        theme === "dark" || (theme === "system" && mediaQuery.matches);
+
+      setIsDark(nextIsDark);
+      document.body.classList.toggle("dark", nextIsDark);
+      document.body.classList.toggle("s-dark", nextIsDark);
+    };
+
+    const handleSystemChange = () => {
+      if (theme === "system") {
+        updateTheme();
+      }
+    };
+
+    updateTheme();
+    mediaQuery.addEventListener("change", handleSystemChange);
+    return () => mediaQuery.removeEventListener("change", handleSystemChange);
+  }, [theme]);
+
+  const handleThemeChange = (newTheme: Theme) => {
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider
+      value={{ theme, isDark, setTheme: handleThemeChange }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return context;
+};

--- a/front/components/trackers/TrackerDataSourceSelectedTree.tsx
+++ b/front/components/trackers/TrackerDataSourceSelectedTree.tsx
@@ -2,7 +2,6 @@ import {
   BracesIcon,
   classNames,
   ExternalLinkIcon,
-  FolderIcon,
   IconButton,
   Tree,
 } from "@dust-tt/sparkle";
@@ -15,6 +14,7 @@ import { useState } from "react";
 
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { DataSourceViewPermissionTree } from "@app/components/DataSourceViewPermissionTree";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewSelectionConfigurationByImportance } from "@app/lib/connectors";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
@@ -22,7 +22,6 @@ import {
   canBeExpanded,
   getDisplayNameForDataSource,
 } from "@app/lib/data_sources";
-
 export const TrackerDataSourceSelectedTree = ({
   owner,
   dataSourceConfigurations,
@@ -30,6 +29,7 @@ export const TrackerDataSourceSelectedTree = ({
   owner: LightWorkspaceType;
   dataSourceConfigurations: DataSourceViewSelectionConfigurations;
 }) => {
+  const { isDark } = useTheme();
   const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
     null
   );
@@ -48,10 +48,10 @@ export const TrackerDataSourceSelectedTree = ({
         {orderDatasourceViewSelectionConfigurationByImportance(
           Object.values(dataSourceConfigurations)
         ).map((dsConfig) => {
-          const LogoComponent = getConnectorProviderLogoWithFallback(
-            dsConfig.dataSourceView.dataSource.connectorProvider,
-            FolderIcon
-          );
+          const LogoComponent = getConnectorProviderLogoWithFallback({
+            provider: dsConfig.dataSourceView.dataSource.connectorProvider,
+            isDark,
+          });
 
           return (
             <Tree.Item

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -21,10 +21,11 @@ import { isEqual, uniqBy } from "lodash";
 import { useCallback, useMemo, useState } from "react";
 
 import {
-  MODEL_PROVIDER_LOGOS,
+  getModelProviderLogo,
   REASONING_MODEL_CONFIGS,
   USED_MODEL_CONFIGS,
 } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 
 type ProviderStates = Record<ModelProviderIdType, boolean>;
 
@@ -59,6 +60,7 @@ interface ProviderManagementModalProps {
 export function ProviderManagementModal({
   owner,
 }: ProviderManagementModalProps) {
+  const { isDark } = useTheme();
   const sendNotifications = useSendNotification();
 
   const initialProviderStates: ProviderStates = useMemo(() => {
@@ -176,7 +178,7 @@ export function ProviderManagementModal({
           <div className="flex flex-col gap-4">
             <ContextItem.List>
               {MODEL_PROVIDER_IDS.map((provider) => {
-                const LogoComponent = MODEL_PROVIDER_LOGOS[provider];
+                const LogoComponent = getModelProviderLogo(provider, isDark);
                 if (!modelProviders[provider]) {
                   return null;
                 }

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -4,6 +4,7 @@ import {
   DriveLogo,
   FolderIcon,
   GithubLogo,
+  GithubWhiteLogo,
   GlobeAltIcon,
   IntercomLogo,
   MicrosoftLogo,
@@ -12,6 +13,7 @@ import {
   SlackLogo,
   SnowflakeLogo,
   ZendeskLogo,
+  ZendeskWhiteLogo,
 } from "@dust-tt/sparkle";
 import type {
   ConnectorPermission,
@@ -42,7 +44,9 @@ export type ConnectorProviderConfiguration = {
   status: "preview" | "built" | "rolling_out";
   rollingOutFlag?: WhitelistableFeature;
   hide: boolean;
-  logoComponent: (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
+  getLogoComponent: (
+    isDark?: boolean
+  ) => (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
   optionsComponent?: (props: ConnectorOptionsProps) => React.JSX.Element;
   description: string;
   mismatchError: string;
@@ -86,7 +90,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     mismatchError: `You cannot select another Confluence Domain.\nPlease contact us at support@dust.tt if you initially selected the wrong Domain.`,
     guideLink: "https://docs.dust.tt/docs/confluence-connection",
     selectLabel: "Select pages",
-    logoComponent: ConfluenceLogo,
+    getLogoComponent: () => {
+      return ConfluenceLogo;
+    },
     isNested: true,
     isSearchEnabled: false,
     permissions: {
@@ -106,7 +112,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     mismatchError: `You cannot select another Notion Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
     guideLink: "https://docs.dust.tt/docs/notion-connection",
     selectLabel: "Synchronized content",
-    logoComponent: NotionLogo,
+    getLogoComponent: () => {
+      return NotionLogo;
+    },
     isNested: true,
     isSearchEnabled: false,
     permissions: {
@@ -127,7 +135,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     mismatchError: `You cannot select another Google Drive Domain.\nPlease contact us at support@dust.tt if you initially selected a wrong shared Drive.`,
     guideLink: "https://docs.dust.tt/docs/google-drive-connection",
     selectLabel: "Select folders and files",
-    logoComponent: DriveLogo,
+    getLogoComponent: () => {
+      return DriveLogo;
+    },
     isNested: true,
     isSearchEnabled: false,
     permissions: {
@@ -147,7 +157,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     mismatchError: `You cannot select another Slack Team.\nPlease contact us at support@dust.tt if you initially selected the wrong Team.`,
     guideLink: "https://docs.dust.tt/docs/slack-connection",
     selectLabel: "Select channels",
-    logoComponent: SlackLogo,
+    getLogoComponent: () => {
+      return SlackLogo;
+    },
     optionsComponent: SlackBotEnableView,
     isNested: false,
     isSearchEnabled: true,
@@ -169,7 +181,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     mismatchError: `You cannot select another GitHub Organization.\nPlease contact us at support@dust.tt if you initially selected a wrong Organization or if you completely uninstalled the GitHub app.`,
     guideLink: "https://docs.dust.tt/docs/github-connection",
     selectLabel: "Synchronized content",
-    logoComponent: GithubLogo,
+    getLogoComponent: (isDark?: boolean) => {
+      return isDark ? GithubWhiteLogo : GithubLogo;
+    },
     optionsComponent: GithubCodeEnableView,
     isNested: true,
     isSearchEnabled: false,
@@ -191,7 +205,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     mismatchError: `You cannot select another Intercom Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
     guideLink: "https://docs.dust.tt/docs/intercom-connection",
     selectLabel: "Select pages",
-    logoComponent: IntercomLogo,
+    getLogoComponent: () => {
+      return IntercomLogo;
+    },
     optionsComponent: IntercomConfigView,
     isNested: true,
     isSearchEnabled: false,
@@ -213,7 +229,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     mismatchError: `You cannot select another Microsoft account.\nPlease contact us at support@dust.tt if you initially selected a wrong account.`,
     guideLink: "https://docs.dust.tt/docs/microsoft-connection",
     selectLabel: "Select folders and files",
-    logoComponent: MicrosoftLogo,
+    getLogoComponent: () => {
+      return MicrosoftLogo;
+    },
     isNested: true,
     isSearchEnabled: false,
     permissions: {
@@ -231,7 +249,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     limitations: null,
     mismatchError: `You cannot change the URL. Please add a new Public URL instead.`,
     guideLink: "https://docs.dust.tt/docs/website-connection",
-    logoComponent: GlobeAltIcon,
+    getLogoComponent: () => {
+      return GlobeAltIcon;
+    },
     isNested: true,
     isSearchEnabled: false,
     permissions: {
@@ -248,7 +268,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     description: "Query a Snowflake database.",
     limitations: null,
     mismatchError: `You cannot change the Snowflake account. Please add a new Snowflake connection instead.`,
-    logoComponent: SnowflakeLogo,
+    getLogoComponent: () => {
+      return SnowflakeLogo;
+    },
     isNested: true,
     isSearchEnabled: false,
     guideLink: "https://docs.dust.tt/docs/snowflake-connection",
@@ -270,7 +292,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "Dust will index the content accessible to the authorized account only. Attachments are not indexed.",
     mismatchError: `You cannot select another Zendesk Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
     guideLink: "https://docs.dust.tt/docs/zendesk-connection",
-    logoComponent: ZendeskLogo,
+    getLogoComponent: (isDark?: boolean) => {
+      return isDark ? ZendeskWhiteLogo : ZendeskLogo;
+    },
     isNested: true,
     isSearchEnabled: false,
     permissions: {
@@ -287,7 +311,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     description: "Query a BigQuery database.",
     limitations: null,
     mismatchError: `You cannot change the BigQuery project. Please add a new BigQuery connection instead.`,
-    logoComponent: BigQueryLogo,
+    getLogoComponent: () => {
+      return BigQueryLogo;
+    },
     isNested: true,
     isSearchEnabled: false,
     guideLink: "https://docs.dust.tt/docs/bigquery",
@@ -308,7 +334,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "Authorize access to your Salesforce organization, in order to query your Salesforce data from Dust.",
     limitations: null,
     mismatchError: `You cannot change the Salesforce instance URL. Please add a new Salesforce connection instead.`,
-    logoComponent: SalesforceLogo,
+    getLogoComponent: () => {
+      return SalesforceLogo;
+    },
     isNested: true,
     isSearchEnabled: false,
     permissions: {
@@ -331,14 +359,19 @@ export const REMOTE_DATABASE_CONNECTOR_PROVIDERS: ConnectorProvider[] = [
   "bigquery",
 ];
 
-export function getConnectorProviderLogoWithFallback(
-  provider: ConnectorProvider | null,
-  fallback: ComponentType = FolderIcon
-): ComponentType {
+export function getConnectorProviderLogoWithFallback({
+  provider,
+  fallback = FolderIcon,
+  isDark,
+}: {
+  provider: ConnectorProvider | null;
+  fallback?: ComponentType;
+  isDark?: boolean;
+}): ComponentType {
   if (!provider) {
     return fallback;
   }
-  return CONNECTOR_CONFIGURATIONS[provider].logoComponent;
+  return CONNECTOR_CONFIGURATIONS[provider].getLogoComponent(isDark);
 }
 
 export const isValidConnectorSuffix = (suffix: string): boolean => {

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -21,6 +21,7 @@ import { useRouter } from "next/router";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -59,6 +60,7 @@ export default function EditDustAssistant({
   globalSpace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
+  const { isDark } = useTheme();
   const sendNotification = useSendNotification();
 
   const {
@@ -235,10 +237,11 @@ export default function EditDustAssistant({
                         title={getDisplayNameForDataSource(dsView.dataSource)}
                         visual={
                           <ContextItem.Visual
-                            visual={getConnectorProviderLogoWithFallback(
-                              dsView.dataSource.connectorProvider,
-                              CloudArrowDownIcon
-                            )}
+                            visual={getConnectorProviderLogoWithFallback({
+                              provider: dsView.dataSource.connectorProvider,
+                              fallback: CloudArrowDownIcon,
+                              isDark,
+                            })}
                           />
                         }
                         action={


### PR DESCRIPTION
## Description

This PR does 2 things: 
- Move the logic to set the dark mode classes in a React context. 
- Update the logic to get Provider and Connectors logo to handle the white version required for Zendesk, GitHub, Anthropic and OpenAI. 

The diff looks big but the changes are quite straightforward! 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
