### PR TITLE
Use a combination of stream and pub/sub to avoid using 2 redis per conversations

### DIFF
--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -26,9 +26,14 @@ import { assertNever, Err, Ok } from "@dust-tt/types";
 import type { RedisClientType } from "redis";
 import { commandOptions } from "redis";
 
+import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisClient } from "@app/lib/api/redis";
+import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
+import { redisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
+import { createCallbackPromise } from "@app/lib/utils";
 import { wakeLock } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
 
@@ -67,11 +72,11 @@ export async function postUserMessageWithPubSub(
     mentions,
     context,
   });
-  return handleUserMessageEvents(
+  return handleUserMessageEvents(auth, {
     conversation,
-    postMessageEvents,
-    resolveAfterFullGeneration
-  );
+    generator: postMessageEvents,
+    resolveAfterFullGeneration,
+  });
 }
 
 export async function editUserMessageWithPubSub(
@@ -102,37 +107,51 @@ export async function editUserMessageWithPubSub(
     content,
     mentions,
   });
-  return handleUserMessageEvents(conversation, editMessageEvents, false);
+  return handleUserMessageEvents(auth, {
+    conversation,
+    generator: editMessageEvents,
+    resolveAfterFullGeneration: false,
+  });
 }
 
 const END_OF_STREAM_EVENTS = ["agent_message_success", "agent_error"];
 
 function addEndOfStreamToMessageChannel(
-  redis: RedisClientType,
-  streamChannel: string
+  auth: Authenticator,
+  { redis, channel }: { redis: RedisClientType; channel: string }
 ) {
-  return redis.xAdd(streamChannel, "*", {
-    payload: JSON.stringify({ type: "end-of-stream" }),
+  return publishEvent(auth, {
+    redis,
+    origin: "message_events",
+    channel,
+    event: JSON.stringify({ type: "end-of-stream" }),
   });
 }
 
 async function handleUserMessageEvents(
-  conversation: ConversationType,
-  messageEventGenerator: AsyncGenerator<
-    | UserMessageErrorEvent
-    | UserMessageNewEvent
-    | AgentMessageNewEvent
-    | AgentErrorEvent
-    | AgentDisabledErrorEvent
-    | AgentActionSpecificEvent
-    | AgentActionSuccessEvent
-    | GenerationTokensEvent
-    | AgentGenerationCancelledEvent
-    | AgentMessageSuccessEvent
-    | ConversationTitleEvent,
-    void
-  >,
-  resolveAfterFullGeneration = false
+  auth: Authenticator,
+  {
+    conversation,
+    generator,
+    resolveAfterFullGeneration = false,
+  }: {
+    conversation: ConversationType;
+    generator: AsyncGenerator<
+      | UserMessageErrorEvent
+      | UserMessageNewEvent
+      | AgentMessageNewEvent
+      | AgentErrorEvent
+      | AgentDisabledErrorEvent
+      | AgentActionSpecificEvent
+      | AgentActionSuccessEvent
+      | GenerationTokensEvent
+      | AgentGenerationCancelledEvent
+      | AgentMessageSuccessEvent
+      | ConversationTitleEvent,
+      void
+    >;
+    resolveAfterFullGeneration?: boolean;
+  }
 ): Promise<
   Result<
     {
@@ -158,16 +177,20 @@ async function handleUserMessageEvents(
       let userMessage: UserMessageType | undefined = undefined;
       const agentMessages: AgentMessageType[] = [];
       try {
-        for await (const event of messageEventGenerator) {
+        for await (const event of generator) {
           switch (event.type) {
             case "user_message_new":
             case "agent_message_new":
             case "conversation_title": {
               const pubsubChannel = getConversationChannelId(conversation.sId);
-              await redis.xAdd(pubsubChannel, "*", {
-                payload: JSON.stringify(event),
+
+              await publishEvent(auth, {
+                redis,
+                origin: "user_message_events",
+                channel: pubsubChannel,
+                event: JSON.stringify(event),
               });
-              await redis.expire(pubsubChannel, 60 * 10);
+
               if (event.type === "user_message_new") {
                 userMessage = event.message;
                 if (!resolveAfterFullGeneration) {
@@ -202,10 +225,13 @@ async function handleUserMessageEvents(
             case "agent_generation_cancelled":
             case "agent_message_success": {
               const pubsubChannel = getMessageChannelId(event.messageId);
-              await redis.xAdd(pubsubChannel, "*", {
-                payload: JSON.stringify(event),
+
+              await publishEvent(auth, {
+                redis,
+                origin: "user_message_events",
+                channel: pubsubChannel,
+                event: JSON.stringify(event),
               });
-              await redis.expire(pubsubChannel, 60 * 10);
 
               if (
                 event.type === "agent_message_success" &&
@@ -215,7 +241,10 @@ async function handleUserMessageEvents(
               }
 
               if (END_OF_STREAM_EVENTS.includes(event.type)) {
-                await addEndOfStreamToMessageChannel(redis, pubsubChannel);
+                await addEndOfStreamToMessageChannel(auth, {
+                  redis,
+                  channel: pubsubChannel,
+                });
               }
               break;
             }
@@ -319,10 +348,14 @@ export async function retryAgentMessageWithPubSub(
                 const pubsubChannel = getConversationChannelId(
                   conversation.sId
                 );
-                await redis.xAdd(pubsubChannel, "*", {
-                  payload: JSON.stringify(event),
+
+                await publishEvent(auth, {
+                  redis,
+                  origin: "retry_agent_message",
+                  channel: pubsubChannel,
+                  event: JSON.stringify(event),
                 });
-                await redis.expire(pubsubChannel, 60 * 10);
+
                 didResolve = true;
                 resolve(new Ok(event.message));
                 break;
@@ -361,13 +394,18 @@ export async function retryAgentMessageWithPubSub(
               case "agent_generation_cancelled":
               case "agent_message_success": {
                 const pubsubChannel = getMessageChannelId(event.messageId);
-                await redis.xAdd(pubsubChannel, "*", {
-                  payload: JSON.stringify(event),
+                await publishEvent(auth, {
+                  redis,
+                  origin: "retry_agent_message",
+                  channel: pubsubChannel,
+                  event: JSON.stringify(event),
                 });
-                await redis.expire(pubsubChannel, 60 * 10);
 
                 if (END_OF_STREAM_EVENTS.includes(event.type)) {
-                  await addEndOfStreamToMessageChannel(redis, pubsubChannel);
+                  await addEndOfStreamToMessageChannel(auth, {
+                    redis,
+                    channel: pubsubChannel,
+                  });
                 }
 
                 break;
@@ -408,8 +446,16 @@ export async function retryAgentMessageWithPubSub(
 }
 
 export async function* getConversationEvents(
-  conversationId: string,
-  lastEventId: string | null
+  auth: Authenticator,
+  {
+    conversationId,
+    lastEventId,
+    signal,
+  }: {
+    conversationId: string;
+    lastEventId: string | null;
+    signal: AbortSignal;
+  }
 ): AsyncGenerator<
   {
     eventId: string;
@@ -421,30 +467,84 @@ export async function* getConversationEvents(
   },
   void
 > {
-  const redis = await getRedisClient({ origin: "conversation_events" });
   const pubsubChannel = getConversationChannelId(conversationId);
 
-  while (true) {
-    // Use an isolated connection to avoid blocking the main connection.
-    const events = await redis.xRead(
-      commandOptions({ isolated: true }),
-      { key: pubsubChannel, id: lastEventId ? lastEventId : "0-0" },
-      { COUNT: 32, BLOCK: 60 * 1000 }
+  const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const useHybridEvents = flags.includes("hybrid_events");
+
+  if (useHybridEvents) {
+    const start = Date.now();
+    const TIMEOUT = 60000; // 1 minute
+
+    const callbackPromise = createCallbackPromise<EventPayload | "close">();
+    const { history, unsubscribe } = await redisHybridManager.subscribe(
+      pubsubChannel,
+      callbackPromise.callback,
+      lastEventId,
+      "conversation_events"
     );
-    if (!events) {
-      return;
+
+    // Unsubscribe if the signal is aborted
+    signal.addEventListener("abort", unsubscribe, { once: true });
+
+    for (const event of history) {
+      yield {
+        eventId: event.id,
+        data: JSON.parse(event.message.payload),
+      };
     }
 
-    for (const event of events) {
-      for (const message of event.messages) {
-        const payloadStr = message.message["payload"];
-        const messageId = message.id;
-        const payload = JSON.parse(payloadStr);
-        lastEventId = messageId;
-        yield {
-          eventId: messageId,
-          data: payload,
+    try {
+      // Do not loop forever, we will timeout after some time to avoid blocking the load balancer
+      while (Date.now() - start < TIMEOUT) {
+        if (signal.aborted) {
+          break;
+        }
+
+        const rawEvent = await callbackPromise.promise;
+        // to reset the promise for the next event
+        callbackPromise.reset();
+
+        if (rawEvent === "close") {
+          break;
+        }
+
+        const event = {
+          eventId: rawEvent.id,
+          data: JSON.parse(rawEvent.message.payload),
         };
+
+        yield event;
+      }
+    } catch (e) {
+      logger.error({ error: e }, "Error getting conversation events");
+    } finally {
+      unsubscribe();
+    }
+  } else {
+    const redis = await getRedisClient({ origin: "conversation_events" });
+    while (true) {
+      // Use an isolated connection to avoid blocking the main connection.
+      const events = await redis.xRead(
+        commandOptions({ isolated: true }),
+        { key: pubsubChannel, id: lastEventId ? lastEventId : "0-0" },
+        { COUNT: 32, BLOCK: 60 * 1000 }
+      );
+      if (!events) {
+        return;
+      }
+
+      for (const event of events) {
+        for (const message of event.messages) {
+          const payloadStr = message.message["payload"];
+          const messageId = message.id;
+          const payload = JSON.parse(payloadStr);
+          lastEventId = messageId;
+          yield {
+            eventId: messageId,
+            data: payload,
+          };
+        }
       }
     }
   }
@@ -489,8 +589,12 @@ export async function cancelMessageGenerationEvent(
 }
 
 export async function* getMessagesEvents(
-  messageId: string,
-  lastEventId: string | null
+  auth: Authenticator,
+  {
+    messageId,
+    lastEventId,
+    signal,
+  }: { messageId: string; lastEventId: string | null; signal: AbortSignal }
 ): AsyncGenerator<
   {
     eventId: string;
@@ -504,35 +608,94 @@ export async function* getMessagesEvents(
   void
 > {
   const pubsubChannel = getMessageChannelId(messageId);
-  const redis = await getRedisClient({ origin: "message_events" });
 
-  while (true) {
-    // Use an isolated connection to avoid blocking the main connection.
-    const events = await redis.xRead(
-      commandOptions({ isolated: true }),
-      { key: pubsubChannel, id: lastEventId ? lastEventId : "0-0" },
-      { COUNT: 32, BLOCK: 60 * 1000 }
+  const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const useHybridEvents = flags.includes("hybrid_events");
+
+  if (useHybridEvents) {
+    const start = Date.now();
+    const TIMEOUT = 60000; // 1 minute
+
+    const callbackPromise = createCallbackPromise<EventPayload | "close">();
+    const { history, unsubscribe } = await redisHybridManager.subscribe(
+      pubsubChannel,
+      callbackPromise.callback,
+      lastEventId,
+      "message_events"
     );
-    if (!events) {
-      return;
-    }
 
-    for (const event of events) {
-      for (const message of event.messages) {
-        const payloadStr = message.message["payload"];
-        const messageId = message.id;
-        const payload = JSON.parse(payloadStr);
-        lastEventId = messageId;
+    // Unsubscribe if the signal is aborted
+    signal.addEventListener("abort", unsubscribe, { once: true });
 
-        // If the payload is an end-of-stream event, we stop the generator.
-        if (payload.type === "end-of-stream") {
-          return;
+    try {
+      for (const event of history) {
+        yield {
+          eventId: event.id,
+          data: JSON.parse(event.message.payload),
+        };
+      }
+
+      // Do not loop forever, we will timeout after some time to avoid blocking the load balancer
+      while (Date.now() - start < TIMEOUT) {
+        if (signal.aborted) {
+          break;
         }
 
-        yield {
-          eventId: messageId,
-          data: payload,
+        const rawEvent = await callbackPromise.promise;
+        // to reset the promise for the next event
+        callbackPromise.reset();
+
+        if (rawEvent === "close") {
+          break;
+        }
+
+        const event = {
+          eventId: rawEvent.id,
+          data: JSON.parse(rawEvent.message.payload),
         };
+
+        // If the payload is an end-of-stream event, we stop the generator.
+        if (event.data.type === "end-of-stream") {
+          break;
+        }
+
+        yield event;
+      }
+    } catch (e) {
+      logger.error({ error: e }, "Error getting messages events");
+    } finally {
+      unsubscribe();
+    }
+  } else {
+    const redis = await getRedisClient({ origin: "message_events" });
+    while (true) {
+      // Use an isolated connection to avoid blocking the main connection.
+      const events = await redis.xRead(
+        commandOptions({ isolated: true }),
+        { key: pubsubChannel, id: lastEventId ? lastEventId : "0-0" },
+        { COUNT: 32, BLOCK: 60 * 1000 }
+      );
+      if (!events) {
+        return;
+      }
+
+      for (const event of events) {
+        for (const message of event.messages) {
+          const payloadStr = message.message["payload"];
+          const messageId = message.id;
+          const payload = JSON.parse(payloadStr);
+          lastEventId = messageId;
+
+          // If the payload is an end-of-stream event, we stop the generator.
+          if (payload.type === "end-of-stream") {
+            return;
+          }
+
+          yield {
+            eventId: messageId,
+            data: payload,
+          };
+        }
       }
     }
   }
@@ -544,4 +707,29 @@ function getConversationChannelId(channelId: string) {
 
 function getMessageChannelId(messageId: string) {
   return `message-${messageId}`;
+}
+
+async function publishEvent(
+  auth: Authenticator,
+  {
+    redis,
+    origin,
+    channel,
+    event,
+  }: {
+    redis: RedisClientType;
+    origin: RedisUsageTagsType;
+    channel: string;
+    event: string;
+  }
+) {
+  const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (flags.includes("hybrid_events")) {
+    await redisHybridManager.publish(channel, event, origin);
+  } else {
+    await redis.xAdd(channel, "*", {
+      payload: event,
+    });
+    await redis.expire(channel, 60 * 10);
+  }
 }

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -1,0 +1,345 @@
+// redis-hybrid-manager.ts
+import type { RedisClientType } from "redis";
+import { createClient } from "redis";
+
+import type { RedisUsageTagsType } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
+
+type EventCallback = (event: EventPayload | "close") => void;
+
+export type EventPayload = {
+  id: string;
+  message: {
+    payload: string;
+  };
+};
+
+/**
+ * Redis Hybrid Manager that combines Streams and Pub/Sub
+ * - Uses Streams for message history
+ * - Uses Pub/Sub for real-time updates
+ * - Publishes to both for guaranteed delivery
+ */
+class RedisHybridManager {
+  private static instance: RedisHybridManager;
+  private subscriptionClient: RedisClientType | null = null;
+  private streamAndPublishClient: RedisClientType | null = null;
+  private subscribers: Map<string, Set<EventCallback>> = new Map();
+  private pubSubReconnectTimer: NodeJS.Timeout | null = null;
+  private streamReconnectTimer: NodeJS.Timeout | null = null;
+
+  private CHANNEL_PREFIX = "channel:";
+  private STREAM_PREFIX = "stream:";
+
+  private constructor() {}
+
+  public static getInstance(): RedisHybridManager {
+    if (!RedisHybridManager.instance) {
+      RedisHybridManager.instance = new RedisHybridManager();
+    }
+    return RedisHybridManager.instance;
+  }
+
+  /**
+   * Get or initialize the Redis client
+   */
+  private async getSubscriptionClient(): Promise<RedisClientType> {
+    if (!this.subscriptionClient) {
+      const { REDIS_URI } = process.env;
+      if (!REDIS_URI) {
+        throw new Error("REDIS_URI is not defined");
+      }
+
+      this.subscriptionClient = createClient({
+        url: REDIS_URI,
+        socket: {
+          reconnectStrategy: (retries) => {
+            return Math.min(retries * 100, 3000); // Exponential backoff with max 3s
+          },
+        },
+      });
+
+      // Set up error handler
+      this.subscriptionClient.on("error", (err) => {
+        logger.error({ error: err }, "Redis subscription client error");
+        this.scheduleSubscriptionReconnect();
+      });
+
+      // Set up reconnect handler
+      this.subscriptionClient.on("connect", () => {
+        logger.debug("Redis subscription client connected");
+
+        if (this.pubSubReconnectTimer) {
+          clearTimeout(this.pubSubReconnectTimer);
+          this.pubSubReconnectTimer = null;
+        }
+
+        // Resubscribe to all channels
+        if (this.subscriptionClient) {
+          void this.subscriptionClient.pSubscribe(
+            `${this.CHANNEL_PREFIX}*`,
+            this.onMessage
+          );
+        }
+      });
+
+      await this.subscriptionClient.connect();
+    }
+
+    return this.subscriptionClient;
+  }
+
+  private async getStreamAndPublishClient(): Promise<RedisClientType> {
+    if (!this.streamAndPublishClient) {
+      const { REDIS_URI } = process.env;
+      if (!REDIS_URI) {
+        throw new Error("REDIS_URI is not defined");
+      }
+
+      this.streamAndPublishClient = createClient({
+        url: REDIS_URI,
+        socket: {
+          reconnectStrategy: (retries) => {
+            return Math.min(retries * 100, 3000); // Exponential backoff with max 3s
+          },
+        },
+      });
+
+      // Set up error handler
+      this.streamAndPublishClient.on("error", (err) => {
+        logger.error({ error: err }, "Redis stream and publish client error");
+        this.scheduleStreamAndPublishReconnect();
+      });
+
+      // Set up reconnect handler
+      this.streamAndPublishClient.on("connect", () => {
+        logger.debug("Redis stream and publish client connected");
+        if (this.streamReconnectTimer) {
+          clearTimeout(this.streamReconnectTimer);
+          this.streamReconnectTimer = null;
+        }
+      });
+
+      await this.streamAndPublishClient.connect();
+    }
+
+    return this.streamAndPublishClient;
+  }
+
+  /**
+   * Schedule a reconnection attempt for the subscription client
+   */
+  private scheduleSubscriptionReconnect(): void {
+    if (this.pubSubReconnectTimer) {
+      return;
+    }
+
+    this.pubSubReconnectTimer = setTimeout(async () => {
+      this.pubSubReconnectTimer = null;
+      try {
+        await this.getSubscriptionClient();
+      } catch (error) {
+        logger.error(
+          { error },
+          "Error reconnecting subscription client to Redis"
+        );
+        this.scheduleSubscriptionReconnect();
+      }
+    }, 5000);
+  }
+
+  /**
+   * Schedule a reconnection attempt for the stream and publish client
+   */
+  private scheduleStreamAndPublishReconnect(): void {
+    if (this.streamReconnectTimer) {
+      return;
+    }
+
+    this.streamReconnectTimer = setTimeout(async () => {
+      this.streamReconnectTimer = null;
+      try {
+        await this.getStreamAndPublishClient();
+      } catch (error) {
+        logger.error(
+          { error },
+          "Error reconnecting stream and publish client to Redis"
+        );
+        this.scheduleStreamAndPublishReconnect();
+      }
+    }, 5000);
+  }
+
+  /**
+   * Publish an event to both a stream and a pub/sub channel
+   */
+  public async publish(
+    channelName: string,
+    data: string,
+    origin: RedisUsageTagsType
+  ): Promise<string> {
+    const streamAndPublishClient = await this.getStreamAndPublishClient();
+    const streamName = this.getStreamName(channelName);
+    const pubSubChannelName = this.getPubSubChannelName(channelName);
+
+    const startTime = Date.now();
+
+    try {
+      // Publish to stream for history
+      const eventId = await streamAndPublishClient.xAdd(streamName, "*", {
+        payload: data,
+      });
+
+      // Set expiration on the stream
+      await streamAndPublishClient.expire(streamName, 60 * 10); // 10 minutes
+
+      const eventPayload: EventPayload = {
+        id: eventId,
+        message: { payload: data },
+      };
+
+      // Publish to pub/sub for real-time updates
+      await streamAndPublishClient.publish(
+        pubSubChannelName,
+        // Mimick the format of the event from the stream so that the subscriber can use the same logic
+        JSON.stringify(eventPayload)
+      );
+
+      const duration = Date.now() - startTime;
+      logger.debug(
+        {
+          duration,
+          pubSubChannelName,
+          streamName,
+          origin,
+        },
+        "Redis hybrid publish completed"
+      );
+
+      return eventId;
+    } catch (error) {
+      logger.error(
+        {
+          error,
+          pubSubChannelName,
+          streamName,
+          origin,
+        },
+        "Error publishing to Redis"
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Subscribe to a channel for real-time updates
+   * and fetch history from the corresponding stream
+   */
+  public async subscribe(
+    channelName: string,
+    callback: EventCallback,
+    lastEventId: string | null = null,
+    origin: string
+  ): Promise<{ history: EventPayload[]; unsubscribe: () => void }> {
+    // Ensure the subscription client is connected
+    await this.getSubscriptionClient();
+
+    const streamClient = await this.getStreamAndPublishClient();
+    const streamName = this.getStreamName(channelName);
+    const pubSubChannelName = this.getPubSubChannelName(channelName);
+    const history: EventPayload[] = [];
+
+    try {
+      // Non-blocking read from stream to get history
+      const events = await streamClient.xRead(
+        { key: streamName, id: lastEventId ?? "0-0" },
+        { COUNT: 100 } // No BLOCK parameter for non-blocking read
+      );
+
+      if (events) {
+        history.push(
+          ...events.flatMap((event) =>
+            event.messages.map((message) => ({
+              id: message.id,
+              message: { payload: message.message["payload"] },
+            }))
+          )
+        );
+      }
+    } catch (error) {
+      logger.error(
+        {
+          error,
+          pubSubChannelName,
+          streamName,
+          lastEventId,
+        },
+        "Error fetching history from stream"
+      );
+    }
+
+    // Add to subscribers map
+    if (!this.subscribers.has(pubSubChannelName)) {
+      this.subscribers.set(pubSubChannelName, new Set());
+    }
+
+    this.subscribers.get(pubSubChannelName)!.add(callback);
+
+    return {
+      history,
+      unsubscribe: () => {
+        const subscribers = this.subscribers.get(pubSubChannelName);
+        if (subscribers) {
+          callback("close");
+          subscribers.delete(callback);
+
+          if (subscribers.size === 0) {
+            // No more subscribers for this channel
+            this.subscribers.delete(pubSubChannelName);
+            logger.debug(
+              { pubSubChannelName: pubSubChannelName, origin },
+              "Unsubscribed from Redis channel"
+            );
+          }
+        }
+      },
+    };
+  }
+
+  private onMessage = (message: string, channel: string) => {
+    const subscribers = this.subscribers.get(channel);
+    if (subscribers && subscribers.size > 0) {
+      try {
+        const event: EventPayload = JSON.parse(message);
+
+        subscribers.forEach((callback) => {
+          try {
+            callback(event);
+          } catch (error) {
+            logger.error({ error, channel }, "Error in subscriber callback");
+          }
+        });
+      } catch (error) {
+        logger.error({ error, channel }, "Error parsing message");
+      }
+    }
+  };
+
+  /**
+   * Get the pub/sub channel name for a given channel name
+   */
+  private getPubSubChannelName(channelName: string): string {
+    return `${this.CHANNEL_PREFIX}${channelName}`;
+  }
+
+  /**
+   * Map a channel name to a stream name
+   * By default, they're the same, but you can override this
+   */
+  private getStreamName(channelName: string): string {
+    return `${this.STREAM_PREFIX}${channelName}`;
+  }
+}
+
+// Export a singleton instance
+export const redisHybridManager = RedisHybridManager.getInstance();

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -6,7 +6,7 @@ import { statsDClient } from "@app/logger/withlogging";
 
 let client: RedisClientType;
 
-type RedisUsageTagsType =
+export type RedisUsageTagsType =
   | "agent_recent_authors"
   | "agent_usage"
   | "assistant_generation"

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -304,3 +304,27 @@ export const isMobile = (navigator: Navigator) =>
   /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i.test(
     (navigator.userAgent || navigator.vendor).substr(0, 4)
   );
+
+export function createCallbackPromise<T>(): {
+  promise: Promise<T>;
+  callback: (value: T) => void;
+  reset: () => void;
+} {
+  let resolveCallback: (value: T) => void;
+
+  let promise = new Promise<T>((resolve) => {
+    resolveCallback = resolve;
+  });
+
+  return {
+    get promise() {
+      return promise;
+    },
+    callback: (value: T) => resolveCallback(value),
+    reset: () => {
+      promise = new Promise<T>((resolve) => {
+        resolveCallback = resolve;
+      });
+    },
+  };
+}

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -48,8 +48,6 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const eventStream = getConversationEvents(conversation.sId, lastEventId);
-
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -57,10 +55,30 @@ async function handler(
       });
       res.flushHeaders();
 
+      // Create an AbortController to handle client disconnection
+      const controller = new AbortController();
+      const { signal } = controller;
+
+      // Handle client disconnection
+      req.on("close", () => {
+        controller.abort();
+      });
+
+      const eventStream = getConversationEvents(auth, {
+        conversationId: conversation.sId,
+        lastEventId,
+        signal,
+      });
+
       for await (const event of eventStream) {
         res.write(`data: ${JSON.stringify(event)}\n\n`);
         // @ts-expect-error - We need it for streaming but it does not exists in the types.
         res.flush();
+
+        // If the client disconnected, stop the event stream
+        if (signal.aborted) {
+          break;
+        }
       }
       res.write("data: done\n\n");
       // @ts-expect-error - We need it for streaming but it does not exists in the types.

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -85,8 +85,6 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const eventStream = getMessagesEvents(messageId, lastEventId);
-
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -94,10 +92,30 @@ async function handler(
       });
       res.flushHeaders();
 
+      // Create an AbortController to handle client disconnection
+      const controller = new AbortController();
+      const { signal } = controller;
+
+      // Handle client disconnection
+      req.on("close", () => {
+        controller.abort();
+      });
+
+      const eventStream = getMessagesEvents(auth, {
+        messageId,
+        lastEventId,
+        signal,
+      });
+
       for await (const event of eventStream) {
         res.write(`data: ${JSON.stringify(event)}\n\n`);
         // @ts-expect-error - We need it for streaming but it does not exists in the types.
         res.flush();
+
+        // If the client disconnected, stop the event stream
+        if (signal.aborted) {
+          break;
+        }
       }
       res.write("data: done\n\n");
       // @ts-expect-error - We need it for streaming but it does not exists in the types.

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -794,6 +794,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
   | "search_knowledge_builder"
   | "attach_from_datasources"
+  | "hybrid_events"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -21,6 +21,7 @@ export const WHITELISTABLE_FEATURES = [
   "advanced_notion_management",
   "search_knowledge_builder",
   "attach_from_datasources",
+  "hybrid_events",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

Conversations and Messages Server Side Events are currently implemented with a blocking xRead() on Redis stream which use an exclusive connexion to redis. Meaning that we have at least 1 redis connection per listener to conversation and an extra 1 when listening to a message event (eg: when the Agent is answering).

We have thousands of redis connexions simultaneously during the day which isn't great for scaling.

### This PR refactor the implementation to use a dual system:
- a redis stream for storing events (up to 10 minutes same as today)
- a redis pub/sub for realtime events

The intent is to have one redis connexion per node (actually, 2, because you cannot use the same connexion for sub and for pub / writing to stream), shared across all current listeners to events.

- When a client start listening to events, we call `subscribe()` in pubsub.ts with a callback for upcoming events concerning it's channel.
- `subscribe()` immediately returns historical events (after lastEventId if provided, like today) and add the callback as a channel listener for upcoming events
- In pubsub.ts methods that generate events for SSE, the callback is wrapped in a promise so we can use the await pattern to wait for events and yield them back to the request handler.

The ability to get historical events has been preserved because it allows us to handle gracefully disconnexion (reload, deploy and everything that can happen on the internet).

**The change is totally transparent for the clients.**

It also improves how we handle requests being closed from client : I believe the current implementation will block no matter what for up to 1 minute on xRead().

**Everything is behind a feature flag** so we can use it for a bit before switching everyone, the current implementation has been left untouched.

## Tests

I did several tests, reloading the page, opening multiple tabs, closing one, sending messages in differents conversations in parallel etc.. I'm fairly confident that it works fine.

## Risk

Low as it's behind a feature flag, but be careful as it touches something quite low level.

## Deploy Plan

Deploy `front`