### PR TITLE
fix: truncate doc title and tags to 512 chars in connectors

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -54,6 +54,9 @@ export const MAX_SMALL_DOCUMENT_TXT_LEN = 500000;
 export const MAX_LARGE_DOCUMENT_TXT_LEN = 5000000;
 export const MAX_FILE_SIZE_TO_DOWNLOAD = 128 * 1024 * 1024;
 
+const MAX_TITLE_LENGTH = 512;
+const MAX_TAG_LENGTH = 512;
+
 type UpsertContext = {
   sync_type: "batch" | "incremental";
 };
@@ -156,9 +159,9 @@ async function _upsertDataSourceDocument({
         section: documentContent,
         source_url: documentUrl ?? null,
         timestamp,
-        title,
+        title: safeSubstring(title, 0, MAX_TITLE_LENGTH),
         mime_type: mimeType,
-        tags: tags?.map((tag) => safeSubstring(tag, 0, 512)),
+        tags: tags?.map((tag) => safeSubstring(tag, 0, MAX_TAG_LENGTH)),
         parent_id: parentId,
         parents,
         light_document_output: true,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -683,7 +683,7 @@ export async function upsertDataSourceRemoteTable({
     table_id: tableId,
     remote_database_table_id: remoteDatabaseTableId,
     remote_database_secret_id: remoteDatabaseSecretId,
-    title,
+    title: safeSubstring(title, 0, MAX_TITLE_LENGTH),
     mime_type: mimeType,
   };
   const dustRequestConfig: AxiosRequestConfig = {
@@ -903,7 +903,7 @@ export async function upsertDataSourceTableFromCsv({
     tableId,
     truncate,
     async: true,
-    title,
+    title: safeSubstring(title, 0, MAX_TITLE_LENGTH),
     mimeType,
     timestamp: null,
     tags: tags ?? null,
@@ -1330,7 +1330,7 @@ export async function _upsertDataSourceFolder({
     dataSourceId: dataSourceConfig.dataSourceId,
     folderId,
     timestamp: timestampMs ? timestampMs : now.getTime(),
-    title,
+    title: safeSubstring(title, 0, MAX_TITLE_LENGTH),
     parentId,
     parents,
     mimeType,


### PR DESCRIPTION
## Description

We don't accept more than 512 characters in `front`. Instead of skipping we simply truncate.


## Tests

N/A


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
