### PR TITLE
Optimize Confluence API Usage with V1 Search Endpoint

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -190,6 +190,7 @@ export async function bulkFetchConfluencePageRefs(
       hasChildren: p.childTypes.page.value,
       hasReadRestrictions,
       id: p.id,
+      // Ancestors is an array of the page's ancestors, starting with the root page.
       parentId: p.ancestors[p.ancestors.length - 1]?.id ?? null,
       version: p.version.number,
     };

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -116,9 +116,11 @@ export async function pageHasReadRestrictions(
 }
 
 export interface ConfluencePageRef {
+  hasChildren: boolean;
+  hasReadRestrictions: boolean;
   id: string;
-  version: number;
   parentId: string | null;
+  version: number;
 }
 
 const PAGE_FETCH_LIMIT = 100;
@@ -172,19 +174,26 @@ export async function bulkFetchConfluencePageRefs(
     spaceId: string;
   }
 ) {
-  // Fetch the details of the pages (version and parentId).
+  // Fetch page metadata (version, parent, permissions, etc.) for the given page IDs
   const pagesWithDetails = await client.getPagesByIdsInSpace({
     spaceId,
-    sort: "id",
     pageIds,
     limit,
   });
 
-  const pageRefs: ConfluencePageRef[] = pagesWithDetails.pages.map((p) => ({
-    id: p.id,
-    version: p.version.number,
-    parentId: p.parentId,
-  }));
+  const pageRefs: ConfluencePageRef[] = pagesWithDetails.results.map((p) => {
+    const hasReadRestrictions =
+      p.restrictions.read.restrictions.group.results.length > 0 ||
+      p.restrictions.read.restrictions.user.results.length > 0;
+
+    return {
+      hasChildren: p.childTypes.page.value,
+      hasReadRestrictions,
+      id: p.id,
+      parentId: p.ancestors[p.ancestors.length - 1]?.id ?? null,
+      version: p.version.number,
+    };
+  });
 
   return pageRefs;
 }

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -22,6 +22,7 @@ const ConfluenceAccessibleResourcesCodec = t.array(
 const ConfluenceSpaceCodec = t.intersection([
   t.type({
     id: t.string,
+    key: t.string,
     name: t.string,
     _links: t.type({
       webui: t.string,
@@ -53,6 +54,49 @@ const ConfluencePageCodec = t.intersection([
     _links: t.type({
       tinyui: t.string,
     }),
+  }),
+  CatchAllCodec,
+]);
+
+const SearchConfluencePageCodec = t.intersection([
+  t.type({
+    id: t.string,
+    type: t.string,
+    status: t.string,
+    title: t.string,
+
+    // Version info.
+    version: t.type({
+      number: t.number,
+    }),
+
+    // Restrictions.
+    restrictions: t.type({
+      read: t.type({
+        restrictions: t.type({
+          user: t.type({
+            results: t.array(t.unknown),
+          }),
+          group: t.type({
+            results: t.array(t.unknown),
+          }),
+        }),
+      }),
+    }),
+
+    // Children info
+    childTypes: t.type({
+      page: t.type({
+        value: t.boolean,
+      }),
+    }),
+
+    // Ancestors (parent chain)
+    ancestors: t.array(
+      t.type({
+        id: t.string,
+      })
+    ),
   }),
   CatchAllCodec,
 ]);
@@ -200,6 +244,8 @@ export class ConfluenceClient {
   ): Promise<T> {
     const response = await (async () => {
       try {
+        console.log("Doing request", { endpoint, retryCount });
+
         return await fetch(`${this.apiUrl}${endpoint}`, {
           headers: {
             Authorization: `Bearer ${this.authToken}`,
@@ -547,42 +593,37 @@ export class ConfluenceClient {
 
   async getPagesByIdsInSpace({
     spaceId,
-    sort,
-    pageCursor,
     pageIds,
     limit,
   }: {
     spaceId: string;
-    sort?: "id" | "-modified-date";
-    pageCursor?: string | null;
-    pageIds?: string[];
+    pageIds: string[];
     limit?: number;
   }) {
+    // First get space info to get the key.
+    // TODO(2025-02-18 flav) Save the key in the DB.
+    const space = await this.getSpaceById(spaceId);
+
+    // Build CQL query to get pages with specific IDs.
+    const idClause = pageIds?.length ? ` AND id in (${pageIds.join(",")})` : "";
+    const cqlQuery = `type=page AND space="${space.key}"${idClause}`;
+
     const params = new URLSearchParams({
-      sort: sort ?? "id",
+      cql: cqlQuery,
       limit: limit?.toString() ?? "25",
-      status: "current",
-      "space-id": spaceId,
+      expand: [
+        "version", // to check if page changed.
+        "restrictions.read.restrictions.user", // to check user permissions.
+        "restrictions.read.restrictions.group", // to check group permissions.
+        "childTypes.page", // to know if it has children.
+        "ancestors", // to get parent info.
+      ].join(","),
     });
 
-    if (pageCursor) {
-      params.append("cursor", pageCursor);
-    }
-
-    if (pageIds && pageIds.length > 0) {
-      params.append("id", pageIds.join(","));
-    }
-
-    const pages = await this.request(
-      `${this.restApiBaseUrl}/pages?${params.toString()}`,
-      ConfluencePaginatedResults(ConfluencePageCodec)
+    return this.request(
+      `${this.legacyRestApiBaseUrl}/content/search?${params.toString()}`,
+      ConfluencePaginatedResults(SearchConfluencePageCodec)
     );
-    const nextPageCursor = extractCursorFromLinks(pages._links);
-
-    return {
-      pages: pages.results,
-      nextPageCursor,
-    };
   }
 
   async getPageById(pageId: string) {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -244,8 +244,6 @@ export class ConfluenceClient {
   ): Promise<T> {
     const response = await (async () => {
       try {
-        console.log("Doing request", { endpoint, retryCount });
-
         return await fetch(`${this.apiUrl}${endpoint}`, {
           headers: {
             Authorization: `Bearer ${this.authToken}`,

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -431,7 +431,7 @@ export async function confluenceCheckAndUpsertPageActivity({
   );
 
   // Check restrictions.
-  const hasReadRestrictions = await pageHasReadRestrictions(client, pageId);
+  const { hasReadRestrictions } = pageRef;
   if (hasReadRestrictions) {
     localLogger.info("Skipping restricted Confluence page.");
     return false;
@@ -712,8 +712,6 @@ export async function fetchAndUpsertRootPagesActivity(params: {
       allowedRootPageIds.push(rootPageRef.id);
     }
   }
-
-  console.log(">> allowedRootPageIds", allowedRootPageIds);
 
   return allowedRootPageIds;
 }

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -280,6 +280,11 @@ export async function confluenceSyncTopLevelChildPagesWorkflow(
       }
     }
 
+    // Only attempt to fetch children if the page has known children.
+    if (isPageRef && !current.hasChildren) {
+      continue;
+    }
+
     // Get child pages using either initial empty cursor or saved cursor.
     const { childPageRefs, nextPageCursor } =
       await confluenceGetActiveChildPageRefsActivity({


### PR DESCRIPTION
## Problem Statement
We're consistently hitting Confluence API rate limits due to our current approach that requires multiple API calls:
1. Initial call to list all pages (1 list page + 1 fetch metadata version and parentId)
2. For each page:
   - Check restrictions (1 call)
   - Check for children (1 call)
   - Fetch content if version changed (1 call)

Using a space with 1000 pages as example:
- 800 unchanged pages × (restrictions + children) = 800 × 2 = 1,600 calls
- 200 changed pages × (restrictions + children + content) = 200 × 3 = 600 calls
- Plus initial "list pages" call = 1
- Total: 2,201 API calls

## Solution
This PR introduces a hack to work around V2 API limitations by using V1's search endpoint with expanded fields. While V2 API is more modern, it's very limiting on batch operations.

### Key Changes
1. Use `/rest/api/content/search` with CQL query to get pages [doc](https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content/#api-wiki-rest-api-content-search-get))
   - This endpoint requires the scope `search:confluence` which is already in our Atlassian app 
2. Leverage expand parameter to get in a single call:
   - `version` - detect changes
   - `restrictions.read.restrictions.*` - check permissions
   - `childTypes.page` - check for children
   - `ancestors` - get parent chain

### Impact Analysis
Using the same 1000-page space example:
- 2 calls to get all pages with metadata (1 to list + 1 to fetch all metadata)
- 200 calls to fetch changed content
- Total: 201 API calls

**Potential win: ~91% reduction in API calls** (from 2,201 to 201)

(ignoring the pagination needed on the calls to get the pages.)

Additional benefits:
- Early stop DFS when page has no children (no extra API call needed)
- Skip entire subtrees when parent is restricted
- Skip content fetch for unchanged pages

### Future Improvements
This is marked as a hack because:
1. Store the space key in DB to save one more call. 

However, given our current rate limiting issues, this significant reduction in API calls makes it a worthwhile tradeoff.