### PR TITLE
Sparkle: fix border search input when disabled

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.405",
+  "version": "0.2.406",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.405",
+      "version": "0.2.406",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.405",
+  "version": "0.2.406",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Container.tsx
+++ b/sparkle/src/components/Container.tsx
@@ -18,7 +18,7 @@ export const Container = React.forwardRef<HTMLDivElement, ContainerProps>(
       <div
         ref={ref}
         className={cn(
-          "s-mx-auto s-w-full s-bg-white s-@container dark:s-bg-black",
+          "s-mx-auto s-w-full s-bg-white s-@container dark:s-bg-slate-950",
           className
         )}
         {...props}

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -17,7 +17,7 @@ export const menuStyleClasses = {
   container: cn(
     "s-rounded-xl s-border-hovering s-p-1",
     "s-border dark:s-border-primary-600",
-    "s-bg-white dark:s-bg-black",
+    "s-bg-white dark:s-bg-slate-950",
     "s-text-primary-950 dark:s-text-primary-950-night",
     "s-z-50 s-min-w-[8rem] s-overflow-hidden",
     "data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 data-[side=bottom]:s-slide-in-from-top-2 data-[side=left]:s-slide-in-from-right-2 data-[side=right]:s-slide-in-from-left-2 data-[side=top]:s-slide-in-from-bottom-2"

--- a/sparkle/src/components/DropzoneOverlay.tsx
+++ b/sparkle/src/components/DropzoneOverlay.tsx
@@ -21,7 +21,7 @@ export default function DropzoneOverlay({
     <Icon
       visual={ArrowUpOnSquareIcon}
       size="lg"
-      className="s-text-white dark:s-text-black"
+      className="s-text-white dark:s-text-slate-950"
     />
   ),
 }: DropzoneOverlayProps) {

--- a/sparkle/src/components/DropzoneOverlay.tsx
+++ b/sparkle/src/components/DropzoneOverlay.tsx
@@ -49,7 +49,7 @@ export default function DropzoneOverlay({
     <div
       className={cn(
         "s-absolute s-inset-0 s-z-50 s-flex s-h-full s-w-full s-flex-col s-items-center s-justify-center s-gap-0",
-        "s-bg-white/80 dark:s-bg-black/80",
+        "dark:s-bg-slate-90/80 s-bg-white/80",
         "s-text-element-800 dark:s-text-element-800-night"
       )}
       onMouseLeave={() => {

--- a/sparkle/src/components/IconButton.tsx
+++ b/sparkle/src/components/IconButton.tsx
@@ -42,16 +42,16 @@ const styleVariants: Record<ButtonVariantType, string> = {
     "s-text-element-500 dark:s-text-element-500-night"
   ),
   ghost: cn(
-    "s-text-white dark:s-text-black",
+    "s-text-white dark:s-text-slate-950",
     "hover:s-text-slate-100 dark:hover:s-text-slate-100-night",
     "active:s-text-slate-200 dark:active:s-text-slate-200-night",
-    "s-text-white/50 dark:s-text-black/50"
+    "s-text-white/50 dark:s-text-slate-950/50"
   ),
   "ghost-secondary": cn(
     "s-text-white",
     "hover:s-text-slate-100 dark:hover:s-text-slate-100-night",
     "active:s-text-slate-200 dark:active:s-text-slate-200-night",
-    "s-text-white/50 dark:s-text-black/50"
+    "s-text-white/50 dark:s-text-slate-950/50"
   ),
 };
 

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -41,7 +41,8 @@ const stateVariantStyles: Record<InputStateType, string> = {
   ),
   disabled: cn(
     "disabled:s-cursor-not-allowed",
-    "disabled:s-text-muted-foreground dark:disabled:s-text-muted-foreground-night"
+    "disabled:s-text-muted-foreground dark:disabled:s-text-muted-foreground-night",
+    "disabled:s-border-border-dark dark:disabled:s-border-border-dark-night"
   ),
   error: cn(
     "s-border-border-warning/30 dark:s-border-border-warning-night/30",

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -64,7 +64,7 @@ const messageVariant = cva("", {
 
 const inputStyleClasses = cva(
   cn(
-    "dark:s-text-white",
+    "dark:s-text-slate-50",
     "s-text-sm s-rounded-xl s-flex s-h-9 s-w-full s-px-3 s-py-1.5 ",
     "s-bg-muted-background dark:s-bg-muted-background-night",
     "s-border focus-visible:s-ring",

--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -71,7 +71,7 @@ export function SliderToggle({
           "s-transform s-rounded-full s-drop-shadow s-transition-transform s-duration-300 s-ease-out",
           disabled
             ? "s-bg-structure-100 dark:s-bg-structure-100-night"
-            : "s-bg-white dark:s-bg-black",
+            : "s-bg-white dark:s-bg-slate-950",
           size ? cusrsorSizeClasses[size] : "",
           selected ? cusrsorTranslateSizeClasses[size] : "s-translate-x-[2px]"
         )}

--- a/sparkle/src/components/SplitButton.tsx
+++ b/sparkle/src/components/SplitButton.tsx
@@ -139,9 +139,9 @@ const SplitButton = React.forwardRef<HTMLButtonElement, SplitButtonProps>(
 );
 
 const flexSeparatorVariants: Record<ButtonVariantType, string> = {
-  primary: "s-bg-white/50 dark:s-bg-black/50",
-  highlight: "s-bg-white/50 dark:s-bg-black/50",
-  warning: "s-bg-white/50 dark:s-bg-black/50",
+  primary: "s-bg-white/50 dark:s-bg-slate-950/50",
+  highlight: "s-bg-white/50 dark:s-bg-slate-950/50",
+  warning: "s-bg-white/50 dark:s-bg-slate-950/50",
   outline: "s-bg-separator dark:s-bg-separator-night",
   ghost: "s-bg-separator dark:s-bg-separator-night",
   "ghost-secondary": "s-bg-separator dark:s-bg-separator-night",

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -22,7 +22,7 @@ const TooltipContent = React.forwardRef<
     sideOffset={sideOffset}
     className={classNames(
       "s-z-50 s-max-w-sm s-overflow-hidden s-whitespace-pre-wrap s-break-words s-rounded-md s-border",
-      "s-bg-white dark:s-bg-black",
+      "s-bg-white dark:s-bg-slate-950",
       "s-text-foreground dark:s-text-foreground-night",
       "s-border-border dark:s-border-border-night",
       "s-px-3 s-py-1.5 s-text-sm s-shadow-md",

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -105,7 +105,9 @@ const ButtonBySize = ({
 }) => (
   <>
     <Separator />
-    <h3 className="s-text-primary dark:s-text-white">{size?.toUpperCase()}</h3>
+    <h3 className="s-text-primary dark:s-text-slate-50">
+      {size?.toUpperCase()}
+    </h3>
     <div className="s-flex s-items-center s-gap-4">
       <Button size={size} label="Button" />
       <Button size={size} variant="outline" label="Button" />


### PR DESCRIPTION
## Description

This PR does two things: 
- Replace the sparkle `darkbg-black` by `dark:s-bg-slate-950` (designer reco).
- Add specific borders to input component to fix weird behavior on Search input. I used the expected color so no expected change on existing inputs

## Tests

Storybook. 

## Risk

/ 

## Deploy Plan

Publish Sparkle. 
