### PR TITLE
Reduce Confluence workflow activities number

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -28,7 +28,8 @@ const {
   confluenceSaveStartSyncActivity,
   confluenceSaveSuccessSyncActivity,
   confluenceUpdatePagesParentIdsActivity,
-  confluenceCheckAndUpsertPageActivity,
+  confluenceCheckAndUpsertSinglePageActivity,
+  confluenceUpsertLeafPagesActivity,
   confluenceGetActiveChildPageRefsActivity,
   fetchConfluenceSpaceIdsForConnectorActivity,
   confluenceUpsertPageWithFullParentsActivity,
@@ -56,6 +57,8 @@ const {
 // since a Confluence page can have an unbounded number of pages.
 const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 10_000;
 const TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB = 10;
+
+const MAX_LEAF_PAGES_PER_BATCH = 50;
 
 export async function confluenceSyncWorkflow({
   connectorId,
@@ -242,20 +245,43 @@ interface confluenceSyncTopLevelChildPagesWorkflowInput {
 
 /**
  * This workflow implements a DFS algorithm to synchronize all pages not subject to restrictions.
- * It uses a stack to process pages and their children, with a special handling for pagination:
- * - Regular pages are processed and their children are added to the stack
- * - Cursor elements in the stack represent continuation points for pages with many children
+ * It uses a stack to process pages and their children, with special handling for:
+ *
+ * 1. Pagination:
+ *    - Regular pages are processed and their children are added to the stack
+ *    - Cursor elements in the stack represent continuation points for pages with many children
+ *
+ * 2. Leaf pages optimization:
+ *    - Pages without children are batched together to reduce activity calls
+ *    - Batches are automatically flushed when full or before workflow continuation
+ *
  * This ensures we never store too many pages in the workflow history while maintaining proper
- * traversal.
+ * traversal and optimal performance.
  *
  * The workflow stops importing child pages if a parent page is restricted.
- * Page restriction checks are performed by `confluenceCheckAndUpsertPageActivity`.
+ * Page restriction checks are performed by `confluenceCheckAndUpsertSinglePageActivity`.
  */
 export async function confluenceSyncTopLevelChildPagesWorkflow(
   params: confluenceSyncTopLevelChildPagesWorkflowInput
 ) {
   const { space, topLevelPageRefs, visitedAtMs } = params;
+
+  // Step 1: Setup.
   const stack: StackElement[] = [...topLevelPageRefs];
+  let leafPagesBatch: ConfluencePageRef[] = [];
+
+  // Step 2: Define a helper to "commit" the current batch of leaves.
+  async function flushLeafPagesBatch() {
+    if (leafPagesBatch.length > 0) {
+      await confluenceUpsertLeafPagesActivity({
+        ...params,
+        space,
+        pageRefs: leafPagesBatch,
+        visitedAtMs,
+      });
+      leafPagesBatch = [];
+    }
+  }
 
   while (stack.length > 0) {
     const current = stack.pop();
@@ -266,22 +292,29 @@ export async function confluenceSyncTopLevelChildPagesWorkflow(
     // Check if it's a page reference or cursor.
     const isPageRef = "id" in current;
 
-    // If it's a page, process it first.
+    // Step 3: If this is a real page and it has no children, buffer it for batch processing.
+    if (isPageRef && !current.hasChildren) {
+      leafPagesBatch.push(current);
+
+      // Check if we reached the threshold and, if so, flush the batch.
+      if (leafPagesBatch.length >= MAX_LEAF_PAGES_PER_BATCH) {
+        await flushLeafPagesBatch();
+      }
+      continue;
+    }
+
+    // Step 4: For pages that do have children (or a cursor item), process them normally.
     if (isPageRef) {
-      const successfullyUpsert = await confluenceCheckAndUpsertPageActivity({
-        ...params,
-        space,
-        pageRef: current,
-        visitedAtMs,
-      });
+      const successfullyUpsert =
+        await confluenceCheckAndUpsertSinglePageActivity({
+          ...params,
+          space,
+          pageRef: current,
+          visitedAtMs,
+        });
       if (!successfullyUpsert) {
         continue;
       }
-    }
-
-    // Only attempt to fetch children if the page has known children.
-    if (isPageRef && !current.hasChildren) {
-      continue;
     }
 
     // Get child pages using either initial empty cursor or saved cursor.
@@ -301,7 +334,7 @@ export async function confluenceSyncTopLevelChildPagesWorkflow(
       });
     }
 
-    // Check if we would exceed limits by continuing.
+    // Step 5: Check workflow size constraints, flush any batch, then continue as new if needed.
     const hasReachedWorkflowLimits =
       workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH ||
       workflowInfo().historySize >
@@ -310,12 +343,16 @@ export async function confluenceSyncTopLevelChildPagesWorkflow(
       hasReachedWorkflowLimits &&
       (stack.length > 0 || childPageRefs.length > 0 || nextPageCursor !== null)
     ) {
+      await flushLeafPagesBatch();
+
       await continueAsNew<typeof confluenceSyncTopLevelChildPagesWorkflow>({
         ...params,
         topLevelPageRefs: stack,
       });
     }
   }
+
+  await flushLeafPagesBatch();
 }
 
 async function startConfluenceRemoveSpaceWorkflow(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Following #10906 and #10928, this PR optimizes the average case sync performance. Most Confluence pages aren't changed between successive syncs, and many are "leaf" pages (no children). This PR optimizes for this common case by:

1. Adding a new activity to batch process leaf pages
2. Keeping the DFS approach only for pages that have children (required for proper restriction handling)
3. Using concurrent execution within batches (with conservative limits to avoid Confluence rate limits)

Impact:
- Reduced Temporal activity count -> Lower costs
- Faster workflow execution through batching
- Preserved correct restriction handling for parent/child relationships

Implementation:
- Added `confluenceUpsertLeafPagesActivity` that batches leaf pages (50 at a time)
- Reused core upsert logic via `concurrentExecutor`
- Kept single-page activity for pages with children
- Added configurable concurrency limits

The changes are minimal risk as they only affect how we process leaf pages, not the core sync logic or data model.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
⚠️ This will break all existing workflows.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [x] Stop all Confluence workflows
- [x] Deploy
- [x] Restart all Confluence workflows
