### PR TITLE
[front] Auto-expand tree on search result

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -74,6 +74,7 @@ type ContextType = {
   showExpand?: boolean;
   useResourcesHook: UseResourcesHook;
   emptyComponent: ReactNode;
+  defaultExpandedIds?: string[];
 };
 
 const ContentNodeTreeContext = React.createContext<ContextType | undefined>(
@@ -131,7 +132,8 @@ function ContentNodeTreeChildren({
   // But if the user types in the search bar, we want to reset the button to "select all".
   const [selectAllClicked, setSelectAllClicked] = useState(false);
 
-  const { useResourcesHook, emptyComponent } = useContentNodeTreeContext();
+  const { useResourcesHook, emptyComponent, defaultExpandedIds } =
+    useContentNodeTreeContext();
 
   const { resources, isResourcesLoading, isResourcesError, resourcesError } =
     useResourcesHook(parentId);
@@ -207,6 +209,9 @@ function ContentNodeTreeChildren({
             }
             visual={getVisualForContentNode(n)}
             className={`whitespace-nowrap tree-depth-${depth}`}
+            defaultCollapsed={
+              !defaultExpandedIds || !defaultExpandedIds.includes(n.internalId)
+            }
             checkbox={
               (n.preventSelection !== true || checkedState === "partial") &&
               selectedNodes
@@ -397,6 +402,10 @@ interface ContentNodeTreeProps {
    * The component to display when an item is expanded and it has no children.
    */
   emptyComponent?: ReactNode;
+  /**
+   * The ids of the nodes to be expanded by default.
+   */
+  defaultExpandedIds?: string[];
 }
 
 export function ContentNodeTree({
@@ -409,6 +418,7 @@ export function ContentNodeTree({
   showExpand,
   useResourcesHook,
   emptyComponent,
+  defaultExpandedIds,
 }: ContentNodeTreeProps) {
   return (
     <ContentNodeTreeContextProvider
@@ -419,6 +429,7 @@ export function ContentNodeTree({
         showExpand,
         useResourcesHook,
         emptyComponent,
+        defaultExpandedIds,
       }}
     >
       <ContentNodeTreeChildren

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -119,6 +119,7 @@ export default function DataSourceSelectionSection({
                       />
                     )
                   }
+                  // defaultCollapsed={false}
                   areActionsFading={dsConfig.tagsFilter === null}
                 >
                   {dsConfig.isSelectAll && (
@@ -141,6 +142,7 @@ export default function DataSourceSelectionSection({
                         type={node.expandable ? "node" : "leaf"}
                         visual={getVisualForContentNode(node)}
                         className="whitespace-nowrap"
+                        // defaultCollapsed={false}
                         actions={
                           <div className="mr-8 flex flex-row gap-2">
                             <IconButton

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -119,7 +119,6 @@ export default function DataSourceSelectionSection({
                       />
                     )
                   }
-                  defaultCollapsed={false}
                   areActionsFading={dsConfig.tagsFilter === null}
                 >
                   {dsConfig.isSelectAll && (
@@ -142,7 +141,6 @@ export default function DataSourceSelectionSection({
                         type={node.expandable ? "node" : "leaf"}
                         visual={getVisualForContentNode(node)}
                         className="whitespace-nowrap"
-                        defaultCollapsed={false}
                         actions={
                           <div className="mr-8 flex flex-row gap-2">
                             <IconButton

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -119,7 +119,7 @@ export default function DataSourceSelectionSection({
                       />
                     )
                   }
-                  // defaultCollapsed={false}
+                  defaultCollapsed={false}
                   areActionsFading={dsConfig.tagsFilter === null}
                 >
                   {dsConfig.isSelectAll && (
@@ -142,7 +142,7 @@ export default function DataSourceSelectionSection({
                         type={node.expandable ? "node" : "leaf"}
                         visual={getVisualForContentNode(node)}
                         className="whitespace-nowrap"
-                        // defaultCollapsed={false}
+                        defaultCollapsed={false}
                         actions={
                           <div className="mr-8 flex flex-row gap-2">
                             <IconButton


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/2215

## Description

Auto expand tree items from  DataSourceViewSelector.tsx based on search result set in a local state
No impact now as we don't set search results

## Tests

tested locally by setting state on random node

## Risk

n/a

## Deploy Plan

deploy front
