### PR TITLE
[front] Add html format in clipboard for formnatted paste

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -35,6 +35,7 @@ import {
   isWebsearchActionType,
   removeNulls,
 } from "@dust-tt/types";
+import { marked } from "marked";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import {
@@ -419,10 +420,21 @@ export function AgentMessage({
             tooltip="Copy to clipboard"
             variant="outline"
             size="xs"
-            onClick={() => {
-              void navigator.clipboard.writeText(
-                cleanUpCitations(agentMessageToRender.content || "")
+            onClick={async () => {
+              const markdownText = cleanUpCitations(
+                agentMessageToRender.content || ""
               );
+              // Convert markdown to HTML (you'll need to add a markdown-to-html converter)
+              const htmlContent = await marked(markdownText);
+
+              void navigator.clipboard.write([
+                new ClipboardItem({
+                  "text/plain": new Blob([markdownText], {
+                    type: "text/plain",
+                  }),
+                  "text/html": new Blob([htmlContent], { type: "text/html" }),
+                }),
+              ]);
             }}
             icon={ClipboardIcon}
             className="text-muted-foreground"

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -424,7 +424,7 @@ export function AgentMessage({
               const markdownText = cleanUpCitations(
                 agentMessageToRender.content || ""
               );
-              // Convert markdown to HTML (you'll need to add a markdown-to-html converter)
+              // Convert markdown to HTML
               const htmlContent = await marked(markdownText);
 
               void navigator.clipboard.write([


### PR DESCRIPTION
## Description

This adds text/html format in clipboard when copying so that format is kept when pasting in google docs / gmail / other apps that supports html paste.

## Tests

tested locally 

## Risk

none

## Deploy Plan

deploy front
