### PR TITLE
[front] - chore: add parent name in builder search

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -21,10 +21,16 @@ import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import type { ContentNodeTreeItemStatus, TreeSelectionModelUpdater } from "@app/components/ContentNodeTree";
+import type {
+  ContentNodeTreeItemStatus,
+  TreeSelectionModelUpdater,
+} from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { CONNECTOR_CONFIGURATIONS, getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import {
+  CONNECTOR_CONFIGURATIONS,
+  getConnectorProviderLogoWithFallback,
+} from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import {

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -21,16 +21,10 @@ import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import type {
-  ContentNodeTreeItemStatus,
-  TreeSelectionModelUpdater,
-} from "@app/components/ContentNodeTree";
+import type { ContentNodeTreeItemStatus, TreeSelectionModelUpdater } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import {
-  CONNECTOR_CONFIGURATIONS,
-  getConnectorProviderLogoWithFallback,
-} from "@app/lib/connector_providers";
+import { CONNECTOR_CONFIGURATIONS, getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import {
@@ -264,6 +258,9 @@ export function DataSourceViewsSelector({
             >
               {getVisualForContentNode(item)({ className: "min-w-4" })}
               <span className="text-sm">{item.title}</span>
+              {item.parentTitle && (
+                <span className="text-sm text-slate-500">{`:/${item.parentTitle}`}</span>
+              )}
               {item.dataSourceView.dataSource.connectorProvider && (
                 <div className="ml-auto">
                   {CONNECTOR_CONFIGURATIONS[

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -99,6 +99,7 @@ export function getContentNodeFromCoreNode(
     preventSelection: FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(
       coreNode.mime_type
     ),
+    parentTitle: coreNode.parent_title,
     dataSourceView,
   };
 }

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -29,6 +29,7 @@ export type DataSourceViewsWithDetails = DataSourceViewType & {
 export type DataSourceViewContentNode = ContentNode & {
   dataSourceView: DataSourceViewType;
   parentInternalIds: string[] | null;
+  parentTitle?: string;
 };
 
 export type DataSourceViewSelectionConfiguration = {


### PR DESCRIPTION
## Description

This PR aims at displaying the parent name of the searched items in the assistant builder, see screenshot below:

![Screenshot 2025-02-24 at 10 42 18](https://github.com/user-attachments/assets/41116f61-ebf7-4421-afeb-edafbd985a81)

**References:**
- https://github.com/dust-tt/dust/issues/11021

## Risk

Low

## Deploy Plan

Deploy `front`