### PR TITLE
[Nodes core] UpdateParents check that parents valid for datasourceview

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -208,7 +208,7 @@ function removeCatchAllFoldersIfEmpty(
   );
 }
 
-export function makeCoreDataSourceViewFilter(
+function makeCoreDataSourceViewFilter(
   dataSourceView: DataSourceViewResource | DataSourceViewType
 ): CoreAPIDatasourceViewFilter {
   return {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -208,7 +208,7 @@ function removeCatchAllFoldersIfEmpty(
   );
 }
 
-function makeCoreDataSourceViewFilter(
+export function makeCoreDataSourceViewFilter(
   dataSourceView: DataSourceViewResource | DataSourceViewType
 ): CoreAPIDatasourceViewFilter {
   return {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -27,6 +27,7 @@ import type {
 import { Op } from "sequelize";
 
 import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
@@ -48,8 +49,6 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
-import config from "@app/lib/api/config";
-import { makeCoreDataSourceViewFilter } from "@app/lib/api/data_source_view";
 
 const getDataSourceCategory = (
   dataSourceResource: DataSourceResource
@@ -538,7 +537,12 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
     const coreRes = await coreAPI.searchNodes({
       filter: {
-        data_source_views: [makeCoreDataSourceViewFilter(this)],
+        data_source_views: [
+          {
+            data_source_id: this.dataSource.dustAPIDataSourceId,
+            view_filter: [],
+          },
+        ],
         node_ids: parentsToAdd,
       },
     });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -555,7 +555,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     const coreParents = new Set(
       coreRes.value.nodes.map((node) => node.node_id)
     );
-    if (!parentsToAdd.every((parent) => coreParents.has(parent))) {
+    if (parentsToAdd.some((parent) => !coreParents.has(parent))) {
       return new Err(
         new Error("Some parents do not exist in this data source view.")
       );


### PR DESCRIPTION
Description
---
When updating parents of a datasourceview, checks that parents exist in the datasource

Goals is to defend further against cross-workspace issues (by providing a parent from another workspace)

Fixes https://github.com/dust-tt/dust/issues/9923

Risk
---
standard

Deploy
---
front