### PR TITLE
fix: remove include

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -46,6 +46,7 @@ import {
   removeNulls,
 } from "@dust-tt/types";
 import { isEqual, sortBy } from "lodash";
+import _ from "lodash";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -239,56 +240,52 @@ export async function getUserConversations(
   }
 
   const participations = await ConversationParticipant.findAll({
-    attributes: ["userId", "updatedAt"],
+    attributes: ["userId", "updatedAt", "conversationId"],
     where: {
       userId: user.id,
       action: "posted",
     },
-    include: [
-      {
-        model: Conversation,
-        as: "conversation",
-        required: true,
-      },
-    ],
     order: [["updatedAt", "DESC"]],
   });
 
-  const conversations = participations.reduce<ConversationWithoutContentType[]>(
-    (acc, p) => {
-      if (!p.conversation) {
-        logger.error("Participation without conversation");
-        return acc;
-      }
-      if (
-        p.conversation.workspaceId !== owner.id ||
-        (p.conversation.visibility === "deleted" && !includeDeleted) ||
-        (p.conversation.visibility === "test" && !includeTest)
-      ) {
-        return acc;
-      }
-
-      const conversation: ConversationWithoutContentType = {
-        id: p.conversation.id,
-        created: p.conversation.createdAt.getTime(),
-        updated: p.updatedAt.getTime(),
-        sId: p.conversation.sId,
+  const conversations = (
+    await Conversation.findAll({
+      where: {
+        id: { [Op.in]: _.uniq(participations.map((p) => p.conversationId)) },
+        workspaceId: owner.id,
+        ...(includeDeleted ? {} : { visibility: { [Op.ne]: "deleted" } }),
+        ...(includeTest ? {} : { visibility: { [Op.ne]: "test" } }),
+      },
+    })
+  ).map(
+    (c) =>
+      ({
+        id: c.id,
+        created: c.createdAt.getTime(),
+        updated: c.updatedAt.getTime(),
+        sId: c.sId,
         owner,
-        title: p.conversation.title,
-        visibility: p.conversation.visibility,
-        requestedGroupIds: getConversationRequestedGroupIdsFromModel(
-          owner,
-          p.conversation
-        ),
+        title: c.title,
+        visibility: c.visibility,
+        requestedGroupIds: getConversationRequestedGroupIdsFromModel(owner, c),
         // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
         groupIds: [],
-      };
-
-      return [...acc, conversation];
-    },
-    []
+      }) satisfies ConversationWithoutContentType
   );
-  return conversations;
+
+  const conversationById = _.keyBy(conversations, "id");
+
+  return removeNulls(
+    participations.map((p) => {
+      const conv: ConversationWithoutContentType | null =
+        conversationById[p.conversationId];
+      if (!conv) {
+        logger.error("Participation without conversation");
+        return null;
+      }
+      return conv;
+    })
+  );
 }
 
 async function createOrUpdateParticipation({


### PR DESCRIPTION
## Description

Conversation participants still isn't using the index due to this join (and doing a sequential scan as a result_.

Without the join we're getting a much better index only scan:
```
Index Only Scan using conversation_participants_user_id_action_updated on conversation_participants conversation_participant  (cost=0.43..2495.10 rows=2231 width=24) (actual time=2.
965..14.349 rows=1844 loops=1)
   Index Cond: (("userId" = 4425) AND (action = 'posted'::text))
   Heap Fetches: 760
 Planning Time: 21.262 ms
 Execution Time: 16.884 ms
```

## Tests

Tested locally


## Risk

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
