### PR TITLE
[sparkle] - enh(SearchInputWithPopover): add enter callback

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.413",
+  "version": "0.2.414",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.413",
+      "version": "0.2.414",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.413",
+  "version": "0.2.414",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -104,6 +104,7 @@ type SearchInputWithPopoverBaseProps<T> = SearchInputProps & {
   mountPortalContainer?: HTMLElement;
   items: T[];
   renderItem: (item: T, selected: boolean) => React.ReactNode;
+  onItemSelect?: (item: T) => void;
   noResults?: string;
 };
 
@@ -111,6 +112,7 @@ function BaseSearchInputWithPopover<T>(
   {
     items,
     renderItem,
+    onItemSelect,
     contentClassName,
     className,
     open,
@@ -160,6 +162,9 @@ function BaseSearchInputWithPopover<T>(
       case "Enter":
         e.preventDefault();
         onOpenChange(false);
+        if (items[selectedIndex] && onItemSelect) {
+          onItemSelect(items[selectedIndex]);
+        }
         break;
     }
   };
@@ -210,7 +215,9 @@ function BaseSearchInputWithPopover<T>(
               </div>
             ))
           ) : (
-            <div className="s-p-2 s-text-sm s-text-gray-500">{noResults ?? ""}</div>
+            <div className="s-p-2 s-text-sm s-text-gray-500">
+              {noResults ?? ""}
+            </div>
           )}
           <ScrollBar className="s-py-0" />
         </ScrollArea>

--- a/sparkle/src/stories/Notification.stories.tsx
+++ b/sparkle/src/stories/Notification.stories.tsx
@@ -19,7 +19,6 @@ export const Example = () => {
   );
 };
 
-
 const NotificationExample = () => {
   const sendNotification = useSendNotification();
 

--- a/sparkle/src/stories/SearchInput.stories.tsx
+++ b/sparkle/src/stories/SearchInput.stories.tsx
@@ -86,11 +86,15 @@ export function SearchInputWithPopoverScrollableExample() {
       open={open}
       onOpenChange={setOpen}
       items={filteredItems}
-      renderItem={(item, selected ) => (
+      onItemSelect={(item) => console.log(item)}
+      renderItem={(item, selected) => (
         <div
           key={item}
           role="option"
-          className={cn("s-cursor-pointer s-py-2 hover:s-bg-primary-100 dark:hover:s-bg-primary-100-night", selected && "s-bg-primary-100")}
+          className={cn(
+            "s-cursor-pointer s-py-2 hover:s-bg-primary-100 dark:hover:s-bg-primary-100-night",
+            selected && "s-bg-primary-100"
+          )}
           onClick={() => {
             setValue(item);
             setOpen(false);


### PR DESCRIPTION
## Description

This PR aims at adding a props to the `SearchInputWithPopover` component to trigger a callback when pressing "Enter".

## Risk

Low

## Deploy Plan

Publish sparkle