### PR TITLE
Prevent setting parents in `api/v1` when not coming from connectors

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -499,6 +499,28 @@ async function handler(
         });
       }
 
+      // Prohibit passing parents when not coming from connectors.
+      if (!auth.isSystemKey() && r.data.parents) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Setting a custom hierarchy is not supported yet. Please omit the parents field.",
+          },
+        });
+      }
+      if (!auth.isSystemKey() && r.data.parent_id) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Setting a custom hierarchy is not supported yet. Please omit the parent_id field.",
+          },
+        });
+      }
+
       // Enforce parents consistency: we expect users to either not pass them (recommended) or pass them correctly.
       const parentsDisclaimerMessage =
         "The use of the parents field is discouraged, this field is intended for internal uses only.";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -148,14 +148,6 @@ export const config = {
  *                 items:
  *                   type: string
  *                 description: Tags to associate with the document.
- *               parent_id:
- *                 type: string
- *                 description: 'Reserved for internal use, should not be set. Document ID of the direct parent to associate with the document.'
- *               parents:
- *                 type: array
- *                 items:
- *                   type: string
- *                 description: 'Reserved for internal use, should not be set. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order.'
  *               timestamp:
  *                 type: number
  *                 description: Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000).

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -522,15 +522,13 @@ async function handler(
       }
 
       // Enforce parents consistency: we expect users to either not pass them (recommended) or pass them correctly.
-      const parentsDisclaimerMessage =
-        "The use of the parents field is discouraged, this field is intended for internal uses only.";
       if (r.data.parents) {
         if (r.data.parents.length === 0) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid parents: parents must have at least one element.\n${parentsDisclaimerMessage}`,
+              message: `Invalid parents: parents must have at least one element.`,
             },
           });
         }
@@ -539,7 +537,7 @@ async function handler(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid parents: parents[0] should be equal to document_id.\n${parentsDisclaimerMessage}`,
+              message: `Invalid parents: parents[0] should be equal to document_id.`,
             },
           });
         }
@@ -551,7 +549,7 @@ async function handler(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid parent id: parents[1] and parent_id should be equal.\n${parentsDisclaimerMessage}`,
+              message: `Invalid parent id: parents[1] and parent_id should be equal.`,
             },
           });
         }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -521,19 +521,18 @@ async function handler(
             },
           });
         }
-      }
-      if (
-        r.data.parents &&
-        (r.data.parents.length >= 2 || r.data.parent_id !== null) &&
-        r.data.parents[1] !== r.data.parent_id
-      ) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid parent id: parents[1] and parent_id should be equal.\n${parentsDisclaimerMessage}`,
-          },
-        });
+        if (
+          (r.data.parents.length >= 2 || r.data.parent_id !== null) &&
+          r.data.parents[1] !== r.data.parent_id
+        ) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid parent id: parents[1] and parent_id should be equal.\n${parentsDisclaimerMessage}`,
+            },
+          });
+        }
       }
 
       const documentId = req.query.documentId as string;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -378,6 +378,28 @@ async function handler(
         });
       }
 
+      // Prohibit passing parents when not coming from connectors.
+      if (!auth.isSystemKey() && parents) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Setting a custom hierarchy is not supported yet. Please omit the parents field.",
+          },
+        });
+      }
+      if (!auth.isSystemKey() && parentId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Setting a custom hierarchy is not supported yet. Please omit the parent_id field.",
+          },
+        });
+      }
+
       // Enforce parents consistency: we expect users to either not pass them (recommended) or pass them correctly.
       if (parents) {
         if (parents.length === 0) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -416,7 +416,7 @@ async function handler(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid parents: parents[0] should be equal to document_id.`,
+              message: `Invalid parents: parents[0] should be equal to table_id.`,
             },
           });
         }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -110,14 +110,6 @@ import { apiError } from "@app/logger/withlogging";
  *                 items:
  *                   type: string
  *                 description: Tags associated with the table
- *               parents:
- *                 type: array
- *                 items:
- *                   type: string
- *                   description: 'Reserved for internal use, should not be set. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order'
- *               parent_id:
- *                 type: string
- *                 description: 'Reserved for internal use, should not be set. ID of the direct parent to associate with the table'
  *               mime_type:
  *                 type: string
  *                 description: 'Reserved for internal use, should not be set. Mime type of the table'

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -379,15 +379,13 @@ async function handler(
       }
 
       // Enforce parents consistency: we expect users to either not pass them (recommended) or pass them correctly.
-      const parentsDisclaimerMessage =
-        "The use of the parents field is discouraged, this field is intended for internal uses only.";
       if (parents) {
         if (parents.length === 0) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid parents: parents must have at least one element.\n${parentsDisclaimerMessage}`,
+              message: `Invalid parents: parents must have at least one element.`,
             },
           });
         }
@@ -396,7 +394,7 @@ async function handler(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid parents: parents[0] should be equal to document_id.\n${parentsDisclaimerMessage}`,
+              message: `Invalid parents: parents[0] should be equal to document_id.`,
             },
           });
         }
@@ -410,7 +408,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid parent id: parents[1] and parent_id should be equal.\n${parentsDisclaimerMessage}`,
+            message: `Invalid parent id: parents[1] and parent_id should be equal.`,
           },
         });
       }

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2292,17 +2292,6 @@
                     },
                     "description": "Tags to associate with the document."
                   },
-                  "parent_id": {
-                    "type": "string",
-                    "description": "Reserved for internal use, should not be set. Document ID of the direct parent to associate with the document."
-                  },
-                  "parents": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Reserved for internal use, should not be set. Document and ancestor ids, with the following convention: parents[0] === documentId, parents[1] === parent_id, and then ancestors ids in order."
-                  },
                   "timestamp": {
                     "type": "number",
                     "description": "Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000)."
@@ -3481,17 +3470,6 @@
                       "type": "string"
                     },
                     "description": "Tags associated with the table"
-                  },
-                  "parents": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "description": "Reserved for internal use, should not be set. Table and ancestor ids, with the following convention: parents[0] === table_id, parents[1] === parent_id, and then ancestors ids in order"
-                    }
-                  },
-                  "parent_id": {
-                    "type": "string",
-                    "description": "Reserved for internal use, should not be set. ID of the direct parent to associate with the table"
                   },
                   "mime_type": {
                     "type": "string",


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10473.
- This PR prevents setting parents in `api/v1` when not coming from connectors, which would otherwise cause the node to not appear in the UI.
- We have already confirmed that the number of people who pass parents in `api/v1` is close to 0, and that no one relies on it (given that it does not do anything).
- Note: documenting the `documents/parents` endpoint does not have a lot of sense now.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Deploy docs.