### PR TITLE
[front] - feat(SearchInputWithPopover): press "Enter"

### DIFF
--- a/front/components/assistant_builder/tags/TagSearchInput.tsx
+++ b/front/components/assistant_builder/tags/TagSearchInput.tsx
@@ -1,4 +1,4 @@
-import { Button, Chip, cn, SearchInputWithPopover } from "@dust-tt/sparkle";
+import { Chip, cn, SearchInputWithPopover } from "@dust-tt/sparkle";
 import type { DataSourceTag } from "@dust-tt/types";
 import React from "react";
 
@@ -45,22 +45,23 @@ export const TagSearchInput = ({
         disabled={disabled}
         noResults="No results found"
         items={availableTags}
+        onItemSelect={(item) => {
+          onTagAdd(item);
+          setSearchInputValue("");
+        }}
         renderItem={(item, selected) => (
-          <Button
-            key={`${item.tag}`}
-            variant="ghost"
-            label={item.tag}
-            size="sm"
+          <div
             className={cn(
-              "justify-start",
-              selected &&
-                "border-border-dark bg-primary-150 text-primary-900 dark:border-primary-600 dark:bg-primary-700 dark:text-primary-900-night"
+              "flex cursor-pointer items-center gap-2 rounded-lg px-2 py-2 hover:bg-structure-50 dark:hover:bg-structure-50-night",
+              selected && "bg-structure-50 dark:bg-structure-50-night"
             )}
             onClick={() => {
               onTagAdd(item);
               setSearchInputValue("");
             }}
-          />
+          >
+            <span className="text-sm font-semibold">{item.tag}</span>
+          </div>
         )}
       ></SearchInputWithPopover>
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -241,10 +241,17 @@ export function DataSourceViewsSelector({
             }
           }}
           items={searchResultNodes}
+          onItemSelect={(item) => {
+            setSearchResult(item);
+            setSearchSpaceText("");
+            setSelectionConfigurations((prevState) =>
+              updateSelection(item, prevState)
+            );
+          }}
           renderItem={(item, selected) => (
             <div
               className={cn(
-                "flex cursor-pointer items-center gap-2 px-2 py-2 hover:bg-structure-50 dark:hover:bg-structure-50-night",
+                "flex cursor-pointer items-center gap-2 rounded-lg px-2 py-2 hover:bg-structure-50 dark:hover:bg-structure-50-night",
                 selected && "bg-structure-50 dark:bg-structure-50-night"
               )}
               onClick={() => {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.413",
+        "@dust-tt/sparkle": "^0.2.414",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11336,9 +11336,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.413",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.413.tgz",
-      "integrity": "sha512-C4NKuJ7mnRU6C+bbt5YcDSP458kCudlbkO4OgR7zy6DYY6IuNxanzZA3ODy2x3FXC6HjLrth+pu8efP5e9HkdQ==",
+      "version": "0.2.414",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.414.tgz",
+      "integrity": "sha512-22vjvu15GAexutIalU0DjSuFIIqyWw3eEQfYI9BZwbY79FEGbhQA0coPcMhy9ZpBzDB0V5u56Ex8seIOMrBWHA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.413",
+    "@dust-tt/sparkle": "^0.2.414",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",


### PR DESCRIPTION
## Description

This PR enables pressing "Enter" on the `SearchInputWithPopover` component to trigger a callback on the currently selected item.

**References:**
- https://github.com/dust-tt/tasks/issues/2214

## Risk

Low

## Deploy Plan

Deploy `front`