### PR TITLE
enh(Intercom) - Add Help Center node as parent of collections

### DIFF
--- a/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
+++ b/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
@@ -101,6 +101,7 @@ async function createFolderNodes(execute: boolean) {
             const collectionParents = await getParentIdsForCollection({
               connectorId: connector.id,
               collectionId: collection.collectionId,
+              helpCenterId: helpCenter.helpCenterId,
             });
             console.log(
               `[${connector.id}] -> ${JSON.stringify({ folderId: collectionInternalId, parents: collectionParents })}`

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -121,15 +121,18 @@ export async function getParentIdsForArticle({
   documentId,
   connectorId,
   parentCollectionId,
+  helpCenterId,
 }: {
   documentId: string;
   connectorId: number;
   parentCollectionId: string;
+  helpCenterId: string;
 }): Promise<[string, string, ...string[]]> {
   // Get collection parents
   const collectionParents = await getParentIdsForCollection({
     connectorId,
     collectionId: parentCollectionId,
+    helpCenterId,
   });
 
   return [documentId, ...collectionParents];
@@ -138,9 +141,11 @@ export async function getParentIdsForArticle({
 export async function getParentIdsForCollection({
   connectorId,
   collectionId,
+  helpCenterId,
 }: {
   connectorId: number;
   collectionId: string;
+  helpCenterId: string;
 }): Promise<[string, ...string[]]> {
   const parentIds = [];
 
@@ -172,5 +177,6 @@ export async function getParentIdsForCollection({
   return [
     getHelpCenterCollectionInternalId(connectorId, collectionId),
     ...parentIds,
+    getHelpCenterInternalId(connectorId, helpCenterId),
   ];
 }

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -13,6 +13,7 @@ import {
 } from "@connectors/connectors/intercom/lib/intercom_api";
 import type { IntercomSyncAllConversationsStatus } from "@connectors/connectors/intercom/lib/types";
 import {
+  getHelpCenterInternalId,
   getTeamInternalId,
   getTeamsInternalId,
 } from "@connectors/connectors/intercom/lib/utils";
@@ -167,6 +168,20 @@ export async function syncHelpCenterOnlyActivity({
     });
     return false;
   }
+
+  const helpCenterInternalId = getHelpCenterInternalId(
+    connectorId,
+    helpCenterId
+  );
+  await upsertDataSourceFolder({
+    dataSourceConfig,
+    folderId: helpCenterInternalId,
+    title: helpCenterOnIntercom.display_name || "Help Center",
+    parents: [helpCenterInternalId],
+    parentId: null,
+    mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
+    timestampMs: currentSyncMs,
+  });
 
   // If all children collections are not allowed anymore we delete the Help Center data
   const collectionsWithReadPermission = await IntercomCollection.findAll({

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -222,6 +222,7 @@ export async function upsertCollectionWithChildren({
   const collectionParents = await getParentIdsForCollection({
     connectorId,
     collectionId,
+    helpCenterId,
   });
   await upsertDataSourceFolder({
     dataSourceConfig,
@@ -407,6 +408,7 @@ export async function upsertArticle({
       documentId,
       connectorId,
       parentCollectionId,
+      helpCenterId,
     });
 
     await upsertDataSourceDocument({

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -13,6 +13,7 @@ import {
   getCollectionInAppUrl,
   getHelpCenterArticleInternalId,
   getHelpCenterCollectionInternalId,
+  getHelpCenterInternalId,
   getParentIdsForArticle,
   getParentIdsForCollection,
 } from "@connectors/connectors/intercom/lib/utils";
@@ -50,6 +51,11 @@ export async function removeHelpCenter({
   helpCenter: IntercomHelpCenter;
   loggerArgs: Record<string, string | number>;
 }): Promise<void> {
+  await deleteDataSourceFolder({
+    dataSourceConfig,
+    folderId: getHelpCenterInternalId(connectorId, helpCenter.helpCenterId),
+  });
+
   const level1Collections = await IntercomCollection.findAll({
     where: {
       connectorId,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10246.
- This PR adds a Help Center node in the data source view selection, Assistant builder, etc.. (every screen where Content nodes are displayed beside Connection Admin which already displayed a Help Center).
- No backfill is expected as the Help Center is fully synced on each incremental sync.
- This is a new feature as only the collection were shown and selectable as `parentsIn` previously.

## Tests

- Tested locally, no automated test.

## Risk

- Relatively contained, at worst an incorrect Content node tree is displayed.

## Deploy Plan

- Deploy connectors.