### PR TITLE
Remove affinity in once workspace is done relocating

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -474,6 +474,10 @@ export async function setWorkspaceRelocated(
   return updateWorkspaceMetadata(owner, { maintenance: "relocation-done" });
 }
 
+export function isWorkspaceRelocationDone(owner: LightWorkspaceType): boolean {
+  return owner.metadata?.maintenance === "relocation-done";
+}
+
 export async function updateExtensionConfiguration(
   auth: Authenticator,
   blacklistedDomains: string[]


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR ensures that if new users browse to dust.tt while their workspace has been relocated the region affinity is not true anymore and they get redirected to their new region.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
