### PR TITLE
fix(Poke dark mode) - fix text+icon color in `CommandDialog`

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -80,7 +80,7 @@ export function PokeSearchCommand() {
       <PokeCommandDialog
         open={open}
         onOpenChange={setOpen}
-        className="bg-structure-50 sm:max-w-[600px]"
+        className="bg-structure-50 text-muted-foreground dark:text-muted-foreground-night sm:max-w-[600px]"
         shouldFilter={false}
       >
         <PokeCommandInput

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -80,7 +80,7 @@ export function PokeSearchCommand() {
       <PokeCommandDialog
         open={open}
         onOpenChange={setOpen}
-        className="bg-structure-50 text-muted-foreground dark:text-muted-foreground-night sm:max-w-[600px]"
+        className="bg-structure-50 sm:max-w-[600px]"
         shouldFilter={false}
       >
         <PokeCommandInput

--- a/front/components/poke/shadcn/ui/command.tsx
+++ b/front/components/poke/shadcn/ui/command.tsx
@@ -117,7 +117,13 @@ const CommandDialog = ({
         <DialogContent className={cn("overflow-hidden p-0", className)}>
           <Command
             shouldFilter={shouldFilter}
-            className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+            className={cn(
+              "text-muted-foreground dark:text-muted-foreground-night",
+              "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+              "[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2",
+              "[&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12",
+              "[&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+            )}
           >
             {children}
           </Command>


### PR DESCRIPTION
## Description

- The text typed by the user in Poke's CMD+K was invisible due to being black on a black background.
- This PR fixes that.

## Tests

- n/a

## Risk

- n/a

## Deploy Plan

- Deploy front.