### PR TITLE
Remove the "Untitled Document' default value when title tag is passed

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -337,9 +337,7 @@ export async function upsertDocument({
   const nonNullTags = tags || [];
   const titleInTags = nonNullTags
     .find((t) => t.startsWith("title:"))
-    ?.split(":")
-    .slice(1)
-    .join(":");
+    ?.substring(6);
   if (!titleInTags) {
     nonNullTags.push(`title:${title}`);
   }
@@ -647,9 +645,7 @@ export async function upsertTable({
   const tableTags = params.tags ?? [];
   const titleInTags = tableTags
     .find((t) => t.startsWith("title:"))
-    ?.split(":")
-    .slice(1)
-    .join(":");
+    ?.substring(6);
   if (!titleInTags) {
     tableTags.push(`title:${params.title}`);
   }

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -236,6 +236,7 @@ const upsertTableToDatasource: ProcessingFunction = async (
     tableId = upsertArgs.tableId ?? tableId;
   }
   const { title: upsertTitle, ...restArgs } = upsertArgs ?? {};
+  const title = upsertTitle ?? file.fileName;
 
   const upsertTableRes = await upsertTable({
     auth,
@@ -247,10 +248,14 @@ const upsertTableToDatasource: ProcessingFunction = async (
       description: "Table uploaded from file",
       truncate: true,
       csv: content.trim(),
-      tags: [`title:${file.fileName}`, `fileId:${file.sId}`],
+      tags: [
+        `title:${title}`,
+        `fileId:${file.sId}`,
+        `fileName:${file.fileName}`,
+      ],
       parents: [tableId],
       async: false,
-      title: upsertTitle ?? file.fileName,
+      title,
       mimeType: file.contentType,
       sourceUrl: file.getPrivateUrl(auth),
 

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -23,8 +23,11 @@ import type {
   UpsertDocumentArgs,
   UpsertTableArgs,
 } from "@app/lib/api/data_sources";
-import { isUpsertTableArgs } from "@app/lib/api/data_sources";
-import { upsertDocument, upsertTable } from "@app/lib/api/data_sources";
+import {
+  isUpsertTableArgs,
+  upsertDocument,
+  upsertTable,
+} from "@app/lib/api/data_sources";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
@@ -193,18 +196,19 @@ const upsertDocumentToDatasource: ProcessingFunction = async (
     documentId = upsertArgs.document_id;
   }
   const { title: upsertTitle, ...restArgs } = upsertArgs ?? {};
+  const title = upsertTitle ?? file.fileName;
   const upsertDocumentRes = await upsertDocument({
     // Beware, most values here are default values that are overridden by the ...restArgs below.
     document_id: documentId,
     source_url: sourceUrl,
     text: content,
     parents: [documentId],
-    tags: [`title:${file.fileName}`, `fileId:${file.sId}`],
+    tags: [`title:${title}`, `fileId:${file.sId}`, `fileName:${file.fileName}`],
     light_document_output: true,
     dataSource,
     auth,
     mime_type: file.contentType,
-    title: upsertTitle ?? file.fileName,
+    title,
 
     // Used to override defaults.
     ...restArgs,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -567,9 +567,7 @@ async function handler(
       const tags = r.data.tags || [];
       const titleInTags = tags
         .find((t) => t.startsWith("title:"))
-        ?.split(":")
-        .slice(1)
-        .join(":");
+        ?.substring(6);
       if (!titleInTags) {
         tags.push(`title:${title}`);
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -560,8 +560,6 @@ async function handler(
       }
 
       const documentId = req.query.documentId as string;
-
-      let title = r.data.title;
       const mimeType = r.data.mime_type ?? "application/octet-stream";
 
       const tags = r.data.tags || [];
@@ -569,27 +567,20 @@ async function handler(
         .find((t) => t.startsWith("title:"))
         ?.substring(6);
 
-      // Fill title with titleInTags if provided, add a fallback if none is provided.
-      title ??= titleInTags;
-      if (!title) {
-        logger.error(
-          { dataSourceId: dataSource.sId, documentId },
-          "[CoreNodes] No title information provided in both the tags and the title."
-        );
-        title ??= "Untitled Document";
-      }
+      // Use titleInTags if no title is provided.
+      const title = r.data.title || titleInTags || "Untitled Document";
 
       if (!titleInTags) {
         tags.push(`title:${title}`);
       }
 
-      // Enforce consistency between title and titleWithTags.
-      if (titleInTags && title && titleInTags !== title) {
+      if (titleInTags && titleInTags !== title) {
         logger.error(
           { dataSourceId: dataSource.sId, documentId, titleInTags, title },
           "[CoreNodes] Inconsistency between tags and title."
         );
-        // TODO(2025-02-18 aubin): uncomment what follows.
+        // TODO(2025-02-18 aubin): uncomment what follows (move the comment up).
+        // // Enforce consistency between title and titleWithTags.
         // return apiError(req, res, {
         //   status_code: 400,
         //   api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -334,7 +334,7 @@ async function handler(
         } else {
           const titleTag = tags?.find((t) => t.startsWith("title:"));
           if (titleTag) {
-            title = titleTag.split(":").slice(1).join(":");
+            title = titleTag.substring(6);
           } else {
             title = name;
           }


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2032.
- This PR handles an edge case where no document title is provided but one is passed in the tags, causing a discrepancy.
- The new behavior is as follows:
  - If we have a title either in the `title` parameter, or in the tags, we use it.
  - If we have none, we use "Untitled Document".
  - If we have two different titles we error.
- We probably want to keep the fallback value of "Untitled Document" if none is passed to avoid breaking retro-compatibility too much.
- This PR also handles file reuploading in static datasources, when the underlying file is changed we keep the existing title.

## Tests

## Risk


## Deploy Plan

- Deploy front.