### PR TITLE
[core] Adding composite indices on data_source_nodes

### DIFF
--- a/core/src/stores/migrations/20250228_add_nodes_indices.sql
+++ b/core/src/stores/migrations/20250228_add_nodes_indices.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY idx_data_sources_nodes_data_source_document ON data_sources_nodes(data_source, document);
+CREATE INDEX CONCURRENTLY idx_data_sources_nodes_data_source_table ON data_sources_nodes(data_source, "table");
+CREATE INDEX CONCURRENTLY idx_data_sources_nodes_data_source_folder ON data_sources_nodes(data_source, folder);

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -626,7 +626,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 31] = [
+pub const SQL_INDEXES: [&'static str; 34] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -691,6 +691,12 @@ pub const SQL_INDEXES: [&'static str; 31] = [
         idx_data_sources_nodes_table ON data_sources_nodes(\"table\");",
     "CREATE INDEX IF NOT EXISTS
         idx_data_sources_nodes_folder ON data_sources_nodes(folder);",
+    "CREATE INDEX IF NOT EXISTS
+        idx_data_sources_nodes_data_source_document ON data_sources_nodes(data_source, document);",
+    "CREATE INDEX IF NOT EXISTS
+        idx_data_sources_nodes_data_source_table ON data_sources_nodes(data_source, \"table\");",
+    "CREATE INDEX IF NOT EXISTS
+        idx_data_sources_nodes_data_source_folder ON data_sources_nodes(data_source, folder);",
     "CREATE INDEX IF NOT EXISTS
         idx_data_sources_nodes_parents_second ON data_sources_nodes (data_source, (parents[2]));",
     "CREATE INDEX IF NOT EXISTS


### PR DESCRIPTION
## Description

Add composite indices on data_sources_nodes , adding data_source 
This should help queries on data_source_nodes with join on doc/tables/folder , as they are always filtered by data_source

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk



## Deploy Plan

deploy indices