### PR TITLE
enh(sparkle) - Force the color of the icon in a `SheetTitle` to `text-brand

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.429",
+  "version": "0.2.430",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.429",
+      "version": "0.2.430",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.429",
+  "version": "0.2.430",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -218,7 +218,7 @@ const SheetTitle = React.forwardRef<
   SheetTitleProps
 >(({ className, icon, ...props }, ref) => (
   <>
-    {icon && <Icon visual={icon} size="lg" />}
+    {icon && <Icon visual={icon} size="lg" className="s-text-brand" />}
     <SheetPrimitive.Title
       ref={ref}
       className={cn("s-text-lg s-font-semibold", className)}


### PR DESCRIPTION
## Description

- This PR force sets the color of the icon in a `SheetTitle` to `s-text-brand` (it's green emerald-ish).
- The goal here is to enforce consistency in the use of icons within `SheetTitle`s.

## Tests

- Storybook story.

## Risk

- N/A.

## Deploy Plan

- Publish sparkle.