### PR TITLE
enh(front) - Fix the label "and `n` items" in content node trees

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -48,8 +48,10 @@ const unselectedChildren = (
 
 export type UseResourcesHook = (parentId: string | null) => {
   resources: ContentNode[];
+  totalResourceCount?: number; // This count can be higher than resources.length if the call is paginated.
   isResourcesLoading: boolean;
   isResourcesError: boolean;
+  isResourcesTruncated?: boolean;
   resourcesError?: APIError | null;
 };
 
@@ -127,7 +129,7 @@ function ContentNodeTreeChildren({
 
   const sendNotification = useSendNotification();
   const [search, setSearch] = useState("");
-  // This is to control when to dislpay the "Select All" vs "unselect All" button.
+  // This is to control when to display the "Select All" vs "unselect All" button.
   // If the user pressed "select all", we want to display "unselect all" and vice versa.
   // But if the user types in the search bar, we want to reset the button to "select all".
   const [selectAllClicked, setSelectAllClicked] = useState(false);
@@ -222,7 +224,7 @@ function ContentNodeTreeChildren({
                     onCheckedChange: (v) => {
                       if (setSelectedNodes) {
                         if (checkedState === "partial") {
-                          // Handle clicking on partial : unselect all selected children
+                          // Handle clicking on partial: unselect all selected children
                           setSelectedNodes((prev) =>
                             unselectedChildren(prev, n, sendNotification)
                           );

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -127,7 +127,7 @@ function ContentNodeTreeChildren({
 
   const sendNotification = useSendNotification();
   const [search, setSearch] = useState("");
-  // This is to control when to dislpay the "Select All" vs "unselect All" button.
+  // This is to control when to display the "Select All" vs "unselect All" button.
   // If the user pressed "select all", we want to display "unselect all" and vice versa.
   // But if the user types in the search bar, we want to reset the button to "select all".
   const [selectAllClicked, setSelectAllClicked] = useState(false);
@@ -222,7 +222,7 @@ function ContentNodeTreeChildren({
                     onCheckedChange: (v) => {
                       if (setSelectedNodes) {
                         if (checkedState === "partial") {
-                          // Handle clicking on partial : unselect all selected children
+                          // Handle clicking on partial: unselect all selected children
                           setSelectedNodes((prev) =>
                             unselectedChildren(prev, n, sendNotification)
                           );

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -152,7 +152,7 @@ function ContentNodeTreeChildren({
   // The count below does not take into account the search, it's: total number of nodes - number of nodes displayed.
   const hiddenNodesCount = totalResourceCount
     ? Math.max(0, totalResourceCount - filteredNodes.length)
-    : filteredNodes.length;
+    : 0;
 
   const getCheckedState = useCallback(
     (node: ContentNode) => {

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -127,7 +127,7 @@ function ContentNodeTreeChildren({
 
   const sendNotification = useSendNotification();
   const [search, setSearch] = useState("");
-  // This is to control when to display the "Select All" vs "unselect All" button.
+  // This is to control when to dislpay the "Select All" vs "unselect All" button.
   // If the user pressed "select all", we want to display "unselect all" and vice versa.
   // But if the user types in the search bar, we want to reset the button to "select all".
   const [selectAllClicked, setSelectAllClicked] = useState(false);
@@ -222,7 +222,7 @@ function ContentNodeTreeChildren({
                     onCheckedChange: (v) => {
                       if (setSelectedNodes) {
                         if (checkedState === "partial") {
-                          // Handle clicking on partial: unselect all selected children
+                          // Handle clicking on partial : unselect all selected children
                           setSelectedNodes((prev) =>
                             unselectedChildren(prev, n, sendNotification)
                           );

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -137,12 +137,22 @@ function ContentNodeTreeChildren({
   const { useResourcesHook, emptyComponent, defaultExpandedIds } =
     useContentNodeTreeContext();
 
-  const { resources, isResourcesLoading, isResourcesError, resourcesError } =
-    useResourcesHook(parentId);
+  const {
+    resources,
+    isResourcesLoading,
+    isResourcesError,
+    resourcesError,
+    isResourcesTruncated,
+    totalResourceCount,
+  } = useResourcesHook(parentId);
 
   const filteredNodes = resources.filter(
     (n) => search.trim().length === 0 || n.title.includes(search)
   );
+  // The count below does not take into account the search, it's: total number of nodes - number of nodes displayed.
+  const hiddenNodesCount = totalResourceCount
+    ? Math.max(0, totalResourceCount - filteredNodes.length)
+    : filteredNodes.length;
 
   const getCheckedState = useCallback(
     (node: ContentNode) => {
@@ -305,6 +315,11 @@ function ContentNodeTreeChildren({
           />
         );
       })}
+      {hiddenNodesCount > 0 && (
+        <Tree.Empty
+          label={`${filteredNodes.length > 0 ? "and " : ""}${hiddenNodesCount}${isResourcesTruncated ? "+" : ""} item${hiddenNodesCount > 1 ? "s" : ""}`}
+        />
+      )}
     </Tree>
   );
 

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -29,8 +29,10 @@ const getUseResourceHook =
         preventSelection:
           n.preventSelection || (viewType === "table" && n.type !== "table"),
       })),
+      totalResourceCount: res.totalNodesCount,
       isResourcesLoading: res.isNodesLoading,
       isResourcesError: res.isNodesError,
+      isResourcesTruncated: !res.totalNodesCountIsAccurate,
     };
   };
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -64,7 +64,13 @@ const getUseResourceHook =
     useContentNodes: typeof useDataSourceViewContentNodes
   ) =>
   (parentId: string | null) => {
-    const { nodes, isNodesLoading, isNodesError } = useContentNodes({
+    const {
+      nodes,
+      isNodesLoading,
+      isNodesError,
+      totalNodesCountIsAccurate,
+      totalNodesCount,
+    } = useContentNodes({
       owner,
       dataSourceView,
       parentId: parentId ?? undefined,
@@ -76,8 +82,10 @@ const getUseResourceHook =
         preventSelection:
           n.preventSelection || (viewType === "table" && n.type !== "table"),
       })),
+      totalResourceCount: totalNodesCount,
       isResourcesLoading: isNodesLoading,
       isResourcesError: isNodesError,
+      isResourcesTruncated: !totalNodesCountIsAccurate,
     };
   };
 

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -453,16 +453,17 @@ const SpaceDataSourceViewItem = ({
   const router = useRouter();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const { isNodesLoading, nodes } = useDataSourceViewContentNodes({
-    dataSourceView: item,
-    owner,
-    parentId: node?.internalId,
-    viewType: "all",
-    disabled: !isExpanded,
-    swrOptions: {
-      revalidateOnFocus: false,
-    },
-  });
+  const { isNodesLoading, nodes, totalNodesCountIsAccurate, totalNodesCount } =
+    useDataSourceViewContentNodes({
+      dataSourceView: item,
+      owner,
+      parentId: node?.internalId,
+      viewType: "all",
+      disabled: !isExpanded,
+      swrOptions: {
+        revalidateOnFocus: false,
+      },
+    });
 
   const basePath = `/w/${owner.sId}/spaces/${space.sId}/categories/${item.category}/data_source_views/${item.sId}`;
 
@@ -504,18 +505,7 @@ const SpaceDataSourceViewItem = ({
 
   const isEmpty = isExpanded && !isNodesLoading && nodes.length === 0;
   const expandableNodes = nodes.filter((node) => node.expandable);
-  const notExpandableNodes = nodes.filter((node) => !node.expandable);
-  const notExpandableNodesLabel =
-    notExpandableNodes.length === 1 ? "item" : "items";
-
-  // TODO(nodes-core): remove this upon project cleanup
-  // if looking at a static datasource view with more than the pagination limit,
-  // show a ">" to indicate that there are more items
-  const staticDsPlusIfMoreThanLimit =
-    item.category === "folder" &&
-    nodes.length >= DEFAULT_STATIC_DATA_SOURCE_PAGINATION_LIMIT
-      ? "+"
-      : "";
+  const hiddenNodesCount = Math.max(0, totalNodesCount - nodes.length);
 
   return (
     <Tree.Item
@@ -543,13 +533,9 @@ const SpaceDataSourceViewItem = ({
               node={node}
             />
           ))}
-          {notExpandableNodes.length > 0 && (
+          {hiddenNodesCount > 0 && (
             <Tree.Empty
-              label={
-                expandableNodes.length
-                  ? `and ${notExpandableNodes.length} ${notExpandableNodesLabel}`
-                  : `${notExpandableNodes.length}${staticDsPlusIfMoreThanLimit} ${notExpandableNodesLabel}`
-              }
+              label={`${expandableNodes.length > 0 ? "and " : ""}${hiddenNodesCount}${totalNodesCountIsAccurate ? "" : "+"} item${hiddenNodesCount > 1 ? "s" : ""}`}
               onItemClick={async () => {
                 await setNavigationSelection({ lastSpaceId: space.sId });
                 void router.push(dataSourceViewPath);

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -43,10 +43,6 @@ import {
   useSpacesAsAdmin,
 } from "@app/lib/swr/spaces";
 
-// TODO(nodes-core): remove this upon project cleanup
-// copied from lib/api/data_source_view.ts
-const DEFAULT_STATIC_DATA_SOURCE_PAGINATION_LIMIT = 10_000;
-
 interface SpaceSideBarMenuProps {
   owner: LightWorkspaceType;
   isAdmin: boolean;

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -161,7 +161,9 @@ export async function getContentNodesForDataSourceView(
 
   return new Ok({
     nodes: sortedNodes,
-    total: coreRes.value.hit_count,
+    total:
+      coreRes.value.hit_count -
+      (coreRes.value.nodes.length - sortedNodes.length), // Deducing the number of folders we hid from the total count.
     totalIsAccurate: coreRes.value.hit_count_is_accurate,
     nextPageCursor: nextPageCursor,
   });


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2252.

This PR aims at enhancing the relevance of the "and `n` items" label we can see in the `SpaceSideBarMenu`, which was not perfectly accurate.

Old behavior:
- The count displayed in the label did not take into account the pagination correctly, and therefore had a hard limit at 10_000 nodes (previously hardcoded, now completely removed).
- A "+" (and 10000+ items) is added if we have 10k nodes for a static data source.

New behavior:
- The count displayed is accurate: it's the total number of hits on the ES index minus the number of nodes already displayed.
- The "+" is added if the number of hits is not accurate (we set a limit for performance reasons, currently set to `MAX_TOTAL_HITS_TRACKED = 10000`).

## Tests

- Tested locally, no automated test.

## Risk

- Low.

## Deploy Plan

- Deploy front.