### PR TITLE
[sparkle] - refactor(collapsible): revamp Collapsible

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.431",
+  "version": "0.2.432",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.431",
+      "version": "0.2.432",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -14,6 +14,7 @@
         "@headlessui/react": "^1.7.19",
         "@radix-ui/react-aspect-ratio": "^1.1.0",
         "@radix-ui/react-checkbox": "^1.1.2",
+        "@radix-ui/react-collapsible": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.0",
@@ -3804,6 +3805,192 @@
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.3.tgz",
+      "integrity": "sha512-jFSerheto1X03MUC0g6R7LedNW9EEGWdg9W1+MlpkMLwGkgkbUXLPBH/KIuWKXUoeYRVY11llqbTBDzuLg7qrw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -100,6 +100,7 @@
     "@headlessui/react": "^1.7.19",
     "@radix-ui/react-aspect-ratio": "^1.1.0",
     "@radix-ui/react-checkbox": "^1.1.2",
+    "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-label": "^2.1.0",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.431",
+  "version": "0.2.432",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -155,7 +155,7 @@ const CollapsibleContent = React.forwardRef<
 CollapsibleContent.displayName = "CollapsibleContent";
 
 export interface CollapsibleComponentProps {
-  rootProps?: Omit<CollapsibleProps, "children">;
+  rootProps?: Omit<CollapsibleProps, "children" | "open">;
   triggerProps?: Omit<CollapsibleTriggerProps, "children" | "defaultOpen">;
   triggerChildren?: React.ReactNode;
   contentProps?: Omit<CollapsibleContentProps, "children">;
@@ -170,12 +170,15 @@ const CollapsibleComponent = React.forwardRef<
     { rootProps, triggerProps, triggerChildren, contentProps, contentChildren },
     ref
   ) => {
+    const [open, setOpen] = React.useState(!!rootProps?.defaultOpen);
     return (
-      <Collapsible ref={ref} {...rootProps}>
-        <CollapsibleTrigger
-          {...triggerProps}
-          defaultOpen={rootProps?.defaultOpen ?? false}
-        >
+      <Collapsible
+        ref={ref}
+        {...rootProps}
+        open={open}
+        onOpenChange={(open) => setOpen(open)}
+      >
+        <CollapsibleTrigger {...triggerProps} defaultOpen={open}>
           {triggerChildren}
         </CollapsibleTrigger>
         <CollapsibleContent {...contentProps}>

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -1,10 +1,50 @@
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { ChevronDownIcon, ChevronRightIcon } from "@sparkle/icons/solid";
 import { cn } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
+
+const labelVariants = cva(
+  "s-inline-flex s-transition-colors s-ease-out s-duration-400 s-box-border s-gap-x-2 s-select-none s-text-sm",
+  {
+    variants: {
+      variant: {
+        primary: "s-text-action-600 dark:s-text-action-600-night",
+        secondary: "s-text-foreground dark:s-text-foreground-night",
+      },
+      disabled: {
+        true: "s-text-muted dark:s-text-muted-night",
+        false:
+          "group-hover/col:s-text-action-500 dark:group-hover/col:s-text-action-500-night active:s-text-action-700 dark:active:s-text-action-700-night",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      disabled: false,
+    },
+  }
+);
+
+const chevronVariants = cva("s-transition-transform s-duration-150", {
+  variants: {
+    variant: {
+      primary: "s-text-muted-foreground dark:s-text-muted-foreground-night",
+      secondary: "s-text-muted-foreground dark:s-text-muted-foreground-night",
+    },
+    disabled: {
+      true: "s-text-muted dark:s-text-muted-night",
+      false:
+        "group-hover/col:s-text-action-500 dark:group-hover/col:s-text-action-500-night active:s-text-action-700 dark:active:s-text-action-700-night",
+    },
+  },
+  defaultVariants: {
+    variant: "primary",
+    disabled: false,
+  },
+});
 
 export interface CollapsibleProps
   extends CollapsiblePrimitive.CollapsibleProps {
@@ -23,10 +63,9 @@ const Collapsible = React.forwardRef<
 Collapsible.displayName = "Collapsible";
 
 export interface CollapsibleTriggerProps
-  extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger> {
+  extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger>,
+    Omit<VariantProps<typeof labelVariants>, "disabled"> {
   label?: string;
-  variant?: "primary" | "secondary";
-  disabled?: boolean;
 }
 
 const CollapsibleTrigger = React.forwardRef<
@@ -37,7 +76,7 @@ const CollapsibleTrigger = React.forwardRef<
     {
       label,
       children,
-      className = "",
+      className,
       disabled = false,
       variant = "primary",
       ...props
@@ -46,79 +85,33 @@ const CollapsibleTrigger = React.forwardRef<
   ) => {
     const [isOpen, setIsOpen] = React.useState(false);
 
-    const labelClasses = {
-      primary: {
-        base: "s-text-action-500 dark:s-text-action-500-night s-inline-flex s-transition-colors s-ease-out s-duration-400 s-box-border s-gap-x-2 s-select-none",
-        hover:
-          "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
-        active: "active:s-text-action-600 dark:active:s-text-action-600-night",
-        disabled: "s-element-500 dark:s-element-500-night",
-      },
-
-      secondary: {
-        base: "s-text-foreground dark:s-text-foreground-night s-inline-flex s-transition-colors s-ease-out s-duration-400 s-box-border s-gap-x-2 s-select-none",
-        hover:
-          "group-hover/col:s-text-action-500 dark:group-hover/col:s-text-action-500-night",
-        active: "active:s-text-action-600 dark:active:s-text-action-600-night",
-        disabled: "s-element-500 dark:s-element-500-night",
-      },
-    };
-
-    const chevronClasses = {
-      primary: {
-        base: "s-text-element-600 dark:s-text-element-600-night",
-        hover:
-          "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
-        active: "active:s-text-action-700 dark:active:s-text-action-700-night",
-        disabled: "s-element-500 dark:s-element-500-night",
-      },
-      secondary: {
-        base: "s-text-element-600 dark:s-text-element-600-night",
-        hover:
-          "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
-        active: "active:s-text-action-700 dark:active:s-text-action-700-night",
-        disabled: "s-element-500 dark:s-element-500-night",
-      },
-    };
-
-    const finalLabelClasses = cn(
-      labelClasses[variant].base,
-      !disabled ? labelClasses[variant].active : "",
-      !disabled ? labelClasses[variant].hover : "",
-      disabled ? labelClasses[variant].disabled : ""
-    );
-
-    const finalChevronClasses = cn(
-      chevronClasses[variant].base,
-      !disabled ? chevronClasses[variant].active : "",
-      !disabled ? chevronClasses[variant].hover : "",
-      disabled ? chevronClasses[variant].disabled : "",
-      "s-transition-transform s-duration-300"
-    );
-
     return (
       <CollapsiblePrimitive.Trigger
         ref={ref}
         disabled={disabled}
         className={cn(
+          "s-group/col s-flex s-items-center s-gap-1 s-font-medium focus:s-outline-none focus:s-ring-0",
           disabled ? "s-cursor-default" : "s-cursor-pointer",
-          className,
-          "s-group/col s-flex s-items-center s-justify-items-center s-gap-1 s-text-sm s-font-medium focus:s-outline-none focus:s-ring-0"
+          className
         )}
         onClick={() => setIsOpen((prev) => !prev)}
         {...props}
       >
-        <div className="s-transition-transform s-duration-200 data-[state=open]:s-rotate-90">
+        <span
+          className={cn(
+            "s-transition-transform s-duration-200",
+            chevronVariants({ variant, disabled })
+          )}
+        >
           <Icon
             visual={isOpen ? ChevronDownIcon : ChevronRightIcon}
             size="sm"
-            className={finalChevronClasses}
           />
-        </div>
+        </span>
         {children ? (
           children
         ) : (
-          <span className={finalLabelClasses}>{label}</span>
+          <span className={labelVariants({ variant, disabled })}>{label}</span>
         )}
       </CollapsiblePrimitive.Trigger>
     );
@@ -126,17 +119,29 @@ const CollapsibleTrigger = React.forwardRef<
 );
 CollapsibleTrigger.displayName = "CollapsibleTrigger";
 
+const contentVariants = cva("s-overflow-hidden s-transition-all", {
+  variants: {
+    variant: {
+      default: "s-text-foreground dark:s-text-foreground-night",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
 export interface CollapsibleContentProps
-  extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content> {}
+  extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>,
+    VariantProps<typeof contentVariants> {}
 
 const CollapsibleContent = React.forwardRef<
   React.ElementRef<typeof CollapsiblePrimitive.Content>,
   CollapsibleContentProps
->(({ children, className, ...props }, ref) => (
+>(({ children, className, variant, ...props }, ref) => (
   <CollapsiblePrimitive.Content
     ref={ref}
     className={cn(
-      "s-overflow-hidden s-text-primary-500 dark:s-text-primary-500-night",
+      contentVariants({ variant }),
       "data-[state=closed]:s-animate-collapse-up data-[state=open]:s-animate-collapse-down",
       className
     )}

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -66,6 +66,7 @@ export interface CollapsibleTriggerProps
   extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger>,
     Omit<VariantProps<typeof labelVariants>, "disabled"> {
   label?: string;
+  defaultOpen?: boolean;
 }
 
 const CollapsibleTrigger = React.forwardRef<
@@ -78,12 +79,13 @@ const CollapsibleTrigger = React.forwardRef<
       children,
       className,
       disabled = false,
+      defaultOpen = false,
       variant = "primary",
       ...props
     },
     ref
   ) => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = React.useState(defaultOpen);
 
     return (
       <CollapsiblePrimitive.Trigger
@@ -152,4 +154,41 @@ const CollapsibleContent = React.forwardRef<
 ));
 CollapsibleContent.displayName = "CollapsibleContent";
 
-export { Collapsible, CollapsibleContent, CollapsibleTrigger };
+export interface CollapsibleComponentProps {
+  rootProps: Omit<CollapsibleProps, "children">;
+  triggerProps: Omit<CollapsibleTriggerProps, "children" | "defaultOpen">;
+  triggerChildren?: React.ReactNode;
+  contentProps: Omit<CollapsibleContentProps, "children">;
+  contentChildren?: React.ReactNode;
+}
+
+const CollapsibleComponent = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Root>,
+  CollapsibleComponentProps
+>(
+  (
+    { rootProps, triggerProps, triggerChildren, contentProps, contentChildren },
+    ref
+  ) => {
+    return (
+      <Collapsible ref={ref} {...rootProps}>
+        <CollapsibleTrigger
+          {...triggerProps}
+          defaultOpen={rootProps.defaultOpen}
+        >
+          {triggerChildren}
+        </CollapsibleTrigger>
+        <CollapsibleContent {...contentProps}>
+          {contentChildren}
+        </CollapsibleContent>
+      </Collapsible>
+    );
+  }
+);
+
+export {
+  Collapsible,
+  CollapsibleComponent,
+  CollapsibleContent,
+  CollapsibleTrigger,
+};

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -156,7 +156,7 @@ CollapsibleContent.displayName = "CollapsibleContent";
 
 export interface CollapsibleComponentProps {
   rootProps: Omit<CollapsibleProps, "children">;
-  triggerProps: Omit<CollapsibleTriggerProps, "children" | "defaultOpen">;
+  triggerProps?: Omit<CollapsibleTriggerProps, "children" | "defaultOpen">;
   triggerChildren?: React.ReactNode;
   contentProps?: Omit<CollapsibleContentProps, "children">;
   contentChildren?: React.ReactNode;

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -66,7 +66,7 @@ export interface CollapsibleTriggerProps
   extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger>,
     Omit<VariantProps<typeof labelVariants>, "disabled"> {
   label?: string;
-  defaultOpen?: boolean;
+  isOpen?: boolean;
 }
 
 const CollapsibleTrigger = React.forwardRef<
@@ -79,14 +79,12 @@ const CollapsibleTrigger = React.forwardRef<
       children,
       className,
       disabled = false,
-      defaultOpen = false,
+      isOpen = false,
       variant = "primary",
       ...props
     },
     ref
   ) => {
-    const [isOpen, setIsOpen] = React.useState(defaultOpen);
-
     return (
       <CollapsiblePrimitive.Trigger
         ref={ref}
@@ -96,7 +94,6 @@ const CollapsibleTrigger = React.forwardRef<
           disabled ? "s-cursor-default" : "s-cursor-pointer",
           className
         )}
-        onClick={() => setIsOpen((prev) => !prev)}
         {...props}
       >
         <span
@@ -178,7 +175,7 @@ const CollapsibleComponent = React.forwardRef<
         open={open}
         onOpenChange={(open) => setOpen(open)}
       >
-        <CollapsibleTrigger {...triggerProps} defaultOpen={open}>
+        <CollapsibleTrigger {...triggerProps} isOpen={open}>
           {triggerChildren}
         </CollapsibleTrigger>
         <CollapsibleContent {...contentProps}>

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -1,141 +1,152 @@
-import { Disclosure, Transition } from "@headlessui/react";
-import React, { createContext, useContext } from "react";
+import * as React from "react";
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
 
 import { ChevronDownIcon, ChevronRightIcon } from "@sparkle/icons/solid";
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
 
-const OpenStateContext = createContext<boolean | undefined>(undefined);
-
-const useOpenState = (): boolean => {
-  const context = useContext(OpenStateContext);
-  if (context === undefined) {
-    throw new Error("useOpenState must be used within a OpenStateProvider");
-  }
-  return context;
-};
-
-export interface CollapsibleProps {
+export interface CollapsibleProps
+  extends CollapsiblePrimitive.CollapsibleProps {
   children: React.ReactNode;
-  defaultOpen?: boolean;
-}
-
-export const Collapsible: React.FC<CollapsibleProps> & {
-  Button: React.FC<CollapsibleButtonProps>;
-  Panel: React.FC<CollapsiblePanelProps>;
-} = ({ children, defaultOpen }) => (
-  <Disclosure defaultOpen={defaultOpen}>
-    {({ open }) => (
-      <OpenStateContext.Provider value={open}>
-        {children}
-      </OpenStateContext.Provider>
-    )}
-  </Disclosure>
-);
-
-export interface CollapsibleButtonProps {
-  label?: string;
   className?: string;
-  disabled?: boolean;
-  children?: React.ReactNode;
+}
+
+const Collapsible = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Root>,
+  CollapsibleProps
+>(({ children, className, ...props }, ref) => (
+  <CollapsiblePrimitive.Root ref={ref} className={className} {...props}>
+    {children}
+  </CollapsiblePrimitive.Root>
+));
+Collapsible.displayName = "Collapsible";
+
+export interface CollapsibleTriggerProps
+  extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger> {
+  label?: string;
   variant?: "primary" | "secondary";
-}
-Collapsible.Button = function ({
-  label,
-  children,
-  className = "",
-  disabled = false,
-  variant = "primary",
-}: CollapsibleButtonProps) {
-  const open = useOpenState();
-
-  const labelClasses = {
-    primary: {
-      base: "s-text-action-500 dark:s-text-action-500-night s-inline-flex s-transition-colors s-ease-out s-duration-400 s-box-border s-gap-x-2 s-select-none",
-      hover:
-        "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
-      active: "active:s-text-action-600 dark:active:s-text-action-600-night",
-      disabled: "s-element-500 dark:s-element-500-night",
-    },
-
-    secondary: {
-      base: "s-text-foreground dark:s-text-foreground-night s-inline-flex s-transition-colors s-ease-out s-duration-400 s-box-border s-gap-x-2 s-select-none",
-      hover:
-        "group-hover/col:s-text-action-500 dark:group-hover/col:s-text-action-500-night",
-      active: "active:s-text-action-600 dark:active:s-text-action-600-night",
-      disabled: "s-element-500 dark:s-element-500-night",
-    },
-  };
-
-  const chevronClasses = {
-    primary: {
-      base: "s-text-element-600 dark:s-text-element-600-night",
-      hover:
-        "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
-      active: "active:s-text-action-700 dark:active:s-text-action-700-night",
-      disabled: "s-element-500 dark:s-element-500-night",
-    },
-    secondary: {
-      base: "s-text-element-600 dark:s-text-element-600-night",
-      hover:
-        "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
-      active: "active:s-text-action-700 dark:active:s-text-action-700-night",
-      disabled: "s-element-500 dark:s-element-500-night",
-    },
-  };
-
-  const finalLabelClasses = classNames(
-    labelClasses[variant].base,
-    !disabled ? labelClasses[variant].active : "",
-    !disabled ? labelClasses[variant].hover : "",
-    disabled ? labelClasses[variant].disabled : ""
-  );
-
-  const finalChevronClasses = classNames(
-    chevronClasses[variant].base,
-    !disabled ? chevronClasses[variant].active : "",
-    !disabled ? chevronClasses[variant].hover : "",
-    disabled ? chevronClasses[variant].disabled : ""
-  );
-
-  return (
-    <Disclosure.Button
-      disabled={disabled}
-      className={classNames(
-        disabled ? "s-cursor-default" : "s-cursor-pointer",
-        className,
-        "s-group/col s-flex s-items-center s-justify-items-center s-gap-1 s-text-sm s-font-medium focus:s-outline-none focus:s-ring-0"
-      )}
-    >
-      <Icon
-        visual={open ? ChevronDownIcon : ChevronRightIcon}
-        size="sm"
-        className={finalChevronClasses}
-      />
-      {children ? children : <span className={finalLabelClasses}>{label}</span>}
-    </Disclosure.Button>
-  );
-};
-
-export interface CollapsiblePanelProps {
-  children: React.ReactNode;
-  open?: boolean;
+  disabled?: boolean;
 }
 
-Collapsible.Panel = ({ children }: CollapsiblePanelProps) => (
-  <Transition
-    enter="s-transition s-duration-300 s-ease-out"
-    enterFrom="s-transform s-scale-95 s-opacity-0"
-    enterTo="s-transform s-scale-100 s-opacity-100"
-    leave="s-transition s-duration-300 s-ease-out"
-    leaveFrom="s-transform s-scale-100 s-opacity-100"
-    leaveTo="s-transform s-scale-95 s-opacity-0"
-  >
-    <Disclosure.Panel>
-      <div className="s-text-primary-500 dark:s-text-primary-500-night">
-        {children}
-      </div>
-    </Disclosure.Panel>
-  </Transition>
+const CollapsibleTrigger = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Trigger>,
+  CollapsibleTriggerProps
+>(
+  (
+    {
+      label,
+      children,
+      className = "",
+      disabled = false,
+      variant = "primary",
+      ...props
+    },
+    ref
+  ) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    const labelClasses = {
+      primary: {
+        base: "s-text-action-500 dark:s-text-action-500-night s-inline-flex s-transition-colors s-ease-out s-duration-400 s-box-border s-gap-x-2 s-select-none",
+        hover:
+          "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
+        active: "active:s-text-action-600 dark:active:s-text-action-600-night",
+        disabled: "s-element-500 dark:s-element-500-night",
+      },
+
+      secondary: {
+        base: "s-text-foreground dark:s-text-foreground-night s-inline-flex s-transition-colors s-ease-out s-duration-400 s-box-border s-gap-x-2 s-select-none",
+        hover:
+          "group-hover/col:s-text-action-500 dark:group-hover/col:s-text-action-500-night",
+        active: "active:s-text-action-600 dark:active:s-text-action-600-night",
+        disabled: "s-element-500 dark:s-element-500-night",
+      },
+    };
+
+    const chevronClasses = {
+      primary: {
+        base: "s-text-element-600 dark:s-text-element-600-night",
+        hover:
+          "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
+        active: "active:s-text-action-700 dark:active:s-text-action-700-night",
+        disabled: "s-element-500 dark:s-element-500-night",
+      },
+      secondary: {
+        base: "s-text-element-600 dark:s-text-element-600-night",
+        hover:
+          "group-hover/col:s-text-action-400 dark:group-hover/col:s-text-action-400-night",
+        active: "active:s-text-action-700 dark:active:s-text-action-700-night",
+        disabled: "s-element-500 dark:s-element-500-night",
+      },
+    };
+
+    const finalLabelClasses = cn(
+      labelClasses[variant].base,
+      !disabled ? labelClasses[variant].active : "",
+      !disabled ? labelClasses[variant].hover : "",
+      disabled ? labelClasses[variant].disabled : ""
+    );
+
+    const finalChevronClasses = cn(
+      chevronClasses[variant].base,
+      !disabled ? chevronClasses[variant].active : "",
+      !disabled ? chevronClasses[variant].hover : "",
+      disabled ? chevronClasses[variant].disabled : "",
+      "s-transition-transform s-duration-300"
+    );
+
+    return (
+      <CollapsiblePrimitive.Trigger
+        ref={ref}
+        disabled={disabled}
+        className={cn(
+          disabled ? "s-cursor-default" : "s-cursor-pointer",
+          className,
+          "s-group/col s-flex s-items-center s-justify-items-center s-gap-1 s-text-sm s-font-medium focus:s-outline-none focus:s-ring-0"
+        )}
+        onClick={() => setIsOpen((prev) => !prev)}
+        {...props}
+      >
+        <div className="s-transition-transform s-duration-200 data-[state=open]:s-rotate-90">
+          <Icon
+            visual={isOpen ? ChevronDownIcon : ChevronRightIcon}
+            size="sm"
+            className={finalChevronClasses}
+          />
+        </div>
+        {children ? (
+          children
+        ) : (
+          <span className={finalLabelClasses}>{label}</span>
+        )}
+      </CollapsiblePrimitive.Trigger>
+    );
+  }
 );
+CollapsibleTrigger.displayName = "CollapsibleTrigger";
+
+export interface CollapsibleContentProps
+  extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content> {}
+
+const CollapsibleContent = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Content>,
+  CollapsibleContentProps
+>(({ children, className, ...props }, ref) => (
+  <CollapsiblePrimitive.Content
+    ref={ref}
+    className={cn(
+      "s-overflow-hidden s-text-primary-500 dark:s-text-primary-500-night",
+      "s-transition-all s-duration-300 s-ease-out",
+      "data-[state=closed]:s-h-0 data-[state=closed]:s-opacity-0",
+      "data-[state=open]:s-h-auto data-[state=open]:s-opacity-100",
+      className
+    )}
+    {...props}
+  >
+    <div className="s-py-2">{children}</div>
+  </CollapsiblePrimitive.Content>
+));
+CollapsibleContent.displayName = "CollapsibleContent";
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -155,7 +155,7 @@ const CollapsibleContent = React.forwardRef<
 CollapsibleContent.displayName = "CollapsibleContent";
 
 export interface CollapsibleComponentProps {
-  rootProps: Omit<CollapsibleProps, "children">;
+  rootProps?: Omit<CollapsibleProps, "children">;
   triggerProps?: Omit<CollapsibleTriggerProps, "children" | "defaultOpen">;
   triggerChildren?: React.ReactNode;
   contentProps?: Omit<CollapsibleContentProps, "children">;
@@ -174,7 +174,7 @@ const CollapsibleComponent = React.forwardRef<
       <Collapsible ref={ref} {...rootProps}>
         <CollapsibleTrigger
           {...triggerProps}
-          defaultOpen={rootProps.defaultOpen}
+          defaultOpen={rootProps?.defaultOpen ?? false}
         >
           {triggerChildren}
         </CollapsibleTrigger>

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -158,7 +158,7 @@ export interface CollapsibleComponentProps {
   rootProps: Omit<CollapsibleProps, "children">;
   triggerProps: Omit<CollapsibleTriggerProps, "children" | "defaultOpen">;
   triggerChildren?: React.ReactNode;
-  contentProps: Omit<CollapsibleContentProps, "children">;
+  contentProps?: Omit<CollapsibleContentProps, "children">;
   contentChildren?: React.ReactNode;
 }
 

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+import * as React from "react";
 
 import { ChevronDownIcon, ChevronRightIcon } from "@sparkle/icons/solid";
 import { cn } from "@sparkle/lib/utils";
@@ -137,9 +137,7 @@ const CollapsibleContent = React.forwardRef<
     ref={ref}
     className={cn(
       "s-overflow-hidden s-text-primary-500 dark:s-text-primary-500-night",
-      "s-transition-all s-duration-300 s-ease-out",
-      "data-[state=closed]:s-h-0 data-[state=closed]:s-opacity-0",
-      "data-[state=open]:s-h-auto data-[state=open]:s-opacity-100",
+      "data-[state=closed]:s-animate-collapse-up data-[state=open]:s-animate-collapse-down",
       className
     )}
     {...props}

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -27,9 +27,9 @@ export * from "./Citation";
 export { default as CollapseButton } from "./CollapseButton";
 export {
   Collapsible,
+  CollapsibleComponent,
   CollapsibleContent,
   CollapsibleTrigger,
-  CollapsibleComponent,
 } from "./Collapsible";
 export { ColorPicker } from "./ColorPicker";
 export { default as ConfettiBackground } from "./ConfettiBackground";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -29,6 +29,7 @@ export {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  CollapsibleComponent,
 } from "./Collapsible";
 export { ColorPicker } from "./ColorPicker";
 export { default as ConfettiBackground } from "./ConfettiBackground";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -25,7 +25,11 @@ export {
 export { Chip } from "./Chip";
 export * from "./Citation";
 export { default as CollapseButton } from "./CollapseButton";
-export { Collapsible } from "./Collapsible";
+export {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./Collapsible";
 export { ColorPicker } from "./ColorPicker";
 export { default as ConfettiBackground } from "./ConfettiBackground";
 export { Container } from "./Container";

--- a/sparkle/src/stories/Collapsible.stories.tsx
+++ b/sparkle/src/stories/Collapsible.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 
-import { Chip, Collapsible } from "../index_with_tw_base";
+import {
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../index_with_tw_base";
 
 const meta = {
   title: "Primitives/Collapsible",
@@ -13,49 +18,49 @@ export default meta;
 export const CollapsibleExample = () => (
   <div>
     <Collapsible>
-      <Collapsible.Button label="Click me" />
-      <Collapsible.Panel>
+      <CollapsibleTrigger label="Click me" />
+      <CollapsibleContent>
         <div className="s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-slate-200">
           Hello
         </div>
-      </Collapsible.Panel>
+      </CollapsibleContent>
     </Collapsible>
 
     <Collapsible>
-      <Collapsible.Button label="Click me" />
-      <Collapsible.Panel>
+      <CollapsibleTrigger label="Click me" />
+      <CollapsibleContent>
         <div className="s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-slate-200">
           Hello
         </div>
-      </Collapsible.Panel>
+      </CollapsibleContent>
     </Collapsible>
     <Collapsible>
-      <Collapsible.Button label="Click me" />
-      <Collapsible.Panel>
+      <CollapsibleTrigger label="Click me" />
+      <CollapsibleContent>
         <div className="s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-slate-200">
           Hello
         </div>
-      </Collapsible.Panel>
+      </CollapsibleContent>
     </Collapsible>
     <Collapsible>
-      <Collapsible.Button>
+      <CollapsibleTrigger>
         <Chip>Click me custom</Chip>
-      </Collapsible.Button>
-      <Collapsible.Panel>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
         <div className="mt-1 s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-slate-200">
           Anything goes for the Collapsible button
         </div>
-      </Collapsible.Panel>
+      </CollapsibleContent>
     </Collapsible>
     <Collapsible defaultOpen={true}>
-      <Collapsible.Button>
+      <CollapsibleTrigger>
         <Chip>Click me custom</Chip>
-      </Collapsible.Button>
-      <Collapsible.Panel>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
         <div className="mt-1 s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-slate-200">
           This one is open by default
         </div>
-      </Collapsible.Panel>
+      </CollapsibleContent>
     </Collapsible>
   </div>
 );

--- a/sparkle/src/stories/Collapsible.stories.tsx
+++ b/sparkle/src/stories/Collapsible.stories.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import {
   Chip,
   Collapsible,
+  CollapsibleComponent,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../index_with_tw_base";
@@ -52,15 +53,17 @@ export const CollapsibleExample = () => (
         </div>
       </CollapsibleContent>
     </Collapsible>
-    <Collapsible defaultOpen={true}>
-      <CollapsibleTrigger>
-        <Chip>Click me custom</Chip>
-      </CollapsibleTrigger>
-      <CollapsibleContent>
-        <div className="mt-1 s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-slate-200">
-          This one is open by default
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
+    <div className="s-rounded-md s-border s-border-gray-200 s-p-4">
+      <h3 className="s-mb-2 s-font-medium">Default Open</h3>
+      <CollapsibleComponent
+        rootProps={{ defaultOpen: true }}
+        triggerProps={{ label: "Open by default" }}
+        contentChildren={
+          <div className="s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-slate-200">
+            This collapsible is open by default
+          </div>
+        }
+      />
+    </div>
   </div>
 );

--- a/sparkle/src/styles/global_with_tw_base.css
+++ b/sparkle/src/styles/global_with_tw_base.css
@@ -25,4 +25,22 @@
   }
 }
 
+@keyframes collapse-down {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--radix-collapsible-content-height);
+  }
+}
+
+@keyframes collapse-up {
+  from {
+    height: var(--radix-collapsible-content-height);
+  }
+  to {
+    height: 0;
+  }
+}
+
 @import url("https://use.typekit.net/jnb2umy.css");

--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -216,8 +216,8 @@ module.exports = {
         "cursor-blink": "cursor-blink 0.9s infinite;",
         "move-square": "move-square 3s ease-out infinite",
         rainbow: "rainbow var(--speed, 6s) infinite linear",
-        "collapse-down": "collapse-down 300ms ease-out",
-        "collapse-up": "collapse-up 300ms ease-out",
+        "collapse-down": "collapse-down 150ms ease-out",
+        "collapse-up": "collapse-up 150ms ease-out",
       },
       colors: {
         brand: {

--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -204,6 +204,20 @@ module.exports = {
           "0%": { "background-position": "0%" },
           "100%": { "background-position": "200%" },
         },
+        "collapse-down": {
+          from: { height: "0", opacity: "0" },
+          to: {
+            height: "var(--radix-collapsible-content-height)",
+            opacity: "1",
+          },
+        },
+        "collapse-up": {
+          from: {
+            height: "var(--radix-collapsible-content-height)",
+            opacity: "1",
+          },
+          to: { height: "0", opacity: "0" },
+        },
       },
       animation: {
         "shiny-text": "shiny-text 2s infinite",

--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -216,6 +216,8 @@ module.exports = {
         "cursor-blink": "cursor-blink 0.9s infinite;",
         "move-square": "move-square 3s ease-out infinite",
         rainbow: "rainbow var(--speed, 6s) infinite linear",
+        "collapse-down": "collapse-down 300ms ease-out",
+        "collapse-up": "collapse-up 300ms ease-out",
       },
       colors: {
         brand: {


### PR DESCRIPTION
## Description

This PR refactors the `Collapsible` component to use Radix UI's collapsible primitive instead of HeadlessUI.

## Risk

Breaking UI

## Deploy Plan

- Publish alpha
- Upgrade sparkle version in front
- Publish sparkle
- Deploy front