### PR TITLE
fix(Salesforce) - Launch the sync workflow upon creating the connector

### DIFF
--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -59,6 +59,11 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
       },
       {}
     );
+    const launchResult = await launchSalesforceSyncWorkflow(connector.id);
+    if (launchResult.isErr()) {
+      await connector.delete();
+      throw launchResult.error;
+    }
 
     return new Ok(connector.id.toString());
   }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2292.
- This PR launches the sync workflow upon creating the connector, ensuring that the sync starts when we set permissions for the very first time.

## Tests

yes

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.