### PR TITLE
Flav/change connector update

### DIFF
--- a/connectors/migrations/20230505_add_notion_connector_state.ts
+++ b/connectors/migrations/20230505_add_notion_connector_state.ts
@@ -29,6 +29,7 @@ async function main() {
         );
         await NotionConnectorState.create({
           connectorId: connector.id,
+          notionWorkspaceId: "",
         });
       }
     }

--- a/connectors/migrations/20250304_add_notion_workspace_id_to_connector_state.ts
+++ b/connectors/migrations/20250304_add_notion_workspace_id_to_connector_state.ts
@@ -1,0 +1,88 @@
+import { concurrentExecutor } from "@dust-tt/types";
+import type { Logger } from "pino";
+import { makeScript } from "scripts/helpers";
+
+import { workspaceIdFromConnectionId } from "@connectors/connectors/notion";
+import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+async function updateConnector(
+  connector: ConnectorResource,
+  logger: Logger,
+  execute: boolean
+) {
+  const notionState = await NotionConnectorState.findOne({
+    where: { connectorId: connector.id },
+  });
+  if (!notionState) {
+    logger.info(
+      { connectorId: connector.id },
+      "Notion connector state not found."
+    );
+
+    throw new Error("Notion connector state not found.");
+  }
+
+  const workspaceIdRes = await workspaceIdFromConnectionId(
+    connector.connectionId
+  );
+
+  if (workspaceIdRes.isErr()) {
+    logger.error(
+      { connectorId: connector.id, error: workspaceIdRes.error },
+      "Error getting workspace ID from connection ID"
+    );
+
+    throw new Error("Error getting workspace ID from connection ID");
+  }
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      notionWorkspaceId: workspaceIdRes.value,
+    },
+    "Updating Notion connector state..."
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  await NotionConnectorState.update(
+    {
+      notionWorkspaceId: workspaceIdRes.value,
+    },
+    { where: { connectorId: connector.id } }
+  );
+}
+
+async function backfillConnectorStates(logger: Logger, execute: boolean) {
+  const connectors = await ConnectorResource.listByType("notion", {});
+
+  await concurrentExecutor(
+    connectors,
+    async (connector) => updateConnector(connector, logger, execute),
+    {
+      concurrency: 10,
+    }
+  );
+}
+
+makeScript(
+  {
+    connectorId: { type: "number", required: false },
+  },
+  async ({ connectorId, execute }, logger) => {
+    if (connectorId) {
+      const connectors = await ConnectorResource.fetchByIds("notion", [
+        connectorId,
+      ]);
+      const connector = connectors[0];
+      if (connector) {
+        await updateConnector(connector, logger, execute);
+      }
+    } else {
+      await backfillConnectorStates(logger, execute);
+    }
+  }
+);

--- a/connectors/migrations/20250304_add_notion_workspace_id_to_connector_state.ts
+++ b/connectors/migrations/20250304_add_notion_workspace_id_to_connector_state.ts
@@ -23,6 +23,14 @@ async function updateConnector(
     throw new Error("Notion connector state not found.");
   }
 
+  if (notionState.notionWorkspaceId) {
+    logger.info(
+      { connectorId: connector.id },
+      "Notion workspace ID already exists."
+    );
+    return;
+  }
+
   const workspaceIdRes = await workspaceIdFromConnectionId(
     connector.connectionId
   );

--- a/connectors/migrations/db/migration_55.sql
+++ b/connectors/migrations/db/migration_55.sql
@@ -1,0 +1,2 @@
+-- Migration created on Mar 04, 2025
+ALTER TABLE "public"."notion_connector_states" ADD COLUMN "notionWorkspaceId" VARCHAR(255);

