### PR TITLE
[sparkle] - enh(SearchInputWithPopover): optional info message

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.421",
+  "version": "0.2.422",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.421",
+      "version": "0.2.422",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.421",
+  "version": "0.2.422",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -101,7 +101,7 @@ const textVariants = cva("s-text-sm", {
 
 export interface ContentMessageProps {
   title?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
   size?: ContentMessageSizeType;
   variant?: ContentMessageVariantType;
@@ -130,7 +130,7 @@ export function ContentMessage({
           {title && <div className={titleVariants({ variant })}>{title}</div>}
         </div>
       )}
-      <div className={textVariants({ variant })}>{children}</div>
+      {children && <div className={textVariants({ variant })}>{children}</div>}
     </div>
   );
 }

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -12,9 +12,9 @@ import {
   ScrollBar,
   Spinner,
 } from "@sparkle/components";
+import { ContentMessageProps } from "@sparkle/components/ContentMessage";
 import { MagnifyingGlassIcon, XMarkIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
-import { ContentMessageProps } from "@sparkle/components/ContentMessage";
 
 export interface SearchInputProps {
   placeholder?: string;

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, Ref, useEffect, useRef, useState } from "react";
 
 import {
   Button,
+  ContentMessage,
   Icon,
   Input,
   PopoverContent,
@@ -13,6 +14,7 @@ import {
 } from "@sparkle/components";
 import { MagnifyingGlassIcon, XMarkIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
+import { ContentMessageProps } from "@sparkle/components/ContentMessage";
 
 export interface SearchInputProps {
   placeholder?: string;
@@ -108,6 +110,7 @@ type SearchInputWithPopoverBaseProps<T> = SearchInputProps & {
   onItemSelect?: (item: T) => void;
   noResults?: string;
   isLoading?: boolean;
+  contentMessage?: ContentMessageProps;
 };
 
 function BaseSearchInputWithPopover<T>(
@@ -125,6 +128,7 @@ function BaseSearchInputWithPopover<T>(
     mountPortalContainer,
     noResults,
     isLoading,
+    contentMessage,
     ...searchInputProps
   }: SearchInputWithPopoverBaseProps<T>,
   ref: Ref<HTMLInputElement>
@@ -207,28 +211,35 @@ function BaseSearchInputWithPopover<T>(
         mountPortal={mountPortal}
         mountPortalContainer={mountPortalContainer}
       >
-        <ScrollArea
-          role="listbox"
-          className="s-flex s-max-h-72 s-flex-col"
-          hideScrollBar
-        >
-          {items.length > 0 ? (
-            items.map((item, index) => (
-              <div key={index} ref={(el) => (itemRefs.current[index] = el)}>
-                {renderItem(item, selectedIndex === index)}
+        <div className="s-flex s-flex-col">
+          <ScrollArea
+            role="listbox"
+            className="s-flex s-max-h-72 s-flex-col"
+            hideScrollBar
+          >
+            {items.length > 0 ? (
+              items.map((item, index) => (
+                <div key={index} ref={(el) => (itemRefs.current[index] = el)}>
+                  {renderItem(item, selectedIndex === index)}
+                </div>
+              ))
+            ) : isLoading ? (
+              <div className="s-flex s-justify-center s-py-8">
+                <Spinner variant="dark" size="md" />
               </div>
-            ))
-          ) : isLoading ? (
-            <div className="s-flex s-justify-center s-py-8">
-              <Spinner variant="dark" size="md" />
-            </div>
-          ) : (
-            <div className="s-p-2 s-text-sm s-text-gray-500">
-              {noResults ?? ""}
+            ) : (
+              <div className="s-p-2 s-text-sm s-text-gray-500">
+                {noResults ?? ""}
+              </div>
+            )}
+            <ScrollBar className="s-py-0" />
+          </ScrollArea>
+          {contentMessage && (
+            <div className="s-p-1">
+              <ContentMessage {...contentMessage} />
             </div>
           )}
-          <ScrollBar className="s-py-0" />
-        </ScrollArea>
+        </div>
       </PopoverContent>
     </PopoverRoot>
   );

--- a/sparkle/src/stories/SearchInput.stories.tsx
+++ b/sparkle/src/stories/SearchInput.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
 
-import { cn, SearchInput, SearchInputWithPopover } from "../index_with_tw_base";
+import {
+  cn,
+  InformationCircleIcon,
+  SearchInput,
+  SearchInputWithPopover,
+} from "../index_with_tw_base";
 
 const meta = {
   title: "Components/SearchInput",
@@ -87,6 +92,13 @@ export function SearchInputWithPopoverScrollableExample() {
       onOpenChange={setOpen}
       items={filteredItems}
       onItemSelect={(item) => console.log(item)}
+      contentMessage={{
+        title: "Yo",
+        variant: "amber",
+        icon: InformationCircleIcon,
+        className: "s-w-full",
+        size: "lg",
+      }}
       renderItem={(item, selected) => (
         <div
           key={item}


### PR DESCRIPTION
## Description

This PR aims at enhancing the `SearchInputWithPopover` to optionally render a `ContentMessage` at the end of the popover.

![Screenshot 2025-02-26 at 13 59 09](https://github.com/user-attachments/assets/c6e81214-8eeb-485a-943f-fcc43e8f1d4d)

**References:**
- https://github.com/dust-tt/tasks/issues/2213#issuecomment-2681924389

## Risk

None

## Deploy Plan

- Publish sparkle