### PR TITLE
Use 30m start-to-close, add logger info

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -22,13 +22,14 @@ const {
   reportInitialSyncProgressActivity,
   getChannelsToGarbageCollect,
   attemptChannelJoinActivity,
-  deleteChannel,
   deleteChannelsFromConnectorDb,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
 
-const { syncThread, syncNonThreaded } = proxyActivities<typeof activities>({
+const { deleteChannel, syncThread, syncNonThreaded } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "30 minutes",
 });
 


### PR DESCRIPTION
## Description

deleteChannel requires a little bit more time than 10 min - activity was retried a few ties because of timeout but finally managed to pass.
Adding info in log to have a better view of deletion progress

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors