### PR TITLE
Better align slugification between front and core

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -88,10 +88,6 @@ impl UpsertQueueCSVContent {
         let s = with_separators.to_lowercase().trim().to_string();
         let s = WHITESPACE.replace_all(&s, "_").to_string();
         let s = NON_ASCII.replace_all(&s, "_").to_string();
-        // let s = s
-        //     .chars()
-        //     .map(|c| if c.is_alphanumeric() { c } else { '_' }) // Replace non-word chars
-        //     .collect::<String>();
 
         UNDERSCORES.replace_all(&s, "_").to_string()
     }


### PR DESCRIPTION
## Description

Better align slugification between `front` and `core`

Goal is to get this to 0: https://app.datadoghq.eu/logs?query=%22%5BCSV-FILE%5D%20mismatch%3A%20headers%20and%20schema%20mismatch%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&storage=hot&stream_sort=desc&viz=stream&from_ts=1739906011453&to_ts=1739909611453&live=true

## Tests

Updated tests

## Risk

N/A

## Deploy Plan

- deploy `core`