### PR TITLE
[sparkle] Allows to pass portal container

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.406",
+  "version": "0.2.408",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.406",
+      "version": "0.2.408",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.406",
+  "version": "0.2.408",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Popover.tsx
+++ b/sparkle/src/components/Popover.tsx
@@ -13,6 +13,7 @@ interface PopoverContentProps
   extends React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> {
   fullWidth?: boolean;
   mountPortal?: boolean;
+  mountPortalContainer?: HTMLElement;
 }
 
 const PopoverContent = React.forwardRef<
@@ -25,6 +26,7 @@ const PopoverContent = React.forwardRef<
       align = "center",
       sideOffset = 4,
       mountPortal = true,
+      mountPortalContainer,
       fullWidth = false,
       ...props
     },
@@ -54,7 +56,9 @@ const PopoverContent = React.forwardRef<
     );
 
     return mountPortal ? (
-      <PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>
+      <PopoverPrimitive.Portal container={mountPortalContainer}>
+        {content}
+      </PopoverPrimitive.Portal>
     ) : (
       content
     );

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -102,6 +102,7 @@ export interface SearchInputWithPopoverProps extends SearchInputProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   mountPortal?: boolean;
+  mountPortalContainer?: HTMLElement;
 }
 
 export const SearchInputWithPopover = forwardRef<
@@ -118,6 +119,7 @@ export const SearchInputWithPopover = forwardRef<
       value,
       onChange,
       mountPortal = false,
+      mountPortalContainer,
       ...searchInputProps
     },
     ref
@@ -153,6 +155,7 @@ export const SearchInputWithPopover = forwardRef<
           onCloseAutoFocus={(e) => e.preventDefault()}
           onInteractOutside={() => onOpenChange(false)}
           mountPortal={mountPortal}
+          mountPortalContainer={mountPortalContainer}
         >
           <ScrollArea
             role="listbox"

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -118,7 +118,7 @@ export const SearchInputWithPopover = forwardRef<
       onOpenChange,
       value,
       onChange,
-      mountPortal = false,
+      mountPortal,
       mountPortalContainer,
       ...searchInputProps
     },


### PR DESCRIPTION
## Description

When using a portal, you can also pass the target container.
Useful mainly when using a component inside a modal sheet.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
