### PR TITLE
Add mime types in content nodes returned by connectors

### DIFF
--- a/connectors/src/connectors/bigquery/lib/permissions.ts
+++ b/connectors/src/connectors/bigquery/lib/permissions.ts
@@ -4,7 +4,7 @@ import type {
   ModelId,
   Result,
 } from "@dust-tt/types";
-import { Err, EXCLUDE_SCHEMAS, Ok } from "@dust-tt/types";
+import { Err, EXCLUDE_SCHEMAS, MIME_TYPES, Ok } from "@dust-tt/types";
 
 import {
   fetchDatabases,
@@ -52,7 +52,11 @@ export const fetchAvailableChildrenInBigQuery = async ({
         const permission = syncedDatabasesInternalIds.includes(internalId)
           ? "read"
           : "none";
-        return getContentNodeFromInternalId(internalId, permission);
+        return getContentNodeFromInternalId(
+          internalId,
+          permission,
+          MIME_TYPES.BIGQUERY
+        );
       })
     );
   }
@@ -82,7 +86,11 @@ export const fetchAvailableChildrenInBigQuery = async ({
         const permission = syncedSchemasInternalIds.includes(internalId)
           ? "read"
           : "none";
-        return getContentNodeFromInternalId(internalId, permission);
+        return getContentNodeFromInternalId(
+          internalId,
+          permission,
+          MIME_TYPES.BIGQUERY
+        );
       })
     );
   }
@@ -106,7 +114,11 @@ export const fetchAvailableChildrenInBigQuery = async ({
         const permission = syncedTablesInternalIds.includes(internalId)
           ? "read"
           : "none";
-        return getContentNodeFromInternalId(internalId, permission);
+        return getContentNodeFromInternalId(
+          internalId,
+          permission,
+          MIME_TYPES.BIGQUERY
+        );
       })
     );
   }
@@ -138,13 +150,21 @@ export const fetchReadNodes = async ({
 
   return new Ok([
     ...availableDatabases.map((db) =>
-      getContentNodeFromInternalId(db.internalId, "read")
+      getContentNodeFromInternalId(db.internalId, "read", MIME_TYPES.BIGQUERY)
     ),
     ...availableSchemas.map((schema) =>
-      getContentNodeFromInternalId(schema.internalId, "read")
+      getContentNodeFromInternalId(
+        schema.internalId,
+        "read",
+        MIME_TYPES.BIGQUERY
+      )
     ),
     ...availableTables.map((table) =>
-      getContentNodeFromInternalId(table.internalId, "read")
+      getContentNodeFromInternalId(
+        table.internalId,
+        "read",
+        MIME_TYPES.BIGQUERY
+      )
     ),
   ]);
 };
@@ -183,7 +203,11 @@ export const fetchSyncedChildren = async ({
         },
       });
       const schemaContentNodes = schemas.map((schema) =>
-        getContentNodeFromInternalId(schema.internalId, "read")
+        getContentNodeFromInternalId(
+          schema.internalId,
+          "read",
+          MIME_TYPES.BIGQUERY
+        )
       );
       return new Ok(schemaContentNodes);
     }
@@ -208,12 +232,18 @@ export const fetchSyncedChildren = async ({
       }),
     ]);
     const schemas = availableSchemas.map((schema) =>
-      getContentNodeFromInternalId(schema.internalId, "read")
+      getContentNodeFromInternalId(
+        schema.internalId,
+        "read",
+        MIME_TYPES.BIGQUERY
+      )
     );
     availableTables.forEach((table) => {
       const schemaToAdd = `${table.databaseName}.${table.schemaName}`;
       if (!schemas.find((s) => s.internalId === schemaToAdd)) {
-        schemas.push(getContentNodeFromInternalId(schemaToAdd, "none"));
+        schemas.push(
+          getContentNodeFromInternalId(schemaToAdd, "none", MIME_TYPES.BIGQUERY)
+        );
       }
     });
     return new Ok(schemas);
@@ -230,7 +260,11 @@ export const fetchSyncedChildren = async ({
       },
     });
     const tables = availableTables.map((table) =>
-      getContentNodeFromInternalId(table.internalId, "read")
+      getContentNodeFromInternalId(
+        table.internalId,
+        "read",
+        MIME_TYPES.BIGQUERY
+      )
     );
     return new Ok(tables);
   }
