### PR TITLE
[.github] - fix: add Docker authentication

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -34,6 +34,10 @@ runs:
       with:
         install_components: "docker-credential-gcr"
 
+    - name: "Configure GCP Docker Auth"
+      shell: bash
+      run: gcloud auth configure-docker ${{ inputs.region }}-docker.pkg.dev --quiet
+
     - name: "Setup Depot"
       uses: "depot/setup-action@v1"
 


### PR DESCRIPTION
## Description

This PR configures Docker to use GCP credential helper for the specified region to authenticate with GCP's Container Registry

## Risk

None

## Deploy Plan

N/A