### PR TITLE
[sparkle] - chore(DataTable): add top and bottom borders

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.425",
+  "version": "0.2.426",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.425",
+      "version": "0.2.426",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.425",
+  "version": "0.2.426",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -369,7 +369,7 @@ DataTable.Row = function Row({
   return (
     <tr
       className={cn(
-        "s-group/dt s-border-b s-transition-colors s-duration-300 s-ease-out",
+        "s-group/dt s-justify-center s-border-y s-transition-colors s-duration-300 s-ease-out",
         "s-border-separator dark:s-border-separator-night",
         onClick
           ? "s-cursor-pointer hover:s-bg-muted dark:hover:s-bg-muted-night"


### PR DESCRIPTION
## Description

This PR adds top and bottom borders to the table headers.

![Screenshot 2025-02-27 at 15 14 17](https://github.com/user-attachments/assets/cf2cfd2c-dc12-45f5-9d47-cb9e257a9f03)

## Risk

Low

## Deploy Plan

Publish sparkle