### PR TITLE
feat(salesforce): make condition field optional in where clause

### DIFF
--- a/core/src/databases/remote_databases/salesforce/sandbox/convert.rs
+++ b/core/src/databases/remote_databases/salesforce/sandbox/convert.rs
@@ -789,6 +789,26 @@ mod tests {
     }
 
     #[test]
+    fn test_json_to_soql_where_clause_without_condition() {
+        let json = r#"{
+            "object": "Contact",
+            "fields": ["Id", "Name", "Title", "Phone", "Email", "Department", "MailingCity", "MailingState"],
+            "where": {
+                "filters": [
+                    {"field": "AccountId", "operator": "=", "value": "001Qy00000ccRXcIAM"}
+                ]
+            }
+        }"#;
+
+        let query = serde_json::from_str::<StructuredQuery>(json).unwrap();
+        let soql = convert_to_soql(&query).unwrap();
+        assert_eq!(
+            soql,
+            "SELECT Id, Name, Title, Phone, Email, Department, MailingCity, MailingState FROM Contact WHERE AccountId = '001Qy00000ccRXcIAM'"
+        );
+    }
+
+    #[test]
     fn test_json_to_soql_special_character_escaping() {
         let json = r#"{
             "object": "Contact", 

--- a/core/src/databases/remote_databases/salesforce/sandbox/structured_query.rs
+++ b/core/src/databases/remote_databases/salesforce/sandbox/structured_query.rs
@@ -50,10 +50,16 @@ pub struct StructuredQuery {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WhereClause {
     /// The logical condition for combining filters ("AND" or "OR").
+    #[serde(default = "default_logical_operator")]
     pub condition: LogicalOperator,
 
     /// The list of filters to apply.
     pub filters: Vec<Filter>,
+}
+
+/// Default function for logical operator.
+fn default_logical_operator() -> LogicalOperator {
+    LogicalOperator::And
 }
 
 /// Represents a logical operator for combining filters.
@@ -220,6 +226,7 @@ pub enum GroupType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HavingClause {
     /// The logical condition for combining filters ("AND" or "OR").
+    #[serde(default = "default_logical_operator")]
     pub condition: LogicalOperator,
 
     /// The list of aggregate filters to apply.


### PR DESCRIPTION
## Description

- Add default \AND\ condition when not specified in the where clause
- Also apply the same improvement to the having clause

This should be OK, because it isn't ambiguous. And it's fair to assume the condition is "AND" if there are several filters and the cond ins't specified.
```
{
  "object": "Contact",
  "fields": ["Id", "Name", "Title", "Phone", "Email", "Department", "MailingCity", "MailingState"],
  "where": {
    "filters": [
      {"field": "AccountId", "operator": "=", "value": "001Qy00000ccRXcIAM"}
    ]
  }
}
```

## Tests

Add test to validate the new format

## Risk

N/A

## Deploy Plan

deploy core