### PR TITLE
Revert "Do not run GDrive GC on errored connectors"

### DIFF
--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -18,7 +18,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   const frontReplica = getFrontReplicaDbConnection();
   const GdriveDataSources: { id: number; connectorId: string }[] =
     await frontReplica.query(
-      `SELECT id, "connectorId" FROM data_sources WHERE "connectorProvider" = 'google_drive' AND "errorType" IS NULL`,
+      `SELECT id, "connectorId" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
       { type: QueryTypes.SELECT }
     );
 


### PR DESCRIPTION
Reverts dust-tt/dust#11144

Oversaw that the query was being done on data sources rather than connectors.