### PR TITLE
[connectors] Catch if message can't be posted

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -128,12 +128,23 @@ export async function botAnswerMessage(
       "Unexpected exception answering to Slack Chat Bot message"
     );
     const slackClient = await getSlackClient(connector.id);
-    await slackClient.chat.postMessage({
-      channel: slackChannel,
-      text: "An unexpected error occurred. Our team has been notified",
-      thread_ts: slackMessageTs,
-    });
-
+    try {
+      await slackClient.chat.postMessage({
+        channel: slackChannel,
+        text: "An unexpected error occurred. Our team has been notified",
+        thread_ts: slackMessageTs,
+      });
+    } catch (e) {
+      logger.error(
+        {
+          slackChannel,
+          slackMessageTs,
+          slackTeamId,
+          error: e,
+        },
+        "Failed to post error message to Slack"
+      );
+    }
     return new Err(new Error("An unexpected error occurred"));
   }
 }


### PR DESCRIPTION
## Description

It can happen that we can't post the error message to slack ( if we have a "cannot_reply_to_message" on the answer message, we won't also be able to post an error message)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy connectors
