### PR TITLE
Fix(Poke dark mode) - invisible text in input bar

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -1,3 +1,4 @@
+import { Input } from "@dust-tt/sparkle";
 import type {
   DataSourceType,
   DocumentType,
@@ -132,7 +133,7 @@ export default function DataSourceView({
       <div className="mt-8 flex flex-col">
         <div className="sm:col-span-6">
           <div className="mt-1 flex rounded-md shadow-sm">
-            <input
+            <Input
               type="text"
               autoComplete="off"
               name="search_query"

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -1,4 +1,4 @@
-import { BookOpenIcon, Icon, Spinner } from "@dust-tt/sparkle";
+import { BookOpenIcon, Icon, Input, Spinner } from "@dust-tt/sparkle";
 import { UsersIcon } from "lucide-react";
 import moment from "moment";
 import Link from "next/link";
@@ -133,8 +133,7 @@ const Dashboard = () => {
   return (
     <>
       <h1 className="mb-4 text-2xl font-bold">Search in Workspaces</h1>
-      <input
-        className="w-full rounded-lg border border-gray-300 p-2 focus:outline-none focus:ring-2 focus:ring-blue-600"
+      <Input
         type="text"
         placeholder="Search"
         value={searchTerm}

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -645,7 +645,7 @@ function TemplatesPage({
                           } cursor-pointer px-4 py-2`}
                           onClick={onClick}
                         >
-                          <input
+                          <Input
                             type="checkbox"
                             onChange={() => {}}
                             checked={checked}


### PR DESCRIPTION
## Description

- In dark mode, Poke's input bars (like the main one for searching workspaces) are white so the text becomes invisible.
- This PR fixes that by using `sparkle`'s `Input` component.

Before:
<img width="304" alt="Screenshot 2025-02-21 at 3 52 45 PM" src="https://github.com/user-attachments/assets/ddf57497-85ad-4b92-859b-aee9f005b8df" />

After:
<img width="304" alt="Screenshot 2025-02-21 at 3 53 43 PM" src="https://github.com/user-attachments/assets/5090ba0c-29d3-4f31-8657-4d113d95f6d1" />

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy front.