### PR TITLE
fix(Google Drive) - Fix catching of TablesError

### DIFF
--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -192,17 +192,12 @@ export async function updateParentsField(
         sheet.driveFileId,
         sheet.driveSheetId
       );
-      // TODO(2025-02-19 aubin): remove this after the entries are unstuck.
-      try {
-        await updateDataSourceTableParents({
-          dataSourceConfig,
-          tableId,
-          parents: [tableId, ...parentIds],
-          parentId: file.dustFileId,
-        });
-      } catch (e) {
-        return;
-      }
+      await updateDataSourceTableParents({
+        dataSourceConfig,
+        tableId,
+        parents: [tableId, ...parentIds],
+        parentId: file.dustFileId,
+      });
     }
   } else {
     await updateDataSourceDocumentParents({


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/dust/pull/10877/files introduced an error in the catching of `TablesError`.
- Still unsure as to why an additional try catch is needed, anyway this PR fixes that.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy connectors.
- Remove stuck entries in upsert queue.