### PR TITLE
core: clean-up bakward compatible support for CSV buckets

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2207,39 +2207,14 @@ async fn data_sources_delete(
 
 #[derive(serde::Deserialize)]
 struct DatabasesTablesValidateCSVContentPayload {
-    bucket: Option<String>,
-    bucket_csv_path: Option<String>,
-    upsert_queue_bucket_csv_path: Option<String>,
+    bucket: String,
+    bucket_csv_path: String,
 }
 
 async fn tables_validate_csv_content(
     Json(payload): Json<DatabasesTablesValidateCSVContentPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    // Backward compatibility moving from `upsert_queue_bucket_csv_path` to `bucket` and
-    // `bucket_csv_path`.
-    // TODO(spolu): to remove once front is migrated.
-    let (bucket, bucket_csv_path) = match (payload.bucket, payload.bucket_csv_path) {
-        (Some(bucket), Some(bucket_csv_path)) => (bucket, bucket_csv_path),
-        _ => match payload.upsert_queue_bucket_csv_path {
-            Some(upsert_queue_bucket_csv_path) => (
-                UpsertQueueCSVContent::get_upsert_queue_bucket()
-                    .await
-                    .unwrap(),
-                upsert_queue_bucket_csv_path,
-            ),
-            _ => {
-                return error_response(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_csv_content",
-                    "Failed to validate the CSV content - either `bucket` and \
-                          `bucket_csv_path` or `upsert_queue_bucket_csv_path` should be defined",
-                    None,
-                );
-            }
-        },
-    };
-
-    match LocalTable::validate_csv_content(&bucket, &bucket_csv_path).await {
+    match LocalTable::validate_csv_content(&payload.bucket, &payload.bucket_csv_path).await {
         Ok(schema) => (
             StatusCode::OK,
             Json(APIResponse {
@@ -2696,9 +2671,8 @@ async fn tables_update_parents(
 
 #[derive(serde::Deserialize)]
 struct DatabasesTablesUpsertCSVContentPayload {
-    bucket: Option<String>,
-    bucket_csv_path: Option<String>,
-    upsert_queue_bucket_csv_path: Option<String>,
+    bucket: String,
+    bucket_csv_path: String,
     truncate: Option<bool>,
 }
 
@@ -2708,30 +2682,6 @@ async fn tables_csv_upsert(
     Json(payload): Json<DatabasesTablesUpsertCSVContentPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
-
-    // Backward compatibility moving from `upsert_queue_bucket_csv_path` to `bucket` and
-    // `bucket_csv_path`.
-    // TODO(spolu): to remove once front is migrated.
-    let (bucket, bucket_csv_path) = match (payload.bucket, payload.bucket_csv_path) {
-        (Some(bucket), Some(bucket_csv_path)) => (bucket, bucket_csv_path),
-        _ => match payload.upsert_queue_bucket_csv_path {
-            Some(upsert_queue_bucket_csv_path) => (
-                UpsertQueueCSVContent::get_upsert_queue_bucket()
-                    .await
-                    .unwrap(),
-                upsert_queue_bucket_csv_path,
-            ),
-            _ => {
-                return error_response(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_csv_content",
-                    "Failed to validate the CSV content - either `bucket` and \
-                          `bucket_csv_path` or `upsert_queue_bucket_csv_path` should be defined",
-                    None,
-                );
-            }
-        },
-    };
 
     match state
         .store
@@ -2768,8 +2718,8 @@ async fn tables_csv_upsert(
                     .upsert_csv_content(
                         state.store.clone(),
                         state.databases_store.clone(),
-                        &bucket,
-                        &bucket_csv_path,
+                        &payload.bucket,
+                        &payload.bucket_csv_path,
                         match payload.truncate {
                             Some(v) => v,
                             None => false,

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -22,13 +22,6 @@ const MAX_COLUMN_NAME_LENGTH: usize = 1024;
 const MAX_TABLE_ROWS: usize = 500_000;
 
 impl UpsertQueueCSVContent {
-    pub async fn get_upsert_queue_bucket() -> Result<String> {
-        match std::env::var("DUST_UPSERT_QUEUE_BUCKET") {
-            Ok(bucket) => Ok(bucket),
-            Err(_) => Err(anyhow!("DUST_UPSERT_QUEUE_BUCKET is not set")),
-        }
-    }
-
     pub async fn parse(&self) -> Result<Vec<Row>> {
         let now = utils::now();
         let bucket = &self.bucket;


### PR DESCRIPTION
## Description

Clean-up of backward compatible code to support deploy of the new bucket handling

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `core`