### PR TITLE
fix(Zendesk) - Ignore 404 on Zendesk article diff fetch

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -334,6 +334,7 @@ export async function fetchRecentlyUpdatedArticles({
           { ...e.data, role, suspended, active }
         );
       }
+      return { articles: [], hasMore: false, endTime: 0 };
     }
     throw e;
   }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -334,6 +334,10 @@ export async function fetchRecentlyUpdatedArticles({
           { ...e.data, role, suspended, active }
         );
       }
+      logger.warn(
+        { subdomain, brandSubdomain },
+        "[Zendesk] Could not fetch article diff."
+      );
       return { articles: [], hasMore: false, endTime: 0 };
     }
     throw e;


### PR DESCRIPTION
## Description

- This PR ignores 404 errors when fetching the articles updated since a certain date.
- This error can occur when a Help Center is not fully configured, which can easily be detected by checking that the Help Center only contains the sample articles ("Welcome to your Help Center!", "How do I customize my Help Center?
", ... there are 6 of them).
- This PR also fixes a potential bug that would occur when two categories with the same ID but within different brands are selected in the same `setPermissions`.

## Tests

- n/a

## Risk

- Low.

## Deploy Plan

- Stop all Zendesk connectors.
- Deploy connectors.
- Resume all Zendesk connectors.