### PR TITLE
Add log on inconsistent titles in tags

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -257,7 +257,7 @@ export async function syncOneFile({
       ? new Date(file.createdDateTime)
       : undefined;
 
-    const tags = [`title:${file.name}`];
+    const tags = file.name ? [`title:${file.name}`] : [];
 
     if (file.lastModifiedDateTime) {
       tags.push(`updatedAt:${file.lastModifiedDateTime}`);

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -372,7 +372,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
               upsertContext: {
                 sync_type: "batch",
               },
-              title: pageTitle,
+              title: stripNullBytes(pageTitle),
               mimeType: "text/html",
               async: true,
             });

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -323,7 +323,24 @@ export async function upsertDocument({
         }
       : section || null;
 
-  const nonNullTags = tags || [];
+  const nonNullTags = tags || [`title:${title}`];
+  const titleInTags = nonNullTags
+    .find((t) => t.startsWith("title:"))
+    ?.split(":")
+    .slice(1)
+    .join(":");
+
+  if (titleInTags && titleInTags !== title) {
+    logger.error(
+      { documentId, titleInTags, title },
+      "[CoreNodes] Inconsistency between tags and title."
+    );
+    // TODO(2025-02-18 aubin): uncomment what follows.
+    // new DustError(
+    //   "invalid_title_in_tags",
+    //   "Invalid tags: title passed in tags does not match the table title."
+    // )
+  }
 
   // Add selection of tags as prefix to the section if they are present.
   let tagsPrefix = "";

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -620,7 +620,7 @@ export async function upsertTable({
     //   status_code: 400,
     //   api_error: {
     //     type: "invalid_request_error",
-    //     message: `Invalid parent id: parents[1] and parent_id should be equal.`,
+    //     message: `Invalid tags: title passed in tags does not match the table title.`,
     //   },
     // });
   }

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -603,6 +603,28 @@ export async function upsertTable({
     });
   }
 
+  const tableTags = params.tags ?? [`title:${params.title}`];
+  const titleInTags = tableTags
+    .find((t) => t.startsWith("title:"))
+    ?.split(":")
+    .slice(1)
+    .join(":");
+
+  if (titleInTags && titleInTags !== params.title) {
+    logger.error(
+      { tableId, titleInTags, title: params.title },
+      "[CoreNodes] Inconsistency between tags and title."
+    );
+    // TODO(2025-02-18 aubin): uncomment what follows.
+    // return apiError(req, res, {
+    //   status_code: 400,
+    //   api_error: {
+    //     type: "invalid_request_error",
+    //     message: `Invalid parent id: parents[1] and parent_id should be equal.`,
+    //   },
+    // });
+  }
+
   let standardizedSourceUrl: string | null = null;
   if (params.sourceUrl) {
     const { valid: isSourceUrlValid, standardized } = validateUrl(
@@ -641,7 +663,7 @@ export async function upsertTable({
         tableName: name,
         tableDescription: description,
         tableTimestamp: params.timestamp ?? null,
-        tableTags: params.tags ?? [],
+        tableTags,
         tableParentId,
         tableParents,
         csv: csv ?? null,
@@ -674,7 +696,7 @@ export async function upsertTable({
     tableName: name,
     tableDescription: description,
     tableTimestamp: params.timestamp ?? null,
-    tableTags: params.tags || [],
+    tableTags,
     tableParentId,
     tableParents,
     csv: csv ?? null,

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -12,6 +12,7 @@ export type DustErrorCode =
   | "invalid_url"
   | "invalid_parents"
   | "invalid_parent_id"
+  | "invalid_title_in_tags"
   // Table
   | "missing_csv"
   | "invalid_rows"

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -569,7 +569,7 @@ async function handler(
         //   status_code: 400,
         //   api_error: {
         //     type: "invalid_request_error",
-        //     message: `Invalid parent id: parents[1] and parent_id should be equal.`,
+        //     message: `Invalid tags: title passed in tags does not match the document title.`,
         //   },
         // });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -552,13 +552,35 @@ async function handler(
       const title = r.data.title ?? "Untitled document";
       const mimeType = r.data.mime_type ?? "application/octet-stream";
 
+      const tags = r.data.tags || [`title:${title}`];
+      const titleInTags = tags
+        .find((t) => t.startsWith("title:"))
+        ?.split(":")
+        .slice(1)
+        .join(":");
+
+      if (titleInTags && titleInTags !== title) {
+        logger.error(
+          { documentId, titleInTags, title },
+          "[CoreNodes] Inconsistency between tags and title."
+        );
+        // TODO(2025-02-18 aubin): uncomment what follows.
+        // return apiError(req, res, {
+        //   status_code: 400,
+        //   api_error: {
+        //     type: "invalid_request_error",
+        //     message: `Invalid parent id: parents[1] and parent_id should be equal.`,
+        //   },
+        // });
+      }
+
       if (r.data.async === true) {
         const enqueueRes = await enqueueUpsertDocument({
           upsertDocument: {
             workspaceId: owner.sId,
             dataSourceId: dataSource.sId,
             documentId,
-            tags: r.data.tags || [],
+            tags,
             parentId: r.data.parent_id || null,
             parents: r.data.parents || [documentId],
             timestamp: r.data.timestamp || null,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -1,8 +1,4 @@
-import type {
-  DeleteFolderResponseType,
-  GetFolderResponseType,
-  UpsertFolderResponseType,
-} from "@dust-tt/client";
+import type { DeleteFolderResponseType, GetFolderResponseType, UpsertFolderResponseType } from "@dust-tt/client";
 import { UpsertDataSourceFolderRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
@@ -45,7 +41,6 @@ async function handler(
     });
   }
 
-  const owner = auth.getNonNullableWorkspace();
   const coreAPI = new CoreAPI(apiConfig.getCoreAPIConfig(), logger);
   if (!auth.isSystemKey()) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -14,7 +14,7 @@ import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
-import { apiError, statsDClient } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 /**
  * @ignoreswagger
@@ -133,16 +133,38 @@ async function handler(
         });
       }
 
-      const statsDTags = [
-        `data_source_id:${dataSource.id}`,
-        `workspace_id:${owner.sId}`,
-        `data_source_name:${dataSource.name}`,
-        `folder_id:${fId}`,
-      ];
-      if (!r.data.parents || r.data.parents.length === 0) {
-        statsDClient.increment("folder_empty_parents.count", 1, statsDTags);
-      } else if (r.data.parents[0] != fId) {
-        statsDClient.increment("folder_no_self_ref.count", 1, statsDTags);
+      // Enforce parents consistency: we expect users to either not pass them (recommended) or pass them correctly.
+      if (parents) {
+        if (parents.length === 0) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid parents: parents must have at least one element.`,
+            },
+          });
+        }
+        if (parents[0] !== fId) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid parents: parents[0] should be equal to document_id.`,
+            },
+          });
+        }
+        if (
+          (parents.length >= 2 || parentId !== null) &&
+          parents[1] !== parentId
+        ) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid parent id: parents[1] and parent_id should be equal.`,
+            },
+          });
+        }
       }
 
       // Create folder with the Dust internal API.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -1,4 +1,8 @@
-import type { DeleteFolderResponseType, GetFolderResponseType, UpsertFolderResponseType } from "@dust-tt/client";
+import type {
+  DeleteFolderResponseType,
+  GetFolderResponseType,
+  UpsertFolderResponseType,
+} from "@dust-tt/client";
 import { UpsertDataSourceFolderRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2032.
- This PR adds a log on node upserts (in front) on `tags.title !== title`.
- This PR adds the title in the tags by default.
- This PR also adds some missing validation on parents on folder upserts, which has 0 risk because we already have validation in core and the metrics was at 0.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy front.
