### PR TITLE
Fix retrieving parent title for content nodes

### DIFF
--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -120,6 +120,13 @@ export function getLocationForDataSourceViewContentNode(
 ) {
   const { dataSource } = node.dataSourceView;
   const { connectorProvider } = dataSource;
+  const providerName = connectorProvider
+    ? CONNECTOR_CONFIGURATIONS[connectorProvider].name
+    : "Folders";
 
-  return `${connectorProvider ? CONNECTOR_CONFIGURATIONS[connectorProvider].name : "Folders"}/../${node.parentTitle}`;
+  if (!node.parentTitle) {
+    return providerName;
+  }
+
+  return `${providerName}/../${node.parentTitle}`;
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/2284.

This PR addresses an issue with retrieving parent titles for nodes matching a search query. The problem stemmed from the Elasticsearch query not considering the data source of the nodes.

Since `node_id` is not globally unique across data sources, we could potentially retrieve more parent nodes than the original number of nodes in the results. The ES query was capped to return at most the number of matching nodes, which could lead to missing the correct parent nodes.

To fix this, the PR now includes `data_source_internal_id` in the query parameters, ensuring we retrieve the correct parent title associated with each node rather than potentially retrieving unrelated nodes that happen to share the same ID from different data sources. It also fixes the location path displayed for folders.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
