### PR TITLE
fix(Zendesk) - use main subdomain in calls to `/users/me` instead of brand subdomains

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -296,10 +296,12 @@ export async function fetchZendeskCategoriesInBrand(
  * https://developer.zendesk.com/documentation/help_center/help-center-api/understanding-incremental-article-exports/
  */
 export async function fetchRecentlyUpdatedArticles({
+  subdomain,
   brandSubdomain,
   accessToken,
   startTime, // start time in Unix epoch time, in seconds
 }: {
+  subdomain: string;
   brandSubdomain: string;
   accessToken: string;
   startTime: number;
@@ -320,7 +322,7 @@ export async function fetchRecentlyUpdatedArticles({
   } catch (e) {
     if (isZendeskNotFoundError(e)) {
       const user = await fetchZendeskCurrentUser({
-        subdomain: brandSubdomain,
+        subdomain,
         accessToken,
       });
       // only admins and agents can fetch this endpoint: https://developer.zendesk.com/documentation/help_center/help-center-api/understanding-incremental-article-exports/#authenticating-the-requests

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -109,6 +109,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
   });
 
   const { articles, hasMore, endTime } = await fetchRecentlyUpdatedArticles({
+    subdomain,
     brandSubdomain,
     accessToken,
     startTime,


### PR DESCRIPTION
## Description

- Fix the error observed [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZUj1GPBKbgVRAAAABhBWlVqMUhja0FBQUQzNUQyTVZlT1R3QUEAAAAkMDE5NTIzZDQtYWJmNC00MzAyLWExNDYtMGQ0NzRiOTBjMDQxAAAN3w&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1696875926644&to_ts=1696876826644&live=true).
- A call to `/users/me` failed with the error: "There is no help desk configured at this address. This means that the address is available and that you can claim it at http://www.zendesk.com/signup".
- The call was made using the brand subdomain, this PR suggests using the main subdomain instead by assuming that certain features can be disabled brand by brand and impact this endpoint.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy connectors.