### PR TITLE
enh(core) - Add the hit count to `/nodes/search` endpoint

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3343,7 +3343,7 @@ async fn nodes_search(
     State(state): State<Arc<APIState>>,
     Json(payload): Json<NodesSearchPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    let (nodes, next_cursor) = match state
+    let (nodes, hit_count, hit_count_is_accurate, next_cursor) = match state
         .search_store
         .search_nodes(
             payload.query,
@@ -3353,7 +3353,9 @@ async fn nodes_search(
         )
         .await
     {
-        Ok((nodes, next_cursor)) => (nodes, next_cursor),
+        Ok((nodes, hit_count, hit_count_is_accurate, next_cursor)) => {
+            (nodes, hit_count, hit_count_is_accurate, next_cursor)
+        }
         Err(e) => {
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -3370,6 +3372,8 @@ async fn nodes_search(
             error: None,
             response: Some(json!({
                 "nodes": nodes,
+                "hit_count": hit_count,
+                "hit_count_is_accurate": hit_count_is_accurate,
                 "next_page_cursor": next_cursor,
             })),
         }),

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -23,6 +23,9 @@ use crate::{
 };
 
 const MAX_PAGE_SIZE: u64 = 1000;
+// Number of hits that is tracked exactly, above this value we only get a lower bound on the hit count.
+// Note: this is the default value.
+const MAX_TOTAL_HITS_TRACKED: i64 = 10000;
 
 #[derive(serde::Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
@@ -193,6 +196,7 @@ impl SearchStore for ElasticsearchSearchStore {
         let mut search = Search::new()
             .size(options.limit.unwrap_or(MAX_PAGE_SIZE))
             .query(bool_query)
+            .track_total_hits(MAX_TOTAL_HITS_TRACKED)
             .sort(sort);
 
         if let Some(cursor) = options.cursor {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -231,6 +231,8 @@ export interface CoreAPISearchCursorRequest {
 export interface CoreAPISearchNodesResponse {
   nodes: CoreAPIContentNode[];
   next_page_cursor: string | null;
+  hit_count: number;
+  hit_count_is_accurate: boolean;
 }
 
 export interface CoreAPISearchTagsResponse {


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2039.
- In order to leverage in front the pagination exposed by the search nodes endpoint, we need the total number of nodes matching the ES query.
- This PR adds the total number of hits in the elasticsearch response and whether this total is accurate or not.
- These two fields are returned in core api's response.
- Note: the number of hits loses its meaning as soon as we filter the nodes in the front, which we do. The pagination is thus dependent on moving the filter on the node type in the ES query.

## Tests

- Tested locally, no automated test.

## Risk

- No impact for now, fields not read.
- No impact on the query speed, fields are already returned in ES's response, only a matter of reading them.

## Deploy Plan

- Deploy core.