### PR TITLE
[Elasticsearch] Fix: broken migration file

### DIFF
--- a/core/src/search_stores/migrations/20250224_default_search_analyzer.http
+++ b/core/src/search_stores/migrations/20250224_default_search_analyzer.http
@@ -1,4 +1,4 @@
-PUT core.data_sources_nodes/_mapping
+PUT core.data_sources_nodes_4/_mapping
 {
   "properties": {
     "title": {
@@ -13,20 +13,21 @@ PUT core.data_sources_nodes/_mapping
           "type": "keyword"
         }
       },
-      "tags": {
+      "analyzer": "standard"
+    },
+    "tags": {
+      "type": "text",
+      "fields": {
+        "edge": {
           "type": "text",
-          "fields": {
-            "edge": {
-              "type": "text",
-              "analyzer": "edge_analyzer",
-              "search_analyzer": "standard"
-            },
-            "keyword": {
-              "type": "keyword"
-            }
-          },
-          "analyzer": "standard"
+          "analyzer": "tag_edge_analyzer",
+          "search_analyzer": "standard"
         },
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "tag_normalizer"
+        }
+      },
       "analyzer": "standard"
     }
   }


### PR DESCRIPTION
Description
---
Migration file for search analyzer was malformed and different from the command posted on [slack](https://dust4ai.slack.com/archives/C050SM8NSPK/p1740475712572969?thread_ts=1740475082.120829&cid=C050SM8NSPK), so could not be used in update scripts. This PR puts back what was run as papertrail in slack in the migration file, for traceability and so it can be used by the script (e.g. to update ES locally quickly)

Risk
---
na

Deploy
---
na
