### PR TITLE
enh(Zendesk) - Include new tickets in the sync

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -33,7 +33,9 @@ export function shouldSyncTicket(
   return [
     "closed",
     "solved",
-    ...(configuration.syncUnresolvedTickets ? ["open", "pending", "hold"] : []),
+    ...(configuration.syncUnresolvedTickets
+      ? ["new", "open", "pending", "hold"]
+      : []),
   ].includes(ticket.status);
 }
 


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/dust/pull/10991 adds an optional configuration in Zendesk connectors to sync unresolved tickets.
- The "new" status was missing from the status to sync when the option was enabled.
- This PR addresses that.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy `connectors`.