### PR TITLE
[front/db] - fix(migration): update dsv conversationId column type

### DIFF
--- a/front/migrations/db/migration_174.sql
+++ b/front/migrations/db/migration_174.sql
@@ -1,2 +1,8 @@
-ALTER TABLE "public"."data_source_views" ADD COLUMN "conversationId" INTEGER REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-CREATE INDEX CONCURRENTLY "data_source_views_workspace_id_conversation_id" ON "data_source_views" ("workspaceId", "conversationId");
+DROP INDEX IF EXISTS "data_source_views_workspace_id_conversation_id";
+ALTER TABLE "public"."data_source_views" DROP COLUMN IF EXISTS "conversationId";
+
+ALTER TABLE "public"."data_source_views"
+  ADD COLUMN "conversationId" BIGINT REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX CONCURRENTLY "data_source_views_workspace_id_conversation_id" 
+  ON "public"."data_source_views" ("workspaceId", "conversationId");


### PR DESCRIPTION
## Description

This PR fixes the front migration 174 to use a bigint instead of integer

## Risk

Low

## Deploy Plan

Apply migration in EU & US