### PR TITLE
enh: improve xp for having same crawler in diff spaces

### DIFF
--- a/front/components/spaces/websites/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteModal.tsx
@@ -166,7 +166,12 @@ export default function SpaceWebsiteModal({
         if (action.field === "url" && !webCrawlerConfiguration) {
           const validated = validateUrl(action.value);
           if (validated.valid) {
-            newState.name = urlToDataSourceName(action.value);
+            const name = urlToDataSourceName(action.value);
+            if (space.kind !== "global") {
+              newState.name = `${name} (${space.name})`;
+            } else {
+              newState.name = name;
+            }
           }
         }
         return newState;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -37,6 +37,7 @@ import {
   isConnectorProviderAssistantDefaultSelected,
   isValidConnectorSuffix,
 } from "@app/lib/connector_providers";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
@@ -378,6 +379,21 @@ const handleDataSourceWithProvider = async ({
         type: "internal_server_error",
         message: "Failed to create the data source.",
         data_source_error: dustDataSource.error,
+      },
+    });
+  }
+
+  // Check if there's already a data source with the same name
+  const existingDataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    dataSourceName
+  );
+  if (existingDataSource) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "A data source with the same name already exists.",
       },
     });
   }


### PR DESCRIPTION
## Description

We currently have a constraint that prevents several data sources from having the same name in the same workspace.
While we have made good progress towards getting rid of this, we still relying on this in some places of the code, and it is still being heavily used in prod. So it isn't trivial to get rid of this entirely.

There is a legitimate use case for this, as people want to have multiple times the same webcrawler in different spaces.

Webcrawler configs allow to define a custom name, so there is no real blocker, but the experience is un-intuitive (error is a 500 with an internal error message).

My fix is:
- if we're not in the global space, we automatically append ` ($spaceName)` to the data source name
- while unlikely, if we still run into the issue, the message is much clearer (explaining that the DS name is already taken)

fixes https://github.com/dust-tt/tasks/issues/2225

## Tests

manual

## Risk

Low

## Deploy Plan

Deploy front