### PR TITLE
core: table upsert from CSV 

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,78 +5,78 @@ edition = "2021"
 
 # SERVICES
 
-[[bin]]
-name = "core-api"
-path = "bin/core_api.rs"
-
-[[bin]]
-name = "oauth"
-path = "bin/oauth.rs"
-
-[[bin]]
-name = "sqlite-worker"
-path = "bin/sqlite_worker.rs"
-
-# UTILS
-
-[[bin]]
-name = "init_db"
-path = "bin/init_db.rs"
-
-[[bin]]
-name = "elasticsearch_create_index"
-path = "bin/elasticsearch/create_index.rs"
-
-[[bin]]
-name = "elasticsearch_backfill_index"
-path = "bin/elasticsearch/backfill_index.rs"
-
-[[bin]]
-name = "elasticsearch_backfill_folders_index"
-path = "bin/elasticsearch/backfill_folders_index.rs"
-
-[[bin]]
-name = "qdrant_create_collection"
-path = "bin/qdrant/create_collection.rs"
-
 # [[bin]]
-# name = "qdrant_migrator"
-# path = "bin/qdrant/migrator.rs"
-
+# name = "core-api"
+# path = "bin/core_api.rs"
+# 
 # [[bin]]
-# name = "qdrant_migrate_embedder"
-# path = "bin/qdrant/migrate_embedder.rs"
-
-[[bin]]
-name = "qdrant_delete_orphaned_points"
-path = "bin/qdrant/delete_orphaned_points.rs"
-
-
+# name = "oauth"
+# path = "bin/oauth.rs"
+# 
 # [[bin]]
-# name = "oauth_generate_key"
-# path = "bin/oauth_generate_key.rs"
-
-# MIGRATIONS
-
-[[bin]]
-name = "create_nodes"
-path = "bin/migrations/20241204_create_nodes.rs"
-
-[[bin]]
-name = "fix_created_dsdocs"
-path = "bin/migrations/20241203_fix_created_dsdocs.rs"
-
-[[bin]]
-name = "elasticsearch_backfill_document_tags_index"
-path = "bin/migrations/20250205_backfill_document_tags_index.rs"
-
-[[test]]
-name = "oauth_connections_test"
-path = "src/oauth/tests/functional_connections.rs"
-
-[[test]]
-name = "oauth_credentials_test"
-path = "src/oauth/tests/functional_credentials.rs"
+# name = "sqlite-worker"
+# path = "bin/sqlite_worker.rs"
+# 
+# # UTILS
+# 
+# [[bin]]
+# name = "init_db"
+# path = "bin/init_db.rs"
+# 
+# [[bin]]
+# name = "elasticsearch_create_index"
+# path = "bin/elasticsearch/create_index.rs"
+# 
+# [[bin]]
+# name = "elasticsearch_backfill_index"
+# path = "bin/elasticsearch/backfill_index.rs"
+# 
+# [[bin]]
+# name = "elasticsearch_backfill_folders_index"
+# path = "bin/elasticsearch/backfill_folders_index.rs"
+# 
+# [[bin]]
+# name = "qdrant_create_collection"
+# path = "bin/qdrant/create_collection.rs"
+# 
+# # [[bin]]
+# # name = "qdrant_migrator"
+# # path = "bin/qdrant/migrator.rs"
+# 
+# # [[bin]]
+# # name = "qdrant_migrate_embedder"
+# # path = "bin/qdrant/migrate_embedder.rs"
+# 
+# [[bin]]
+# name = "qdrant_delete_orphaned_points"
+# path = "bin/qdrant/delete_orphaned_points.rs"
+# 
+# 
+# # [[bin]]
+# # name = "oauth_generate_key"
+# # path = "bin/oauth_generate_key.rs"
+# 
+# # MIGRATIONS
+# 
+# [[bin]]
+# name = "create_nodes"
+# path = "bin/migrations/20241204_create_nodes.rs"
+# 
+# [[bin]]
+# name = "fix_created_dsdocs"
+# path = "bin/migrations/20241203_fix_created_dsdocs.rs"
+# 
+# [[bin]]
+# name = "elasticsearch_backfill_document_tags_index"
+# path = "bin/migrations/20250205_backfill_document_tags_index.rs"
+# 
+# [[test]]
+# name = "oauth_connections_test"
+# path = "src/oauth/tests/functional_connections.rs"
+# 
+# [[test]]
+# name = "oauth_credentials_test"
+# path = "src/oauth/tests/functional_credentials.rs"
 
 [dependencies]
 anyhow = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,78 +5,78 @@ edition = "2021"
 
 # SERVICES
 
