### PR TITLE
enh(Sparkle) - Allow disabling button navigation in `DataTable` and `Pagination`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.422",
+  "version": "0.2.423",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.422",
+      "version": "0.2.423",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.422",
+  "version": "0.2.423",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -81,7 +81,6 @@ interface DataTableProps<TData extends TBaseData> {
   sorting?: SortingState;
   setSorting?: (sorting: SortingState) => void;
   isServerSideSorting?: boolean;
-  disablePaginationButtons?: boolean;
 }
 
 function shouldRenderColumn(
@@ -109,7 +108,6 @@ export function DataTable<TData extends TBaseData>({
   sorting,
   setSorting,
   isServerSideSorting = false,
-  disablePaginationButtons = false,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -259,7 +257,6 @@ export function DataTable<TData extends TBaseData>({
             setPagination={table.setPagination}
             rowCount={table.getRowCount()}
             rowCountIsCapped={rowCountIsCapped}
-            disablePaginationButtons={disablePaginationButtons}
           />
         </div>
       )}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -81,6 +81,7 @@ interface DataTableProps<TData extends TBaseData> {
   sorting?: SortingState;
   setSorting?: (sorting: SortingState) => void;
   isServerSideSorting?: boolean;
+  disablePageButtons?: boolean;
 }
 
 function shouldRenderColumn(
@@ -108,6 +109,7 @@ export function DataTable<TData extends TBaseData>({
   sorting,
   setSorting,
   isServerSideSorting = false,
+  disablePageButtons = false,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -257,6 +259,7 @@ export function DataTable<TData extends TBaseData>({
             setPagination={table.setPagination}
             rowCount={table.getRowCount()}
             rowCountIsCapped={rowCountIsCapped}
+            disablePageButtons={disablePageButtons}
           />
         </div>
       )}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -81,7 +81,7 @@ interface DataTableProps<TData extends TBaseData> {
   sorting?: SortingState;
   setSorting?: (sorting: SortingState) => void;
   isServerSideSorting?: boolean;
-  disablePageButtons?: boolean;
+  disablePaginationNumbers?: boolean;
 }
 
 function shouldRenderColumn(
@@ -109,7 +109,7 @@ export function DataTable<TData extends TBaseData>({
   sorting,
   setSorting,
   isServerSideSorting = false,
-  disablePageButtons = false,
+  disablePaginationNumbers = false,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -259,7 +259,7 @@ export function DataTable<TData extends TBaseData>({
             setPagination={table.setPagination}
             rowCount={table.getRowCount()}
             rowCountIsCapped={rowCountIsCapped}
-            disablePageButtons={disablePageButtons}
+            disablePaginationNumbers={disablePaginationNumbers}
           />
         </div>
       )}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -81,6 +81,7 @@ interface DataTableProps<TData extends TBaseData> {
   sorting?: SortingState;
   setSorting?: (sorting: SortingState) => void;
   isServerSideSorting?: boolean;
+  disablePaginationButtons?: boolean;
 }
 
 function shouldRenderColumn(
@@ -108,6 +109,7 @@ export function DataTable<TData extends TBaseData>({
   sorting,
   setSorting,
   isServerSideSorting = false,
+  disablePaginationButtons = false,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -257,6 +259,7 @@ export function DataTable<TData extends TBaseData>({
             setPagination={table.setPagination}
             rowCount={table.getRowCount()}
             rowCountIsCapped={rowCountIsCapped}
+            disablePaginationButtons={disablePaginationButtons}
           />
         </div>
       )}

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -18,7 +18,7 @@ interface PaginationProps {
   rowCountIsCapped?: boolean;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
-  singleStepForward?: boolean;
+  preventMultiPageForward?: boolean;
 }
 
 export function Pagination({
@@ -29,7 +29,7 @@ export function Pagination({
   rowCountIsCapped = false,
   pagination,
   setPagination,
-  singleStepForward = false,
+  preventMultiPageForward = false,
 }: PaginationProps) {
   // pageIndex is 0-based
   const { pageIndex, pageSize } = pagination;
@@ -62,7 +62,7 @@ export function Pagination({
     pagesShownInControls,
     onPaginationButtonClick,
     size,
-    { singleStepForward }
+    { preventMultiPageForward }
   );
 
   return (
@@ -166,7 +166,7 @@ function getPageButtons(
   slots: number,
   onPageClick: (currentPage: number) => void,
   size: Size,
-  { singleStepForward = false }: { singleStepForward?: boolean }
+  { preventMultiPageForward = false }: { preventMultiPageForward?: boolean }
 ) {
   const pagination: React.ReactNode[] = [];
 
@@ -189,10 +189,12 @@ function getPageButtons(
   let start, end;
   if (currentPage <= halfSlots + 1) {
     start = 1;
-    end = singleStepForward ? currentPage + 1 : remainingSlots - 1;
+    // If we prevent multi-page forward, we only want to show the next page index, not the ones up to the remaining slots.
+    end = preventMultiPageForward ? currentPage + 1 : remainingSlots - 1;
   } else if (currentPage >= totalPages - halfSlots - 2) {
     start = totalPages - remainingSlots;
-    end = singleStepForward ? totalPages - 1 : totalPages - 2;
+    // If we prevent multi-page forward, we don't skip the last page because it won't be included in the last push below.
+    end = preventMultiPageForward ? totalPages - 1 : totalPages - 2;
   } else {
     start = currentPage - halfSlots + 1;
     end = currentPage + halfSlots - 1;
@@ -212,7 +214,7 @@ function getPageButtons(
     pagination.push(renderEllipses(size));
   }
 
-  if (!singleStepForward) {
+  if (!preventMultiPageForward) {
     pagination.push(
       renderPageNumber(totalPages - 1, currentPage, onPageClick, size)
     );

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -18,6 +18,7 @@ interface PaginationProps {
   rowCountIsCapped?: boolean;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
+  singleStepForward?: boolean;
 }
 
 export function Pagination({
@@ -28,6 +29,7 @@ export function Pagination({
   rowCountIsCapped = false,
   pagination,
   setPagination,
+  singleStepForward = false,
 }: PaginationProps) {
   // pageIndex is 0-based
   const { pageIndex, pageSize } = pagination;
@@ -59,7 +61,8 @@ export function Pagination({
     numPages,
     pagesShownInControls,
     onPaginationButtonClick,
-    size
+    size,
+    { singleStepForward }
   );
 
   return (
@@ -162,7 +165,8 @@ function getPageButtons(
   totalPages: number,
   slots: number,
   onPageClick: (currentPage: number) => void,
-  size: Size
+  size: Size,
+  { singleStepForward = false }: { singleStepForward?: boolean }
 ) {
   const pagination: React.ReactNode[] = [];
 
@@ -185,10 +189,10 @@ function getPageButtons(
   let start, end;
   if (currentPage <= halfSlots + 1) {
     start = 1;
-    end = remainingSlots - 1;
+    end = singleStepForward ? currentPage + 1 : remainingSlots - 1;
   } else if (currentPage >= totalPages - halfSlots - 2) {
     start = totalPages - remainingSlots;
-    end = totalPages - 2;
+    end = singleStepForward ? totalPages - 1 : totalPages - 2;
   } else {
     start = currentPage - halfSlots + 1;
     end = currentPage + halfSlots - 1;
@@ -208,9 +212,11 @@ function getPageButtons(
     pagination.push(renderEllipses(size));
   }
 
-  pagination.push(
-    renderPageNumber(totalPages - 1, currentPage, onPageClick, size)
-  ); // Always show the last page
+  if (!singleStepForward) {
+    pagination.push(
+      renderPageNumber(totalPages - 1, currentPage, onPageClick, size)
+    );
+  }
 
   return pagination;
 }

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -18,7 +18,6 @@ interface PaginationProps {
   rowCountIsCapped?: boolean;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
-  singleStepForward?: boolean;
 }
 
 export function Pagination({
@@ -29,7 +28,6 @@ export function Pagination({
   rowCountIsCapped = false,
   pagination,
   setPagination,
-  singleStepForward = false,
 }: PaginationProps) {
   // pageIndex is 0-based
   const { pageIndex, pageSize } = pagination;
@@ -61,8 +59,7 @@ export function Pagination({
     numPages,
     pagesShownInControls,
     onPaginationButtonClick,
-    size,
-    { singleStepForward }
+    size
   );
 
   return (
@@ -165,8 +162,7 @@ function getPageButtons(
   totalPages: number,
   slots: number,
   onPageClick: (currentPage: number) => void,
-  size: Size,
-  { singleStepForward = false }: { singleStepForward?: boolean }
+  size: Size
 ) {
   const pagination: React.ReactNode[] = [];
 
@@ -189,10 +185,10 @@ function getPageButtons(
   let start, end;
   if (currentPage <= halfSlots + 1) {
     start = 1;
-    end = singleStepForward ? currentPage + 1 : remainingSlots - 1;
+    end = remainingSlots - 1;
   } else if (currentPage >= totalPages - halfSlots - 2) {
     start = totalPages - remainingSlots;
-    end = singleStepForward ? totalPages - 1 : totalPages - 2;
+    end = totalPages - 2;
   } else {
     start = currentPage - halfSlots + 1;
     end = currentPage + halfSlots - 1;
@@ -212,11 +208,9 @@ function getPageButtons(
     pagination.push(renderEllipses(size));
   }
 
-  if (!singleStepForward) {
-    pagination.push(
-      renderPageNumber(totalPages - 1, currentPage, onPageClick, size)
-    );
-  }
+  pagination.push(
+    renderPageNumber(totalPages - 1, currentPage, onPageClick, size)
+  ); // Always show the last page
 
   return pagination;
 }

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -18,6 +18,7 @@ interface PaginationProps {
   rowCountIsCapped?: boolean;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
+  disablePageButtons?: boolean;
 }
 
 export function Pagination({
@@ -28,6 +29,7 @@ export function Pagination({
   rowCountIsCapped = false,
   pagination,
   setPagination,
+  disablePageButtons = false,
 }: PaginationProps) {
   // pageIndex is 0-based
   const { pageIndex, pageSize } = pagination;
@@ -58,7 +60,7 @@ export function Pagination({
     pageIndex,
     numPages,
     pagesShownInControls,
-    onPaginationButtonClick,
+    !disablePageButtons ? onPaginationButtonClick : null,
     size
   );
 
@@ -123,10 +125,10 @@ export function Pagination({
 function renderPageNumber(
   pageNumber: number,
   currentPage: number,
-  onPageClick: (currentPage: number) => void,
+  onPageClick: ((currentPage: number) => void) | null,
   size: Size
 ) {
-  return (
+  return onPageClick ? (
     <button
       key={pageNumber}
       className={classNames(
@@ -140,6 +142,19 @@ function renderPageNumber(
     >
       {pageNumber + 1}
     </button>
+  ) : (
+    <div
+      key={pageNumber}
+      className={classNames(
+        "s-font-medium s-transition-colors s-duration-200",
+        currentPage === pageNumber
+          ? "s-text-foreground dark:s-text-foreground-night"
+          : "s-text-primary-400 dark:s-text-primary-400-night",
+        size === "xs" ? "s-text-xs" : "s-text-sm"
+      )}
+    >
+      {pageNumber + 1}
+    </div>
   );
 }
 
@@ -161,7 +176,7 @@ function getPageButtons(
   currentPage: number,
   totalPages: number,
   slots: number,
-  onPageClick: (currentPage: number) => void,
+  onPageClick: ((currentPage: number) => void) | null,
   size: Size
 ) {
   const pagination: React.ReactNode[] = [];

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -18,7 +18,7 @@ interface PaginationProps {
   rowCountIsCapped?: boolean;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
-  disablePageButtons?: boolean;
+  disablePaginationNumbers?: boolean;
 }
 
 export function Pagination({
@@ -29,7 +29,7 @@ export function Pagination({
   rowCountIsCapped = false,
   pagination,
   setPagination,
-  disablePageButtons = false,
+  disablePaginationNumbers = false,
 }: PaginationProps) {
   // pageIndex is 0-based
   const { pageIndex, pageSize } = pagination;
@@ -60,7 +60,7 @@ export function Pagination({
     pageIndex,
     numPages,
     pagesShownInControls,
-    !disablePageButtons ? onPaginationButtonClick : null,
+    !disablePaginationNumbers ? onPaginationButtonClick : null,
     size
   );
 

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -60,8 +60,8 @@ export function Pagination({
     pageIndex,
     numPages,
     pagesShownInControls,
-    !disablePaginationNumbers ? onPaginationButtonClick : null,
-    size
+    size,
+    !disablePaginationNumbers ? onPaginationButtonClick : undefined
   );
 
   return (
@@ -125,8 +125,8 @@ export function Pagination({
 function renderPageNumber(
   pageNumber: number,
   currentPage: number,
-  onPageClick: ((currentPage: number) => void) | null,
-  size: Size
+  size: Size,
+  onPageClick?: (currentPage: number) => void
 ) {
   return onPageClick ? (
     <button
@@ -176,15 +176,15 @@ function getPageButtons(
   currentPage: number,
   totalPages: number,
   slots: number,
-  onPageClick: ((currentPage: number) => void) | null,
-  size: Size
+  size: Size,
+  onPageClick?: (currentPage: number) => void
 ) {
   const pagination: React.ReactNode[] = [];
 
   // If total pages are less than or equal to slots, show all pages
   if (totalPages <= slots) {
     for (let i = 0; i < totalPages; i++) {
-      pagination.push(renderPageNumber(i, currentPage, onPageClick, size));
+      pagination.push(renderPageNumber(i, currentPage, size, onPageClick));
     }
     return pagination;
   }
@@ -195,7 +195,7 @@ function getPageButtons(
   // Ensure current page is within bounds
   currentPage = Math.max(0, Math.min(currentPage, totalPages - 1));
 
-  pagination.push(renderPageNumber(0, currentPage, onPageClick, size)); // Always show the first page
+  pagination.push(renderPageNumber(0, currentPage, size, onPageClick)); // Always show the first page
   // Determine the range of pages to display
   let start, end;
   if (currentPage <= halfSlots + 1) {
@@ -215,7 +215,7 @@ function getPageButtons(
 
   // Add the range of pages
   for (let i = start; i <= end; i++) {
-    pagination.push(renderPageNumber(i, currentPage, onPageClick, size));
+    pagination.push(renderPageNumber(i, currentPage, size, onPageClick));
   }
 
   // Add ellipsis if there is a gap between the end of the range and the last page
@@ -224,7 +224,7 @@ function getPageButtons(
   }
 
   pagination.push(
-    renderPageNumber(totalPages - 1, currentPage, onPageClick, size)
+    renderPageNumber(totalPages - 1, currentPage, size, onPageClick)
   ); // Always show the last page
 
   return pagination;

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -18,7 +18,7 @@ interface PaginationProps {
   rowCountIsCapped?: boolean;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
-  preventMultiPageForward?: boolean;
+  singleStepForward?: boolean;
 }
 
 export function Pagination({
@@ -29,7 +29,7 @@ export function Pagination({
   rowCountIsCapped = false,
   pagination,
   setPagination,
-  preventMultiPageForward = false,
+  singleStepForward = false,
 }: PaginationProps) {
   // pageIndex is 0-based
   const { pageIndex, pageSize } = pagination;
@@ -62,7 +62,7 @@ export function Pagination({
     pagesShownInControls,
     onPaginationButtonClick,
     size,
-    { preventMultiPageForward }
+    { singleStepForward }
   );
 
   return (
@@ -166,7 +166,7 @@ function getPageButtons(
   slots: number,
   onPageClick: (currentPage: number) => void,
   size: Size,
-  { preventMultiPageForward = false }: { preventMultiPageForward?: boolean }
+  { singleStepForward = false }: { singleStepForward?: boolean }
 ) {
   const pagination: React.ReactNode[] = [];
 
@@ -189,12 +189,10 @@ function getPageButtons(
   let start, end;
   if (currentPage <= halfSlots + 1) {
     start = 1;
-    // If we prevent multi-page forward, we only want to show the next page index, not the ones up to the remaining slots.
-    end = preventMultiPageForward ? currentPage + 1 : remainingSlots - 1;
+    end = singleStepForward ? currentPage + 1 : remainingSlots - 1;
   } else if (currentPage >= totalPages - halfSlots - 2) {
     start = totalPages - remainingSlots;
-    // If we prevent multi-page forward, we don't skip the last page because it won't be included in the last push below.
-    end = preventMultiPageForward ? totalPages - 1 : totalPages - 2;
+    end = singleStepForward ? totalPages - 1 : totalPages - 2;
   } else {
     start = currentPage - halfSlots + 1;
     end = currentPage + halfSlots - 1;
@@ -214,7 +212,7 @@ function getPageButtons(
     pagination.push(renderEllipses(size));
   }
 
-  if (!preventMultiPageForward) {
+  if (!singleStepForward) {
     pagination.push(
       renderPageNumber(totalPages - 1, currentPage, onPageClick, size)
     );

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -128,7 +128,7 @@ function renderPageNumber(
   size: Size,
   onPageClick?: (currentPage: number) => void
 ) {
-  return onPageClick ? (
+  return (
     <button
       key={pageNumber}
       className={classNames(
@@ -138,23 +138,11 @@ function renderPageNumber(
           : "s-text-primary-400 dark:s-text-primary-400-night",
         size === "xs" ? "s-text-xs" : "s-text-sm"
       )}
-      onClick={() => onPageClick(pageNumber)}
+      onClick={() => onPageClick && onPageClick(pageNumber)}
+      disabled={!onPageClick}
     >
       {pageNumber + 1}
     </button>
-  ) : (
-    <div
-      key={pageNumber}
-      className={classNames(
-        "s-font-medium s-transition-colors s-duration-200",
-        currentPage === pageNumber
-          ? "s-text-foreground dark:s-text-foreground-night"
-          : "s-text-primary-400 dark:s-text-primary-400-night",
-        size === "xs" ? "s-text-xs" : "s-text-sm"
-      )}
-    >
-      {pageNumber + 1}
-    </div>
   );
 }
 

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -404,7 +404,7 @@ export const DataTablePaginatedPageButtonsDisabledExample = () => {
         setPagination={setPagination}
         columns={columns}
         columnsBreakpoints={{ lastUpdated: "sm" }}
-        disablePageButtons
+        disablePaginationNumbers
       />
     </div>
   );

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -380,6 +380,36 @@ export const DataTablePaginatedExample = () => {
   );
 };
 
+export const DataTablePaginatedPageButtonsDisabledExample = () => {
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 2,
+  });
+  const [filter, setFilter] = React.useState<string>("");
+
+  return (
+    <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
+      <Input
+        name="filter"
+        placeholder="Filter"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+      />
+      <DataTable
+        className="s-w-full s-max-w-4xl s-overflow-x-auto"
+        data={data}
+        filter={filter}
+        filterColumn="name"
+        pagination={pagination}
+        setPagination={setPagination}
+        columns={columns}
+        columnsBreakpoints={{ lastUpdated: "sm" }}
+        disablePageButtons
+      />
+    </div>
+  );
+};
+
 export const DataTablePaginatedServerSideExample = () => {
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,

--- a/sparkle/src/stories/Pagination.stories.tsx
+++ b/sparkle/src/stories/Pagination.stories.tsx
@@ -58,6 +58,21 @@ export const PaginationNoPageButtons = () => {
   );
 };
 
+export const PaginationButtonsDisabled = () => {
+  const [pagination, setPagination] = React.useState({
+    pageIndex: 0,
+    pageSize: 50,
+  });
+  return (
+    <Pagination
+      rowCount={960}
+      pagination={pagination}
+      setPagination={setPagination}
+      disablePageButtons
+    />
+  );
+};
+
 export const PaginationWithUrl = () => {
   const { pagination, setPagination } = usePaginationFromUrl({
     urlPrefix: "example",

--- a/sparkle/src/stories/Pagination.stories.tsx
+++ b/sparkle/src/stories/Pagination.stories.tsx
@@ -75,3 +75,19 @@ export const PaginationWithUrl = () => {
     </>
   );
 };
+
+export const PaginationWithSingleStepForward = () => {
+  const [pagination, setPagination] = React.useState({
+    pageIndex: 0,
+    pageSize: 50,
+  });
+  return (
+    <Pagination
+      rowCount={960}
+      size="xs"
+      pagination={pagination}
+      setPagination={setPagination}
+      singleStepForward
+    />
+  );
+};

--- a/sparkle/src/stories/Pagination.stories.tsx
+++ b/sparkle/src/stories/Pagination.stories.tsx
@@ -68,7 +68,7 @@ export const PaginationButtonsDisabled = () => {
       rowCount={960}
       pagination={pagination}
       setPagination={setPagination}
-      disablePageButtons
+      disablePaginationNumbers
     />
   );
 };

--- a/sparkle/src/stories/Pagination.stories.tsx
+++ b/sparkle/src/stories/Pagination.stories.tsx
@@ -75,19 +75,3 @@ export const PaginationWithUrl = () => {
     </>
   );
 };
-
-export const PaginationWithSingleStepForward = () => {
-  const [pagination, setPagination] = React.useState({
-    pageIndex: 0,
-    pageSize: 50,
-  });
-  return (
-    <Pagination
-      rowCount={960}
-      size="xs"
-      pagination={pagination}
-      setPagination={setPagination}
-      singleStepForward
-    />
-  );
-};


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2039.
- This PR adds a prop `disablePaginationButtons` to the `Pagination` and `DataTable` components.
- This PR disables the action of the page numbers in the pagination.
- This change is required for `DataTable`s where the use of cursor-based pagination did not allow navigating to more than one page forward at a time.

## Tests

- Added to storybook.

## Risk

- Low.

## Deploy Plan

- Publish `sparkle`.