### PR TITLE
[Node Core] Front cleaning 2

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -32,6 +32,7 @@ import type {
   ConnectorType,
   ContentNode,
   DataSourceType,
+  DataSourceViewType,
   LightWorkspaceType,
   UpdateConnectorRequestBody,
   WorkspaceType,
@@ -69,6 +70,7 @@ import {
   isRemoteDatabase,
 } from "@app/lib/data_sources";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
+import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useSpaceDataSourceViews, useSystemSpace } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
 import {
@@ -563,7 +565,7 @@ function DataSourceDeletionModal({
 
 interface ConnectorPermissionsModalProps {
   connector: ConnectorType;
-  dataSource: DataSourceType;
+  dataSourceView: DataSourceViewType;
   isAdmin: boolean;
   isOpen: boolean;
   onClose: (save: boolean) => void;
@@ -574,7 +576,7 @@ interface ConnectorPermissionsModalProps {
 
 export function ConnectorPermissionsModal({
   connector,
-  dataSource,
+  dataSourceView,
   isAdmin,
   isOpen,
   onClose,
@@ -588,6 +590,8 @@ export function ConnectorPermissionsModal({
   const [selectedNodes, setSelectedNodes] = useState<
     Record<string, ContentNodeTreeItemStatus>
   >({});
+
+  const dataSource = dataSourceView.dataSource;
 
   const isDeletable =
     dataSource.connectorProvider &&
@@ -613,16 +617,14 @@ export function ConnectorPermissionsModal({
     [owner, dataSource]
   );
 
-  const { resources: allSelectedResources, isResourcesLoading } =
-    useConnectorPermissions({
-      dataSource,
-      filterPermission: "read",
+  const { nodes: allSelectedResources, isNodesLoading } =
+    useDataSourceViewContentNodes({
       owner,
-      parentId: null,
+      dataSourceView,
       viewType: "all",
-      includeParents: true,
       disabled: !canUpdatePermissions,
     });
+
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const advancedNotionManagement =
     dataSource.connectorProvider === "notion" &&
@@ -848,7 +850,7 @@ export function ConnectorPermissionsModal({
                       canUpdatePermissions ? selectedNodes : undefined
                     }
                     setSelectedNodes={
-                      canUpdatePermissions && !isResourcesLoading
+                      canUpdatePermissions && !isNodesLoading
                         ? setSelectedNodes
                         : undefined
                     }

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -578,7 +578,7 @@ export const SpaceDataSourceViewContentList = ({
                 <ConnectorPermissionsModal
                   owner={owner}
                   connector={connector}
-                  dataSource={dataSourceView.dataSource}
+                  dataSourceView={dataSourceView}
                   isOpen={showConnectorPermissionsModal}
                   onClose={(save) => {
                     setShowConnectorPermissionsModal(false);

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -534,7 +534,7 @@ export const SpaceResourcesList = ({
         <ConnectorPermissionsModal
           owner={owner}
           connector={selectedDataSourceView.dataSource.connector}
-          dataSource={selectedDataSourceView.dataSource}
+          dataSourceView={selectedDataSourceView}
           isOpen={showConnectorPermissionsModal && !!selectedDataSourceView}
           onClose={() => setShowConnectorPermissionsModal(false)}
           readOnly={false}

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -364,6 +364,7 @@ export const SpaceResourcesList = ({
     canWriteInSpace,
     isFolder,
     onSelect,
+    isDark,
   ]);
 
   const onSelectedDataUpdated = useCallback(async () => {

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -42,38 +42,7 @@ function getVisualForFileContentNode(node: ContentNode & { type: "file" }) {
   return DocumentIcon;
 }
 
-// TODO(nodes-core) clean this up to always rely on the mime type.
-export function getVisualForContentNode(node: ContentNode, useMimeType = true) {
-  if (useMimeType) {
-    return getVisualForContentNodeBasedOnMimeType(node);
-  } else {
-    return getVisualForContentNodeBasedOnType(node);
-  }
-}
-
-function getVisualForContentNodeBasedOnType(node: ContentNode) {
-  switch (node.type) {
-    case "database":
-      return Square3Stack3DIcon;
-
-    case "file":
-      return getVisualForFileContentNode(
-        node as ContentNode & { type: "file" }
-      );
-
-    case "folder":
-      return FolderIcon;
-
-    default:
-      assertNever(node.type);
-  }
-}
-
-function getVisualForContentNodeBasedOnMimeType(node: ContentNode) {
-  if (!node.mimeType) {
-    // Hotfix to allow using the connNodes param.
-    return getVisualForContentNodeBasedOnType(node);
-  }
+export function getVisualForContentNode(node: ContentNode) {
   if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
     if (node.providerVisibility === "private") {
       return LockIcon;


### PR DESCRIPTION
## Description
Following PR #10854 
Fixes https://github.com/dust-tt/tasks/issues/1939
- removing former getVisualForContentNode
- connector permissions modal relies on new core content nodes

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
standard

## Deploy Plan
front
