### PR TITLE
[sparkle] - refacto(Notifications): use `sonner` notifications

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -41,6 +41,7 @@
         "remark-directive": "^2.0.1",
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
+        "sonner": "^1.7.4",
         "tailwind-merge": "^2.5.3",
         "tailwind-scrollbar-hide": "^1.1.7",
         "unist-util-visit": "^5.0.0"
@@ -28351,6 +28352,15 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.404",
+  "version": "0.2.405",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.404",
+      "version": "0.2.405",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.404",
+  "version": "0.2.405",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -127,6 +127,7 @@
     "remark-directive": "^2.0.1",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
+    "sonner": "^1.7.4",
     "tailwind-merge": "^2.5.3",
     "tailwind-scrollbar-hide": "^1.1.7",
     "unist-util-visit": "^5.0.0"

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -1,6 +1,5 @@
-import { Transition } from "@headlessui/react";
-import React, { useEffect } from "react";
-import { createPortal } from "react-dom";
+import React from "react";
+import { toast, Toaster } from "sonner";
 
 import { CheckCircleIcon, XCircleIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
@@ -26,51 +25,41 @@ export interface NotificationProps {
   onClick?: () => void;
 }
 
-export function Notification({
-  description,
-  title,
-  variant,
-  onClick,
-  className = "",
-}: NotificationProps) {
+function NotificationContent({ type, title, description }: NotificationType) {
   return (
     <div
       className={cn(
         "s-pointer-events-auto s-flex s-max-w-[400px] s-flex-row s-items-center s-gap-2 s-rounded-xl s-border",
         "s-border-structure-100 dark:s-border-structure-100-night",
         "s-bg-structure-0 dark:s-bg-structure-0-night",
-        "s-p-4",
-        "s-shadow-xl",
-        className
+        "s-p-4 s-shadow-xl"
       )}
-      onClick={onClick}
     >
-      {variant === "success" ? (
+      {type === "success" ? (
         <Icon
           size="lg"
           visual={CheckCircleIcon}
           className="s-pt-0.5 s-text-success-500 dark:s-text-success-500-night"
+          aria-hidden="true"
         />
       ) : (
         <Icon
           size="lg"
           visual={XCircleIcon}
           className="s-pt-0.5 s-text-warning-500 dark:s-text-warning-500-night"
+          aria-hidden="true"
         />
       )}
-
       <div className="s-flex s-flex-col">
-        <div className="s-flex s-grow s-flex-row s-gap-6">
-          <div
-            className={cn(
-              "s-text-md s-line-clamp-1 s-h-6 s-grow s-font-semibold",
-              variant === "success"
-                ? "s-text-success-500 dark:s-text-success-500-night"
-                : "s-text-warning-500 dark:s-text-warning-500-night"
-            )}
-          >
-            {title || variant}
-          </div>
+        <div
+          className={cn(
+            "s-text-md s-line-clamp-1 s-h-6 s-grow s-font-semibold",
+            type === "success"
+              ? "s-text-success-500 dark:s-text-success-500-night"
+              : "s-text-warning-500 dark:s-text-warning-500-night"
+          )}
+        >
+          {title || type}
         </div>
         {description && (
           <div
@@ -87,95 +76,42 @@ export function Notification({
   );
 }
 
-function NotificationWithTransition({
-  title,
-  description,
-  type,
-}: NotificationType) {
-  const [showNotification, setShowNotification] = React.useState(true);
-  useEffect(() => {
-    setTimeout(() => {
-      setShowNotification(false);
-    }, NOTIFICATION_DELAY);
-  }, []);
-  return (
-    <Transition
-      show={showNotification}
-      appear={true}
-      enter="s-transition s-ease-in-out s-duration-300 s-transform"
-      enterFrom="s-translate-y-16 s-opacity-0"
-      enterTo="s-translate-y-0 s-opacity-100"
-      leave="s-transition s-ease-in-out s-duration-300 s-transform"
-      leaveFrom="s-translate-y-0 s-opacity-100"
-      leaveTo="s-translate-y-16 s-opacity-0"
-    >
-      <Notification
-        variant={type}
-        description={description}
-        title={title}
-        onClick={() => setShowNotification(false)}
-      />
-    </Transition>
-  );
-}
+export const Notification = {
+  Area: ({ children }: { children: React.ReactNode }) => {
+    const sendNotification = React.useCallback((notification: NotificationType) => {
+      toast.custom(() => (
+        <NotificationContent
+          type={notification.type}
+          title={notification.title}
+          description={notification.description}
+        />
+      ), {
+        duration: NOTIFICATION_DELAY,
+      });
+    }, []);
 
-function NotificationsList({
-  notifications,
-}: {
-  notifications: (NotificationType & { id: string })[];
-}) {
-  return (
-    <div className="s-pointer-events-none s-fixed s-bottom-0 s-right-0 s-z-60 s-w-96">
-      <div className="s-flex s-flex-col s-items-center s-justify-center s-gap-4 s-p-4">
-        {notifications.map((n) => {
-          return (
-            <NotificationWithTransition
-              key={n.id}
-              title={n.title}
-              description={n.description}
-              type={n.type}
-            />
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-Notification.Area = ({ children }: { children: React.ReactNode }) => {
-  const [notifications, setNotifications] = React.useState<
-    (NotificationType & { id: string })[]
-  >([]);
-
-  function sendNotification(n: NotificationType) {
-    const id = Math.random().toString();
-    setNotifications((notifications) => [...notifications, { ...n, id }]);
-    /* After a delay allowing for the notification exit animation, remove the
-    notification from the list */
-    setTimeout(() => {
-      setNotifications((notifications) =>
-        notifications.filter((n) => n.id !== id)
-      );
-    }, NOTIFICATION_DELAY + 1000);
-  }
-
-  return (
-    <NotificationsContext.Provider value={sendNotification}>
-      {children}
-      {
-        /** Notifications are created at DOM root via a Portal. This is to avoid
-         * them being made inert by headlessUI modals */
-        typeof window === "object" ? (
-          createPortal(
-            <NotificationsList notifications={notifications} />,
-            document.body
-          )
-        ) : (
-          <NotificationsList notifications={notifications} />
-        ) // SSR (otherwise hydration issues)
-      }
-    </NotificationsContext.Provider>
-  );
+    return (
+      <NotificationsContext.Provider value={sendNotification}>
+        {children}
+        <Toaster
+          position="bottom-right"
+          toastOptions={{
+            unstyled: true,
+            className: cn(
+              "s-transition-all s-duration-300",
+              "data-[state=open]:s-animate-in data-[state=closed]:s-animate-out",
+              "data-[swipe=move]:s-translate-x-[var(--toast-swipe-move-x)]",
+              "data-[state=closed]:s-fade-out-80 data-[state=closed]:s-slide-out-to-right-full",
+              "data-[state=open]:s-slide-in-from-right-full"
+            ),
+          }}
+          duration={NOTIFICATION_DELAY}
+          visibleToasts={9}
+          closeButton={false}
+        />
+      </NotificationsContext.Provider>
+    );
+  },
 };
 
 export const useSendNotification = () => React.useContext(NotificationsContext);

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -78,25 +78,29 @@ function NotificationContent({ type, title, description }: NotificationType) {
 
 export const Notification = {
   Area: ({ children }: { children: React.ReactNode }) => {
-    const sendNotification = React.useCallback((notification: NotificationType) => {
-      toast.custom(() => (
-        <NotificationContent
-          type={notification.type}
-          title={notification.title}
-          description={notification.description}
-        />
-      ), {
-        duration: NOTIFICATION_DELAY,
-      });
-    }, []);
+    const sendNotification = React.useCallback(
+      (notification: NotificationType) => {
+        toast.custom(
+          () => (
+            <NotificationContent
+              type={notification.type}
+              title={notification.title}
+              description={notification.description}
+            />
+          ),
+          {
+            duration: NOTIFICATION_DELAY,
+          }
+        );
+      },
+      []
+    );
 
     return (
       <NotificationsContext.Provider value={sendNotification}>
         {children}
         <Toaster
-          position="bottom-right"
           toastOptions={{
-            unstyled: true,
             className: cn(
               "s-transition-all s-duration-300",
               "data-[state=open]:s-animate-in data-[state=closed]:s-animate-out",
@@ -105,9 +109,12 @@ export const Notification = {
               "data-[state=open]:s-slide-in-from-right-full"
             ),
           }}
+          className="s-flex s-flex-col s-items-end"
           duration={NOTIFICATION_DELAY}
           visibleToasts={9}
           closeButton={false}
+          expand={false}
+          invert={false}
         />
       </NotificationsContext.Provider>
     );

--- a/sparkle/src/stories/Notification.stories.tsx
+++ b/sparkle/src/stories/Notification.stories.tsx
@@ -7,57 +7,44 @@ import { Button, Notification } from "../index_with_tw_base";
 
 const meta: Meta<typeof Notification> = {
   title: "Modules/Notification",
-  component: Notification,
-  decorators: [
-    (Story) => (
-      <Notification.Area>
-        <Story />
-      </Notification.Area>
-    ),
-  ],
 } satisfies Meta<typeof Notification>;
 
 export default meta;
 
-export const NotificationExample = () => {
+export const Example = () => {
   return (
-    <>
-      <div className="s-flex s-gap-6">
-        <Notification
-          title="Success"
-          description="This is a success notification"
-          variant="success"
-        />
-        <Notification
-          title="Failure"
-          description="This is a success notification"
-          variant="error"
-        />
-        <div>
-          <Notification title="Failure" variant="error" />
-        </div>
-        <Notification
-          title="Failure with a very long title clamped on one line."
-          description='Got: {"error":{"type":"invalid_request_error","message":"Invalid request body: Expecting string at name but instead got: undefined"}}'
-          variant="error"
-        />
-      </div>
-    </>
+    <Notification.Area>
+      <NotificationExample />
+    </Notification.Area>
   );
 };
 
-export const NotificationAreaExample = () => {
+
+const NotificationExample = () => {
   const sendNotification = useSendNotification();
+
   return (
-    <Button
-      onClick={() =>
-        sendNotification({
-          title: "Success",
-          description: "it works",
-          type: "success",
-        })
-      }
-      label="click"
-    />
+    <div className="s-flex s-flex-col s-gap-4">
+      <Button
+        onClick={() =>
+          sendNotification({
+            title: "Success",
+            description: "Operation completed successfully",
+            type: "success",
+          })
+        }
+        label="Show Success"
+      />
+      <Button
+        onClick={() =>
+          sendNotification({
+            title: "Error",
+            description: "Something went wrong",
+            type: "error",
+          })
+        }
+        label="Show Error"
+      />
+    </div>
   );
 };


### PR DESCRIPTION
## Description

This PR aims at refactoring our existing notifications to use [sonner](https://github.com/emilkowalski/sonner?tab=readme-ov-file) toasts as our notification system.

This notification system is the one used by shadcn and the `Notification` component is compatible with the current implementation. Style-wise everything should be iso.

## Risk

UX, break notification system

## Deploy Plan

- Publish alpha
- Test front
- Publish sparkle