### PR TITLE
Remove retrieval document sorting

### DIFF
--- a/front/lib/resources/retrieval_document_resource.ts
+++ b/front/lib/resources/retrieval_document_resource.ts
@@ -104,7 +104,6 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
           [Op.in]: actionIds,
         },
       },
-      order: [["documentTimestamp", "DESC"]],
       include: [
         {
           model: RetrievalDocumentChunk,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1740046405045069).

This PR removes the sort on `RetrievalDocument`. The sort is not relevant/used but COSTLY since the only place that uses this function, re-sort the results:

https://github.com/dust-tt/dust/blob/0520bd9d8c3b833d9df8f2e5d52e5e6beb7e81fc/front/lib/api/assistant/actions/retrieval.ts#L851-896

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
