### PR TITLE
enh(Poke) - Improve readability of the statistics printed by compute_statistics

### DIFF
--- a/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
+++ b/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
@@ -1,5 +1,4 @@
-import { Err, Ok } from "@dust-tt/types";
-import { CoreAPI } from "@dust-tt/types/src";
+import { CoreAPI, Err, maxFileSizeToHumanReadable, Ok } from "@dust-tt/types";
 
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
@@ -18,7 +17,7 @@ export const computeStatsPlugin = createPlugin({
   manifest: {
     id: "compute-stats",
     name: "Compute statistics",
-    description: "Compute statistics for the data source",
+    description: "Gather statistics for the data source",
     resourceTypes: ["data_sources"],
     args: {},
   },
@@ -43,7 +42,7 @@ export const computeStatsPlugin = createPlugin({
       display: "json",
       value: {
         name,
-        text_size,
+        text_size: maxFileSizeToHumanReadable(text_size),
         document_count,
       },
     });

--- a/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
+++ b/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
@@ -42,7 +42,7 @@ export const computeStatsPlugin = createPlugin({
       display: "json",
       value: {
         name,
-        text_size: maxFileSizeToHumanReadable(text_size),
+        text_size: maxFileSizeToHumanReadable(text_size, 2),
         document_count,
       },
     });

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -51,7 +51,7 @@ export function maxFileSizeToHumanReadable(size: number) {
   }
 
   if (size < 1024 * 1024) {
-    return `${size / 1024} KB`;
+    return `${size / 1024} kB`;
   }
 
   return `${size / (1024 * 1024)} MB`;

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -45,16 +45,16 @@ export const MAX_FILE_SIZES: Record<FileFormatCategory, number> = {
   image: 5 * 1024 * 1024, // 5 MB
 };
 
-export function maxFileSizeToHumanReadable(size: number) {
+export function maxFileSizeToHumanReadable(size: number, decimals = 0) {
   if (size < 1024) {
-    return `${size} B`;
+    return `${size.toFixed(decimals)} B`;
   }
 
   if (size < 1024 * 1024) {
-    return `${size / 1024} kB`;
+    return `${(size / 1024).toFixed(decimals)} kB`;
   }
 
-  return `${size / (1024 * 1024)} MB`;
+  return `${(size / (1024 * 1024)).toFixed(decimals)} MB`;
 }
 
 const BIG_FILE_SIZE = 5_000_000;

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -54,7 +54,11 @@ export function maxFileSizeToHumanReadable(size: number, decimals = 0) {
     return `${(size / 1024).toFixed(decimals)} KB`;
   }
 
-  return `${(size / (1024 * 1024)).toFixed(decimals)} MB`;
+  if (size < 1024 * 1024 * 1024) {
+    return `${(size / (1024 * 1024)).toFixed(decimals)} MB`;
+  }
+
+  return `${(size / (1024 * 1024 * 1024)).toFixed(decimals)} GB`;
 }
 
 const BIG_FILE_SIZE = 5_000_000;

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -51,7 +51,7 @@ export function maxFileSizeToHumanReadable(size: number, decimals = 0) {
   }
 
   if (size < 1024 * 1024) {
-    return `${(size / 1024).toFixed(decimals)} kB`;
+    return `${(size / 1024).toFixed(decimals)} KB`;
   }
 
   return `${(size / (1024 * 1024)).toFixed(decimals)} MB`;


### PR DESCRIPTION
## Description

- In the Poke data source plugin "Compute statistics", this PR uses `maxFileSizeToHumanReadable` to print the total text size (prints the size in KB or MB instead of one very long number).

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy `front`.