### PR TITLE
fix: increase file name limit to 512

### DIFF
--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2361,7 +2361,7 @@ export type GetWorkspaceUsageRequestType = z.infer<
 
 export const FileUploadUrlRequestSchema = z.object({
   contentType: SupportedFileContentFragmentTypeSchema,
-  fileName: z.string().max(256, "File name must be less than 256 characters"),
+  fileName: z.string().max(4096, "File name must be less than 4096 characters"),
   fileSize: z.number(),
   useCase: z.union([z.literal("conversation"), z.literal("upsert_table")]),
   useCaseMetadata: z


### PR DESCRIPTION
## Description

we now create files from connectors for tables. We use the table ID for these, and this ID can be really long on microsoft.

there's no fundamental reason to have strict limits on this so bumping to 4096

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
