### PR TITLE
Fix Breadcrumbs order

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -152,16 +152,23 @@ export async function getContentNodesForDataSourceView(
     nextPageCursor = coreRes.value.next_page_cursor;
   } while (nextPageCursor && resultNodes.length < limit);
 
+  const nodes = resultNodes.map((node) =>
+    getContentNodeFromCoreNode(
+      dataSourceView instanceof DataSourceViewResource
+        ? dataSourceView.toJSON()
+        : dataSourceView,
+      node,
+      viewType
+    )
+  );
+  const sortedNodes = !internalIds
+    ? nodes
+    : internalIds.flatMap((id) =>
+        nodes.filter((node) => node.internalId === id)
+      );
+
   return new Ok({
-    nodes: resultNodes.map((node) =>
-      getContentNodeFromCoreNode(
-        dataSourceView instanceof DataSourceViewResource
-          ? dataSourceView.toJSON()
-          : dataSourceView,
-        node,
-        viewType
-      )
-    ),
+    nodes: sortedNodes,
     total: resultNodes.length,
     nextPageCursor: nextPageCursor,
   });


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/1919.
- The breadcrumbs were in an inconsistent order.
- When passing the internal IDs of the nodes to retrieve to core, we don't have strong guarantees on the order of the results.
- This PR adds a sorting in `getContentNodesForDataSourceView ` on the results if internal IDs are passed.
- The sorting is highly inefficient, if it proves to be too slow we'll explore sorting in elasticsearch or at the very least do a more optimized sorting that is not O(n^2).

## Tests

- Tested locally, no automated test.

## Risk

- Slow down server-side props (in AssistantBuilder notably).

## Deploy Plan

- Deploy front.