### PR TITLE
[connectors] Remove tables upsert from CSV retry

### DIFF
--- a/connectors/migrations/20241030_fix_notion_parents.ts
+++ b/connectors/migrations/20241030_fix_notion_parents.ts
@@ -156,7 +156,6 @@ async function updateParentsFieldForConnector(
                 documentId,
                 parents,
                 parentId: parents[1] || null,
-                retries: 3,
               });
             }
             if (tableId) {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -320,12 +320,7 @@ export async function deleteDataSourceDocument(
   }
 }
 
-export const updateDataSourceDocumentParents = withRetries(
-  _updateDataSourceDocumentParents,
-  { retries: 3 }
-);
-
-async function _updateDataSourceDocumentParents({
+export async function updateDataSourceDocumentParents({
   documentId,
   ...params
 }: {


### PR DESCRIPTION
## Description

The retry is not useful + underlying problem (bad unwrap was fixed by @fontanierh)
The retry changes the type of the error and prevents TablesError handling

Removing it should properly skip files that are not valid for upsert.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`