### PR TITLE
Add script to upsert single Google Drive spreadsheet

### DIFF
--- a/connectors/migrations/20250219_upsert_google_drive_spreadsheet.ts
+++ b/connectors/migrations/20250219_upsert_google_drive_spreadsheet.ts
@@ -1,0 +1,45 @@
+import { makeScript } from "scripts/helpers";
+
+import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
+import { syncSpreadSheet } from "@connectors/connectors/google_drive/temporal/spreadsheets";
+import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+makeScript(
+  {
+    connectorId: { type: "number" },
+    spreadsheetId: { type: "string" },
+  },
+  async ({ connectorId, spreadsheetId }) => {
+    const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      throw new Error("Connector not found.");
+    }
+    const authCredentials = await getAuthObject(connector.connectionId);
+
+    // Fetch spreadsheet metadata.
+    const spreadsheetData = await getGoogleDriveObject({
+      authCredentials,
+      driveObjectId: spreadsheetId,
+    });
+    if (!spreadsheetData) {
+      throw new Error("Spreadsheet not found");
+    }
+
+    // Sync spreadsheet and its sheets.
+    const result = await syncSpreadSheet(
+      authCredentials,
+      connectorId,
+      spreadsheetData,
+      new Date().getTime()
+    );
+
+    if (!result.isSupported) {
+      throw new Error("Spreadsheet sync not supported");
+    }
+
+    if (result.skipReason) {
+      throw new Error(`Spreadsheet sync skipped: ${result.skipReason}`);
+    }
+  }
+);


### PR DESCRIPTION
## Description

- This PR adds a script that upserts a single Google Drive spreadsheet.
- This script will be used to unlock an incremental sync that attempts to update the parents on a missing table (connectors log [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZUVEKx2OetClwAAABhBWlVWRUxyQkFBREJzaWwxazIxMXF3QWcAAAAkMDE5NTE1MTAtYzJkZC00MWUzLTkxYjctOGNhZjVjOGEyYjgwAAAA1w&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1739801196850&to_ts=1739815596850&live=true) and front logs [here](https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20%40url%3A%2Fapi%2Fv1%2Fw%2FlQ67Ci4jN2%2Fdata_sources%2Fdts_vomozgZB12Wz%2A%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZUVlimLtT69mwAAABhBWlVWbGpNOEFBQldVdUZfbjFDSEdnQWIAAAAkMDE5NTE1OTYtYzVhYi00YTQ3LWJmZWQtYmZiN2Y3ZmI1N2Y3AAKE9Q&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1739809944123&to_ts=1739824344123&live=true)).

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy connectors (to have the script on the pod).