### PR TITLE
Sparkle: Add portal attribute to SearchPopover

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.403",
+  "version": "0.2.404",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.403",
+      "version": "0.2.404",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.403",
+  "version": "0.2.404",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Popover.tsx
+++ b/sparkle/src/components/Popover.tsx
@@ -45,6 +45,7 @@ const PopoverContent = React.forwardRef<
           "s-z-50 s-rounded-xl s-border s-shadow-md s-outline-none",
           "s-bg-background dark:s-bg-background-night",
           "s-text-primary-950 dark:s-text-primary-950-night",
+          "s-border-border dark:s-border-border-night",
           fullWidth ? "s-grow" : "s-w-72 s-p-4",
           className
         )}

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -101,6 +101,7 @@ export interface SearchInputWithPopoverProps extends SearchInputProps {
   contentClassName?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  mountPortal?: boolean;
 }
 
 export const SearchInputWithPopover = forwardRef<
@@ -116,6 +117,7 @@ export const SearchInputWithPopover = forwardRef<
       onOpenChange,
       value,
       onChange,
+      mountPortal = false,
       ...searchInputProps
     },
     ref
@@ -150,6 +152,7 @@ export const SearchInputWithPopover = forwardRef<
           onOpenAutoFocus={(e) => e.preventDefault()}
           onCloseAutoFocus={(e) => e.preventDefault()}
           onInteractOutside={() => onOpenChange(false)}
+          mountPortal={mountPortal}
         >
           <ScrollArea
             role="listbox"

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -24,6 +24,7 @@ const TooltipContent = React.forwardRef<
       "s-z-50 s-max-w-sm s-overflow-hidden s-whitespace-pre-wrap s-break-words s-rounded-md s-border",
       "s-bg-white dark:s-bg-black",
       "s-text-foreground dark:s-text-foreground-night",
+      "s-border-border dark:s-border-border-night",
       "s-px-3 s-py-1.5 s-text-sm s-shadow-md",
       "s-animate-in s-fade-in-0 s-zoom-in-95",
       "data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=closed]:s-zoom-out-95 data-[side=bottom]:s-slide-in-from-top-2 data-[side=left]:s-slide-in-from-right-2 data-[side=right]:s-slide-in-from-left-2 data-[side=top]:s-slide-in-from-bottom-2",


### PR DESCRIPTION
## Description

Adds portal attribute to Search Popover component and add missing border that were not defined (both light and dark)

## Tests

Storybook. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish Sparkle. 
