### PR TITLE
refactor(content nodes) - Move the logic for setting `preventSelection` into the endpoint

### DIFF
--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -24,11 +24,7 @@ const getUseResourceHook =
       viewType,
     });
     return {
-      resources: res.nodes.map((n) => ({
-        ...n,
-        preventSelection:
-          n.preventSelection || (viewType === "table" && n.type !== "table"),
-      })),
+      resources: res.nodes,
       totalResourceCount: res.totalNodesCount,
       isResourcesLoading: res.isNodesLoading,
       isResourcesError: res.isNodesError,

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -78,11 +78,7 @@ const getUseResourceHook =
       viewType,
     });
     return {
-      resources: nodes.map((n) => ({
-        ...n,
-        preventSelection:
-          n.preventSelection || (viewType === "table" && n.type !== "table"),
-      })),
+      resources: nodes,
       totalResourceCount: totalNodesCount,
       isResourcesLoading: isNodesLoading,
       isResourcesError: isNodesError,

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -96,9 +96,9 @@ export function getContentNodeFromCoreNode(
     type: coreNode.node_type,
     expandable: isExpandable(coreNode, viewType),
     mimeType: coreNode.mime_type,
-    preventSelection: FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(
-      coreNode.mime_type
-    ),
+    preventSelection:
+      FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(coreNode.mime_type) ||
+      (viewType === "table" && coreNode.node_type !== "table"),
     parentTitle: coreNode.parent_title,
     dataSourceView,
   };


### PR DESCRIPTION
## Description

- Following the migration of content nodes from `connectors` to `core`, the `viewType` logic is now handled at a deeper level.
- Similarly the existing logic on `preventSelection` (in `viewType` table you can't select non-tables nodes) can be moved at the endpoint level rather than in the front-end.
- The end goal here is to centralize the logic surrounding the content nodes metadata since these are not specific to the call site (the metadata was designed to allow this, by passing around the `viewType` notably).

## Tests

- Tested locally, no automated test.

## Risk

- Low.

## Deploy Plan

- Deploy front.