### PR TITLE
enh(Confluence) - Remove skip on pages with empty content

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -288,65 +288,63 @@ async function upsertConfluencePageToDataSource({
   const pageCreatedAt = new Date(page.createdAt);
   const lastPageVersionCreatedAt = new Date(page.version.createdAt);
 
-  if (markdown) {
-    const renderedMarkdown = await renderMarkdownSection(
-      dataSourceConfig,
-      markdown
+  const renderedMarkdown = await renderMarkdownSection(
+    dataSourceConfig,
+    markdown
+  );
+
+  // Log labels info
+  if (page.labels.results.length > 0) {
+    localLogger.info(
+      { labelsCount: page.labels.results.length },
+      "Confluence page has labels."
     );
-
-    // Log labels info
-    if (page.labels.results.length > 0) {
-      localLogger.info(
-        { labelsCount: page.labels.results.length },
-        "Confluence page has labels."
-      );
-    }
-
-    // Use label names for tags instead of IDs
-    const customTags = page.labels.results.map((l) => l.name);
-
-    const tags = [
-      `createdAt:${pageCreatedAt.getTime()}`,
-      `space:${spaceName}`,
-      `title:${page.title}`,
-      `updatedAt:${lastPageVersionCreatedAt.getTime()}`,
-      `version:${page.version.number}`,
-      ...filterCustomTags(customTags, localLogger),
-    ];
-
-    const renderedPage = await renderDocumentTitleAndContent({
-      dataSourceConfig,
-      title: `Page ${page.title}`,
-      createdAt: pageCreatedAt,
-      updatedAt: lastPageVersionCreatedAt,
-      content: renderedMarkdown,
-      additionalPrefixes: {
-        labels: page.labels.results.map((l) => l.name).join(", ") || "none",
-      },
-    });
-
-    const documentId = makePageInternalId(page.id);
-    const documentUrl = makeConfluenceDocumentUrl({
-      baseUrl: confluenceConfig.url,
-      suffix: page._links.tinyui,
-    });
-
-    await upsertDataSourceDocument({
-      dataSourceConfig,
-      documentContent: renderedPage,
-      documentId,
-      documentUrl,
-      loggerArgs,
-      parents,
-      parentId: parents[1],
-      tags,
-      timestampMs: lastPageVersionCreatedAt.getTime(),
-      upsertContext: { sync_type: syncType },
-      title: page.title,
-      mimeType: MIME_TYPES.CONFLUENCE.PAGE,
-      async: true,
-    });
   }
+
+  // Use label names for tags instead of IDs
+  const customTags = page.labels.results.map((l) => l.name);
+
+  const tags = [
+    `createdAt:${pageCreatedAt.getTime()}`,
+    `space:${spaceName}`,
+    `title:${page.title}`,
+    `updatedAt:${lastPageVersionCreatedAt.getTime()}`,
+    `version:${page.version.number}`,
+    ...filterCustomTags(customTags, localLogger),
+  ];
+
+  const renderedPage = await renderDocumentTitleAndContent({
+    dataSourceConfig,
+    title: `Page ${page.title}`,
+    createdAt: pageCreatedAt,
+    updatedAt: lastPageVersionCreatedAt,
+    content: renderedMarkdown,
+    additionalPrefixes: {
+      labels: page.labels.results.map((l) => l.name).join(", ") || "none",
+    },
+  });
+
+  const documentId = makePageInternalId(page.id);
+  const documentUrl = makeConfluenceDocumentUrl({
+    baseUrl: confluenceConfig.url,
+    suffix: page._links.tinyui,
+  });
+
+  await upsertDataSourceDocument({
+    dataSourceConfig,
+    documentContent: renderedPage,
+    documentId,
+    documentUrl,
+    loggerArgs,
+    parents,
+    parentId: parents[1],
+    tags,
+    timestampMs: lastPageVersionCreatedAt.getTime(),
+    upsertContext: { sync_type: syncType },
+    title: page.title,
+    mimeType: MIME_TYPES.CONFLUENCE.PAGE,
+    async: true,
+  });
 }
 
 async function upsertConfluencePageInDb(

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -51,6 +51,7 @@ import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
+
 /**
  * This type represents the ID that should be passed as parentId to a content node to hide it from the UI.
  * This behavior is typically used to hide content nodes whose position in the ContentNodeTree cannot be resolved at time of upsertion.
@@ -287,6 +288,10 @@ async function upsertConfluencePageToDataSource({
   const markdown = turndownService.turndown(page.body.storage.value);
   const pageCreatedAt = new Date(page.createdAt);
   const lastPageVersionCreatedAt = new Date(page.version.createdAt);
+
+  if (!markdown) {
+    logger.warn({ ...loggerArgs }, "Upserting page with empty content.");
+  }
 
   const renderedMarkdown = await renderMarkdownSection(
     dataSourceConfig,


### PR DESCRIPTION
## Description

- In the context of https://github.com/dust-tt/tasks/issues/2224, we observed that certain pages were missing from core, therefore not appearing in the UI and not allowing the discovery of their children pages.
- The page that was the focus of the investigation was not upserted because it had an empty markdown content.
- Given that we now rely on `core` for fetching content nodes, we want to have a node upserted no matter if the page has no value for semantic search or not.
- This PR suggests upserting these nodes as such, as a temporary solution until a better one is crafted.

## Tests

- n/a.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Resync the connector in https://github.com/dust-tt/tasks/issues/2224.