### PR TITLE
[front] - feat(builder):  search ds

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -21,16 +21,10 @@ import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import type {
-  ContentNodeTreeItemStatus,
-  TreeSelectionModelUpdater,
-} from "@app/components/ContentNodeTree";
+import type { ContentNodeTreeItemStatus, TreeSelectionModelUpdater } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import {
-  CONNECTOR_CONFIGURATIONS,
-  getConnectorProviderLogoWithFallback,
-} from "@app/lib/connector_providers";
+import { CONNECTOR_CONFIGURATIONS, getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import {
@@ -119,7 +113,7 @@ export function DataSourceViewsSelector({
 }: DataSourceViewsSelectorProps) {
   // TODO(20250221, search-kb): remove this once the feature flag is enabled by default
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
-  const searchFeatureFlag = !featureFlags.includes("search_knowledge_builder");
+  const searchFeatureFlag = featureFlags.includes("search_knowledge_builder");
 
   const [searchResult, setSearchResult] = useState<
     DataSourceViewContentNode | undefined

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -141,7 +141,7 @@ export function DataSourceViewsSelector({
     owner,
     viewType,
     search: searchDsv,
-    disabled: searchFeatureFlag,
+    disabled: !searchFeatureFlag,
   });
 
   const includesConnectorIDs: (string | null)[] = [];
@@ -225,43 +225,45 @@ export function DataSourceViewsSelector({
 
   return (
     <div>
-      <SearchInputWithPopover
-        value={searchDsv}
-        onChange={setSearchDsv}
-        name="search-dsv"
-        open={searchResultNodes.length > 0 && !!searchDsv}
-        onOpenChange={(open) => {
-          if (!open) {
-            setSearchDsv("");
-          }
-        }}
-        items={searchResultNodes}
-        renderItem={(item) => (
-          <ContextItem
-            title={item.title}
-            onClick={() => {
-              setSearchResult(item);
+      {searchFeatureFlag && (
+        <SearchInputWithPopover
+          value={searchDsv}
+          onChange={setSearchDsv}
+          name="search-dsv"
+          open={searchResultNodes.length > 0 && !!searchDsv}
+          onOpenChange={(open) => {
+            if (!open) {
               setSearchDsv("");
-              setSelectionConfigurations((prevState) =>
-                updateSelectionWithNode(item, prevState)
-              );
-            }}
-            visual={CONTENT_NODE_TYPE_ICONS[item.type]}
-            subElement={
-              <ContextItem.Visual
-                visual={
-                  item.dataSourceView.dataSource.connectorProvider
-                    ? CONNECTOR_CONFIGURATIONS[
-                        item.dataSourceView.dataSource.connectorProvider
-                      ].getLogoComponent()
-                    : FolderIcon
-                }
-              />
             }
-          />
-        )}
-        noResults="No results found"
-      />
+          }}
+          items={searchResultNodes}
+          renderItem={(item) => (
+            <ContextItem
+              title={item.title}
+              onClick={() => {
+                setSearchResult(item);
+                setSearchDsv("");
+                setSelectionConfigurations((prevState) =>
+                  updateSelectionWithNode(item, prevState)
+                );
+              }}
+              visual={CONTENT_NODE_TYPE_ICONS[item.type]}
+              subElement={
+                <ContextItem.Visual
+                  visual={
+                    item.dataSourceView.dataSource.connectorProvider
+                      ? CONNECTOR_CONFIGURATIONS[
+                          item.dataSourceView.dataSource.connectorProvider
+                        ].getLogoComponent()
+                      : FolderIcon
+                  }
+                />
+              }
+            />
+          )}
+          noResults="No results found"
+        />
+      )}
       <Tree
         isLoading={false}
         key={`dataSourceViewsSelector-${searchResult ? searchResult.internalId : ""}`}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -21,10 +21,16 @@ import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import type { ContentNodeTreeItemStatus, TreeSelectionModelUpdater } from "@app/components/ContentNodeTree";
+import type {
+  ContentNodeTreeItemStatus,
+  TreeSelectionModelUpdater,
+} from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { CONNECTOR_CONFIGURATIONS, getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import {
+  CONNECTOR_CONFIGURATIONS,
+  getConnectorProviderLogoWithFallback,
+} from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import {

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -24,16 +24,10 @@ import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useMemo, useState } from "react";
 
-import type {
-  ContentNodeTreeItemStatus,
-  TreeSelectionModelUpdater,
-} from "@app/components/ContentNodeTree";
+import type { ContentNodeTreeItemStatus, TreeSelectionModelUpdater } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import {
-  CONNECTOR_CONFIGURATIONS,
-  getConnectorProviderLogoWithFallback,
-} from "@app/lib/connector_providers";
+import { CONNECTOR_CONFIGURATIONS, getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import {
   canBeExpanded,
@@ -205,10 +199,12 @@ export function DataSourceViewsSelector({
         }}
         items={searchResultNodes}
         renderItem={(item) => (
-          <div className="items-center">
             <ContextItem
               title={item.title}
-              onClick={() => setSearchResult(item)}
+              onClick={() => {
+                setSearchResult(item)
+                setSearchDsv("")
+              }}
               visual={CONTENT_NODE_TYPE_ICONS[item.type]}
               subElement={
                 <ContextItem.Visual
@@ -222,7 +218,6 @@ export function DataSourceViewsSelector({
                 />
               }
             />
-          </div>
         )}
         noResults="No results found"
       />
@@ -313,7 +308,7 @@ export function DataSourceViewsSelector({
             visual={GlobeAltIcon}
             type="node"
             defaultCollapsed={
-              !searchResult || isWebsite(searchResult.dataSourceView.dataSource)
+              !searchResult || !isWebsite(searchResult.dataSourceView.dataSource)
             }
           >
             {websites.map((dataSourceView) => (

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
   CloudArrowLeftRightIcon,
-  ContextItem,
+  cn,
   FolderIcon,
   GlobeAltIcon,
   ListCheckIcon,
@@ -119,7 +119,7 @@ export function DataSourceViewsSelector({
 }: DataSourceViewsSelectorProps) {
   // TODO(20250221, search-kb): remove this once the feature flag is enabled by default
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
-  const searchFeatureFlag = featureFlags.includes("search_knowledge_builder");
+  const searchFeatureFlag = !featureFlags.includes("search_knowledge_builder");
 
   const [searchResult, setSearchResult] = useState<
     DataSourceViewContentNode | undefined
@@ -241,9 +241,12 @@ export function DataSourceViewsSelector({
             }
           }}
           items={searchResultNodes}
-          renderItem={(item) => (
-            <ContextItem
-              title={item.title}
+          renderItem={(item, selected) => (
+            <div
+              className={cn(
+                "flex cursor-pointer items-center gap-2 px-2 py-2 hover:bg-structure-50 dark:hover:bg-structure-50-night",
+                selected && "bg-structure-50 dark:bg-structure-50-night"
+              )}
               onClick={() => {
                 setSearchResult(item);
                 setSearchSpaceText("");
@@ -251,19 +254,17 @@ export function DataSourceViewsSelector({
                   updateSelection(item, prevState)
                 );
               }}
-              visual={getVisualForContentNode(item)({})}
-              subElement={
-                <ContextItem.Visual
-                  visual={
+            >
+              {getVisualForContentNode(item)({ className: "min-w-4" })}
+              <span className="text-sm">{item.title}</span>
+              {item.dataSourceView.dataSource.connectorProvider && (
+                <div className="ml-auto">
+                  {CONNECTOR_CONFIGURATIONS[
                     item.dataSourceView.dataSource.connectorProvider
-                      ? CONNECTOR_CONFIGURATIONS[
-                          item.dataSourceView.dataSource.connectorProvider
-                        ].getLogoComponent()
-                      : FolderIcon
-                  }
-                />
-              }
-            />
+                  ].getLogoComponent()({})}
+                </div>
+              )}
+            </div>
           )}
           noResults="No results found"
         />

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -44,8 +44,8 @@ import {
   isWebsite,
 } from "@app/lib/data_sources";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { useSpaceSearch } from "@app/lib/swr/spaces";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 export const CONTENT_NODE_TYPE_ICONS: Record<
   ContentNodeType,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -599,12 +599,14 @@ export function useSpaceSearch({
   owner,
   viewType,
   search,
+  disabled = false,
   limit = DEFAULT_SEARCH_LIMIT,
 }: {
   dataSourceViews: DataSourceViewType[];
   owner: LightWorkspaceType;
   viewType: ContentNodesViewType;
   search: string;
+  disabled?: boolean;
   limit?: number;
 }) {
   const body = {
@@ -642,6 +644,7 @@ export function useSpaceSearch({
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
+      disabled,
     }
   );
 


### PR DESCRIPTION
## Description

This PR aims at enabling data source search in the assistant builder. It is currently hidden behind a feature flag.

Note: style is not final, need to do a tiny rework of the `ContextItem` component.

![Screenshot 2025-02-21 at 14 49 20](https://github.com/user-attachments/assets/7a4570e4-0704-487b-b2e3-0ce0bf7844cd)

**References:**
- https://github.com/dust-tt/tasks/issues/2214

## Risk

Low

## Deploy Plan

- Deploy `front`