@@ -255,7 +289,11 @@ export const getBatchContentNodes = async ({
   const nodes: ContentNode[] = [];
   for (const internalId of internalIds) {
     if (tables.find((table) => table.internalId.startsWith(internalId))) {
-      const node = getContentNodeFromInternalId(internalId, "read");
+      const node = getContentNodeFromInternalId(
+        internalId,
+        "read",
+        MIME_TYPES.BIGQUERY
+      );
       nodes.push(node);
     }
   }

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -4,7 +4,7 @@ import type {
   ModelId,
   Result,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, MIME_TYPES, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import { listConfluenceSpaces } from "@connectors/connectors/confluence/lib/confluence_api";
@@ -54,6 +54,7 @@ export function createContentNodeFromSpace(
     expandable: isExpandable,
     permission,
     lastUpdatedAt: null,
+    mimeType: MIME_TYPES.CONFLUENCE.SPACE,
   };
 }
 
@@ -75,6 +76,7 @@ export function createContentNodeFromPage(
     expandable: isExpandable,
     permission: "read",
     lastUpdatedAt: null,
+    mimeType: MIME_TYPES.CONFLUENCE.PAGE,
   };
 }
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -5,6 +5,7 @@ import type {
   Result,
 } from "@dust-tt/types";
 import { assertNever, Err, Ok } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types/src";
 import { Op } from "sequelize";
 
 import type { GithubRepo } from "@connectors/connectors/github/lib/github_api";
@@ -298,6 +299,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
             expandable: true,
             permission: "read",
             lastUpdatedAt: null,
+            mimeType: MIME_TYPES.GITHUB.REPOSITORY,
           }))
         );
       }
@@ -368,6 +370,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: false,
               permission: "read",
               lastUpdatedAt: latestIssue.updatedAt.getTime(),
+              mimeType: MIME_TYPES.GITHUB.ISSUES,
             });
           }
 
@@ -381,6 +384,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: false,
               permission: "read",
               lastUpdatedAt: latestDiscussion.updatedAt.getTime(),
+              mimeType: MIME_TYPES.GITHUB.DISCUSSIONS,
             });
           }
 
@@ -394,6 +398,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: true,
               permission: "read",
               lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
+              mimeType: MIME_TYPES.GITHUB.CODE_ROOT,
             });
           }
 
@@ -435,6 +440,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: true,
               permission: "read",
               lastUpdatedAt: directory.codeUpdatedAt.getTime(),
+              mimeType: MIME_TYPES.GITHUB.CODE_DIRECTORY,
             });
           });
 
@@ -448,6 +454,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: false,
               permission: "read",
               lastUpdatedAt: file.codeUpdatedAt.getTime(),
+              mimeType: MIME_TYPES.GITHUB.CODE_FILE,
             });
           });
 
@@ -609,6 +616,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         expandable: true,
         permission: "read",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.GITHUB.REPOSITORY,
       });
     });
 
@@ -627,6 +635,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         expandable: false,
         permission: "read",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.GITHUB.ISSUES,
       });
     });
     allDiscussionsFromRepoIds.forEach((repoId) => {
@@ -643,6 +652,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         expandable: false,
         permission: "read",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.GITHUB.DISCUSSIONS,
       });
     });
 
@@ -661,6 +671,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         expandable: false,
         permission: "read",
         lastUpdatedAt: issue.updatedAt.getTime(),
+        mimeType: MIME_TYPES.GITHUB.ISSUE,
       });
     });
 
@@ -679,6 +690,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         expandable: false,
         permission: "read",
         lastUpdatedAt: discussion.updatedAt.getTime(),
+        mimeType: MIME_TYPES.GITHUB.DISCUSSION,
       });
     });
 
@@ -693,6 +705,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         expandable: true,
         permission: "read",
         lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
+        mimeType: MIME_TYPES.GITHUB.CODE_ROOT,
       });
     });
 
@@ -707,6 +720,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         expandable: true,
         permission: "read",
         lastUpdatedAt: directory.codeUpdatedAt.getTime(),
+        mimeType: MIME_TYPES.GITHUB.CODE_DIRECTORY,
       });
     });
 
@@ -721,6 +735,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         expandable: false,
         permission: "read",
         lastUpdatedAt: file.codeUpdatedAt.getTime(),
