### PR TITLE
feat(Poke) - Add plugin to compute data source statistics

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -1,4 +1,5 @@
 import {
+  BracesIcon,
   Button,
   Chip,
   Dialog,
@@ -13,7 +14,6 @@ import type {
   DataSourceType,
 } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
-import { CodeIcon } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -68,7 +68,7 @@ export function ViewDataSourceTable({
                 variant="outline"
                 size="sm"
                 onClick={() => setShowRawObjectsModal(true)}
-                icon={CodeIcon}
+                icon={BracesIcon}
                 label="Show raw objects"
               />
             </div>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Chip,
   Dialog,
+  DialogContainer,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -253,7 +254,7 @@ function RawObjectsModal({
         <DialogHeader>
           <DialogTitle>Data source raw objects</DialogTitle>
         </DialogHeader>
-        <div className="mx-2 my-4 overflow-y-auto">
+        <DialogContainer>
           <span className="text-sm font-bold">dataSource</span>
           <JsonViewer
             theme={isDark ? "dark" : "light"}
@@ -275,7 +276,7 @@ function RawObjectsModal({
             rootName={false}
             defaultInspectDepth={1}
           />
-        </div>
+        </DialogContainer>
       </DialogContent>
     </Dialog>
   );

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -218,27 +218,6 @@ export function ViewDataSourceTable({
                         )}
                       </PokeTableCell>
                     </PokeTableRow>
-                    <PokeTableRow>
-                      <PokeTableCell>Total text size</PokeTableCell>
-                      <PokeTableCell>
-                        {connector?.lastSyncSuccessfulTime ? (
-                          <span className="font-bold text-green-600">
-                            {timeAgoFrom(connector?.lastSyncSuccessfulTime, {
-                              useLongFormat: true,
-                            })}
-                          </span>
-                        ) : (
-                          <span className="font-bold text-warning-600">
-                            "Never"
-                          </span>
-                        )}
-                        {isWebhookBasedProvider(connector.type) && (
-                          <span className="pl-2 italic text-gray-500">
-                            (webhook-based)
-                          </span>
-                        )}
-                      </PokeTableCell>
-                    </PokeTableRow>
                   </>
                 )}
               </PokeTableBody>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -13,6 +13,7 @@ import type {
   DataSourceType,
 } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
+import { CodeIcon } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -67,6 +68,7 @@ export function ViewDataSourceTable({
                 variant="outline"
                 size="sm"
                 onClick={() => setShowRawObjectsModal(true)}
+                icon={CodeIcon}
                 label="Show raw objects"
               />
             </div>
@@ -197,6 +199,27 @@ export function ViewDataSourceTable({
                     </PokeTableRow>
                     <PokeTableRow>
                       <PokeTableCell>Last sync success</PokeTableCell>
+                      <PokeTableCell>
+                        {connector?.lastSyncSuccessfulTime ? (
+                          <span className="font-bold text-green-600">
+                            {timeAgoFrom(connector?.lastSyncSuccessfulTime, {
+                              useLongFormat: true,
+                            })}
+                          </span>
+                        ) : (
+                          <span className="font-bold text-warning-600">
+                            "Never"
+                          </span>
+                        )}
+                        {isWebhookBasedProvider(connector.type) && (
+                          <span className="pl-2 italic text-gray-500">
+                            (webhook-based)
+                          </span>
+                        )}
+                      </PokeTableCell>
+                    </PokeTableRow>
+                    <PokeTableRow>
+                      <PokeTableCell>Total text size</PokeTableCell>
                       <PokeTableCell>
                         {connector?.lastSyncSuccessfulTime ? (
                           <span className="font-bold text-green-600">

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -67,7 +67,7 @@ export function ViewDataSourceTable({
                 variant="outline"
                 size="sm"
                 onClick={() => setShowRawObjectsModal(true)}
-                label="🤓 Show raw objects"
+                label="Show raw objects"
               />
             </div>
             {isPaused && isRunning && (

--- a/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
+++ b/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
@@ -1,0 +1,51 @@
+import { Err, Ok } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types/src";
+
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+
+async function computeStatistics(dataSource: DataSourceResource) {
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+  return coreAPI.getDataSourceStats({
+    projectId: dataSource.dustAPIProjectId,
+    dataSourceId: dataSource.dustAPIDataSourceId,
+  });
+}
+
+export const computeStatsPlugin = createPlugin({
+  manifest: {
+    id: "compute-stats",
+    name: "Compute statistics",
+    description: "Compute statistics for the data source",
+    resourceTypes: ["data_sources"],
+    args: {},
+  },
+  execute: async (auth, dataSourceId) => {
+    if (!dataSourceId) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const result = await computeStatistics(dataSource);
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    const { name, text_size, document_count } = result.value;
+
+    return new Ok({
+      display: "json",
+      value: {
+        name,
+        text_size,
+        document_count,
+      },
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
+++ b/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
@@ -37,7 +37,7 @@ export const computeStatsPlugin = createPlugin({
       return new Err(new Error(result.error.message));
     }
 
-    const { name, text_size, document_count } = result.value;
+    const { name, text_size, document_count } = result.value.data_source;
 
     return new Ok({
       display: "json",

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -1,3 +1,4 @@
+export * from "./compute_statistics";
 export * from "./garbage_collect_google_drive_document";
 export * from "./mark_connector_as_error";
 export * from "./notion_url_sync";

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -279,12 +279,14 @@ export type CoreAPINodesSearchFilter = t.TypeOf<
 >;
 
 export interface CoreAPIDataSourceStatsResponse {
-  data_source_id: string;
-  data_source_internal_id: string;
-  timestamp: number;
-  name: string;
-  text_size: number;
-  document_count: number;
+  data_source: {
+    data_source_id: string;
+    data_source_internal_id: string;
+    timestamp: number;
+    name: string;
+    text_size: number;
+    document_count: number;
+  };
 }
 
 export interface CoreAPIUpsertDataSourceDocumentPayload {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2188.
- This PR adds a Poke data source plugin to compute statistics on a data source, notably the text size (only includes the documents, not the table) and the document count.
- The data is fetched from `core` (elasticsearch).
- This PR also fixes the dark mode on the `RawObjectsModal` and replaces the emoji on the button that opens it with an icon.

<img width="476" alt="Screenshot 2025-02-28 at 7 25 26 PM" src="https://github.com/user-attachments/assets/fa1d0bfd-79dd-43b9-a91a-513eec5c50b1" />

<img width="497" alt="Screenshot 2025-02-28 at 7 23 25 PM" src="https://github.com/user-attachments/assets/cad8ae7e-681e-423d-abce-e8eb54560f12" />

## Tests

- Tested locally.
- Not sure how long the computation takes for a large data source.

## Risk

- Low.

## Deploy Plan

- Deploy front.