### PR TITLE
Wrap `PokeLayout` in a `ThemeProvider`

### DIFF
--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import RootLayout from "@app/components/app/RootLayout";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
+import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { usePokeRegion } from "@app/lib/swr/poke";
 
@@ -15,9 +16,11 @@ export default function PokeLayout({
   children: React.ReactNode;
 }) {
   return (
-    <RootLayout>
-      <PokeLayoutContent>{children}</PokeLayoutContent>
-    </RootLayout>
+    <ThemeProvider>
+      <RootLayout>
+        <PokeLayoutContent>{children}</PokeLayoutContent>
+      </RootLayout>
+    </ThemeProvider>
   );
 }
 


### PR DESCRIPTION
## Description

- The poke `DataSourceView` page is broken. It contains a `DataSourceViewSelector`, which uses the hook `useTheme`, without being in a `ThemeProvider` context (added pretty much everywhere except in poke).
- This PR fixes that.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy front.