### PR TITLE
enh(sparkle): pagination row count cap

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.410",
+  "version": "0.2.411",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.410",
+      "version": "0.2.411",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.410",
+  "version": "0.2.411",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -69,6 +69,7 @@ interface ColumnBreakpoint {
 interface DataTableProps<TData extends TBaseData> {
   data: TData[];
   totalRowCount?: number;
+  rowCountIsCapped?: boolean;
   columns: ColumnDef<TData, any>[]; // eslint-disable-line @typescript-eslint/no-explicit-any
   className?: string;
   widthClassName?: string;
@@ -95,6 +96,7 @@ function shouldRenderColumn(
 export function DataTable<TData extends TBaseData>({
   data,
   totalRowCount,
+  rowCountIsCapped = false,
   columns,
   className,
   widthClassName = "s-w-full",
@@ -254,6 +256,7 @@ export function DataTable<TData extends TBaseData>({
             pagination={table.getState().pagination}
             setPagination={table.setPagination}
             rowCount={table.getRowCount()}
+            rowCountIsCapped={rowCountIsCapped}
           />
         </div>
       )}

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -15,6 +15,7 @@ interface PaginationProps {
   showDetails?: boolean;
   showPageButtons?: boolean;
   rowCount: number;
+  rowCountIsCapped?: boolean;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
 }
@@ -24,6 +25,7 @@ export function Pagination({
   showDetails = true,
   showPageButtons = true,
   rowCount,
+  rowCountIsCapped = false,
   pagination,
   setPagination,
 }: PaginationProps) {
@@ -110,7 +112,9 @@ export function Pagination({
       >
         {controlsAreHidden
           ? `${rowCount} items`
-          : `Showing ${firstItemOnPageIndex}-${lastItemOnPageIndex} of ${rowCount} items`}
+          : `Showing ${firstItemOnPageIndex}-${lastItemOnPageIndex} of ${rowCount}${
+              rowCountIsCapped ? "+" : ""
+            } items`}
       </span>
     </div>
   );

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -421,3 +421,58 @@ export const DataTablePaginatedServerSideExample = () => {
     </div>
   );
 };
+
+export const DataTablePaginatedServerSideRowCountCappedExample = () => {
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 2,
+  });
+  const [sorting, setSorting] = React.useState<SortingState>([
+    { id: "name", desc: true },
+  ]);
+  const [filter, setFilter] = React.useState<string>("");
+  const rows = useMemo(() => {
+    if (sorting.length > 0) {
+      const order = sorting[0].desc ? -1 : 1;
+      return data
+        .sort((a: Data, b: Data) => {
+          return (
+            a.name.toLowerCase().localeCompare(b.name.toLowerCase()) * order
+          );
+        })
+        .slice(
+          pagination.pageIndex * pagination.pageSize,
+          (pagination.pageIndex + 1) * pagination.pageSize
+        );
+    }
+    return data.slice(
+      pagination.pageIndex * pagination.pageSize,
+      (pagination.pageIndex + 1) * pagination.pageSize
+    );
+  }, [data, pagination, sorting]);
+  return (
+    <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
+      <Input
+        name="filter"
+        placeholder="Filter"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+      />
+      <DataTable
+        className="s-w-full s-max-w-4xl s-overflow-x-auto"
+        data={rows}
+        totalRowCount={data.length}
+        rowCountIsCapped={true}
+        filter={filter}
+        filterColumn="name"
+        pagination={pagination}
+        setPagination={setPagination}
+        columns={columns}
+        sorting={sorting}
+        setSorting={setSorting}
+        columnsBreakpoints={{ lastUpdated: "sm" }}
+        isServerSideSorting={true}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

Needed for https://github.com/dust-tt/tasks/issues/2218

We limit number of items we show in a ds view to 1000, and we should "showing x items out of y", but if y===1000 we need to display 1000+

<img width="973" alt="Screenshot 2025-02-20 at 14 27 45" src="https://github.com/user-attachments/assets/e794d6de-fdd1-4802-b211-44759575c7ad" />



## Tests

N/A

## Risk

N/A

## Deploy Plan

Publish sparkle