### PR TITLE
[front] - chore(dsv): join table `data_source_view_for_conversations`

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -27,6 +27,7 @@ import {
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { RetrievalDocumentResource } from "@app/lib/resources/retrieval_document_resource";
+import { DataSourceViewForConversation } from "@app/lib/resources/storage/models/data_source_view_conversation";
 
 const DESTROY_MESSAGE_BATCH = 50;
 
@@ -230,6 +231,10 @@ export async function destroyConversation(
   }
 
   await ConversationParticipant.destroy({
+    where: { conversationId: conversation.id },
+  });
+
+  await DataSourceViewForConversation.destroy({
     where: { conversationId: conversation.id },
   });
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -914,7 +914,8 @@ export async function createDataSourceWithoutProvider(
         conversationId: conversation?.id,
       },
       space,
-      auth.user()
+      auth.user(),
+      conversation
     );
 
   try {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -49,6 +49,8 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
+import { ConversationWithoutContentPublicType } from "@dust-tt/client";
+import { DataSourceViewForConversation } from "@app/lib/resources/storage/models/data_source_view_conversation";
 
 const getDataSourceCategory = (
   dataSourceResource: DataSourceResource
@@ -104,6 +106,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     dataSource: DataSourceResource,
     editedByUser?: UserType | null,
+    conversation?: ConversationWithoutContentPublicType | null,
     transaction?: Transaction
   ) {
     const dataSourceView = await DataSourceViewResource.model.create(
@@ -122,6 +125,17 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       space
     );
     dsv.ds = dataSource;
+
+    if (conversation) {
+      // dataSourceView attached to a conversation, we create an entry in the
+      // join table
+      await DataSourceViewForConversation.create({
+        conversationId: conversation.id,
+        dataSourceViewId: dataSourceView.id,
+        workspaceId: blob.workspaceId,
+      });
+    }
+
     return dsv;
   }
 
@@ -129,6 +143,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     blob: Omit<CreationAttributes<DataSourceModel>, "editedAt" | "vaultId">,
     space: SpaceResource,
     editedByUser?: UserType | null,
+    conversation?: ConversationWithoutContentPublicType | null,
     transaction?: Transaction
   ) {
     const createDataSourceAndView = async (t: Transaction) => {
@@ -142,6 +157,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         space,
         dataSource,
         editedByUser,
+        conversation,
         t
       );
     };
@@ -177,6 +193,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     dataSource: DataSourceResource,
     editedByUser?: UserType | null,
+    conversation?: ConversationWithoutContentPublicType | null,
     transaction?: Transaction
   ) {
     return this.makeNew(
@@ -189,6 +206,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       space,
       dataSource,
       editedByUser,
+      conversation,
       transaction
     );
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -1,6 +1,7 @@
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
+import type { ConversationWithoutContentPublicType } from "@dust-tt/client";
 import type {
   ConversationType,
   DataSourceViewCategory,
@@ -39,6 +40,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { DataSourceViewForConversation } from "@app/lib/resources/storage/models/data_source_view_conversation";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -49,8 +51,6 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
-import { ConversationWithoutContentPublicType } from "@dust-tt/client";
-import { DataSourceViewForConversation } from "@app/lib/resources/storage/models/data_source_view_conversation";
 
 const getDataSourceCategory = (
   dataSourceResource: DataSourceResource

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -642,6 +642,12 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         dataSourceViewId: this.id,
       },
     });
