### PR TITLE
[front] Remove raw CSV support for table upsert (file only)

### DIFF
--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -63,7 +63,8 @@ async function generateSnippet(
     const schemaRes = await coreAPI.tableValidateCSVContent({
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
-      upsertQueueBucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+      bucket: file.getBucketForVersion("processed").name,
+      bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
     });
 
     if (schemaRes.isErr()) {
@@ -74,7 +75,7 @@ async function generateSnippet(
       });
     }
 
-    let snippet = `CSV file with headers: ${schemaRes.value.schema.map((c) => c.name).join(",")}`;
+    let snippet = `${file.contentType} file with headers: ${schemaRes.value.schema.map((c) => c.name).join(",")}`;
     if (snippet.length > 256) {
       snippet = snippet.slice(0, 242) + "... (truncated)";
     }

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -135,7 +135,9 @@ export async function upsertTableFromCsv({
       });
     }
 
-    if (file.useCase !== "upsert_table") {
+    // Table upserts can come from both upsert_table and conversations use-cases (internal CSV apis
+    // and JIT).
+    if (!["upsert_table", "conversation"].includes(file.useCase)) {
       return new Err({
         type: "invalid_request_error",
         message:

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/csv.ts
@@ -1,13 +1,5 @@
 import handler from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv";
 
-export const config = {
-  api: {
-    bodyParser: {
-      sizeLimit: "50mb",
-    },
-  },
-};
-
 /**
  * @ignoreswagger
  * Legacy endpoint. Still relied on by connectors.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -149,7 +149,7 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
       }
 
       if ((url as string).endsWith("/csv")) {
-        expect(req.upsert_queue_bucket_csv_path).toBe(
+        expect(req.bucket_csv_path).toBe(
           `files/w/${workspace.sId}/${file.sId}/processed`
         );
         expect(req.truncate).toBe(true);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -14,7 +14,7 @@ import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./csv";
 
-const CORE_ROWS_FAKE_RESPONSE = {
+const CORE_TABLES_FAKE_RESPONSE = {
   response: {
     table: {
       project: { project_id: 47 },
@@ -96,77 +96,6 @@ vi.mock("@app/lib/file_storage", () => ({
 }));
 
 describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv", () => {
-  itInTransaction("returns when called with a valid CSV", async (t) => {
-    const { req, res, workspace, globalGroup } =
-      await createPublicApiMockRequest({
-        systemKey: true,
-        method: "POST",
-      });
-
-    const space = await SpaceFactory.global(workspace, t);
-    await GroupSpaceFactory.associate(space, globalGroup);
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      space,
-      t
-    );
-
-    req.query.spaceId = space.sId;
-    req.query.dsId = dataSourceView.dataSource.sId;
-
-    req.body = {
-      name: "footable",
-      truncate: true,
-      title: "Wonderful table",
-      mimeType: "text/csv",
-      description: "desc",
-      csv: "foo,bar,viz\n1,2,3\n4,5,6",
-      tableId: "fooTable-1",
-    };
-
-    // First fetch is to create the table
-    global.fetch = vi.fn().mockImplementation(async (url, init) => {
-      const req = JSON.parse(init.body);
-
-      if ((url as string).endsWith("/tables")) {
-        expect(req.table_id).toBe("fooTable-1");
-        expect(req.name).toBe("footable");
-        expect(req.parents[0]).toBe("fooTable-1");
-        expect(req.source_url).toBeNull();
-        return Promise.resolve(
-          new Response(JSON.stringify(CORE_ROWS_FAKE_RESPONSE), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        );
-      }
-
-      if ((url as string).endsWith("/rows")) {
-        expect(req.rows[0].row_id).toBe("0");
-        expect(req.rows[0].value.bar).toBe(2);
-        expect(req.rows[1].value.foo).toBe(4);
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              response: {
-                success: true,
-              },
-            }),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            }
-          )
-        );
-      }
-    });
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData()).toEqual(CORE_ROWS_FAKE_RESPONSE.response);
-  });
-
   itInTransaction("succesfully upserts a CSV received as file", async (t) => {
     const { req, res, workspace, globalGroup } =
       await createPublicApiMockRequest({
@@ -212,17 +141,18 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
         expect(req.parents[0]).toBe("fooTable-1");
         expect(req.source_url).toBeNull();
         return Promise.resolve(
-          new Response(JSON.stringify(CORE_ROWS_FAKE_RESPONSE), {
+          new Response(JSON.stringify(CORE_TABLES_FAKE_RESPONSE), {
             status: 200,
             headers: { "Content-Type": "application/json" },
           })
         );
       }
 
-      if ((url as string).endsWith("/rows")) {
-        expect(req.rows[0].row_id).toBe("0");
-        expect(req.rows[0].value.bar).toBe(2);
-        expect(req.rows[1].value.foo).toBe(4);
+      if ((url as string).endsWith("/csv")) {
+        expect(req.upsert_queue_bucket_csv_path).toBe(
+          `files/w/${workspace.sId}/${file.sId}/processed`
+        );
+        expect(req.truncate).toBe(true);
         return Promise.resolve(
           new Response(
             JSON.stringify({

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -15,14 +15,6 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 
-export const config = {
-  api: {
-    bodyParser: {
-      sizeLimit: "50mb",
-    },
-  },
-};
-
 /**
  * @ignoreswagger
  * System API key only endpoint. Undocumented.
@@ -127,6 +119,7 @@ async function handler(
           case "invalid_url":
           case "title_too_long":
           case "missing_csv":
+          case "invalid_csv":
             return apiError(req, res, {
               status_code: 400,
               api_error: {
@@ -139,14 +132,6 @@ async function handler(
               status_code: 500,
               api_error: {
                 type: "data_source_error",
-                message: upsertRes.error.message,
-              },
-            });
-          case "invalid_csv":
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_rows_request_error",
                 message: upsertRes.error.message,
               },
             });

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -226,7 +226,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
         }
 
         if ((url as string).endsWith("/csv")) {
-          expect(req.upsert_queue_bucket_csv_path).toBe(
+          expect(req.bucket_csv_path).toBe(
             `files/w/${workspace.sId}/${file.sId}/processed`
           );
           expect(req.truncate).toBe(true);
@@ -246,7 +246,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
         }
 
         if ((url as string).endsWith("/validate_csv_content")) {
-          expect(req.upsert_queue_bucket_csv_path).toBe(
+          expect(req.bucket_csv_path).toBe(
             `files/w/${workspace.sId}/${file.sId}/processed`
           );
           return Promise.resolve(

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -10,7 +10,7 @@ import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./files";
 
-const CORE_FAKE_RESPONSE = {
+const CORE_TABLES_FAKE_RESPONSE = {
   response: {
     table: {
       project: { project_id: 47 },
@@ -35,6 +35,28 @@ const CORE_FAKE_RESPONSE = {
       remote_database_table_id: null,
       remote_database_secret_id: null,
     },
+  },
+};
+
+const CORE_VALIDATE_CSV_FAKE_RESPONSE = {
+  response: {
+    schema: [
+      {
+        name: "foo",
+        value_type: "int",
+        possible_values: ["1", "4"],
+      },
+      {
+        name: "bar",
+        value_type: "int",
+        possible_values: ["2", "5"],
+      },
+      {
+        name: "baz",
+        value_type: "int",
+        possible_values: ["3", "6"],
+      },
+    ],
   },
 };
 
@@ -195,7 +217,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
           expect(req.name).toBe("Test Table");
           expect(req.description).toBe("Test Description");
           return Promise.resolve(
-            new Response(JSON.stringify(CORE_FAKE_RESPONSE), {
+            new Response(JSON.stringify(CORE_TABLES_FAKE_RESPONSE), {
               status: 200,
               headers: { "Content-Type": "application/json" },
             })
@@ -203,10 +225,11 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
           //
         }
 
-        if ((url as string).endsWith("/rows")) {
-          expect(req.rows[0].row_id).toBe("0");
-          expect(req.rows[0].value.bar).toBe(2);
-          expect(req.rows[1].value.foo).toBe(4);
+        if ((url as string).endsWith("/csv")) {
+          expect(req.upsert_queue_bucket_csv_path).toBe(
+            `files/w/${workspace.sId}/${file.sId}/processed`
+          );
+          expect(req.truncate).toBe(true);
           return Promise.resolve(
             new Response(
               JSON.stringify({
@@ -219,6 +242,18 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
                 headers: { "Content-Type": "application/json" },
               }
             )
+          );
+        }
+
+        if ((url as string).endsWith("/validate_csv_content")) {
+          expect(req.upsert_queue_bucket_csv_path).toBe(
+            `files/w/${workspace.sId}/${file.sId}/processed`
+          );
+          return Promise.resolve(
+            new Response(JSON.stringify(CORE_VALIDATE_CSV_FAKE_RESPONSE), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            })
           );
         }
       });

--- a/front/temporal/upsert_tables/activities.ts
+++ b/front/temporal/upsert_tables/activities.ts
@@ -86,7 +86,6 @@ export async function upsertTableActivity(
     tableTags: upsertQueueItem.tableTags || [],
     tableParentId: upsertQueueItem.tableParentId || null,
     tableParents: upsertQueueItem.tableParents || [],
-    csv: upsertQueueItem.csv,
     fileId: upsertQueueItem.fileId ?? null,
     truncate: upsertQueueItem.truncate,
     title: upsertQueueItem.title,
@@ -116,23 +115,6 @@ export async function upsertTableActivity(
       message: `Upsert error: ${JSON.stringify(tableRes.error)}`,
       type: "upsert_queue_upsert_table_error",
     };
-    if (
-      "csvParsingError" in tableRes.error &&
-      (tableRes.error.csvParsingError.type === "too_many_columns" ||
-        tableRes.error.csvParsingError.type === "invalid_header")
-    ) {
-      logger.error(
-        {
-          error: tableRes.error,
-          latencyMs: Date.now() - upsertTimestamp,
-          delaySinceEnqueueMs: Date.now() - enqueueTimestamp,
-          csvSize: upsertQueueItem.csv?.length || 0,
-          panic: true,
-        },
-        "[UpsertQueue] Invalid table (headers or columns) -- skipping, this should have been caught prior to enqueuing"
-      );
-      return;
-    }
 
     throw error;
   }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2218,8 +2218,7 @@ export const UpsertTableFromCsvRequestSchema = z.object({
   mimeType: z.string(),
   sourceUrl: z.string().nullable().optional(),
   tableId: z.string(),
-  csv: z.string().optional(),
-  fileId: z.string().optional(),
+  fileId: z.string(),
 });
 
 export type UpsertTableFromCsvRequestType = z.infer<


### PR DESCRIPTION
## Description

- remove raw CSV support in favor of files in front

Still WIP

## Tests

Covered by tests

Things to test in dev:
- [x] Conversation ingestion of excel files
- [x] Conversation ingestion of CSVs
- [ ] Conversation outputing files ingestion
- [x] e2e upsert of tables from connectors
- [x] upsert of tables from the UI
- [x] upsert of CSV with truncation=false

## Risk

High on table upserts. Mostly mitigated by monitoring schema/row mismatches here:

https://app.datadoghq.eu/logs?query=%22%5BCSV-FILE%5D%20mistmatch%3A%20row%20and%20schema%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1739989435826&to_ts=1740003835826&live=true

## Deploy Plan

- deploy `front`