### PR TITLE
[sparkle] - feat(DataTable): implement virtual scrolling for DataTable component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.432",
+  "version": "0.2.433",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.432",
+      "version": "0.2.433",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.432",
+  "version": "0.2.433",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -37,7 +37,13 @@ import {
   Tooltip,
 } from "@sparkle/components";
 import { useCopyToClipboard } from "@sparkle/hooks";
-import { ArrowDownIcon, ArrowUpIcon, ClipboardCheckIcon, ClipboardIcon, MoreIcon } from "@sparkle/icons";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  MoreIcon,
+} from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
 import { breakpoints, useWindowSize } from "./WindowUtility";
@@ -270,6 +276,8 @@ export interface ScrollableDataTableProps<TData extends TBaseData>
   isLoading?: boolean;
 }
 
+const COLUMN_HEIGHT = 50;
+
 export function ScrollableDataTable<TData extends TBaseData>({
   data,
   totalRowCount,
@@ -306,10 +314,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
 
   const columnsWithSize = React.useMemo(() => {
     if (!tableWidth || !columns.length) {
-      return columns.map((col) => ({
-        ...col,
-        size: col.size || 150,
-      }));
+      return columns;
     }
 
     const equalWidth = Math.floor(tableWidth / columns.length);
@@ -343,7 +348,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => tableContainerRef.current,
-    estimateSize: () => 50,
+    estimateSize: () => COLUMN_HEIGHT,
   });
 
   useEffect(() => {
@@ -353,13 +358,14 @@ export function ScrollableDataTable<TData extends TBaseData>({
 
     const observer = new IntersectionObserver(
       (entries) => {
+        // retrieving the sentinel div
         if (entries[0].isIntersecting && !isLoading) {
           onLoadMore();
         }
       },
       {
         root: tableContainerRef.current,
-        rootMargin: "300px 0px",
+        rootMargin: "200% 0% 0% 0%",
         threshold: 0.1,
       }
     );
@@ -383,11 +389,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
         )}
         ref={tableContainerRef}
       >
-        <DataTable.Root
-          className="s-table-fixed"
-          containerClassName="!s-overflow-visible"
-          style={{ width: "100%" }}
-        >
+        <DataTable.Root className="s-w-full s-table-fixed">
           <DataTable.Header className="s-sticky s-top-0 s-z-20 s-bg-white s-shadow-sm dark:s-bg-background-night">
             {table.getHeaderGroups().map((headerGroup) => (
               <DataTable.Row
@@ -428,12 +430,10 @@ export function ScrollableDataTable<TData extends TBaseData>({
               </DataTable.Row>
             ))}
           </DataTable.Header>
-
           <DataTable.Body
+            className="s-relative s-w-full"
             style={{
               height: `${rowVirtualizer.getTotalSize()}px`,
-              position: "relative",
-              width: "100%",
             }}
           >
             {rowVirtualizer.getVirtualItems().map((virtualRow) => {
@@ -480,6 +480,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
               );
             })}
 
+            {/*sentinel div used for the intersection observer*/}
             <div
               ref={loadMoreRef}
               className="s-absolute s-bottom-0 s-h-1 s-w-full"

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -37,13 +37,7 @@ import {
   Tooltip,
 } from "@sparkle/components";
 import { useCopyToClipboard } from "@sparkle/hooks";
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  ClipboardCheckIcon,
-  ClipboardIcon,
-  MoreIcon,
-} from "@sparkle/icons";
+import { ArrowDownIcon, ArrowUpIcon, ClipboardCheckIcon, ClipboardIcon, MoreIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
 import { breakpoints, useWindowSize } from "./WindowUtility";
@@ -627,7 +621,7 @@ DataTable.Row = function Row({
   return (
     <tr
       className={cn(
-        "s-group/dt s-justify-center s-border-y s-transition-colors s-duration-300 s-ease-out",
+        "s-group/dt s-justify-center s-border-b s-transition-colors s-duration-300 s-ease-out",
         "s-border-separator dark:s-border-separator-night",
         onClick
           ? "s-cursor-pointer hover:s-bg-muted dark:hover:s-bg-muted-night"

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -329,8 +329,6 @@ export function ScrollableDataTable<TData extends TBaseData>({
     if (!tableContainerRef.current || !table || !tableWidth) {
       return;
     }
-
-    // Get all visible columns
     const columns = table.getAllColumns();
 
     // Calculate ideal widths and handle minimums
@@ -346,23 +344,21 @@ export function ScrollableDataTable<TData extends TBaseData>({
       {} as Record<string, number>
     );
 
-    // Ensure total width matches container
+    // Ensure total width matches tableWidth
     const totalIdealWidth = Object.values(idealSizing).reduce(
       (a, b) => a + b,
       0
     );
     const widthDifference = tableWidth - totalIdealWidth;
 
+    // adjust largest column
     if (widthDifference !== 0) {
-      // Find column best able to absorb the difference
       const adjustColumnId = Object.entries(idealSizing).sort(
-        (a, b) => b[1] - a[1] // Prefer larger columns first
+        (a, b) => b[1] - a[1]
       )[0][0];
 
       idealSizing[adjustColumnId] += widthDifference;
     }
-
-    // Apply final sizing
     table.setColumnSizing(idealSizing);
   }, [table, tableWidth]);
 

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -464,7 +464,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
                   id={row.id}
                   widthClassName={widthClassName}
                   onClick={row.original.onClick}
-                  className="s-absolute s-h-full s-w-full"
+                  className="s-absolute s-w-full"
                   style={{
                     transform: `translateY(${virtualRow.start}px)`,
                   }}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -321,7 +321,6 @@ export function ScrollableDataTable<TData extends TBaseData>({
     columns,
     rowCount: totalRowCount,
     getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
     enableColumnResizing: true,
   });
 
@@ -437,7 +436,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
                         minWidth: columnSizing[header.id],
                       }}
                     >
-                      <div className="s-flex s-w-full s-items-center s-space-x-1 s-truncate">
+                      <div className="s-flex s-w-full s-items-center s-space-x-1">
                         <span className="s-truncate">
                           {flexRender(
                             header.column.columnDef.header,
@@ -462,9 +461,10 @@ export function ScrollableDataTable<TData extends TBaseData>({
               return (
                 <DataTable.Row
                   key={row.id}
+                  id={row.id}
                   widthClassName={widthClassName}
                   onClick={row.original.onClick}
-                  className="s-absolute s-w-full"
+                  className="s-absolute s-h-full s-w-full"
                   style={{
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
@@ -482,17 +482,20 @@ export function ScrollableDataTable<TData extends TBaseData>({
                       <DataTable.Cell
                         column={cell.column}
                         key={cell.id}
+                        id={cell.id}
                         className="s-max-w-0"
                         style={{
                           width: columnSizing[cell.column.id],
                           minWidth: columnSizing[cell.column.id],
                         }}
                       >
-                        <div className="s-flex s-items-center s-space-x-1 s-truncate s-whitespace-nowrap">
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
-                          )}
+                        <div className="s-flex s-items-center s-space-x-1">
+                          <span className="s-truncate">
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </span>
                         </div>
                       </DataTable.Cell>
                     );

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -344,7 +344,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
     );
     const widthDifference = tableWidth - totalIdealWidth;
 
-    // adjust largest column
+    // adjust the largest column with leftover size
     if (widthDifference !== 0) {
       const adjustColumnId = Object.entries(idealSizing).sort(
         (a, b) => b[1] - a[1]

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -44,7 +44,7 @@ export {
 } from "./ConversationMessage";
 export { Counter } from "./Counter";
 export type { DataTableMoreButtonProps, MenuItem } from "./DataTable";
-export { DataTable } from "./DataTable";
+export { DataTable, ScrollableDataTable } from "./DataTable";
 export {
   Dialog,
   DialogClose,

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -4,7 +4,7 @@ import {
   PaginationState,
   SortingState,
 } from "@tanstack/react-table";
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import {
   DataTable,
@@ -17,6 +17,7 @@ import {
   DialogTitle,
   DropdownMenu,
   Input,
+  ScrollableDataTable,
 } from "@sparkle/components/";
 import { MenuItem } from "@sparkle/components/DataTable";
 import { FolderIcon } from "@sparkle/icons";
@@ -515,6 +516,69 @@ export const DataTablePaginatedServerSideRowCountCappedExample = () => {
         columnsBreakpoints={{ lastUpdated: "sm" }}
         isServerSideSorting={true}
       />
+    </div>
+  );
+};
+
+const createData = (start: number, count: number) => {
+  return Array(count)
+    .fill(0)
+    .map((_, i) => ({
+      name: `Item ${start + i + 1}`,
+      usedBy: Math.floor(Math.random() * 100),
+      addedBy: `UserUserUserUserUserUserUserUserUserUserUser ${Math.floor(Math.random() * 10) + 1}`,
+      lastUpdated: `2023-08-${Math.floor(Math.random() * 30) + 1}`,
+      size: `${Math.floor(Math.random() * 200)}kb`,
+      menuItems: [
+        { kind: "item", label: "test", onClick: () => console.log("hey") },
+      ],
+    })) as TransformedData[];
+};
+
+export const ScrollableDataTableExample = () => {
+  const [filter, setFilter] = useState("");
+  const [data, setData] = useState(() => createData(0, 50));
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Load more data when user scrolls to bottom
+  const loadMore = useCallback(() => {
+    setIsLoading(true);
+
+    // Simulate API call delay
+    setTimeout(() => {
+      setData((prevData) => [...prevData, ...createData(prevData.length, 50)]);
+      setIsLoading(false);
+    }, 1000);
+  }, []);
+
+  return (
+    <div className="s-flex s-w-full s-max-w-4xl s-flex-col s-gap-6">
+      <h3 className="s-text-lg s-font-medium">
+        Virtualized ScrollableDataTable with Infinite Scrolling
+      </h3>
+
+      <div className="s-flex s-flex-col s-gap-4">
+        <Input
+          name="filter"
+          placeholder="Filter"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+
+        <ScrollableDataTable
+          data={data}
+          filter={filter}
+          filterColumn="name"
+          columns={columns}
+          onLoadMore={loadMore}
+          isLoading={isLoading}
+          maxHeight="s-max-h-[500px]"
+        />
+
+        <div className="s-text-sm s-text-muted-foreground">
+          Loaded {data.length} rows. Scroll to the bottom to load more.
+        </div>
+      </div>
     </div>
   );
 };

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -180,6 +180,7 @@ const columns: ColumnDef<Data>[] = [
     accessorKey: "name",
     header: "Name",
     sortingFn: "text",
+    id: "name",
     meta: {
       className: "s-w-full",
       tooltip: "User's full name",
@@ -198,6 +199,7 @@ const columns: ColumnDef<Data>[] = [
   },
   {
     accessorKey: "usedBy",
+    id: "usedBy",
     meta: {
       className: "s-w-[82px] s-hidden @xs/table:s-table-cell",
     },
@@ -209,6 +211,7 @@ const columns: ColumnDef<Data>[] = [
   {
     accessorKey: "addedBy",
     header: "Added by",
+    is: "addedBy",
     meta: {
       className: "s-w-[128px]",
     },
@@ -222,6 +225,7 @@ const columns: ColumnDef<Data>[] = [
   },
   {
     accessorKey: "lastUpdated",
+    id: "lastUpdated",
     header: "Last updated",
     meta: {
       className: "s-w-[128px] s-hidden @sm/table:s-table-cell",
@@ -233,6 +237,7 @@ const columns: ColumnDef<Data>[] = [
   },
   {
     accessorKey: "size",
+    id: "size",
     header: "Size",
     meta: {
       className: "s-w-[48px] s-hidden @sm/table:s-table-cell",
@@ -551,8 +556,8 @@ export const ScrollableDataTableExample = () => {
     }, 1000);
   }, []);
 
-  const columnsWithSize = columns.map((column) => {
-    return { ...column };
+  const columnsWithSize = columns.map((column, index) => {
+    return { ...column, meta: { sizeRatio: index % 2 === 0 ? 15 : 10 } };
   });
   return (
     <div className="s-flex s-w-full s-max-w-4xl s-flex-col s-gap-6">

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -211,7 +211,7 @@ const columns: ColumnDef<Data>[] = [
   {
     accessorKey: "addedBy",
     header: "Added by",
-    is: "addedBy",
+    id: "addedBy",
     meta: {
       className: "s-w-[128px]",
     },

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -551,6 +551,9 @@ export const ScrollableDataTableExample = () => {
     }, 1000);
   }, []);
 
+  const columnsWithSize = columns.map((column) => {
+    return { ...column };
+  });
   return (
     <div className="s-flex s-w-full s-max-w-4xl s-flex-col s-gap-6">
       <h3 className="s-text-lg s-font-medium">
@@ -569,7 +572,7 @@ export const ScrollableDataTableExample = () => {
           data={data}
           filter={filter}
           filterColumn="name"
-          columns={columns}
+          columns={columnsWithSize}
           onLoadMore={loadMore}
           isLoading={isLoading}
           maxHeight="s-max-h-[500px]"

--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -88,6 +88,11 @@ module.exports = {
       zIndex: {
         60: "60",
       },
+      height: {
+        100: "400px",
+        125: "500px",
+        150: "600px",
+      },
       minHeight: (theme) => ({
         ...theme("spacing"),
       }),


### PR DESCRIPTION
## Description

Implements virtual scrolling for the `DataTable` component to improve performance when displaying large datasets. The virtual rendering optimizes the rendering process by only displaying rows that are currently visible in the viewport. This implementation leverages `@tanstack/react-virtual` to handle the virtualization logic efficiently.

**References:**
- https://tanstack.com/table/latest/docs/framework/react/examples/virtualized-infinite-scrolling

## Risk

Low, new component

## Deploy Plan

Publish sparkle