### PR TITLE
[front] More generic error messages

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -348,7 +348,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
         messageId: agentMessage.sId,
         error: {
           code: "process_execution_error",
-          message: `Error running process app: ${res.error.message}`,
+          message: "An error occured while extracting data.",
         },
       };
       return;
@@ -374,7 +374,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
           messageId: agentMessage.sId,
           error: {
             code: "process_execution_error",
-            message: `Error running process app: ${event.content.message}`,
+            message: "An error occured while extracting data.",
           },
         };
         return;
@@ -398,7 +398,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
             messageId: agentMessage.sId,
             error: {
               code: "process_execution_error",
-              message: `Error running process app: ${e.error}`,
+              message: "An error occured while extracting data.",
             },
           };
           return;

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -552,7 +552,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
         messageId: agentMessage.sId,
         error: {
           code: "retrieval_search_error",
-          message: `Error searching data sources: ${res.error.message}`,
+          message: "An error occured while searching our data sources.",
         },
       };
       return;
@@ -596,7 +596,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
           messageId: agentMessage.sId,
           error: {
             code: "retrieval_search_error",
-            message: `Error searching data sources: ${event.content.message}`,
+            message: "An error occured while searching our data sources.",
           },
         };
         return;
@@ -620,7 +620,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
             messageId: agentMessage.sId,
             error: {
               code: "retrieval_search_error",
-              message: `Error searching data sources: ${e.error}`,
+              message: "An error occured while searching our data sources.",
             },
           };
           return;


### PR DESCRIPTION
fixes: [#2269](https://github.com/dust-tt/tasks/issues/2269)

## Description

Hiding original error message on retrieval an process -  context : https://dust4ai.slack.com/archives/C05B529FHV1/p1740646642261159?thread_ts=1740558733.907379&cid=C05B529FHV1

Are we ok to hide the original cause to the user ? real error is still logged. If this is ok I can do the same for other actions (and check copy).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Original error message is not shown anymore

## Deploy Plan

deploy front 
