### PR TITLE
fix(Zendesk) - Reduce size of prefixes in Zendesk tickets

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -215,8 +215,6 @@ export async function syncTicket({
       additionalPrefixes: {
         metadata: metadata.join(", "),
         labels: ticket.tags.join(", ") || "none",
-        customFields:
-          ticket.custom_fields.map(({ value }) => value).join(", ") || "none",
       },
     });
 
@@ -238,7 +236,6 @@ export async function syncTicket({
         `updatedAt:${updatedAtDate.getTime()}`,
         `createdAt:${createdAtDate.getTime()}`,
         ...metadata,
-        ...ticket.custom_fields.map(({ id, value }) => `${id}:${value}`),
         ...filterCustomTags(ticket.tags, logger),
       ],
       parents,

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -202,7 +202,9 @@ export async function syncTicket({
       ...(ticket.due_at
         ? [`dueDate:${new Date(ticket.due_at).toISOString()}`]
         : []),
-      `satisfactionRating:${ticket.satisfaction_rating.score}`,
+      ...(ticket.satisfaction_rating.score !== "unoffered" // Special value when no rating was provided.
+        ? [`satisfactionRating:${ticket.satisfaction_rating.score}`]
+        : []),
       `hasIncidents:${ticket.has_incidents ? "Yes" : "No"}`,
     ];
 

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -215,7 +215,10 @@ export async function syncTicket({
       createdAt: createdAtDate,
       updatedAt: updatedAtDate,
       additionalPrefixes: {
-        metadata: metadata.join(", "),
+        metadata: metadata
+          // We remove IDs from the prefixes since they do not hold any semantic meaning.
+          .filter((field) => !["organizationId", "groupId"].includes(field))
+          .join(", "),
         labels: ticket.tags.join(", ") || "none",
       },
     });


### PR DESCRIPTION
## Description

- We have some entries stuck in the upsert-queue (log [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZUU6wTY4HpDTQAAABhBWlVVNndzRUFBREJzaWwxa3g0Y09nRFcAAAAkMDE5NTE0ZWItMThjNC00YWRiLWI3ZjItZGMyYzY2YWRlYTE1AAA8Zg&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1739811812676&to_ts=1739812712676&live=true)).
- The metadata tags added to the prefixes exceed largely half the max chunk size.
- This PR decreases the size of the prefixes by putting all the metadata in one prefix, which allows for truncating.
- It removes the `customFields` altogether, given that we only have the IDs of the custom field this do not add any kind of value (we have stuff like "360022071911:null, "360022071912:false", which we can't make anything out of).
- The group and organization IDs are also removed from the prefixes, given that they are IDs (kept in the tags).
- The satisfaction rating is also removed if no satisfaction rating was given (there's a special value).

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy connectors.