### PR TITLE
[.github] - fix: ensure playwright test flag is correctly passed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,7 @@ jobs:
                 image_tag: '${{ needs.prepare.outputs.short_sha }}',
                 slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
                 slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}',
-                run_playwright: ${{ inputs.run_playwright_tests }},
+                run_playwright: '${{ inputs.run_playwright_tests }}',
                 playwright_sha: '${{ github.sha }}'
               }
             })


### PR DESCRIPTION
## Description

This PR add quotes to the `run_playwright_tests` input to ensure it's passed as a string to the GitHub Actions workflow configuration

## Risk

None

## Deploy Plan

N/A