### PR TITLE
Remove unused csv content path

### DIFF
--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -117,7 +117,7 @@ export const TableUploadOrEditModal = ({
             parentId: undefined,
             parents: undefined,
             async: undefined,
-            csv: undefined,
+            fileId: undefined,
           });
         } else {
           // Replacing the content of an existing table with a new file.

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -10,14 +10,6 @@ import type { DataSourceViewResource } from "@app/lib/resources/data_source_view
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
-export const config = {
-  api: {
-    bodyParser: {
-      sizeLimit: "8mb",
-    },
-  },
-};
-
 export type GetDataSourceViewTableResponseBody = {
   table: CoreAPITable;
 };

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -16,14 +16,6 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 
-export const config = {
-  api: {
-    bodyParser: {
-      sizeLimit: "8mb",
-    },
-  },
-};
-
 export type PatchTableResponseBody = {
   table?: { table_id: string };
 };

--- a/types/src/front/api_handlers/public/data_sources.ts
+++ b/types/src/front/api_handlers/public/data_sources.ts
@@ -71,7 +71,7 @@ export const PatchDataSourceTableRequestBodySchema = t.type({
   parents: t.union([t.array(t.string), t.undefined, t.null]),
   truncate: t.boolean,
   async: t.union([t.boolean, t.undefined]),
-  csv: t.union([t.string, t.undefined]),
+  fileId: t.union([t.string, t.undefined]),
   title: t.string,
   mimeType: t.string,
   sourceUrl: t.union([t.string, t.undefined, t.null]),


### PR DESCRIPTION
## Description

Remove possibility of uploading CSV content from our internal table patch endpoint (not used anyway right now, this endpoint is only used with csv: undefined to patch the table information)

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`