### PR TITLE
Add Elasticsearch query clause limit handling

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -36,7 +36,7 @@ use dust::{
     blocks::block::BlockType,
     data_sources::{
         data_source::{self, Section},
-        node::{Node, ProviderVisibility},
+        node::ProviderVisibility,
         qdrant::QdrantClients,
     },
     databases::{
@@ -3505,7 +3505,7 @@ async fn nodes_search(
     State(state): State<Arc<APIState>>,
     Json(payload): Json<NodesSearchPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    let (nodes, hit_count, hit_count_is_accurate, next_cursor) = match state
+    let (nodes, hit_count, hit_count_is_accurate, next_cursor, warning_code) = match state
         .search_store
         .search_nodes(
             payload.query,
@@ -3515,9 +3515,13 @@ async fn nodes_search(
         )
         .await
     {
-        Ok((nodes, hit_count, hit_count_is_accurate, next_cursor)) => {
-            (nodes, hit_count, hit_count_is_accurate, next_cursor)
-        }
+        Ok((nodes, hit_count, hit_count_is_accurate, next_cursor, warning_code)) => (
+            nodes,
+            hit_count,
+            hit_count_is_accurate,
+            next_cursor,
+            warning_code,
+        ),
         Err(e) => {
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -3537,6 +3541,7 @@ async fn nodes_search(
                 "hit_count": hit_count,
                 "hit_count_is_accurate": hit_count_is_accurate,
                 "next_page_cursor": next_cursor,
+                "warning_code": warning_code,
             })),
         }),
     )

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -1,5 +1,6 @@
 import type {
   DataSourceViewContentNode,
+  SearchWarningCode,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { CoreAPI, MIN_SEARCH_QUERY_SIZE } from "@dust-tt/types";
@@ -31,6 +32,7 @@ const SearchRequestBody = t.type({
 
 export type PostSpaceSearchResponseBody = {
   nodes: DataSourceViewContentNode[];
+  warningCode: SearchWarningCode | null;
 };
 
 async function handler(
@@ -210,7 +212,10 @@ async function handler(
       viewType
     );
   });
-  return res.status(200).json({ nodes });
+
+  return res
+    .status(200)
+    .json({ nodes, warningCode: searchRes.value.warning_code });
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -1,6 +1,7 @@
 import type {
   ContentNodesViewType,
   DataSourceViewContentNode,
+  SearchWarningCode,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { assertNever, CoreAPI, MIN_SEARCH_QUERY_SIZE } from "@dust-tt/types";
@@ -48,6 +49,7 @@ const SearchRequestBody = t.type({
 
 export type PostSpaceSearchResponseBody = {
   nodes: DataSourceViewContentNode[];
+  warningCode: SearchWarningCode | null;
 };
 
 async function handler(
@@ -180,7 +182,10 @@ async function handler(
 
     return getContentNodeFromCoreNode(dataSourceView.toJSON(), node, viewType);
   });
-  return res.status(200).json({ nodes });
+
+  return res
+    .status(200)
+    .json({ nodes, warningCode: searchRes.value.warning_code });
 }
 
 export default withSessionAuthenticationForWorkspace(

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -228,11 +228,14 @@ export interface CoreAPISearchCursorRequest {
   cursor?: string;
 }
 
+export type SearchWarningCode = "truncated-query-clauses";
+
 export interface CoreAPISearchNodesResponse {
   nodes: CoreAPIContentNode[];
   next_page_cursor: string | null;
   hit_count: number;
   hit_count_is_accurate: boolean;
+  warning_code: SearchWarningCode | null;
 }
 
 export interface CoreAPISearchTagsResponse {
@@ -1845,6 +1848,7 @@ export class CoreAPI {
         options,
       }),
     });
+
     return this._resultFromResponse(response);
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Elasticsearch has a default [limit](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-settings.html) of 1024 clauses in boolean queries. When this limit is exceeded, queries fail with a "too many clauses" error, causing search operations to fail completely. This is particularly problematic for workspaces with many data sources or complex view filters.

This PR implements a best-effort approach to prevent Elasticsearch queries from exceeding the clause limit:
- Added a `QueryClauseCounter` helper to track clause usage during query construction
- Modified query building to prioritize data sources when requested
- Implemented graceful degradation by skipping additional data source views when approaching the limit
- Added a warning code system to inform downstream consumers when results are incomplete

### Best-effort approach
Rather than building a complete DSL layer to precisely count clauses (which would be complex and brittle), we've implemented a pragmatic solution:
- We count clauses conservatively as we build the query
- Each boolean operation, term filter, and match query counts as one clause
- When we reach the limit, we stop adding new components to the query

This ensures we return partial results rather than failing completely
The approach is "best-effort" because Elasticsearch's internal clause counting is complex and depends on query analysis and optimization. Our counter provides a reasonable approximation that prevents most limit-related failures while keeping the implementation simple.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
