### PR TITLE
enh(Sparkle) - Allow disabling button navigation in `DataTable`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.423",
+  "version": "0.2.424",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.423",
+      "version": "0.2.424",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.423",
+  "version": "0.2.424",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -81,6 +81,7 @@ interface DataTableProps<TData extends TBaseData> {
   sorting?: SortingState;
   setSorting?: (sorting: SortingState) => void;
   isServerSideSorting?: boolean;
+  disablePaginationButtons?: boolean;
 }
 
 function shouldRenderColumn(
@@ -108,6 +109,7 @@ export function DataTable<TData extends TBaseData>({
   sorting,
   setSorting,
   isServerSideSorting = false,
+  disablePaginationButtons = false,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -257,6 +259,7 @@ export function DataTable<TData extends TBaseData>({
             setPagination={table.setPagination}
             rowCount={table.getRowCount()}
             rowCountIsCapped={rowCountIsCapped}
+            disablePaginationButtons={disablePaginationButtons}
           />
         </div>
       )}


### PR DESCRIPTION
## Description

- Part of 
- Follow up on https://github.com/dust-tt/dust/pull/11082.
- This PR adds and allows passing the `disablePaginationButtons` from the `DataTable` to the `Pagination` component.

## Tests

- No automated test.

## Risk

- Low.

## Deploy Plan

- Publish `sparkle`.