### PR TITLE
Fix: skip missing channel when syncing metadata

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -97,9 +97,14 @@ export async function updateSlackChannelInCoreDb(
     },
   });
   if (!channelOnDb) {
-    throw new Error(
-      `Could not find channel ${channelId} in connectors db for connector ${connectorId}`
+    logger.warn(
+      {
+        connectorId,
+        channelId,
+      },
+      "Could not find channel in connectors db, skipping for now."
     );
+    return;
   }
 
   const folderId = slackChannelInternalIdFromSlackChannelId(channelId);


### PR DESCRIPTION
## Description

Remove errors in connectors for slack webhook concerning channels we are not aware of.

## Risk

Just skipping the error.

## Deploy Plan

Deploy `connectors`