### PR TITLE
[front] - fix: prevent default action on save button click in modal

### DIFF
--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -445,7 +445,8 @@ export const TableUploadOrEditModal = ({
           }}
           rightButtonProps={{
             label: isUpserting ? "Saving..." : "Save",
-            onClick: async () => {
+            onClick: async (event: MouseEvent) => {
+              event.preventDefault();
               await onSave();
             },
             disabled:


### PR DESCRIPTION
## Description

This PR ensures that we do not close the table modal before validating the submitted values.

## Risk

Low

## Deploy Plan

Deploy `front`