### PR TITLE
[front] - refacto: DataSourceViewsSelector

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -18,7 +18,7 @@ import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
-import { DataSourceViewsSelector } from "@app/components/data_source_view/DataSourceViewSelector";
+import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
 import {
   supportsDocumentsData,
   supportsStructuredData,
@@ -107,7 +107,7 @@ export default function AssistantBuilderDataSourceModal({
             id="dataSourceViewsSelector"
             className="overflow-y-auto scrollbar-hide"
           >
-            <DataSourceViewsSelector
+            <DataSourceViewsSpaceSelector
               useCase="assistantBuilder"
               dataSourceViews={supportedDataSourceViewsForViewType}
               allowedSpaces={allowedSpaces}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -4,7 +4,6 @@ import {
   FolderIcon,
   GlobeAltIcon,
   ListCheckIcon,
-  Spinner,
   Tree,
 } from "@dust-tt/sparkle";
 import type {
@@ -13,15 +12,11 @@ import type {
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
   LightWorkspaceType,
-  SpaceType,
 } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
-import { useCallback } from "react";
-import { useMemo } from "react";
-
-import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
+import { useCallback, useMemo } from "react";
 import type {
   ContentNodeTreeItemStatus,
   TreeSelectionModelUpdater,
@@ -39,7 +34,6 @@ import {
   isWebsite,
 } from "@app/lib/data_sources";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
-import { useSpaces } from "@app/lib/swr/spaces";
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 
@@ -85,15 +79,16 @@ const getNodesFromConfig = (
     {}
   );
 
+export type useCaseDataSourceViewsSelector =
+  | "spaceDatasourceManagement"
+  | "assistantBuilder"
+  | "transcriptsProcessing"
+  | "trackerBuilder";
+
 interface DataSourceViewsSelectorProps {
   owner: LightWorkspaceType;
-  useCase:
-    | "spaceDatasourceManagement"
-    | "assistantBuilder"
-    | "transcriptsProcessing"
-    | "trackerBuilder";
+  useCase: useCaseDataSourceViewsSelector;
   dataSourceViews: DataSourceViewType[];
-  allowedSpaces?: SpaceType[];
   selectionConfigurations: DataSourceViewSelectionConfigurations;
   setSelectionConfigurations: Dispatch<
     SetStateAction<DataSourceViewSelectionConfigurations>
@@ -106,14 +101,11 @@ export function DataSourceViewsSelector({
   owner,
   useCase,
   dataSourceViews,
-  allowedSpaces,
   selectionConfigurations,
   setSelectionConfigurations,
   viewType,
   isRootSelectable,
 }: DataSourceViewsSelectorProps) {
-  const { spaces, isSpacesLoading } = useSpaces({ workspaceId: owner.sId });
-
   const includesConnectorIDs: (string | null)[] = [];
   const excludesConnectorIDs: (string | null)[] = [];
 
@@ -161,84 +153,59 @@ export function DataSourceViewsSelector({
     managedDsv.length > 0 &&
     (useCase === "assistantBuilder" || useCase === "trackerBuilder");
 
-  const defaultSpace = useMemo(() => {
-    const firstKey = Object.keys(selectionConfigurations)[0] ?? null;
-    return firstKey
-      ? selectionConfigurations[firstKey]?.dataSourceView?.spaceId ?? ""
-      : "";
-  }, [selectionConfigurations]);
-
-  const filteredSpaces = useMemo(() => {
-    const spaceIds = [...new Set(dataSourceViews.map((dsv) => dsv.spaceId))];
-
-    return spaces.filter((s) => spaceIds.includes(s.sId));
-  }, [spaces, dataSourceViews]);
-
-  if (isSpacesLoading) {
-    return <Spinner />;
-  }
-
-  if (filteredSpaces.length > 1) {
-    return (
-      <SpaceSelector
-        spaces={filteredSpaces}
-        allowedSpaces={allowedSpaces}
-        defaultSpace={defaultSpace}
-        renderChildren={(space) => {
-          const dataSourceViewsForSpace = space
-            ? dataSourceViews.filter((dsv) => dsv.spaceId === space.sId)
-            : dataSourceViews;
-
-          if (dataSourceViewsForSpace.length === 0) {
-            return <>No data source in this space.</>;
-          }
-
-          return (
-            <DataSourceViewsSelector
-              owner={owner}
-              useCase={useCase}
-              dataSourceViews={dataSourceViewsForSpace}
-              selectionConfigurations={selectionConfigurations}
-              setSelectionConfigurations={setSelectionConfigurations}
-              viewType={viewType}
-              isRootSelectable={isRootSelectable}
-            />
-          );
-        }}
-      />
-    );
-  } else {
-    return (
-      <Tree isLoading={false}>
-        {displayManagedDsv && (
-          <Tree.Item
-            key="connected"
-            label="Connected Data"
-            visual={CloudArrowLeftRightIcon}
-            type="node"
-          >
-            {orderDatasourceViews
-              .filter((dsv) => isManaged(dsv.dataSource))
-              .map((dataSourceView) => (
-                <DataSourceViewSelector
-                  key={dataSourceView.sId}
-                  owner={owner}
-                  selectionConfiguration={
-                    selectionConfigurations[dataSourceView.sId] ??
-                    defaultSelectionConfiguration(dataSourceView)
-                  }
-                  setSelectionConfigurations={setSelectionConfigurations}
-                  viewType={viewType}
-                  isRootSelectable={isRootSelectable}
-                  defaultCollapsed={filteredDSVs.length > 1}
-                  useCase={useCase}
-                />
-              ))}
-          </Tree.Item>
-        )}
-        {managedDsv.length > 0 &&
-          useCase === "spaceDatasourceManagement" &&
-          managedDsv.map((dataSourceView) => (
+  return (
+    <Tree isLoading={false}>
+      {displayManagedDsv && (
+        <Tree.Item
+          key="connected"
+          label="Connected Data"
+          visual={CloudArrowLeftRightIcon}
+          type="node"
+        >
+          {orderDatasourceViews
+            .filter((dsv) => isManaged(dsv.dataSource))
+            .map((dataSourceView) => (
+              <DataSourceViewSelector
+                key={dataSourceView.sId}
+                owner={owner}
+                selectionConfiguration={
+                  selectionConfigurations[dataSourceView.sId] ??
+                  defaultSelectionConfiguration(dataSourceView)
+                }
+                setSelectionConfigurations={setSelectionConfigurations}
+                viewType={viewType}
+                isRootSelectable={isRootSelectable}
+                defaultCollapsed={filteredDSVs.length > 1}
+                useCase={useCase}
+              />
+            ))}
+        </Tree.Item>
+      )}
+      {managedDsv.length > 0 &&
+        useCase === "spaceDatasourceManagement" &&
+        managedDsv.map((dataSourceView) => (
+          <DataSourceViewSelector
+            key={dataSourceView.sId}
+            owner={owner}
+            selectionConfiguration={
+              selectionConfigurations[dataSourceView.sId] ??
+              defaultSelectionConfiguration(dataSourceView)
+            }
+            setSelectionConfigurations={setSelectionConfigurations}
+            viewType={viewType}
+            isRootSelectable={false}
+            defaultCollapsed={filteredDSVs.length > 1}
+            useCase={useCase}
+          />
+        ))}
+      {folders.length > 0 && (
+        <Tree.Item
+          key="folders"
+          label="Folders"
+          visual={FolderIcon}
+          type="node"
+        >
+          {folders.map((dataSourceView) => (
             <DataSourceViewSelector
               key={dataSourceView.sId}
               owner={owner}
@@ -248,62 +215,39 @@ export function DataSourceViewsSelector({
               }
               setSelectionConfigurations={setSelectionConfigurations}
               viewType={viewType}
-              isRootSelectable={false}
+              isRootSelectable={isRootSelectable}
               defaultCollapsed={filteredDSVs.length > 1}
               useCase={useCase}
             />
           ))}
-        {folders.length > 0 && (
-          <Tree.Item
-            key="folders"
-            label="Folders"
-            visual={FolderIcon}
-            type="node"
-          >
-            {folders.map((dataSourceView) => (
-              <DataSourceViewSelector
-                key={dataSourceView.sId}
-                owner={owner}
-                selectionConfiguration={
-                  selectionConfigurations[dataSourceView.sId] ??
-                  defaultSelectionConfiguration(dataSourceView)
-                }
-                setSelectionConfigurations={setSelectionConfigurations}
-                viewType={viewType}
-                isRootSelectable={isRootSelectable}
-                defaultCollapsed={filteredDSVs.length > 1}
-                useCase={useCase}
-              />
-            ))}
-          </Tree.Item>
-        )}
-        {websites.length > 0 && useCase !== "transcriptsProcessing" && (
-          <Tree.Item
-            key="websites"
-            label="Websites"
-            visual={GlobeAltIcon}
-            type="node"
-          >
-            {websites.map((dataSourceView) => (
-              <DataSourceViewSelector
-                key={dataSourceView.sId}
-                owner={owner}
-                selectionConfiguration={
-                  selectionConfigurations[dataSourceView.sId] ??
-                  defaultSelectionConfiguration(dataSourceView)
-                }
-                setSelectionConfigurations={setSelectionConfigurations}
-                viewType={viewType}
-                isRootSelectable={isRootSelectable}
-                defaultCollapsed={filteredDSVs.length > 1}
-                useCase={useCase}
-              />
-            ))}
-          </Tree.Item>
-        )}
-      </Tree>
-    );
-  }
+        </Tree.Item>
+      )}
+      {websites.length > 0 && useCase !== "transcriptsProcessing" && (
+        <Tree.Item
+          key="websites"
+          label="Websites"
+          visual={GlobeAltIcon}
+          type="node"
+        >
+          {websites.map((dataSourceView) => (
+            <DataSourceViewSelector
+              key={dataSourceView.sId}
+              owner={owner}
+              selectionConfiguration={
+                selectionConfigurations[dataSourceView.sId] ??
+                defaultSelectionConfiguration(dataSourceView)
+              }
+              setSelectionConfigurations={setSelectionConfigurations}
+              viewType={viewType}
+              isRootSelectable={isRootSelectable}
+              defaultCollapsed={filteredDSVs.length > 1}
+              useCase={useCase}
+            />
+          ))}
+        </Tree.Item>
+      )}
+    </Tree>
+  );
 }
 
 interface DataSourceViewSelectorProps {

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -17,6 +17,7 @@ import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useMemo } from "react";
+
 import type {
   ContentNodeTreeItemStatus,
   TreeSelectionModelUpdater,

--- a/front/components/data_source_view/DataSourceViewsSpaceSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewsSpaceSelector.tsx
@@ -46,13 +46,36 @@ export const DataSourceViewsSpaceSelector = ({
       : "";
   }, [selectionConfigurations]);
 
+  const filteredSpaces = useMemo(() => {
+    const spaceIds = [...new Set(dataSourceViews.map((dsv) => dsv.spaceId))];
+    return spaces.filter((s) => spaceIds.includes(s.sId));
+  }, [spaces, dataSourceViews]);
+
   if (isSpacesLoading) {
     return <Spinner />;
   }
 
+  if (filteredSpaces.length === 1) {
+    const dataSourceViewsForSpace = filteredSpaces[0]
+      ? dataSourceViews.filter((dsv) => dsv.spaceId === filteredSpaces[0].sId)
+      : dataSourceViews;
+
+    return (
+      <DataSourceViewsSelector
+        owner={owner}
+        useCase={useCase}
+        dataSourceViews={dataSourceViewsForSpace}
+        selectionConfigurations={selectionConfigurations}
+        setSelectionConfigurations={setSelectionConfigurations}
+        viewType={viewType}
+        isRootSelectable={isRootSelectable}
+      />
+    );
+  }
+
   return (
     <SpaceSelector
-      spaces={spaces}
+      spaces={filteredSpaces}
       allowedSpaces={allowedSpaces}
       defaultSpace={defaultSpace}
       renderChildren={(space) => {

--- a/front/components/trackers/TrackerBuilderDataSourceModal.tsx
+++ b/front/components/trackers/TrackerBuilderDataSourceModal.tsx
@@ -19,7 +19,7 @@ import { assertNever } from "@dust-tt/types";
 import type { SetStateAction } from "react";
 import { useCallback, useMemo, useState } from "react";
 
-import { DataSourceViewsSelector } from "@app/components/data_source_view/DataSourceViewSelector";
+import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
 import {
   supportsDocumentsData,
   supportsStructuredData,
@@ -91,7 +91,7 @@ export default function TrackerBuilderDataSourceModal({
             id="dataSourceViewsSelector"
             className="overflow-y-auto scrollbar-hide"
           >
-            <DataSourceViewsSelector
+            <DataSourceViewsSpaceSelector
               useCase="trackerBuilder"
               dataSourceViews={supportedDataSourceViewsForViewType}
               allowedSpaces={allowedSpaces}

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -34,6 +34,7 @@ import { useEffect, useState } from "react";
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -46,7 +47,6 @@ import {
 } from "@app/lib/swr/labs";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { PatchTranscriptsConfiguration } from "@app/pages/api/w/[wId]/labs/transcripts/[tId]";
-import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
 
 const defaultTranscriptConfigurationState = {
   provider: "",

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -34,7 +34,6 @@ import { useEffect, useState } from "react";
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { DataSourceViewsSelector } from "@app/components/data_source_view/DataSourceViewSelector";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -47,6 +46,7 @@ import {
 } from "@app/lib/swr/labs";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { PatchTranscriptsConfiguration } from "@app/pages/api/w/[wId]/labs/transcripts/[tId]";
+import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
 
 const defaultTranscriptConfigurationState = {
   provider: "",
@@ -886,7 +886,7 @@ export default function LabsTranscriptsIndex({
                           {!isSpacesLoading &&
                             storeInFolder &&
                             selectionConfigurations && (
-                              <DataSourceViewsSelector
+                              <DataSourceViewsSpaceSelector
                                 useCase="transcriptsProcessing"
                                 dataSourceViews={dataSourcesViews}
                                 allowedSpaces={spaces}
@@ -897,7 +897,7 @@ export default function LabsTranscriptsIndex({
                                 setSelectionConfigurations={
                                   handleSetSelectionConfigurations
                                 }
-                                viewType={"documents"}
+                                viewType="documents"
                                 isRootSelectable={true}
                               />
                             )}


### PR DESCRIPTION
## Description

This PR aims at splitting the `DataSourceViewsSelector` into two components to avoid recursive rendering.

## Risk

Breaking dsv selection. Has been tested locally.

## Deploy Plan

Deploy front