### PR TITLE
[front] - fix(migrations): fix migration script `20250303_backfill_conversation_ids`

### DIFF
--- a/front/migrations/20250303_backfill_conversation_ids.ts
+++ b/front/migrations/20250303_backfill_conversation_ids.ts
@@ -55,12 +55,14 @@ async function backfillDataSourceViewConversationId(
 
       if (execute) {
         const dsvForConversations = dataSourceViews.map((view) => ({
-          conversationId: dataSource.conversationId!,
+          conversationId: dataSource.conversationId,
           dataSourceViewId: view.id,
           workspaceId: workspace.id,
         }));
 
-        await DataSourceViewForConversation.bulkCreate(dsvForConversations);
+        await DataSourceViewForConversation.bulkCreate(dsvForConversations, {
+          ignoreDuplicates: true,
+        });
 
         logger.info(
           {


### PR DESCRIPTION
## Description

This PR adds `ignoreDuplicates` flag to `bulkCreate` operation to prevent duplicate entries and errors during the backfilling of `DataSourceViewForConversation` entries.

## Risk

Low 

## Deploy Plan

- Run migration script