+    await DataSourceViewForConversation.destroy({
+      where: {
+        dataSourceViewId: this.id,
+      },
+      transaction,
+    });
 
     const deletedCount = await DataSourceViewModel.destroy({
       where: {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -129,11 +129,14 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     if (conversation) {
       // dataSourceView attached to a conversation, we create an entry in the
       // join table
-      await DataSourceViewForConversation.create({
-        conversationId: conversation.id,
-        dataSourceViewId: dataSourceView.id,
-        workspaceId: blob.workspaceId,
-      });
+      await DataSourceViewForConversation.create(
+        {
+          conversationId: conversation.id,
+          dataSourceViewId: dataSourceView.id,
+          workspaceId: blob.workspaceId,
+        },
+        { transaction }
+      );
     }
 
     return dsv;

--- a/front/lib/resources/storage/models/data_source_view_conversation.ts
+++ b/front/lib/resources/storage/models/data_source_view_conversation.ts
@@ -1,0 +1,60 @@
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
+
+import { Conversation } from "@app/lib/models/assistant/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+
+export class DataSourceViewForConversation extends WorkspaceAwareModel<DataSourceViewForConversation> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<Conversation["id"]>;
+  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
+}
+
+DataSourceViewForConversation.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    modelName: "data_source_view_for_conversation",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["conversationId", "dataSourceViewId"],
+        name: "data_source_view_for_conversation_unique",
+      },
+      { fields: ["conversationId"] },
+      { fields: ["dataSourceViewId"] },
+    ],
+  }
+);
+
+Conversation.hasMany(DataSourceViewForConversation, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+DataSourceViewForConversation.belongsTo(Conversation, {
+  foreignKey: { name: "conversationId", allowNull: false },
+});
+
+DataSourceViewModel.hasMany(DataSourceViewForConversation, {
+  foreignKey: { name: "dataSourceViewId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+DataSourceViewForConversation.belongsTo(DataSourceViewModel, {
+  foreignKey: { name: "dataSourceViewId", allowNull: false },
+});

--- a/front/lib/resources/storage/models/data_source_view_conversation.ts
+++ b/front/lib/resources/storage/models/data_source_view_conversation.ts
@@ -29,7 +29,7 @@ DataSourceViewForConversation.init(
     },
   },
   {
-    modelName: "data_source_view_for_conversation",
+    modelName: "data_source_view_for_conversations",
     sequelize: frontSequelize,
     indexes: [
       {

--- a/front/lib/resources/storage/models/data_source_view_conversation.ts
+++ b/front/lib/resources/storage/models/data_source_view_conversation.ts
@@ -35,10 +35,9 @@ DataSourceViewForConversation.init(
       {
         unique: true,
         fields: ["conversationId", "dataSourceViewId"],
-        name: "data_source_view_for_conversation_unique",
       },
-      { fields: ["conversationId"] },
-      { fields: ["dataSourceViewId"] },
+      { fields: ["conversationId"], concurrently: true },
+      { fields: ["dataSourceViewId"], concurrently: true },
     ],
   }
 );

--- a/front/migrations/20250303_backfill_conversation_ids.ts
+++ b/front/migrations/20250303_backfill_conversation_ids.ts
@@ -1,0 +1,101 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import { concurrentExecutor } from "@dust-tt/types";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { DataSourceViewForConversation } from "@app/lib/resources/storage/models/data_source_view_conversation";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+async function backfillDataSourceViewConversationId(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // Get the conversations space
+  const conversationsSpace =
+    await SpaceResource.fetchWorkspaceConversationsSpace(auth);
+  if (!conversationsSpace) {
+    logger.info({ workspaceId: workspace.sId }, "No conversations space found");
+    return;
+  }
+
+  const dataSources: DataSourceModel[] = await DataSourceModel.findAll({
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    where: {
+      workspaceId: workspace.id,
+      vaultId: conversationsSpace.id,
+      conversationId: {
+        [Op.not]: null,
+      },
+    },
+  });
+
+  logger.info(
+    { workspaceId: workspace.sId, count: dataSources.length },
+    "Found dataSources in conversation vault"
+  );
+
+  await concurrentExecutor(
+    dataSources,
+    async (dataSource) => {
+      const dataSourceViews = await DataSourceViewModel.findAll({
+        where: {
+          workspaceId: workspace.id,
+          dataSourceId: dataSource.id,
+        },
+      });
+
+      if (execute) {
+        const dsvForConversations = dataSourceViews.map((view) => ({
+          conversationId: dataSource.conversationId!,
+          dataSourceViewId: view.id,
+          workspaceId: workspace.id,
+        }));
+
+        await DataSourceViewForConversation.bulkCreate(dsvForConversations);
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            dataSourceId: dataSource.id,
+            conversationId: dataSource.conversationId,
+            viewCount: dataSourceViews.length,
+          },
+          `Created ${dsvForConversations.length} join table entries for workspace ${workspace.sId}`
+        );
+      } else {
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            dataSourceId: dataSource.id,
+            conversationId: dataSource.conversationId,
+            viewCount: dataSourceViews.length,
+          },
+          "Would create join table entries"
+        );
+      }
+    },
+    {
+      concurrency: 10,
+    }
+  );
+
+  logger.info(
+    { workspaceId: workspace.sId, dataSourceCount: dataSources.length },
+    "Done creating join table entries"
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillDataSourceViewConversationId(workspace, logger, execute);
+  });
+});

