### PR TITLE
Implement server-side pagination in `SpaceDataSourceViewContentList`

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -434,7 +434,7 @@ export const SpaceDataSourceViewContentList = ({
   useEffect(() => {
     if (!isTablesValidating && !isDocumentsValidating) {
       // If the view only has content in one of the two views, we switch to that view.
-      // if both view have content, or neither views have content, we default to documents.
+      // if both views have content, or neither view has content, we default to documents.
       if (hasTables && !hasDocuments) {
         handleViewTypeChange("table");
       } else if (!hasTables && hasDocuments) {

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -349,7 +349,7 @@ export const SpaceDataSourceViewContentList = ({
       ) {
         // Next page - update the history and the cursor.
         setTablePagination(newTablePagination);
-        if (newTablePagination.pageIndex === cursorHistory.length + 1) {
+        if (newTablePagination.pageIndex === cursorHistory.length) {
           setCursorHistory((prev) => [...prev, nextPageCursor]);
         }
         setCurrentCursor(nextPageCursor);

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -1,4 +1,4 @@
-import type { HistoryOptions, MenuItem } from "@dust-tt/sparkle";
+import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Button,
   cn,
@@ -64,7 +64,6 @@ import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
 
 const DEFAULT_VIEW_TYPE = "all";
-const ROWS_COUNT_CAPPED = 1000;
 
 type RowData = DataSourceViewContentNode & {
   icon: React.ComponentType;
@@ -291,6 +290,7 @@ export const SpaceDataSourceViewContentList = ({
     nodes: childrenNodes,
     nextPageCursor,
     totalNodesCount,
+    totalNodesCountIsAccurate,
   } = useDataSourceViewContentNodes({
     dataSourceView,
     owner,
@@ -726,8 +726,8 @@ export const SpaceDataSourceViewContentList = ({
             )}
             sorting={sorting}
             setSorting={setSorting}
-            totalRowCount={nextPageCursor ? totalNodesCount + 1 : undefined}
-            rowCountIsCapped={totalNodesCount === ROWS_COUNT_CAPPED}
+            totalRowCount={totalNodesCount}
+            rowCountIsCapped={!totalNodesCountIsAccurate}
             pagination={tablePagination}
             setPagination={handlePaginationChange}
             columnsBreakpoints={columnsBreakpoints}

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -215,7 +215,7 @@ function useCursorPaginationForDataTable(pageSize: number) {
   const [cursorPagination, setCursorPagination] =
     useState<CursorPaginationParams>({ cursor: null, limit: pageSize });
 
-  // We keep a history of the cursors to allow going back in pages (leverage SWR's cache).
+  // We keep a history of the cursors to allow going back in pages.
   const [cursorHistory, setCursorHistory] = useState<
     CursorPaginationParams["cursor"][]
   >([null]);
@@ -234,7 +234,8 @@ function useCursorPaginationForDataTable(pageSize: number) {
   const handlePaginationChange = useCallback(
     (newTablePagination: PaginationState, nextPageCursor: string | null) => {
       if (
-        newTablePagination.pageIndex > tablePagination.pageIndex &&
+        // This pagination only supports going forward one page at a time.
+        newTablePagination.pageIndex === tablePagination.pageIndex + 1 &&
         nextPageCursor
       ) {
         // Next page - update the history and the cursor.
@@ -254,11 +255,12 @@ function useCursorPaginationForDataTable(pageSize: number) {
     },
     [tablePagination.pageIndex, cursorHistory, pageSize]
   );
+
   return {
     cursorPagination,
+    tablePagination,
     resetPagination,
     handlePaginationChange,
-    tablePagination,
   };
 }
 

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -28,11 +28,7 @@ import {
   isValidContentNodesViewType,
   MIN_SEARCH_QUERY_SIZE,
 } from "@dust-tt/types";
-import type {
-  CellContext,
-  ColumnDef,
-  SortingState,
-} from "@tanstack/react-table";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useRouter } from "next/router";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -231,7 +227,6 @@ export const SpaceDataSourceViewContentList = ({
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
     useState(false);
   const sendNotification = useSendNotification();
-  const [sorting, setSorting] = React.useState<SortingState>([]);
   const contentActionsRef = useRef<ContentActionsRef>(null);
 
   const {
@@ -685,8 +680,6 @@ export const SpaceDataSourceViewContentList = ({
               "pb-4",
               isSearchValidating && "pointer-events-none opacity-50"
             )}
-            sorting={sorting}
-            setSorting={setSorting}
             totalRowCount={totalNodesCount}
             rowCountIsCapped={!totalNodesCountIsAccurate}
             pagination={tablePagination}

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -337,14 +337,7 @@ export const SpaceDataSourceViewContentList = ({
 
   const handlePaginationChange = useCallback(
     (newTablePagination: PaginationState) => {
-      if (newTablePagination.pageSize !== tablePagination.pageSize) {
-        // Handle page size change
-        setTablePagination(newTablePagination);
-        setCursorPagination({
-          cursor: null,
-          limit: newTablePagination.pageSize,
-        });
-      } else if (
+      if (
         newTablePagination.pageIndex > tablePagination.pageIndex &&
         nextPageCursor
       ) {

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -237,12 +237,12 @@ export const SpaceDataSourceViewContentList = ({
   // State for cursor pagination (in URL).
   const { cursorPagination, setCursorPagination } = useCursorPaginationFromUrl({
     urlPrefix: "table",
-    initialPageSize: 25,
+    initialLimit: 25,
   });
   // State for DataTable pagination.
   const [tablePagination, setTablePagination] = useState<PaginationState>({
     pageIndex: cursorPagination.cursor ? 1 : 0,
-    pageSize: cursorPagination.pageSize,
+    pageSize: cursorPagination.limit,
   });
   const [viewType, setViewType] = useHashParam(
     "viewType",
@@ -262,13 +262,13 @@ export const SpaceDataSourceViewContentList = ({
     (newViewType: ContentNodesViewType) => {
       if (newViewType !== viewType) {
         setCursorPagination(
-          { cursor: null, pageSize: cursorPagination.pageSize },
+          { cursor: null, limit: cursorPagination.limit },
           "replace"
         );
         setViewType(newViewType);
       }
     },
-    [setCursorPagination, setViewType, viewType, cursorPagination.pageSize]
+    [setCursorPagination, setViewType, viewType, cursorPagination.limit]
   );
 
   const { searchResultNodes, isSearchLoading, isSearchValidating } =
@@ -295,10 +295,7 @@ export const SpaceDataSourceViewContentList = ({
     dataSourceView,
     owner,
     parentId,
-    pagination: {
-      cursor: cursorPagination.cursor,
-      limit: cursorPagination.pageSize,
-    },
+    pagination: cursorPagination,
     viewType: isValidContentNodesViewType(viewType)
       ? viewType
       : DEFAULT_VIEW_TYPE,
@@ -346,7 +343,7 @@ export const SpaceDataSourceViewContentList = ({
         setTablePagination(newTablePagination);
         setCursorPagination({
           cursor: null,
-          pageSize: newTablePagination.pageSize,
+          limit: newTablePagination.pageSize,
         });
       } else if (
         newTablePagination.pageIndex > tablePagination.pageIndex &&
@@ -356,14 +353,14 @@ export const SpaceDataSourceViewContentList = ({
         setTablePagination(newTablePagination);
         setCursorPagination({
           cursor: nextPageCursor,
-          pageSize: tablePagination.pageSize,
+          limit: tablePagination.pageSize,
         });
       } else if (newTablePagination.pageIndex < tablePagination.pageIndex) {
         // Previous page - reset cursor
         setTablePagination(newTablePagination);
         setCursorPagination({
           cursor: null,
-          pageSize: tablePagination.pageSize,
+          limit: tablePagination.pageSize,
         });
       }
     },
@@ -615,7 +612,7 @@ export const SpaceDataSourceViewContentList = ({
                 value={dataSourceSearch}
                 onChange={(s) => {
                   setCursorPagination(
-                    { cursor: null, pageSize: cursorPagination.pageSize },
+                    { cursor: null, limit: cursorPagination.limit },
                     "replace"
                   );
                   setDataSourceSearch(s);

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -723,6 +723,7 @@ export const SpaceDataSourceViewContentList = ({
             pagination={tablePagination}
             setPagination={handlePaginationChange}
             columnsBreakpoints={columnsBreakpoints}
+            disablePaginationNumbers
           />
         )}
         {searchFeatureFlag &&

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -53,6 +53,7 @@ import {
 import { EditSpaceManagedDataSourcesViews } from "@app/components/spaces/EditSpaceManagedDatasourcesViews";
 import { FoldersHeaderMenu } from "@app/components/spaces/FoldersHeaderMenu";
 import { WebsitesHeaderMenu } from "@app/components/spaces/WebsitesHeaderMenu";
+import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
 import {
@@ -233,11 +234,12 @@ export const SpaceDataSourceViewContentList = ({
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const contentActionsRef = useRef<ContentActionsRef>(null);
 
-  // State for cursor pagination (in URL).
-  const { cursorPagination, setCursorPagination } = useCursorPaginationFromUrl({
-    urlPrefix: "table",
-    initialLimit: 25,
-  });
+  // State for cursor pagination.
+  const [cursorPagination, setCursorPagination] =
+    React.useState<CursorPaginationParams>({
+      limit: 25,
+      cursor: null,
+    });
   // State for DataTable pagination.
   const [tablePagination, setTablePagination] = useState<PaginationState>({
     pageIndex: cursorPagination.cursor ? 1 : 0,
@@ -260,10 +262,7 @@ export const SpaceDataSourceViewContentList = ({
   const handleViewTypeChange = useCallback(
     (newViewType: ContentNodesViewType) => {
       if (newViewType !== viewType) {
-        setCursorPagination(
-          { cursor: null, limit: cursorPagination.limit },
-          "replace"
-        );
+        setCursorPagination({ cursor: null, limit: cursorPagination.limit });
         setViewType(newViewType);
       }
     },
@@ -611,10 +610,10 @@ export const SpaceDataSourceViewContentList = ({
                 placeholder="Search (Name)"
                 value={dataSourceSearch}
                 onChange={(s) => {
-                  setCursorPagination(
-                    { cursor: null, limit: cursorPagination.limit },
-                    "replace"
-                  );
+                  setCursorPagination({
+                    cursor: null,
+                    limit: cursorPagination.limit,
+                  });
                   setDataSourceSearch(s);
                 }}
               />

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -726,7 +726,7 @@ export const SpaceDataSourceViewContentList = ({
             )}
             sorting={sorting}
             setSorting={setSorting}
-            totalRowCount={totalNodesCount}
+            totalRowCount={nextPageCursor ? totalNodesCount + 1 : undefined}
             rowCountIsCapped={totalNodesCount === ROWS_COUNT_CAPPED}
             pagination={tablePagination}
             setPagination={handlePaginationChange}

--- a/front/hooks/useCursorPaginationForDataTable.ts
+++ b/front/hooks/useCursorPaginationForDataTable.ts
@@ -9,7 +9,7 @@ import type { CursorPaginationParams } from "@app/lib/api/pagination";
  * - Assumes that only a next cursor is retrieved when fetching new data,
  * and therefore stores an entire history of previous cursors.
  * - Does not support hash parameters and therefore link sharing, since going back requires the previous cursor
- * and going back several times required the full history.
+ * and going back several times requires the full history.
  * - Ties the cursor pagination with the table pagination, and exposes a `tablePagination` that can directly be used in
  * a `DataTable`.
  * - Does not support moving forward more than one page at a time (will ignore the action).

--- a/front/hooks/useCursorPaginationForDataTable.ts
+++ b/front/hooks/useCursorPaginationForDataTable.ts
@@ -3,6 +3,20 @@ import { useCallback, useState } from "react";
 
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
 
+/**
+ * Hook to manage pagination for a table where the data is fetched using cursor pagination.
+ *
+ * - Assumes that only a next cursor is retrieved when fetching new data,
+ * and therefore stores an entire history of previous cursors.
+ * - Does not support hash parameters and therefore link sharing, since going back requires the previous cursor
+ * and going back several times required the full history.
+ * - Ties the cursor pagination with the table pagination, and exposes a `tablePagination` that can directly be used in
+ * a `DataTable`.
+ * - Does not support moving forward more than one page at a time (will ignore the action).
+ *
+ * Users of this hook should eventually be updated to a less stateful pagination mechanism,
+ *  where, for instance, both a next and a previous cursor would be exposed when fetching a page.
+ */
 export function useCursorPaginationForDataTable(pageSize: number) {
   const [cursorPagination, setCursorPagination] =
     useState<CursorPaginationParams>({ cursor: null, limit: pageSize });

--- a/front/hooks/useCursorPaginationForDataTable.ts
+++ b/front/hooks/useCursorPaginationForDataTable.ts
@@ -1,0 +1,57 @@
+import type { PaginationState } from "@tanstack/react-table";
+import { useCallback, useState } from "react";
+
+import type { CursorPaginationParams } from "@app/lib/api/pagination";
+
+export function useCursorPaginationForDataTable(pageSize: number) {
+  const [cursorPagination, setCursorPagination] =
+    useState<CursorPaginationParams>({ cursor: null, limit: pageSize });
+
+  // We keep a history of the cursors to allow going back in pages.
+  const [cursorHistory, setCursorHistory] = useState<
+    CursorPaginationParams["cursor"][]
+  >([null]);
+
+  const [tablePagination, setTablePagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize,
+  });
+
+  const resetPagination = useCallback(() => {
+    setTablePagination({ pageIndex: 0, pageSize: pageSize });
+    setCursorHistory([null]);
+    setCursorPagination({ cursor: null, limit: pageSize });
+  }, [pageSize]);
+
+  const handlePaginationChange = useCallback(
+    (newTablePagination: PaginationState, nextPageCursor: string | null) => {
+      if (
+        // This pagination only supports going forward one page at a time.
+        newTablePagination.pageIndex === tablePagination.pageIndex + 1 &&
+        nextPageCursor
+      ) {
+        // Next page - update the history and the cursor.
+        setTablePagination(newTablePagination);
+        if (newTablePagination.pageIndex === cursorHistory.length) {
+          setCursorHistory((prev) => [...prev, nextPageCursor]);
+        }
+        setCursorPagination({ cursor: nextPageCursor, limit: pageSize });
+      } else if (newTablePagination.pageIndex < tablePagination.pageIndex) {
+        // Older page - use the appropriate cursor.
+        setTablePagination(newTablePagination);
+        setCursorPagination({
+          cursor: cursorHistory[newTablePagination.pageIndex],
+          limit: pageSize,
+        });
+      }
+    },
+    [tablePagination.pageIndex, cursorHistory, pageSize]
+  );
+
+  return {
+    cursorPagination,
+    tablePagination,
+    resetPagination,
+    handlePaginationChange,
+  };
+}

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -31,6 +31,7 @@ interface GetContentNodesForDataSourceViewParams {
 interface GetContentNodesForDataSourceViewResult {
   nodes: DataSourceViewContentNode[];
   total: number;
+  totalIsAccurate: boolean;
   nextPageCursor: string | null;
 }
 
@@ -158,7 +159,8 @@ export async function getContentNodesForDataSourceView(
 
   return new Ok({
     nodes: sortedNodes,
-    total: resultNodes.length,
+    total: coreRes.value.hit_count,
+    totalIsAccurate: coreRes.value.hit_count_is_accurate,
     nextPageCursor: nextPageCursor,
   });
 }

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -20,6 +20,8 @@ import type { DustError } from "@app/lib/error";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 
+const DEFAULT_PAGINATION_LIMIT = 1000;
+
 // If `internalIds` is not provided, it means that the request is for all the content nodes in the view.
 interface GetContentNodesForDataSourceViewParams {
   internalIds?: string[];
@@ -89,7 +91,7 @@ export async function getContentNodesForDataSourceView(
     pagination,
   }: GetContentNodesForDataSourceViewParams
 ): Promise<Result<GetContentNodesForDataSourceViewResult, Error>> {
-  const limit = pagination?.limit ?? 1000;
+  const limit = pagination?.limit ?? DEFAULT_PAGINATION_LIMIT;
 
   // There's an early return possible on !dataSourceView.dataSource.connectorId && internalIds?.length === 0,
   // won't include it for now as we are shadow-reading.

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -14,11 +14,7 @@ import {
   FOLDERS_TO_HIDE_IF_EMPTY_MIME_TYPES,
   getContentNodeFromCoreNode,
 } from "@app/lib/api/content_nodes";
-import type {
-  CursorPaginationParams,
-  OffsetPaginationParams,
-} from "@app/lib/api/pagination";
-import { isCursorPaginationParams } from "@app/lib/api/pagination";
+import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -28,8 +24,7 @@ import logger from "@app/logger/logger";
 interface GetContentNodesForDataSourceViewParams {
   internalIds?: string[];
   parentId?: string;
-  // TODO(nodes-core): remove offset pagination upon project cleanup
-  pagination?: CursorPaginationParams | OffsetPaginationParams;
+  pagination?: CursorPaginationParams;
   viewType: ContentNodesViewType;
 }
 
@@ -122,12 +117,7 @@ export async function getContentNodesForDataSourceView(
         ? undefined
         : ROOT_PARENT_ID);
 
-  // TODO(nodes-core): remove offset pagination upon project cleanup
-  let nextPageCursor: string | null = pagination
-    ? isCursorPaginationParams(pagination)
-      ? pagination.cursor
-      : null
-    : null;
+  let nextPageCursor: string | null = pagination ? pagination.cursor : null;
 
   let resultNodes: CoreAPIContentNode[] = [];
   do {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -31,6 +31,7 @@ interface GetContentNodesForDataSourceViewParams {
 interface GetContentNodesForDataSourceViewResult {
   nodes: DataSourceViewContentNode[];
   total: number;
+  nextPageCursor: string | null;
 }
 
 function filterNodesByViewType(

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -121,27 +121,25 @@ export async function getContentNodesForDataSourceView(
   let nextPageCursor: string | null = pagination ? pagination.cursor : null;
 
   let resultNodes: CoreAPIContentNode[] = [];
-  do {
-    const coreRes = await coreAPI.searchNodes({
-      filter: {
-        data_source_views: [makeCoreDataSourceViewFilter(dataSourceView)],
-        node_ids,
-        parent_id,
-      },
-      options: { limit, cursor: nextPageCursor ?? undefined },
-    });
+  const coreRes = await coreAPI.searchNodes({
+    filter: {
+      data_source_views: [makeCoreDataSourceViewFilter(dataSourceView)],
+      node_ids,
+      parent_id,
+    },
+    options: { limit, cursor: nextPageCursor ?? undefined },
+  });
 
-    if (coreRes.isErr()) {
-      return new Err(new Error(coreRes.error.message));
-    }
+  if (coreRes.isErr()) {
+    return new Err(new Error(coreRes.error.message));
+  }
 
-    const filteredNodes = removeCatchAllFoldersIfEmpty(
-      filterNodesByViewType(coreRes.value.nodes, viewType)
-    );
+  const filteredNodes = removeCatchAllFoldersIfEmpty(
+    filterNodesByViewType(coreRes.value.nodes, viewType)
+  );
 
-    resultNodes = [...resultNodes, ...filteredNodes].slice(0, limit);
-    nextPageCursor = coreRes.value.next_page_cursor;
-  } while (nextPageCursor && resultNodes.length < limit);
+  resultNodes = [...resultNodes, ...filteredNodes].slice(0, limit);
+  nextPageCursor = coreRes.value.next_page_cursor;
 
   const nodes = resultNodes.map((node) =>
     getContentNodeFromCoreNode(

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -93,7 +93,7 @@ const CursorPaginationParamsCodec = t.type({
 
 export interface CursorPaginationParams {
   limit: number;
-  cursor: string;
+  cursor: string | null;
 }
 
 export function getCursorPaginationParams(

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -88,7 +88,7 @@ export function getPaginationParams(
 
 const CursorPaginationParamsCodec = t.type({
   limit: LimitCodec,
-  cursor: t.string,
+  cursor: t.union([t.string, t.null, t.undefined]),
 });
 
 export interface CursorPaginationParams {

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -84,41 +84,41 @@ export function getPaginationParams(
   return new Ok(queryValidation.right);
 }
 
-// Offset pagination.
+// Cursor pagination.
 
-const OffsetPaginationParamsCodec = t.type({
+const CursorPaginationParamsCodec = t.type({
   limit: LimitCodec,
-  offset: t.number,
+  cursor: t.string,
 });
 
-export interface OffsetPaginationParams {
+export interface CursorPaginationParams {
   limit: number;
-  offset: number;
+  cursor: string;
 }
 
-export function getOffsetPaginationParams(
+export function getCursorPaginationParams(
   req: NextApiRequest
-): Result<OffsetPaginationParams | undefined, InvalidPaginationParamsError> {
-  const { limit, offset } = req.query;
+): Result<CursorPaginationParams | undefined, InvalidPaginationParamsError> {
+  const { limit, cursor } = req.query;
   if (!req.query.limit) {
     return new Ok(undefined);
   }
 
-  if (typeof limit !== "string" || (offset && typeof offset !== "string")) {
+  if (typeof limit !== "string" || (cursor && typeof cursor !== "string")) {
     return new Err(
       new InvalidPaginationParamsError(
         "Invalid pagination parameters",
-        "limit and offset must be strings"
+        "limit and cursor must be strings"
       )
     );
   }
 
   const rawParams = {
-    limit: parseInt(limit),
-    offset: offset ? parseInt(offset) : 0,
+    limit: parseInt(limit, 10),
+    cursor,
   };
 
-  const queryValidation = OffsetPaginationParamsCodec.decode(rawParams);
+  const queryValidation = CursorPaginationParamsCodec.decode(rawParams);
 
   // Validate and decode the raw parameters.
   if (isLeft(queryValidation)) {
@@ -133,15 +133,4 @@ export function getOffsetPaginationParams(
   }
 
   return new Ok(queryValidation.right);
-}
-
-export interface CursorPaginationParams {
-  limit: number;
-  cursor: string;
-}
-
-export function isCursorPaginationParams(
-  pagination: CursorPaginationParams | OffsetPaginationParams
-): pagination is CursorPaginationParams {
-  return "cursor" in pagination;
 }

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -98,7 +98,7 @@ export interface CursorPaginationParams {
 
 export function getCursorPaginationParams(
   req: NextApiRequest,
-  defaultLimit: number
+  { defaultLimit }: { defaultLimit: number }
 ): Result<CursorPaginationParams | undefined, InvalidPaginationParamsError> {
   const rawParams = {
     cursor: req.query.cursor ?? null,

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -88,7 +88,7 @@ export function getPaginationParams(
 
 const CursorPaginationParamsCodec = t.type({
   limit: LimitCodec,
-  cursor: t.union([t.string, t.null, t.undefined]),
+  cursor: t.union([t.string, t.null]),
 });
 
 export interface CursorPaginationParams {
@@ -97,25 +97,14 @@ export interface CursorPaginationParams {
 }
 
 export function getCursorPaginationParams(
-  req: NextApiRequest
+  req: NextApiRequest,
+  defaultLimit: number
 ): Result<CursorPaginationParams | undefined, InvalidPaginationParamsError> {
-  const { limit, cursor } = req.query;
-  if (!req.query.limit) {
-    return new Ok(undefined);
-  }
-
-  if (typeof limit !== "string" || (cursor && typeof cursor !== "string")) {
-    return new Err(
-      new InvalidPaginationParamsError(
-        "Invalid pagination parameters",
-        "limit and cursor must be strings"
-      )
-    );
-  }
-
   const rawParams = {
-    limit: parseInt(limit, 10),
-    cursor,
+    cursor: req.query.cursor ?? null,
+    limit: req.query.limit
+      ? parseInt(req.query.limit as string, 10)
+      : defaultLimit,
   };
 
   const queryValidation = CursorPaginationParamsCodec.decode(rawParams);

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -97,14 +97,15 @@ export interface CursorPaginationParams {
 }
 
 export function getCursorPaginationParams(
-  req: NextApiRequest,
-  { defaultLimit }: { defaultLimit: number }
+  req: NextApiRequest
 ): Result<CursorPaginationParams | undefined, InvalidPaginationParamsError> {
+  if (!req.query.limit) {
+    return new Ok(undefined);
+  }
+
   const rawParams = {
     cursor: req.query.cursor ?? null,
-    limit: req.query.limit
-      ? parseInt(req.query.limit as string, 10)
-      : defaultLimit,
+    limit: parseInt(req.query.limit as string, 10),
   };
 
   const queryValidation = CursorPaginationParamsCodec.decode(rawParams);

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -124,6 +124,7 @@ export function useDataSourceViewContentNodes({
   mutateRegardlessOfQueryParams: KeyedMutator<GetDataSourceViewContentNodes>;
   nodes: GetDataSourceViewContentNodes["nodes"];
   totalNodesCount: number;
+  totalNodesCountIsAccurate: boolean;
   nextPageCursor: string | null;
 } {
   const params = new URLSearchParams();
@@ -174,6 +175,7 @@ export function useDataSourceViewContentNodes({
     mutateRegardlessOfQueryParams,
     nodes: useMemo(() => (data ? data.nodes : []), [data]),
     totalNodesCount: data ? data.total : 0,
+    totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,
   };
 }

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -3,12 +3,11 @@ import type {
   DataSourceViewType,
   LightWorkspaceType,
 } from "@dust-tt/types";
-import type { PaginationState } from "@tanstack/react-table";
 import { useMemo } from "react";
 import type { Fetcher, KeyedMutator, SWRConfiguration } from "swr";
 
+import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import {
-  appendPaginationParams,
   fetcher,
   fetcherMultiple,
   fetcherWithBody,
@@ -113,7 +112,7 @@ export function useDataSourceViewContentNodes({
   dataSourceView?: DataSourceViewType;
   internalIds?: string[];
   parentId?: string;
-  pagination?: PaginationState;
+  pagination?: CursorPaginationParams;
   viewType?: ContentNodesViewType;
   disabled?: boolean;
   swrOptions?: SWRConfiguration;
@@ -125,9 +124,15 @@ export function useDataSourceViewContentNodes({
   mutateRegardlessOfQueryParams: KeyedMutator<GetDataSourceViewContentNodes>;
   nodes: GetDataSourceViewContentNodes["nodes"];
   totalNodesCount: number;
+  nextPageCursor: string | null;
 } {
   const params = new URLSearchParams();
-  appendPaginationParams(params, pagination);
+  if (pagination?.cursor) {
+    params.append("cursor", pagination.cursor);
+  }
+  if (pagination?.limit) {
+    params.append("limit", pagination.limit.toString());
+  }
 
   const url = dataSourceView
     ? `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes?${params}`
@@ -169,6 +174,7 @@ export function useDataSourceViewContentNodes({
     mutateRegardlessOfQueryParams,
     nodes: useMemo(() => (data ? data.nodes : []), [data]),
     totalNodesCount: data ? data.total : 0,
+    nextPageCursor: data?.nextPageCursor || null,
   };
 }
 

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -122,7 +122,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getCursorPaginationParams(req);
+  const paginationRes = getCursorPaginationParams(req, { defaultLimit: 50 });
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -10,7 +10,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
-import { getOffsetPaginationParams } from "@app/lib/api/pagination";
+import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -122,7 +122,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getOffsetPaginationParams(req);
+  const paginationRes = getCursorPaginationParams(req);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -25,6 +25,8 @@ const GetContentNodesOrChildrenRequestBody = t.type({
 export type PokeGetDataSourceViewContentNodes = {
   nodes: DataSourceViewContentNode[];
   total: number;
+  totalIsAccurate: boolean;
+  nextPageCursor: string | null;
 };
 
 // This endpoints serves two purposes:

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -124,7 +124,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getCursorPaginationParams(req, { defaultLimit: 50 });
+  const paginationRes = getCursorPaginationParams(req);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -84,7 +84,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getCursorPaginationParams(req, { defaultLimit: 50 });
+  const paginationRes = getCursorPaginationParams(req);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -10,7 +10,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
-import { getOffsetPaginationParams } from "@app/lib/api/pagination";
+import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -82,7 +82,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getOffsetPaginationParams(req);
+  const paginationRes = getCursorPaginationParams(req);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -25,6 +25,7 @@ const GetContentNodesOrChildrenRequestBody = t.type({
 export type GetDataSourceViewContentNodes = {
   nodes: DataSourceViewContentNode[];
   total: number;
+  totalIsAccurate: boolean;
   nextPageCursor: string | null;
 };
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -83,7 +83,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getCursorPaginationParams(req);
+  const paginationRes = getCursorPaginationParams(req, { defaultLimit: 50 });
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -25,6 +25,7 @@ const GetContentNodesOrChildrenRequestBody = t.type({
 export type GetDataSourceViewContentNodes = {
   nodes: DataSourceViewContentNode[];
   total: number;
+  nextPageCursor: string | null;
 };
 
 // This endpoints serves two purposes:

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
-import { getOffsetPaginationParams } from "@app/lib/api/pagination";
+import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -34,7 +34,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const paginationRes = getOffsetPaginationParams(req);
+      const paginationRes = getCursorPaginationParams(req);
       if (paginationRes.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -34,9 +34,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const paginationRes = getCursorPaginationParams(req, {
-        defaultLimit: 50,
-      });
+      const paginationRes = getCursorPaginationParams(req);
       if (paginationRes.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -34,7 +34,9 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const paginationRes = getCursorPaginationParams(req);
+      const paginationRes = getCursorPaginationParams(req, {
+        defaultLimit: 50,
+      });
       if (paginationRes.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -7,13 +7,7 @@ import { useMemo } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
-import {
-  appendPaginationParams,
-  fetcher,
-  fetcherWithBody,
-  useSWRInfiniteWithDefaults,
-  useSWRWithDefaults,
-} from "@app/lib/swr/swr";
+import { fetcher, fetcherWithBody, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListDataSourceViews } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
 import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
@@ -121,94 +115,5 @@ export function usePokeDataSourceViewContentNodes({
     totalNodesCount: data ? data.total : 0,
     totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,
-  };
-}
-
-interface DataSourceViewContentNodesWithInfiniteScrollProps {
-  dataSourceView?: DataSourceViewType;
-  internalIds?: string[];
-  owner: LightWorkspaceType;
-  pageSize?: number;
-  parentId?: string;
-  viewType?: ContentNodesViewType;
-}
-
-export function usePokeDataSourceViewContentNodesWithInfiniteScroll({
-  owner,
-  dataSourceView,
-  internalIds,
-  parentId,
-  pageSize = 50,
-  viewType,
-}: DataSourceViewContentNodesWithInfiniteScrollProps): {
-  isNodesError: boolean;
-  isNodesLoading: boolean;
-  isNodesValidating: boolean;
-  nodes: PokeGetDataSourceViewContentNodes["nodes"];
-  totalNodesCount: number;
-  hasMore: boolean;
-  nextPage: () => Promise<void>;
-} {
-  const url =
-    dataSourceView && viewType
-      ? `/api/poke/workspaces/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes`
-      : null;
-
-  const body = {
-    internalIds,
-    parentId,
-    viewType,
-  };
-
-  const fetcher: Fetcher<
-    PokeGetDataSourceViewContentNodes,
-    [string, object, string]
-  > = fetcherWithBody;
-
-  const { data, error, setSize, size, isValidating } =
-    useSWRInfiniteWithDefaults(
-      (index) => {
-        if (!url) {
-          // No URL, return an empty array to skip the fetch
-          return null;
-        }
-
-        // Append the pagination params to the URL
-        const params = new URLSearchParams();
-        appendPaginationParams(params, {
-          pageIndex: index,
-          pageSize,
-        });
-
-        return JSON.stringify([url + "?" + params.toString(), body]);
-      },
-      async (fetchKey) => {
-        if (!fetchKey) {
-          return undefined;
-        }
-
-        // Get the URL and body from the fetchKey
-        const params = JSON.parse(fetchKey);
-
-        return fetcher(params);
-      },
-      {
-        revalidateFirstPage: false,
-      }
-    );
-
-  return {
-    isNodesError: !!error,
-    isNodesLoading: !error && !data,
-    isNodesValidating: isValidating,
-    nodes: useMemo(
-      () => (data ? data.flatMap((d) => (d ? d.nodes : [])) : []),
-      [data]
-    ),
-    totalNodesCount: data?.[0] ? data[0].total : 0,
-    hasMore: size * pageSize < (data?.[0] ? data[0].total : 0),
-    nextPage: async () => {
-      await setSize((size) => size + 1);
-    },
   };
 }

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -3,10 +3,10 @@ import type {
   DataSourceViewType,
   LightWorkspaceType,
 } from "@dust-tt/types";
-import type { PaginationState } from "@tanstack/react-table";
 import { useMemo } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
+import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import {
   appendPaginationParams,
   fetcher,
@@ -42,7 +42,7 @@ export interface DataSourceViewContentNodesProps {
   disabled?: boolean;
   internalIds?: string[];
   owner: LightWorkspaceType;
-  pagination?: PaginationState;
+  pagination?: CursorPaginationParams;
   parentId?: string;
   viewType?: ContentNodesViewType;
 }
@@ -63,9 +63,16 @@ export function usePokeDataSourceViewContentNodes({
   mutateRegardlessOfQueryParams: KeyedMutator<PokeGetDataSourceViewContentNodes>;
   nodes: PokeGetDataSourceViewContentNodes["nodes"];
   totalNodesCount: number;
+  totalNodesCountIsAccurate: boolean;
+  nextPageCursor: string | null;
 } {
   const params = new URLSearchParams();
-  appendPaginationParams(params, pagination);
+  if (pagination && pagination.cursor) {
+    params.set("cursor", pagination.cursor.toString());
+  }
+  if (pagination && pagination.limit) {
+    params.set("limit", pagination.limit.toString());
+  }
 
   const url =
     dataSourceView && viewType
@@ -112,6 +119,8 @@ export function usePokeDataSourceViewContentNodes({
     mutateRegardlessOfQueryParams,
     nodes: useMemo(() => (data ? data.nodes : []), [data]),
     totalNodesCount: data ? data.total : 0,
+    totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
+    nextPageCursor: data?.nextPageCursor || null,
   };
 }
 

--- a/sparkle/src/hooks/usePaginationFromUrl.ts
+++ b/sparkle/src/hooks/usePaginationFromUrl.ts
@@ -45,65 +45,33 @@ export const usePaginationFromUrl = ({
   return res;
 };
 
-interface CursorPaginationState {
-  cursor: string | null;
-  limit: number;
-}
-
 interface UseCursorPaginationFromUrlProps {
   urlPrefix?: string;
-  initialLimit?: number;
   defaultHistory?: HistoryOptions;
 }
 
 export function useCursorPaginationFromUrl({
   urlPrefix = "",
-  initialLimit = 25,
   defaultHistory = "push",
 }: UseCursorPaginationFromUrlProps = {}) {
   const [cursorParam, setCursorParam] = useHashParam(
     urlPrefix ? `${urlPrefix}Cursor` : "cursor"
   );
-  const [limitParam, setLimitParam] = useHashParam(
-    urlPrefix ? `${urlPrefix}PageSize` : "pageSize"
-  );
 
   const cursor = cursorParam || null;
-  const limit = limitParam ? parseInt(limitParam, 10) : initialLimit;
 
   return useMemo(() => {
-    const cursorPagination: CursorPaginationState = { cursor, limit };
-
     const setCursorPagination = (
-      newValue: CursorPaginationState,
+      newCursor: string | null,
       history?: HistoryOptions
     ) => {
-      if (newValue.cursor !== cursor || newValue.limit !== limit) {
-        if (newValue.cursor) {
-          setCursorParam(newValue.cursor, {
-            history: history ?? defaultHistory,
-          });
-        } else {
-          setCursorParam(undefined, {
-            history: history ?? defaultHistory,
-          });
-        }
-
-        if (newValue.limit !== initialLimit) {
-          setLimitParam(newValue.limit.toString());
-        } else {
-          setLimitParam(undefined);
-        }
+      if (newCursor !== cursor) {
+        setCursorParam(newCursor ?? undefined, {
+          history: history ?? defaultHistory,
+        });
       }
     };
 
-    return { cursorPagination, setCursorPagination };
-  }, [
-    cursor,
-    limit,
-    initialLimit,
-    setCursorParam,
-    defaultHistory,
-    setLimitParam,
-  ]);
+    return { cursor, setCursorPagination };
+  }, [cursor, setCursorParam, defaultHistory]);
 }

--- a/sparkle/src/hooks/usePaginationFromUrl.ts
+++ b/sparkle/src/hooks/usePaginationFromUrl.ts
@@ -44,34 +44,3 @@ export const usePaginationFromUrl = ({
 
   return res;
 };
-
-interface UseCursorPaginationFromUrlProps {
-  urlPrefix?: string;
-  defaultHistory?: HistoryOptions;
-}
-
-export function useCursorPaginationFromUrl({
-  urlPrefix = "",
-  defaultHistory = "push",
-}: UseCursorPaginationFromUrlProps = {}) {
-  const [cursorParam, setCursorParam] = useHashParam(
-    urlPrefix ? `${urlPrefix}Cursor` : "cursor"
-  );
-
-  const cursor = cursorParam || null;
-
-  return useMemo(() => {
-    const setCursorPagination = (
-      newCursor: string | null,
-      history?: HistoryOptions
-    ) => {
-      if (newCursor !== cursor) {
-        setCursorParam(newCursor ?? undefined, {
-          history: history ?? defaultHistory,
-        });
-      }
-    };
-
-    return { cursor, setCursorPagination };
-  }, [cursor, setCursorParam, defaultHistory]);
-}

--- a/sparkle/src/hooks/usePaginationFromUrl.ts
+++ b/sparkle/src/hooks/usePaginationFromUrl.ts
@@ -44,3 +44,66 @@ export const usePaginationFromUrl = ({
 
   return res;
 };
+
+interface CursorPaginationState {
+  cursor: string | null;
+  pageSize: number;
+}
+
+interface UseCursorPaginationFromUrlProps {
+  urlPrefix?: string;
+  initialPageSize?: number;
+  defaultHistory?: HistoryOptions;
+}
+
+export function useCursorPaginationFromUrl({
+  urlPrefix = "",
+  initialPageSize = 25,
+  defaultHistory = "push",
+}: UseCursorPaginationFromUrlProps = {}) {
+  const [cursorParam, setCursorParam] = useHashParam(
+    urlPrefix ? `${urlPrefix}Cursor` : "cursor"
+  );
+  const [pageSizeParam, setPageSizeParam] = useHashParam(
+    urlPrefix ? `${urlPrefix}PageSize` : "pageSize"
+  );
+
+  const cursor = cursorParam || null;
+  const pageSize = pageSizeParam ? parseInt(pageSizeParam) : initialPageSize;
+
+  return useMemo(() => {
+    const pagination: CursorPaginationState = { cursor, pageSize };
+
+    const setPagination = (
+      newValue: CursorPaginationState,
+      history?: HistoryOptions
+    ) => {
+      if (newValue.cursor !== cursor || newValue.pageSize !== pageSize) {
+        if (newValue.cursor) {
+          setCursorParam(newValue.cursor, {
+            history: history ?? defaultHistory,
+          });
+        } else {
+          setCursorParam(undefined, {
+            history: history ?? defaultHistory,
+          });
+        }
+
+        if (newValue.pageSize !== initialPageSize) {
+          setPageSizeParam(newValue.pageSize.toString());
+        } else {
+          setPageSizeParam(undefined);
+        }
+      }
+    };
+
+    return { pagination, setPagination };
+  }, [
+    cursor,
+    pageSize,
+    initialPageSize,
+    setCursorParam,
+    setPageSizeParam,
+    defaultHistory,
+  ]);
+}

--- a/sparkle/src/hooks/usePaginationFromUrl.ts
+++ b/sparkle/src/hooks/usePaginationFromUrl.ts
@@ -47,38 +47,38 @@ export const usePaginationFromUrl = ({
 
 interface CursorPaginationState {
   cursor: string | null;
-  pageSize: number;
+  limit: number;
 }
 
 interface UseCursorPaginationFromUrlProps {
   urlPrefix?: string;
-  initialPageSize?: number;
+  initialLimit?: number;
   defaultHistory?: HistoryOptions;
 }
 
 export function useCursorPaginationFromUrl({
   urlPrefix = "",
-  initialPageSize = 25,
+  initialLimit = 25,
   defaultHistory = "push",
 }: UseCursorPaginationFromUrlProps = {}) {
   const [cursorParam, setCursorParam] = useHashParam(
     urlPrefix ? `${urlPrefix}Cursor` : "cursor"
   );
-  const [pageSizeParam, setPageSizeParam] = useHashParam(
+  const [limitParam, setLimitParam] = useHashParam(
     urlPrefix ? `${urlPrefix}PageSize` : "pageSize"
   );
 
   const cursor = cursorParam || null;
-  const pageSize = pageSizeParam ? parseInt(pageSizeParam) : initialPageSize;
+  const limit = limitParam ? parseInt(limitParam, 10) : initialLimit;
 
   return useMemo(() => {
-    const pagination: CursorPaginationState = { cursor, pageSize };
+    const cursorPagination: CursorPaginationState = { cursor, limit };
 
-    const setPagination = (
+    const setCursorPagination = (
       newValue: CursorPaginationState,
       history?: HistoryOptions
     ) => {
-      if (newValue.cursor !== cursor || newValue.pageSize !== pageSize) {
+      if (newValue.cursor !== cursor || newValue.limit !== limit) {
         if (newValue.cursor) {
           setCursorParam(newValue.cursor, {
             history: history ?? defaultHistory,
@@ -89,21 +89,21 @@ export function useCursorPaginationFromUrl({
           });
         }
 
-        if (newValue.pageSize !== initialPageSize) {
-          setPageSizeParam(newValue.pageSize.toString());
+        if (newValue.limit !== initialLimit) {
+          setLimitParam(newValue.limit.toString());
         } else {
-          setPageSizeParam(undefined);
+          setLimitParam(undefined);
         }
       }
     };
 
-    return { pagination, setPagination };
+    return { cursorPagination, setCursorPagination };
   }, [
     cursor,
-    pageSize,
-    initialPageSize,
+    limit,
+    initialLimit,
     setCursorParam,
-    setPageSizeParam,
     defaultHistory,
+    setLimitParam,
   ]);
 }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2039.
- This PR implements pagination in the `DataTable` in `SpaceDataSourceViewContentList` through a custom hook `useCursorPaginationForDataTable`, which operates as follows:
   - Assumes that only a next cursor is retrieved when fetching new data, and therefore stores an entire history of previous cursors to allow going back in pages.
   - Does not support hash parameters and therefore link sharing, since going back requires the previous cursor and going back several times requires the full history.
   - Ties the cursor pagination with the table pagination, and exposes a `tablePagination` that can directly be used in a `DataTable`.
   - Does not support moving forward more than one page at a time (will ignore the action).
- Sorting is disabled on the `DataTable`, the clicks on the page numbers is also disabled.
- An ideal solution to make the pagination more stateless and enable hash parameters would require changing the elasticsearch query to return a cursor for the previous page in addition to the cursor for the next page.

## Tests

- Tested locally, no automated test.

## Risk

- Medium.

## Deploy Plan

- Deploy front