### PR TITLE
[front] Ensure file title can fit in db

### DIFF
--- a/front/lib/api/assistant/actions/conversation/include_file.ts
+++ b/front/lib/api/assistant/actions/conversation/include_file.ts
@@ -346,7 +346,10 @@ export class ConversationIncludeFileConfigurationServerRunner extends BaseAction
     // action for the model (token count) and the rendering of the action details (file title).
     await action.update({
       tokensCount: tokensRes.value.tokens.length,
-      fileTitle: fileRes.value.title,
+      fileTitle:
+        fileRes.value.title?.length > 255
+          ? `...${fileRes.value.title?.slice(-252)}`
+          : fileRes.value.title,
     });
 
     yield {


### PR DESCRIPTION
## Description

Avoid issue : `DatabaseError: value too long for type character varying(255)` when title is too long


## Tests


## Risk

none

## Deploy Plan

deploy front 
