### PR TITLE
fix(Intercom) - Prevent articles with empty content from being skipped

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -378,20 +378,22 @@ export async function upsertArticle({
       ? ` - ${parentCollection.description}`
       : "";
 
-  const articleContentInMarkdown =
+  let articleContentInMarkdown =
     typeof article.body === "string"
       ? turndownService.turndown(article.body)
       : "";
 
-  // append the collection description at the beginning of the article
-  const markdown = `CATEGORY: ${categoryContent}\n\n${articleContentInMarkdown}`;
-
   if (!articleContentInMarkdown) {
     logger.warn(
       { ...loggerArgs, connectorId, articleId: article.id },
-      "[Intercom] Article has no content. Skipping sync."
+      "[Intercom] Article has no content."
     );
+    // We still sync articles that have no content to have the node appear.
+    articleContentInMarkdown = "Article without content.";
   }
+
+  // append the collection description at the beginning of the article
+  const markdown = `CATEGORY: ${categoryContent}\n\n${articleContentInMarkdown}`;
 
   const createdAtDate = new Date(article.created_at * 1000);
   const updatedAtDate = new Date(article.updated_at * 1000);

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -386,62 +386,62 @@ export async function upsertArticle({
   // append the collection description at the beginning of the article
   const markdown = `CATEGORY: ${categoryContent}\n\n${articleContentInMarkdown}`;
 
-  if (articleContentInMarkdown) {
-    const createdAtDate = new Date(article.created_at * 1000);
-    const updatedAtDate = new Date(article.updated_at * 1000);
-
-    const renderedMarkdown = await renderMarkdownSection(
-      dataSourceConfig,
-      markdown
-    );
-    const renderedPage = await renderDocumentTitleAndContent({
-      dataSourceConfig,
-      title: article.title,
-      content: renderedMarkdown,
-      createdAt: createdAtDate,
-      updatedAt: updatedAtDate,
-    });
-
-    const documentId = getHelpCenterArticleInternalId(connectorId, article.id);
-
-    const parents = await getParentIdsForArticle({
-      documentId,
-      connectorId,
-      parentCollectionId,
-      helpCenterId,
-    });
-
-    await upsertDataSourceDocument({
-      dataSourceConfig,
-      documentId,
-      documentContent: renderedPage,
-      documentUrl: articleUrl,
-      timestampMs: updatedAtDate.getTime(),
-      tags: [
-        `title:${article.title}`,
-        `createdAt:${createdAtDate.getTime()}`,
-        `updatedAt:${updatedAtDate.getTime()}`,
-      ],
-      parents,
-      parentId: parents[1],
-      loggerArgs: {
-        ...loggerArgs,
-        articleId: article.id,
-      },
-      upsertContext: {
-        sync_type: "batch",
-      },
-      title: article.title,
-      mimeType: MIME_TYPES.INTERCOM.ARTICLE,
-      async: true,
-    });
-    await articleOnDb.update({
-      lastUpsertedTs: new Date(currentSyncMs),
-    });
-  } else {
+  if (!articleContentInMarkdown) {
     logger.warn(
       { ...loggerArgs, connectorId, articleId: article.id },
       "[Intercom] Article has no content. Skipping sync."
     );
   }
+
+  const createdAtDate = new Date(article.created_at * 1000);
+  const updatedAtDate = new Date(article.updated_at * 1000);
+
+  const renderedMarkdown = await renderMarkdownSection(
+    dataSourceConfig,
+    markdown
+  );
+  const renderedPage = await renderDocumentTitleAndContent({
+    dataSourceConfig,
+    title: article.title,
+    content: renderedMarkdown,
+    createdAt: createdAtDate,
+    updatedAt: updatedAtDate,
+  });
+
+  const documentId = getHelpCenterArticleInternalId(connectorId, article.id);
+
+  const parents = await getParentIdsForArticle({
+    documentId,
+    connectorId,
+    parentCollectionId,
+    helpCenterId,
+  });
+
+  await upsertDataSourceDocument({
+    dataSourceConfig,
+    documentId,
+    documentContent: renderedPage,
+    documentUrl: articleUrl,
+    timestampMs: updatedAtDate.getTime(),
+    tags: [
+      `title:${article.title}`,
+      `createdAt:${createdAtDate.getTime()}`,
+      `updatedAt:${updatedAtDate.getTime()}`,
+    ],
+    parents,
+    parentId: parents[1],
+    loggerArgs: {
+      ...loggerArgs,
+      articleId: article.id,
+    },
+    upsertContext: {
+      sync_type: "batch",
+    },
+    title: article.title,
+    mimeType: MIME_TYPES.INTERCOM.ARTICLE,
+    async: true,
+  });
+  await articleOnDb.update({
+    lastUpsertedTs: new Date(currentSyncMs),
+  });
 }

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -385,7 +385,7 @@ export async function upsertArticle({
 
   if (!articleContentInMarkdown) {
     logger.warn(
-      { ...loggerArgs, connectorId, articleId: article.id },
+      { ...loggerArgs, articleId: article.id },
       "[Intercom] Article has no content."
     );
     // We still sync articles that have no content to have the node appear.


### PR DESCRIPTION
## Description

- Currently, Intercom article upserts are skipped if the articles has no content.
- Given that we now check retrieve content nodes from `core`, this also means that the article now does not appear in the UI (it's a regression, it used to appear when read from `connectors`).
- This PR removes this behavior and always upserts the article.
- No backfill needed since for Intercom we resync the Help Centers on a cron schedule.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy `connectors`.