### PR TITLE
Update notification description upon document upload in folder

### DIFF
--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -50,7 +50,7 @@ export const DocumentOrTableDeleteDialog = ({
 
       sendNotification({
         type: "success",
-        title: `${_.capitalize(itemType)} deletion successfully submitted`,
+        title: `${_.capitalize(itemType)} deletion submitted`,
         description: `Deletion of ${itemType} ${contentNode.title} ongoing, it will complete shortly.`,
       });
       onClose(true);

--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -50,8 +50,8 @@ export const DocumentOrTableDeleteDialog = ({
 
       sendNotification({
         type: "success",
-        title: `${_.capitalize(itemType)} successfully deleted`,
-        description: `The ${itemType} ${contentNode.title} was deleted`,
+        title: `${_.capitalize(itemType)} deletion successfully submitted`,
+        description: `Deletion of ${itemType} ${contentNode.title} ongoing, it will complete shortly.`,
       });
       onClose(true);
     } catch (error) {

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -143,8 +143,8 @@ export function useCreateDataSourceViewDocument(
 
       sendNotification({
         type: "success",
-        title: "Document creation submitted",
-        description: "Document processing ongoing, it will appear shortly",
+        title: "Document processing",
+        description: "Your document will appear shortly",
       });
 
       const response: PostDocumentResponseBody = await res.json();

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -143,7 +143,7 @@ export function useCreateDataSourceViewDocument(
 
       sendNotification({
         type: "success",
-        title: "Document created",
+        title: "Document creation submitted",
         description: "Document processing ongoing, it will appear shortly",
       });
 

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -1,6 +1,7 @@
 import { useSendNotification } from "@dust-tt/sparkle";
-import type { DataSourceViewType, LightWorkspaceType } from "@dust-tt/types";
 import type {
+  DataSourceViewType,
+  LightWorkspaceType,
   PatchDataSourceWithNameDocumentRequestBody,
   PostDataSourceWithNameDocumentRequestBody,
 } from "@dust-tt/types";
@@ -143,7 +144,7 @@ export function useCreateDataSourceViewDocument(
       sendNotification({
         type: "success",
         title: "Document created",
-        description: "Document has been created",
+        description: "Document processing ongoing, it will appear shortly",
       });
 
       const response: PostDocumentResponseBody = await res.json();


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/10720.
- The creation/deletion of documents into static data sources takes a few seconds to be reflected in the UI with the added row being visible (takes ~4s due to the embedding mostly).
- This PR updates the notification message to make this behavior more transparent to the user.

The notification incorrectly appears twice, this is tracked in another card.

<img width="1199" alt="Screenshot 2025-03-04 at 8 58 20 AM" src="https://github.com/user-attachments/assets/04043645-1ec0-4c23-8882-eb08c899d8f1" />

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.