### PR TITLE
feat(core) - Add `core` endpoint to get stats on data source

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3561,7 +3561,7 @@ async fn data_sources_stats(
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_server_error",
-                "Failed to search data sources",
+                "Failed to get stats relative to data source",
                 Some(e),
             );
         }

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1505,7 +1505,7 @@ struct DatasourceSearchPayload {
     target_document_tokens: Option<usize>,
 }
 
-async fn data_sources_search(
+async fn data_sources_documents_search(
     Path((project_id, data_source_id)): Path<(i64, String)>,
     State(state): State<Arc<APIState>>,
     Json(payload): Json<DatasourceSearchPayload>,
@@ -4011,7 +4011,7 @@ fn main() {
         // Provided by the data_source block.
         .route(
             "/projects/:project_id/data_sources/:data_source_id/search",
-            post(data_sources_search),
+            post(data_sources_documents_search),
         )
         .route(
             "/projects/:project_id/data_sources/:data_source_id/documents",

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3560,7 +3560,7 @@ async fn data_sources_search(
     State(state): State<Arc<APIState>>,
     Json(payload): Json<DataSourcesSearchPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    let data_sources = match state
+    let data_source = match state
         .search_store
         .search_data_source(payload.filter, payload.options)
         .await
@@ -3581,7 +3581,7 @@ async fn data_sources_search(
         Json(APIResponse {
             error: None,
             response: Some(json!({
-                "data_sources": data_sources,
+                "data_source": data_source,
             })),
         }),
     )

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3552,7 +3552,6 @@ async fn nodes_search(
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 struct DataSourcesSearchPayload {
-    query: Option<String>,
     filter: DataSourcesSearchFilter,
     options: Option<DataSourcesSearchOptions>,
 }
@@ -3561,9 +3560,9 @@ async fn data_sources_search(
     State(state): State<Arc<APIState>>,
     Json(payload): Json<DataSourcesSearchPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    let (data_sources, hit_count, hit_count_is_accurate, warning_code) = match state
+    let data_sources = match state
         .search_store
-        .search_data_source(payload.query, payload.filter, payload.options)
+        .search_data_source(payload.filter, payload.options)
         .await
     {
         Ok(result) => result,
@@ -3583,9 +3582,6 @@ async fn data_sources_search(
             error: None,
             response: Some(json!({
                 "data_sources": data_sources,
-                "hit_count": hit_count,
-                "hit_count_is_accurate": hit_count_is_accurate,
-                "warning_code": warning_code,
             })),
         }),
     )

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -2480,6 +2480,7 @@ pub struct DataSourceESDocument {
     pub data_source_internal_id: String,
     pub timestamp: u64,
     pub name: String,
+    pub text_size: Option<i64>,
 }
 
 impl From<&DataSource> for DataSourceESDocument {
@@ -2489,6 +2490,7 @@ impl From<&DataSource> for DataSourceESDocument {
             data_source_internal_id: ds.internal_id().to_string(),
             timestamp: ds.created(),
             name: ds.name().to_string(),
+            text_size: None,
         }
     }
 }

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -2481,6 +2481,7 @@ pub struct DataSourceESDocument {
     pub timestamp: u64,
     pub name: String,
     pub text_size: Option<i64>,
+    pub document_count: Option<i64>,
 }
 
 impl From<&DataSource> for DataSourceESDocument {
@@ -2491,6 +2492,7 @@ impl From<&DataSource> for DataSourceESDocument {
             timestamp: ds.created(),
             name: ds.name().to_string(),
             text_size: None,
+            document_count: None,
         }
     }
 }

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -2480,8 +2480,6 @@ pub struct DataSourceESDocument {
     pub data_source_internal_id: String,
     pub timestamp: u64,
     pub name: String,
-    pub text_size: Option<i64>,
-    pub document_count: Option<i64>,
 }
 
 impl From<&DataSource> for DataSourceESDocument {
@@ -2491,8 +2489,6 @@ impl From<&DataSource> for DataSourceESDocument {
             data_source_internal_id: ds.internal_id().to_string(),
             timestamp: ds.created(),
             name: ds.name().to_string(),
-            text_size: None,
-            document_count: None,
         }
     }
 }
@@ -2501,6 +2497,29 @@ impl From<serde_json::Value> for DataSourceESDocument {
     fn from(value: serde_json::Value) -> Self {
         serde_json::from_value(value)
             .expect("Failed to deserialize DataSourceESDocument from JSON value")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataSourceESDocumentWithStats {
+    pub data_source_id: String,
+    pub data_source_internal_id: String,
+    pub timestamp: u64,
+    pub name: String,
+    pub text_size: i64,
+    pub document_count: i64,
+}
+
+impl From<(DataSourceESDocument, i64, i64)> for DataSourceESDocumentWithStats {
+    fn from((document, text_size, document_count): (DataSourceESDocument, i64, i64)) -> Self {
+        Self {
+            data_source_id: document.data_source_id,
+            data_source_internal_id: document.data_source_internal_id,
+            timestamp: document.timestamp,
+            name: document.name,
+            text_size,
+            document_count,
+        }
     }
 }
 

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -952,17 +952,19 @@ impl ElasticsearchSearchStore {
                     .as_array()
                     .unwrap();
 
-                match buckets.first() {
-                    Some(bucket) => {
+                buckets
+                    .first()
+                    .map(|bucket| {
                         Ok(DataSourceESDocumentWithStats::from((
                             data_source,
                             // We unwrap here because if we got a bucket, then it necessarily contains these fields.
                             bucket["total_size"]["value"].as_f64().unwrap().round() as i64,
                             bucket["doc_count"].as_i64().unwrap(),
                         )))
-                    }
-                    None => Err(anyhow::anyhow!("Data source stats computation failed.")),
-                }
+                    })
+                    .unwrap_or(Err(anyhow::anyhow!(
+                        "Data source stats computation failed."
+                    )))
             }
             _ => Err(anyhow::anyhow!(
                 "Invalid search item type, expected a DataSource."

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -1082,18 +1082,24 @@ impl ElasticsearchSearchStore {
                 .as_array()
                 .unwrap();
 
-            let size_by_ds: HashMap<String, i64> = buckets
+            let metadata_map: HashMap<String, (i64, i64)> = buckets
                 .iter()
                 .map(|bucket| {
                     (
                         bucket["key"].as_str().unwrap().to_string(),
-                        bucket["total_size"]["value"].as_i64().unwrap(),
+                        (
+                            bucket["total_size"]["value"].as_i64().unwrap(),
+                            bucket["doc_count"].as_i64().unwrap(),
+                        ),
                     )
                 })
                 .collect();
 
             result.iter_mut().for_each(|ds| {
-                ds.text_size = size_by_ds.get(&ds.data_source_id).copied();
+                let (text_size, document_count) =
+                    metadata_map.get(&ds.data_source_id).unwrap_or(&(0, 0));
+                ds.text_size = Some(text_size.clone());
+                ds.document_count = Some(document_count.clone());
             });
         }
 

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -923,39 +923,6 @@ impl ElasticsearchSearchStore {
         Ok(base_sort)
     }
 
-    // Builds the Sort for searching data sources, defaulting to sorting alphabetically by name
-    // and using the data_source_id as a tie-breaker.
-    fn build_search_data_sources_sort(&self, sort: Option<Vec<SortSpec>>) -> Result<Vec<Sort>> {
-        let mut base_sort = match sort {
-            Some(sort) => {
-                if sort.iter().any(|s| s.field == "data_source_id") {
-                    return Err(anyhow::anyhow!(
-                        "Explicit sort on data_source_id is not allowed, it is used as a tie-breaker."
-                    ));
-                }
-                sort.into_iter()
-                    .map(|s| {
-                        Sort::FieldSort(FieldSort::new(s.field).order(match s.direction {
-                            SortDirection::Asc => SortOrder::Asc,
-                            SortDirection::Desc => SortOrder::Desc,
-                        }))
-                    })
-                    .collect()
-            }
-            // Default to sorting alphabetically by name.
-            None => vec![Sort::FieldSort(
-                FieldSort::new("name.keyword").order(SortOrder::Asc),
-            )],
-        };
-
-        // Add the data source ID as a tie-breaker.
-        base_sort.push(Sort::FieldSort(
-            FieldSort::new("data_source_id").order(SortOrder::Asc),
-        ));
-
-        Ok(base_sort)
-    }
-
     async fn process_search_data_sources_results(
         &self,
         item: SearchItem,

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -84,6 +84,17 @@ pub struct NodesSearchFilter {
     include_data_sources: Option<bool>,
 }
 
+#[derive(serde::Deserialize)]
+pub struct DataSourcesSearchOptions {
+    sort: Option<Vec<SortSpec>>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct DataSourcesSearchFilter {
+    data_source_id: Option<String>,
+    include_text_size: Option<bool>,
+}
+
 #[derive(Debug, Clone)]
 pub enum NodeItem {
     Document(Document),
@@ -118,6 +129,13 @@ pub trait SearchStore {
     async fn delete_node(&self, node: NodeItem) -> Result<()>;
 
     // Data sources.
+    async fn search_data_source(
+        &self,
+        query: Option<String>,
+        filter: DataSourcesSearchFilter,
+        options: Option<DataSourcesSearchOptions>,
+        store: Box<dyn Store + Sync + Send>,
+    ) -> Result<()>;
     async fn index_data_source(&self, data_source: &DataSource) -> Result<()>;
     async fn delete_data_source(&self, data_source: &DataSource) -> Result<()>;
 
@@ -382,6 +400,16 @@ impl SearchStore for ElasticsearchSearchStore {
     }
 
     // Data sources.
+
+    async fn search_data_source(
+        &self,
+        query: Option<String>,
+        filter: DataSourcesSearchFilter,
+        options: Option<DataSourcesSearchOptions>,
+        store: Box<dyn Store + Sync + Send>,
+    ) -> Result<()> {
+        todo!()
+    }
 
     async fn index_data_source(&self, data_source: &DataSource) -> Result<()> {
         self.index_document(data_source).await

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -844,7 +844,10 @@ impl ElasticsearchSearchStore {
         for (pos, item) in items.into_iter().enumerate() {
             match item {
                 SearchItem::DataSource(data_source) => {
-                    result.push((pos, self.create_data_source_node(data_source)));
+                    result.push((
+                        pos,
+                        CoreContentNode::from_es_data_source_document(data_source),
+                    ));
                 }
                 SearchItem::Node(node) => {
                     position_map.insert(node.node_id.clone(), pos);
@@ -869,10 +872,6 @@ impl ElasticsearchSearchStore {
         // Restore original order.
         result.sort_by_key(|(pos, _)| *pos);
         Ok(result.into_iter().map(|(_, node)| node).collect())
-    }
-
-    fn create_data_source_node(&self, item: DataSourceESDocument) -> CoreContentNode {
-        CoreContentNode::from_es_data_source_document(item)
     }
 
     /// Compute core content nodes from a list of nodes.

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -439,7 +439,6 @@ impl SearchStore for ElasticsearchSearchStore {
             Some(_) => vec![],
         };
 
-        // Build and run search
         let search = Search::new()
             .query(bool_query)
             .track_total_hits(MAX_TOTAL_HITS_TRACKED)

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -278,10 +278,10 @@ impl SearchStore for ElasticsearchSearchStore {
         }
 
         // Build search query with potential truncation.
-        let (bool_query, warning_code) = self.build_search_query(query.clone(), filter)?;
+        let (bool_query, warning_code) = self.build_search_node_query(query.clone(), filter)?;
 
         let sort = match query {
-            None => self.build_sort(options.sort)?,
+            None => self.build_search_nodes_sort(options.sort)?,
             Some(_) => vec![],
         };
 
@@ -364,7 +364,7 @@ impl SearchStore for ElasticsearchSearchStore {
         };
 
         let compute_node_start = utils::now();
-        let result = self.process_search_results(items, store).await?;
+        let result = self.process_search_nodes_results(items, store).await?;
         info!(
             duration = utils::now() - compute_node_start,
             data_source_id = data_source_id,
@@ -584,7 +584,7 @@ impl SearchStore for ElasticsearchSearchStore {
 }
 
 impl ElasticsearchSearchStore {
-    fn build_search_query(
+    fn build_search_node_query(
         &self,
         query: Option<String>,
         filter: NodesSearchFilter,
@@ -739,7 +739,7 @@ impl ElasticsearchSearchStore {
 
     // Enrich search results with children counts and parent titles.
 
-    async fn process_search_results(
+    async fn process_search_nodes_results(
         &self,
         items: Vec<SearchItem>,
         store: Box<dyn Store + Sync + Send>,
@@ -868,7 +868,7 @@ impl ElasticsearchSearchStore {
     }
 
     // Always add node_id as a tie-breaker
-    fn build_sort(&self, sort: Option<Vec<SortSpec>>) -> Result<Vec<Sort>> {
+    fn build_search_nodes_sort(&self, sort: Option<Vec<SortSpec>>) -> Result<Vec<Sort>> {
         let mut base_sort = match sort {
             Some(sort) => {
                 if sort.iter().any(|s| s.field == "node_id") {

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -422,7 +422,7 @@ impl SearchStore for ElasticsearchSearchStore {
             Err(anyhow::anyhow!("Found more than one matching data source."))
         } else {
             if let Some(item) = items.first() {
-                Some(self.process_search_data_sources_results(item.clone()).await).transpose()
+                Some(self.compute_data_sources_stats(item.clone()).await).transpose()
             } else {
                 Ok(None)
             }
@@ -923,10 +923,7 @@ impl ElasticsearchSearchStore {
         Ok(base_sort)
     }
 
-    async fn process_search_data_sources_results(
-        &self,
-        item: SearchItem,
-    ) -> Result<DataSourceESDocument> {
+    async fn compute_data_sources_stats(&self, item: SearchItem) -> Result<DataSourceESDocument> {
         match item {
             SearchItem::DataSource(mut data_source) => {
                 let search = Search::new()

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -1014,7 +1014,9 @@ impl ElasticsearchSearchStore {
                         .unwrap();
 
                     if let Some(bucket) = buckets.first() {
-                        data_source.text_size = bucket["total_size"]["value"].as_i64();
+                        data_source.text_size = bucket["total_size"]["value"]
+                            .as_f64()
+                            .map(|f| f.round() as i64);
                         data_source.document_count = bucket["doc_count"].as_i64();
                     }
                 }

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -440,16 +440,18 @@ impl SearchStore for ElasticsearchSearchStore {
             // This should never ever happen since we are searching by data_source_id.
             Err(anyhow::anyhow!("Found more than one matching data source."))
         } else {
-            items
-                .first()
-                .map(async |item| {
+            if let Some(item) = items.first() {
+                Some(
                     self.process_search_data_sources_results(
                         item.clone(),
                         options.unwrap_or_default().include_text_size,
                     )
-                    .await
-                })
+                    .await,
+                )
                 .transpose()
+            } else {
+                Ok(None)
+            }
         }
     }
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -478,7 +478,7 @@ export async function handleDataSourceSearch({
   const credentials = dustManagedCredentials();
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const data = await coreAPI.searchInDataSource(
+  const data = await coreAPI.searchDataSource(
     dataSource.dustAPIProjectId,
     dataSource.dustAPIDataSourceId,
     {

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -478,7 +478,7 @@ export async function handleDataSourceSearch({
   const credentials = dustManagedCredentials();
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const data = await coreAPI.searchDataSource(
+  const data = await coreAPI.searchInDataSource(
     dataSource.dustAPIProjectId,
     dataSource.dustAPIDataSourceId,
     {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -20,13 +20,7 @@ import { dustManagedCredentials } from "../../front/lib/api/credentials";
 import { EmbeddingProviderIdType } from "../../front/lib/assistant";
 import { Project } from "../../front/project";
 import { CredentialsType } from "../../front/provider";
-import {
-  BlockType,
-  RunConfig,
-  RunRunType,
-  RunStatus,
-  TraceType,
-} from "../../front/run";
+import { BlockType, RunConfig, RunRunType, RunStatus, TraceType } from "../../front/run";
 import { LightWorkspaceType } from "../../front/user";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
@@ -856,7 +850,7 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
-  async searchDataSource(
+  async searchInDataSource(
     projectId: string,
     dataSourceId: string,
     payload: {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -271,15 +271,7 @@ export type CoreAPINodesSearchFilter = t.TypeOf<
   typeof CoreAPINodesSearchFilterSchema
 >;
 
-export type CoreAPIDataSourcesSearchOptions = {
-  include_text_size: boolean;
-};
-
-export type CoreAPIDataSourcesSearchFilter = {
-  data_source_id: string;
-};
-
-export interface CoreAPISearchDataSourcesResponse {
+export interface CoreAPIDataSourceStatsResponse {
   data_source_id: string;
   data_source_internal_id: string;
   timestamp: number;
@@ -867,7 +859,7 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
-  async searchInDataSource(
+  async searchDataSource(
     projectId: string,
     dataSourceId: string,
     payload: {
@@ -1863,24 +1855,18 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
-  async searchDataSources({
-    filter,
-    options,
+  async getDataSourceStats({
+    dataSourceId,
   }: {
-    filter: CoreAPIDataSourcesSearchFilter;
-    options?: CoreAPIDataSourcesSearchOptions;
-  }): Promise<CoreAPIResponse<CoreAPISearchDataSourcesResponse>> {
+    dataSourceId: string;
+  }): Promise<CoreAPIResponse<CoreAPIDataSourceStatsResponse>> {
     const response = await this._fetchWithError(
-      `${this._url}/data_sources/search`,
+      `${this._url}/data_sources/${encodeURIComponent(dataSourceId)}/stats`,
       {
-        method: "POST",
+        method: "GET",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          filter,
-          options,
-        }),
       }
     );
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -282,8 +282,8 @@ export interface CoreAPIDataSourceStatsResponse {
   data_source_internal_id: string;
   timestamp: number;
   name: string;
-  text_size: number | null;
-  document_count: number | null;
+  text_size: number;
+  document_count: number;
 }
 
 export interface CoreAPIUpsertDataSourceDocumentPayload {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -20,13 +20,7 @@ import { dustManagedCredentials } from "../../front/lib/api/credentials";
 import { EmbeddingProviderIdType } from "../../front/lib/assistant";
 import { Project } from "../../front/project";
 import { CredentialsType } from "../../front/provider";
-import {
-  BlockType,
-  RunConfig,
-  RunRunType,
-  RunStatus,
-  TraceType,
-} from "../../front/run";
+import { BlockType, RunConfig, RunRunType, RunStatus, TraceType } from "../../front/run";
 import { LightWorkspaceType } from "../../front/user";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
@@ -1862,12 +1856,16 @@ export class CoreAPI {
   }
 
   async getDataSourceStats({
+    projectId,
     dataSourceId,
   }: {
+    projectId: string;
     dataSourceId: string;
   }): Promise<CoreAPIResponse<CoreAPIDataSourceStatsResponse>> {
     const response = await this._fetchWithError(
-      `${this._url}/data_sources/${encodeURIComponent(dataSourceId)}/stats`,
+      `${this._url}/projects/${encodeURIComponent(
+        projectId
+      )}/data_sources/${encodeURIComponent(dataSourceId)}/stats`,
       {
         method: "GET",
         headers: {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -271,6 +271,23 @@ export type CoreAPINodesSearchFilter = t.TypeOf<
   typeof CoreAPINodesSearchFilterSchema
 >;
 
+export type CoreAPIDataSourcesSearchOptions = {
+  include_text_size: boolean;
+};
+
+export type CoreAPIDataSourcesSearchFilter = {
+  data_source_id: string;
+};
+
+export interface CoreAPISearchDataSourcesResponse {
+  data_source_id: string;
+  data_source_internal_id: string;
+  timestamp: number;
+  name: string;
+  text_size: number | null;
+  document_count: number | null;
+}
+
 export interface CoreAPIUpsertDataSourceDocumentPayload {
   projectId: string;
   dataSourceId: string;
@@ -1842,6 +1859,30 @@ export class CoreAPI {
         options,
       }),
     });
+
+    return this._resultFromResponse(response);
+  }
+
+  async searchDataSources({
+    filter,
+    options,
+  }: {
+    filter: CoreAPIDataSourcesSearchFilter;
+    options?: CoreAPIDataSourcesSearchOptions;
+  }): Promise<CoreAPIResponse<CoreAPISearchDataSourcesResponse>> {
+    const response = await this._fetchWithError(
+      `${this._url}/data_sources/search`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          filter,
+          options,
+        }),
+      }
+    );
 
     return this._resultFromResponse(response);
   }

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -20,7 +20,13 @@ import { dustManagedCredentials } from "../../front/lib/api/credentials";
 import { EmbeddingProviderIdType } from "../../front/lib/assistant";
 import { Project } from "../../front/project";
 import { CredentialsType } from "../../front/provider";
-import { BlockType, RunConfig, RunRunType, RunStatus, TraceType } from "../../front/run";
+import {
+  BlockType,
+  RunConfig,
+  RunRunType,
+  RunStatus,
+  TraceType,
+} from "../../front/run";
 import { LightWorkspaceType } from "../../front/user";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2188.
- This PR adds an endpoint in `core` `/projects/:project_id/data_sources/:data_source_id/stats` that allows retrieving statistics for a data source.
- The stats are computed using the elasticsearch index, they include the total text size for the data source + the document count (provided for free by elasticsearch).

## Tests

- Tested locally, no automated test.

## Risk

- Low.

## Deploy Plan

- Deploy core.