+        mimeType: MIME_TYPES.GITHUB.CODE_FILE,
       });
     });
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -4,8 +4,7 @@ import type {
   ContentNodesViewType,
   Result,
 } from "@dust-tt/types";
-import { assertNever, Err, Ok } from "@dust-tt/types";
-import { MIME_TYPES } from "@dust-tt/types/src";
+import { assertNever, Err, MIME_TYPES, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import type { GithubRepo } from "@connectors/connectors/github/lib/github_api";

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -9,6 +9,7 @@ import {
   getGoogleIdsFromSheetContentNodeInternalId,
   getGoogleSheetContentNodeInternalId,
   isGoogleSheetContentNodeInternalId,
+  MIME_TYPES,
   Ok,
   removeNulls,
 } from "@dust-tt/types";
@@ -336,6 +337,10 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                   viewType,
                 }),
                 permission: "read",
+                mimeType:
+                  type === "folder"
+                    ? MIME_TYPES.GOOGLE_DRIVE.FOLDER
+                    : f.mimeType,
               };
             },
             { concurrency: 4 }
@@ -356,6 +361,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                   sourceUrl: null,
                   expandable: false,
                   permission: "read",
+                  mimeType: "text/csv",
                 };
               })
             );
@@ -679,6 +685,8 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
             viewType,
           }),
           permission: "read",
+          mimeType:
+            type === "folder" ? MIME_TYPES.GOOGLE_DRIVE.FOLDER : f.mimeType,
         };
       },
       { concurrency: 4 }
@@ -715,6 +723,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       sourceUrl: getSourceUrlForGoogleDriveSheet(s),
       expandable: false,
       permission: "read",
+      mimeType: "text/csv",
     }));
 
     // Return the nodes in the same order as the input internalIds.
@@ -979,6 +988,7 @@ async function getFoldersAsContentNodes({
           viewType,
         }),
         permission: "read",
+        mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
       };
     },
     { concurrency: 4 }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -414,6 +414,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                 }))
                   ? "read"
                   : "none",
+                mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
               };
             })
           );
@@ -429,6 +430,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
             lastUpdatedAt: null,
             expandable: true,
             permission: "none",
+            mimeType: MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
           });
 
           nodes.sort((a, b) => {
@@ -506,6 +508,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                 }))
                   ? "read"
                   : "none",
+                mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
               };
             })
           );

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -4,7 +4,7 @@ import type {
   ContentNodesViewType,
   Result,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, MIME_TYPES, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import {
@@ -630,6 +630,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
         expandable: true,
         permission: helpCenter.permission,
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
       });
     }
     for (const collection of collections) {
@@ -650,6 +651,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
         expandable: true,
         permission: collection.permission,
         lastUpdatedAt: collection.lastUpsertedTs?.getTime() || null,
+        mimeType: MIME_TYPES.INTERCOM.COLLECTION,
       });
     }
     for (const article of articles) {
@@ -670,6 +672,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
         expandable: false,
         permission: article.permission,
         lastUpdatedAt: article.lastUpsertedTs?.getTime() || null,
+        mimeType: MIME_TYPES.INTERCOM.ARTICLE,
       });
     }
     if (isAllConversations) {
@@ -685,6 +688,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
             ? "read"
             : "none",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     }
     for (const team of teams) {
@@ -697,6 +701,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
         expandable: false,
         permission: team.permission,
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.INTERCOM.TEAM,
       });
     }
 

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -4,6 +4,7 @@ import type {
   ContentNodesViewType,
   ModelId,
 } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 
 import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
 import {
@@ -143,6 +144,7 @@ export async function retrieveIntercomConversationsPermissions({
         preventSelection: false,
         permission: isAllConversationsSynced ? "read" : "none",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     } else if (isRootLevel && hasTeamsWithReadPermission) {
       nodes.push({
@@ -155,6 +157,7 @@ export async function retrieveIntercomConversationsPermissions({
         preventSelection: false,
         permission: "read",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     }
 
@@ -169,6 +172,7 @@ export async function retrieveIntercomConversationsPermissions({
           expandable: false,
           permission: team.permission,
           lastUpdatedAt: null,
+          mimeType: MIME_TYPES.INTERCOM.TEAM,
         });
       });
     }
@@ -186,6 +190,7 @@ export async function retrieveIntercomConversationsPermissions({
         preventSelection: false,
         permission: isAllConversationsSynced ? "read" : "none",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     }
     if (parentInternalId === allTeamsInternalId) {
@@ -202,6 +207,7 @@ export async function retrieveIntercomConversationsPermissions({
           expandable: false,
           permission: isTeamInDb ? "read" : "none",
           lastUpdatedAt: null,
+          mimeType: MIME_TYPES.INTERCOM.TEAM,
         });
       });
     }

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -4,6 +4,7 @@ import type {
   ContentNodesViewType,
   ModelId,
 } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
@@ -373,6 +374,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         expandable: true,
         permission: helpCenter.permission,
         lastUpdatedAt: helpCenter.updatedAt.getTime(),
+        mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
       }));
     } else {
       const helpCenters = await fetchIntercomHelpCenters({ accessToken });
@@ -386,6 +388,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         preventSelection: true,
         permission: "none",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
       }));
     }
     nodes.sort((a, b) => {
@@ -432,6 +435,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         expandable: true,
         permission: collection.permission,
         lastUpdatedAt: collection.updatedAt.getTime() || null,
+        mimeType: MIME_TYPES.INTERCOM.COLLECTION,
       }));
     } else {
       const collectionsInIntercom = await fetchIntercomCollections({
@@ -460,6 +464,7 @@ export async function retrieveIntercomHelpCentersPermissions({
           expandable: false, // WE DO NOT LET EXPAND BELOW LEVEL 1 WHEN SELECTING NODES
           permission: matchingCollectionInDb ? "read" : "none",
           lastUpdatedAt: matchingCollectionInDb?.updatedAt.getTime() || null,
+          mimeType: MIME_TYPES.INTERCOM.COLLECTION,
         };
       });
     }
@@ -499,6 +504,7 @@ export async function retrieveIntercomHelpCentersPermissions({
           expandable: true,
           permission: collection.permission,
           lastUpdatedAt: collection.lastUpsertedTs?.getTime() || null,
+          mimeType: MIME_TYPES.INTERCOM.COLLECTION,
         })
       );
 
