### PR TITLE
fix(content node pagination) - Add back loop on pages

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -136,7 +136,8 @@ export async function getContentNodesForDataSourceView(
         parent_id,
       },
       options: {
-        // We limit the results to the remaining number of nodes we need to make sure we get a correct nextPageCursor.
+        // We limit the results to the remaining number of nodes
+        // we still need to make sure we get a correct nextPageCursor at the end of this loop.
         limit: limit - resultNodes.length,
         cursor: nextPageCursor ?? undefined,
       },

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -124,25 +124,38 @@ export async function getContentNodesForDataSourceView(
   let nextPageCursor: string | null = pagination ? pagination.cursor : null;
 
   let resultNodes: CoreAPIContentNode[] = [];
-  const coreRes = await coreAPI.searchNodes({
-    filter: {
-      data_source_views: [makeCoreDataSourceViewFilter(dataSourceView)],
-      node_ids,
-      parent_id,
-    },
-    options: { limit, cursor: nextPageCursor ?? undefined },
-  });
+  let hitCount;
+  let hiddenNodesCount = 0;
+  let totalIsAccurate;
 
-  if (coreRes.isErr()) {
-    return new Err(new Error(coreRes.error.message));
-  }
+  do {
+    const coreRes = await coreAPI.searchNodes({
+      filter: {
+        data_source_views: [makeCoreDataSourceViewFilter(dataSourceView)],
+        node_ids,
+        parent_id,
+      },
+      options: {
+        // We limit the results to the remaining number of nodes we need to make sure we get a correct nextPageCursor.
+        limit: limit - resultNodes.length,
+        cursor: nextPageCursor ?? undefined,
+      },
+    });
 
-  const filteredNodes = removeCatchAllFoldersIfEmpty(
-    filterNodesByViewType(coreRes.value.nodes, viewType)
-  );
+    if (coreRes.isErr()) {
+      return new Err(new Error(coreRes.error.message));
+    }
 
-  resultNodes = [...resultNodes, ...filteredNodes].slice(0, limit);
-  nextPageCursor = coreRes.value.next_page_cursor;
+    hitCount = coreRes.value.hit_count;
+    totalIsAccurate = coreRes.value.hit_count_is_accurate;
+    const filteredNodes = removeCatchAllFoldersIfEmpty(
+      filterNodesByViewType(coreRes.value.nodes, viewType)
+    );
+    hiddenNodesCount += coreRes.value.nodes.length - filteredNodes.length;
+
+    resultNodes = [...resultNodes, ...filteredNodes].slice(0, limit);
+    nextPageCursor = coreRes.value.next_page_cursor;
+  } while (resultNodes.length < limit && nextPageCursor);
 
   const nodes = resultNodes.map((node) =>
     getContentNodeFromCoreNode(
@@ -161,10 +174,8 @@ export async function getContentNodesForDataSourceView(
 
   return new Ok({
     nodes: sortedNodes,
-    total:
-      coreRes.value.hit_count -
-      (coreRes.value.nodes.length - sortedNodes.length), // Deducing the number of folders we hid from the total count.
-    totalIsAccurate: coreRes.value.hit_count_is_accurate,
+    total: hitCount - hiddenNodesCount, // Deducing the number of folders we hid from the total count.
+    totalIsAccurate,
     nextPageCursor: nextPageCursor,
   });
 }


### PR DESCRIPTION
## Description

- The filter on view type is still handled in `front`.
- The pages returned by `getContentNodesForDataSourceView` therefore have a variable size.
- This PR adds a loop that exhausts the pages until we get the required number of nodes.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.