### PR TITLE
Fix a few incorrect Content node types

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -363,7 +363,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
             nodes.push({
               internalId: getIssuesInternalId(repoId),
               parentInternalId,
-              type: "Table",
+              type: "Folder",
               title: "Issues",
               sourceUrl: getIssuesUrl(repo.url),
               expandable: false,
@@ -628,7 +628,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       nodes.push({
         internalId: getIssuesInternalId(repoId),
         parentInternalId: getRepositoryInternalId(repoId),
-        type: "Table",
+        type: "Folder",
         title: "Issues",
         sourceUrl: getIssuesUrl(repo.url),
         expandable: false,

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -624,7 +624,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
           helpCenter.helpCenterId
         ),
         parentInternalId: null,
-        type: "Table",
+        type: "Folder",
         title: helpCenter.name,
         sourceUrl: null,
         expandable: true,

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -368,7 +368,7 @@ export async function retrieveIntercomHelpCentersPermissions({
           helpCenter.helpCenterId
         ),
         parentInternalId: null,
-        type: "Table",
+        type: "Folder",
         title: helpCenter.name,
         sourceUrl: null,
         expandable: true,
@@ -381,7 +381,7 @@ export async function retrieveIntercomHelpCentersPermissions({
       nodes = helpCenters.map((helpCenter) => ({
         internalId: getHelpCenterInternalId(connectorId, helpCenter.id),
         parentInternalId: null,
-        type: "Table",
+        type: "Folder",
         title: helpCenter.display_name || "Help Center",
         sourceUrl: null,
         expandable: true,


### PR DESCRIPTION
## Description

- In the cleanup of content node types from connectors https://github.com/dust-tt/dust/pull/10872/files, a few content nodes were incorrectly flagged as Tables instead of Folders.
- This was due to the fact that the type was previously directly correlated with the icon used, some very non-table nodes were using the "database" type (Intercom Help Center, GitHub issues).
- The translation "database" -> "Table" is therefore not entirely correct.

## Tests

- n/a.

## Risk

- n/a.

## Deploy Plan

- Deploy connectors.