### PR TITLE
Bump Redis max connections

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -36,7 +36,7 @@ export async function getRedisClient({
       isolationPoolOptions: {
         acquireTimeoutMillis: 10000, // Max time to wait for a connection: 10 seconds.
         min: 1,
-        max: 500, // Maximum number of concurrent connections for streaming.
+        max: 800, // Maximum number of concurrent connections for streaming.
         evictionRunIntervalMillis: 15000, // Check for idle connections every 15 seconds.
         idleTimeoutMillis: 30000, // Connections idle for more than 30 seconds will be eligible for eviction.
       },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1739976933499499).

This PR bumps the number of Redis connection per pod from 500 to 800 to avoid timeout/streaming errors. The current approach that relies on `xRead/xAdd` is pretty limiting and consumes a lot of connections for nothing.

Will look into improving the situation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
