### PR TITLE
[front] Use buffer instead of decoded string to fix encoding issue

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -60,10 +60,10 @@ async function handler(
       let event: Stripe.Event | null = null;
 
       // Collect raw body using stream pipeline
-      let rawBody = "";
+      let rawBody = Buffer.from("");
       const collector = new Writable({
         write(chunk, encoding, callback) {
-          rawBody += chunk.toString();
+          rawBody = Buffer.concat([rawBody, chunk]);
           callback();
         },
       });
@@ -102,11 +102,6 @@ async function handler(
           },
         });
       }
-
-      logger.info(
-        { sig, stripeError: false, rawBody },
-        "Processing Strip event."
-      );
 
       let subscription;
       let stripeSubscription;

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -2,7 +2,7 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever, ConnectorsAPI, removeNulls } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { pipeline, Writable } from "stream";
-import Stripe from "stripe";
+import type Stripe from "stripe";
 import { promisify } from "util";
 
 import apiConfig from "@app/lib/api/config";
@@ -76,21 +76,10 @@ async function handler(
           apiConfig.getStripeSecretWebhookKey()
         );
       } catch (error) {
-        // This will happen for events targeted to a different region.
-        if (
-          error instanceof Stripe.errors.StripeSignatureVerificationError &&
-          error.type === "StripeSignatureVerificationError"
-        ) {
-          logger.error(
-            { error, sig, stripeError: true, rawBody },
-            "Invalid signature check when building Stripe event."
-          );
-        } else {
-          logger.error(
-            { error, stripeError: true },
-            "Error constructing Stripe event in Webhook."
-          );
-        }
+        logger.error(
+          { error, stripeError: true },
+          "Error constructing Stripe event in Webhook."
+        );
       }
 
       if (!event) {
@@ -102,6 +91,11 @@ async function handler(
           },
         });
       }
+
+      logger.info(
+        { sig, stripeError: false, event },
+        "Processing Strip event."
+      );
 
       let subscription;
       let stripeSubscription;


### PR DESCRIPTION
## Description

Restore previous logging, use Buffer to aggregate requests data

## Tests


## Risk

break event parsing, can be rollbacked

## Deploy Plan

deploy front