### PR TITLE
feat(salesforce): require client_id and client_secret in auth flow

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -313,6 +313,7 @@ pub struct Connection {
     encrypted_access_token: Option<Vec<u8>>,
     encrypted_refresh_token: Option<Vec<u8>>,
     encrypted_raw_json: Option<Vec<u8>>,
+    related_credential_id: Option<String>,
 }
 
 impl Connection {
@@ -328,6 +329,7 @@ impl Connection {
         encrypted_access_token: Option<Vec<u8>>,
         encrypted_refresh_token: Option<Vec<u8>>,
         encrypted_raw_json: Option<Vec<u8>>,
+        related_credential_id: Option<String>,
     ) -> Self {
         Connection {
             connection_id,
@@ -341,6 +343,7 @@ impl Connection {
             encrypted_access_token,
             encrypted_refresh_token,
             encrypted_raw_json,
+            related_credential_id,
         }
     }
 
@@ -445,6 +448,10 @@ impl Connection {
         }
     }
 
+    pub fn related_credential_id(&self) -> Option<String> {
+        self.related_credential_id.clone()
+    }
+
     async fn reload(&mut self, store: Box<dyn OAuthStore + Sync + Send>) -> Result<()> {
         let connection = store
             .retrieve_connection_by_provider(self.provider, &self.connection_id)
@@ -460,6 +467,7 @@ impl Connection {
         self.encrypted_access_token = connection.encrypted_access_token;
         self.encrypted_refresh_token = connection.encrypted_refresh_token;
         self.encrypted_raw_json = connection.encrypted_raw_json;
+        self.related_credential_id = connection.related_credential_id;
 
         Ok(())
     }
@@ -469,8 +477,11 @@ impl Connection {
         provider: ConnectionProvider,
         metadata: serde_json::Value,
         migrated_credentials: Option<MigratedCredentials>,
+        related_credential_id: Option<String>,
     ) -> Result<Self> {
-        let mut c = store.create_connection(provider, metadata).await?;
+        let mut c = store
+            .create_connection(provider, metadata, related_credential_id)
+            .await?;
 
         if let Some(creds) = migrated_credentials {
             c.redirect_uri = Some(creds.redirect_uri);

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -17,6 +17,7 @@ pub enum CredentialProvider {
     Snowflake,
     Modjo,
     Bigquery,
+    Salesforce,
 }
 
 impl fmt::Display for CredentialProvider {
@@ -41,8 +42,8 @@ impl FromStr for CredentialProvider {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CredentialMetadata {
-    user_id: String,
-    workspace_id: String,
+    pub user_id: String,
+    pub workspace_id: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -129,6 +130,9 @@ impl Credential {
                     "universe_domain",
                     "location",
                 ]
+            }
+            CredentialProvider::Salesforce => {
+                vec!["client_id", "client_secret"]
             }
         };
 

--- a/core/src/stores/migrations/20250228_oauth_connection_add_related_credential_id.sql
+++ b/core/src/stores/migrations/20250228_oauth_connection_add_related_credential_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE connections ADD COLUMN related_credential_id TEXT;

--- a/front/components/data_source/CreateConnectionConfirmationModal.tsx
+++ b/front/components/data_source/CreateConnectionConfirmationModal.tsx
@@ -11,6 +11,8 @@ import {
   SheetTitle,
 } from "@dust-tt/sparkle";
 import {
+  isValidSalesforceClientId,
+  isValidSalesforceClientSecret,
   isValidSalesforceDomain,
   isValidZendeskSubdomain,
 } from "@dust-tt/types";
@@ -50,6 +52,10 @@ export function CreateConnectionConfirmationModal({
         return (
           !!extraConfig.instance_url &&
           isValidSalesforceDomain(extraConfig.instance_url) &&
+          !!extraConfig.client_id &&
+          isValidSalesforceClientId(extraConfig.client_id) &&
+          !!extraConfig.client_secret &&
+          isValidSalesforceClientSecret(extraConfig.client_secret) &&
           !!extraConfig.code_verifier &&
           !!extraConfig.code_challenge
         );
@@ -207,16 +213,48 @@ export function CreateConnectionConfirmationModal({
 
               {connectorProviderConfiguration.connectorProvider ===
                 "salesforce" && (
-                <Input
-                  label="Salesforce instance URL"
-                  message="The URL of your Salesforce organization instance."
-                  name="instance_url"
-                  value={extraConfig.instance_url ?? ""}
-                  placeholder="https://my-org.salesforce.com"
-                  onChange={(e) => {
-                    setExtraConfig({ instance_url: e.target.value });
-                  }}
-                />
+                <>
+                  <Input
+                    label="Salesforce instance URL"
+                    message="The URL of your Salesforce organization instance."
+                    name="instance_url"
+                    value={extraConfig.instance_url ?? ""}
+                    placeholder="https://my-org.salesforce.com"
+                    onChange={(e) => {
+                      setExtraConfig((prev) => ({
+                        ...prev,
+                        instance_url: e.target.value,
+                      }));
+                    }}
+                  />
+                  <Input
+                    label="Client ID"
+                    message="The client ID from your Salesforce connected app."
+                    name="client_id"
+                    value={extraConfig.client_id ?? ""}
+                    placeholder="3MVG9..."
+                    onChange={(e) => {
+                      setExtraConfig((prev) => ({
+                        ...prev,
+                        client_id: e.target.value,
+                      }));
+                    }}
+                  />
+                  <Input
+                    label="Client Secret"
+                    message="The client secret from your Salesforce connected app."
+                    name="client_secret"
+                    value={extraConfig.client_secret ?? ""}
+                    placeholder="..."
+                    type="password"
+                    onChange={(e) => {
+                      setExtraConfig((prev) => ({
+                        ...prev,
+                        client_secret: e.target.value,
+                      }));
+                    }}
+                  />
+                </>
               )}
 
               <div className="flex justify-center pt-2">

--- a/front/pages/api/w/[wId]/credentials/index.ts
+++ b/front/pages/api/w/[wId]/credentials/index.ts
@@ -2,6 +2,7 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import {
   BigQueryCredentialsWithLocationSchema,
   OAuthAPI,
+  SalesforceCredentialsSchema,
   SnowflakeCredentialsSchema,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/Either";
@@ -25,9 +26,15 @@ const PostBigQueryCredentialsBodySchema = t.type({
   credentials: BigQueryCredentialsWithLocationSchema,
 });
 
+const PostSalesforceCredentialsBodySchema = t.type({
+  provider: t.literal("salesforce"),
+  credentials: SalesforceCredentialsSchema,
+});
+
 const PostCredentialsBodySchema = t.union([
   PostSnowflakeCredentialsBodySchema,
   PostBigQueryCredentialsBodySchema,
+  PostSalesforceCredentialsBodySchema,
 ]);
 
 export type PostCredentialsBody = t.TypeOf<typeof PostCredentialsBodySchema>;

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -67,6 +67,14 @@ export function isValidSalesforceDomain(s: unknown): s is string {
   );
 }
 
+export function isValidSalesforceClientId(s: unknown): s is string {
+  return typeof s === "string" && s.trim().length > 0;
+}
+
+export function isValidSalesforceClientSecret(s: unknown): s is string {
+  return typeof s === "string" && s.trim().length > 0;
+}
+
 // Credentials Providers
 
 export const PROVIDERS_WITH_WORKSPACE_CONFIGURATIONS = [
@@ -81,6 +89,7 @@ export const CREDENTIALS_PROVIDERS = [
   "snowflake",
   "modjo",
   "bigquery",
+  "salesforce",
 ] as const;
 export type CredentialsProvider = (typeof CREDENTIALS_PROVIDERS)[number];
 
@@ -149,10 +158,19 @@ export const ApiKeyCredentialsSchema = t.type({
 });
 export type ModjoCredentials = t.TypeOf<typeof ApiKeyCredentialsSchema>;
 
+export const SalesforceCredentialsSchema = t.type({
+  client_id: t.string,
+  client_secret: t.string,
+});
+export type SalesforceCredentials = t.TypeOf<
+  typeof SalesforceCredentialsSchema
+>;
+
 export type ConnectionCredentials =
   | SnowflakeCredentials
   | ModjoCredentials
-  | BigQueryCredentialsWithLocation;
+  | BigQueryCredentialsWithLocation
+  | SalesforceCredentials;
 
 export function isSnowflakeCredentials(
   credentials: ConnectionCredentials
@@ -174,6 +192,12 @@ export function isBigQueryWithLocationCredentials(
     "project_id" in credentials &&
     "location" in credentials
   );
+}
+
+export function isSalesforceCredentials(
+  credentials: ConnectionCredentials
+): credentials is SalesforceCredentials {
+  return "client_id" in credentials && "client_secret" in credentials;
 }
 
 export type OauthAPIPostCredentialsResponse = {

--- a/types/src/oauth/oauth_api.ts
+++ b/types/src/oauth/oauth_api.ts
@@ -58,15 +58,30 @@ export class OAuthAPI {
     provider,
     metadata,
     migratedCredentials,
+    relatedCredential,
   }: {
     provider: OAuthProvider;
     metadata: Record<string, unknown> | null;
     migratedCredentials?: MigratedCredentialsType;
+    relatedCredential?: {
+      content: Record<string, unknown>;
+      metadata: {
+        workspace_id: string;
+        user_id: string;
+      };
+    };
   }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
     const body: {
       provider: OAuthProvider;
       metadata: Record<string, unknown> | null;
       migrated_credentials?: MigratedCredentialsType;
+      related_credential?: {
+        content: Record<string, unknown>;
+        metadata: {
+          workspace_id: string;
+          user_id: string;
+        };
+      };
     } = {
       provider,
       metadata,
@@ -74,6 +89,10 @@ export class OAuthAPI {
 
     if (migratedCredentials) {
       body.migrated_credentials = migratedCredentials;
+    }
+
+    if (relatedCredential) {
+      body.related_credential = relatedCredential;
     }
 
     const response = await this._fetchWithError(`${this._url}/connections`, {

--- a/x/henry/mp-sandbox-agent/simple_research.ts
+++ b/x/henry/mp-sandbox-agent/simple_research.ts
@@ -1,0 +1,56 @@
+// simple_research.ts
+import * as dotenv from "dotenv";
+import { Agent } from "./agent";
+import { fetchWeather } from "./tools/fetch_weather";
+import { scrapePages } from "./tools/scrape";
+import { searchWeb } from "./tools/serp";
+import { logger, LogLevel } from "./utils/logger";
+import { wrapError } from "./utils/errors";
+import type { AnyTool } from "./tools/types";
+import { loadModelConfig } from "./utils/config";
+
+// Load environment variables from .env file
+dotenv.config();
+
+async function main() {
+  try {
+    // Set log level to INFO
+    logger.setLevel(LogLevel.INFO);
+    logger.setTimestamps(false); // Cleaner output
+    
+    // Load and validate model configuration
+    loadModelConfig();
+    
+    const request = "Deeply research what diffusion LLMs are. Focus on the most recent news and developments. Be thorough and comprehensive in your research, covering the technical concepts, recent breakthroughs, and practical applications.";
+
+    console.log("# Research on Diffusion LLMs with Claude 3.7\n");
+    console.log("Query: " + request + "\n");
+
+    const agent = await Agent.create(request);
+    
+    // Convert typed tools to AnyTool for compatibility
+    const asAnyTool = <T>(tool: T): AnyTool => tool as unknown as AnyTool;
+    
+    const tools: Record<string, AnyTool> = {
+      fetch_weather: asAnyTool(fetchWeather),
+      scrape_pages: asAnyTool(scrapePages),
+      search_web: asAnyTool(searchWeb),
+    };
+    
+    let answer: string | null = null;
+    while (answer === null) {
+      answer = await agent.step(tools);
+    }
+    
+    console.log("\n## Final Research Results\n");
+    console.log(answer);
+    
+  } catch (error) {
+    // Wrap and log the error with full context
+    const wrappedError = wrapError(error, "Failed to execute agent");
+    logger.logError(wrappedError, "Application terminated with error");
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Description

We're switching our strategy for the Salesforce connection. Instead of offering a packaged app, we're going with a a Local External Client App, meaning that each customer will create the External Client App on their own org.

This means we need to collect and store a `client_id` and `client_secret` before initiating the oauth flow. 

The solution we're going with is to store these 2 additional fields as a `credential` in the `oauth` server, and adding a `related_credential_id` field on `connection`. The payload for creating a `connection` now accepts a `related_credential` optional payload to create the related `credential`.

 This is better than using the `connection` metadata, because:
- we often transport metadata between services
- metadata doesn't have the same high-security guarantees than credentials (we protect them, but we assume this data is inherently less sensitive)

Using a `credential` that never leaves `oauth` seems like a no-brainer for this info that is even more sensitive than an access token.

## Tests

Manual

## Risk

inverted 80/20 given oauth changes

## Deploy Plan
1. apply SQL migration on oauth DB
2. Deploy `core` / `oauth` and front