### PR TITLE
[core] Add ingestion filter to filter out unwanted tags

### DIFF
--- a/core/bin/elasticsearch/backfill_folders_index.rs
+++ b/core/bin/elasticsearch/backfill_folders_index.rs
@@ -51,7 +51,7 @@ async fn list_data_source_nodes(
 
     let stmt = c
         .prepare(
-            "SELECT dsn.timestamp, dsn.title, dsn.mime_type, dsn.provider_visibility, dsn.parents, dsn.node_id, dsn.document, dsn.\"table\", dsn.folder, ds.data_source_id, ds.internal_id, dsn.source_url, dsn.id \
+            "SELECT dsn.timestamp, dsn.title, dsn.mime_type, dsn.provider_visibility, dsn.parents, dsn.node_id, dsn.document, dsn.\"table\", dsn.folder, dns.tags_array, ds.data_source_id, ds.internal_id, dsn.source_url, dsn.id \
                FROM data_sources_nodes dsn JOIN data_sources ds ON dsn.data_source = ds.id \
                WHERE dsn.id > $1 AND folder IS NOT NULL ORDER BY dsn.id ASC LIMIT $2",
         )
@@ -71,8 +71,9 @@ async fn list_data_source_nodes(
             let document_row_id = row.get::<_, Option<i64>>(6);
             let table_row_id = row.get::<_, Option<i64>>(7);
             let folder_row_id = row.get::<_, Option<i64>>(8);
-            let data_source_id: String = row.get::<_, String>(9);
-            let data_source_internal_id: String = row.get::<_, String>(10);
+            let tags_array: Vec<String> = row.get::<_, Vec<String>>(9);
+            let data_source_id: String = row.get::<_, String>(10);
+            let data_source_internal_id: String = row.get::<_, String>(11);
             let (node_type, element_row_id) = match (document_row_id, table_row_id, folder_row_id) {
                 (Some(id), None, None) => (NodeType::Document, id),
                 (None, Some(id), None) => (NodeType::Table, id),
@@ -94,7 +95,7 @@ async fn list_data_source_nodes(
                     parents.get(1).cloned(),
                     parents,
                     source_url,
-                    None,
+                    Some(tags_array),
                 ),
                 row_id,
                 element_row_id,

--- a/core/bin/migrations/20250205_backfill_document_tags_index.rs
+++ b/core/bin/migrations/20250205_backfill_document_tags_index.rs
@@ -28,9 +28,6 @@ struct Args {
     #[arg(long, help = "The cursor to start from", default_value = "0")]
     start_cursor: i64,
 
-    #[arg(long, help = "The data source id to backfill", default_value = "1")]
-    data_source_id: i64,
-
     #[arg(long, help = "The batch size", default_value = "100")]
     batch_size: usize,
 
@@ -55,7 +52,6 @@ async fn main() {
 
 async fn list_data_source_documents(
     pool: &Pool<PostgresConnectionManager<NoTls>>,
-    data_source_id: i64,
     id_cursor: i64,
     batch_size: i64,
 ) -> Result<Vec<(i64, String, Vec<String>, String, String)>, Box<dyn std::error::Error>> {
@@ -63,12 +59,10 @@ async fn list_data_source_documents(
 
     let q = "SELECT dsn.id, dsn.node_id, dsn.tags_array, ds.data_source_id, ds.internal_id \
             FROM data_sources_nodes dsn JOIN data_sources ds ON dsn.data_source = ds.id \
-            WHERE ds.id = $1 AND dsn.id > $2 ORDER BY dsn.id ASC LIMIT $3";
+            WHERE dsn.id > $1 ORDER BY dsn.id ASC LIMIT $2";
 
     let stmt = c.prepare(q).await?;
-    let rows = c
-        .query(&stmt, &[&data_source_id, &id_cursor, &batch_size])
-        .await?;
+    let rows = c.query(&stmt, &[&id_cursor, &batch_size]).await?;
 
     let nodes: Vec<(i64, String, Vec<String>, String, String)> = rows
         .iter()
@@ -91,7 +85,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let index_version = args.index_version;
     let batch_size = args.batch_size;
     let start_cursor = args.start_cursor;
-    let data_source_id = args.data_source_id;
+
     let url = std::env::var("ELASTICSEARCH_URL").expect("ELASTICSEARCH_URL must be set");
     let username =
         std::env::var("ELASTICSEARCH_USERNAME").expect("ELASTICSEARCH_USERNAME must be set");
@@ -140,7 +134,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let pool = store.raw_pool();
     let c = pool.get().await?;
     let last_id = c
-        .query_one("SELECT MAX(id) FROM data_sources_nodes", &[])
+        .query_one("SELECT MAX(id) FROM data_sources_documents", &[])
         .await?;
     let last_id: i64 = last_id.get(0);
     println!("Last id in data_sources_nodes: {}", last_id);
@@ -149,8 +143,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             "Processing {} nodes, starting at id {}. ",
             batch_size, next_cursor
         );
-        let (nodes, next_id_cursor) =
-            get_node_batch(pool, data_source_id, next_cursor, batch_size).await?;
+        let (nodes, next_id_cursor) = get_node_batch(pool, next_cursor, batch_size).await?;
+
         next_cursor = match next_id_cursor {
             Some(cursor) => cursor,
             None => {
@@ -168,14 +162,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             .flat_map(|node| {
                 [
                     json!({"update": {"_id": format!("{}__{}", node.4, node.1) }}),
-                    json!({"doc": {"tags": node.2.into_iter()
-                        .filter(|tag| !tag.starts_with("createdAt:"))
-                        .filter(|tag| !tag.starts_with("updatedAt:"))
-                        .filter(|tag| !tag.starts_with("title:"))
-                        .collect::<Vec<String>>()}}),
+                    json!({"doc": {"tags": node.2}}),
                 ]
             })
             .collect();
+
         let nodes_body: Vec<JsonBody<_>> = nodes_values.into_iter().map(|v| v.into()).collect();
 
         search_store
@@ -199,20 +190,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
 async fn get_node_batch(
     pool: &Pool<PostgresConnectionManager<NoTls>>,
-    data_source_id: i64,
     next_cursor: i64,
     batch_size: usize,
 ) -> Result<
     (Vec<(i64, String, Vec<String>, String, String)>, Option<i64>),
     Box<dyn std::error::Error>,
 > {
-    let nodes = list_data_source_documents(
-        &pool,
-        data_source_id,
-        next_cursor,
-        batch_size.try_into().unwrap(),
-    )
-    .await?;
+    let nodes =
+        list_data_source_documents(&pool, next_cursor, batch_size.try_into().unwrap()).await?;
     let last_node = nodes.last().cloned();
     let nodes_length = nodes.len();
     match last_node {

--- a/core/src/search_stores/indices/data_sources_nodes_3.settings.europe-west1.json
+++ b/core/src/search_stores/indices/data_sources_nodes_3.settings.europe-west1.json
@@ -2,6 +2,7 @@
   "number_of_shards": 2,
   "number_of_replicas": 1,
   "refresh_interval": "30s",
+  "default_pipeline": "tag_filter",
   "analysis": {
     "analyzer": {
       "icu_analyzer": {
@@ -17,7 +18,10 @@
       "edge_analyzer": {
         "type": "custom",
         "tokenizer": "icu_tokenizer",
-        "filter": ["lowercase", "edge_ngram_filter"]
+        "filter": [
+          "lowercase",
+          "edge_ngram_filter"
+        ]
       }
     },
     "filter": {

--- a/core/src/search_stores/indices/data_sources_nodes_3.settings.local.json
+++ b/core/src/search_stores/indices/data_sources_nodes_3.settings.local.json
@@ -2,6 +2,7 @@
   "number_of_shards": 1,
   "number_of_replicas": 0,
   "refresh_interval": "30s",
+  "default_pipeline": "tag_filter",
   "analysis": {
     "analyzer": {
       "icu_analyzer": {
@@ -17,7 +18,10 @@
       "edge_analyzer": {
         "type": "custom",
         "tokenizer": "icu_tokenizer",
-        "filter": ["lowercase", "edge_ngram_filter"]
+        "filter": [
+          "lowercase",
+          "edge_ngram_filter"
+        ]
       }
     },
     "filter": {

--- a/core/src/search_stores/indices/data_sources_nodes_3.settings.us-central1.json
+++ b/core/src/search_stores/indices/data_sources_nodes_3.settings.us-central1.json
@@ -2,6 +2,7 @@
   "number_of_shards": 2,
   "number_of_replicas": 1,
   "refresh_interval": "30s",
+  "default_pipeline": "tag_filter",
   "analysis": {
     "analyzer": {
       "icu_analyzer": {
@@ -17,7 +18,10 @@
       "edge_analyzer": {
         "type": "custom",
         "tokenizer": "icu_tokenizer",
-        "filter": ["lowercase", "edge_ngram_filter"]
+        "filter": [
+          "lowercase",
+          "edge_ngram_filter"
+        ]
       }
     },
     "filter": {

--- a/core/src/search_stores/migrations/20250217_tags_filter_pipeline.http
+++ b/core/src/search_stores/migrations/20250217_tags_filter_pipeline.http
@@ -1,0 +1,13 @@
+PUT _ingest/pipeline/tag_filter
+{
+  "description": "Filter out unwanted tag values",
+  "processors": [
+    {
+      "script": {
+        "lang": "painless",
+        "source": "def tags = ctx.tags;if (tags != null) {ctx.tags = tags.stream().filter(tag -> !tag.startsWith(\"createdAt:\")).filter(tag -> !tag.startsWith(\"updatedAt:\")).filter(tag -> !tag.startsWith(\"title:\")).collect(Collectors.toList());}",
+        "if": "ctx.tags != null && ctx.tags.length > 0"
+      }
+    }
+  ]
+}

--- a/core/src/search_stores/migrations/20250217_tags_filter_to_index.http
+++ b/core/src/search_stores/migrations/20250217_tags_filter_to_index.http
@@ -1,0 +1,6 @@
+PUT core.data_sources_nodes/_settings
+{
+  "settings": {
+    "index.default_pipeline": "tag_filter"
+  }
+}


### PR DESCRIPTION
## Description

- Update the backfill folder to also push tags to index
- Add ingestion filter as painless script to filter out unwanted tags

## Tests

Tested locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy filter :

```
./admin/elasticsearch_run_command_from_file.sh src/search_stores/migrations/20250217_tags_filter_pipeline.http
./admin/elasticsearch_run_command_from_file.sh src/search_stores/migrations/20250217_tags_filter_to_index.http
```

Reindex docs:
```
cargo run --bin elasticsearch_backfill_index -- --index-version 3
```