### PR TITLE
[connectors] Disable ocr in connectors

### DIFF
--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -110,10 +110,9 @@ export async function handleTextExtraction(
     return new Err(new Error("unsupported_content_type"));
   }
 
-  const pageRes = await new TextExtraction(
-    apiConfig.getTextExtractionUrl(),
-    "no_ocr"
-  ).fromBuffer(Buffer.from(data), mimeType);
+  const pageRes = await new TextExtraction(apiConfig.getTextExtractionUrl(), {
+    enableOcr: false,
+  }).fromBuffer(Buffer.from(data), mimeType);
 
   if (pageRes.isErr()) {
     localLogger.warn(

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -112,6 +112,7 @@ export async function handleTextExtraction(
 
   const pageRes = await new TextExtraction(apiConfig.getTextExtractionUrl(), {
     enableOcr: false,
+    logger: localLogger,
   }).fromBuffer(Buffer.from(data), mimeType);
 
   if (pageRes.isErr()) {

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -111,7 +111,8 @@ export async function handleTextExtraction(
   }
 
   const pageRes = await new TextExtraction(
-    apiConfig.getTextExtractionUrl()
+    apiConfig.getTextExtractionUrl(),
+    "no_ocr"
   ).fromBuffer(Buffer.from(data), mimeType);
 
   if (pageRes.isErr()) {

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -131,7 +131,7 @@ const extractTextFromFileAndUpload: ProcessingFunction = async (
 
     const processedStream = await new TextExtraction(
       config.getTextExtractionUrl(),
-      { enableOcr: true }
+      { enableOcr: true, logger }
     ).fromStream(readStream, file.contentType);
 
     await pipeline(processedStream, writeStream);

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -130,7 +130,8 @@ const extractTextFromFileAndUpload: ProcessingFunction = async (
     const writeStream = file.getWriteStream({ auth, version: "processed" });
 
     const processedStream = await new TextExtraction(
-      config.getTextExtractionUrl()
+      config.getTextExtractionUrl(),
+      { enableOcr: true }
     ).fromStream(readStream, file.contentType);
 
     await pipeline(processedStream, writeStream);

--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -6,6 +6,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import { Readable } from "stream";
 
+import { LoggerInterface } from "../logger";
 import { Err, Ok, Result } from "../result";
 import { assertNever } from "../utils/assert_never";
 import {
@@ -94,7 +95,13 @@ export function isTextExtractionSupportedContentType(
 const DEFAULT_HANDLER = "text";
 
 export class TextExtraction {
-  constructor(readonly url: string, readonly options: { enableOcr: boolean }) {}
+  constructor(
+    readonly url: string,
+    readonly options: {
+      enableOcr: boolean;
+      logger: LoggerInterface;
+    }
+  ) {}
 
   getAdditionalHeaders(): HeadersInit {
     return {
@@ -192,6 +199,8 @@ export class TextExtraction {
 
       return new Ok(decodedReponse.right);
     } catch (err) {
+      this.options.logger.error({ error: err }, "Error while extracting text");
+
       const errorMessage =
         err instanceof Error ? err.message : "Unexpected error";
 

--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -94,7 +94,13 @@ export function isTextExtractionSupportedContentType(
 const DEFAULT_HANDLER = "text";
 
 export class TextExtraction {
-  constructor(readonly url: string) {}
+  constructor(readonly url: string, readonly ocrStrategy?: "no_ocr" | "auto") {}
+
+  getAdditionalHeaders(): HeadersInit {
+    return this.ocrStrategy
+      ? { "X-Tika-PDFOcrStrategy": this.ocrStrategy }
+      : {};
+  }
 
   // Method to extract text from a buffer.
   async fromBuffer(
@@ -118,6 +124,7 @@ export class TextExtraction {
       method: "PUT",
       headers: {
         "Content-Type": contentType,
+        ...this.getAdditionalHeaders(),
       },
       body: Readable.toWeb(fileStream),
       duplex: "half",
@@ -166,6 +173,7 @@ export class TextExtraction {
         headers: {
           Accept: "application/json",
           "Content-Type": contentType,
+          ...this.getAdditionalHeaders(),
         },
         body: fileBuffer,
       });

--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -93,6 +93,7 @@ export function isTextExtractionSupportedContentType(
 }
 
 const DEFAULT_HANDLER = "text";
+const DEFAULT_TIMEOUT_IN_MS = 60000;
 
 export class TextExtraction {
   constructor(
@@ -106,7 +107,7 @@ export class TextExtraction {
   getAdditionalHeaders(): HeadersInit {
     return {
       "X-Tika-PDFOcrStrategy": this.options.enableOcr ? "auto" : "no_ocr",
-      "X-Tika-Timeout-Millis": "60000",
+      "X-Tika-Timeout-Millis": DEFAULT_TIMEOUT_IN_MS.toString(),
     };
   }
 

--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -98,8 +98,11 @@ export class TextExtraction {
 
   getAdditionalHeaders(): HeadersInit {
     return this.ocrStrategy
-      ? { "X-Tika-PDFOcrStrategy": this.ocrStrategy }
-      : {};
+      ? {
+          "X-Tika-PDFOcrStrategy": this.ocrStrategy,
+          "X-Tika-Timeout-Millis": "60000",
+        }
+      : { "X-Tika-Timeout-Millis": "60000" };
   }
 
   // Method to extract text from a buffer.

--- a/types/src/shared/text_extraction/index.ts
+++ b/types/src/shared/text_extraction/index.ts
@@ -94,15 +94,13 @@ export function isTextExtractionSupportedContentType(
 const DEFAULT_HANDLER = "text";
 
 export class TextExtraction {
-  constructor(readonly url: string, readonly ocrStrategy?: "no_ocr" | "auto") {}
+  constructor(readonly url: string, readonly options: { enableOcr: boolean }) {}
 
   getAdditionalHeaders(): HeadersInit {
-    return this.ocrStrategy
-      ? {
-          "X-Tika-PDFOcrStrategy": this.ocrStrategy,
-          "X-Tika-Timeout-Millis": "60000",
-        }
-      : { "X-Tika-Timeout-Millis": "60000" };
+    return {
+      "X-Tika-PDFOcrStrategy": this.options.enableOcr ? "auto" : "no_ocr",
+      "X-Tika-Timeout-Millis": "60000",
+    };
   }
 
   // Method to extract text from a buffer.


### PR DESCRIPTION
## Description

This PR changes the Text Extraction behavior to only enable OCR in `auto` mode when uploading files on the public API or in the Input Bar. We noticed some timeouts after 5 minutes (ALB), this PR ensures all text extractions must complete within 1 minute. It also adds some logging so we can instrument Tika latency and timeout in the future.

## Tests

## Risk


## Deploy Plan

deploy connectors
