### PR TITLE
[front] - chore(dataSourceView):  add `conversationId`

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -27,6 +27,8 @@ import {
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { RetrievalDocumentResource } from "@app/lib/resources/retrieval_document_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { ConversationWithoutContentPublicType } from "@dust-tt/client";
 
 const DESTROY_MESSAGE_BATCH = 50;
 
@@ -156,6 +158,28 @@ async function destroyConversationDataSource(
   }
 }
 
+async function destroyConversationDataSourceView(
+  auth: Authenticator,
+  {
+    conversation,
+  }: {
+    conversation: ConversationWithoutContentPublicType;
+  }
+) {
+  // Find all dataSourceViews that have this conversationId
+  const dataSourceViews =
+    await DataSourceViewResource.fetchByConversationWithoutContentPublic(
+      auth,
+      conversation
+    );
+
+  if (dataSourceViews) {
+    for (const dsv of dataSourceViews) {
+      await dsv.delete(auth, { hardDelete: true });
+    }
+  }
+}
+
 // This belongs to the ConversationResource. The authenticator is expected to have access to the
 // groups involved in the conversation.
 export async function destroyConversation(
@@ -233,6 +257,7 @@ export async function destroyConversation(
     where: { conversationId: conversation.id },
   });
 
+  await destroyConversationDataSourceView(auth, { conversation });
   await destroyConversationDataSource(auth, { conversation });
 
   const c = await Conversation.findOne({

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,3 +1,4 @@
+import { ConversationWithoutContentPublicType } from "@dust-tt/client";
 import type { ConversationWithoutContentType, ModelId } from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
@@ -26,9 +27,8 @@ import {
 } from "@app/lib/models/assistant/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { RetrievalDocumentResource } from "@app/lib/resources/retrieval_document_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { ConversationWithoutContentPublicType } from "@dust-tt/client";
+import { RetrievalDocumentResource } from "@app/lib/resources/retrieval_document_resource";
 
 const DESTROY_MESSAGE_BATCH = 50;
 
@@ -167,11 +167,10 @@ async function destroyConversationDataSourceView(
   }
 ) {
   // Find all dataSourceViews that have this conversationId
-  const dataSourceViews =
-    await DataSourceViewResource.fetchByConversationWithoutContentPublic(
-      auth,
-      conversation
-    );
+  const dataSourceViews = await DataSourceViewResource.fetchByConversation(
+    auth,
+    conversation
+  );
 
   if (dataSourceViews) {
     for (const dsv of dataSourceViews) {

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,4 +1,4 @@
-import { ConversationWithoutContentPublicType } from "@dust-tt/client";
+import type { ConversationWithoutContentPublicType } from "@dust-tt/client";
 import type { ConversationWithoutContentType, ModelId } from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -45,10 +45,11 @@ async function getJITActions(
       filesUsableAsRetrievalQuery.length > 0
     ) {
       // Get the datasource view for the conversation.
-      const dataSourceView = await DataSourceViewResource.fetchByConversation(
-        auth,
-        conversation
-      );
+      const dataSourceView =
+        await DataSourceViewResource.fetchByDataSourceConversation(
+          auth,
+          conversation
+        );
 
       if (!dataSourceView) {
         logger.warn(

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -914,7 +914,8 @@ export async function createDataSourceWithoutProvider(
         conversationId: conversation?.id,
       },
       space,
-      auth.user()
+      auth.user(),
+      conversation
     );
 
   try {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -104,6 +104,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     dataSource: DataSourceResource,
     editedByUser?: UserType | null,
+    conversation?: ConversationType,
     transaction?: Transaction
   ) {
     const dataSourceView = await DataSourceViewResource.model.create(
@@ -112,6 +113,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         editedByUserId: editedByUser?.id ?? null,
         editedAt: new Date(),
         vaultId: space.id,
+        ...(conversation && { conversationId: conversation.id }),
       },
       { transaction }
     );
@@ -129,6 +131,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     blob: Omit<CreationAttributes<DataSourceModel>, "editedAt" | "vaultId">,
     space: SpaceResource,
     editedByUser?: UserType | null,
+    conversation?: ConversationType,
     transaction?: Transaction
   ) {
     const createDataSourceAndView = async (t: Transaction) => {
@@ -142,7 +145,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         space,
         dataSource,
         editedByUser,
-        t
+        conversation
       );
     };
 
@@ -177,6 +180,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     dataSource: DataSourceResource,
     editedByUser?: UserType | null,
+    conversation?: ConversationType,
     transaction?: Transaction
   ) {
     return this.makeNew(
@@ -189,6 +193,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       space,
       dataSource,
       editedByUser,
+      conversation,
       transaction
     );
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -1,7 +1,7 @@
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-import { ConversationWithoutContentPublicType } from "@dust-tt/client";
+import type { ConversationWithoutContentPublicType } from "@dust-tt/client";
 import type {
   ConversationType,
   DataSourceViewCategory,
@@ -105,10 +105,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     dataSource: DataSourceResource,
     editedByUser?: UserType | null,
-    conversation?:
-      | ConversationType
-      | ConversationWithoutContentPublicType
-      | null,
+    conversation?: ConversationWithoutContentPublicType | null,
     transaction?: Transaction
   ) {
     const dataSourceView = await DataSourceViewResource.model.create(
@@ -135,10 +132,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     blob: Omit<CreationAttributes<DataSourceModel>, "editedAt" | "vaultId">,
     space: SpaceResource,
     editedByUser?: UserType | null,
-    conversation?:
-      | ConversationType
-      | ConversationWithoutContentPublicType
-      | null,
+    conversation?: ConversationWithoutContentPublicType | null,
     transaction?: Transaction
   ) {
     const createDataSourceAndView = async (t: Transaction) => {
@@ -188,10 +182,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     dataSource: DataSourceResource,
     editedByUser?: UserType | null,
-    conversation?:
-      | ConversationType
-      | ConversationWithoutContentPublicType
-      | null,
+    conversation?: ConversationWithoutContentPublicType | null,
     transaction?: Transaction
   ) {
     return this.makeNew(

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -49,6 +49,7 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
+import { ConversationWithoutContentPublicType } from "@dust-tt/client";
 
 const getDataSourceCategory = (
   dataSourceResource: DataSourceResource
@@ -104,7 +105,10 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     dataSource: DataSourceResource,
     editedByUser?: UserType | null,
-    conversation?: ConversationType,
+    conversation?:
+      | ConversationType
+      | ConversationWithoutContentPublicType
+      | null,
     transaction?: Transaction
   ) {
     const dataSourceView = await DataSourceViewResource.model.create(
@@ -131,7 +135,10 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     blob: Omit<CreationAttributes<DataSourceModel>, "editedAt" | "vaultId">,
     space: SpaceResource,
     editedByUser?: UserType | null,
-    conversation?: ConversationType,
+    conversation?:
+      | ConversationType
+      | ConversationWithoutContentPublicType
+      | null,
     transaction?: Transaction
   ) {
     const createDataSourceAndView = async (t: Transaction) => {
@@ -180,7 +187,10 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     dataSource: DataSourceResource,
     editedByUser?: UserType | null,
-    conversation?: ConversationType,
+    conversation?:
+      | ConversationType
+      | ConversationWithoutContentPublicType
+      | null,
     transaction?: Transaction
   ) {
     return this.makeNew(

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -445,6 +445,23 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     return dataSourceViews[0] ?? null;
   }
 
+  static async fetchByConversationWithoutContentPublic(
+    auth: Authenticator,
+    conversation: ConversationWithoutContentPublicType
+  ): Promise<DataSourceViewResource[]> {
+    const dataSourceViews = await this.baseFetch(
+      auth,
+      {},
+      {
+        where: {
+          kind: "default",
+          conversationId: conversation.id,
+        },
+      }
+    );
+    return dataSourceViews;
+  }
+
   static async search(
     auth: Authenticator,
     searchParams: {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -418,7 +418,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     return dataSourceViews ?? null;
   }
 
-  static async fetchByConversation(
+  static async fetchByDataSourceConversation(
     auth: Authenticator,
     conversation: ConversationType
   ): Promise<DataSourceViewResource | null> {
@@ -445,7 +445,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     return dataSourceViews[0] ?? null;
   }
 
-  static async fetchByConversationWithoutContentPublic(
+  static async fetchByConversation(
     auth: Authenticator,
     conversation: ConversationWithoutContentPublicType
   ): Promise<DataSourceViewResource[]> {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -114,7 +114,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         editedByUserId: editedByUser?.id ?? null,
         editedAt: new Date(),
         vaultId: space.id,
-        ...(conversation && { conversationId: conversation.id }),
+        conversationId: conversation?.id ?? null,
       },
       { transaction }
     );

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -152,7 +152,8 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         space,
         dataSource,
         editedByUser,
-        conversation
+        conversation,
+        t
       );
     };
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -1,6 +1,7 @@
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
+import { ConversationWithoutContentPublicType } from "@dust-tt/client";
 import type {
   ConversationType,
   DataSourceViewCategory,
@@ -49,7 +50,6 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
-import { ConversationWithoutContentPublicType } from "@dust-tt/client";
 
 const getDataSourceCategory = (
   dataSourceResource: DataSourceResource

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -63,6 +63,7 @@ DataSourceViewModel.init(
     indexes: [
       { fields: ["workspaceId", "id"] },
       { fields: ["workspaceId", "vaultId"] },
+      { fields: ["workspaceId", "conversationId"] },
       {
         fields: ["workspaceId", "dataSourceId", "vaultId", "deletedAt"],
         unique: true,

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -2,12 +2,12 @@ import type { DataSourceViewKind } from "@dust-tt/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import { Conversation } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { Conversation } from "@app/lib/models/assistant/conversation";
 
 export class DataSourceViewModel extends SoftDeletableWorkspaceAwareModel<DataSourceViewModel> {
   declare id: CreationOptional<number>;
@@ -27,6 +27,8 @@ export class DataSourceViewModel extends SoftDeletableWorkspaceAwareModel<DataSo
   declare dataSourceForView: NonAttribute<DataSourceModel>;
   declare editedByUser: NonAttribute<UserModel>;
   declare space: NonAttribute<SpaceModel>;
+
+  declare conversationId: ForeignKey<Conversation["id"]> | null;
 }
 DataSourceViewModel.init(
   {

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -97,7 +97,7 @@ DataSourceViewModel.belongsTo(UserModel, {
 });
 
 Conversation.hasMany(DataSourceViewModel, {
-  as: "conversation",
+  as: "conversationForView",
   foreignKey: { name: "conversationId", allowNull: true },
   onDelete: "RESTRICT",
 });

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -7,6 +7,7 @@ import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { Conversation } from "@app/lib/models/assistant/conversation";
 
 export class DataSourceViewModel extends SoftDeletableWorkspaceAwareModel<DataSourceViewModel> {
   declare id: CreationOptional<number>;
@@ -92,4 +93,10 @@ DataSourceViewModel.belongsTo(DataSourceModel, {
 DataSourceViewModel.belongsTo(UserModel, {
   as: "editedByUser",
   foreignKey: { name: "editedByUserId", allowNull: true },
+});
+
+Conversation.hasMany(DataSourceViewModel, {
+  as: "conversation",
+  foreignKey: { name: "conversationId", allowNull: true },
+  onDelete: "RESTRICT",
 });

--- a/front/migrations/20250227_backfill_conversation_ids.ts
+++ b/front/migrations/20250227_backfill_conversation_ids.ts
@@ -1,0 +1,97 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import { concurrentExecutor } from "@dust-tt/types";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+async function backfillDataSourceViewConversationId(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // Get the conversations space
+  const conversationsSpace =
+    await SpaceResource.fetchWorkspaceConversationsSpace(auth);
+  if (!conversationsSpace) {
+    logger.info({ workspaceId: workspace.sId }, "No conversations space found");
+    return;
+  }
+
+  // Find all dataSources in conversations space with a conversationId
+  const dataSources: DataSourceModel[] = await DataSourceModel.findAll({
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    where: {
+      workspaceId: workspace.id,
+      vaultId: conversationsSpace.id,
+      conversationId: {
+        [Op.not]: null
+      }
+    },
+  });
+
+  logger.info(
+    { workspaceId: workspace.sId, count: dataSources.length },
+    "Found dataSources in conversation vault"
+  );
+
+  await concurrentExecutor(
+    dataSources,
+    async (dataSource) => {
+      if (execute) {
+        const [updatedCount] = await DataSourceViewModel.update(
+          {
+            conversationId: dataSource.conversationId,
+          },
+          {
+            where: {
+              workspaceId: workspace.id,
+              dataSourceId: dataSource.id,
+            },
+          }
+        );
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            dataSourceId: dataSource.id,
+            conversationId: dataSource.conversationId,
+            updatedCount,
+          },
+          "Updated dataSourceViews"
+        );
+      } else {
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            dataSourceId: dataSource.id,
+            conversationId: dataSource.conversationId,
+          },
+          "Would update dataSourceViews"
+        );
+      }
+    },
+    {
+      concurrency: 10,
+    }
+  );
+
+  logger.info(
+    { workspaceId: workspace.sId, dataSourceCount: dataSources.length },
+    "Done updating dataSourceViews"
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillDataSourceViewConversationId(workspace, logger, execute);
+  });
+});

--- a/front/migrations/20250227_backfill_conversation_ids.ts
+++ b/front/migrations/20250227_backfill_conversation_ids.ts
@@ -33,8 +33,8 @@ async function backfillDataSourceViewConversationId(
       workspaceId: workspace.id,
       vaultId: conversationsSpace.id,
       conversationId: {
-        [Op.not]: null
-      }
+        [Op.not]: null,
+      },
     },
   });
 

--- a/front/migrations/db/migration_174.sql
+++ b/front/migrations/db/migration_174.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."data_source_views" ADD COLUMN "conversationId" INTEGER REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+CREATE INDEX CONCURRENTLY "data_source_views_workspace_id_conversation_id" ON "data_source_views" ("workspaceId", "conversationId");

--- a/front/tests/utils/DataSourceViewFactory.ts
+++ b/front/tests/utils/DataSourceViewFactory.ts
@@ -22,6 +22,7 @@ export class DataSourceViewFactory {
       },
       space,
       null,
+      null,
       t
     );
   }


### PR DESCRIPTION
## Description

This PR adds `conversationId` field to `DataSourceViewModel` to associate data source views with conversations. This enables tracking which conversation a data source view was created from, following the same logic as data sources. The association helps differentiate data source views created in conversations from those created elsewhere.

**References:**
- https://github.com/dust-tt/tasks/issues/2268

## Risk

Implies a migration

## Deploy Plan

- Deploy migrations to add conversationId column and index
- Deploy `front`
- Run backfill script to populate `conversationId` in existing data source views