--- a/front/migrations/db/migration_174.sql
+++ b/front/migrations/db/migration_174.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "data_source_view_for_conversation" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "conversationId" BIGINT NOT NULL REFERENCES "conversations"("id") ON DELETE RESTRICT,
+    "dataSourceViewId" BIGINT NOT NULL REFERENCES "data_source_views"("id") ON DELETE RESTRICT,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces"("id") ON DELETE RESTRICT
+);
+
+CREATE UNIQUE INDEX "dsv_conversation_unique_idx"
+    ON "data_source_view_for_conversation" ("conversationId", "dataSourceViewId");
+CREATE INDEX CONCURRENTLY "dsv_conversation_conversation_id_idx"
+    ON "data_source_view_for_conversation" ("conversationId");
+CREATE INDEX CONCURRENTLY "dsv_conversation_dsv_id_idx"
+    ON "data_source_view_for_conversation" ("dataSourceViewId");

--- a/front/migrations/db/migration_174.sql
+++ b/front/migrations/db/migration_174.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS "data_source_view_for_conversation" (
+CREATE TABLE IF NOT EXISTS "data_source_view_for_conversations" (
     "id" BIGSERIAL PRIMARY KEY,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -8,8 +8,8 @@ CREATE TABLE IF NOT EXISTS "data_source_view_for_conversation" (
 );
 
 CREATE UNIQUE INDEX "dsv_conversation_unique_idx"
-    ON "data_source_view_for_conversation" ("conversationId", "dataSourceViewId");
-CREATE INDEX CONCURRENTLY "dsv_conversation_conversation_id_idx"
-    ON "data_source_view_for_conversation" ("conversationId");
-CREATE INDEX CONCURRENTLY "dsv_conversation_dsv_id_idx"
-    ON "data_source_view_for_conversation" ("dataSourceViewId");
+    ON "data_source_view_for_conversations" ("conversationId", "dataSourceViewId");
+CREATE INDEX CONCURRENTLY "dsv_conversations_conversation_id_idx"
+    ON "data_source_view_for_conversations" ("conversationId");
+CREATE INDEX CONCURRENTLY "dsv_conversations_dsv_id_idx"
+    ON "data_source_view_for_conversations" ("dataSourceViewId");

--- a/front/tests/utils/DataSourceViewFactory.ts
+++ b/front/tests/utils/DataSourceViewFactory.ts
@@ -22,6 +22,7 @@ export class DataSourceViewFactory {
       },
       space,
       null,
+      null,
       t
     );
   }


### PR DESCRIPTION
## Description

This PR adds a join table `data_source_view_for_conversations` to track the relationship between data source views and conversations. This replaces the previously planned conversationId column on the `data_source_views` table.

**References:**
 - https://github.com/dust-tt/tasks/issues/2268

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

1. Deploy the migration to create the join table and indexes
2. Deploy front code changes
3. Run the backfill script to populate data_source_view_for_conversations entries for existing data source views