### PR TITLE
core: remove | as supported delimiter as front does not support it

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -151,7 +151,7 @@ impl UpsertQueueCSVContent {
         let n = rdr.read(&mut buffer).await?;
         buffer.truncate(n);
 
-        let candidates = b",;\t|";
+        let candidates = b",;\t";
 
         let mut counts = vec![0; candidates.len()];
         let mut in_quotes = false;


### PR DESCRIPTION
## Description

Do not attemp to use | as delimiter as front does not.
Mismatch example: https://app.datadoghq.eu/logs?query=%22%5BCSV-FILE%5D%20mismatch%3A%20headers%20and%20schema%20mismatch%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZUaqqrd-z4KxgAAABhBWlVhcXF2eUFBQ3BYQWhla0t4YW1RQ0EAAAAkMDE5NTFhYWEtZGU0OC00NDAxLTkyMTItZmY1YmE3ODk2MDY5AAAw3g&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&storage=hot&stream_sort=desc&viz=stream&from_ts=1739905596121&to_ts=1739909196121&live=true

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `core`