### PR TITLE
 [Search KB] Exclude webcrawler contents when searching

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -652,6 +652,8 @@ impl ElasticsearchSearchStore {
         // Add the outer bool query with should clause.
         counter.add(1);
 
+        // Queries on DATA_SOURCE_INDEX_NAME are prioritized over queries on
+        // DATA_SOURCE_NODE_INDEX_NAME, if we run out of clauses.
         if filter.data_source_views.iter().any(|f| {
             matches!(
                 f.search_scope,

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -53,13 +53,13 @@ pub enum TagsQueryType {
 }
 
 // For each data source view, the scope of search can be:
-// - DataSourceTitle: only check if the datasource title matches the query;
+// - DataSourceName: only check if the datasource name matches the query;
 // - NodesTitles: check if any of the datasource's nodes titles match the query;
-// - Both: check if either the datasource title or any of its nodes titles match the query;
+// - Both: check if either the datasource name or any of its nodes titles match the query;
 #[derive(serde::Deserialize, Clone, Copy, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum SearchScopeType {
-    DataSourceTitle,
+    DataSourceName,
     NodesTitles,
     Both,
 }
@@ -655,7 +655,7 @@ impl ElasticsearchSearchStore {
         if filter.data_source_views.iter().any(|f| {
             matches!(
                 f.search_scope,
-                SearchScopeType::DataSourceTitle | SearchScopeType::Both
+                SearchScopeType::DataSourceName | SearchScopeType::Both
             )
         }) {
             let data_sources_query = Query::bool()
@@ -685,15 +685,15 @@ impl ElasticsearchSearchStore {
     }
 
     /// On the data source index, we only want to add a clause if the search scope is
-    /// DataSourceTitle or Both. On the data source node index, we only want to add a clause
-    /// if the search scope is ChildrenTitles or Both.
+    /// DataSourceName or Both. On the data source node index, we only want to add a clause
+    /// if the search scope is NodesTitles or Both.
     fn should_add_data_source_clause(
         &self,
         filter: &DatasourceViewFilter,
         index_name: &str,
     ) -> bool {
         match (filter.search_scope, index_name) {
-            (SearchScopeType::DataSourceTitle | SearchScopeType::Both, DATA_SOURCE_INDEX_NAME) => {
+            (SearchScopeType::DataSourceName | SearchScopeType::Both, DATA_SOURCE_INDEX_NAME) => {
                 true
             }
             (SearchScopeType::NodesTitles | SearchScopeType::Both, DATA_SOURCE_NODE_INDEX_NAME) => {

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -52,11 +52,15 @@ pub enum TagsQueryType {
     Match,
 }
 
+// For each data source view, the scope of search can be:
+// - DataSourceTitle: only check if the datasource title matches the query;
+// - NodesTitles: check if any of the datasource's nodes titles match the query;
+// - Both: check if either the datasource title or any of its nodes titles match the query;
 #[derive(serde::Deserialize, Clone, Copy, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum SearchScopeType {
     DataSourceTitle,
-    ChildrenTitles,
+    NodesTitles,
     Both,
 }
 
@@ -86,14 +90,13 @@ pub struct DatasourceViewFilter {
 }
 
 fn default_search_scope() -> SearchScopeType {
-    SearchScopeType::ChildrenTitles
+    SearchScopeType::NodesTitles
 }
 
 #[derive(serde::Deserialize, Debug)]
 pub struct NodesSearchFilter {
     data_source_views: Vec<DatasourceViewFilter>,
     excluded_node_mime_types: Option<Vec<String>>,
-    include_data_sources: Option<bool>,
     node_ids: Option<Vec<String>>,
     node_types: Option<Vec<NodeType>>,
     parent_id: Option<String>,
@@ -693,10 +696,9 @@ impl ElasticsearchSearchStore {
             (SearchScopeType::DataSourceTitle | SearchScopeType::Both, DATA_SOURCE_INDEX_NAME) => {
                 true
             }
-            (
-                SearchScopeType::ChildrenTitles | SearchScopeType::Both,
-                DATA_SOURCE_NODE_INDEX_NAME,
-            ) => true,
+            (SearchScopeType::NodesTitles | SearchScopeType::Both, DATA_SOURCE_NODE_INDEX_NAME) => {
+                true
+            }
             _ => false,
         }
     }

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -649,11 +649,18 @@ impl ElasticsearchSearchStore {
         // Add the outer bool query with should clause.
         counter.add(1);
 
-        let data_sources_query = Query::bool()
-            .filter(Query::term("_index", DATA_SOURCE_INDEX_NAME))
-            .must(self.build_data_sources_content_query(&query, &filter, &mut counter)?);
+        if filter.data_source_views.iter().any(|f| {
+            matches!(
+                f.search_scope,
+                SearchScopeType::DataSourceTitle | SearchScopeType::Both
+            )
+        }) {
+            let data_sources_query = Query::bool()
+                .filter(Query::term("_index", DATA_SOURCE_INDEX_NAME))
+                .must(self.build_data_sources_content_query(&query, &filter, &mut counter)?);
 
-        should_queries.push(data_sources_query);
+            should_queries.push(data_sources_query);
+        }
 
         // Build nodes query only if we have clauses left.
         if !counter.is_full() {

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -300,7 +300,7 @@ export async function searchContenNodesInSpace(
       // For webcrawler datasources, we want to search the only datasource
       // title, not the nodes titles.
       if (dsv.dataSource.connectorProvider === "webcrawler") {
-        return "data_source_title";
+        return "data_source_name";
       }
 
       return "both";

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -301,7 +301,7 @@ export async function searchContenNodesInSpace(
       return "both";
     }
 
-    return "children_titles";
+    return "nodes_titles";
   };
 
   const searchRes = await coreAPI.searchNodes({

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -290,15 +290,29 @@ export async function searchContenNodesInSpace(
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
+  // If we search datasources, then for webcrawler, we only want to search the
+  // data source title, not the children titles.
+  const searchScopeForDsv = (dsv: DataSourceViewResource) => {
+    if (includeDataSources) {
+      if (dsv.dataSource.connectorProvider === "webcrawler") {
+        return "data_source_title";
+      }
+
+      return "both";
+    }
+
+    return "children_titles";
+  };
+
   const searchRes = await coreAPI.searchNodes({
     query,
     filter: {
       data_source_views: dataSourceViews.map((dsv) => ({
         data_source_id: dsv.dataSource.dustAPIDataSourceId,
         view_filter: dsv.parentsIn ?? [],
+        search_scope: searchScopeForDsv(dsv),
       })),
       excluded_node_mime_types: excludedNodeMimeTypes,
-      include_data_sources: includeDataSources,
       node_types: getCoreViewTypeFilter(viewType),
     },
     options: {

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -267,7 +267,7 @@ function searchScopeForDsv({
   includeDataSources: boolean;
   isSingleDsv: boolean;
 }): CoreAPISearchScope {
-  // On a single datasource view, we never want to match the datasource title.
+  // On a single datasource view, we never want to match the datasource name.
   if (isSingleDsv) {
     return "nodes_titles";
   }

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -1,6 +1,7 @@
 import type {
   ContentNodesViewType,
   CoreAPIError,
+  CoreAPISearchScope,
   DataSourceViewContentNode,
   DataSourceWithAgentsUsageType,
   Result,
@@ -257,6 +258,33 @@ function getCoreViewTypeFilter(viewType: ContentNodesViewType) {
   }
 }
 
+function searchScopeForDsv({
+  dsv,
+  includeDataSources,
+  isSingleDsv,
+}: {
+  dsv: DataSourceViewResource;
+  includeDataSources: boolean;
+  isSingleDsv: boolean;
+}): CoreAPISearchScope {
+  // On a single datasource view, we never want to match the datasource title.
+  if (isSingleDsv) {
+    return "nodes_titles";
+  }
+
+  if (includeDataSources) {
+    // For webcrawler datasources, we want to search the only datasource
+    // title, not the nodes titles.
+    if (dsv.dataSource.connectorProvider === "webcrawler") {
+      return "data_source_name";
+    }
+
+    return "both";
+  }
+
+  return "nodes_titles";
+}
+
 export async function searchContenNodesInSpace(
   auth: Authenticator,
   space: SpaceResource,
@@ -290,45 +318,18 @@ export async function searchContenNodesInSpace(
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-  const searchScopeForDsv = (dsv: DataSourceViewResource) => {
-    // On a single datasource view, we never want to match the datasource title.
-    if (dataSourceViews.length === 1) {
-      return "nodes_titles";
-    }
-
-    if (includeDataSources) {
-      // For webcrawler datasources, we want to search the only datasource
-      // title, not the nodes titles.
-      if (dsv.dataSource.connectorProvider === "webcrawler") {
-        return "data_source_name";
-      }
-
-      return "both";
-    }
-
-    return "nodes_titles";
-  };
-
-  logger.info({
-    query,
-    includeDataSources,
-    filter: {
-      data_source_views: dataSourceViews.map((dsv) => ({
-        data_source_id: dsv.dataSource.dustAPIDataSourceId,
-        view_filter: dsv.parentsIn ?? [],
-        search_scope: searchScopeForDsv(dsv),
-      })),
-      node_types: getCoreViewTypeFilter(viewType),
-    },
-  });
-
+  const isSingleDsv = dataSourceViews.length === 1;
   const searchRes = await coreAPI.searchNodes({
     query,
     filter: {
       data_source_views: dataSourceViews.map((dsv) => ({
         data_source_id: dsv.dataSource.dustAPIDataSourceId,
         view_filter: dsv.parentsIn ?? [],
-        search_scope: searchScopeForDsv(dsv),
+        search_scope: searchScopeForDsv({
+          dsv,
+          includeDataSources,
+          isSingleDsv,
+        }),
       })),
       excluded_node_mime_types: excludedNodeMimeTypes,
       node_types: getCoreViewTypeFilter(viewType),

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -249,17 +249,21 @@ export interface CoreAPISearchTagsResponse {
   };
 }
 
+export const CoreAPISearchScopeSchema = t.union([
+  t.literal("nodes_titles"),
+  t.literal("data_source_name"),
+  t.literal("both"),
+]);
+
+export type CoreAPISearchScope = t.TypeOf<typeof CoreAPISearchScopeSchema>;
+
 export const CoreAPIDatasourceViewFilterSchema = t.intersection([
   t.type({
     data_source_id: t.string,
     view_filter: t.array(t.string),
   }),
   t.partial({
-    search_scope: t.union([
-      t.literal("nodes_titles"),
-      t.literal("data_source_name"),
-      t.literal("both"),
-    ]),
+    search_scope: CoreAPISearchScopeSchema,
   }),
 ]);
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -257,7 +257,7 @@ export const CoreAPIDatasourceViewFilterSchema = t.intersection([
   t.partial({
     search_scope: t.union([
       t.literal("nodes_titles"),
-      t.literal("data_source_title"),
+      t.literal("data_source_name"),
       t.literal("both"),
     ]),
   }),

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -256,7 +256,7 @@ export const CoreAPIDatasourceViewFilterSchema = t.intersection([
   }),
   t.partial({
     search_scope: t.union([
-      t.literal("children_titles"),
+      t.literal("nodes_titles"),
       t.literal("data_source_title"),
       t.literal("both"),
     ]),

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -249,10 +249,19 @@ export interface CoreAPISearchTagsResponse {
   };
 }
 
-export const CoreAPIDatasourceViewFilterSchema = t.type({
-  data_source_id: t.string,
-  view_filter: t.array(t.string),
-});
+export const CoreAPIDatasourceViewFilterSchema = t.intersection([
+  t.type({
+    data_source_id: t.string,
+    view_filter: t.array(t.string),
+  }),
+  t.partial({
+    search_scope: t.union([
+      t.literal("children_titles"),
+      t.literal("data_source_title"),
+      t.literal("both"),
+    ]),
+  }),
+]);
 
 export type CoreAPIDatasourceViewFilter = t.TypeOf<
   typeof CoreAPIDatasourceViewFilterSchema
@@ -267,7 +276,6 @@ export const CoreAPINodesSearchFilterSchema = t.intersection([
   }),
   t.partial({
     excluded_node_mime_types: t.union([t.readonlyArray(t.string), t.undefined]),
-    include_data_sources: t.boolean,
     node_ids: t.array(t.string),
     node_types: t.array(t.string),
     parent_id: t.string,


### PR DESCRIPTION
Description
---
Closes https://github.com/dust-tt/tasks/issues/2241

- new param `search_scope` on data source view filter
- 3 options to either search data source title, nodes title, or both (defaults to nodes title, most common & standard use case)
- remove include_ds param

Risks
---
low, gated

Deploy
---
core
front
