### PR TITLE
Flav/sparkle markdown variants

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.413",
+  "version": "0.2.414",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.413",
+      "version": "0.2.414",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.413",
+  "version": "0.2.414",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -88,6 +88,7 @@ export type { LinkWrapperProps } from "./LinkWrapper";
 export { LinkWrapper } from "./LinkWrapper";
 export { LoadingBlock } from "./LoadingBlock";
 export * from "./markdown";
+export { markdownStyles } from "./markdown/styles";
 export * from "./NavigationList";
 export type { NotificationType } from "./Notification";
 export { Notification, useSendNotification } from "./Notification";

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -10,7 +10,7 @@ export const blockquoteVariants = cva(
       variant: {
         muted: [
           "s-text-foreground dark:s-text-foreground-night",
-          "s-bg-white dark:s-bg-muted-background-night",
+          "s-bg-slate-100 dark:s-bg-muted-night",
         ],
         surface: [
           "s-text-foreground dark:s-text-foreground-night",

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -1,25 +1,29 @@
+import { cva } from "class-variance-authority";
 import React from "react";
 
 import { ContentBlockWrapper } from "@sparkle/components";
-import { cn } from "@sparkle/lib/utils";
 
-export const blockquoteVariants = {
-  base: "s-w-full s-text-base s-italic s-rounded-2xl s-py-3 s-pl-5 s-pr-12",
-  variant: {
-    muted: cn(
-      "s-text-foreground dark:s-text-foreground-night",
-      "s-bg-white dark:s-bg-muted-background-night"
-    ),
-    surface: cn(
-      "s-text-foreground dark:s-text-foreground-night",
-      "s-bg-muted-background dark:s-bg-muted-background-night"
-    ),
-  },
-};
+export const blockquoteVariants = cva(
+  ["s-w-full s-text-base s-italic s-rounded-2xl s-py-3 s-pl-5 s-pr-12"],
+  {
+    variants: {
+      variant: {
+        muted: [
+          "s-text-foreground dark:s-text-foreground-night",
+          "s-bg-white dark:s-bg-muted-background-night",
+        ],
+        surface: [
+          "s-text-foreground dark:s-text-foreground-night",
+          "s-bg-muted-background dark:s-bg-muted-background-night",
+        ],
+      },
+    },
+  }
+);
 
 interface BlockquoteBlockProps {
   children: React.ReactNode;
-  variant?: keyof typeof blockquoteVariants.variant;
+  variant?: "muted" | "surface";
 }
 
 export function BlockquoteBlock({
@@ -44,12 +48,7 @@ export function BlockquoteBlock({
 
   return (
     <ContentBlockWrapper content={clipboardContent} className="s-my-2">
-      <blockquote
-        className={cn(
-          blockquoteVariants.base,
-          blockquoteVariants.variant[variant]
-        )}
-      >
+      <blockquote className={blockquoteVariants({ variant })}>
         {children}
       </blockquote>
     </ContentBlockWrapper>

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -3,9 +3,29 @@ import React from "react";
 import { ContentBlockWrapper } from "@sparkle/components";
 import { cn } from "@sparkle/lib/utils";
 
-type BlockquoteBlockProps = { children: React.ReactNode };
+export const blockquoteVariants = {
+  base: "s-w-full s-text-base s-italic s-rounded-2xl s-py-3 s-pl-5 s-pr-12",
+  variant: {
+    muted: cn(
+      "s-text-foreground dark:s-text-foreground-night",
+      "s-bg-white dark:s-bg-muted-background-night"
+    ),
+    surface: cn(
+      "s-text-foreground dark:s-text-foreground-night",
+      "s-bg-muted-background dark:s-bg-muted-background-night"
+    ),
+  },
+};
 
-export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
+interface BlockquoteBlockProps {
+  children: React.ReactNode;
+  variant?: keyof typeof blockquoteVariants.variant;
+}
+
+export function BlockquoteBlock({
+  children,
+  variant = "surface",
+}: BlockquoteBlockProps) {
   const elementAt1 = React.Children.toArray(children)[1];
   const childrenContent =
     elementAt1 && React.isValidElement(elementAt1)
@@ -26,10 +46,8 @@ export function BlockquoteBlock({ children }: BlockquoteBlockProps) {
     <ContentBlockWrapper content={clipboardContent} className="s-my-2">
       <blockquote
         className={cn(
-          "s-w-full s-text-base s-italic",
-          "s-rounded-2xl s-py-3 s-pl-5 s-pr-12",
-          "s-text-foreground dark:s-text-foreground-night",
-          "s-bg-muted-background dark:s-bg-muted-background-night"
+          blockquoteVariants.base,
+          blockquoteVariants.variant[variant]
         )}
       >
         {children}

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -1,34 +1,40 @@
+import { cva } from "class-variance-authority";
 import React, { Suspense } from "react";
 import { amber, emerald, pink, sky, slate, violet } from "tailwindcss/colors";
-
-import { cn } from "@sparkle/lib";
 
 const SyntaxHighlighter = React.lazy(
   () => import("react-syntax-highlighter/dist/esm/default-highlight")
 );
 
-export const codeBlockVariants = {
-  base: cn(
+export const codeBlockVariants = cva(
+  [
     "s-mx-0.5 s-cursor-text s-rounded-lg s-border s-px-1.5 s-py-1",
-    "s-border-border-dark dark:s-border-border-dark-night"
-  ),
-  variant: {
-    muted: cn(
-      "s-bg-slate-100 dark:s-bg-muted-night",
-      "s-text-slate-900 dark:s-text-slate-200"
-    ),
-    surface: cn(
-      "s-bg-muted dark:s-bg-muted-night",
-      "s-text-amber-600 dark:s-text-amber-600-night"
-    ),
-  },
-};
+    "s-border-border-dark dark:s-border-border-dark-night",
+  ],
+  {
+    variants: {
+      variant: {
+        muted: [
+          "s-bg-slate-100 dark:s-bg-muted-night",
+          "s-text-slate-900 dark:s-text-slate-200",
+        ],
+        surface: [
+          "s-bg-muted dark:s-bg-muted-night",
+          "s-text-amber-600 dark:s-text-amber-600-night",
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: "surface",
+    },
+  }
+);
 
 type CodeBlockProps = {
   children?: React.ReactNode;
   className?: string;
   inline?: boolean;
-  variant?: keyof typeof codeBlockVariants.variant;
+  variant?: "muted" | "surface";
   wrapLongLines?: boolean;
 };
 
@@ -154,10 +160,6 @@ export function CodeBlock({
       </div>
     </Suspense>
   ) : (
-    <code
-      className={cn(codeBlockVariants.base, codeBlockVariants.variant[variant])}
-    >
-      {children}
-    </code>
+    <code className={codeBlockVariants({ variant })}>{children}</code>
   );
 }

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -7,10 +7,28 @@ const SyntaxHighlighter = React.lazy(
   () => import("react-syntax-highlighter/dist/esm/default-highlight")
 );
 
+export const codeBlockVariants = {
+  base: cn(
+    "s-mx-0.5 s-cursor-text s-rounded-lg s-border s-px-1.5 s-py-1",
+    "s-border-border-dark dark:s-border-border-dark-night"
+  ),
+  variant: {
+    muted: cn(
+      "s-bg-slate-100 dark:s-bg-muted-night",
+      "s-text-slate-900 dark:s-text-slate-200"
+    ),
+    surface: cn(
+      "s-bg-muted dark:s-bg-muted-night",
+      "s-text-amber-600 dark:s-text-amber-600-night"
+    ),
+  },
+};
+
 type CodeBlockProps = {
   children?: React.ReactNode;
   className?: string;
   inline?: boolean;
+  variant?: keyof typeof codeBlockVariants.variant;
   wrapLongLines?: boolean;
 };
 
@@ -18,6 +36,7 @@ export function CodeBlock({
   children,
   className,
   inline,
+  variant = "surface",
   wrapLongLines = false,
 }: CodeBlockProps): JSX.Element {
   const match = /language-(\w+)/.exec(className || "");
@@ -136,12 +155,7 @@ export function CodeBlock({
     </Suspense>
   ) : (
     <code
-      className={cn(
-        "s-mx-0.5 s-cursor-text s-rounded-lg s-border s-px-1.5 s-py-1",
-        "s-border-border-dark dark:s-border-border-dark-night",
-        "s-bg-muted dark:s-bg-muted-night",
-        "s-text-amber-600 dark:s-text-amber-600-night"
-      )}
+      className={cn(codeBlockVariants.base, codeBlockVariants.variant[variant])}
     >
       {children}
     </code>

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -1,10 +1,11 @@
+import { cva } from "class-variance-authority";
 import React from "react";
 
 import { cn } from "@sparkle/lib";
 
-export const ulBlockVariants = {
-  base: "s-list-disc s-py-2 s-pl-8 first:s-pt-0 last:s-pb-0",
-};
+export const ulBlockVariants = cva([
+  "s-list-disc s-py-2 s-pl-8 first:s-pt-0 last:s-pb-0",
+]);
 
 interface UlBlockProps {
   children: React.ReactNode;
@@ -14,15 +15,13 @@ interface UlBlockProps {
 
 export function UlBlock({ children, textColor, textSize }: UlBlockProps) {
   return (
-    <ul className={cn(ulBlockVariants.base, textColor, textSize)}>
-      {children}
-    </ul>
+    <ul className={cn(ulBlockVariants(), textColor, textSize)}>{children}</ul>
   );
 }
 
-export const olBlockVariants = {
-  base: "s-list-decimal s-py-3 s-pl-8 first:s-pt-0 last:s-pb-0",
-};
+export const olBlockVariants = cva([
+  "s-list-decimal s-py-3 s-pl-8 first:s-pt-0 last:s-pb-0",
+]);
 
 interface OlBlockProps {
   children: React.ReactNode;
@@ -38,15 +37,15 @@ export function OlBlock({
   textSize,
 }: OlBlockProps) {
   return (
-    <ol start={start} className={cn(olBlockVariants.base, textColor, textSize)}>
+    <ol start={start} className={cn(olBlockVariants(), textColor, textSize)}>
       {children}
     </ol>
   );
 }
 
-export const liBlockVariants = {
-  base: "s-break-words first:s-pt-0 last:s-pb-0 s-py-1 @md:s-py-2",
-};
+export const liBlockVariants = cva([
+  "s-break-words first:s-pt-0 last:s-pb-0 s-py-1 @md:s-py-2",
+]);
 
 interface LiBlockProps {
   children: React.ReactNode;
@@ -62,7 +61,7 @@ export function LiBlock({
   textSize,
 }: LiBlockProps) {
   return (
-    <li className={cn(liBlockVariants.base, textColor, textSize, className)}>
+    <li className={cn(liBlockVariants(), textColor, textSize, className)}>
       {children}
     </li>
   );

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+import { cn } from "@sparkle/lib";
+
+export const ulBlockVariants = {
+  base: "s-list-disc s-py-2 s-pl-8 first:s-pt-0 last:s-pb-0",
+};
+
+interface UlBlockProps {
+  children: React.ReactNode;
+  textColor: string;
+  textSize: string;
+}
+
+export function UlBlock({ children, textColor, textSize }: UlBlockProps) {
+  return (
+    <ul className={cn(ulBlockVariants.base, textColor, textSize)}>
+      {children}
+    </ul>
+  );
+}
+
+export const olBlockVariants = {
+  base: "s-list-decimal s-py-3 s-pl-8 first:s-pt-0 last:s-pb-0",
+};
+
+interface OlBlockProps {
+  children: React.ReactNode;
+  start?: number;
+  textColor: string;
+  textSize: string;
+}
+
+export function OlBlock({
+  children,
+  start,
+  textColor,
+  textSize,
+}: OlBlockProps) {
+  return (
+    <ol start={start} className={cn(olBlockVariants.base, textColor, textSize)}>
+      {children}
+    </ol>
+  );
+}
+
+export const liBlockVariants = {
+  base: "s-break-words first:s-pt-0 last:s-pb-0 s-py-1 @md:s-py-2",
+};
+
+interface LiBlockProps {
+  children: React.ReactNode;
+  className?: string;
+  textColor: string;
+  textSize: string;
+}
+
+export function LiBlock({
+  children,
+  className,
+  textColor,
+  textSize,
+}: LiBlockProps) {
+  return (
+    <li className={cn(liBlockVariants.base, textColor, textSize, className)}>
+      {children}
+    </li>
+  );
+}

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -13,7 +13,10 @@ import { visit } from "unist-util-visit";
 import { Checkbox } from "@sparkle/components";
 import { BlockquoteBlock } from "@sparkle/components/markdown/BlockquoteBlock";
 import { CodeBlockWithExtendedSupport } from "@sparkle/components/markdown/CodeBlockWithExtendedSupport";
+import { LiBlock, OlBlock, UlBlock } from "@sparkle/components/markdown/List";
 import { MarkdownContentContext } from "@sparkle/components/markdown/MarkdownContentContext";
+import { ParagraphBlock } from "@sparkle/components/markdown/ParagraphBlock";
+import { PreBlock } from "@sparkle/components/markdown/PreBlock";
 import {
   TableBlock,
   TableBodyBlock,
@@ -259,129 +262,6 @@ function LinkBlock({
     >
       {children}
     </a>
-  );
-}
-
-function PreBlock({ children }: { children: React.ReactNode }) {
-  const validChildrenContent =
-    Array.isArray(children) && children[0]
-      ? children[0].props.children[0]
-      : null;
-
-  let fallbackData: string | null = null;
-  if (!validChildrenContent) {
-    fallbackData =
-      Array.isArray(children) && children[0]
-        ? children[0].props?.node?.data?.meta
-        : null;
-  }
-
-  return (
-    <pre
-      className={cn(
-        "s-my-2 s-w-full s-break-all s-rounded-2xl s-border",
-        "s-border-border-dark dark:s-border-border-dark-night",
-        "s-bg-muted-background dark:s-bg-muted-background-night"
-      )}
-    >
-      {validChildrenContent ? children : fallbackData || children}
-    </pre>
-  );
-}
-
-function UlBlock({
-  children,
-  textColor,
-  textSize,
-}: {
-  children: React.ReactNode;
-  textColor: string;
-  textSize: string;
-}) {
-  return (
-    <ul
-      className={cn(
-        "s-list-disc s-py-2 s-pl-8 first:s-pt-0 last:s-pb-0",
-        textColor,
-        textSize
-      )}
-    >
-      {children}
-    </ul>
-  );
-}
-
-function OlBlock({
-  children,
-  start,
-  textColor,
-  textSize,
-}: {
-  children: React.ReactNode;
-  start?: number;
-  textColor: string;
-  textSize: string;
-}) {
-  return (
-    <ol
-      start={start}
-      className={cn(
-        "s-list-decimal s-py-3 s-pl-8 first:s-pt-0 last:s-pb-0",
-        textColor,
-        textSize
-      )}
-    >
-      {children}
-    </ol>
-  );
-}
-
-function LiBlock({
-  children,
-  textColor,
-  textSize,
-  className = "",
-}: {
-  children: React.ReactNode;
-  textColor: string;
-  className?: string;
-  textSize: string;
-}) {
-  return (
-    <li
-      className={cn(
-        "s-break-words first:s-pt-0 last:s-pb-0",
-        "s-py-1 @md:s-py-2",
-        textColor,
-        textSize,
-        className
-      )}
-    >
-      {children}
-    </li>
-  );
-}
-
-function ParagraphBlock({
-  children,
-  textColor,
-  textSize,
-}: {
-  children: React.ReactNode;
-  textColor: string;
-  textSize: string;
-}) {
-  return (
-    <div
-      className={cn(
-        "s-whitespace-pre-wrap s-break-words s-font-normal first:s-pt-0 last:s-pb-0",
-        "s-py-1 @md:s-py-2 @md:s-leading-7",
-        textSize,
-        textColor
-      )}
-    >
-      {children}
-    </div>
   );
 }
 

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -1,13 +1,12 @@
+import { cva } from "class-variance-authority";
 import React from "react";
 
 import { cn } from "@sparkle/lib";
 
-export const paragraphBlockVariants = {
-  base: cn(
-    "s-whitespace-pre-wrap s-break-words s-font-normal first:s-pt-0 last:s-pb-0",
-    "s-py-1 @md:s-py-2 @md:s-leading-7"
-  ),
-};
+export const paragraphBlockVariants = cva([
+  "s-whitespace-pre-wrap s-break-words s-font-normal first:s-pt-0 last:s-pb-0",
+  "s-py-1 @md:s-py-2 @md:s-leading-7",
+]);
 
 interface ParagraphBlockProps {
   children: React.ReactNode;
@@ -21,7 +20,7 @@ export function ParagraphBlock({
   textSize,
 }: ParagraphBlockProps) {
   return (
-    <div className={cn(paragraphBlockVariants.base, textSize, textColor)}>
+    <div className={cn(paragraphBlockVariants(), textSize, textColor)}>
       {children}
     </div>
   );

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { cn } from "@sparkle/lib";
+
+export const paragraphBlockVariants = {
+  base: cn(
+    "s-whitespace-pre-wrap s-break-words s-font-normal first:s-pt-0 last:s-pb-0",
+    "s-py-1 @md:s-py-2 @md:s-leading-7"
+  ),
+};
+
+interface ParagraphBlockProps {
+  children: React.ReactNode;
+  textColor: string;
+  textSize: string;
+}
+
+export function ParagraphBlock({
+  children,
+  textColor,
+  textSize,
+}: ParagraphBlockProps) {
+  return (
+    <div className={cn(paragraphBlockVariants.base, textSize, textColor)}>
+      {children}
+    </div>
+  );
+}

--- a/sparkle/src/components/markdown/PreBlock.tsx
+++ b/sparkle/src/components/markdown/PreBlock.tsx
@@ -1,21 +1,26 @@
+import { cva } from "class-variance-authority";
 import React from "react";
 
 import { cn } from "@sparkle/lib";
 
-export const preBlockVariants = {
-  base: cn(
+export const preBlockVariants = cva(
+  [
     "s-my-2 s-w-full s-break-all s-rounded-2xl s-border",
-    "s-border-border-dark dark:s-border-border-dark-night"
-  ),
-  variant: {
-    muted: "s-bg-gray-700 s-text-gray-500 dark:s-bg-muted-background-night",
-    surface: "s-bg-muted-background dark:s-bg-muted-background-night",
-  },
-};
+    "s-border-border-dark dark:s-border-border-dark-night",
+  ],
+  {
+    variants: {
+      variant: {
+        muted: "s-bg-gray-700 s-text-gray-500 dark:s-bg-muted-background-night",
+        surface: "s-bg-muted-background dark:s-bg-muted-background-night",
+      },
+    },
+  }
+);
 
 interface PreBlockProps {
   children: React.ReactNode;
-  variant?: keyof typeof preBlockVariants.variant;
+  variant?: "muted" | "surface";
 }
 
 export function PreBlock({ children, variant = "surface" }: PreBlockProps) {
@@ -33,9 +38,7 @@ export function PreBlock({ children, variant = "surface" }: PreBlockProps) {
   }
 
   return (
-    <pre
-      className={cn(preBlockVariants.base, preBlockVariants.variant[variant])}
-    >
+    <pre className={preBlockVariants({ variant })}>
       {validChildrenContent ? children : fallbackData || children}
     </pre>
   );

--- a/sparkle/src/components/markdown/PreBlock.tsx
+++ b/sparkle/src/components/markdown/PreBlock.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+import { cn } from "@sparkle/lib";
+
+export const preBlockVariants = {
+  base: cn(
+    "s-my-2 s-w-full s-break-all s-rounded-2xl s-border",
+    "s-border-border-dark dark:s-border-border-dark-night"
+  ),
+  variant: {
+    muted: "s-bg-gray-700 s-text-gray-500 dark:s-bg-muted-background-night",
+    surface: "s-bg-muted-background dark:s-bg-muted-background-night",
+  },
+};
+
+interface PreBlockProps {
+  children: React.ReactNode;
+  variant?: keyof typeof preBlockVariants.variant;
+}
+
+export function PreBlock({ children, variant = "surface" }: PreBlockProps) {
+  const validChildrenContent =
+    Array.isArray(children) && children[0]
+      ? children[0].props.children[0]
+      : null;
+
+  let fallbackData: string | null = null;
+  if (!validChildrenContent) {
+    fallbackData =
+      Array.isArray(children) && children[0]
+        ? children[0].props?.node?.data?.meta
+        : null;
+  }
+
+  return (
+    <pre
+      className={cn(preBlockVariants.base, preBlockVariants.variant[variant])}
+    >
+      {validChildrenContent ? children : fallbackData || children}
+    </pre>
+  );
+}

--- a/sparkle/src/components/markdown/PreBlock.tsx
+++ b/sparkle/src/components/markdown/PreBlock.tsx
@@ -1,8 +1,6 @@
 import { cva } from "class-variance-authority";
 import React from "react";
 
-import { cn } from "@sparkle/lib";
-
 export const preBlockVariants = cva(
   [
     "s-my-2 s-w-full s-break-all s-rounded-2xl s-border",

--- a/sparkle/src/components/markdown/styles.ts
+++ b/sparkle/src/components/markdown/styles.ts
@@ -1,0 +1,21 @@
+import { blockquoteVariants } from "@sparkle/components/markdown/BlockquoteBlock";
+import { codeBlockVariants } from "@sparkle/components/markdown/CodeBlock";
+import {
+  liBlockVariants,
+  olBlockVariants,
+  ulBlockVariants,
+} from "@sparkle/components/markdown/List";
+import { paragraphBlockVariants } from "@sparkle/components/markdown/ParagraphBlock";
+import { preBlockVariants } from "@sparkle/components/markdown/PreBlock";
+
+// This exports markdown styles for all components.
+// It is used in the InputBar component.
+export const markdownStyles = {
+  blockquote: blockquoteVariants,
+  code: codeBlockVariants,
+  list: liBlockVariants,
+  orderedList: olBlockVariants,
+  paragraph: paragraphBlockVariants,
+  pre: preBlockVariants,
+  unorderedList: ulBlockVariants,
+};


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR exposes the Markdown styles currently only accessible within Sparkle so they can be used in the `InputBar` component to render markdown.

We will use two variants here: 
- `muted` to be used when the Markdown component is used on our slate background (e.g `UserMessage`, `InputBar`)
- `surface` to be used when the Markdown component is rendered on our "white" background. (e.g: `AgentMessage`). This is the default variant.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
