### PR TITLE
Backfill data source name in core

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -440,6 +440,23 @@ impl DataSource {
         Ok(())
     }
 
+    pub async fn update_name(
+        &mut self,
+        store: Box<dyn Store + Sync + Send>,
+        search_store: Box<dyn SearchStore + Sync + Send>,
+        name: &str,
+    ) -> Result<()> {
+        self.name = name.to_string();
+
+        store
+            .update_data_source_name(&self.project, &self.data_source_id, &self.name)
+            .await?;
+
+        search_store.index_data_source(self).await?;
+
+        Ok(())
+    }
+
     pub fn created(&self) -> u64 {
         self.created
     }

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1334,6 +1334,31 @@ impl Store for PostgresStore {
         Ok(())
     }
 
+    async fn update_data_source_name(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        name: &str,
+    ) -> Result<()> {
+        let project_id = project.project_id();
+        let data_source_id = data_source_id.to_string();
+        let name = name.to_string();
+
+        let pool = self.pool.clone();
+        let c = pool.get().await?;
+
+        let stmt = c
+            .prepare(
+                "UPDATE data_sources SET name = $1 \
+                   WHERE project = $2 AND data_source_id = $3",
+            )
+            .await?;
+        c.execute(&stmt, &[&name, &project_id, &data_source_id])
+            .await?;
+
+        Ok(())
+    }
+
     async fn load_data_source_document(
         &self,
         project: &Project,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -177,6 +177,12 @@ pub trait Store {
         data_source_id: &str,
         config: &DataSourceConfig,
     ) -> Result<()>;
+    async fn update_data_source_name(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        name: &str,
+    ) -> Result<()>;
     async fn load_data_source_document(
         &self,
         project: &Project,

--- a/front/migrations/20250225_backfill_core_data_source_name.ts
+++ b/front/migrations/20250225_backfill_core_data_source_name.ts
@@ -1,0 +1,53 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import { concurrentExecutor, CoreAPI } from "@dust-tt/types";
+
+import config from "@app/lib/api/config";
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+async function backfillCoreDataSourceName(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+  await concurrentExecutor(
+    dataSources,
+    async (dataSource) => {
+      if (execute) {
+        await coreAPI.updateDataSource({
+          projectId: dataSource.dustAPIProjectId,
+          dataSourceId: dataSource.dustAPIDataSourceId,
+          name: dataSource.name,
+        });
+      } else {
+        logger.info(
+          { dataSourceId: dataSource.dustAPIDataSourceId },
+          "Would update data source name"
+        );
+      }
+    },
+    {
+      concurrency: 10,
+    }
+  );
+
+  logger.info(
+    { workspaceId: workspace.sId, dataSourceCount: dataSources.length },
+    "Done updating data source names"
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillCoreDataSourceName(workspace, logger, execute);
+  });
+});

--- a/front/migrations/20250225_backfill_core_data_source_name.ts
+++ b/front/migrations/20250225_backfill_core_data_source_name.ts
@@ -15,7 +15,13 @@ async function backfillCoreDataSourceName(
 ) {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-  const dataSources = await DataSourceResource.listByWorkspace(auth);
+  const dataSources = await DataSourceResource.listByWorkspace(
+    auth,
+    {
+      includeDeleted: true,
+    },
+    true /* includeConversationDataSources*/
+  );
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -775,6 +775,33 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
+  async updateDataSource({
+    projectId,
+    dataSourceId,
+    name,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+    name: string;
+  }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
+    const response = await this._fetchWithError(
+      `${this._url}/projects/${encodeURIComponent(
+        projectId
+      )}/data_sources/${encodeURIComponent(dataSourceId)}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name,
+        }),
+      }
+    );
+
+    return this._resultFromResponse(response);
+  }
+
   async getDataSource({
     projectId,
     dataSourceId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/11039.

This PR adds:
- an endpoint on the Core API to update the data source name (DB + ES)
- a script to backfill all data source names (including the conversation data source -- we might revisit later)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
