### PR TITLE
Add validation on the length of the titles passed in `api/v1`

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -158,9 +158,7 @@ async function _upsertDataSourceDocument({
         timestamp,
         title,
         mime_type: mimeType,
-        tags: tags?.map((tag) =>
-          tag.startsWith("title:") ? tag : safeSubstring(tag, 0, 512)
-        ),
+        tags: tags?.map((tag) => safeSubstring(tag, 0, 512)),
         parent_id: parentId,
         parents,
         light_document_output: true,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -158,7 +158,9 @@ async function _upsertDataSourceDocument({
         timestamp,
         title,
         mime_type: mimeType,
-        tags: tags?.map((tag) => safeSubstring(tag, 0, 512)),
+        tags: tags?.map((tag) =>
+          tag.startsWith("title:") ? tag : safeSubstring(tag, 0, 512)
+        ),
         parent_id: parentId,
         parents,
         light_document_output: true,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -585,6 +585,7 @@ export async function upsertTable({
         | "invalid_url"
         | "table_not_found"
         | "file_not_found"
+        | "title_too_long"
         | "invalid_parent_id"
         | "invalid_parents"
         | "internal_error";

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -331,7 +331,11 @@ export async function upsertDocument({
     .slice(1)
     .join(":");
 
-  if (titleInTags && titleInTags !== title) {
+  if (
+    titleInTags &&
+    !titleInTags.startsWith(title) &&
+    !title.startsWith(titleInTags)
+  ) {
     logger.error(
       { documentId, titleInTags, title },
       "[CoreNodes] Inconsistency between tags and title."
@@ -628,7 +632,11 @@ export async function upsertTable({
     .slice(1)
     .join(":");
 
-  if (titleInTags && titleInTags !== params.title) {
+  if (
+    titleInTags &&
+    !titleInTags.startsWith(params.title) &&
+    !params.title.startsWith(titleInTags)
+  ) {
     logger.error(
       { tableId, titleInTags, title: params.title },
       "[CoreNodes] Inconsistency between tags and title."

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -324,12 +324,15 @@ export async function upsertDocument({
         }
       : section || null;
 
-  const nonNullTags = tags || [`title:${title}`];
+  const nonNullTags = tags || [];
   const titleInTags = nonNullTags
     .find((t) => t.startsWith("title:"))
     ?.split(":")
     .slice(1)
     .join(":");
+  if (!titleInTags) {
+    nonNullTags.push(`title:${title}`);
+  }
 
   if (
     titleInTags &&
@@ -625,12 +628,15 @@ export async function upsertTable({
     });
   }
 
-  const tableTags = params.tags ?? [`title:${params.title}`];
+  const tableTags = params.tags ?? [];
   const titleInTags = tableTags
     .find((t) => t.startsWith("title:"))
     ?.split(":")
     .slice(1)
     .join(":");
+  if (!titleInTags) {
+    tableTags.push(`title:${params.title}`);
+  }
 
   if (
     titleInTags &&

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -336,7 +336,7 @@ export async function upsertDocument({
 
   if (titleInTags && titleInTags !== title) {
     logger.error(
-      { documentId, titleInTags, title },
+      { dataSourceId: dataSource.sId, documentId, titleInTags, title },
       "[CoreNodes] Inconsistency between tags and title."
     );
     // TODO(2025-02-18 aubin): uncomment what follows.
@@ -636,7 +636,12 @@ export async function upsertTable({
 
   if (titleInTags && titleInTags !== params.title) {
     logger.error(
-      { tableId, titleInTags, title: params.title },
+      {
+        dataSourceId: dataSource.sId,
+        tableId,
+        titleInTags,
+        title: params.title,
+      },
       "[CoreNodes] Inconsistency between tags and title."
     );
     // TODO(2025-02-18 aubin): uncomment what follows.

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -299,6 +299,16 @@ export async function upsertDocument({
     );
   }
 
+  // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
+  if (title && title.length > 512) {
+    return new Err(
+      new DustError(
+        "title_too_long",
+        "Invalid title: title too long (max 512 characters)."
+      )
+    );
+  }
+
   let sourceUrl: string | null = null;
   if (source_url) {
     const { valid: isSourceUrlValid, standardized: standardizedSourceUrl } =
@@ -621,6 +631,15 @@ export async function upsertTable({
       name: "dust_error",
       code: "invalid_parent_id",
       message: "Invalid parents: parents[1] and parent_id should be equal",
+    });
+  }
+
+  // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
+  if (params.title && params.title.length > 512) {
+    return new Err({
+      name: "dust_error",
+      code: "title_too_long",
+      message: `Invalid title: title too long (max 512 characters).`,
     });
   }
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -46,6 +46,7 @@ import { rowsFromCsv, upsertTableFromCsv } from "@app/lib/api/tables";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes";
 import { DustError } from "@app/lib/error";
 import { Lock } from "@app/lib/lock";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -300,11 +301,11 @@ export async function upsertDocument({
   }
 
   // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
-  if (title && title.length > 512) {
+  if (title && title.length > MAX_NODE_TITLE_LENGTH) {
     return new Err(
       new DustError(
         "title_too_long",
-        "Invalid title: title too long (max 512 characters)."
+        `Invalid title: title too long (max ${MAX_NODE_TITLE_LENGTH} characters).`
       )
     );
   }
@@ -635,11 +636,11 @@ export async function upsertTable({
   }
 
   // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
-  if (params.title && params.title.length > 512) {
+  if (params.title && params.title.length > MAX_NODE_TITLE_LENGTH) {
     return new Err({
       name: "dust_error",
       code: "title_too_long",
-      message: `Invalid title: title too long (max 512 characters).`,
+      message: `Invalid title: title too long (max ${MAX_NODE_TITLE_LENGTH} characters).`,
     });
   }
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -334,11 +334,7 @@ export async function upsertDocument({
     nonNullTags.push(`title:${title}`);
   }
 
-  if (
-    titleInTags &&
-    !titleInTags.startsWith(title) &&
-    !title.startsWith(titleInTags)
-  ) {
+  if (titleInTags && titleInTags !== title) {
     logger.error(
       { documentId, titleInTags, title },
       "[CoreNodes] Inconsistency between tags and title."
@@ -638,11 +634,7 @@ export async function upsertTable({
     tableTags.push(`title:${params.title}`);
   }
 
-  if (
-    titleInTags &&
-    !titleInTags.startsWith(params.title) &&
-    !params.title.startsWith(titleInTags)
-  ) {
+  if (titleInTags && titleInTags !== params.title) {
     logger.error(
       { tableId, titleInTags, title: params.title },
       "[CoreNodes] Inconsistency between tags and title."

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -10,6 +10,9 @@ import {
 import type { ContentNode } from "@dust-tt/types";
 import { assertNever, MIME_TYPES } from "@dust-tt/types";
 
+// Since titles will be synced in ES we don't support arbitrarily large titles.
+export const MAX_NODE_TITLE_LENGTH = 512;
+
 // Mime types that should be represented with a Channel icon.
 export const CHANNEL_MIME_TYPES = [
   MIME_TYPES.GITHUB.DISCUSSIONS,

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -12,6 +12,7 @@ export type DustErrorCode =
   | "invalid_url"
   | "invalid_parents"
   | "invalid_parent_id"
+  | "title_too_long"
   | "invalid_title_in_tags"
   // Table
   | "missing_csv"

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -559,7 +559,11 @@ async function handler(
         .slice(1)
         .join(":");
 
-      if (titleInTags && titleInTags !== title) {
+      if (
+        titleInTags &&
+        !titleInTags.startsWith(title) &&
+        !title.startsWith(titleInTags)
+      ) {
         logger.error(
           { documentId, titleInTags, title },
           "[CoreNodes] Inconsistency between tags and title."

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -547,6 +547,17 @@ async function handler(
         }
       }
 
+      // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
+      if (r.data.title && r.data.title.length > 512) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid title: title too long (max 512 characters).`,
+          },
+        });
+      }
+
       const documentId = req.query.documentId as string;
 
       const title = r.data.title ?? "Untitled document";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -562,11 +562,7 @@ async function handler(
         tags.push(`title:${title}`);
       }
 
-      if (
-        titleInTags &&
-        !titleInTags.startsWith(title) &&
-        !title.startsWith(titleInTags)
-      ) {
+      if (titleInTags && titleInTags !== title) {
         logger.error(
           { documentId, titleInTags, title },
           "[CoreNodes] Inconsistency between tags and title."

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -564,7 +564,7 @@ async function handler(
 
       if (titleInTags && titleInTags !== title) {
         logger.error(
-          { documentId, titleInTags, title },
+          { dataSourceId: dataSource.sId, documentId, titleInTags, title },
           "[CoreNodes] Inconsistency between tags and title."
         );
         // TODO(2025-02-18 aubin): uncomment what follows.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -19,6 +19,7 @@ import { fromError } from "zod-validation-error";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes";
 import { runDocumentUpsertHooks } from "@app/lib/document_upsert_hooks/hooks";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -548,12 +549,12 @@ async function handler(
       }
 
       // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
-      if (r.data.title && r.data.title.length > 512) {
+      if (r.data.title && r.data.title.length > MAX_NODE_TITLE_LENGTH) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid title: title too long (max 512 characters).`,
+            message: `Invalid title: title too long (max ${MAX_NODE_TITLE_LENGTH} characters).`,
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -552,12 +552,15 @@ async function handler(
       const title = r.data.title ?? "Untitled document";
       const mimeType = r.data.mime_type ?? "application/octet-stream";
 
-      const tags = r.data.tags || [`title:${title}`];
+      const tags = r.data.tags || [];
       const titleInTags = tags
         .find((t) => t.startsWith("title:"))
         ?.split(":")
         .slice(1)
         .join(":");
+      if (!titleInTags) {
+        tags.push(`title:${title}`);
+      }
 
       if (
         titleInTags &&

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -125,6 +125,7 @@ async function handler(
           case "invalid_parents":
           case "invalid_parent_id":
           case "invalid_url":
+          case "title_too_long":
           case "missing_csv":
             return apiError(req, res, {
               status_code: 400,


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2032.
- This PR enforce that the length of the titles passed to `api/v1` are smaller than a threshold (set to 512 characters).
- This PR also adds the `dataSourceId` to the logged inconsistencies with the tags.

## Tests

## Risk

- N/A

## Deploy Plan

- Deploy front.