### PR TITLE
enh(MimeTypes) - Add `BigQueryMimeType` to `DustMimeType`

### DIFF
--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -23,7 +23,7 @@ type UnderscoreToDash<T extends string> = T extends `${infer A}_${infer B}`
  * - The underscores in the provider name are stripped in the generated mime type.
  * - The underscores in the resource type are replaced with dashes in the generated mime type.
  */
-function getMimeTypes<
+function generateMimeTypes<
   P extends ConnectorProvider,
   T extends Uppercase<string>[]
 >({
@@ -53,11 +53,11 @@ function getMimeTypes<
 }
 
 export const MIME_TYPES = {
-  CONFLUENCE: getMimeTypes({
+  CONFLUENCE: generateMimeTypes({
     provider: "confluence",
     resourceTypes: ["SPACE", "PAGE"],
   }),
-  GITHUB: getMimeTypes({
+  GITHUB: generateMimeTypes({
     provider: "github",
     resourceTypes: [
       "REPOSITORY",
@@ -70,13 +70,13 @@ export const MIME_TYPES = {
       "DISCUSSION",
     ],
   }),
-  GOOGLE_DRIVE: getMimeTypes({
+  GOOGLE_DRIVE: generateMimeTypes({
     provider: "google_drive",
     // Spreadsheets are handled as data_source_folders for sheets
     // For other files and sheets, we keep Google's mime types
     resourceTypes: ["SHARED_WITH_ME", "FOLDER", "SPREADSHEET"],
   }),
-  INTERCOM: getMimeTypes({
+  INTERCOM: generateMimeTypes({
     provider: "intercom",
     resourceTypes: [
       "COLLECTION",
@@ -87,30 +87,30 @@ export const MIME_TYPES = {
       "HELP_CENTER",
     ],
   }),
-  MICROSOFT: getMimeTypes({
+  MICROSOFT: generateMimeTypes({
     provider: "microsoft",
     // for files, we keep Microsoft's mime types Spreadsheets, that contain many
     // sheet, resemble folders and are stored as such, but with the special
     // mimetype below
     resourceTypes: ["FOLDER", "SPREADSHEET"],
   }),
-  NOTION: getMimeTypes({
+  NOTION: generateMimeTypes({
     provider: "notion",
     resourceTypes: ["UNKNOWN_FOLDER", "SYNCING_FOLDER", "DATABASE", "PAGE"],
   }),
-  SLACK: getMimeTypes({
+  SLACK: generateMimeTypes({
     provider: "slack",
     resourceTypes: ["CHANNEL", "THREAD", "MESSAGES"],
   }),
-  SNOWFLAKE: getMimeTypes({
+  SNOWFLAKE: generateMimeTypes({
     provider: "snowflake",
     resourceTypes: ["DATABASE", "SCHEMA", "TABLE"],
   }),
-  WEBCRAWLER: getMimeTypes({
+  WEBCRAWLER: generateMimeTypes({
     provider: "webcrawler",
     resourceTypes: ["FOLDER"], // pages are upserted as text/html, not an internal mime type
   }),
-  ZENDESK: getMimeTypes({
+  ZENDESK: generateMimeTypes({
     provider: "zendesk",
     resourceTypes: [
       "BRAND",
@@ -121,7 +121,7 @@ export const MIME_TYPES = {
       "TICKET",
     ],
   }),
-  BIGQUERY: getMimeTypes({
+  BIGQUERY: generateMimeTypes({
     provider: "bigquery",
     resourceTypes: ["DATABASE", "SCHEMA", "TABLE"],
   }),

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -128,6 +128,9 @@ export const MIME_TYPES = {
   }),
 };
 
+export type BigQueryMimeType =
+  (typeof MIME_TYPES.BIGQUERY)[keyof typeof MIME_TYPES.BIGQUERY];
+
 export type ConfluenceMimeType =
   (typeof MIME_TYPES.CONFLUENCE)[keyof typeof MIME_TYPES.CONFLUENCE];
 
@@ -159,6 +162,7 @@ export type ZendeskMimeType =
   (typeof MIME_TYPES.ZENDESK)[keyof typeof MIME_TYPES.ZENDESK];
 
 export type DustMimeType =
+  | BigQueryMimeType
   | ConfluenceMimeType
   | GithubMimeType
   | GoogleDriveMimeType

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -74,7 +74,7 @@ export const MIME_TYPES = {
     provider: "google_drive",
     // Spreadsheets may contain many sheets, thus resemble folders and are
     // stored as such, but with the special mimeType below.
-    // For other files and sheets, we keep Google's mime types.
+    // For files and sheets, we keep Google's mime types.
     resourceTypes: ["SHARED_WITH_ME", "FOLDER", "SPREADSHEET"],
   }),
   INTERCOM: generateMimeTypes({
@@ -90,9 +90,9 @@ export const MIME_TYPES = {
   }),
   MICROSOFT: generateMimeTypes({
     provider: "microsoft",
-    // for files, we keep Microsoft's mime types Spreadsheets, that contain many
-    // sheet, resemble folders and are stored as such, but with the special
-    // mimetype below
+    // Spreadsheets may contain many sheets, thus resemble folders and are
+    // stored as such, but with the special mimeType below.
+    // For files and sheets, we keep Microsoft's mime types.
     resourceTypes: ["FOLDER", "SPREADSHEET"],
   }),
   NOTION: generateMimeTypes({

--- a/types/src/shared/internal_mime_types.ts
+++ b/types/src/shared/internal_mime_types.ts
@@ -72,8 +72,9 @@ export const MIME_TYPES = {
   }),
   GOOGLE_DRIVE: generateMimeTypes({
     provider: "google_drive",
-    // Spreadsheets are handled as data_source_folders for sheets
-    // For other files and sheets, we keep Google's mime types
+    // Spreadsheets may contain many sheets, thus resemble folders and are
+    // stored as such, but with the special mimeType below.
+    // For other files and sheets, we keep Google's mime types.
     resourceTypes: ["SHARED_WITH_ME", "FOLDER", "SPREADSHEET"],
   }),
   INTERCOM: generateMimeTypes({


### PR DESCRIPTION
## Description

- This PR adds a missing type `BigQueryMimeType` and adds it to DustMimeType.
- Also took the opportunity to rename `getMimeTypes` into `generateMimeTypes` since it is more accurate, and unformize the comments.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- No deploy a priori.