### PR TITLE
[front/lib/api] - chore: pass `DataSourceView` in `getContentNodes`

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -411,6 +411,7 @@ export function DataSourceViewSelector({
             .filter((v) => v.isSelected)
             .map((v) => ({
               ...v.node,
+              dataSourceView,
               parentInternalIds: v.parents,
             })),
           isSelectAll: false,

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -7,7 +7,7 @@ import type {
 import { assertNever, MIME_TYPES } from "@dust-tt/types";
 
 import { SPREADSHEET_MIME_TYPES } from "@app/lib/content_nodes";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 
 export const NON_EXPANDABLE_NODES_MIME_TYPES = [
   MIME_TYPES.SLACK.CHANNEL,
@@ -76,7 +76,7 @@ function isExpandable(
 }
 
 export function getContentNodeFromCoreNode(
-  dataSourceView: DataSourceViewResource | DataSourceViewType,
+  dataSourceView: DataSourceViewType,
   coreNode: CoreAPIContentNode,
   viewType: ContentNodesViewType
 ): DataSourceViewContentNode {
@@ -99,9 +99,6 @@ export function getContentNodeFromCoreNode(
     preventSelection: FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(
       coreNode.mime_type
     ),
-    dataSourceView:
-      dataSourceView instanceof DataSourceViewResource
-        ? dataSourceView.toJSON()
-        : dataSourceView,
+    dataSourceView,
   };
 }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -7,7 +7,7 @@ import type {
 import { assertNever, MIME_TYPES } from "@dust-tt/types";
 
 import { SPREADSHEET_MIME_TYPES } from "@app/lib/content_nodes";
-import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 
 export const NON_EXPANDABLE_NODES_MIME_TYPES = [
   MIME_TYPES.SLACK.CHANNEL,
@@ -76,6 +76,7 @@ function isExpandable(
 }
 
 export function getContentNodeFromCoreNode(
+  dataSourceView: DataSourceViewResource | DataSourceViewType,
   coreNode: CoreAPIContentNode,
   viewType: ContentNodesViewType
 ): DataSourceViewContentNode {
@@ -98,5 +99,9 @@ export function getContentNodeFromCoreNode(
     preventSelection: FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(
       coreNode.mime_type
     ),
+    dataSourceView:
+      dataSourceView instanceof DataSourceViewResource
+        ? dataSourceView.toJSON()
+        : dataSourceView,
   };
 }

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -196,7 +196,7 @@ export async function getContentNodesForDataSourceView(
 
   return new Ok({
     nodes: resultNodes.map((node) =>
-      getContentNodeFromCoreNode(node, viewType)
+      getContentNodeFromCoreNode(dataSourceView, node, viewType)
     ),
     total: resultNodes.length,
     nextPageCursor: nextPageCursor,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -21,7 +21,7 @@ import type {
 import { isCursorPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
-import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 
 export function filterAndCropContentNodesByView(
@@ -196,7 +196,13 @@ export async function getContentNodesForDataSourceView(
 
   return new Ok({
     nodes: resultNodes.map((node) =>
-      getContentNodeFromCoreNode(dataSourceView, node, viewType)
+      getContentNodeFromCoreNode(
+        dataSourceView instanceof DataSourceViewResource
+          ? dataSourceView.toJSON()
+          : dataSourceView,
+        node,
+        viewType
+      )
     ),
     total: resultNodes.length,
     nextPageCursor: nextPageCursor,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -141,11 +141,28 @@ async function handler(
     });
   }
 
-  return res.status(200).json({
-    nodes: searchRes.value.nodes.map((node) =>
-      getContentNodeFromCoreNode(node, viewType)
-    ),
+  const dataSourceViewById = new Map(
+    datasourceViews.map((dsv) => [dsv.dataSource.dustAPIDataSourceId, dsv])
+  );
+
+  const nodes = searchRes.value.nodes.flatMap((node) => {
+    const dataSourceView = dataSourceViewById.get(node.data_source_id);
+
+    if (!dataSourceView) {
+      logger.error(
+        {
+          nodeId: node.node_id,
+          expectedDataSourceId: node.data_source_id,
+          availableDataSourceIds: Array.from(dataSourceViewById.keys()),
+        },
+        "DataSourceView lookup failed for node"
+      );
+      return [];
+    }
+
+    return getContentNodeFromCoreNode(dataSourceView, node, viewType);
   });
+  return res.status(200).json({ nodes });
 }
 
 export default withSessionAuthenticationForWorkspace(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -160,7 +160,7 @@ async function handler(
       return [];
     }
 
-    return getContentNodeFromCoreNode(dataSourceView, node, viewType);
+    return getContentNodeFromCoreNode(dataSourceView.toJSON(), node, viewType);
   });
   return res.status(200).json({ nodes });
 }

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -27,6 +27,7 @@ export type DataSourceViewsWithDetails = DataSourceViewType & {
 };
 
 export type DataSourceViewContentNode = ContentNode & {
+  dataSourceView: DataSourceViewType;
   parentInternalIds: string[] | null;
 };
 

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -1,4 +1,7 @@
-import { AdminCommandType, AdminResponseType } from "../../connectors/admin/cli";
+import {
+  AdminCommandType,
+  AdminResponseType,
+} from "../../connectors/admin/cli";
 import { ConnectorsAPIError, isConnectorsAPIError } from "../../connectors/api";
 import { UpdateConnectorConfigurationType } from "../../connectors/api_handlers/connector_configuration";
 import { ConnectorCreateRequestBody } from "../../connectors/api_handlers/create_connector";

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -1,7 +1,4 @@
-import {
-  AdminCommandType,
-  AdminResponseType,
-} from "../../connectors/admin/cli";
+import { AdminCommandType, AdminResponseType } from "../../connectors/admin/cli";
 import { ConnectorsAPIError, isConnectorsAPIError } from "../../connectors/api";
 import { UpdateConnectorConfigurationType } from "../../connectors/api_handlers/connector_configuration";
 import { ConnectorCreateRequestBody } from "../../connectors/api_handlers/create_connector";
@@ -12,6 +9,7 @@ import { ContentNodeType } from "../../core/content_node";
 import { ConnectorProvider, DataSourceType } from "../../front/data_source";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
+import { DataSourceViewType } from "../data_source_view";
 
 export type ConnectorsAPIResponse<T> = Result<T, ConnectorsAPIError>;
 export type ConnectorSyncStatus = "succeeded" | "failed";
@@ -87,18 +85,19 @@ export type ProviderVisibility = "public" | "private";
  * https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
  */
 export interface ContentNode {
+  dataSourceView: DataSourceViewType;
+  expandable: boolean;
   internalId: string;
+  lastUpdatedAt: number | null;
+  mimeType: string;
   // The direct parent ID of this content node
   parentInternalId: string | null;
-  type: ContentNodeType;
-  title: string;
-  sourceUrl: string | null;
-  expandable: boolean;
-  preventSelection?: boolean;
   permission: ConnectorPermission;
-  lastUpdatedAt: number | null;
+  preventSelection?: boolean;
   providerVisibility?: ProviderVisibility;
-  mimeType: string;
+  sourceUrl: string | null;
+  title: string;
+  type: ContentNodeType;
 }
 
 type GetContentNodesReturnType<Key extends string> = ConnectorsAPIResponse<{

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -12,7 +12,6 @@ import { ContentNodeType } from "../../core/content_node";
 import { ConnectorProvider, DataSourceType } from "../../front/data_source";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
-import { DataSourceViewType } from "../data_source_view";
 
 export type ConnectorsAPIResponse<T> = Result<T, ConnectorsAPIError>;
 export type ConnectorSyncStatus = "succeeded" | "failed";
@@ -88,7 +87,6 @@ export type ProviderVisibility = "public" | "private";
  * https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
  */
 export interface ContentNode {
-  dataSourceView: DataSourceViewType;
   expandable: boolean;
   internalId: string;
   lastUpdatedAt: number | null;


### PR DESCRIPTION
## Description

This PR passes `DataSourceView` information to content nodes to ensure proper context is available for rendering and permissions management. 
This change adds a dataSourceView field to the DataSourceViewContentNode type, which is populated with either a serialized instance of DataSourceViewResource or a DataSourceViewType 

## Risk

Low

## Deploy Plan

Deploy `front`