### PR TITLE
fix(Slack) - Update channel timestamps

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -1,12 +1,19 @@
 import type { ConnectorPermission, ModelId, Result } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, MIME_TYPES, Ok } from "@dust-tt/types";
 import type { CodedError, WebAPIPlatformError } from "@slack/web-api";
 import { ErrorCode } from "@slack/web-api";
 import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
 
+import {
+  getSlackChannelSourceUrl,
+  slackChannelInternalIdFromSlackChannelId,
+} from "@connectors/connectors/slack/lib/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 
 import { getSlackClient } from "./slack_client";
 
@@ -63,6 +70,51 @@ export async function updateSlackChannelInConnectorsDb({
     agentConfigurationId: channel.agentConfigurationId,
     private: channel.private,
   };
+}
+
+export async function updateSlackChannelInCoreDb(
+  connectorId: ModelId,
+  channelId: string,
+  timestampMs: number
+) {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const slackConfiguration =
+    await SlackConfigurationResource.fetchByConnectorId(connectorId);
+  if (!slackConfiguration) {
+    throw new Error(
+      `Could not find slack configuration for connector ${connector}`
+    );
+  }
+
+  const channelOnDb = await SlackChannel.findOne({
+    where: {
+      connectorId: connector.id,
+      slackChannelId: channelId,
+    },
+  });
+  if (!channelOnDb) {
+    throw new Error(
+      `Could not find channel ${channelId} in connectors db for connector ${connectorId}`
+    );
+  }
+
+  const folderId = slackChannelInternalIdFromSlackChannelId(channelId);
+
+  await upsertDataSourceFolder({
+    dataSourceConfig: dataSourceConfigFromConnector(connector),
+    folderId,
+    title: `#${channelOnDb.slackChannelName}`,
+    parentId: null,
+    parents: [folderId],
+    mimeType: MIME_TYPES.SLACK.CHANNEL,
+    sourceUrl: getSlackChannelSourceUrl(channelId, slackConfiguration),
+    providerVisibility: channelOnDb.private ? "private" : "public",
+    timestampMs,
+  });
 }
 
 export async function joinChannel(

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -75,7 +75,7 @@ export async function updateSlackChannelInConnectorsDb({
 export async function updateSlackChannelInCoreDb(
   connectorId: ModelId,
   channelId: string,
-  timestampMs: number
+  timestampMs: number | undefined
 ) {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -20,6 +20,7 @@ import { Op, Sequelize } from "sequelize";
 import {
   joinChannel,
   updateSlackChannelInConnectorsDb,
+  updateSlackChannelInCoreDb,
 } from "@connectors/connectors/slack/lib/channels";
 import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
@@ -378,6 +379,14 @@ export async function syncChannel(
     nextCursor: allSkip ? undefined : messages.response_metadata?.next_cursor,
     weeksSynced: weeksSynced,
   };
+}
+
+export async function syncChannelMetadata(
+  connectorId: ModelId,
+  channelId: string,
+  timestampsMs: number
+) {
+  await updateSlackChannelInCoreDb(connectorId, channelId, timestampsMs);
 }
 
 export async function getMessagesForChannel(

--- a/connectors/src/connectors/slack/temporal/config.ts
+++ b/connectors/src/connectors/slack/temporal/config.ts
@@ -1,2 +1,2 @@
-const WORKFLOW_VERSION = 4;
+const WORKFLOW_VERSION = 5;
 export const QUEUE_NAME = `slack-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -18,6 +18,7 @@ const {
   syncChannel,
   fetchUsers,
   saveSuccessSyncActivity,
+  syncChannelMetadata,
   reportInitialSyncProgressActivity,
   getChannelsToGarbageCollect,
   attemptChannelJoinActivity,
@@ -158,6 +159,11 @@ export async function syncOneThreadDebounced(
     }
 
     console.log(`Talked to slack after debouncing ${debounceCount} time(s)`);
+    await syncChannelMetadata(
+      connectorId,
+      channelId,
+      parseInt(threadTs, 10) * 1000
+    );
     await syncThread(channelId, channel.name, threadTs, connectorId);
     await saveSuccessSyncActivity(connectorId);
   }
@@ -192,9 +198,10 @@ export async function syncOneMessageDebounced(
     if (!channel.name) {
       throw new Error(`Could not find channel name for channel ${channelId}`);
     }
-    const messageTs = parseInt(threadTs) * 1000;
+    const messageTs = parseInt(threadTs, 10) * 1000;
     const startTsMs = getWeekStart(new Date(messageTs)).getTime();
     const endTsMs = getWeekEnd(new Date(messageTs)).getTime();
+    await syncChannelMetadata(connectorId, channelId, endTsMs);
     await syncNonThreaded(
       channelId,
       channel.name,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2245.
- This PR aims at uniformizing the meaning of the `timestamp` column in `data_sources_nodes` for Slack channels, where this column currently contains the date the channel started being indexed.

## Tests

- Tested locally, no automated test.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.