### PR TITLE
feat(Zendesk) - Allow syncing unresolved tickets

### DIFF
--- a/connectors/migrations/db/migration_53.sql
+++ b/connectors/migrations/db/migration_53.sql
@@ -1,0 +1,2 @@
+-- Migration created on Feb 20, 2025
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "syncUnresolvedTickets" BOOLEAN NOT NULL DEFAULT false;

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -46,6 +46,7 @@ import {
   launchZendeskFullSyncWorkflow,
   launchZendeskGarbageCollectionWorkflow,
   launchZendeskSyncWorkflow,
+  launchZendeskTicketReSyncWorkflow,
   stopZendeskWorkflows,
 } from "@connectors/connectors/zendesk/temporal/client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -91,7 +92,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
       },
-      { subdomain, retentionPeriodDays: 180 }
+      { subdomain, retentionPeriodDays: 180, syncUnresolvedTickets: false }
     );
     const loggerArgs = {
       workspaceId: dataSourceConfig.workspaceId,
@@ -726,8 +727,40 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     configKey: string;
     configValue: string;
   }): Promise<Result<void, Error>> {
-    logger.info({ configKey, configValue }, "Setting configuration key");
-    throw new Error("Method not implemented.");
+    const { connectorId } = this;
+    const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      logger.error({ connectorId }, "[Zendesk] Connector not found.");
+      throw new Error("[Zendesk] Connector not found.");
+    }
+
+    switch (configKey) {
+      case "zendeskSyncUnresolvedTicketsEnabled": {
+        const zendeskConfiguration =
+          await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+        if (!zendeskConfiguration) {
+          logger.error({ connectorId }, "[Zendesk] Configuration not found.");
+          throw new Error(
+            "Error retrieving Zendesk configuration to update connector configuration."
+          );
+        }
+
+        await zendeskConfiguration.update({
+          syncUnresolvedTickets: configValue === "true",
+        });
+
+        const result = await launchZendeskTicketReSyncWorkflow(connector);
+        if (result.isErr()) {
+          return result;
+        }
+
+        return new Ok(undefined);
+      }
+
+      default: {
+        return new Err(new Error(`Invalid config key ${configKey}`));
+      }
+    }
   }
 
   async getConfigurationKey({
@@ -735,8 +768,30 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }: {
     configKey: string;
   }): Promise<Result<string | null, Error>> {
-    logger.info({ configKey }, "Getting configuration key");
-    throw new Error("Method not implemented.");
+    const { connectorId } = this;
+    const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      throw new Error(`Connector not found (connectorId: ${connectorId})`);
+    }
+
+    switch (configKey) {
+      case "zendeskSyncUnresolvedTicketsEnabled": {
+        const zendeskConfiguration =
+          await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+        if (!zendeskConfiguration) {
+          logger.error({ connectorId }, "[Zendesk] Configuration not found.");
+          return new Err(
+            new Error(
+              "Error retrieving Zendesk configuration to get connector configuration."
+            )
+          );
+        }
+
+        return new Ok(zendeskConfiguration.syncUnresolvedTickets.toString());
+      }
+      default:
+        return new Err(new Error(`Invalid config key ${configKey}`));
+    }
   }
 
   /**

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -134,14 +134,15 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
-      throw new Error(`Connector ${connectorId} not found`);
+      throw new Error("[Zendesk] Connector not found.");
     }
 
     const configuration =
       await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
     if (!configuration) {
+      logger.error({ connectorId }, "[Zendesk] Configuration not found.");
       throw new Error(
-        "Error retrieving Zendesk configuration to update connector"
+        "Error retrieving Zendesk configuration to update connector."
       );
     }
 
@@ -191,7 +192,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
-      return new Err(new Error("Connector not found"));
+      throw new Error("[Zendesk] Connector not found.");
     }
 
     const result = await connector.delete();
@@ -211,9 +212,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
-      throw new Error(
-        `[Zendesk] Connector not found. ConnectorId: ${connectorId}`
-      );
+      logger.error({ connectorId }, "[Zendesk] Connector not found.");
+      throw new Error("[Zendesk] Connector not found.");
     }
     return stopZendeskWorkflows(connector);
   }
@@ -226,7 +226,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
-      return new Err(new Error("Connector not found"));
+      throw new Error("[Zendesk] Connector not found.");
     }
     if (connector.isPaused()) {
       logger.warn(
@@ -276,7 +276,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
-      return new Err(new Error("Connector not found"));
+      throw new Error("[Zendesk] Connector not found.");
     }
 
     // launching an incremental workflow taking the diff starting from the given timestamp
@@ -747,7 +747,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
-      return new Err(new Error("Connector not found"));
+      throw new Error("[Zendesk] Connector not found.");
     }
     await connector.markAsPaused();
     return this.stop();
@@ -762,7 +762,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
-      return new Err(new Error("Connector not found"));
+      throw new Error("[Zendesk] Connector not found.");
     }
     await connector.markAsUnpaused();
     // launch a gc and an incremental workflow (sync workflow without signals).

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -16,6 +16,7 @@ import {
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
 import logger from "@connectors/logger/logger";
+import type { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
@@ -23,6 +24,17 @@ const turndownService = new TurndownService();
 
 function apiUrlToDocumentUrl(apiUrl: string): string {
   return apiUrl.replace("/api/v2/", "/").replace(".json", "");
+}
+
+export function shouldSyncTicket(
+  ticket: ZendeskFetchedTicket,
+  configuration: ZendeskConfigurationResource
+): boolean {
+  return [
+    "closed",
+    "solved",
+    ...(configuration.syncUnresolvedTickets ? ["open", "pending", "hold"] : []),
+  ].includes(ticket.status);
 }
 
 export function extractMetadataFromDocumentUrl(ticketUrl: string): {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -8,7 +8,10 @@ import {
 } from "@connectors/connectors/zendesk/lib/id_conversions";
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import { syncCategory } from "@connectors/connectors/zendesk/lib/sync_category";
-import { syncTicket } from "@connectors/connectors/zendesk/lib/sync_ticket";
+import {
+  shouldSyncTicket,
+  syncTicket,
+} from "@connectors/connectors/zendesk/lib/sync_ticket";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   changeZendeskClientSubdomain,
@@ -654,12 +657,12 @@ export async function syncZendeskTicketBatchActivity({
     return { hasMore: false, nextLink: "" };
   }
 
-  const closedTickets = tickets.filter((t) =>
-    ["closed", "solved"].includes(t.status)
+  const ticketsToSync = tickets.filter((t) =>
+    shouldSyncTicket(t, configuration)
   );
 
   const comments2d = await concurrentExecutor(
-    closedTickets,
+    ticketsToSync,
     async (ticket) =>
       fetchZendeskTicketComments({
         accessToken,
@@ -679,7 +682,7 @@ export async function syncZendeskTicketBatchActivity({
   });
 
   const res = await concurrentExecutor(
-    _.zip(closedTickets, comments2d),
+    _.zip(ticketsToSync, comments2d),
     async ([ticket, comments]) => {
       if (!ticket || !comments) {
         throw new Error(

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -48,6 +48,7 @@ export class ZendeskConfiguration extends ConnectorBaseModel<ZendeskConfiguratio
 
   declare subdomain: string;
   declare retentionPeriodDays: number;
+  declare syncUnresolvedTickets: boolean;
 }
 
 ZendeskConfiguration.init(
@@ -70,6 +71,11 @@ ZendeskConfiguration.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 180, // approximately 6 months
+    },
+    syncUnresolvedTickets: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -1,12 +1,14 @@
 import {
   ContextItem,
-  IntercomLogo,
   SliderToggle,
   useSendNotification,
+  ZendeskLogo,
+  ZendeskWhiteLogo,
 } from "@dust-tt/sparkle";
 import type { APIError, DataSourceType, WorkspaceType } from "@dust-tt/types";
 import { useState } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 
 export function ZendeskConfigView({
@@ -20,6 +22,8 @@ export function ZendeskConfigView({
   isAdmin: boolean;
   dataSource: DataSourceType;
 }) {
+  const { isDark } = useTheme();
+
   const configKey = "zendeskSyncUnresolvedTicketsEnabled";
 
   const { configValue, mutateConfig } = useConnectorConfig({
@@ -61,7 +65,11 @@ export function ZendeskConfigView({
     <ContextItem.List>
       <ContextItem
         title="Sync unresolved tickets"
-        visual={<ContextItem.Visual visual={IntercomLogo} />}
+        visual={
+          <ContextItem.Visual
+            visual={isDark ? ZendeskWhiteLogo : ZendeskLogo}
+          />
+        }
         action={
           <div className="relative">
             <SliderToggle

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -1,0 +1,87 @@
+import {
+  ContextItem,
+  IntercomLogo,
+  SliderToggle,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import type { APIError, DataSourceType, WorkspaceType } from "@dust-tt/types";
+import { useState } from "react";
+
+import { useConnectorConfig } from "@app/lib/swr/connectors";
+
+export function ZendeskConfigView({
+  owner,
+  readOnly,
+  isAdmin,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+}) {
+  const configKey = "zendeskSyncUnresolvedTicketsEnabled";
+
+  const { configValue, mutateConfig } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey,
+  });
+  const syncUnresolvedTicketsEnabled = configValue === "true";
+
+  const sendNotification = useSendNotification();
+  const [loading, setLoading] = useState(false);
+
+  const handleSetNewConfig = async (configValue: boolean) => {
+    setLoading(true);
+    const res = await fetch(
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
+      {
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+        body: JSON.stringify({ configValue: configValue.toString() }),
+      }
+    );
+    if (res.ok) {
+      await mutateConfig();
+      setLoading(false);
+    } else {
+      setLoading(false);
+      const err = (await res.json()) as { error: APIError };
+      sendNotification({
+        type: "error",
+        title: "Failed to edit Zendesk configuration",
+        description: err.error.message,
+      });
+    }
+    return true;
+  };
+
+  return (
+    <ContextItem.List>
+      <ContextItem
+        title="Sync unresolved tickets"
+        visual={<ContextItem.Visual visual={IntercomLogo} />}
+        action={
+          <div className="relative">
+            <SliderToggle
+              size="xs"
+              onClick={async () => {
+                await handleSetNewConfig(!syncUnresolvedTicketsEnabled);
+              }}
+              selected={syncUnresolvedTicketsEnabled}
+              disabled={readOnly || !isAdmin || loading}
+            />
+          </div>
+        }
+      >
+        <ContextItem.Description>
+          <div className="text-element-700">
+            If activated, Dust will also sync the unresolved tickets (by default
+            only the closed and solved tickets are synced).
+          </div>
+        </ContextItem.Description>
+      </ContextItem>
+    </ContextItem.List>
+  );
+}

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -77,8 +77,7 @@ export function ZendeskConfigView({
       >
         <ContextItem.Description>
           <div className="text-element-700">
-            If activated, Dust will also sync the unresolved tickets (by default
-            only the closed and solved tickets are synced).
+            If activated, Dust will also sync the unresolved tickets.
           </div>
         </ContextItem.Description>
       </ContextItem>

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -86,6 +86,9 @@ export function ZendeskConfigView({
         <ContextItem.Description>
           <div className="text-element-700">
             If activated, Dust will also sync the unresolved tickets.
+            <br /> Be aware that this may significantly increase the number of
+            synced tickets, potentially negatively affecting the response
+            quality due to the added noise.
           </div>
         </ContextItem.Description>
       </ContextItem>

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -29,6 +29,7 @@ import type { ComponentType } from "react";
 import { GithubCodeEnableView } from "@app/components/data_source/GithubCodeEnableView";
 import { IntercomConfigView } from "@app/components/data_source/IntercomConfigView";
 import { SlackBotEnableView } from "@app/components/data_source/SlackBotEnableView";
+import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
 
 interface ConnectorOptionsProps {
   owner: WorkspaceType;
@@ -295,6 +296,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     getLogoComponent: (isDark?: boolean) => {
       return isDark ? ZendeskWhiteLogo : ZendeskLogo;
     },
+    optionsComponent: ZendeskConfigView,
     isNested: true,
     isSearchEnabled: false,
     permissions: {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -74,14 +74,15 @@ async function handler(
     });
   }
 
-  // We only allow setting and retrieving `botEnabled` (slack) and `codeSyncEnabled` (github). This
-  // is mainly to prevent users from enabling other configs that are not released (e.g. google_drive
-  // `pdfEnabled`).
+  // We only allow setting and retrieving `botEnabled` (Slack), `codeSyncEnabled` (GitHub),
+  // `intercomConversationsNotesSyncEnabled` (Intercom) and `zendeskSyncUnresolvedTicketsEnabled` (Zendesk).
+  // This is mainly to prevent users from enabling other configs that are not released (e.g., google_drive `pdfEnabled`).
   if (
     ![
       "botEnabled",
       "codeSyncEnabled",
       "intercomConversationsNotesSyncEnabled",
+      "zendeskSyncUnresolvedTicketsEnabled",
     ].includes(configKey)
   ) {
     return apiError(req, res, {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2231.
- This PR adds a configuration setting to sync the unresolved tickets in a Zendesk connector.
  - When selected, we will sync tickets with the following status: "closed", "solved".
  - When unselected, we will sync tickets with the following status: "closed", "solved", "open", "pending", "hold".
- The setting is disabled by default.
- The key used to identify this setting is named `zendeskSyncUnresolvedTicketsEnabled`.
- Changing the setting triggers a full-resync of the tickets (not the Help Center).

## Tests

- Tested locally.

## Risk

- Relatively low.

## Deploy Plan

- Run `migration_53.sql`.
- Deploy connectors.
- Deploy front.