### PR TITLE
Labels: Allow filtering both auto and custom tags

### DIFF
--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -454,38 +454,33 @@ function RetrievalActionTagsFilterPopover({
     return null;
   }
 
-  const tagsAuto: boolean = tagsFilter === "auto";
+  const isTagsAuto: boolean = tagsFilter.mode === "auto";
   const tagsIn: DataSourceTag[] = [];
   const tagsNot: DataSourceTag[] = [];
 
-  if (tagsFilter !== "auto") {
-    tagsIn.push(
-      ...tagsFilter.in.map((tag) => ({
+  tagsIn.push(
+    ...tagsFilter.in.map((tag) => ({
+      tag,
+      dustAPIDataSourceId,
+      connectorProvider,
+    }))
+  );
+  if (tagsFilter.not) {
+    tagsNot.push(
+      ...tagsFilter.not.map((tag) => ({
         tag,
         dustAPIDataSourceId,
         connectorProvider,
       }))
     );
-    if (tagsFilter.not) {
-      tagsNot.push(
-        ...tagsFilter.not.map((tag) => ({
-          tag,
-          dustAPIDataSourceId,
-          connectorProvider,
-        }))
-      );
-    }
   }
 
   let tagsCounter: number | null = null;
-  let tagsLabel = "Filters";
-  if (tagsFilter === "auto") {
-    tagsLabel = "Filters (auto)";
-  } else if (
-    tagsFilter &&
-    (tagsFilter.in.length > 0 || tagsFilter.not.length > 0)
-  ) {
-    tagsCounter = tagsFilter.in.length + tagsFilter.not.length;
+  const tagsLabel = "Filters";
+
+  if (tagsFilter && (tagsFilter.in.length > 0 || tagsFilter.not.length > 0)) {
+    tagsCounter =
+      tagsFilter.in.length + tagsFilter.not.length + (isTagsAuto ? 1 : 0);
   }
 
   return (
@@ -522,7 +517,7 @@ function RetrievalActionTagsFilterPopover({
               </div>
             </div>
           )}
-          {tagsAuto && (
+          {isTagsAuto && (
             <div className="flex flex-col gap-2">
               <div className="flex flex-row flex-wrap gap-1">
                 <Chip

--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -475,13 +475,8 @@ function RetrievalActionTagsFilterPopover({
     );
   }
 
-  let tagsCounter: number | null = null;
-  const tagsLabel = "Filters";
-
-  if (tagsFilter && (tagsFilter.in.length > 0 || tagsFilter.not.length > 0)) {
-    tagsCounter =
-      tagsFilter.in.length + tagsFilter.not.length + (isTagsAuto ? 1 : 0);
-  }
+  const tagsCounter =
+    tagsFilter.in.length + tagsFilter.not.length + (isTagsAuto ? 1 : 0);
 
   return (
     <PopoverRoot modal={true}>
@@ -489,7 +484,7 @@ function RetrievalActionTagsFilterPopover({
         <Button
           variant="outline"
           size="xs"
-          label={tagsLabel}
+          label="Filters"
           isSelect
           counterValue={tagsCounter ? tagsCounter.toString() : "auto"}
           isCounter={tagsCounter !== null}
@@ -519,10 +514,11 @@ function RetrievalActionTagsFilterPopover({
           )}
           {isTagsAuto && (
             <div className="flex flex-col gap-2">
+              <Label>Conversation filtering</Label>
               <div className="flex flex-row flex-wrap gap-1">
                 <Chip
                   color="emerald"
-                  label="Conversation filtering."
+                  label="Activated"
                   icon={SparklesIcon}
                   isBusy
                 />

--- a/front/components/assistant_builder/tags/helpers.ts
+++ b/front/components/assistant_builder/tags/helpers.ts
@@ -10,7 +10,7 @@ export function getActionTags(
   dsConfig: DataSourceViewSelectionConfiguration,
   mode: "in" | "not"
 ): DataSourceTag[] {
-  if (!dsConfig.tagsFilter || dsConfig.tagsFilter === "auto") {
+  if (!dsConfig.tagsFilter) {
     return [];
   }
   const dscFilter =

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -487,7 +487,11 @@ async function processActionSpecification({
     inputs.push(retrievalAutoTimeFrameInputSpecification());
   }
 
-  if (actionConfiguration.dataSources.some((ds) => ds.filter.tags === "auto")) {
+  if (
+    actionConfiguration.dataSources.some(
+      (ds) => ds.filter.tags?.mode === "auto"
+    )
+  ) {
     inputs.push(...retrievalTagsInputSpecification());
   }
 

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -255,9 +255,13 @@ export function applyDataSourceFilters(
       assert(dsView, `Data source view ${ds.dataSourceViewId} not found`);
 
       const tagsIn =
-        ds.filter.tags === "auto" ? globalTagsIn : ds.filter.tags.in;
+        ds.filter.tags.mode === "auto"
+          ? [...(globalTagsIn ?? []), ...(ds.filter.tags.in ?? [])]
+          : ds.filter.tags.in;
       const tagsNot =
-        ds.filter.tags === "auto" ? globalTagsNot : ds.filter.tags.not;
+        ds.filter.tags.mode === "auto"
+          ? [...(globalTagsNot ?? []), ...(ds.filter.tags.not ?? [])]
+          : ds.filter.tags.not;
 
       if (tagsIn && tagsNot && (tagsIn.length > 0 || tagsNot.length > 0)) {
         config.DATASOURCE.filter.tags.in_map[
@@ -803,7 +807,11 @@ function retrievalActionSpecification({
     inputs.push(retrievalAutoTimeFrameInputSpecification());
   }
 
-  if (actionConfiguration.dataSources.some((ds) => ds.filter.tags === "auto")) {
+  if (
+    actionConfiguration.dataSources.some(
+      (ds) => ds.filter.tags?.mode === "auto"
+    )
+  ) {
     inputs.push(...retrievalTagsInputSpecification());
   }
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1303,16 +1303,14 @@ async function _createAgentDataSourcesConfigData(
         let tagsIn: string[] | null = null;
         let tagsNotIn: string[] | null = null;
 
-        if (tagsFilter === "auto") {
+        if (tagsFilter?.mode === "auto") {
           tagsMode = "auto";
-        } else if (
-          tagsFilter?.in &&
-          tagsFilter?.not &&
-          (tagsFilter.in.length > 0 || tagsFilter.not.length > 0)
-        ) {
+          tagsIn = tagsFilter.in ?? [];
+          tagsNotIn = tagsFilter.not ?? [];
+        } else if (tagsFilter?.mode === "custom") {
           tagsMode = "custom";
-          tagsIn = tagsFilter.in;
-          tagsNotIn = tagsFilter.not;
+          tagsIn = tagsFilter.in ?? [];
+          tagsNotIn = tagsFilter.not ?? [];
         }
 
         return AgentDataSourceConfiguration.create(

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -114,21 +114,12 @@ export function getDataSource(
   const { dataSourceView } = dataSourceConfig;
 
   let tags: DataSourceFilter["tags"] = null;
-  if (
-    dataSourceConfig.tagsMode === "custom" &&
-    dataSourceConfig.tagsIn &&
-    dataSourceConfig.tagsNotIn
-  ) {
+
+  if (dataSourceConfig.tagsMode) {
     tags = {
-      in: dataSourceConfig.tagsIn,
-      not: dataSourceConfig.tagsNotIn,
-      mode: "custom",
-    };
-  } else if (dataSourceConfig.tagsMode === "auto") {
-    tags = {
-      in: [],
-      not: [],
-      mode: "auto",
+      in: dataSourceConfig.tagsIn ?? [],
+      not: dataSourceConfig.tagsNotIn ?? [],
+      mode: dataSourceConfig.tagsMode,
     };
   }
 

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -122,9 +122,14 @@ export function getDataSource(
     tags = {
       in: dataSourceConfig.tagsIn,
       not: dataSourceConfig.tagsNotIn,
+      mode: "custom",
     };
   } else if (dataSourceConfig.tagsMode === "auto") {
-    tags = "auto";
+    tags = {
+      in: [],
+      not: [],
+      mode: "auto",
+    };
   }
 
   return {

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -92,7 +92,11 @@ AgentDataSourceConfiguration.init(
         if ((dsConfig.tagsIn === null) !== (dsConfig.tagsNotIn === null)) {
           throw new Error("Tags must be both set or both null");
         }
-        if (dsConfig.tagsMode === "custom") {
+        if (dsConfig.tagsMode === "auto") {
+          if (!dsConfig.tagsIn || !dsConfig.tagsNotIn) {
+            throw new Error("TagsIn/notIn must be set if tagsMode is custom.");
+          }
+        } else if (dsConfig.tagsMode === "custom") {
           if (!dsConfig.tagsIn?.length && !dsConfig.tagsNotIn?.length) {
             throw new Error(
               "TagsIn/notIn can't be both empty if tagsMode is custom"

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -94,7 +94,7 @@ AgentDataSourceConfiguration.init(
         }
         if (dsConfig.tagsMode === "auto") {
           if (!dsConfig.tagsIn || !dsConfig.tagsNotIn) {
-            throw new Error("TagsIn/notIn must be set if tagsMode is custom.");
+            throw new Error("TagsIn/notIn must be set if tagsMode is auto.");
           }
         } else if (dsConfig.tagsMode === "custom") {
           if (!dsConfig.tagsIn?.length && !dsConfig.tagsNotIn?.length) {

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -65,8 +65,8 @@ const OptionalDataSourceFilterTagsCodec = t.partial({
     t.type({
       in: t.array(t.string),
       not: t.array(t.string),
+      mode: t.union([t.literal("custom"), t.literal("auto")]),
     }),
-    t.literal("auto"),
     t.null,
   ]),
 });

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -4,7 +4,10 @@
 
 import { BaseAction } from "../../../front/assistant/actions/index";
 import { ConnectorProvider } from "../../../front/data_source";
-import { DataSourceViewType } from "../../../front/data_source_view";
+import {
+  DataSourceViewType,
+  TagsFilter,
+} from "../../../front/data_source_view";
 import { ModelId } from "../../../shared/model_id";
 import { ioTsEnum } from "../../../shared/utils/iots_utils";
 
@@ -29,18 +32,9 @@ export function isTimeFrame(arg: RetrievalTimeframe): arg is TimeFrame {
   );
 }
 
-export type DataSourceFilterOld = {
-  parents: { in: string[]; not: string[] } | null;
-  tags?: { in: string[]; not: string[] } | "auto" | null;
-};
-
 export type DataSourceFilter = {
   parents: { in: string[]; not: string[] } | null;
-  tags: {
-    in: string[];
-    not: string[];
-    mode: "custom" | "auto";
-  } | null;
+  tags?: TagsFilter;
 };
 
 export type DataSourceConfiguration = {

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -29,9 +29,18 @@ export function isTimeFrame(arg: RetrievalTimeframe): arg is TimeFrame {
   );
 }
 
-export type DataSourceFilter = {
+export type DataSourceFilterOld = {
   parents: { in: string[]; not: string[] } | null;
   tags?: { in: string[]; not: string[] } | "auto" | null;
+};
+
+export type DataSourceFilter = {
+  parents: { in: string[]; not: string[] } | null;
+  tags: {
+    in: string[];
+    not: string[];
+    mode: "custom" | "auto";
+  } | null;
 };
 
 export type DataSourceConfiguration = {

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -37,7 +37,11 @@ export type DataSourceViewSelectionConfiguration = {
   tagsFilter: TagsFilter;
 };
 
-export type TagsFilter = { in: string[]; not: string[] } | "auto" | null;
+export type TagsFilter = {
+  in: string[];
+  not: string[];
+  mode: "custom" | "auto";
+} | null;
 
 export function defaultSelectionConfiguration(
   dataSourceView: DataSourceViewType


### PR DESCRIPTION
## Description

Our model was: 

```
export type DataSourceFilter = {
  parents: { in: string[]; not: string[] } | null;
  tags?: { in: string[]; not: string[] } | "auto" | null;
};
```

Now: 

```
export type DataSourceFilter = {
  parents: { in: string[]; not: string[] } | null;
  tags?: { mode: "custom" | "auto" in: string[]; not: string[] }  | null;
};
```

## Tests

Locally, and deploying to front edge. 

## Risk

Break the assistant builder, break the retrieval tag filtering. 

## Deploy Plan

Deploy front - no migration needed. 