+[[bin]]
+name = "core-api"
+path = "bin/core_api.rs"
+
+[[bin]]
+name = "oauth"
+path = "bin/oauth.rs"
+
+[[bin]]
+name = "sqlite-worker"
+path = "bin/sqlite_worker.rs"
+
+# UTILS
+
+[[bin]]
+name = "init_db"
+path = "bin/init_db.rs"
+
+[[bin]]
+name = "elasticsearch_create_index"
+path = "bin/elasticsearch/create_index.rs"
+
+[[bin]]
+name = "elasticsearch_backfill_index"
+path = "bin/elasticsearch/backfill_index.rs"
+
+[[bin]]
+name = "elasticsearch_backfill_folders_index"
+path = "bin/elasticsearch/backfill_folders_index.rs"
+
+[[bin]]
+name = "qdrant_create_collection"
+path = "bin/qdrant/create_collection.rs"
+
 # [[bin]]
-# name = "core-api"
-# path = "bin/core_api.rs"
-# 
+# name = "qdrant_migrator"
+# path = "bin/qdrant/migrator.rs"
+
 # [[bin]]
-# name = "oauth"
-# path = "bin/oauth.rs"
-# 
+# name = "qdrant_migrate_embedder"
+# path = "bin/qdrant/migrate_embedder.rs"
+
+[[bin]]
+name = "qdrant_delete_orphaned_points"
+path = "bin/qdrant/delete_orphaned_points.rs"
+
+
 # [[bin]]