@@ -523,6 +529,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         expandable: false,
         permission: article.permission,
         lastUpdatedAt: article.updatedAt.getTime(),
+        mimeType: MIME_TYPES.INTERCOM.ARTICLE,
       }));
 
       collectionNodes.sort((a, b) => {

--- a/connectors/src/connectors/intercom/lib/permissions.ts
+++ b/connectors/src/connectors/intercom/lib/permissions.ts
@@ -1,4 +1,5 @@
 import type { ContentNode, ModelId } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 
 import {
   getHelpCenterCollectionInternalId,
@@ -64,6 +65,7 @@ export async function retrieveSelectedNodes({
       expandable,
       permission: collection.permission,
       lastUpdatedAt: collection.updatedAt.getTime() || null,
+      mimeType: MIME_TYPES.INTERCOM.COLLECTION,
     });
   });
 
@@ -85,6 +87,7 @@ export async function retrieveSelectedNodes({
       expandable: true,
       permission: "read",
       lastUpdatedAt: null,
+      mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
     });
   }
 
@@ -104,6 +107,7 @@ export async function retrieveSelectedNodes({
       expandable: false,
       permission: team.permission,
       lastUpdatedAt: team.updatedAt.getTime() || null,
+      mimeType: MIME_TYPES.INTERCOM.TEAM,
     });
   });
 

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -1,4 +1,5 @@
 import type { ContentNode, ContentNodeType } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 
 import {
   getDriveInternalId,
@@ -29,6 +30,7 @@ export function getSitesRootAsContentNode(): ContentNode {
     preventSelection: true,
     expandable: true,
     permission: "none",
+    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -86,6 +88,7 @@ export function getSiteAsContentNode(
     preventSelection: true,
     expandable: true,
     permission: "none",
+    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -114,6 +117,7 @@ export function getChannelAsContentNode(
     lastUpdatedAt: null,
     expandable: false,
     permission: "none",
+    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -134,6 +138,7 @@ export function getDriveAsContentNode(
     lastUpdatedAt: null,
     expandable: true,
     permission: "none",
+    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 export function getFolderAsContentNode(
@@ -149,22 +154,7 @@ export function getFolderAsContentNode(
     lastUpdatedAt: null,
     expandable: true,
     permission: "none",
-  };
-}
-
-export function getFileAsContentNode(
-  file: microsoftgraph.DriveItem,
-  parentInternalId: string
-): ContentNode {
-  return {
-    internalId: getDriveItemInternalId(file),
-    parentInternalId,
-    type: "file",
-    title: file.name || "unnamed",
-    sourceUrl: file.webUrl ?? null,
-    lastUpdatedAt: null,
-    expandable: false,
-    permission: "none",
+    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -199,5 +189,11 @@ export function getMicrosoftNodeAsContentNode(
     lastUpdatedAt: null,
     expandable: isExpandable,
     permission: "none",
+    mimeType:
+      type === "database"
+        ? MIME_TYPES.MICROSOFT.SPREADSHEET
+        : type === "folder"
+          ? MIME_TYPES.MICROSOFT.FOLDER
+          : node.mimeType || MIME_TYPES.MICROSOFT.FOLDER,
   };
 }

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -48,6 +48,7 @@ export function getTeamsRootAsContentNode(): ContentNode {
     preventSelection: true,
     expandable: true,
     permission: "none",
+    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
@@ -64,6 +65,7 @@ export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
     preventSelection: true,
     expandable: true,
     permission: "none",
+    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -475,6 +475,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         expandable,
         permission: "read",
         lastUpdatedAt: page.lastUpsertedTs?.getTime() || null,
+        mimeType: MIME_TYPES.NOTION.PAGE,
       };
     };
 
@@ -497,6 +498,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         expandable: true,
         permission: "read",
         lastUpdatedAt: db.structuredDataUpsertedTs?.getTime() ?? null,
+        mimeType: MIME_TYPES.NOTION.DATABASE,
       };
     };
 
@@ -518,6 +520,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
           expandable: true,
           permission: "read",
           lastUpdatedAt: null,
+          mimeType: MIME_TYPES.NOTION.UNKNOWN_FOLDER,
         });
       }
     }
