### PR TITLE
Fix core `init_db`

### DIFF
--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -597,7 +597,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
        provider_visibility          TEXT,
        parents                      TEXT[] NOT NULL,
        source_url                   TEXT,
-       tags_array                   TEXT[] NOT NULL,
+       tags_array                   TEXT[] NOT NULL DEFAULT array[]::text[],
        document                     BIGINT,
        \"table\"                    BIGINT,
        folder                       BIGINT,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -541,7 +541,6 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
        created                  BIGINT NOT NULL,
        document_id              TEXT NOT NULL,
        timestamp                BIGINT NOT NULL,
-       tags_array               TEXT[] NOT NULL,
        hash                     TEXT NOT NULL,
        text_size                BIGINT NOT NULL,
        chunk_count              BIGINT NOT NULL,
@@ -571,7 +570,6 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
        name                         TEXT NOT NULL, -- unique within datasource
        description                  TEXT NOT NULL,
        timestamp                    BIGINT NOT NULL,
-       tags_array                   TEXT[] NOT NULL,
        schema                       TEXT, -- json, kept up-to-date automatically with the last insert
        schema_stale_at              BIGINT, -- timestamp when the schema was last invalidated
        data_source                  BIGINT NOT NULL,
@@ -599,6 +597,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
        provider_visibility          TEXT,
        parents                      TEXT[] NOT NULL,
        source_url                   TEXT,
+       tags_array                   TEXT[] NOT NULL,
        document                     BIGINT,
        \"table\"                    BIGINT,
        folder                       BIGINT,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -613,7 +613,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 33] = [
+pub const SQL_INDEXES: [&'static str; 31] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -658,14 +658,10 @@ pub const SQL_INDEXES: [&'static str; 33] = [
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_data_source_document_id_created
        ON data_sources_documents (data_source, document_id, created DESC);",
-    "CREATE INDEX IF NOT EXISTS
-       idx_data_sources_documents_tags_array ON data_sources_documents USING GIN (tags_array);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_databases_table_ids_hash ON databases (table_ids_hash);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_tables_data_source_table_id ON tables (data_source, table_id);",
-    "CREATE INDEX IF NOT EXISTS
-       idx_tables_tags_array ON tables USING GIN (tags_array);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
         idx_sqlite_workers_url ON sqlite_workers (url);",
     "CREATE INDEX IF NOT EXISTS


### PR DESCRIPTION
## Description

- The column `tags_array` was recently moved from the tables `data_source_documents`/`tables` to the table `data_sources_nodes`.
- prod was updated through migrations, however the `init_db` was not updated.
- This PR fixes that.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- No deploy.