### PR TITLE
fix(Zendesk) - Prevent articles with empty content from being skipped

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -31,10 +31,7 @@ export async function deleteArticle(
   dataSourceConfig: DataSourceConfig,
   loggerArgs: Record<string, string | number | null>
 ): Promise<void> {
-  logger.info(
-    { ...loggerArgs, connectorId, articleId },
-    "[Zendesk] Deleting article."
-  );
+  logger.info({ ...loggerArgs, articleId }, "[Zendesk] Deleting article.");
   await deleteDataSourceDocument(
     dataSourceConfig,
     getArticleInternalId({ connectorId, brandId, articleId })
@@ -101,7 +98,6 @@ export async function syncArticle({
   logger.info(
     {
       ...loggerArgs,
-      connectorId,
       articleId: article.id,
       articleUpdatedAt: updatedAtDate,
       dataSourceLastUpsertedAt: articleInDb?.lastUpsertedTs ?? null,
@@ -116,7 +112,7 @@ export async function syncArticle({
 
   if (!articleContentInMarkdown) {
     logger.warn(
-      { ...loggerArgs, connectorId, articleId: article.id },
+      { ...loggerArgs, articleId: article.id },
       "[Zendesk] Article has no content."
     );
     // We still sync articles that have no content to have the node appear.


### PR DESCRIPTION
## Description

- Same as https://github.com/dust-tt/dust/pull/11167 but for Zendesk.
- Currently, Zendesk article upserts are skipped if the article has no content.
- Given that we now check retrieve content nodes from core, this also means that the article now does not appear in the UI (it's a regression, it used to appear when read from connectors).
- This PR removes this behavior and always upserts the article.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy `connectors`.