@@ -567,6 +570,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         expandable: Boolean(hasChildrenByPageId[page.notionPageId]),
         permission: "read",
         lastUpdatedAt: page.lastUpsertedTs?.getTime() || null,
+        mimeType: MIME_TYPES.NOTION.PAGE,
       }))
     );
 
@@ -582,6 +586,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       expandable: true,
       permission: "read",
       lastUpdatedAt: null,
+      mimeType: MIME_TYPES.NOTION.DATABASE,
     }));
 
     const contentNodes = pageNodes.concat(dbNodes);
@@ -599,6 +604,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
           expandable: true,
           permission: "read",
           lastUpdatedAt: null,
+          mimeType: MIME_TYPES.NOTION.UNKNOWN_FOLDER,
         });
       }
     }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -9,6 +9,7 @@ import type {
 import {
   Err,
   isSlackAutoReadPatterns,
+  MIME_TYPES,
   Ok,
   safeParseJSON,
 } from "@dust-tt/types";
@@ -409,6 +410,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         permission: ch.permission,
         lastUpdatedAt: null,
         providerVisibility: ch.private ? "private" : "public",
+        mimeType: MIME_TYPES.SLACK.CHANNEL,
       }));
 
       resources.sort((a, b) => {
@@ -630,6 +632,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       permission: ch.permission,
       lastUpdatedAt: null,
       providerVisibility: ch.private ? "private" : "public",
+      mimeType: MIME_TYPES.SLACK.CHANNEL,
     }));
 
     return new Ok(contentNodes);

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -4,7 +4,13 @@ import type {
   Result,
   SnowflakeCredentials,
 } from "@dust-tt/types";
-import { Err, EXCLUDE_DATABASES, EXCLUDE_SCHEMAS, Ok } from "@dust-tt/types";
+import {
+  Err,
+  EXCLUDE_DATABASES,
+  EXCLUDE_SCHEMAS,
+  MIME_TYPES,
+  Ok,
+} from "@dust-tt/types";
 
 import {
   fetchDatabases,
@@ -58,7 +64,11 @@ export const fetchAvailableChildrenInSnowflake = async ({
         const permission = syncedDatabasesInternalIds.includes(internalId)
           ? "read"
           : "none";
-        return getContentNodeFromInternalId(internalId, permission);
+        return getContentNodeFromInternalId(
+          internalId,
+          permission,
+          MIME_TYPES.SNOWFLAKE
+        );
       })
     );
   }
