### PR TITLE
improve core - front - connectors invalid CSV errors

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1005,7 +1005,7 @@ export async function upsertDataSourceTableFromCsv({
       dustRequestResult.data.error?.type === "invalid_rows_request_error"
     ) {
       throw new TablesError(
-        "invalid_headers",
+        "invalid_csv",
         dustRequestResult.data.error.message
       );
     } else if (dustRequestResult.status === 413) {

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2226,7 +2226,7 @@ async fn tables_validate_csv_content(
         ),
         Err(e) => error_response(
             StatusCode::BAD_REQUEST,
-            "internal_csv_content",
+            "invalid_csv_content",
             "Failed to validate the CSV content",
             Some(e),
         ),

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -577,7 +577,7 @@ export async function upsertTable({
         | "invalid_csv_and_file"
         | "missing_csv"
         | "data_source_error"
-        | "invalid_csv"
+        | "invalid_csv_content"
         | "invalid_url"
         | "table_not_found"
         | "file_not_found"
@@ -697,13 +697,20 @@ export async function upsertTable({
         bucket: file.getBucketForVersion("processed").name,
         bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
       });
-
       if (schemaRes.isErr()) {
-        return new Err({
-          name: "dust_error",
-          code: "invalid_csv",
-          message: schemaRes.error.message,
-        });
+        if (schemaRes.error.code === "invalid_csv_content") {
+          return new Err({
+            name: "dust_error",
+            code: "invalid_csv_content",
+            message: schemaRes.error.message,
+          });
+        } else {
+          return new Err({
+            name: "dust_error",
+            code: "internal_error",
+            message: schemaRes.error.message,
+          });
+        }
       }
     }
 

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -68,11 +68,7 @@ async function generateSnippet(
     });
 
     if (schemaRes.isErr()) {
-      return new Err({
-        name: "dust_error",
-        code: "invalid_csv",
-        message: schemaRes.error.message,
-      });
+      return new Err(new Error("Invalid CSV content"));
     }
 
     let snippet = `${file.contentType} file with headers: ${schemaRes.value.schema.map((c) => c.name).join(",")}`;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -119,11 +119,18 @@ async function handler(
           case "invalid_url":
           case "title_too_long":
           case "missing_csv":
-          case "invalid_csv":
             return apiError(req, res, {
               status_code: 400,
               api_error: {
                 type: "invalid_request_error",
+                message: upsertRes.error.message,
+              },
+            });
+          case "invalid_csv_content":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_rows_request_error",
                 message: upsertRes.error.message,
               },
             });


### PR DESCRIPTION
## Description

Return a specific 400 invalid_rows_request_error in front when the CSV validation didn't work that is handled specifically in connectors

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `core`
- deploy `front`
- deploy `connectors`