### PR TITLE
Flav/fix search space access

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -38,6 +38,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import {
+  DATA_SOURCE_MIME_TYPE,
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
@@ -232,7 +233,7 @@ export function DataSourceViewsSelector({
       (r) => r.internalId === item.internalId
     );
 
-    if (item.mimeType === "application/vnd.dust.datasource") {
+    if (item.mimeType === DATA_SOURCE_MIME_TYPE) {
       return {
         ...prevState,
         [dsv.sId]: {

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -28,6 +28,7 @@ import type { SpaceSearchContextType } from "@app/components/spaces/search/Space
 import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { SpacePageHeader } from "@app/components/spaces/SpacePageHeaders";
 import {
+  DATA_SOURCE_MIME_TYPE,
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
@@ -465,9 +466,14 @@ function SearchResultsTable({
         ...(node.expandable && {
           onClick: () => {
             if (node.expandable) {
-              void router.push(
-                `/w/${owner.sId}/spaces/${node.dataSourceView.spaceId}/categories/${category}/data_source_views/${dataSourceView.sId}?parentId=${parentId}`
-              );
+              const baseUrl = `/w/${owner.sId}/spaces/${node.dataSourceView.spaceId}/categories/${category}/data_source_views/${dataSourceView.sId}`;
+              // If the node is a data source, we don't need to pass the parentId.
+              const url =
+                node.mimeType === DATA_SOURCE_MIME_TYPE
+                  ? baseUrl
+                  : `${baseUrl}?parentId=${parentId}`;
+
+              void router.push(url);
             }
           },
         }),

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -213,7 +213,7 @@ function BackendSearch({
   } = useSpaceSearch({
     dataSourceViews: targetDataSourceViews,
     disabled: !hasSearchKnowledgeBuilderFF || !debouncedSearch,
-    includeDataSources: false,
+    includeDataSources: true,
     owner,
     search: debouncedSearch,
     space,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -282,7 +282,7 @@ export async function searchContenNodesInSpace(
     DustError | CoreAPIError
   >
 > {
-  if (!space.canRead(auth)) {
+  if (!space.canReadOrAdministrate(auth)) {
     return new Err(new DustError("unauthorized", "Unauthorized"));
   }
 

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -39,10 +39,8 @@ export const SPREADSHEET_MIME_TYPES = [
   MIME_TYPES.MICROSOFT.SPREADSHEET,
 ] as readonly string[];
 
-// Mime types that represent a datasource.
-export const DATA_SOURCE_MIME_TYPES = [
-  "application/vnd.dust.datasource",
-] as readonly string[];
+// Mime type that represents a datasource.
+export const DATA_SOURCE_MIME_TYPE = "application/vnd.dust.datasource";
 
 function getVisualForFileContentNode(node: ContentNode & { type: "document" }) {
   if (node.expandable) {
@@ -55,10 +53,10 @@ function getVisualForFileContentNode(node: ContentNode & { type: "document" }) {
 export function getVisualForDataSourceViewContentNode(
   node: DataSourceViewContentNode
 ) {
-  // Handle data sources with connector providers
+  // Handle data sources with connector providers.
   if (
     node.mimeType &&
-    DATA_SOURCE_MIME_TYPES.includes(node.mimeType) &&
+    node.mimeType === DATA_SOURCE_MIME_TYPE &&
     node.dataSourceView?.dataSource?.connectorProvider &&
     CONNECTOR_CONFIGURATIONS[node.dataSourceView.dataSource.connectorProvider]
   ) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR:
- ensures that admins can search content nodes in the system space
- includes data sources when searching in the "knowledge" tab
- gives a slight boost to `data_sources` over `data_sources_nodes`. Given that `data_sources_nodes` has 100x more documents than the `data_sources`, normalizing the scoring is slightly more complex
- fixes the link for content nodes that represent a data source

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