@@ -89,7 +99,11 @@ export const fetchAvailableChildrenInSnowflake = async ({
         const permission = syncedSchemasInternalIds.includes(internalId)
           ? "read"
           : "none";
-        return getContentNodeFromInternalId(internalId, permission);
+        return getContentNodeFromInternalId(
+          internalId,
+          permission,
+          MIME_TYPES.SNOWFLAKE
+        );
       })
     );
   }
@@ -113,7 +127,11 @@ export const fetchAvailableChildrenInSnowflake = async ({
         const permission = syncedTablesInternalIds.includes(internalId)
           ? "read"
           : "none";
-        return getContentNodeFromInternalId(internalId, permission);
+        return getContentNodeFromInternalId(
+          internalId,
+          permission,
+          MIME_TYPES.SNOWFLAKE
+        );
       })
     );
   }
@@ -145,13 +163,21 @@ export const fetchReadNodes = async ({
 
   return new Ok([
     ...availableDatabases.map((db) =>
-      getContentNodeFromInternalId(db.internalId, "read")
+      getContentNodeFromInternalId(db.internalId, "read", MIME_TYPES.SNOWFLAKE)
     ),
     ...availableSchemas.map((schema) =>
-      getContentNodeFromInternalId(schema.internalId, "read")
+      getContentNodeFromInternalId(
+        schema.internalId,
+        "read",
+        MIME_TYPES.SNOWFLAKE
+      )
     ),
     ...availableTables.map((table) =>
-      getContentNodeFromInternalId(table.internalId, "read")
+      getContentNodeFromInternalId(
+        table.internalId,
+        "read",
+        MIME_TYPES.SNOWFLAKE
+      )
     ),
   ]);
 };
@@ -190,7 +216,11 @@ export const fetchSyncedChildren = async ({
         },
       });
       const schemaContentNodes = schemas.map((schema) =>
-        getContentNodeFromInternalId(schema.internalId, "read")
+        getContentNodeFromInternalId(
+          schema.internalId,
+          "read",
+          MIME_TYPES.SNOWFLAKE
+        )
       );
       return new Ok(schemaContentNodes);
     }
@@ -215,12 +245,22 @@ export const fetchSyncedChildren = async ({
       }),
     ]);
     const schemas = availableSchemas.map((schema) =>
-      getContentNodeFromInternalId(schema.internalId, "read")
+      getContentNodeFromInternalId(
+        schema.internalId,
+        "read",
+        MIME_TYPES.SNOWFLAKE
+      )
     );
     availableTables.forEach((table) => {
       const schemaToAdd = `${table.databaseName}.${table.schemaName}`;
       if (!schemas.find((s) => s.internalId === schemaToAdd)) {
-        schemas.push(getContentNodeFromInternalId(schemaToAdd, "none"));
+        schemas.push(
+          getContentNodeFromInternalId(
+            schemaToAdd,
+            "none",
+            MIME_TYPES.SNOWFLAKE
+          )
+        );
       }
     });
     return new Ok(schemas);
@@ -237,7 +277,11 @@ export const fetchSyncedChildren = async ({
       },
     });
     const tables = availableTables.map((table) =>
-      getContentNodeFromInternalId(table.internalId, "read")
+      getContentNodeFromInternalId(
+        table.internalId,
+        "read",
+        MIME_TYPES.SNOWFLAKE
+      )
     );
     return new Ok(tables);
   }
@@ -262,7 +306,11 @@ export const getBatchContentNodes = async ({
   const nodes: ContentNode[] = [];
   for (const internalId of internalIds) {
     if (tables.find((table) => table.internalId.startsWith(internalId))) {
-      const node = getContentNodeFromInternalId(internalId, "read");
+      const node = getContentNodeFromInternalId(
+        internalId,
+        "read",
+        MIME_TYPES.SNOWFLAKE
+      );
       nodes.push(node);
     }
   }

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -9,6 +9,7 @@ import {
   DepthOptions,
   Err,
   isDepthOption,
+  MIME_TYPES,
   Ok,
   WEBCRAWLER_MAX_PAGES,
   WebCrawlerHeaderRedactedValue,
@@ -214,6 +215,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
             permission: "read",
             type: "folder",
             lastUpdatedAt: folder.updatedAt.getTime(),
+            mimeType: MIME_TYPES.WEBCRAWLER.FOLDER,
           };
         })
         .concat(
@@ -240,6 +242,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
               permission: "read",
               type: "file",
               lastUpdatedAt: page.updatedAt.getTime(),
+              mimeType: "text/html",
             };
           })
         )
