### PR TITLE
[front] Add relation table between conversation and message

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -48,6 +48,7 @@ import {
   AgentMessage,
   AgentMessageFeedback,
   Conversation,
+  ConversationHasMessage,
   ConversationParticipant,
   Mention,
   Message,
@@ -166,6 +167,7 @@ async function main() {
   await Message.sync({ alter: true });
   await MessageReaction.sync({ alter: true });
   await Mention.sync({ alter: true });
+  await ConversationHasMessage.sync({ alter: true });
 
   await AgentRetrievalAction.sync({ alter: true });
   await AgentTablesQueryAction.sync({ alter: true });

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -630,3 +630,65 @@ Message.hasMany(Mention, {
 Mention.belongsTo(Message, {
   foreignKey: { name: "messageId", allowNull: false },
 });
+
+export class ConversationHasMessage extends WorkspaceAwareModel<ConversationHasMessage> {
+  declare createdAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<Conversation["id"]>;
+  declare messageId: ForeignKey<Message["id"]>;
+  declare thread: number;
+  declare rank: number;
+  declare conversation: NonAttribute<Conversation>;
+  declare message: NonAttribute<Message>;
+}
+
+ConversationHasMessage.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    rank: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    thread: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    },
+  },
+  {
+    modelName: "conversation_has_message",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["conversationId", "messageId"],
+        unique: true,
+      },
+      {
+        fields: ["conversationId", "thread", "createdAt"],
+      },
+      {
+        fields: ["conversationId", "thread", "rank"],
+      },
+    ],
+  }
+);
+
+Message.hasOne(ConversationHasMessage, {
+  foreignKey: { name: "messageId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationHasMessage.belongsTo(Message, {
+  foreignKey: { name: "messageId", allowNull: false },
+});
+
+Conversation.hasMany(ConversationHasMessage, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationHasMessage.belongsTo(Conversation, {
+  foreignKey: { name: "conversationId", allowNull: false },
+});

--- a/front/migrations/20250305_conversation_has_messages.ts
+++ b/front/migrations/20250305_conversation_has_messages.ts
@@ -1,0 +1,85 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import { Sequelize } from "sequelize";
+
+import { Message } from "@app/lib/models/assistant/conversation";
+import { Workspace } from "@app/lib/models/workspace";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+async function backfillConversationHasMessage(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  let offset = 0;
+  const batchSize = 1000;
+  let messages = [];
+  do {
+    messages = await Message.findAll({
+      attributes: [
+        [Sequelize.fn("MAX", Sequelize.col("version")), "maxVersion"],
+        [Sequelize.fn("MAX", Sequelize.col("id")), "id"],
+      ],
+      where: {
+        workspaceId: workspace.id,
+      },
+      group: ["conversationId", "rank"],
+      order: [["id", "ASC"]],
+      limit: batchSize,
+      offset: offset,
+    });
+
+    const messageIds = messages.map((m) => m.id);
+    if (execute && messageIds.length > 0) {
+      await frontSequelize.query(
+        `INSERT INTO conversation_has_messages ("conversationId", "messageId", "rank", "thread", "workspaceId", "createdAt", "updatedAt")
+                SELECT 
+                    "conversationId",
+                    "id",
+                    "rank",
+                    0,
+                    "workspaceId",
+                    "createdAt",
+                    "updatedAt"
+                    FROM messages 
+                WHERE "id" IN (:messageIds) ON CONFLICT DO NOTHING`,
+        {
+          replacements: {
+            messageIds,
+          },
+        }
+      );
+    }
+
+    offset += batchSize;
+  } while (messages.length === batchSize);
+
+  logger.info(
+    `Done backfilling conversation_has_messages for workspace ${workspace.sId}`
+  );
+}
+
+makeScript({ wId: { type: "string" } }, async ({ execute, wId }, logger) => {
+  if (wId) {
+    const workspace = await Workspace.findOne({
+      where: {
+        sId: wId,
+      },
+    });
+    if (!workspace) {
+      throw new Error(`Workspace ${wId} not found`);
+    }
+    await backfillConversationHasMessage(
+      renderLightWorkspaceType({ workspace }),
+      logger,
+      execute
+    );
+  } else {
+    return runOnAllWorkspaces(async (workspace) => {
+      await backfillConversationHasMessage(workspace, logger, execute);
+    });
+  }
+});


### PR DESCRIPTION
## Description

Add a dedicated table for relation between conversation and message. 
This will prepare the introduction of conversation branching from https://github.com/dust-tt/dust/pull/10771 , avoiding to store an array of threads inside conversation table, and making queries much faster.
- query in messages ( fetchMessagesForPage ) can be updated once backfilled
- thread is backfilled to 0 - for all existing messages with multiple versions, we backfill only one thread, containing last versions of all messages
- rank is still needed here, but order will be possible on createdAt once we introduce conversation branching on agent message retry

## Tests

tested locally : 
- created conversation
- add mention to message
- retry agent mesage
- attach fragment
- view message list

## Risk

can be rolled back - no changes on existing tables, new table can be dropped

## Deploy Plan

run migration_175
deploy front
run backfill
