### PR TITLE
core: take in bucket and bucket_csv_path for CSV operations

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -507,12 +507,14 @@ impl LocalTable {
         &self,
         store: Box<dyn Store + Sync + Send>,
         databases_store: Box<dyn DatabasesStore + Sync + Send>,
-        upsert_queue_bucket_csv_path: &str,
+        bucket: &str,
+        bucket_csv_path: &str,
         truncate: bool,
     ) -> Result<()> {
         let now = utils::now();
         let rows = UpsertQueueCSVContent {
-            upsert_queue_bucket_csv_path: upsert_queue_bucket_csv_path.to_string(),
+            bucket: bucket.to_string(),
+            bucket_csv_path: bucket_csv_path.to_string(),
         }
         .parse()
         .await?;
@@ -615,11 +617,12 @@ impl LocalTable {
         Ok(schema)
     }
 
-    pub async fn validate_csv_content(upsert_queue_bucket_csv_path: &str) -> Result<TableSchema> {
+    pub async fn validate_csv_content(bucket: &str, bucket_csv_path: &str) -> Result<TableSchema> {
         let now = utils::now();
         let rows = Arc::new(
             UpsertQueueCSVContent {
-                upsert_queue_bucket_csv_path: upsert_queue_bucket_csv_path.to_string(),
+                bucket: bucket.to_string(),
+                bucket_csv_path: bucket_csv_path.to_string(),
             }
             .parse()
             .await?,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -720,7 +720,8 @@ export async function upsertTable({
         const schemaRes = await coreAPI.tableValidateCSVContent({
           projectId: dataSource.dustAPIProjectId,
           dataSourceId: dataSource.dustAPIDataSourceId,
-          upsertQueueBucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+          bucket: file.getBucketForVersion("processed").name,
+          bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
         });
 
         if (schemaRes.isErr()) {

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -218,7 +218,8 @@ export async function upsertTableFromCsv({
     const schemaRes = await coreAPI.tableValidateCSVContent({
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
-      upsertQueueBucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+      bucket: file.getBucketForVersion("processed").name,
+      bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
     });
 
     if (schemaRes.isOk()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -239,7 +239,7 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
       }
 
       if ((url as string).endsWith("/validate_csv_content")) {
-        expect(req.upsert_queue_bucket_csv_path).toBe(
+        expect(req.bucket_csv_path).toBe(
           `files/w/${workspace.sId}/${file.sId}/processed`
         );
         return Promise.resolve(

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1231,11 +1231,13 @@ export class CoreAPI {
   async tableValidateCSVContent({
     projectId,
     dataSourceId,
-    upsertQueueBucketCSVPath,
+    bucket,
+    bucketCSVPath,
   }: {
     projectId: string;
     dataSourceId: string;
-    upsertQueueBucketCSVPath: string;
+    bucket: string;
+    bucketCSVPath: string;
   }): Promise<
     CoreAPIResponse<{
       schema: CoreAPITableSchema;
@@ -1253,7 +1255,8 @@ export class CoreAPI {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          upsert_queue_bucket_csv_path: upsertQueueBucketCSVPath,
+          bucket,
+          bucket_csv_path: bucketCSVPath,
         }),
       }
     );
@@ -1497,13 +1500,15 @@ export class CoreAPI {
     projectId,
     dataSourceId,
     tableId,
-    upsertQueueBucketCSVPath,
+    bucket,
+    bucketCSVPath,
     truncate,
   }: {
     projectId: string;
     dataSourceId: string;
     tableId: string;
-    upsertQueueBucketCSVPath: string;
+    bucket: string;
+    bucketCSVPath: string;
     truncate?: boolean;
   }): Promise<
     CoreAPIResponse<{
@@ -1522,7 +1527,8 @@ export class CoreAPI {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          upsert_queue_bucket_csv_path: upsertQueueBucketCSVPath,
+          bucket,
+          bucket_csv_path: bucketCSVPath,
           truncate: truncate || false,
         }),
       }


### PR DESCRIPTION
## Description

Some conversation related files are upserted as CSV and their bucket is not the upsert_queue bucket so we need to support any bucket as told to us by front

Follow-up clean-up the dual support in `core`

## Tests

Updated tests

## Risk

Tested locally + covered by tests

## Deploy Plan

- deploy `front`