@@ -280,6 +283,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         permission: "read",
         type: "folder",
         lastUpdatedAt: folder.updatedAt.getTime(),
+        mimeType: MIME_TYPES.WEBCRAWLER.FOLDER,
       });
     });
     pages.forEach((page) => {
@@ -292,6 +296,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         permission: "read",
         type: "file",
         lastUpdatedAt: page.updatedAt.getTime(),
+        mimeType: "text/html",
       });
     });
 

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -236,6 +236,7 @@ async function getHelpCenterChildren(
           expandable: false,
           permission: "none",
           lastUpdatedAt: null,
+          mimeType: MIME_TYPES.ZENDESK.CATEGORY,
         }
     );
   }

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -4,7 +4,7 @@ import type {
   ContentNodesViewType,
   ModelId,
 } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+import { assertNever, MIME_TYPES } from "@dust-tt/types";
 import type { Client } from "node-zendesk";
 
 import {
@@ -101,6 +101,7 @@ async function getRootLevelContentNodes(
           expandable: true,
           permission: "none",
           lastUpdatedAt: null,
+          mimeType: MIME_TYPES.ZENDESK.BRAND,
         }
     );
   }
@@ -157,6 +158,7 @@ async function getBrandChildren(
       expandable: false,
       permission: "none",
       lastUpdatedAt: null,
+      mimeType: MIME_TYPES.ZENDESK.TICKETS,
     };
     nodes.push(ticketsNode);
 
@@ -176,6 +178,7 @@ async function getBrandChildren(
         expandable: true,
         permission: "none",
         lastUpdatedAt: null,
+        mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
       };
       nodes.push(helpCenterNode);
     }

