### PR TITLE
fix(Slack) - Fix missing upsert on Slack new channels

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -1,18 +1,21 @@
 import { DustAPI } from "@dust-tt/client";
 import type { Result, SlackAutoReadPattern } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, MIME_TYPES, Ok } from "@dust-tt/types";
 
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
-import { slackChannelInternalIdFromSlackChannelId } from "@connectors/connectors/slack/lib/utils";
-import { apiConfig } from "@connectors/lib/api/config";
-import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
-  SlackChannel,
-  SlackConfigurationModel,
-} from "@connectors/lib/models/slack";
+  getSlackChannelSourceUrl,
+  slackChannelInternalIdFromSlackChannelId,
+} from "@connectors/connectors/slack/lib/utils";
+import { apiConfig } from "@connectors/lib/api/config";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { SlackChannel } from "@connectors/lib/models/slack";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 
 function findMatchingChannelPatterns(
   remoteChannelName: string,
@@ -29,11 +32,8 @@ export async function autoReadChannel(
   logger: Logger,
   slackChannelId: string
 ): Promise<Result<undefined, Error>> {
-  const slackConfiguration = await SlackConfigurationModel.findOne({
-    where: {
-      slackTeamId: teamId,
-    },
-  });
+  const slackConfiguration =
+    await SlackConfigurationResource.fetchByTeamId(teamId);
   if (!slackConfiguration) {
     return new Err(
       new Error(`Slack configuration not found for teamId ${teamId}`)

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -72,6 +72,18 @@ export async function autoReadChannel(
       return joinChannelRes;
     }
 
+    await upsertDataSourceFolder({
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
+      folderId: slackChannelInternalIdFromSlackChannelId(slackChannelId),
+      title: `#${remoteChannelName}`,
+      parentId: null,
+      parents: [slackChannelInternalIdFromSlackChannelId(slackChannelId)],
+      mimeType: MIME_TYPES.SLACK.CHANNEL,
+      sourceUrl: getSlackChannelSourceUrl(slackChannelId, slackConfiguration),
+      providerVisibility: remoteChannel.channel?.is_private
+        ? "private"
+        : "public",
+    });
     let channel: SlackChannel | null = null;
     channel = await SlackChannel.findOne({
       where: {

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -100,6 +100,19 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     );
   }
 
+  static async fetchByTeamId(slackTeamId: string) {
+    const blob = await this.model.findOne({
+      where: {
+        slackTeamId,
+      },
+    });
+    if (!blob) {
+      return null;
+    }
+
+    return new this(this.model, blob.get());
+  }
+
   static async fetchByActiveBot(slackTeamId: string) {
     const blob = await this.model.findOne({
       where: {


### PR DESCRIPTION
## Description

- Currently, the webhook on Slack channels creation is missing a `data_sources_folders` upsert, causing an error in the `patchDataSourceView` as detailed in [this thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1740384063326899).

## Tests

- n/a.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Run `./admin/cli.sh slack sync-channel` on the missing channel.
- Update the `dataSourceView` where the PATCH failed.