### PR TITLE
Revoke user: Launch workflow before tracking membership and log error

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -18,6 +18,7 @@ export async function revokeAndTrackMembership(
   });
 
   if (revokeResult.isOk()) {
+    await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
     void ServerSideTracking.trackRevokeMembership({
       user: user.toJSON(),
       workspace,
@@ -25,8 +26,6 @@ export async function revokeAndTrackMembership(
       startAt: revokeResult.value.startAt,
       endAt: revokeResult.value.endAt,
     });
-
-    await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
   }
 
   return revokeResult;

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -483,7 +483,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     Result<
       { role: MembershipRoleType; startAt: Date; endAt: Date },
       {
-        type: "not_found" | "already_revoked";
+        type: "not_found" | "already_revoked" | "invalid_end_at";
       }
     >
   > {
@@ -496,7 +496,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       return new Err({ type: "not_found" });
     }
     if (endAt < membership.startAt) {
-      throw new Error("endAt must be after startAt");
+      return new Err({ type: "invalid_end_at" });
     }
     if (membership.endAt) {
       return new Err({ type: "already_revoked" });

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -73,6 +73,15 @@ async function handler(
           case "already_revoked":
             // Should not happen, but we ignore.
             break;
+          case "invalid_end_at":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Can't revoke membership before it has started.",
+              },
+            });
+            break;
           default:
             assertNever(revokeResult.error.type);
         }

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -76,7 +76,7 @@ async function handler(
           switch (revokeResult.error.type) {
             case "not_found":
               logger.error(
-                { revokeResult },
+                { panic: true, revokeResult },
                 "Failed to revoke membership and track usage."
               );
               return apiError(req, res, {
@@ -89,7 +89,7 @@ async function handler(
             case "already_revoked":
             case "invalid_end_at":
               logger.error(
-                { revokeResult },
+                { panic: true, revokeResult },
                 "Failed to revoke membership and track usage."
               );
               break;

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -13,6 +13,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { showDebugTools } from "@app/lib/development";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 export type PostMemberResponseBody = {
@@ -74,6 +75,10 @@ async function handler(
         if (revokeResult.isErr()) {
           switch (revokeResult.error.type) {
             case "not_found":
+              logger.error(
+                { revokeResult },
+                "Failed to revoke membership and track usage."
+              );
               return apiError(req, res, {
                 status_code: 404,
                 api_error: {
@@ -82,7 +87,11 @@ async function handler(
                 },
               });
             case "already_revoked":
-              // Should not happen, but we ignore.
+            case "invalid_end_at":
+              logger.error(
+                { revokeResult },
+                "Failed to revoke membership and track usage."
+              );
               break;
             default:
               assertNever(revokeResult.error.type);

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -13,6 +13,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { showDebugTools } from "@app/lib/development";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 export type PostMemberResponseBody = {
@@ -82,7 +83,11 @@ async function handler(
                 },
               });
             case "already_revoked":
-              // Should not happen, but we ignore.
+            case "invalid_end_at":
+              logger.error(
+                { revokeResult },
+                "Failed to revoke membership and track usage."
+              );
               break;
             default:
               assertNever(revokeResult.error.type);

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -9,14 +9,14 @@ import { updateWorkspaceUsageWorkflow } from "@app/temporal/usage_queue/workflow
 
 async function shouldProcessUsageUpdate(workflowId: string) {
   // Compute the max usage of the workspace once per hour.
-  const hasRunInPastHour = await rateLimiter({
+  const remainingRunsThisHour = await rateLimiter({
     key: workflowId,
     maxPerTimeframe: 1,
     timeframeSeconds: 60 * 60, // 1 hour.
     logger: logger,
   });
 
-  return hasRunInPastHour === 0;
+  return remainingRunsThisHour > 0;
 }
 
 /**


### PR DESCRIPTION
## Description

This PR:
- Fix the rate limit check on the usage workflow.
- Improve logging hygiene around the usage report:

When we revoke:

If success:
- first launch the workflow.
- then trackRevokeMembership.

Else: 
- log an error. Do we want it panic? 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front; 