### PR TITLE
[front] - deps: bump sparkle 0.2.405

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.404",
+        "@dust-tt/sparkle": "0.2.405-rc-1",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11336,9 +11336,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.404",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.404.tgz",
-      "integrity": "sha512-jjJmA4qNnKP8FRwniWJevvSQDm2l/RDQL4V09hqRQEVivKadHYf16ocgbleu3Puc7xeygj2tLXDovUaXZszxsg==",
+      "version": "0.2.405-rc-1",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.405-rc-1.tgz",
+      "integrity": "sha512-4ExusWg4CRqz5h8iPPdU/bZBNQmpd631ml5wW63sUYEfGDqtSLDdUZZtIDdBngtm8U+XPcqFJLASIG+OS1k+rQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -11372,6 +11372,7 @@
         "remark-directive": "^2.0.1",
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
+        "sonner": "^1.7.4",
         "tailwind-merge": "^2.5.3",
         "tailwind-scrollbar-hide": "^1.1.7",
         "unist-util-visit": "^5.0.0"
@@ -33258,6 +33259,15 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "0.2.405-rc-1",
+        "@dust-tt/sparkle": "0.2.405",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11336,9 +11336,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.405-rc-1",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.405-rc-1.tgz",
-      "integrity": "sha512-4ExusWg4CRqz5h8iPPdU/bZBNQmpd631ml5wW63sUYEfGDqtSLDdUZZtIDdBngtm8U+XPcqFJLASIG+OS1k+rQ==",
+      "version": "0.2.405",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.405.tgz",
+      "integrity": "sha512-SzkAiHdwM0tTLndqGrLQK3YgTjJNs7m2E30HyXmOUyD7fxu7rT2m2d8uz7vGkyRVGzsPsS+psEZ9F1Ak4QhpYw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.404",
+    "@dust-tt/sparkle": "0.2.405-rc-1",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "0.2.405-rc-1",
+    "@dust-tt/sparkle": "0.2.405",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",


### PR DESCRIPTION
## Description

This PR bumps sparkle to use the new notifications component.

**References:**
- https://github.com/dust-tt/dust/pull/10851

## Risk

Low

## Deploy Plan

- Publish sparkle
- Update sparkle version in front
- Deploy front
