### PR TITLE
Ignore Microsoft txt files that mostly contain digits

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -42,6 +42,7 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
+
 async function handleGoogleDriveExport(
   oauth2client: OAuth2Client,
   file: GoogleDriveObjectType,
@@ -230,6 +231,7 @@ async function handleFileExport(
     result = await handleTextExtraction(res.data, localLogger, file.mimeType);
   }
   if (result.isErr()) {
+    localLogger.error({ error: result.error }, "Could not handle file.");
     return null;
   }
 

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -276,6 +276,7 @@ export async function syncOneFile({
     tags.push(...filterCustomTags(columns, localLogger));
 
     if (result.isErr()) {
+      localLogger.error({ error: result.error }, "Could not handle file.");
       if (fileResource) {
         await fileResource.delete();
       }

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -23,7 +23,7 @@ import type { Logger } from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 // We observed cases where tabular data was stored in ASCII in .txt files.
-const MAX_NUMBER_CHAR_RATIO = 0.75;
+const MAX_NUMBER_CHAR_RATIO = 0.66;
 
 export function handleTextFile(
   data: ArrayBuffer,

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -22,6 +22,9 @@ import {
 import type { Logger } from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
+// We observed cases where tabular data was stored in ASCII in .txt files.
+const MAX_NUMBER_CHAR_RATIO = 0.75;
+
 export function handleTextFile(
   data: ArrayBuffer,
   maxDocumentLen: number
@@ -29,11 +32,12 @@ export function handleTextFile(
   if (data.byteLength > 4 * maxDocumentLen) {
     return new Err(new Error("file_too_big"));
   }
-  return new Ok({
-    prefix: null,
-    content: Buffer.from(data).toString("utf-8").trim(),
-    sections: [],
-  });
+  const content = Buffer.from(data).toString("utf-8").trim();
+  const digitCount = (content.match(/\d/g) || []).length;
+  if (digitCount / content.length > MAX_NUMBER_CHAR_RATIO) {
+    return new Err(new Error("too_many_digits"));
+  }
+  return new Ok({ prefix: null, content, sections: [] });
 }
 
 export async function handleCsvFile({

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -33,7 +33,7 @@ export function handleTextFile(
     return new Err(new Error("file_too_big"));
   }
   const content = Buffer.from(data).toString("utf-8").trim();
-  const digitCount = (content.match(/\d/g) || []).length;
+  const digitCount = (content.match(/[\d\n\r]/g) || []).length;
   if (digitCount / content.length > MAX_NUMBER_CHAR_RATIO) {
     return new Err(new Error("too_many_digits"));
   }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2210.
- Follow up on https://dust4ai.slack.com/archives/C05F84CFP0E/p1739859771761819.
- We observed files that were stored as .txt that turned out to be tables stored in ASCII.
- This PR targets those, and more generally aim at ignoring files that mostly contain digits, given that these files do not have a lot of relevance for semantic search.
- This PR also adds logging on ignored files.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.