### PR TITLE
Show add connected data buttons

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -548,18 +548,16 @@ export const SpaceDataSourceViewContentList = ({
           dataSourceView={dataSourceView}
         />
       )}
-      {isManaged(dataSourceView.dataSource) &&
-        space.kind !== "system" &&
-        !isEmpty && (
-          <EditSpaceManagedDataSourcesViews
-            owner={owner}
-            space={space}
-            systemSpace={systemSpace}
-            isAdmin={isAdmin}
-            dataSourceView={dataSourceView}
-            onSelectedDataUpdated={onSelectedDataUpdated}
-          />
-        )}
+      {isManaged(dataSourceView.dataSource) && space.kind !== "system" && (
+        <EditSpaceManagedDataSourcesViews
+          owner={owner}
+          space={space}
+          systemSpace={systemSpace}
+          isAdmin={isAdmin}
+          dataSourceView={dataSourceView}
+          onSelectedDataUpdated={onSelectedDataUpdated}
+        />
+      )}
       {isManaged(dataSourceView.dataSource) &&
         connector &&
         !parentId &&


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/tasks/issues/2286

Usually we can't have an empty datasourceView, but here it happened because they had a view was a node with was unsynced afterwards. Display the "Add data from.." to avoid being stuck here

<img width="984" alt="Screenshot 2025-03-04 at 10 01 47" src="https://github.com/user-attachments/assets/4328b1e8-c2a1-4d00-addc-89b17a5348d7" />



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

show button when not expected ?

## Deploy Plan

deploy front