### PR TITLE
fix: ignore missing crawlers

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -77,7 +77,8 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
   const startCrawlingTime = Date.now();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
-    throw new Error(`Connector ${connectorId} not found.`);
+    logger.error({ connectorId }, "Connector not found");
+    return;
   }
 
   const webCrawlerConfig =
@@ -535,7 +536,8 @@ export async function webCrawlerGarbageCollector(
 ) {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
-    throw new Error(`Connector ${connectorId} not found.`);
+    logger.error({ connectorId }, "Connector not found");
+    return;
   }
 
   const webCrawlerConfig =


### PR DESCRIPTION
## Description

Due to how our workflow is done, it can happen that we try to sync a webcrawler for a connector that no longer exists. In this case, it isn't useful to error out, and we should simply ignore it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
