### PR TITLE
Front/Core: dual validation for table CSVs passed as files

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2206,13 +2206,13 @@ async fn data_sources_delete(
 
 #[derive(serde::Deserialize)]
 struct DatabasesTablesValidateCSVContentPayload {
-    upsert_queue_bucket_path: String,
+    upsert_queue_bucket_csv_path: String,
 }
 
 async fn tables_validate_csv_content(
     Json(payload): Json<DatabasesTablesValidateCSVContentPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    match LocalTable::validate_csv_content(&payload.upsert_queue_bucket_path).await {
+    match LocalTable::validate_csv_content(&payload.upsert_queue_bucket_csv_path).await {
         Ok(schema) => (
             StatusCode::OK,
             Json(APIResponse {

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -58,7 +58,7 @@ impl UpsertQueueCSVContent {
         let mut with_separators = String::new();
         let chars: Vec<char> = s.chars().collect();
         for (i, &c) in chars.iter().enumerate() {
-            if i > 0 && c.is_uppercase() || c.is_ascii_digit() {
+            if i > 0 && (c.is_uppercase() || c.is_ascii_digit()) {
                 if chars[i - 1].is_lowercase() {
                     with_separators.push('_');
                 }
@@ -87,7 +87,7 @@ impl UpsertQueueCSVContent {
             let slug = if curr == "__dust_id" {
                 curr.to_string()
             } else {
-                let s = Self::slugify(curr);
+                let s = Self::slugify(&curr.to_lowercase());
                 if s.is_empty() {
                     format!("col_{}", acc.len())
                 } else {
@@ -245,7 +245,7 @@ mod tests {
         assert_eq!(
             sanitized,
             vec![
-                "hello_world",
+                "helloworld",
                 "b_2fkls",
                 "æuu_cool_",
                 "_",

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -12,7 +12,7 @@ use unicode_normalization::UnicodeNormalization;
 use crate::databases::table::Row;
 
 pub struct UpsertQueueCSVContent {
-    pub upsert_queue_bucket_path: String,
+    pub upsert_queue_bucket_csv_path: String,
 }
 
 const MAX_TABLE_COLUMNS: usize = 512;
@@ -28,7 +28,7 @@ impl UpsertQueueCSVContent {
 
     pub async fn parse(&self) -> Result<Vec<Row>> {
         let bucket = Self::get_upsert_queue_bucket().await?;
-        let path = &self.upsert_queue_bucket_path;
+        let path = &self.upsert_queue_bucket_csv_path;
 
         // This is not the most efficient as we download the entire file here but we will
         // materialize it in memory as Vec<Row> anyway so that's not a massive difference.

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -275,7 +275,7 @@ mod tests {
         // Test first row
         assert_eq!(rows[0].row_id, "0");
         let value = rows[0].value.as_object().unwrap();
-        assert_eq!(value["hell_world"], 1.0);
+        assert_eq!(value["hellworld"], 1.0);
         assert_eq!(value["super_fast"], 2.23);
         assert_eq!(value["c_foo"], 3.0);
         let date = value["date"].as_object().unwrap();
@@ -286,7 +286,7 @@ mod tests {
         // Test second row
         assert_eq!(rows[1].row_id, "1");
         let value = rows[1].value.as_object().unwrap();
-        assert_eq!(value["hell_world"], 4.0);
+        assert_eq!(value["hellworld"], 4.0);
         assert_eq!(value["super_fast"], "hello world");
         assert_eq!(value["c_foo"], 6.0);
         let date = value["date"].as_object().unwrap();

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -586,10 +586,10 @@ impl LocalTable {
         Ok(schema)
     }
 
-    pub async fn validate_csv_content(upsert_queue_bucket_path: &str) -> Result<TableSchema> {
+    pub async fn validate_csv_content(upsert_queue_bucket_csv_path: &str) -> Result<TableSchema> {
         let rows = Arc::new(
             UpsertQueueCSVContent {
-                upsert_queue_bucket_path: upsert_queue_bucket_path.to_string(),
+                upsert_queue_bucket_csv_path: upsert_queue_bucket_csv_path.to_string(),
             }
             .parse()
             .await?,

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -587,6 +587,7 @@ impl LocalTable {
     }
 
     pub async fn validate_csv_content(upsert_queue_bucket_csv_path: &str) -> Result<TableSchema> {
+        let now = utils::now();
         let rows = Arc::new(
             UpsertQueueCSVContent {
                 upsert_queue_bucket_csv_path: upsert_queue_bucket_csv_path.to_string(),
@@ -594,8 +595,18 @@ impl LocalTable {
             .parse()
             .await?,
         );
+        let csv_parse_duration = utils::now() - now;
 
+        let now = utils::now();
         let schema = TableSchema::from_rows_async(rows).await?;
+        let schema_duration = utils::now() - now;
+
+        info!(
+            csv_parse_duration = csv_parse_duration,
+            schema_duration = schema_duration,
+            "CSV validation"
+        );
+
         Ok(schema)
     }
 }

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -41,6 +41,7 @@ import type { Transaction } from "sequelize";
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { default as apiConfig, default as config } from "@app/lib/api/config";
 import { sendGitHubDeletionEmail } from "@app/lib/api/email";
+import { getFileContent } from "@app/lib/api/files/utils";
 import { rowsFromCsv, upsertTableFromCsv } from "@app/lib/api/tables";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
@@ -56,7 +57,6 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { enqueueUpsertTable } from "@app/lib/upsert_queue";
 import logger from "@app/logger/logger";
 import { launchScrubDataSourceWorkflow } from "@app/poke/temporal/client";
-import { getFileContent } from "./files/utils";
 
 export async function getDataSources(
   auth: Authenticator,

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -1,4 +1,7 @@
-import { AdminCommandType, AdminResponseType } from "../../connectors/admin/cli";
+import {
+  AdminCommandType,
+  AdminResponseType,
+} from "../../connectors/admin/cli";
 import { ConnectorsAPIError, isConnectorsAPIError } from "../../connectors/api";
 import { UpdateConnectorConfigurationType } from "../../connectors/api_handlers/connector_configuration";
 import { ConnectorCreateRequestBody } from "../../connectors/api_handlers/create_connector";

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1177,6 +1177,39 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
+  async tableValidateCSVContent({
+    projectId,
+    dataSourceId,
+    upsertQueueBucketCSVPath,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+    upsertQueueBucketCSVPath: string;
+  }): Promise<
+    CoreAPIResponse<{
+      schema: CoreAPITableSchema;
+    }>
+  > {
+    const response = await this._fetchWithError(
+      `${this._url}/projects/${encodeURIComponent(
+        projectId
+      )}/data_sources/${encodeURIComponent(
+        dataSourceId
+      )}/tables/validate_csv_content`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          upsert_queue_bucket_csv_path: upsertQueueBucketCSVPath,
+        }),
+      }
+    );
+
+    return this._resultFromResponse(response);
+  }
+
   async upsertTable({
     projectId,
     dataSourceId,


### PR DESCRIPTION
- **rename variable to be more explicit**
- **types: tableValidateCSVContent**
- **front actually lowercase before slugifying**
- **When given a file, run both core and front rows parsing and compare**

## Description

When a CSV gets submitted as a file, dual validate in front and using core and compare results
(without failing)

It also fixes a behavior of core to better align with front (lowercase before slugifying)

The goal run some comparisons after we merge: https://github.com/dust-tt/dust/pull/10773

Example outputs:

```
[14:07:27.609] INFO (3698279): Parsing CSV
    durationMs: 5.444513000082225
    nbRows: 1
    nbCols: 3
    workspaceId: 1
[14:07:27.729] INFO (3698279): [CSV-FILE] Validated CSV content
    schema: [
      "yeahj_239kdfnklngno_sk",
      "2_asdkjforo_",
      "aperkjkasdkj"
    ]
    headers: [
      "yeahj_239kdfnklngno_sk",
      "2_asdkjforo_",
      "aperkjkasdkj"
    ]
```

## Tests

Tweaked tests in core

## Risk

Low (not yet used)

## Deploy Plan

- deploy `core`
- deploy `front`
