### PR TITLE
Fix labels counter nan + display filters always on assistant modal

### DIFF
--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -410,6 +410,7 @@ function DataSourceViewsSection({
                   }
                 />
               }
+              areActionsFading={false}
             >
               {dataSourceView && isAllSelected && (
                 <DataSourceViewPermissionTree
@@ -480,7 +481,10 @@ function RetrievalActionTagsFilterPopover({
   let tagsLabel = "Filters";
   if (tagsFilter === "auto") {
     tagsLabel = "Filters (auto)";
-  } else if (tagsFilter) {
+  } else if (
+    tagsFilter &&
+    (tagsFilter.in.length > 0 || tagsFilter.not.length > 0)
+  ) {
     tagsCounter = tagsFilter.in.length + tagsFilter.not.length;
   }
 

--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -493,7 +493,7 @@ function RetrievalActionTagsFilterPopover({
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          size="sm"
+          size="xs"
           label={tagsLabel}
           isSelect
           counterValue={tagsCounter ? tagsCounter.toString() : "auto"}

--- a/front/components/assistant_builder/tags/DataSourceTagsFilterDropdown.tsx
+++ b/front/components/assistant_builder/tags/DataSourceTagsFilterDropdown.tsx
@@ -131,7 +131,7 @@ export function DataSourceTagsFilterDropdown({
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          size="sm"
+          size="xs"
           label={tagsLabel}
           isSelect
           counterValue={tagsCounter ? tagsCounter.toString() : "auto"}

--- a/front/components/assistant_builder/tags/DataSourceTagsFilterDropdown.tsx
+++ b/front/components/assistant_builder/tags/DataSourceTagsFilterDropdown.tsx
@@ -111,7 +111,10 @@ export function DataSourceTagsFilterDropdown({
   let tagsLabel = "Filters";
   if (tagsFilter === "auto") {
     tagsLabel = "Filters (auto)";
-  } else if (tagsFilter) {
+  } else if (
+    tagsFilter &&
+    (tagsFilter.in.length > 0 || tagsFilter.not.length > 0)
+  ) {
     tagsCounter = tagsFilter.in.length + tagsFilter.not.length;
   }
 


### PR DESCRIPTION
## Description

Fixes these reported by @pinotalexandre 

1. UI Spacing
   -Could we add spacing between the "Selected data source" row and "Manage selection" button?

3. Counter Display
   - Bug: "NaN" appears after deleting filter
   - Fix: Hide counter when no tags are selected
   - 
6. Filter Button Visibility (Low Priority)
   - Current: Only visible on hover
   - Suggested: Always display filter button when filters are selected (on the assistant modal too)

## Tests

Locally.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
