### PR TITLE
enh(TableQuery) - add a CSV date parser

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -674,6 +674,8 @@ impl Row {
                     // HTTP date
                     DateTime::parse_from_str(trimmed, "%a, %d %b %Y %H:%M:%S GMT")
                         .map(|dt| dt.into()),
+                    // Date with full month, zero-padded number, full year
+                    DateTime::parse_from_str(trimmed, "%B %d, %Y").map(|dt| dt.into()),
                 ]
                 .iter()
                 .find_map(|result| result.ok());

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -446,6 +446,8 @@ export async function rowsFromCsv({
             DateTime.fromSQL,
             // Google Spreadsheet date format parser.
             (text: string) => DateTime.fromFormat(text, "d-MMM-yyyy"),
+            // Full month name format parser
+            (text: string) => DateTime.fromFormat(text, "LLLL dd, yyyy"),
           ];
           const trimmedV = v.trim();
           for (const parse of dateParsers) {


### PR DESCRIPTION
## Description

- `dust-apply https://dust.tt/w/0ec9852c2f/assistant/4ek9ryANEa`.
- Closes https://github.com/dust-tt/tasks/issues/2182.
- This PR adds a date parser for csv data.
- The parser supports dates like "January 08, 2000", which are not ambiguous.

## Tests

- n/a.

## Risk

- Well contained.

## Deploy Plan

- Deploy front.