### PR TITLE
Add Poke workspace plugin to check seat count

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
+++ b/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
@@ -5,7 +5,7 @@ import { checkSeatCountForWorkspace } from "@app/lib/api/workspace";
 import { isSeatBased } from "@app/lib/plans/plan_codes";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 
-export const checkSeatCount = createPlugin(
+export const checkSeatCountPlugin = createPlugin(
   {
     id: "check-seat-count",
     name: "Check the seat count",

--- a/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
+++ b/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
@@ -1,8 +1,7 @@
-import { Err, Ok } from "@dust-tt/types";
+import { Ok } from "@dust-tt/types";
 
 import { createPlugin } from "@app/lib/api/poke/types";
 import { checkSeatCountForWorkspace } from "@app/lib/api/workspace";
-import { isSeatBased } from "@app/lib/plans/plan_codes";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 
 export const checkSeatCountPlugin = createPlugin(
@@ -23,20 +22,16 @@ export const checkSeatCountPlugin = createPlugin(
     const workspace = auth.getNonNullableWorkspace();
 
     if (updateQuantity) {
-      const plan = auth.subscription()?.plan;
-      if (plan && isSeatBased(plan)) {
-        const result = await launchUpdateUsageWorkflow({
-          workspaceId: workspace.sId,
-        });
-        if (result.isErr()) {
-          return result;
-        }
-        return new Ok({
-          display: "text",
-          value: "Usage report workflow launched.",
-        });
+      const result = await launchUpdateUsageWorkflow({
+        workspaceId: workspace.sId,
+      });
+      if (result.isErr()) {
+        return result;
       }
-      return new Err(new Error("Plan does not enforce seat-based billing."));
+      return new Ok({
+        display: "text",
+        value: "Usage report workflow launched.",
+      });
     } else {
       const res = await checkSeatCountForWorkspace(workspace);
       if (res.isErr()) {

--- a/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
+++ b/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
@@ -7,7 +7,7 @@ export const checkSeatCount = createPlugin(
   {
     id: "check-seat-count",
     name: "Check the seat count",
-    description: "Check the seat count between Stripe and Dust.",
+    description: "Check the seat count on Stripe.",
     resourceTypes: ["workspaces"],
     args: {
       updateQuantity: {

--- a/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
+++ b/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
@@ -1,0 +1,37 @@
+import { Ok } from "@dust-tt/types";
+
+import { createPlugin } from "@app/lib/api/poke/types";
+import { checkSeatCountForWorkspace } from "@app/lib/api/workspace";
+
+export const checkSeatCount = createPlugin(
+  {
+    id: "check-seat-count",
+    name: "Check the seat count",
+    description:
+      "Check the seat count between Stripe and Dust for PER_SEAT workspace.",
+    resourceTypes: ["workspaces"],
+    args: {
+      updateQuantity: {
+        type: "boolean",
+        label: "Update quantity in Stripe",
+        description: "Update the quantity in Stripe (to use with caution!).",
+      },
+    },
+  },
+  async (auth, resourceId, args) => {
+    const workspace = auth.getNonNullableWorkspace();
+    const res = await checkSeatCountForWorkspace(
+      auth,
+      workspace,
+      args.updateQuantity
+    );
+    if (res.isErr()) {
+      return res;
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Workspace ${workspace.name} upgrade to business plan.`,
+    });
+  }
+);

--- a/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
+++ b/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
@@ -20,7 +20,6 @@ export const checkSeatCount = createPlugin(
   async (auth, resourceId, args) => {
     const workspace = auth.getNonNullableWorkspace();
     const res = await checkSeatCountForWorkspace(
-      auth,
       workspace,
       args.updateQuantity
     );

--- a/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
+++ b/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
@@ -7,8 +7,7 @@ export const checkSeatCount = createPlugin(
   {
     id: "check-seat-count",
     name: "Check the seat count",
-    description:
-      "Check the seat count between Stripe and Dust for PER_SEAT workspace.",
+    description: "Check the seat count between Stripe and Dust.",
     resourceTypes: ["workspaces"],
     args: {
       updateQuantity: {

--- a/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
+++ b/front/lib/api/poke/plugins/workspaces/check_seat_count.ts
@@ -30,7 +30,7 @@ export const checkSeatCount = createPlugin(
 
     return new Ok({
       display: "text",
-      value: `Workspace ${workspace.name} upgrade to business plan.`,
+      value: res.value,
     });
   }
 );

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -1,3 +1,4 @@
+export * from "./check_seat_count";
 export * from "./conversations_retention";
 export * from "./create_space";
 export * from "./disable_sso_enforcement";

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -9,15 +9,24 @@ import type {
   WorkspaceSegmentationType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { ACTIVE_ROLES, Err, Ok, removeNulls } from "@dust-tt/types";
+import {
+  ACTIVE_ROLES,
+  assertNever,
+  Err,
+  Ok,
+  removeNulls,
+} from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
-import { Subscription } from "@app/lib/models/plan";
+import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
 import { WorkspaceHasDomain } from "@app/lib/models/workspace_has_domain";
-import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { getStripeClient, getStripeSubscription } from "@app/lib/plans/stripe";
+import { getUsageToReportForSubscriptionItem } from "@app/lib/plans/usage";
+import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
+import { REPORT_USAGE_METADATA_KEY } from "@app/lib/plans/usage/types";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
 import type { MembershipsPaginationParams } from "@app/lib/resources/membership_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -517,4 +526,89 @@ export async function upgradeWorkspaceToBusinessPlan(
   );
 
   return new Ok(undefined);
+}
+
+export async function checkSeatCountForWorkspace(
+  auth: Authenticator,
+  workspace: LightWorkspaceType,
+  updateQuantity: boolean
+): Promise<Result<string, Error>> {
+  if (!auth.isDustSuperUser()) {
+    throw new Error("Cannot upgrade workspace to plan: not allowed.");
+  }
+
+  const subscription = await Subscription.findOne({
+    where: {
+      workspaceId: workspace.id,
+      status: "active",
+    },
+    include: [Plan],
+  });
+  if (!subscription) {
+    return new Err(new Error("No subscription found."));
+  }
+  if (!subscription.stripeSubscriptionId) {
+    return new Err(new Error("No Stripe subscription ID found."));
+  }
+
+  const stripeSubscription = await getStripeSubscription(
+    subscription.stripeSubscriptionId
+  );
+  if (!stripeSubscription) {
+    return new Err(
+      new Error(
+        `Cannot update usage in subscription: Stripe subscription ${subscription.stripeSubscriptionId} not found.`
+      )
+    );
+  }
+  const { data: subscriptionItems } = stripeSubscription.items;
+
+  const activeSeats = await countActiveSeatsInWorkspace(workspace.sId);
+
+  for (const item of subscriptionItems) {
+    const usageToReportRes = getUsageToReportForSubscriptionItem(item);
+    if (usageToReportRes.isErr()) {
+      return new Err(usageToReportRes.error);
+    }
+
+    const usageToReport = usageToReportRes.value;
+    if (!usageToReport) {
+      continue;
+    }
+
+    switch (usageToReport) {
+      case "FIXED":
+      case "MAU_1":
+      case "MAU_5":
+      case "MAU_10":
+        return new Err(new Error("Subscription is not PER_SEAT-based."));
+      case "PER_SEAT":
+        const stripe = getStripeClient();
+        const currentQuantity = item.quantity;
+
+        if (currentQuantity !== activeSeats) {
+          if (updateQuantity) {
+            await stripe.subscriptionItems.update(item.id, {
+              quantity: activeSeats,
+            });
+            return new Ok(
+              `Quantity updated from ${currentQuantity} to ${activeSeats}.`
+            );
+          }
+          return new Err(
+            new Error(
+              `Different count, Dust: ${activeSeats}, Stripe: ${currentQuantity}`
+            )
+          );
+        }
+        break;
+
+      default:
+        assertNever(usageToReport);
+    }
+    return new Ok(
+      `Counted ${activeSeats} active seats in both Dust and Stripe.`
+    );
+  }
+  return new Err(new Error(`${REPORT_USAGE_METADATA_KEY} metadata not found.`));
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -529,14 +529,9 @@ export async function upgradeWorkspaceToBusinessPlan(
 }
 
 export async function checkSeatCountForWorkspace(
-  auth: Authenticator,
   workspace: LightWorkspaceType,
   updateQuantity: boolean
 ): Promise<Result<string, Error>> {
-  if (!auth.isDustSuperUser()) {
-    throw new Error("Cannot upgrade workspace to plan: not allowed.");
-  }
-
   const subscription = await Subscription.findOne({
     where: {
       workspaceId: workspace.id,

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -539,7 +539,7 @@ export async function checkSeatCountForWorkspace(
     include: [Plan],
   });
   if (!subscription) {
-    return new Err(new Error("No subscription found."));
+    return new Err(new Error("Workspace has no active subscription."));
   }
   if (!subscription.stripeSubscriptionId) {
     return new Err(new Error("No Stripe subscription ID found."));
@@ -551,7 +551,7 @@ export async function checkSeatCountForWorkspace(
   if (!stripeSubscription) {
     return new Err(
       new Error(
-        `Cannot update usage in subscription: Stripe subscription ${subscription.stripeSubscriptionId} not found.`
+        `Cannot check usage in subscription: Stripe subscription ${subscription.stripeSubscriptionId} not found.`
       )
     );
   }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -530,7 +530,7 @@ export async function upgradeWorkspaceToBusinessPlan(
 
 export async function checkSeatCountForWorkspace(
   workspace: LightWorkspaceType,
-  updateQuantity: boolean
+  {updateQuantity}: {updateQuantity: boolean}
 ): Promise<Result<string, Error>> {
   const subscription = await Subscription.findOne({
     where: {

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -592,7 +592,7 @@ export async function checkSeatCountForWorkspace(
           }
           return new Err(
             new Error(
-              `Different count, Dust: ${activeSeats}, Stripe: ${currentQuantity}`
+              `Incorrect quantity on Stripe: ${currentQuantity}, correct value: ${activeSeats}.`
             )
           );
         }
@@ -601,9 +601,7 @@ export async function checkSeatCountForWorkspace(
       default:
         assertNever(usageToReport);
     }
-    return new Ok(
-      `Counted ${activeSeats} active seats in both Dust and Stripe.`
-    );
+    return new Ok(`Correctly found ${activeSeats} active seats on Stripe.`);
   }
   return new Err(new Error(`${REPORT_USAGE_METADATA_KEY} metadata not found.`));
 }

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -48,3 +48,14 @@ export const isUpgraded = (plan: PlanType | null): boolean => {
   }
   return ![FREE_TEST_PLAN_CODE, FREE_NO_PLAN_CODE].includes(plan.code);
 };
+
+/**
+ * Returns true if the plan is seat-based, meaning that users are billed based
+ * on the number of seats taken.
+ */
+export const isSeatBased = (plan: PlanType | null): boolean => {
+  if (!plan) {
+    return false;
+  }
+  return ![PRO_PLAN_SEAT_29_CODE, PRO_PLAN_SEAT_39_CODE].includes(plan.code);
+};

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -48,14 +48,3 @@ export const isUpgraded = (plan: PlanType | null): boolean => {
   }
   return ![FREE_TEST_PLAN_CODE, FREE_NO_PLAN_CODE].includes(plan.code);
 };
-
-/**
- * Returns true if the plan is seat-based, meaning that users are billed based
- * on the number of seats taken.
- */
-export const isSeatBased = (plan: PlanType | null): boolean => {
-  if (!plan) {
-    return false;
-  }
-  return ![PRO_PLAN_SEAT_29_CODE, PRO_PLAN_SEAT_39_CODE].includes(plan.code);
-};

--- a/front/lib/plans/usage/index.ts
+++ b/front/lib/plans/usage/index.ts
@@ -14,7 +14,7 @@ import {
   REPORT_USAGE_METADATA_KEY,
 } from "@app/lib/plans/usage/types";
 
-function getUsageToReportForSubscriptionItem(
+export function getUsageToReportForSubscriptionItem(
   item: Stripe.SubscriptionItem
 ): Result<SupportedReportUsage | null, InvalidReportUsageError> {
   const usageToReport = item.price.metadata[REPORT_USAGE_METADATA_KEY];

--- a/front/migrations/20250220_workspace_check_seat_count.ts
+++ b/front/migrations/20250220_workspace_check_seat_count.ts
@@ -31,7 +31,7 @@ async function checkWorkspaceSeatCount(
     subscription?.plan.code === PRO_PLAN_SEAT_39_CODE
   ) {
     if (execute) {
-      const result = await checkSeatCountForWorkspace(workspace, false);
+      const result = await checkSeatCountForWorkspace(workspace);
       if (result.isOk()) {
         localLogger.info(
           { message: result.value },

--- a/front/migrations/20250220_workspace_check_seat_count.ts
+++ b/front/migrations/20250220_workspace_check_seat_count.ts
@@ -1,0 +1,48 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+
+import { checkSeatCountForWorkspace } from "@app/lib/api/workspace";
+import { Plan, Subscription } from "@app/lib/models/plan";
+import {
+  PRO_PLAN_SEAT_29_CODE,
+  PRO_PLAN_SEAT_39_CODE,
+} from "@app/lib/plans/plan_codes";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+async function checkWorkspaceSeatCount(
+  workspace: LightWorkspaceType,
+  logger: Logger
+) {
+  const subscription = await Subscription.findOne({
+    where: {
+      workspaceId: workspace.id,
+      status: "active",
+    },
+    include: [Plan],
+  });
+  if (
+    subscription?.plan.code === PRO_PLAN_SEAT_29_CODE ||
+    subscription?.plan.code === PRO_PLAN_SEAT_39_CODE
+  ) {
+    const result = await checkSeatCountForWorkspace(workspace, false);
+    if (result.isOk()) {
+      logger.info(
+        { workspaceId: workspace.sId, message: result.value },
+        "Seat count check succeeded."
+      );
+    }
+    if (result.isErr()) {
+      logger.error(
+        { workspaceId: workspace.sId, error: result.error },
+        "Seat count check failed."
+      );
+    }
+  }
+}
+
+makeScript({}, async (args, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await checkWorkspaceSeatCount(workspace, logger);
+  });
+});


### PR DESCRIPTION
## Description

- This PR adds a Poke plugin to check that the seat count is correct on Stripe.
- The plugin has an option to launch the usage workflow instead of only checking, which should be used with caution.
- This PR also contains a script that will check the values recorded in Stripe for all workspaces that have an active seat-based subscription. The goal here is to run this script and possibly turn it into a production check if other inconsistencies are detected.

## Tests

- Tested locally.

## Risk

- Well contained as this is an admin action performed manually.

## Deploy Plan

- Deploy front.
- Run `migrations/20250220_workspace_check_seat_count.ts`.
