### PR TITLE
fix: client side exception when editing dust global agent

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -11,6 +11,7 @@ import { useSendNotification } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceType,
+  DataSourceViewType,
   LightAgentConfigurationType,
   SpaceType,
   SubscriptionType,
@@ -54,13 +55,30 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   };
 });
 
+function DustAgentDataSourceVisual({
+  dataSourceView,
+}: {
+  dataSourceView: DataSourceViewType;
+}) {
+  const { isDark } = useTheme();
+
+  return (
+    <ContextItem.Visual
+      visual={getConnectorProviderLogoWithFallback({
+        provider: dataSourceView.dataSource.connectorProvider,
+        fallback: CloudArrowDownIcon,
+        isDark,
+      })}
+    />
+  );
+}
+
 export default function EditDustAssistant({
   owner,
   subscription,
   globalSpace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
-  const { isDark } = useTheme();
   const sendNotification = useSendNotification();
 
   const {
@@ -236,13 +254,7 @@ export default function EditDustAssistant({
                         key={dsView.id}
                         title={getDisplayNameForDataSource(dsView.dataSource)}
                         visual={
-                          <ContextItem.Visual
-                            visual={getConnectorProviderLogoWithFallback({
-                              provider: dsView.dataSource.connectorProvider,
-                              fallback: CloudArrowDownIcon,
-                              isDark,
-                            })}
-                          />
+                          <DustAgentDataSourceVisual dataSourceView={dsView} />
                         }
                         action={
                           <SliderToggle


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/2248

We're trying to `useTheme` outside of `AppLayout` so we don't have the theme provider.
Fixed by wrapping the DS view visual in its own component and move the `useTheme` there.

## Tests

Manual

## Risk

N/A

## Deploy Plan

Deploy front