### PR TITLE
[sparkle] - fix: trim plain text 

### DIFF
--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -57,10 +57,9 @@ export function ContentBlockWrapper({
 
     // Replace invisible non-breaking spaces with regular spaces.
     if (rawContent["text/plain"]) {
-      rawContent["text/plain"] = rawContent["text/plain"].replaceAll(
-        "\xa0",
-        " "
-      );
+      rawContent["text/plain"] = rawContent["text/plain"]
+        .replaceAll("\xa0", " ")
+        .trim();
     }
 
     const data = new ClipboardItem(


### PR DESCRIPTION


## Description

This PR strip and trim leading/trailing whitespace from the plain text content before copying to clipboard.

**References:**
- https://github.com/dust-tt/tasks/issues/2058

Note: will be shipped along with next sparkle deploy

## Risk

Low

## Deploy Plan

N/A