### PR TITLE
Let admin update space settings

### DIFF
--- a/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
@@ -2,8 +2,9 @@ import { Chip, InformationCircleIcon, Page } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
-import { useMemo } from "react";
+import React from "react";
 
+import { CreateOrEditSpaceModal } from "@app/components/spaces/CreateOrEditSpaceModal";
 import { SpaceCategoriesList } from "@app/components/spaces/SpaceCategoriesList";
 import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
@@ -66,13 +67,17 @@ export default function Space({
   userId,
   space,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [showSpaceEditionModal, setShowSpaceEditionModal] =
+    React.useState(false);
+
   const { spaceInfo } = useSpaceInfo({
     workspaceId: owner.sId,
     spaceId: space.sId,
   });
 
   const router = useRouter();
-  const isMember = useMemo(
+
+  const isMember = React.useMemo(
     () => spaceInfo?.members?.some((m) => m.sId === userId),
     [userId, spaceInfo?.members]
   );
@@ -99,6 +104,14 @@ export default function Space({
             `/w/${owner.sId}/spaces/${space.sId}/categories/${category}`
           );
         }}
+        isAdmin={isAdmin}
+        onButtonClick={() => setShowSpaceEditionModal(true)}
+      />
+      <CreateOrEditSpaceModal
+        owner={owner}
+        isOpen={showSpaceEditionModal}
+        onClose={() => setShowSpaceEditionModal(false)}
+        space={space}
         isAdmin={isAdmin}
       />
     </Page.Vertical>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While working on https://github.com/dust-tt/dust/pull/11085, we removed by mistake the CTA that let admin update space settings (like name and members). This PR brings it back. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