--- a/connectors/src/lib/remote_databases/content_nodes.ts
+++ b/connectors/src/lib/remote_databases/content_nodes.ts
@@ -1,5 +1,8 @@
-import type { ConnectorPermission, ContentNode } from "@dust-tt/types";
-import { MIME_TYPES } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  ContentNode,
+  MIME_TYPES,
+} from "@dust-tt/types";
 
 /**
  * 3 types of nodes in a remote database content tree:
@@ -28,7 +31,8 @@ export const getContentNodeTypeFromInternalId = (
 
 export const getContentNodeFromInternalId = (
   internalId: string,
-  permission: ConnectorPermission = "none"
+  permission: ConnectorPermission = "none",
+  mimeTypes: typeof MIME_TYPES.BIGQUERY | typeof MIME_TYPES.SNOWFLAKE
 ): ContentNode => {
   const type = getContentNodeTypeFromInternalId(internalId);
   const [databaseName, schemaName, tableName] = internalId.split(".");
@@ -44,7 +48,7 @@ export const getContentNodeFromInternalId = (
       preventSelection: false,
       permission,
       lastUpdatedAt: null,
-      mimeType: MIME_TYPES.BIGQUERY.DATABASE,
+      mimeType: mimeTypes.DATABASE,
     };
   }
   if (type === "schema") {
@@ -58,7 +62,7 @@ export const getContentNodeFromInternalId = (
       preventSelection: false,
       permission,
       lastUpdatedAt: null,
-      mimeType: MIME_TYPES.BIGQUERY.SCHEMA,
+      mimeType: mimeTypes.SCHEMA,
     };
   }
   if (type === "table") {
@@ -72,7 +76,7 @@ export const getContentNodeFromInternalId = (
       preventSelection: false,
       permission,
       lastUpdatedAt: null,
-      mimeType: MIME_TYPES.BIGQUERY.TABLE,
+      mimeType: mimeTypes.TABLE,
     };
   }
   throw new Error(`Invalid internalId: ${internalId}`);

--- a/connectors/src/lib/remote_databases/content_nodes.ts
+++ b/connectors/src/lib/remote_databases/content_nodes.ts
@@ -1,4 +1,5 @@
 import type { ConnectorPermission, ContentNode } from "@dust-tt/types";
+import { MIME_TYPES } from "@dust-tt/types";
 
 /**
  * 3 types of nodes in a remote database content tree:
@@ -43,6 +44,7 @@ export const getContentNodeFromInternalId = (
       preventSelection: false,
       permission,
       lastUpdatedAt: null,
+      mimeType: MIME_TYPES.BIGQUERY.DATABASE,
     };
   }
   if (type === "schema") {
@@ -56,6 +58,7 @@ export const getContentNodeFromInternalId = (
       preventSelection: false,
       permission,
       lastUpdatedAt: null,
+      mimeType: MIME_TYPES.BIGQUERY.SCHEMA,
     };
   }
   if (type === "table") {
@@ -69,6 +72,7 @@ export const getContentNodeFromInternalId = (
       preventSelection: false,
       permission,
       lastUpdatedAt: null,
+      mimeType: MIME_TYPES.BIGQUERY.TABLE,
     };
   }
   throw new Error(`Invalid internalId: ${internalId}`);

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -1,5 +1,5 @@
 import type { ContentNode, Result } from "@dust-tt/types";
-import { Ok } from "@dust-tt/types";
+import { MIME_TYPES, Ok } from "@dust-tt/types";
 import type {
   Attributes,
   CreationAttributes,
@@ -321,6 +321,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
           ? "read"
           : "none",
       lastUpdatedAt: this.updatedAt.getTime(),
+      mimeType: MIME_TYPES.ZENDESK.BRAND,
     };
   }
 
@@ -338,6 +339,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       expandable: true,
       permission: this.helpCenterPermission,
       lastUpdatedAt: null,
+      mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
     };
   }
 
@@ -358,6 +360,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       expandable: expandable,
       permission: this.ticketsPermission,
       lastUpdatedAt: null,
+      mimeType: MIME_TYPES.ZENDESK.TICKETS,
     };
   }
 }
@@ -609,6 +612,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
       expandable: expandable,
       permission,
       lastUpdatedAt: this.updatedAt.getTime(),
+      mimeType: MIME_TYPES.ZENDESK.CATEGORY,
     };
   }
 
@@ -693,6 +697,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
       permission: this.permission,
       lastUpdatedAt: this.updatedAt.getTime(),
       preventSelection: true,
+      mimeType: MIME_TYPES.ZENDESK.TICKET,
     };
   }
 
@@ -894,6 +899,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
       permission: this.permission,
       lastUpdatedAt: this.updatedAt.getTime(),
       preventSelection: true,
+      mimeType: MIME_TYPES.ZENDESK.ARTICLE,
     };
   }
 

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -1,7 +1,4 @@
-import {
-  AdminCommandType,
-  AdminResponseType,
-} from "../../connectors/admin/cli";
+import { AdminCommandType, AdminResponseType } from "../../connectors/admin/cli";
 import { ConnectorsAPIError, isConnectorsAPIError } from "../../connectors/api";
 import { UpdateConnectorConfigurationType } from "../../connectors/api_handlers/connector_configuration";
 import { ConnectorCreateRequestBody } from "../../connectors/api_handlers/create_connector";
@@ -110,7 +107,7 @@ export interface ContentNode {
   permission: ConnectorPermission;
   lastUpdatedAt: number | null;
   providerVisibility?: ProviderVisibility;
-  mimeType?: string;
+  mimeType: string;
 }
 
 export type ContentNodeWithParentIds = ContentNode & {

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -112,7 +112,14 @@ export const MIME_TYPES = {
   }),
   ZENDESK: getMimeTypes({
     provider: "zendesk",
-    resourceTypes: ["HELP_CENTER", "CATEGORY", "ARTICLE", "TICKETS", "TICKET"],
+    resourceTypes: [
+      "BRAND",
+      "HELP_CENTER",
+      "CATEGORY",
+      "ARTICLE",
+      "TICKETS",
+      "TICKET",
+    ],
   }),
   BIGQUERY: getMimeTypes({
     provider: "bigquery",

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -84,6 +84,7 @@ export const MIME_TYPES = {
       "CONVERSATION",
       "TEAM",
       "ARTICLE",
+      "HELP_CENTER",
     ],
   }),
   MICROSOFT: getMimeTypes({


### PR DESCRIPTION
## Description

- This PR adds mime types in the content nodes returned by connectors, making the mime type required in the type `ContentNode`.
- This unlocks partly the cleaning of front and connectors and aligns further `/permissions` and `/nodes/search`.

## Tests

- We can test this PR by merging it and opening the `ContentNodeTree` for every connector we have on our workspace and see if we trigger the `[CoreNodes]` log in front.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.