--- a/connectors/migrations/db/migration_56.sql
+++ b/connectors/migrations/db/migration_56.sql
@@ -1,0 +1,26 @@
+-- -- This migration is dependant on a backfill script
+-- -- The backfill script is: test
+-- -- run psql with --set=backfilled=1 argument if you have rune the script.
+
+CREATE OR REPLACE FUNCTION perform_migration(backfilled boolean DEFAULT false)
+RETURNS VARCHAR AS $$
+BEGIN
+    IF NOT backfilled THEN
+        RAISE NOTICE 'The backfill script: migrations/20250304_add_notion_workspace_id_to_connector_state.ts is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.';
+    END IF;
+
+-- Migration created on Mar 04, 2025
+ALTER TABLE "public"."notion_connector_states" ALTER COLUMN "notionWorkspaceId" SET NOT NULL;
+
+    RETURN 'success';
+END;
+$$ LANGUAGE plpgsql;
+
+\if :{?backfilled}
+   SELECT perform_migration(:'backfilled'::boolean);
+\else
+    \echo '!! Migration was NOT applied !!'
+    \echo 'The backfill script: migrations/20250304_add_notion_workspace_id_to_connector_state.ts is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.'
+\endif
+
+DROP FUNCTION perform_migration(boolean);

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -94,13 +94,16 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     }
 
     if (connectionId) {
-      const [oldGithubInstallationId, newGithubInstallationId] =
-        await Promise.all([
-          installationIdFromConnectionId(c.connectionId),
-          installationIdFromConnectionId(connectionId),
-        ]);
+      const connectorState = await GithubConnectorState.findOne({
+        where: {
+          connectorId: c.id,
+        },
+      });
 
-      if (oldGithubInstallationId !== newGithubInstallationId) {
+      const newGithubInstallationId =
+        await installationIdFromConnectionId(connectionId);
+
+      if (connectorState?.installationId !== newGithubInstallationId) {
         return new Err(
           new ConnectorManagerError(
             "CONNECTOR_OAUTH_TARGET_MISMATCH",

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -17,6 +17,7 @@ import {
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
 import { validateAccessToken } from "@connectors/connectors/notion/lib/notion_api";
+import { validateNotionOAuthResponse } from "@connectors/connectors/notion/lib/utils";
 import {
   launchNotionSyncWorkflow,
   stopNotionSyncWorkflow,
@@ -55,10 +56,24 @@ async function workspaceIdFromConnectionId(connectionId: string) {
   if (tokRes.isErr()) {
     return tokRes;
   }
-  return new Ok(
-    (tokRes.value.scrubbed_raw_json as { workspace_id?: string })
-      .workspace_id ?? null
+
+  const validationRes = validateNotionOAuthResponse(
+    tokRes.value.scrubbed_raw_json,
+    logger
   );
+  if (validationRes.isErr()) {
+    logger.error(
+      {
+        errors: validationRes.error,
+        rawJson: tokRes.value.scrubbed_raw_json,
+      },
+      "Invalid Notion OAuth response"
+    );
+
+    return new Ok(null);
+  }
+
+  return new Ok(validationRes.value.workspace_id);
 }
 
 export class NotionConnectorManager extends BaseConnectorManager<null> {
@@ -84,6 +99,15 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       throw new Error("Notion access token is invalid");
     }
 
+    // Validate the response with our utility function
+    const rawJson = validateNotionOAuthResponse(
+      tokRes.value.scrubbed_raw_json,
+      logger
+    );
+    if (rawJson.isErr()) {
+      throw new Error("Invalid Notion OAuth response");
+    }
+
     const connector = await ConnectorResource.makeNew(
       "notion",
       {
@@ -92,7 +116,9 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
       },
-      {}
+      {
+        notionWorkspaceId: rawJson.value.workspace_id,
+      }
     );
 
     // For each connector, there are 2 special folders (root folders):
@@ -147,44 +173,36 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
 
     if (connectionId) {
       const oldConnectionId = c.connectionId;
-      const [workspaceIdRes, newWorkspaceIdRes] = await Promise.all([
-        workspaceIdFromConnectionId(oldConnectionId),
-        workspaceIdFromConnectionId(connectionId),
-      ]);
+      const newWorkspaceIdRes = await workspaceIdFromConnectionId(connectionId);
 
-      if (workspaceIdRes.isErr() || newWorkspaceIdRes.isErr()) {
-        if (workspaceIdRes.isErr()) {
-          logger.error(
-            {
-              oldConnectionId,
-              connectionId,
-              connectorId: c.id,
-              error: workspaceIdRes.error,
-            },
-            "Error retrieving workspace Id from old connection"
-          );
-        }
-        if (newWorkspaceIdRes.isErr()) {
-          logger.error(
-            {
-              oldConnectionId,
-              connectionId,
-              connectorId: c.id,
-              error: newWorkspaceIdRes.error,
-            },
-            "Error retrieving workspace Id from new connection"
-          );
-        }
-
-        throw new Error(
-          "Error retrieving workspace Ids from connections while checking update validity"
+      if (newWorkspaceIdRes.isErr()) {
+        logger.error(
+          {
+            oldConnectionId,
+            connectionId,
+            connectorId: c.id,
+            error: newWorkspaceIdRes.error,
+          },
+          "Error retrieving workspace Id from new connection"
         );
+        throw new Error("Error retrieving workspace Id from new connection");
       }
 
-      if (!workspaceIdRes.value || !newWorkspaceIdRes.value) {
+      if (!newWorkspaceIdRes.value) {
         throw new Error("Error retrieving connection info to update connector");
       }
-      if (workspaceIdRes.value !== newWorkspaceIdRes.value) {
+
+      const connectorState = await NotionConnectorState.findOne({
+        where: {
+          connectorId: c.id,
+        },
+      });
+
+      if (!connectorState) {
+        throw new Error("Notion connector state not found");
+      }
+
+      if (connectorState.notionWorkspaceId !== newWorkspaceIdRes.value) {
         return new Err(
           new ConnectorManagerError(
             "CONNECTOR_OAUTH_TARGET_MISMATCH",

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -46,7 +46,7 @@ function notionIdFromNodeId(nodeId: string) {
   return _.last(nodeId.split("notion-"))!;
 }
 
-async function workspaceIdFromConnectionId(connectionId: string) {
+export async function workspaceIdFromConnectionId(connectionId: string) {
   const tokRes = await getOAuthConnectionAccessToken({
     config: apiConfig.getOAuthAPIConfig(),
     logger,
@@ -70,7 +70,7 @@ async function workspaceIdFromConnectionId(connectionId: string) {
       "Invalid Notion OAuth response"
     );
 
-    return new Ok(null);
+    return new Err(new Error("Invalid Notion OAuth response"));
   }
 
   return new Ok(validationRes.value.workspace_id);

--- a/connectors/src/connectors/notion/lib/utils.ts
+++ b/connectors/src/connectors/notion/lib/utils.ts
@@ -1,0 +1,37 @@
+import { Err } from "@dust-tt/client/dist/types";
+import { Ok } from "@dust-tt/client/dist/types";
+import type { Result } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import type { Logger } from "pino";
+
+// Define the type codec for the Notion OAuth response
+export const NotionOAuthResponse = t.type({
+  workspace_id: t.string,
+});
+
+export type NotionOAuthResponseType = t.TypeOf<typeof NotionOAuthResponse>;
+
+/**
+ * Validates a Notion OAuth response to ensure it contains a workspace_id
+ *
+ * @param rawJson The raw JSON response from the OAuth service
+ * @param logger Logger instance for error reporting
+ * @returns The validation result (Either)
+ */
+export function validateNotionOAuthResponse(
+  rawJson: unknown,
+  logger: Logger
+): Result<NotionOAuthResponseType, Error> {
+  const validationResult = NotionOAuthResponse.decode(rawJson);
+
+  if (isLeft(validationResult)) {
+    logger.error(
+      { errors: validationResult.left },
+      "Invalid Notion OAuth response"
+    );
+    return new Err(new Error("Invalid Notion OAuth response"));
+  }
+
+  return new Ok(validationResult.right);
+}

--- a/connectors/src/connectors/notion/lib/utils.ts
+++ b/connectors/src/connectors/notion/lib/utils.ts
@@ -1,6 +1,5 @@
-import { Err } from "@dust-tt/client/dist/types";
-import { Ok } from "@dust-tt/client/dist/types";
 import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { Logger } from "pino";

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -14,8 +14,7 @@ export class NotionConnectorState extends ConnectorBaseModel<NotionConnectorStat
   declare lastGarbageCollectionFinishTime?: Date;
   declare parentsLastUpdatedAt?: Date;
 
-  // TODO(2025-03-04): Set this to NOT NULL once we've migrated all existing connectors.
-  declare notionWorkspaceId: string | null;
+  declare notionWorkspaceId: string;
 }
 NotionConnectorState.init(
   {
@@ -43,7 +42,7 @@ NotionConnectorState.init(
     },
     notionWorkspaceId: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
     },
   },
   {

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -15,7 +15,7 @@ export class NotionConnectorState extends ConnectorBaseModel<NotionConnectorStat
   declare parentsLastUpdatedAt?: Date;
 
   // TODO(2025-03-04): Set this to NOT NULL once we've migrated all existing connectors.
-  declare notionWorkspaceId: string;
+  declare notionWorkspaceId: string | null;
 }
 NotionConnectorState.init(
   {

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -13,6 +13,9 @@ export class NotionConnectorState extends ConnectorBaseModel<NotionConnectorStat
 
   declare lastGarbageCollectionFinishTime?: Date;
   declare parentsLastUpdatedAt?: Date;
+
+  // TODO(2025-03-04): Set this to NOT NULL once we've migrated all existing connectors.
+  declare notionWorkspaceId: string;
 }
 NotionConnectorState.init(
   {
@@ -36,6 +39,10 @@ NotionConnectorState.init(
     },
     parentsLastUpdatedAt: {
       type: DataTypes.DATE,
+      allowNull: true,
+    },
+    notionWorkspaceId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
   },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes an issue with workspace relocation between regions. Currently, customers must reconnect their data sources after relocation, but some connectors (GitHub and Notion) prevent this because they require connections to target the same workspace/installation ID. The tokens aren't transferred during relocation.

The solution: instead of fetching connection IDs from oauth, we store workspace/installation IDs directly in our database. GitHub already had this, now adding it for Notion with a new column.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Apply SQL migration
- [x] Run backfill
- [x] Deploy
- [x] Re-run backfill
