### PR TITLE
Fix builder tool modal 

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -607,7 +607,8 @@ function NewActionModal({
     }, 500);
   };
 
-  const onModalSave = () => {
+  const onModalSave = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     if (
       newAction &&
       !titleError &&
@@ -689,6 +690,10 @@ function NewActionModal({
           rightButtonProps={{
             label: "Save",
             onClick: onModalSave,
+            disabled:
+              titleError ||
+              !descriptionValid ||
+              (newAction && hasActionError(newAction)),
           }}
         />
       </SheetContent>


### PR DESCRIPTION
## Description

Fixes small regression from https://github.com/dust-tt/dust/pull/10706/files#diff-f608f9b7ed36ffc4d54a2cd90fa1bf5131894b96c569544657545b2d645b5839L605-L631

-> if the form is not valid, we disable the button and the modals stays opened. 
-> before: the modal was displaying the error and at the same time closing, making the user lose their change. 

## Tests

Locally. 

## Risk

Break something in the builder? 

## Deploy Plan

Deploy front
