### PR TITLE
[front] - fix(dsvSelector): loading state

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -19,6 +19,7 @@ import {
   SheetContainer,
   SheetContent,
   SheetHeader,
+  SheetTitle,
   Spinner,
   Tabs,
   TabsList,
@@ -32,6 +33,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import { isBuilder, removeNulls } from "@dust-tt/types";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useCallback, useState } from "react";
 
 import { AssistantDetailsButtonBar } from "@app/components/assistant/AssistantDetailsButtonBar";
@@ -349,6 +351,9 @@ export function AssistantDetails({
     <Sheet open={!!assistantId} onOpenChange={onClose}>
       <SheetContent size="lg">
         <SheetHeader className="flex flex-col gap-5 pb-0 text-sm text-foreground dark:text-foreground-night">
+          <VisuallyHidden>
+            <SheetTitle />
+          </VisuallyHidden>
           <DescriptionSection />
           {isBuilder(owner) && (
             <Tabs value={selectedTab}>

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -145,6 +145,7 @@ export function DataSourceViewsSelector({
   >();
   const [searchSpaceText, setSearchSpaceText] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState<string>("");
+  const [isDebouncing, setIsDebouncing] = useState(false);
 
   const { searchResultNodes, isSearchLoading, warningCode } = useSpaceSearch({
     dataSourceViews,
@@ -158,13 +159,16 @@ export function DataSourceViewsSelector({
 
   useEffect(() => {
     if (searchFeatureFlag) {
+      setIsDebouncing(true);
       const timeout = setTimeout(() => {
         setDebouncedSearch(
           searchSpaceText.length >= MIN_SEARCH_QUERY_SIZE ? searchSpaceText : ""
         );
+        setIsDebouncing(false);
       }, 300);
       return () => {
         clearTimeout(timeout);
+        setIsDebouncing(false);
       };
     }
   }, [searchSpaceText, searchFeatureFlag]);
@@ -290,7 +294,7 @@ export function DataSourceViewsSelector({
               setSearchSpaceText("");
             }
           }}
-          isLoading={isSearchLoading}
+          isLoading={isSearchLoading || isDebouncing}
           items={searchResultNodes}
           onItemSelect={(item) => {
             setSearchResult(item);


### PR DESCRIPTION
## Description

This PR fixes the loading state of the `SearchInputPopover` in the `DataSourceViewsSpaceSelector`. This was caused by the debouncing.

**References:**
- https://github.com/dust-tt/tasks/issues/2285

## Risk

Low

## Deploy Plan

Deploy `front`