### PR TITLE
[Search-KB] Use keyword search in knowledge (behind FF)

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -25,7 +25,10 @@ import type {
   SpaceType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { isValidContentNodesViewType } from "@dust-tt/types";
+import {
+  isValidContentNodesViewType,
+  MIN_SEARCH_QUERY_SIZE,
+} from "@dust-tt/types";
 import type {
   CellContext,
   ColumnDef,
@@ -59,7 +62,6 @@ import {
 import { useSpaces, useSpaceSearch } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
-import { MIN_KEYWORD_SEARCH_LENGTH } from "@app/pages/api/w/[wId]/spaces/[spaceId]/search";
 
 const DEFAULT_VIEW_TYPE = "all";
 
@@ -289,17 +291,14 @@ export const SpaceDataSourceViewContentList = ({
 
   const isTyping = useMemo(() => {
     return (
-      dataSourceSearch.length >= MIN_KEYWORD_SEARCH_LENGTH &&
+      dataSourceSearch.length >= MIN_SEARCH_QUERY_SIZE &&
       debouncedSearch !== dataSourceSearch &&
       searchFeatureFlag
     );
   }, [dataSourceSearch, debouncedSearch, searchFeatureFlag]);
 
   const nodes = useMemo(() => {
-    if (
-      dataSourceSearch.length >= MIN_KEYWORD_SEARCH_LENGTH &&
-      searchFeatureFlag
-    ) {
+    if (dataSourceSearch.length >= MIN_SEARCH_QUERY_SIZE && searchFeatureFlag) {
       return searchResultNodes;
     }
     return childrenNodes;
@@ -424,7 +423,7 @@ export const SpaceDataSourceViewContentList = ({
     if (searchFeatureFlag) {
       const timeout = setTimeout(() => {
         setDebouncedSearch(
-          dataSourceSearch.length >= MIN_KEYWORD_SEARCH_LENGTH
+          dataSourceSearch.length >= MIN_SEARCH_QUERY_SIZE
             ? dataSourceSearch
             : ""
         );

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -686,6 +686,7 @@ export const SpaceDataSourceViewContentList = ({
         )}
         {searchFeatureFlag &&
           rows.length === 0 &&
+          debouncedSearch.length >= MIN_SEARCH_QUERY_SIZE &&
           !isSearchLoading &&
           !isSearchValidating &&
           !isTyping && (

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -636,8 +636,8 @@ export const SpaceDataSourceViewContentList = ({
               </div>
             )}
         </div>
-        {isNodesLoading && (
-          <div className="mt-8 flex justify-center">
+        {(isNodesLoading || isSearchLoading || isSearchValidating) && (
+          <div className="absolute mt-16 flex justify-center">
             <Spinner />
           </div>
         )}
@@ -664,6 +664,14 @@ export const SpaceDataSourceViewContentList = ({
             columnsBreakpoints={columnsBreakpoints}
           />
         )}
+        {searchFeatureFlag &&
+          rows.length === 0 &&
+          !isSearchLoading &&
+          !isSearchValidating && (
+            <div className="mt-8 flex justify-center">
+              <div>No results found</div>
+            </div>
+          )}
         <ContentActions
           ref={contentActionsRef}
           dataSourceView={dataSourceView}

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -217,7 +217,6 @@ export const SpaceDataSourceViewContentList = ({
 
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
   const [debouncedSearch, setDebouncedSearch] = useState<string>("");
-
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
     useState(false);
   const sendNotification = useSendNotification();
@@ -285,6 +284,14 @@ export const SpaceDataSourceViewContentList = ({
       ? viewType
       : DEFAULT_VIEW_TYPE,
   });
+
+  const isTyping = useMemo(() => {
+    return (
+      dataSourceSearch.length > 2 &&
+      debouncedSearch !== dataSourceSearch &&
+      searchFeatureFlag
+    );
+  }, [dataSourceSearch, debouncedSearch, searchFeatureFlag]);
 
   const nodes = useMemo(() => {
     if (dataSourceSearch.length > 2 && searchFeatureFlag) {
@@ -410,7 +417,9 @@ export const SpaceDataSourceViewContentList = ({
           dataSourceSearch.length >= 3 ? dataSourceSearch : ""
         );
       }, 300);
-      return () => clearTimeout(timeout);
+      return () => {
+        clearTimeout(timeout);
+      };
     }
   }, [dataSourceSearch, searchFeatureFlag]);
 
@@ -667,7 +676,8 @@ export const SpaceDataSourceViewContentList = ({
         {searchFeatureFlag &&
           rows.length === 0 &&
           !isSearchLoading &&
-          !isSearchValidating && (
+          !isSearchValidating &&
+          !isTyping && (
             <div className="mt-8 flex justify-center">
               <div>No results found</div>
             </div>

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -1,6 +1,12 @@
-import type { DataSourceViewType } from "@dust-tt/types";
+import type {
+  ContentNodesViewType,
+  CoreAPIContentNode,
+  DataSourceViewContentNode,
+  DataSourceViewType,
+} from "@dust-tt/types";
 import { assertNever, MIME_TYPES } from "@dust-tt/types";
 
+import { SPREADSHEET_MIME_TYPES } from "@app/lib/content_nodes";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 
 export const NON_EXPANDABLE_NODES_MIME_TYPES = [
@@ -52,4 +58,42 @@ export function getContentNodeInternalIdFromTableId(
     default:
       assertNever(dataSource.connectorProvider);
   }
+}
+
+function expandable(node: CoreAPIContentNode, viewType: ContentNodesViewType) {
+  return (
+    !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
+    node.children_count > 0 &&
+    // if we aren't in tables/all view, spreadsheets are not expandable
+    !(
+      !["tables", "all"].includes(viewType) &&
+      SPREADSHEET_MIME_TYPES.includes(node.mime_type)
+    )
+  );
+}
+
+export function getContentNodeFromCoreNode(
+  coreNode: CoreAPIContentNode,
+  viewType: ContentNodesViewType
+): DataSourceViewContentNode {
+  return {
+    internalId: coreNode.node_id,
+    parentInternalId: coreNode.parent_id ?? null,
+    // TODO(2025-01-27 aubin): remove this once the handling of nodes without a title has been improved in the api/v1
+    title:
+      coreNode.title === "Untitled document"
+        ? coreNode.node_id
+        : coreNode.title,
+    sourceUrl: coreNode.source_url ?? null,
+    permission: "read",
+    lastUpdatedAt: coreNode.timestamp,
+    providerVisibility: coreNode.provider_visibility,
+    parentInternalIds: coreNode.parents,
+    type: coreNode.node_type,
+    expandable: expandable(coreNode, viewType),
+    mimeType: coreNode.mime_type,
+    preventSelection: FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(
+      coreNode.mime_type
+    ),
+  };
 }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -60,7 +60,10 @@ export function getContentNodeInternalIdFromTableId(
   }
 }
 
-function expandable(node: CoreAPIContentNode, viewType: ContentNodesViewType) {
+function isExpandable(
+  node: CoreAPIContentNode,
+  viewType: ContentNodesViewType
+) {
   return (
     !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
     node.children_count > 0 &&
@@ -90,7 +93,7 @@ export function getContentNodeFromCoreNode(
     providerVisibility: coreNode.provider_visibility,
     parentInternalIds: coreNode.parents,
     type: coreNode.node_type,
-    expandable: expandable(coreNode, viewType),
+    expandable: isExpandable(coreNode, viewType),
     mimeType: coreNode.mime_type,
     preventSelection: FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(
       coreNode.mime_type

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -7,6 +7,7 @@ import type {
   LightWorkspaceType,
   SpaceType,
 } from "@dust-tt/types";
+import { MIN_SEARCH_QUERY_SIZE } from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
@@ -28,7 +29,6 @@ import type {
 import type { GetSpaceDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views";
 import type { GetDataSourceViewResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]";
 import type { PostSpaceDataSourceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
-import { MIN_SEARCH_QUERY_SIZE } from "@dust-tt/types";
 
 export function useSpaces({
   workspaceId,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -2,13 +2,13 @@ import { useSendNotification } from "@dust-tt/sparkle";
 import type {
   ContentNodesViewType,
   DataSourceViewCategory,
+  DataSourceViewContentNode,
   DataSourceViewType,
   LightWorkspaceType,
   SpaceType,
 } from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
-import useSWR from "swr";
 
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { getSpaceName } from "@app/lib/spaces";
@@ -28,10 +28,7 @@ import type {
 import type { GetSpaceDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views";
 import type { GetDataSourceViewResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]";
 import type { PostSpaceDataSourceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
-import {
-  MIN_KEYWORD_SEARCH_LENGTH,
-  type PostSpaceSearchResponseBody,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/search";
+import { MIN_SEARCH_QUERY_SIZE } from "@dust-tt/types";
 
 export function useSpaces({
   workspaceId,
@@ -621,7 +618,7 @@ export function useSpaceSearch({
 
   // Only create a key if we have a valid search
   const key =
-    search?.length >= MIN_KEYWORD_SEARCH_LENGTH && spaceId
+    search?.length >= MIN_SEARCH_QUERY_SIZE && spaceId
       ? [`/api/w/${owner.sId}/spaces/${spaceId}/search`, body]
       : null;
 
@@ -649,7 +646,10 @@ export function useSpaceSearch({
   );
 
   return {
-    searchResultNodes: useMemo(() => data?.nodes ?? [], [data]),
+    searchResultNodes: useMemo(
+      () => data?.nodes ?? [],
+      [data]
+    ) as DataSourceViewContentNode[],
     isSearchLoading: isLoading,
     isSearchError: error,
     mutate,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -592,21 +592,26 @@ export function useSystemSpace({
   };
 }
 
+const DEFAULT_SEARCH_LIMIT = 20;
+
 export function useSpaceSearch({
   dataSourceViews,
   owner,
   viewType,
   search,
+  limit = DEFAULT_SEARCH_LIMIT,
 }: {
   dataSourceViews: DataSourceViewType[];
   owner: LightWorkspaceType;
   viewType: ContentNodesViewType;
   search: string;
+  limit?: number;
 }) {
   const body = {
     datasourceViewSids: dataSourceViews.map((dsv) => dsv.sId),
     query: search,
     viewType,
+    limit,
   };
 
   const spaceId = dataSourceViews[0]?.spaceId;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -28,6 +28,7 @@ const SearchRequestBody = t.type({
     t.literal("documents"),
     t.literal("all"),
   ]),
+  limit: t.number,
 });
 
 export type PostSpaceSearchResponseBody = {
@@ -73,7 +74,7 @@ async function handler(
     });
   }
 
-  const { datasourceViewSids, query, viewType } = bodyValidation.right;
+  const { datasourceViewSids, query, viewType, limit } = bodyValidation.right;
 
   if (datasourceViewSids.length === 0) {
     return apiError(req, res, {
@@ -119,6 +120,9 @@ async function handler(
         data_source_id: dsv.dataSource.dustAPIDataSourceId,
         view_filter: dsv.parentsIn ?? [],
       })),
+    },
+    options: {
+      limit,
     },
   });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -2,7 +2,7 @@ import type {
   DataSourceViewContentNode,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
-import { CoreAPI } from "@dust-tt/types";
+import { CoreAPI, MIN_SEARCH_QUERY_SIZE } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -34,8 +34,6 @@ const SearchRequestBody = t.type({
 export type PostSpaceSearchResponseBody = {
   nodes: DataSourceViewContentNode[];
 };
-
-export const MIN_KEYWORD_SEARCH_LENGTH = 3;
 
 async function handler(
   req: NextApiRequest,
@@ -93,12 +91,12 @@ async function handler(
     });
   }
 
-  if (query.length < MIN_KEYWORD_SEARCH_LENGTH) {
+  if (query.length < MIN_SEARCH_QUERY_SIZE) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Query must be at least ${MIN_KEYWORD_SEARCH_LENGTH} characters long.`,
+        message: `Query must be at least ${MIN_SEARCH_QUERY_SIZE} characters long.`,
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -1,0 +1,146 @@
+import type {
+  DataSourceViewContentNode,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+const SearchRequestBody = t.type({
+  datasourceViewSids: t.array(t.string),
+  query: t.string,
+  // should use ContentNodesViewTypeCodec, but the type system
+  // fails to infer the type correctly.
+  viewType: t.union([
+    t.literal("tables"),
+    t.literal("documents"),
+    t.literal("all"),
+  ]),
+});
+
+export type PostSpaceSearchResponseBody = {
+  nodes: DataSourceViewContentNode[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostSpaceSearchResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  if (!space.canReadOrAdministrate(auth)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_view_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const bodyValidation = SearchRequestBody.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const { datasourceViewSids, query, viewType } = bodyValidation.right;
+
+  if (datasourceViewSids.length === 0) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "No datasource view filters provided.",
+      },
+    });
+  }
+
+  if (query.length < 3) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Query must be at least 3 characters long.",
+      },
+    });
+  }
+
+  const datasourceViews = await DataSourceViewResource.fetchByIds(
+    auth,
+    datasourceViewSids
+  );
+
+  if (datasourceViews.some((dsv) => dsv.space.id !== space.id)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "All datasource views must belong to the space.",
+      },
+    });
+  }
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+  const searchRes = await coreAPI.searchNodes({
+    query,
+    filter: {
+      data_source_views: datasourceViews.map((dsv) => ({
+        data_source_id: dsv.dataSource.dustAPIDataSourceId,
+        view_filter: dsv.parentsIn ?? [],
+      })),
+    },
+  });
+
+  if (searchRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: searchRes.error.message,
+      },
+    });
+  }
+
+  return res.status(200).json({
+    nodes: searchRes.value.nodes.map((node) =>
+      getContentNodeFromCoreNode(node, viewType)
+    ),
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -19,7 +19,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 const SearchRequestBody = t.type({
-  datasourceViewSids: t.array(t.string),
+  datasourceViewIds: t.array(t.string),
   query: t.string,
   // should use ContentNodesViewTypeCodec, but the type system
   // fails to infer the type correctly.
@@ -34,6 +34,8 @@ const SearchRequestBody = t.type({
 export type PostSpaceSearchResponseBody = {
   nodes: DataSourceViewContentNode[];
 };
+
+export const MIN_KEYWORD_SEARCH_LENGTH = 3;
 
 async function handler(
   req: NextApiRequest,
@@ -74,7 +76,12 @@ async function handler(
     });
   }
 
-  const { datasourceViewSids, query, viewType, limit } = bodyValidation.right;
+  const {
+    datasourceViewIds: datasourceViewSids,
+    query,
+    viewType,
+    limit,
+  } = bodyValidation.right;
 
   if (datasourceViewSids.length === 0) {
     return apiError(req, res, {
@@ -86,12 +93,12 @@ async function handler(
     });
   }
 
-  if (query.length < 3) {
+  if (query.length < MIN_KEYWORD_SEARCH_LENGTH) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Query must be at least 3 characters long.",
+        message: `Query must be at least ${MIN_KEYWORD_SEARCH_LENGTH} characters long.`,
       },
     });
   }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -792,6 +792,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "deepseek_r1_global_agent_feature"
   | "salesforce_feature"
   | "advanced_notion_management"
+  | "search_knowledge_builder"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/types/src/connectors/content_nodes.ts
+++ b/types/src/connectors/content_nodes.ts
@@ -9,6 +9,8 @@ import * as t from "io-ts";
 // More precisely, the "tables" (resp. "documents") view hides leaves that are documents (resp. tables).
 
 // Define a codec for ContentNodesViewType using io-ts.
+// WARNING: when changing this codec, search and map for comments on ContentNodesViewTypeCodec
+// because parts of the codebase could not use this type directly (and as such commented)
 export const ContentNodesViewTypeCodec = t.union([
   t.literal("tables"),
   t.literal("documents"),

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -215,6 +215,8 @@ export type CoreAPIDatasourceViewFilter = t.TypeOf<
   typeof CoreAPIDatasourceViewFilterSchema
 >;
 
+export const MIN_SEARCH_QUERY_SIZE = 3;
+
 export const CoreAPINodesSearchFilterSchema = t.intersection([
   t.type({
     data_source_views: t.array(CoreAPIDatasourceViewFilterSchema),

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1,6 +1,7 @@
 import { createParser } from "eventsource-parser";
+import * as t from "io-ts";
 
-import { ContentNodeType, CoreAPIContentNode } from "../../core/content_node";
+import { CoreAPIContentNode } from "../../core/content_node";
 import {
   CoreAPIDataSource,
   CoreAPIDataSourceConfig,
@@ -205,17 +206,30 @@ export interface CoreAPISearchTagsResponse {
   };
 }
 
-export type CoreAPIDatasourceViewFilter = {
-  data_source_id: string;
-  view_filter: string[];
-};
+export const CoreAPIDatasourceViewFilterSchema = t.type({
+  data_source_id: t.string,
+  view_filter: t.array(t.string),
+});
 
-export type CoreAPINodesSearchFilter = {
-  data_source_views: CoreAPIDatasourceViewFilter[];
-  node_ids?: string[];
-  parent_id?: string;
-  node_types?: ContentNodeType[];
-};
+export type CoreAPIDatasourceViewFilter = t.TypeOf<
+  typeof CoreAPIDatasourceViewFilterSchema
+>;
+
+export const CoreAPINodesSearchFilterSchema = t.intersection([
+  t.type({
+    data_source_views: t.array(CoreAPIDatasourceViewFilterSchema),
+  }),
+  t.partial({
+    node_ids: t.array(t.string),
+    parent_id: t.string,
+    node_types: t.array(t.string),
+    query: t.string,
+  }),
+]);
+
+export type CoreAPINodesSearchFilter = t.TypeOf<
+  typeof CoreAPINodesSearchFilterSchema
+>;
 
 export interface CoreAPIUpsertDataSourceDocumentPayload {
   projectId: string;

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -20,6 +20,7 @@ export const WHITELISTABLE_FEATURES = [
   "deepseek_r1_global_agent_feature",
   "salesforce_feature",
   "advanced_notion_management",
+  "search_knowledge_builder",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2211

- creates a search endpoint in spaces (given a space id), to do keyword search
- add a feature flag "search_keyboard_builder"
- add SWR and code to use keyword search in knowledge (in datasource)
  - after at least 3 chars are typed
  - debounced 300ms

Risks
---
Low, gated behind ff

Deploy
---
front