### PR TITLE
Fix Google Drive incremental sync on sheet parents update

### DIFF
--- a/connectors/migrations/db/migration_52.sql
+++ b/connectors/migrations/db/migration_52.sql
@@ -1,0 +1,2 @@
+-- Migration created on Feb 18, 2025
+ALTER TABLE "public"."google_drive_sheets" ADD COLUMN "notUpsertedReason" TEXT;

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -192,12 +192,17 @@ export async function updateParentsField(
         sheet.driveFileId,
         sheet.driveSheetId
       );
-      await updateDataSourceTableParents({
-        dataSourceConfig,
-        tableId,
-        parents: [tableId, ...parentIds],
-        parentId: file.dustFileId,
-      });
+      // TODO(2025-02-19 aubin): remove this after the entries are unstuck.
+      try {
+        await updateDataSourceTableParents({
+          dataSourceConfig,
+          tableId,
+          parents: [tableId, ...parentIds],
+          parentId: file.dustFileId,
+        });
+      } catch (e) {
+        return;
+      }
     }
   } else {
     await updateDataSourceDocumentParents({

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -184,6 +184,7 @@ export async function updateParentsField(
       where: {
         driveFileId: file.driveFileId,
         connectorId: connector.id,
+        notUpsertedReason: null,
       },
     });
     for (const sheet of sheets) {

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -28,7 +28,8 @@ import {
   upsertDataSourceFolder,
   upsertDataSourceTableFromCsv,
 } from "@connectors/lib/data_sources";
-import { ProviderWorkflowError, TablesError } from "@connectors/lib/error";
+import type { TablesError } from "@connectors/lib/error";
+import { ProviderWorkflowError } from "@connectors/lib/error";
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
@@ -200,30 +201,13 @@ async function processSheet(
   const rows = getValidRows(sheet.values, loggerArgs);
   // Assuming the first line as headers, at least one additional data line is required.
   if (rows.length > 1) {
-    let upsertError = null;
-    try {
-      upsertError = await upsertGdriveTable(
-        connector,
-        sheet,
-        parents,
-        rows,
-        tags
-      );
-    } catch (err) {
-      if (err instanceof TablesError) {
-        logger.warn(
-          { ...loggerArgs, error: err },
-          "[Spreadsheet] Tables error - skipping (but not failing)."
-        );
-        return false;
-      } else {
-        logger.error(
-          { ...loggerArgs, error: err },
-          "[Spreadsheet] Failed to upsert table."
-        );
-        throw err;
-      }
-    }
+    const upsertError = await upsertGdriveTable(
+      connector,
+      sheet,
+      parents,
+      rows,
+      tags
+    );
 
     await upsertSheetInDb(connector, sheet, upsertError);
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -786,24 +786,25 @@ export async function upsertDataSourceRemoteTable({
  * Other errors are re-thrown.
  *
  * @param fn - Async function to execute that may throw a TablesError
- * @returns A boolean indicating if a TablesError was caught (true) or not (false)
+ * @returns The TablesError that was caught if any, null otherwise.
  * @throws Any non-TablesError that occurs during execution
  */
 
 export const ignoreTablesError = async (
   connectorName: string,
   fn: () => Promise<void>
-) => {
+): Promise<TablesError | null> => {
   try {
     await fn();
     logger.info(`[${connectorName}] Table upserted successfully.`);
+    return null;
   } catch (err) {
     if (err instanceof TablesError) {
       logger.warn(
         { error: err },
         "Invalid rows detected - skipping (but not failing)."
       );
-      return true;
+      return err;
     } else {
       logger.error(
         { error: err },

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -22,7 +22,10 @@ type GeneralWorkflowErrorType =
   | "unhandled_internal_activity_error"
   | "workflow_timeout_failure";
 
-type TablesErrorType = "invalid_headers" | "file_too_large" | "invalid_csv";
+export type TablesErrorType =
+  | "invalid_headers"
+  | "file_too_large"
+  | "invalid_csv";
 
 // Combine both general and provider-specific error types.
 type WorkflowErrorType = GeneralWorkflowErrorType | ProviderErrorType;

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -158,6 +158,7 @@ export class GoogleDriveSheet extends ConnectorBaseModel<GoogleDriveSheet> {
   declare driveFileId: string;
   declare driveSheetId: number;
   declare name: string;
+  declare notUpsertedReason: string | null;
 }
 GoogleDriveSheet.init(
   {
@@ -182,6 +183,10 @@ GoogleDriveSheet.init(
     name: {
       type: DataTypes.TEXT,
       allowNull: false,
+    },
+    notUpsertedReason: {
+      type: DataTypes.TEXT,
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -1,6 +1,7 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import type { TablesErrorType } from "@connectors/lib/error";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
@@ -158,7 +159,7 @@ export class GoogleDriveSheet extends ConnectorBaseModel<GoogleDriveSheet> {
   declare driveFileId: string;
   declare driveSheetId: number;
   declare name: string;
-  declare notUpsertedReason: string | null;
+  declare notUpsertedReason: TablesErrorType | null;
 }
 GoogleDriveSheet.init(
   {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2209.
- Sheets can be skipped when we fail to parse them (e.g. when a column header is too long to parse).
- Since we do not keep track of the sheets that were skipped, this causes the incremental sync to still attempt at updating their parents and thus fail.
- This PR fixes that by keeping track of the sheets that were not upserted in an additional column `notUpsertedReason`.
- This column does not need to be backfilled, it will updated on each upsert.

## Tests

- TBC

## Risk

- Well contained.

## Deploy Plan

- Run `connectors/migrations/db/migration_52.sql`.
- Deploy connectors.