### PR TITLE
Avoid fetching Confluence Space Key

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -131,10 +131,12 @@ export async function getActiveChildPageRefs(
     pageCursor,
     parentPageId,
     spaceId,
+    spaceKey,
   }: {
     pageCursor: string | null;
     parentPageId: string;
     spaceId: string;
+    spaceKey: string;
   }
 ) {
   // Fetch the child pages of the parent page.
@@ -152,11 +154,11 @@ export async function getActiveChildPageRefs(
     return { childPageRefs: [], nextPageCursor };
   }
 
-  // Fetch the details of the child pages (version and parentId).
+  // Fetch child page metadata (version, parent, permissions, etc.).
   const childPageRefs = await bulkFetchConfluencePageRefs(client, {
     limit: PAGE_FETCH_LIMIT,
     pageIds: activeChildPageIds,
-    spaceId,
+    spaceKey,
   });
 
   return { childPageRefs, nextPageCursor };
@@ -167,16 +169,16 @@ export async function bulkFetchConfluencePageRefs(
   {
     limit,
     pageIds,
-    spaceId,
+    spaceKey,
   }: {
     limit: number;
     pageIds: string[];
-    spaceId: string;
+    spaceKey: string;
   }
 ) {
   // Fetch page metadata (version, parent, permissions, etc.) for the given page IDs
   const pagesWithDetails = await client.getPagesByIdsInSpace({
-    spaceId,
+    spaceKey,
     pageIds,
     limit,
   });

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -590,21 +590,17 @@ export class ConfluenceClient {
   }
 
   async getPagesByIdsInSpace({
-    spaceId,
+    spaceKey,
     pageIds,
     limit,
   }: {
-    spaceId: string;
+    spaceKey: string;
     pageIds: string[];
     limit?: number;
   }) {
-    // First get space info to get the key.
-    // TODO(2025-02-18 flav) Save the key in the DB.
-    const space = await this.getSpaceById(spaceId);
-
     // Build CQL query to get pages with specific IDs.
     const idClause = pageIds?.length ? ` AND id in (${pageIds.join(",")})` : "";
-    const cqlQuery = `type=page AND space="${space.key}"${idClause}`;
+    const cqlQuery = `type=page AND space="${spaceKey}"${idClause}`;
 
     const params = new URLSearchParams({
       cql: cqlQuery,

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -162,11 +162,7 @@ export async function confluenceSpaceSyncWorkflow(
 
   await confluenceUpsertSpaceFolderActivity({
     connectorId,
-    space: {
-      id: spaceId,
-      name: space.name,
-      key: space.key,
-    },
+    space,
     baseUrl,
   });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Previously, we shipped improvements to reduce the number of queries on the Confluence API for space and page imports (PR #10906). This required using the V1 API which needs space keys instead of space IDs.

Changes:
- Remove an extra API call previously needed to fetch space keys from space IDs
- Wire space keys directly from the workflow instead of storing them in the DB
- Keep the space key in memory as we already fetch it during the workflow

This change further optimizes our Confluence API usage by eliminating an unnecessary API call.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
⚠️ This will break all existing workflows. We must stop them before deploying and restart them afterward.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [x] Stop all Confluence workflows
- [ ] Deploy
- [ ] Restart all Confluence workflows

