### PR TITLE
fix: display snowflake errors instead of closing modal

### DIFF
--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -79,6 +79,7 @@ export function CreateOrUpdateConnectionSnowflakeModal({
       warehouse: "",
     });
     _onSuccess(ds);
+    onClose();
   }
 
   const createSnowflakeConnection = async () => {
@@ -323,8 +324,8 @@ export function CreateOrUpdateConnectionSnowflakeModal({
                 ? "Update connection"
                 : "Connect and select tables",
             icon: CloudArrowLeftRightIcon,
-            onClick: () => {
-              setIsLoading(true);
+            onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
               dataSourceToUpdate
                 ? void updateSnowflakeConnection()
                 : void createSnowflakeConnection();


### PR DESCRIPTION
## Description

We are closing the modal before the API call completes, so we're not displaying the error.

## Tests

Manual

## Risk

N/A

## Deploy Plan

Deploy front