### PR TITLE
[sparkle] - chore(Tree): pass id to `Tree.Item` 

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.416",
+  "version": "0.2.417",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.416",
+      "version": "0.2.417",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.416",
+  "version": "0.2.417",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -92,6 +92,7 @@ interface TreeItemProps {
   isNavigatable?: boolean;
   isSelected?: boolean;
   onItemClick?: () => void;
+  id?: string;
 }
 
 export interface TreeItemPropsWithChildren extends TreeItemProps {
@@ -127,6 +128,7 @@ Tree.Item = React.forwardRef<
       isNavigatable = false,
       isSelected = false,
       onItemClick,
+      id,
     },
     ref
   ) => {
@@ -161,6 +163,7 @@ Tree.Item = React.forwardRef<
       <>
         <div
           ref={ref}
+          id={id}
           className={cn(
             treeItemStyleClasses.base,
             onItemClick ? "s-cursor-pointer" : "",


### PR DESCRIPTION
## Description

This PR aims at enabling passing an `id` to `Tree.Item`

## Risk

Low

## Deploy Plan

Publish `sparkle`