### PR TITLE
Prevent infinite loop in Google Drive `recurseUpdateParents`

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -624,6 +624,19 @@ async function recurseUpdateParents(
     "Updating parents recursively"
   );
 
+  if (parentIds.includes(file.dustFileId)) {
+    logger.warn(
+      {
+        fileId: file.driveFileId,
+        parentIds,
+        name: file.name,
+        count: children.length,
+      },
+      "Infinite parent loop."
+    );
+    return;
+  }
+
   for (const child of children) {
     await recurseUpdateParents(
       connector,


### PR DESCRIPTION
## Description

- Context here: https://dust4ai.slack.com/archives/C05F84CFP0E/p1739962984053259.
- This PR prevents infinite loops in the incremental sync of Google Drive connectors.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy connectors.