### PR TITLE
[front] - refactor(collapsible): use new `Collapsible`

### DIFF
--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -1,4 +1,4 @@
-import { classNames, Collapsible, Icon } from "@dust-tt/sparkle";
+import { cn, CollapsibleComponent, Icon } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
 interface ActionDetailsWrapperProps {
@@ -15,10 +15,12 @@ export function ActionDetailsWrapper({
   visual,
 }: ActionDetailsWrapperProps) {
   return (
-    <Collapsible defaultOpen={defaultOpen}>
-      <Collapsible.Button>
+    <CollapsibleComponent
+      rootProps={{ defaultOpen }}
+      triggerProps={{}}
+      triggerChildren={
         <div
-          className={classNames(
+          className={cn(
             "text-foreground dark:text-foreground-night",
             "flex flex-row items-center gap-x-2"
           )}
@@ -26,8 +28,8 @@ export function ActionDetailsWrapper({
           <Icon size="sm" visual={visual} />
           <span className="text-base font-semibold">{actionName}</span>
         </div>
-      </Collapsible.Button>
-      <Collapsible.Panel>{children}</Collapsible.Panel>
-    </Collapsible>
+      }
+      contentChildren={children}
+    />
   );
 }

--- a/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
+++ b/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
@@ -4,7 +4,7 @@ import {
   CitationIcons,
   CitationTitle,
   CodeBlock,
-  Collapsible,
+  CollapsibleComponent,
   CommandLineIcon,
   ContentBlockWrapper,
   DocumentIcon,
@@ -56,16 +56,16 @@ export function DustAppRunActionDetails({
           </div>
         </div>
         <div>
-          <Collapsible defaultOpen={defaultOpen}>
-            <Collapsible.Button>
+          <CollapsibleComponent
+            rootProps={{ defaultOpen }}
+            triggerProps={{}}
+            triggerChildren={
               <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
                 Results
               </span>
-            </Collapsible.Button>
-            <Collapsible.Panel>
-              <DustAppRunOutputDetails action={action} />
-            </Collapsible.Panel>
-          </Collapsible>
+            }
+            contentChildren={<DustAppRunOutputDetails action={action} />}
+          />
         </div>
       </div>
     </ActionDetailsWrapper>
@@ -136,13 +136,14 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
               </CitationTitle>
             </Citation>
 
-            <Collapsible defaultOpen={false}>
-              <Collapsible.Button>
+            <CollapsibleComponent
+              rootProps={{ defaultOpen: false }}
+              triggerChildren={
                 <span className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground-night">
                   Preview
                 </span>
-              </Collapsible.Button>
-              <Collapsible.Panel>
+              }
+              contentChildren={
                 <div className="py-2">
                   <CodeBlock
                     className="language-csv max-h-60 overflow-y-auto"
@@ -151,8 +152,8 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
                     {action.resultsFileSnippet}
                   </CodeBlock>
                 </div>
-              </Collapsible.Panel>
-            </Collapsible>
+              }
+            />
           </div>
         )}
 

--- a/front/components/actions/process/ProcessActionDetails.tsx
+++ b/front/components/actions/process/ProcessActionDetails.tsx
@@ -1,7 +1,12 @@
 import type { GetContentToDownloadFunction } from "@dust-tt/sparkle";
-import { Chip, Collapsible, ScanIcon, Tooltip } from "@dust-tt/sparkle";
-import { CodeBlock } from "@dust-tt/sparkle";
-import { ContentBlockWrapper } from "@dust-tt/sparkle";
+import {
+  Chip,
+  CodeBlock,
+  CollapsibleComponent,
+  ContentBlockWrapper,
+  ScanIcon,
+  Tooltip,
+} from "@dust-tt/sparkle";
 import type { ProcessActionType } from "@dust-tt/types";
 import { PROCESS_ACTION_TOP_K } from "@dust-tt/types";
 import { useMemo } from "react";
@@ -27,16 +32,16 @@ export function ProcessActionDetails({
           <ProcessActionQuery action={action} />
         </div>
         <div>
-          <Collapsible defaultOpen={defaultOpen}>
-            <Collapsible.Button>
+          <CollapsibleComponent
+            rootProps={{ defaultOpen }}
+            triggerProps={{}}
+            triggerChildren={
               <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
                 Results
               </span>
-            </Collapsible.Button>
-            <Collapsible.Panel>
-              <ProcessActionOutputDetails action={action} />
-            </Collapsible.Panel>
-          </Collapsible>
+            }
+            contentChildren={<ProcessActionOutputDetails action={action} />}
+          />
         </div>
       </div>
     </ActionDetailsWrapper>

--- a/front/components/actions/retrieval/RetrievalActionDetails.tsx
+++ b/front/components/actions/retrieval/RetrievalActionDetails.tsx
@@ -1,7 +1,7 @@
 import {
   Chip,
   ClockIcon,
-  Collapsible,
+  CollapsibleComponent,
   MagnifyingGlassIcon,
   PaginatedCitationsGrid,
   Tooltip,
@@ -36,16 +36,17 @@ export function RetrievalActionDetails({
           </div>
         </div>
         <div>
-          <Collapsible defaultOpen={defaultOpen}>
-            <Collapsible.Button>
+          <CollapsibleComponent
+            rootProps={{ defaultOpen }}
+            triggerChildren={
               <span className="text-sm font-bold text-foreground dark:text-foreground-night">
                 Results
               </span>
-            </Collapsible.Button>
-            <Collapsible.Panel>
+            }
+            contentChildren={
               <PaginatedCitationsGrid items={documentCitations} />
-            </Collapsible.Panel>
-          </Collapsible>
+            }
+          />
         </div>
       </div>
     </ActionDetailsWrapper>

--- a/front/components/actions/tables_query/TablesQueryActionDetails.tsx
+++ b/front/components/actions/tables_query/TablesQueryActionDetails.tsx
@@ -2,16 +2,16 @@ import {
   Citation,
   CitationIcons,
   CitationTitle,
-  Collapsible,
+  CodeBlock,
+  CollapsibleComponent,
+  ContentBlockWrapper,
   ContentMessage,
   Icon,
   InformationCircleIcon,
+  Markdown,
   TableIcon,
   useSendNotification,
 } from "@dust-tt/sparkle";
-import { CodeBlock } from "@dust-tt/sparkle";
-import { ContentBlockWrapper } from "@dust-tt/sparkle";
-import { Markdown } from "@dust-tt/sparkle";
 import type { LightWorkspaceType, TablesQueryActionType } from "@dust-tt/types";
 import { getTablesQueryResultsFileTitle } from "@dust-tt/types";
 import { useCallback } from "react";
@@ -167,13 +167,13 @@ function QueryTablesResults({
         </Citation>
       </div>
 
-      <Collapsible defaultOpen={false}>
-        <Collapsible.Button>
+      <CollapsibleComponent
+        triggerChildren={
           <span className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground-night">
             Preview
           </span>
-        </Collapsible.Button>
-        <Collapsible.Panel>
+        }
+        contentChildren={
           <div className="py-2">
             <CodeBlock
               className="language-csv max-h-60 overflow-y-auto"
@@ -182,8 +182,8 @@ function QueryTablesResults({
               {action.resultsFileSnippet}
             </CodeBlock>
           </div>
-        </Collapsible.Panel>
-      </Collapsible>
+        }
+      />
     </div>
   );
 }

--- a/front/components/actions/tables_query/TablesQueryActionDetails.tsx
+++ b/front/components/actions/tables_query/TablesQueryActionDetails.tsx
@@ -168,6 +168,7 @@ function QueryTablesResults({
       </div>
 
       <CollapsibleComponent
+        rootProps={{ defaultOpen: false }}
         triggerChildren={
           <span className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground-night">
             Preview

--- a/front/components/actions/websearch/WebsearchActionDetails.tsx
+++ b/front/components/actions/websearch/WebsearchActionDetails.tsx
@@ -1,5 +1,5 @@
 import {
-  Collapsible,
+  CollapsibleComponent,
   ContentMessage,
   GlobeAltIcon,
   InformationCircleIcon,
@@ -40,24 +40,27 @@ export function WebsearchActionDetails({
           </div>
         </div>
         <div>
-          <Collapsible defaultOpen={defaultOpen}>
-            <Collapsible.Button>
+          <CollapsibleComponent
+            rootProps={{ defaultOpen: defaultOpen }}
+            triggerChildren={
               <span className="text-sm font-bold text-foreground dark:text-foreground-night">
                 Results
               </span>
-            </Collapsible.Button>
-            <Collapsible.Panel>
-              <PaginatedCitationsGrid items={resultsCitations} />
-              {formattedError && (
-                <ContentMessage
-                  title="Error searching the web"
-                  icon={InformationCircleIcon}
-                >
-                  {formattedError}
-                </ContentMessage>
-              )}
-            </Collapsible.Panel>
-          </Collapsible>
+            }
+            contentChildren={
+              <>
+                <PaginatedCitationsGrid items={resultsCitations} />
+                {formattedError && (
+                  <ContentMessage
+                    title="Error searching the web"
+                    icon={InformationCircleIcon}
+                  >
+                    {formattedError}
+                  </ContentMessage>
+                )}
+              </>
+            }
+          />
         </div>
       </div>
     </ActionDetailsWrapper>

--- a/front/components/app/blocks/Browser.tsx
+++ b/front/components/app/blocks/Browser.tsx
@@ -1,11 +1,12 @@
-import { Button, Checkbox, Collapsible, Input, Label } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
+import { Button, Checkbox, CollapsibleComponent, Input, Label } from "@dust-tt/sparkle";
 import type {
   AppType,
+  BlockType,
+  RunType,
   SpecificationBlockType,
   SpecificationType,
+  WorkspaceType,
 } from "@dust-tt/types";
-import type { BlockType, RunType } from "@dust-tt/types";
 
 import { filterServiceProviders } from "@app/lib/providers";
 import { useProviders } from "@app/lib/swr/apps";
@@ -44,7 +45,7 @@ export default function Browser({
   onBlockDelete: () => void;
   onBlockUp: () => void;
   onBlockDown: () => void;
-  onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
+  onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;g
 }>) {
   const { providers, isProvidersLoading, isProvidersError } = useProviders({
     owner,
@@ -176,9 +177,10 @@ export default function Browser({
           />
         </div>
 
-        <Collapsible defaultOpen={false}>
-          <Collapsible.Button label="Advanced" />
-          <Collapsible.Panel>
+        <CollapsibleComponent
+          rootProps={{ defaultOpen: false }}
+          triggerProps={{ label: "Advanced" }}
+          contentChildren={
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
               <div className="flex items-center space-x-2">
                 <Label className="whitespace-nowrap">Error as output</Label>
@@ -225,8 +227,8 @@ export default function Browser({
                 />
               </div>
             </div>
-          </Collapsible.Panel>
-        </Collapsible>
+          }
+        />
       </div>
     </Block>
   );

--- a/front/components/app/blocks/Browser.tsx
+++ b/front/components/app/blocks/Browser.tsx
@@ -52,7 +52,6 @@ export default function Browser({
   onBlockUp: () => void;
   onBlockDown: () => void;
   onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
-  g;
 }>) {
   const { providers, isProvidersLoading, isProvidersError } = useProviders({
     owner,

--- a/front/components/app/blocks/Browser.tsx
+++ b/front/components/app/blocks/Browser.tsx
@@ -1,4 +1,10 @@
-import { Button, Checkbox, CollapsibleComponent, Input, Label } from "@dust-tt/sparkle";
+import {
+  Button,
+  Checkbox,
+  CollapsibleComponent,
+  Input,
+  Label,
+} from "@dust-tt/sparkle";
 import type {
   AppType,
   BlockType,
@@ -45,7 +51,8 @@ export default function Browser({
   onBlockDelete: () => void;
   onBlockUp: () => void;
   onBlockDown: () => void;
-  onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;g
+  onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
+  g;
 }>) {
   const { providers, isProvidersLoading, isProvidersError } = useProviders({
     owner,

--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -288,6 +288,7 @@ export default function Chat({
         </div>
         <div>
           <CollapsibleComponent
+            rootProps={{ defaultOpen: false }}
             triggerProps={{ label: "Advanced" }}
             contentChildren={
               <div className="flex flex-row gap-2">
@@ -402,6 +403,7 @@ export default function Chat({
         </div>
         <div>
           <CollapsibleComponent
+            rootProps={{ defaultOpen: false }}
             triggerProps={{ label: "Functions" }}
             contentChildren={
               <div className="flex flex-col gap-2 text-sm">

--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -2,16 +2,19 @@ import "@uiw/react-textarea-code-editor/dist.css";
 
 import {
   Checkbox,
-  Collapsible,
+  CollapsibleComponent,
   Input,
   Label,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
-import type { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
-import type { AppType } from "@dust-tt/types";
-import type { BlockType } from "@dust-tt/types";
-import type { RunType } from "@dust-tt/types";
+import type {
+  AppType,
+  BlockType,
+  RunType,
+  SpecificationBlockType,
+  SpecificationType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 
@@ -284,9 +287,9 @@ export default function Chat({
           </div>
         </div>
         <div>
-          <Collapsible>
-            <Collapsible.Button label="Advanced" />
-            <Collapsible.Panel>
+          <CollapsibleComponent
+            triggerProps={{ label: "Advanced" }}
+            contentChildren={
               <div className="flex flex-row gap-2">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
                   <div className="flex items-center space-x-2">
@@ -345,8 +348,8 @@ export default function Chat({
                   </div>
                 </div>
               </div>
-            </Collapsible.Panel>
-          </Collapsible>
+            }
+          />
         </div>
 
         <div className="flex flex-col gap-2 text-sm">
@@ -398,9 +401,9 @@ export default function Chat({
           </div>
         </div>
         <div>
-          <Collapsible>
-            <Collapsible.Button label="Functions" />
-            <Collapsible.Panel>
+          <CollapsibleComponent
+            triggerProps={{ label: "Functions" }}
+            contentChildren={
               <div className="flex flex-col gap-2 text-sm">
                 <div className="flex w-full font-normal">
                   <div className="w-full leading-4">
@@ -437,8 +440,8 @@ export default function Chat({
                   </div>
                 </div>
               </div>
-            </Collapsible.Panel>
-          </Collapsible>
+            }
+          />
         </div>
       </div>
     </Block>

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -1,13 +1,20 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { Checkbox, Chip, Collapsible, Input, Label } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
+import {
+  Checkbox,
+  Chip,
+  CollapsibleComponent,
+  Input,
+  Label,
+} from "@dust-tt/sparkle";
 import type {
   AppType,
+  BlockType,
+  RunType,
   SpecificationBlockType,
   SpecificationType,
+  WorkspaceType,
 } from "@dust-tt/types";
-import type { BlockType, RunType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 
@@ -270,9 +277,9 @@ export default function DataSource({
         </div>
 
         <div className="w-full">
-          <Collapsible>
-            <Collapsible.Button label="Filters" />
-            <Collapsible.Panel>
+          <CollapsibleComponent
+            triggerProps={{ label: "Filters" }}
+            contentChildren={
               <div className="flex w-full flex-col gap-2">
                 <div className="flex w-full flex-col gap-2">
                   <CodeEditor
@@ -399,8 +406,8 @@ export default function DataSource({
                   </div>
                 </div>
               </div>
-            </Collapsible.Panel>
-          </Collapsible>
+            }
+          />
         </div>
       </div>
     </Block>

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -278,6 +278,7 @@ export default function DataSource({
 
         <div className="w-full">
           <CollapsibleComponent
+            rootProps={{ defaultOpen: false }}
             triggerProps={{ label: "Filters" }}
             contentChildren={
               <div className="flex w-full flex-col gap-2">

--- a/front/components/spaces/websites/AdvancedSettingsSection.tsx
+++ b/front/components/spaces/websites/AdvancedSettingsSection.tsx
@@ -1,4 +1,10 @@
-import { Button, Collapsible, Input, Label, XMarkIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  CollapsibleComponent,
+  Input,
+  Label,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 import { WebCrawlerHeaderRedactedValue } from "@dust-tt/types";
 
 type Header = { key: string; value: string };
@@ -31,9 +37,9 @@ export function AdvancedSettingsSection({
   };
 
   return (
-    <Collapsible>
-      <Collapsible.Button label="Advanced settings" variant="secondary" />
-      <Collapsible.Panel>
+    <CollapsibleComponent
+      triggerProps={{ label: "Advanced settings", variant: "secondary" }}
+      contentChildren={
         <div className="flex w-full flex-col gap-3">
           <Label>Custom Headers</Label>
           <p>Add custom request headers for the web crawler.</p>
@@ -72,7 +78,7 @@ export function AdvancedSettingsSection({
           </div>
           <Button variant="outline" label="Add Header" onClick={addHeader} />
         </div>
-      </Collapsible.Panel>
-    </Collapsible>
+      }
+    />
   );
 }

--- a/front/components/spaces/websites/AdvancedSettingsSection.tsx
+++ b/front/components/spaces/websites/AdvancedSettingsSection.tsx
@@ -38,6 +38,7 @@ export function AdvancedSettingsSection({
 
   return (
     <CollapsibleComponent
+      rootProps={{ defaultOpen: false }}
       triggerProps={{ label: "Advanced settings", variant: "secondary" }}
       contentChildren={
         <div className="flex w-full flex-col gap-3">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.432-rc-3",
+        "@dust-tt/sparkle": "^0.2.432",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11337,9 +11337,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.432-rc-3",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.432-rc-3.tgz",
-      "integrity": "sha512-CMZGoNr761OdWYAxgJvTGk6oPNCJoFeRMcWvl92/3U6jhzUn9cBgVso5dCzrzM1TqYT3MN98Ti2d8zywq9gzHQ==",
+      "version": "0.2.432",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.432.tgz",
+      "integrity": "sha512-PkWgSYJblxZwfdi7PMQsOC05ApvhIv2+TOB0XuQWYbxTplTZCn4bqFwvE9LqeEDexHIE3VdIPJtOPbEy1cYBng==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.430",
+        "@dust-tt/sparkle": "^0.2.432-rc-3",
         "@dust-tt/types": "file:../types",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -11337,16 +11337,16 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.430",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.430.tgz",
-      "integrity": "sha512-L0qKRJg/SO2YOemzJ+jD31m344lKf15lByNgpODvGe+qtmg6JafKgUmVwC0i2YhFm80UfT7sZ7Z0Bg1xmIRYUw==",
-      "license": "ISC",
+      "version": "0.2.432-rc-3",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.432-rc-3.tgz",
+      "integrity": "sha512-CMZGoNr761OdWYAxgJvTGk6oPNCJoFeRMcWvl92/3U6jhzUn9cBgVso5dCzrzM1TqYT3MN98Ti2d8zywq9gzHQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.19",
         "@radix-ui/react-aspect-ratio": "^1.1.0",
         "@radix-ui/react-checkbox": "^1.1.2",
+        "@radix-ui/react-collapsible": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.0",
@@ -15207,6 +15207,192 @@
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.3.tgz",
+      "integrity": "sha512-jFSerheto1X03MUC0g6R7LedNW9EEGWdg9W1+MlpkMLwGkgkbUXLPBH/KIuWKXUoeYRVY11llqbTBDzuLg7qrw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.432-rc-3",
+    "@dust-tt/sparkle": "^0.2.432",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.430",
+    "@dust-tt/sparkle": "^0.2.432-rc-3",
     "@dust-tt/types": "file:../types",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",


### PR DESCRIPTION
## Description

Refactors all usages of the `Collapsible` component to use the new `CollapsibleComponent` from sparkle. The new component uses Radix UI's collapsible primitive instead of HeadlessUI.

## Risk

Low, breaking UI

## Deploy Plan

- Publish sparkle
- Update sparkle version in front
- Deploy front