### PR TITLE
[Connector Permissions] Fix: when changing, use permissions 'read' call

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -639,7 +639,7 @@ export function ConnectorPermissionsModal({
             node: r,
             // content nodes are not synced yet so we cannot access their parents via permissions
             // this is not an issue for this component
-            parents: "not-synced-yet",
+            parents: null,
           },
         }),
         {}

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -72,7 +72,6 @@ import {
   isRemoteDatabase,
 } from "@app/lib/data_sources";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
-import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useSpaceDataSourceViews, useSystemSpace } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
 import {

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -615,10 +615,12 @@ export function ConnectorPermissionsModal({
     [owner, dataSource]
   );
 
-  const { nodes: allSelectedResources, isNodesLoading } =
-    useDataSourceViewContentNodes({
+  const { resources: allSelectedResources, isResourcesLoading } =
+    useConnectorPermissions({
       owner,
-      dataSourceView,
+      dataSource,
+      filterPermission: "read",
+      parentId: null,
       viewType: "all",
       disabled: !canUpdatePermissions,
     });
@@ -636,7 +638,9 @@ export function ConnectorPermissionsModal({
           [r.internalId]: {
             isSelected: true,
             node: r,
-            parents: r.parentInternalIds || [],
+            // content nodes are not synced yet so we cannot access their parents via permissions
+            // this is not an issue for this component
+            parents: "not-synced-yet",
           },
         }),
         {}
@@ -848,7 +852,7 @@ export function ConnectorPermissionsModal({
                       canUpdatePermissions ? selectedNodes : undefined
                     }
                     setSelectedNodes={
-                      canUpdatePermissions && !isNodesLoading
+                      canUpdatePermissions && !isResourcesLoading
                         ? setSelectedNodes
                         : undefined
                     }

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -58,6 +58,7 @@ export type ContentNodeTreeItemStatus = {
   node: ContentNode;
   // when setting permissions on a connector, nodes that are to be selected /
   // unselected may not be synced yet so we cannot easily access their parents
+  // In that case parents is null
   // It is not an issue for this component(see ConnectorPermissionsModal.tsx)
   parents: string[] | null;
 };

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -22,9 +22,7 @@ const unselectedChildren = (
   node: ContentNode,
   sendNotification: (notification: NotificationType) => void
 ) => {
-  if (
-    Object.entries(selection).some(([, v]) => v.parents === "not-synced-yet")
-  ) {
+  if (Object.entries(selection).some(([, v]) => v.parents === null)) {
     sendNotification({
       type: "error",
       title: "Deselecting partial selection unavailable.",
@@ -35,7 +33,8 @@ const unselectedChildren = (
   }
 
   return Object.entries(selection).reduce((acc, [k, v]) => {
-    const shouldUnselect = v.parents.includes(node.internalId);
+    // we checked above all parents were not null
+    const shouldUnselect = v.parents?.includes(node.internalId);
     return {
       ...acc,
       [k]: {
@@ -60,7 +59,7 @@ export type ContentNodeTreeItemStatus = {
   // when setting permissions on a connector, nodes that are to be selected /
   // unselected may not be synced yet so we cannot easily access their parents
   // It is not an issue for this component(see ConnectorPermissionsModal.tsx)
-  parents: string[] | "not-synced-yet";
+  parents: string[] | null;
 };
 
 export type TreeSelectionModelUpdater = (

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -1,10 +1,10 @@
+import type { NotificationType } from "@dust-tt/sparkle";
 import {
   BracesIcon,
   Button,
   ExternalLinkIcon,
   IconButton,
   ListCheckIcon,
-  NotificationType,
   SearchInput,
   Tooltip,
   Tree,
@@ -23,7 +23,7 @@ const unselectedChildren = (
   sendNotification: (notification: NotificationType) => void
 ) => {
   if (
-    Object.entries(selection).some(([_, v]) => v.parents === "not-synced-yet")
+    Object.entries(selection).some(([, v]) => v.parents === "not-synced-yet")
   ) {
     sendNotification({
       type: "error",


### PR DESCRIPTION
Description
--
Fixes https://github.com/dust-tt/tasks/issues/2221

In moving nodes to core, we replaced a call to connectors permissions that was using a content_node endpoint behind the scenes, by a call to core, in `ConnectorPermissionModal`

But this creates an issue: when a user changes permissions, the state in core is only available once synced, which can take a while, so if the user comes back right after, what they just selected will not be marked as selected

This should be fixed by reinstating a call to permissions, that does not uses a content_node connectors endpoint behind the scenes, since the endpoint does not exist anymore.

The PR introduced a not-synced-yet parents status for ContentNodeTreeItemStatus that allows for that, while keeping previous behaviour almost always (edge case of sendnotification likely never happens in practice, since partial nodes do not appear on connector permissions modals afaict)

Risks
---
standard

Deploy
---
front
