### PR TITLE
enh(sparkle) - Allow passing an Icon to a `SheetTitle`, improve dark mode support

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.428",
+  "version": "0.2.429",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.428",
+      "version": "0.2.429",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.428",
+  "version": "0.2.429",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -98,7 +98,11 @@ const SheetContent = React.forwardRef<
     <FocusScope trapped={trapFocusScope} asChild>
       <SheetPrimitive.Content
         ref={ref}
-        className={cn(sheetVariants({ size, side }), className, "s-sheet")}
+        className={cn(
+          sheetVariants({ size, side }),
+          className,
+          "s-sheet s-text-foreground dark:s-text-foreground-night"
+        )}
         {...props}
       >
         {children}
@@ -217,11 +221,7 @@ const SheetTitle = React.forwardRef<
     {icon && <Icon visual={icon} size="lg" />}
     <SheetPrimitive.Title
       ref={ref}
-      className={cn(
-        "s-text-lg s-font-semibold",
-        "s-text-foreground dark:s-text-foreground-night",
-        className
-      )}
+      className={cn("s-text-lg s-font-semibold", className)}
       {...props}
     />
   </>

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -3,7 +3,7 @@ import { FocusScope } from "@radix-ui/react-focus-scope";
 import { cva } from "class-variance-authority";
 import * as React from "react";
 
-import { Button, ScrollArea } from "@sparkle/components";
+import { Button, Icon, ScrollArea } from "@sparkle/components";
 import { XMarkIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
@@ -204,19 +204,27 @@ const SheetFooter = ({
 );
 SheetFooter.displayName = "SheetFooter";
 
+interface SheetTitleProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title> {
+  icon?: React.ComponentType;
+}
+
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <SheetPrimitive.Title
-    ref={ref}
-    className={cn(
-      "s-text-lg s-font-semibold",
-      "s-text-foreground dark:s-text-foreground-night",
-      className
-    )}
-    {...props}
-  />
+  SheetTitleProps
+>(({ className, icon, ...props }, ref) => (
+  <>
+    {icon && <Icon visual={icon} size="lg" />}
+    <SheetPrimitive.Title
+      ref={ref}
+      className={cn(
+        "s-text-lg s-font-semibold",
+        "s-text-foreground dark:s-text-foreground-night",
+        className
+      )}
+      {...props}
+    />
+  </>
 ));
 SheetTitle.displayName = SheetPrimitive.Title.displayName;
 

--- a/sparkle/src/stories/Sheet.stories.tsx
+++ b/sparkle/src/stories/Sheet.stories.tsx
@@ -437,3 +437,31 @@ export function SheetWithThreeButtons() {
     </div>
   );
 }
+
+export function SheetWithIconInTitle() {
+  return (
+    <div>
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button variant="outline" label="Edit demo" />
+        </SheetTrigger>
+        <SheetContent side="left">
+          <SheetHeader hideButton>
+            <SheetTitle icon={RocketIcon}>About me</SheetTitle>
+          </SheetHeader>
+          <SheetContainer>
+            <div className="s-flex s-flex-col s-gap-6">
+              <Input label="Firstname" placeholder="John" />
+              <Input label="Lastname" placeholder="Doe" />
+            </div>
+          </SheetContainer>
+          <SheetFooter
+            sheetCloseClassName="s-flex s-gap-2"
+            leftButtonProps={{ label: "Cancel", variant: "warning" }}
+            rightButtonProps={{ label: "Save", disabled: true }}
+          />
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

- This PR adds a prop `icon` that can be passed to a `SheetTitle`.
- This PR also moves the handling of the text color (between light and dark mode) from the `SheetTitle` to the `SheetContent`, thus affecting the `SheetHeader` and the `SheetFooter` altogether.

## Tests

- Added a story in storybook.

## Risk

- N/A.

## Deploy Plan

- Publish sparkle.