### PR TITLE
Improve handling of diff between tags.title and title

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -83,7 +83,11 @@ export function getContentNodeFromCoreNode(
   return {
     internalId: coreNode.node_id,
     parentInternalId: coreNode.parent_id ?? null,
-    title: coreNode.title,
+    // TODO(2025-01-27 aubin): remove this once the handling of nodes without a title has been improved in the api/v1
+    title:
+      coreNode.title === "Untitled document"
+        ? coreNode.node_id
+        : coreNode.title,
     sourceUrl: coreNode.source_url ?? null,
     permission: "read",
     lastUpdatedAt: coreNode.timestamp,

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -83,11 +83,7 @@ export function getContentNodeFromCoreNode(
   return {
     internalId: coreNode.node_id,
     parentInternalId: coreNode.parent_id ?? null,
-    // TODO(2025-01-27 aubin): remove this once the handling of nodes without a title has been improved in the api/v1
-    title:
-      coreNode.title === "Untitled document"
-        ? coreNode.node_id
-        : coreNode.title,
+    title: coreNode.title,
     sourceUrl: coreNode.source_url ?? null,
     permission: "read",
     lastUpdatedAt: coreNode.timestamp,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -343,15 +343,10 @@ export async function upsertDocument({
   }
 
   if (titleInTags && titleInTags !== title) {
-    logger.error(
+    logger.warn(
       { dataSourceId: dataSource.sId, documentId, titleInTags, title },
-      "[CoreNodes] Inconsistency between tags and title."
+      "Inconsistency between tags and title."
     );
-    // TODO(2025-02-18 aubin): uncomment what follows.
-    // new DustError(
-    //   "invalid_title_in_tags",
-    //   "Invalid tags: title passed in tags does not match the table title."
-    // )
   }
 
   // Add selection of tags as prefix to the section if they are present.
@@ -642,23 +637,15 @@ export async function upsertTable({
   }
 
   if (titleInTags && titleInTags !== params.title) {
-    logger.error(
+    logger.warn(
       {
         dataSourceId: dataSource.sId,
         tableId,
         titleInTags,
         title: params.title,
       },
-      "[CoreNodes] Inconsistency between tags and title."
+      "Inconsistency between tags and title."
     );
-    // TODO(2025-02-18 aubin): uncomment what follows.
-    // return apiError(req, res, {
-    //   status_code: 400,
-    //   api_error: {
-    //     type: "invalid_request_error",
-    //     message: `Invalid tags: title passed in tags does not match the table title.`,
-    //   },
-    // });
   }
 
   let standardizedSourceUrl: string | null = null;

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -342,11 +342,7 @@ export async function upsertDocument({
     nonNullTags.push(`title:${title}`);
   }
 
-  if (
-    titleInTags &&
-    !titleInTags.startsWith(title) &&
-    !title.startsWith(titleInTags)
-  ) {
+  if (titleInTags && titleInTags !== title) {
     logger.error(
       { dataSourceId: dataSource.sId, documentId, titleInTags, title },
       "[CoreNodes] Inconsistency between tags and title."
@@ -645,11 +641,7 @@ export async function upsertTable({
     tableTags.push(`title:${params.title}`);
   }
 
-  if (
-    titleInTags &&
-    !titleInTags.startsWith(params.title) &&
-    !params.title.startsWith(titleInTags)
-  ) {
+  if (titleInTags && titleInTags !== params.title) {
     logger.error(
       {
         dataSourceId: dataSource.sId,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -342,7 +342,11 @@ export async function upsertDocument({
     nonNullTags.push(`title:${title}`);
   }
 
-  if (titleInTags && titleInTags !== title) {
+  if (
+    titleInTags &&
+    !titleInTags.startsWith(title) &&
+    !title.startsWith(titleInTags)
+  ) {
     logger.error(
       { dataSourceId: dataSource.sId, documentId, titleInTags, title },
       "[CoreNodes] Inconsistency between tags and title."
@@ -641,7 +645,11 @@ export async function upsertTable({
     tableTags.push(`title:${params.title}`);
   }
 
-  if (titleInTags && titleInTags !== params.title) {
+  if (
+    titleInTags &&
+    !titleInTags.startsWith(params.title) &&
+    !params.title.startsWith(titleInTags)
+  ) {
     logger.error(
       {
         dataSourceId: dataSource.sId,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -575,19 +575,10 @@ async function handler(
       }
 
       if (titleInTags && titleInTags !== title) {
-        logger.error(
+        logger.warn(
           { dataSourceId: dataSource.sId, documentId, titleInTags, title },
-          "[CoreNodes] Inconsistency between tags and title."
+          "Inconsistency between tags and title."
         );
-        // TODO(2025-02-18 aubin): uncomment what follows (move the comment up).
-        // // Enforce consistency between title and titleWithTags.
-        // return apiError(req, res, {
-        //   status_code: 400,
-        //   api_error: {
-        //     type: "invalid_request_error",
-        //     message: `Invalid tags: title passed in tags does not match the document title.`,
-        //   },
-        // });
       }
 
       if (r.data.async === true) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -574,7 +574,11 @@ async function handler(
         tags.push(`title:${title}`);
       }
 
-      if (titleInTags && titleInTags !== title) {
+      if (
+        titleInTags &&
+        !titleInTags.startsWith(title) &&
+        !title.startsWith(titleInTags)
+      ) {
         logger.error(
           { dataSourceId: dataSource.sId, documentId, titleInTags, title },
           "[CoreNodes] Inconsistency between tags and title."

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -574,11 +574,7 @@ async function handler(
         tags.push(`title:${title}`);
       }
 
-      if (
-        titleInTags &&
-        !titleInTags.startsWith(title) &&
-        !title.startsWith(titleInTags)
-      ) {
+      if (titleInTags && titleInTags !== title) {
         logger.error(
           { dataSourceId: dataSource.sId, documentId, titleInTags, title },
           "[CoreNodes] Inconsistency between tags and title."


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2032.
- Goal here is to monitor the discrepancies between `tags.title` and `title` because at some places we use one or the other.
- A tempting additional goal was to enforce equality, which we probably will not do as this puts unnecessary pressure on `connectors` to truncate the title tag in a specific way: we have a fixed max length for titles and one for tags, both are the same but the title tags starts with `"title:"` so we're gonna have 6 less characters.
- Enforcing equality is therefore not really reasonable, and relaxing the equality to accept prefixes seems overfit on this case, the goal here is to keep a log but not enforce it.
- We don't have any node that has "Untitled Document" as its title but a better title in its tags; i.e. the query below returns nothing. 
```sql
SELECT * FROM data_sources_nodes WHERE title = 'Untitled Document' AND ARRAY_LENGTH(tags_array, 1) > 0 AND tags_array[0] != 'title:Untitled Document' LIMIT 1;
```

## Tests

- n/a.

## Risk

- n/a.

## Deploy Plan

- Deploy front.