### PR TITLE
enh: add better conversation participants index

### DIFF
--- a/front/migrations/db/migration_171.sql
+++ b/front/migrations/db/migration_171.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY "conversation_participants_user_id_action_updated" ON "conversation_participants" ("userId", "action", "updatedAt" DESC) INCLUDE ("id", "conversationId");


### PR DESCRIPTION
## Description

Our conversation participants query [is getting slow](https://console.cloud.google.com/sql/instances/dust-api-db/insights;database=dust-front;duration=PT1H;trace=a2fb6689677221e6bd03b22c70b95dc7;span=42d40abf8352531c;query_hash=3071609214303277939;sort_by=TOTAL_EXEC_TIME/executed?inv=1&invt=Abp5Kg&project=or1g1n-186209)

This is the query plan I am getting:

```
Gather Merge (cost=15892.95..16022.44 rows=1126 width=143) (actual time=22.691..26.452 rows=1844 loops=1)
Workers Planned: 1
Workers Launched: 1
-> Sort (cost=14892.94..14895.76 rows=1126 width=143) (actual time=18.682..18.799 rows=922 loops=2)
Sort Key: conversation_participant."updatedAt" DESC
Sort Method: quicksort Memory: 334kB
Worker 0: Sort Method: quicksort Memory: 228kB
-> Nested Loop (cost=27.69..14835.87 rows=1126 width=143) (actual time=0.568..17.826 rows=922 loops=2)
-> Parallel Bitmap Heap Scan on conversation_participants conversation_participant (cost=27.26..5644.02 rows=1126 width=32) (actual time=0.530..7.918 rows=922 loops=2)
Recheck Cond: ("userId" = 4425)
Filter: ((action)::text = 'posted'::text)
Heap Blocks: exact=587
-> Bitmap Index Scan on "conversation_participants_userId_fk" (cost=0.00..26.78 rows=1914 width=0) (actual time=0.765..0.766 rows=1846 loops=1)
Index Cond: ("userId" = 4425)
-> Index Scan using conversations_pkey on conversations conversation (cost=0.43..8.16 rows=1 width=119) (actual time=0.010..0.010 rows=1 loops=1844)
Index Cond: (id = conversation_participant."conversationId")
```

We currently have:

```
CREATE INDEX CONCURRENTLY "conversation_participants_user_id_action" ON "conversation_participants" ("userId", "action");
```

The reason is that we now sort by "updatedAt", so PG decides that using the index is not worth it.

The fix here is a new index that adds updatedAt as a btree key. Also including `cp.id` and `cp.conversationId` in the index's leaf pages so we can do the conversation participants query as an index-only scan.

Once this index is properly applied, I'll get rid of `conversation_participants_user_id_action`

## Tests

Applied locally but isn't much of a real-world test

## Risk

new indexes are always somewhat risky, but applied concurrently so should be fine

## Deploy Plan

- Apply in US
- Wait for full application
- do query plan again and observe results on prod
- apply in EU
- wait for full application in EU
- get rid of old index in both regions