### PR TITLE
Add dark mode to `JsonViewer`

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -1,11 +1,11 @@
 import {
+  Button,
   Chip,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@dust-tt/sparkle";
-import { Button } from "@dust-tt/sparkle";
 import type {
   ConnectorType,
   CoreAPIDataSource,
@@ -21,6 +21,7 @@ import {
   PokeTableCell,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { isWebhookBasedProvider } from "@app/lib/connector_providers";
 import { formatTimestampToFriendlyDate, timeAgoFrom } from "@app/lib/utils";
 
@@ -238,6 +239,7 @@ function RawObjectsModal({
   coreDataSource: CoreAPIDataSource;
   dataSource: DataSourceType;
 }) {
+  const { isDark } = useTheme();
   return (
     <Dialog
       open={show}
@@ -254,18 +256,21 @@ function RawObjectsModal({
         <div className="mx-2 my-4 overflow-y-auto">
           <span className="text-sm font-bold">dataSource</span>
           <JsonViewer
+            theme={isDark ? "dark" : "light"}
             value={dataSource}
             rootName={false}
             defaultInspectDepth={1}
           />
           <span className="text-sm font-bold">coreDataSource</span>
           <JsonViewer
+            theme={isDark ? "dark" : "light"}
             value={coreDataSource}
             rootName={false}
             defaultInspectDepth={1}
           />
           <span className="text-sm font-bold">connector</span>
           <JsonViewer
+            theme={isDark ? "dark" : "light"}
             value={connector}
             rootName={false}
             defaultInspectDepth={1}

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -6,6 +6,7 @@ import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
@@ -35,6 +36,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 const AssistantDetailsPage = ({
   agentConfigurations,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const { isDark } = useTheme();
   return (
     <div className="mx-auto max-w-4xl pt-8">
       <Page.Vertical align="stretch">
@@ -75,6 +77,7 @@ const AssistantDetailsPage = ({
                       )?.displayName ?? `Unknown Model (${a.model.modelId})`}
                     </div>
                     <JsonViewer
+                      theme={isDark ? "dark" : "light"}
                       value={a.model}
                       rootName={false}
                       defaultInspectDepth={0}
@@ -87,6 +90,7 @@ const AssistantDetailsPage = ({
                           Action {index + 1}: {action.type}
                         </div>
                         <JsonViewer
+                          theme={isDark ? "dark" : "light"}
                           value={action}
                           rootName={false}
                           defaultInspectDepth={0}

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -47,6 +47,7 @@ import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { PokePermissionTree } from "@app/components/poke/PokeConnectorPermissionsTree";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { SlackChannelPatternInput } from "@app/components/poke/PokeSlackChannelPatternInput";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -800,6 +801,7 @@ function NotionUrlCheckOrFind({
   owner: WorkspaceType;
   dsId: string;
 }) {
+  const { isDark } = useTheme();
   const [notionUrl, setNotionUrl] = useState("");
   const [urlDetails, setUrlDetails] = useState<
     NotionCheckUrlResponseType | NotionFindUrlResponseType | null
@@ -877,7 +879,11 @@ function NotionUrlCheckOrFind({
                 <span>
                   {urlDetails.page ? (
                     <>
-                      <JsonViewer value={urlDetails.page} rootName={false} />
+                      <JsonViewer
+                        theme={isDark ? "dark" : "light"}
+                        value={urlDetails.page}
+                        rootName={false}
+                      />
                       {command === "find-url" && (
                         <div>
                           {urlDetails.page.parentType === "page" && (
@@ -909,7 +915,11 @@ function NotionUrlCheckOrFind({
                     </>
                   ) : (
                     <>
-                      <JsonViewer value={urlDetails.db} rootName={false} />
+                      <JsonViewer
+                        theme={isDark ? "dark" : "light"}
+                        value={urlDetails.db}
+                        rootName={false}
+                      />
                       {command === "find-url" && (
                         <div>
                           {urlDetails.db?.parentType === "page" && (
@@ -957,6 +967,7 @@ function ZendeskTicketCheck({
   owner: WorkspaceType;
   dsId: string;
 }) {
+  const { isDark } = useTheme();
   const [brandId, setBrandId] = useState<number | null>(null);
   const [ticketId, setTicketId] = useState<number | null>(null);
   const [ticketUrl, setTicketUrl] = useState<string | null>(null);
@@ -1079,7 +1090,11 @@ function ZendeskTicketCheck({
             {ticketDetails.ticket && (
               <div className="ml-4 pt-2 text-xs text-element-700">
                 <div className="mb-1 font-bold">Details</div>
-                <JsonViewer value={ticketDetails.ticket} rootName={false} />
+                <JsonViewer
+                  theme={isDark ? "dark" : "light"}
+                  value={ticketDetails.ticket}
+                  rootName={false}
+                />
               </div>
             )}
           </div>

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -6,6 +6,7 @@ import type { ReactElement } from "react";
 import { ViewAppTable } from "@app/components/poke/apps/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import PokeLayout from "@app/components/poke/PokeLayout";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -67,6 +68,7 @@ export default function AppPage({
 }
 
 function AppSpecification({ app }: { app: AppType }) {
+  const { isDark } = useTheme();
   return (
     <div className="border-material-200 flex min-h-48 flex-col rounded-lg border bg-slate-100">
       <div className="flex justify-between gap-3 rounded-t-lg bg-slate-300 p-4">
@@ -74,6 +76,7 @@ function AppSpecification({ app }: { app: AppType }) {
       </div>
       <div className="p-4">
         <JsonViewer
+          theme={isDark ? "dark" : "light"}
           value={JSON.parse(app.savedSpecification ?? "{}")}
           rootName={false}
           defaultInspectDepth={2}

--- a/front/pages/poke/[wId]/trackers/[tId]/index.tsx
+++ b/front/pages/poke/[wId]/trackers/[tId]/index.tsx
@@ -5,6 +5,7 @@ import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react-markdown/lib/react-markdown";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { usePokeTracker } from "@app/poke/swr/trackers";
@@ -32,6 +33,7 @@ export default function TrackerDetailPage({
   owner,
   trackerId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { isDark } = useTheme();
   const { data, isLoading, isError } = usePokeTracker({
     owner,
     tId: trackerId,
@@ -62,7 +64,11 @@ export default function TrackerDetailPage({
                 </div>
                 <div className="ml-4 pt-2 text-sm text-element-700">
                   <div className="font-bold">Raw Data</div>
-                  <JsonViewer value={data} defaultInspectDepth={0} />
+                  <JsonViewer
+                    theme={isDark ? "dark" : "light"}
+                    value={data}
+                    defaultInspectDepth={0}
+                  />
                 </div>
               </div>
             </ContextItem.Description>


### PR DESCRIPTION
## Description

- This PR passes the current theme (dark or light) to the `JsonViewer` component.
- The component has a built-in theme handling, it's only a matter of passing the current value.

Here's how it looks:
<img width="726" alt="Screenshot 2025-02-21 at 2 06 42 PM" src="https://github.com/user-attachments/assets/564cb389-5865-420f-9396-1e80a09fc083" />

It looks ok, not amazingly beautiful bu very much usable nonetheless.

## Tests

- Tested locally.

## Risk

- Only used in poke, dark mode under a FF.

## Deploy Plan

- Deploy front.
