### PR TITLE
enh: bump file API file size limit to 50mb

### DIFF
--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -39,9 +39,9 @@ export type FileFormatCategory = "image" | "data" | "code" | "delimited";
 
 // Define max sizes for each category.
 export const MAX_FILE_SIZES: Record<FileFormatCategory, number> = {
-  data: 30 * 1024 * 1024, // 30MB.
-  code: 30 * 1024 * 1024, // 30MB.
-  delimited: 30 * 1024 * 1024, // 30MB.
+  data: 50 * 1024 * 1024, // 50MB.
+  code: 50 * 1024 * 1024, // 50MB.
+  delimited: 50 * 1024 * 1024, // 50MB.
   image: 5 * 1024 * 1024, // 5 MB
 };
 


### PR DESCRIPTION
## Description

We now use the file API for CSV files / tables coming from connectors. So we have a discrepancy between what we allow in the table and what we allow in the file

Taking this opportunity to simply bump everything to 50mb.

## Tests

NA

## Risk

Bigger files

## Deploy Plan

Deploy front