### PR TITLE
fix(scrub worklow) - Add cleanup for `AgentReasoningAction` in conversation destroy

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -8,10 +8,10 @@ import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { AgentConversationIncludeFileAction } from "@app/lib/models/assistant/actions/conversation/include_file";
 import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
+import { AgentReasoningAction } from "@app/lib/models/assistant/actions/reasoning";
 import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
 import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
-import { AgentReasoningAction } from "@app/lib/models/assistant/actions/reasoning";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {
   AgentMessage,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -11,6 +11,7 @@ import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
 import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
+import { AgentReasoningAction } from "@app/lib/models/assistant/actions/reasoning";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {
   AgentMessage,
@@ -61,6 +62,9 @@ async function destroyActionsRelatedResources(agentMessageIds: Array<ModelId>) {
     where: { agentMessageId: agentMessageIds },
   });
   await AgentConversationIncludeFileAction.destroy({
+    where: { agentMessageId: agentMessageIds },
+  });
+  await AgentReasoningAction.destroy({
     where: { agentMessageId: agentMessageIds },
   });
 }


### PR DESCRIPTION
## Description

- `dust-apply https://dust.tt/w/0ec9852c2f/assistant/oWcAbpNE0F`
- We had a scrub workflow stuck: Slack [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1739744838889869), [log](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZUQ3TKN2NEJNwAAABhBWlVRM1RnX0FBQ1FjV0NSSmhLa0NBQUUAAAAkMDE5NTEwZjgtNjdlNy00ZTA3LWFhM2EtMzRmYTRjZmM3ZWIyAAancA&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1739743844000&to_ts=1739744744000&live=false).
- The cause was: `ForeignKeyConstraintError: update or delete on table "agent_messages" violates foreign key constraint "agent_reasoning_actions_agentMessageId_fkey" on table "agent_reasoning_actions"`.
- This PR fixes that by adding the missing delete.

## Tests

- n/a

## Risk

- Low.

## Deploy Plan

- Deploy front.