### PR TITLE
core: [csv] better support for booleans

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -426,6 +426,9 @@ BAR,acme";
                    foo,123,0.231,true,2025-02-14T15:06:52.380Z\n\
                    ,,,,\n\
                     , , , , \n\
+                    , , ,TRUE , \n\
+                    , , ,FALSE, \n\
+                    , , ,t , \n\
                    bar,0,23123.0,false,\"Fri, 14 Feb 2025 15:10:34 GMT\"";
         let (delimiter, rdr) =
             UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;


### PR DESCRIPTION
## Description

Add support for any capitalizaiton of true/false/t/f for booleans. It goes a bit beyond what front was doing (support for t/f).

Goal is to bring this to 0: https://app.datadoghq.eu/logs?query=%22%5BCSV-FILE%5D%20mistmatch%3A%20row%20and%20schema%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1740067112861&to_ts=1740068012861&live=true

## Tests

Covered by tests

## Risk

N/A

## Deploy Plan

- deploy `core`