### PR TITLE
Refactor a bit MS to pickup the sharepointsIds and avoid guessing from url

### DIFF
--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -9,6 +9,7 @@ import type { DriveItem } from "@microsoft/microsoft-graph-types";
 import { getConnectorManager } from "@connectors/connectors";
 import { getClient } from "@connectors/connectors/microsoft";
 import {
+  clientApiGet,
   getItem,
   getParentReferenceInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
@@ -101,6 +102,14 @@ export const microsoft = async ({
       };
 
       return { status: 200, content, type: typeof content };
+    }
+
+    case "list-sites": {
+      const connector = await getConnector(args);
+      const client = await getClient(connector.connectionId);
+      const endpoint = "/sites";
+      const res = await clientApiGet(client, endpoint);
+      return { status: 200, content: res.value, type: typeof res.value };
     }
 
     case "list-columns": {

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -1,11 +1,18 @@
 import type { ContentNode, ContentNodeType } from "@dust-tt/types";
 import { MIME_TYPES } from "@dust-tt/types";
+import type {
+  Channel,
+  Drive,
+  Site,
+  Team,
+} from "@microsoft/microsoft-graph-types";
 
 import {
   getDriveInternalId,
   getDriveItemInternalId,
   getSiteAPIPath,
 } from "@connectors/connectors/microsoft/lib/graph_api";
+import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
 import {
   internalIdFromTypeAndPath,
   typeAndPathFromInternalId,
@@ -51,7 +58,7 @@ export function getTeamsRootAsContentNode(): ContentNode {
     mimeType: MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
-export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
+export function getTeamAsContentNode(team: Team): ContentNode {
   return {
     internalId: internalIdFromTypeAndPath({
       itemAPIPath: `/teams/${team.id}`,
@@ -70,7 +77,7 @@ export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
 }
 
 export function getSiteAsContentNode(
-  site: microsoftgraph.Site,
+  site: Site,
   parentInternalId?: string
 ): ContentNode {
   if (!site.id) {
@@ -95,7 +102,7 @@ export function getSiteAsContentNode(
 }
 
 export function getChannelAsContentNode(
-  channel: microsoftgraph.Channel,
+  channel: Channel,
   parentInternalId: string
 ): ContentNode {
   if (!channel.id) {
@@ -124,7 +131,7 @@ export function getChannelAsContentNode(
 }
 
 export function getDriveAsContentNode(
-  drive: microsoftgraph.Drive,
+  drive: Drive,
   parentInternalId: string
 ): ContentNode {
   if (!drive.id) {
@@ -144,7 +151,7 @@ export function getDriveAsContentNode(
   };
 }
 export function getFolderAsContentNode(
-  folder: microsoftgraph.DriveItem,
+  folder: DriveItem,
   parentInternalId: string
 ): ContentNode {
   return {

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -1,4 +1,27 @@
-import type { DriveItem } from "@microsoft/microsoft-graph-types";
+import type { DriveItem as MicrosoftDriveItem } from "@microsoft/microsoft-graph-types";
+
+export type DriveItem = Pick<
+  MicrosoftDriveItem,
+  | "id"
+  | "name"
+  | "parentReference"
+  | "webUrl"
+  | "file"
+  | "folder"
+  | "root"
+  | "deleted"
+  | "createdBy"
+  | "lastModifiedBy"
+  | "createdDateTime"
+  | "lastModifiedDateTime"
+  | "size"
+  | "sharepointIds"
+  | "listItem" // This must be expanded to get the fields
+>;
+
+// This must match the type above and be used when using the graph API
+export const DRIVE_ITEM_EXPANDS_AND_SELECTS =
+  "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds&$expand=listItem($expand=fields)";
 
 export const MICROSOFT_NODE_TYPES = [
   "sites-root",
@@ -36,19 +59,3 @@ export type MicrosoftNode = {
   mimeType: string | null;
   webUrl: string | null;
 };
-
-export function isMicrosoftDriveItem(obj: unknown): obj is DriveItem {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "id" in obj &&
-    typeof obj.id === "string" &&
-    "name" in obj &&
-    typeof obj.name === "string" &&
-    "parentReference" in obj &&
-    typeof obj.parentReference === "object" &&
-    obj.parentReference !== null &&
-    "driveId" in obj.parentReference &&
-    typeof obj.parentReference.driveId === "string"
-  );
-}

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -11,6 +11,7 @@ import {
   getDriveItemInternalId,
   getFileDownloadURL,
 } from "@connectors/connectors/microsoft/lib/graph_api";
+import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
 import {
   getColumnsFromListItem,
   typeAndPathFromInternalId,
@@ -61,7 +62,7 @@ export async function syncOneFile({
   connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
   providerConfig: MicrosoftConfigurationResource;
-  file: microsoftgraph.DriveItem;
+  file: DriveItem;
   parentInternalId: string;
   startSyncTs: number;
   isBatchSync?: boolean;

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -1,6 +1,7 @@
 import type { Result } from "@dust-tt/types";
 import { Err, MIME_TYPES, Ok, slugify } from "@dust-tt/types";
 import type { Client } from "@microsoft/microsoft-graph-client";
+import type { WorkbookWorksheet } from "@microsoft/microsoft-graph-types";
 import { stringify } from "csv-stringify/sync";
 
 import { getClient } from "@connectors/connectors/microsoft";
@@ -12,6 +13,7 @@ import {
   getWorksheets,
   wrapMicrosoftGraphAPIWithResult,
 } from "@connectors/connectors/microsoft/lib/graph_api";
+import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
 import { getColumnsFromListItem } from "@connectors/connectors/microsoft/lib/utils";
 import { getParents } from "@connectors/connectors/microsoft/temporal/file";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -34,7 +36,7 @@ const MAXIMUM_NUMBER_OF_EXCEL_SHEET_ROWS = 50000;
 async function upsertSpreadsheetInDb(
   connector: ConnectorResource,
   internalId: string,
-  file: microsoftgraph.DriveItem,
+  file: DriveItem,
   parentInternalId: string
 ) {
   return MicrosoftNodeResource.upsert({
@@ -54,8 +56,8 @@ async function upsertSpreadsheetInDb(
 async function upsertWorksheetInDb(
   connector: ConnectorResource,
   internalId: string,
-  worksheet: microsoftgraph.WorkbookWorksheet,
-  spreadsheet: microsoftgraph.DriveItem
+  worksheet: WorkbookWorksheet,
+  spreadsheet: DriveItem
 ) {
   return MicrosoftNodeResource.upsert({
     internalId,
@@ -75,8 +77,8 @@ async function upsertWorksheetInDb(
 async function upsertMSTable(
   connector: ConnectorResource,
   internalId: string,
-  spreadsheet: microsoftgraph.DriveItem,
-  worksheet: microsoftgraph.WorkbookWorksheet,
+  spreadsheet: DriveItem,
+  worksheet: WorkbookWorksheet,
   parents: [string, string, ...string[]],
   rows: string[][],
   tags: string[]
@@ -131,9 +133,9 @@ async function processSheet({
 }: {
   client: Client;
   connector: ConnectorResource;
-  spreadsheet: microsoftgraph.DriveItem;
+  spreadsheet: DriveItem;
   spreadsheetInternalId: string;
-  worksheet: microsoftgraph.WorkbookWorksheet;
+  worksheet: WorkbookWorksheet;
   worksheetInternalId: string;
   localLogger: Logger;
   startSyncTs: number;
@@ -269,7 +271,7 @@ export async function handleSpreadSheet({
   startSyncTs,
 }: {
   connectorId: number;
-  file: microsoftgraph.DriveItem;
+  file: DriveItem;
   parentInternalId: string;
   localLogger: Logger;
   startSyncTs: number;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -330,6 +330,7 @@ export const MicrosoftCommandSchema = t.type({
   command: t.union([
     t.literal("garbage-collect-all"),
     t.literal("check-file"),
+    t.literal("list-sites"),
     t.literal("list-columns"),
     t.literal("start-incremental-sync"),
     t.literal("restart-all-incremental-sync-workflows"),

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -330,8 +330,6 @@ export const MicrosoftCommandSchema = t.type({
   command: t.union([
     t.literal("garbage-collect-all"),
     t.literal("check-file"),
-    t.literal("list-sites"),
-    t.literal("list-columns"),
     t.literal("start-incremental-sync"),
     t.literal("restart-all-incremental-sync-workflows"),
     t.literal("skip-file"),

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -333,6 +333,7 @@ export const MicrosoftCommandSchema = t.type({
     t.literal("start-incremental-sync"),
     t.literal("restart-all-incremental-sync-workflows"),
     t.literal("skip-file"),
+    t.literal("sync-node"),
     t.literal("get-parents"),
   ]),
   args: t.record(


### PR DESCRIPTION
## Description

- Use a narrowed DriveItem type to make sure what we get is aligned with the $select and $expand from the delta (as delta do not return everything by default, it only guarantee to return the changed fields).
- Add the sharepointsIds and remove the "magic" code to find the listId.

## Tests

Locally

## Risk

Medium, could break the connector.

## Deploy Plan

Deploy `connectors`