-# name = "sqlite-worker"
-# path = "bin/sqlite_worker.rs"
-# 
-# # UTILS
-# 
-# [[bin]]
-# name = "init_db"
-# path = "bin/init_db.rs"
-# 
-# [[bin]]
-# name = "elasticsearch_create_index"
-# path = "bin/elasticsearch/create_index.rs"
-# 
-# [[bin]]
-# name = "elasticsearch_backfill_index"
-# path = "bin/elasticsearch/backfill_index.rs"
-# 
-# [[bin]]
-# name = "elasticsearch_backfill_folders_index"
-# path = "bin/elasticsearch/backfill_folders_index.rs"
-# 
-# [[bin]]
-# name = "qdrant_create_collection"
-# path = "bin/qdrant/create_collection.rs"
-# 
-# # [[bin]]
-# # name = "qdrant_migrator"
-# # path = "bin/qdrant/migrator.rs"
-# 
-# # [[bin]]
-# # name = "qdrant_migrate_embedder"
-# # path = "bin/qdrant/migrate_embedder.rs"
-# 
-# [[bin]]
-# name = "qdrant_delete_orphaned_points"
-# path = "bin/qdrant/delete_orphaned_points.rs"
-# 
-# 
-# # [[bin]]
-# # name = "oauth_generate_key"
-# # path = "bin/oauth_generate_key.rs"
-# 
-# # MIGRATIONS
-# 
-# [[bin]]
-# name = "create_nodes"
-# path = "bin/migrations/20241204_create_nodes.rs"
-# 
-# [[bin]]
-# name = "fix_created_dsdocs"
-# path = "bin/migrations/20241203_fix_created_dsdocs.rs"
-# 
-# [[bin]]
-# name = "elasticsearch_backfill_document_tags_index"
-# path = "bin/migrations/20250205_backfill_document_tags_index.rs"
-# 
-# [[test]]
-# name = "oauth_connections_test"
-# path = "src/oauth/tests/functional_connections.rs"
-# 
-# [[test]]
-# name = "oauth_credentials_test"
-# path = "src/oauth/tests/functional_credentials.rs"
+# name = "oauth_generate_key"
+# path = "bin/oauth_generate_key.rs"
+
+# MIGRATIONS
+
+[[bin]]
+name = "create_nodes"
+path = "bin/migrations/20241204_create_nodes.rs"
+
+[[bin]]
+name = "fix_created_dsdocs"
+path = "bin/migrations/20241203_fix_created_dsdocs.rs"
+
+[[bin]]
+name = "elasticsearch_backfill_document_tags_index"
+path = "bin/migrations/20250205_backfill_document_tags_index.rs"
+
+[[test]]
+name = "oauth_connections_test"
+path = "src/oauth/tests/functional_connections.rs"
+
+[[test]]
+name = "oauth_credentials_test"
+path = "src/oauth/tests/functional_credentials.rs"
 
 [dependencies]
 anyhow = "1.0"

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -327,6 +327,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_csv_with_dust_id() -> anyhow::Result<()> {
+        let csv = "hellWorld,super-fast,__dust_id,c/foo,DATE\n\
+                   1,2.23,foo0,3,2025-02-14T15:06:52.380Z\n\
+                   4,hello world,foo1,6,\"Fri, 14 Feb 2025 15:10:34 GMT\"";
+        let (delimiter, rdr) =
+            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?;
+
+        assert_eq!(rows.len(), 2);
+
+        // Test that __dust_id is used to define the row ids.
+        assert_eq!(rows[0].row_id, "foo0");
+        assert_eq!(rows[1].row_id, "foo1");
+
+        // Test that __dust_id is not inserted.
+        let row_0_concatenated_keys = rows[0]
+            .value
+            .as_object()
+            .unwrap()
+            .keys()
+            .into_iter()
+            .map(|k| k.to_string())
+            .collect::<Vec<String>>()
+            .join(",");
+
+        assert_eq!(row_0_concatenated_keys, "hellworld,super_fast,c_foo,date");
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_csv_errors() -> anyhow::Result<()> {
         // Test empty CSV
         let csv = "";

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -503,6 +503,23 @@ impl LocalTable {
         Ok(())
     }
 
+    pub async fn upsert_csv_content(
+        &self,
+        store: Box<dyn Store + Sync + Send>,
+        databases_store: Box<dyn DatabasesStore + Sync + Send>,
+        upsert_queue_bucket_csv_path: &str,
+        truncate: bool,
+    ) -> Result<()> {
+        let rows = UpsertQueueCSVContent {
+            upsert_queue_bucket_csv_path: upsert_queue_bucket_csv_path.to_string(),
+        }
+        .parse()
+        .await?;
+
+        self.upsert_rows(store, databases_store, rows, truncate)
+            .await
+    }
+
     pub async fn retrieve_row(
         &self,
         databases_store: Box<dyn DatabasesStore + Sync + Send>,

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -510,14 +510,26 @@ impl LocalTable {
         upsert_queue_bucket_csv_path: &str,
         truncate: bool,
     ) -> Result<()> {
+        let now = utils::now();
         let rows = UpsertQueueCSVContent {
             upsert_queue_bucket_csv_path: upsert_queue_bucket_csv_path.to_string(),
         }
         .parse()
         .await?;
+        let csv_parse_duration = utils::now() - now;
 
+        let now = utils::now();
         self.upsert_rows(store, databases_store, rows, truncate)
-            .await
+            .await?;
+        let upsert_duration = utils::now() - now;
+
+        info!(
+            csv_parse_duration = csv_parse_duration,
+            upsert_duration = upsert_duration,
+            "CSV upsert"
+        );
+
+        Ok(())
     }
 
     pub async fn retrieve_row(

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1439,6 +1439,44 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
+  async tableUpsertCSVContent({
+    projectId,
+    dataSourceId,
+    tableId,
+    upsertQueueBucketCSVPath,
+    truncate,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+    tableId: string;
+    upsertQueueBucketCSVPath: string;
+    truncate?: boolean;
+  }): Promise<
+    CoreAPIResponse<{
+      schema: CoreAPITableSchema;
+    }>
+  > {
+    const response = await this._fetchWithError(
+      `${this._url}/projects/${encodeURIComponent(
+        projectId
+      )}/data_sources/${encodeURIComponent(
+        dataSourceId
+      )}/tables/${encodeURIComponent(tableId)}/csv`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          upsert_queue_bucket_csv_path: upsertQueueBucketCSVPath,
+          truncate: truncate || false,
+        }),
+      }
+    );
+
+    return this._resultFromResponse(response);
+  }
+
   async getTableRow({
     projectId,
     dataSourceId,


### PR DESCRIPTION
## Description

Add ability to upsert csv content in core using `upsert_queue_bucket_csv_path`
Not yet used in production

## Tests

N/A

## Risk

N/A (not used in prod)

## Deploy Plan

- deploy `core`