### PR TITLE
Fix: github connector stuck, add log for microsoft

### DIFF
--- a/connectors/src/connectors/github/lib/errors.ts
+++ b/connectors/src/connectors/github/lib/errors.ts
@@ -1,9 +1,17 @@
 import { RequestError } from "octokit";
 
-export function isGithubRequestErrorNotFound(
-  error: unknown
-): error is RequestError {
-  return error instanceof RequestError && error.status === 404;
+export function isGithubRequestErrorNotFound(error: unknown): error is {
+  name: string;
+  status: number;
+  message: string;
+} {
+  return (
+    error instanceof Error &&
+    "name" in error &&
+    error.name === "HttpError" &&
+    "status" in error &&
+    error.status === 404
+  );
 }
 
 export function isGithubRequestRedirectCountExceededError(

--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -21,7 +21,7 @@ import { syncFiles } from "@connectors/connectors/microsoft/temporal/activities"
 import { launchMicrosoftIncrementalSyncWorkflow } from "@connectors/connectors/microsoft/temporal/client";
 import { throwOnError } from "@connectors/lib/cli";
 import { terminateWorkflow } from "@connectors/lib/temporal";
-import logger from "@connectors/logger/logger";
+import logger, { getActivityLogger } from "@connectors/logger/logger";
 import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
@@ -86,9 +86,10 @@ export const microsoft = async ({
       const { nodeType, itemAPIPath } = typeAndPathFromInternalId(
         args.internalId
       );
-
+      const logger = getActivityLogger(connector);
       const client = await getClient(connector.connectionId);
       const driveItem = (await getItem(
+        logger,
         client,
         itemAPIPath + nodeType === "file"
           ? `?${DRIVE_ITEM_EXPANDS_AND_SELECTS}`
@@ -211,6 +212,7 @@ export const microsoft = async ({
 
     case "skip-file": {
       const connector = await getConnector(args);
+      const logger = getActivityLogger(connector);
       if (!args.internalId) {
         throw new Error("Missing --internalId argument");
       }
@@ -224,6 +226,7 @@ export const microsoft = async ({
 
       const client = await getClient(connector.connectionId);
       const file = (await getItem(
+        logger,
         client,
         itemAPIPath + `?${DRIVE_ITEM_EXPANDS_AND_SELECTS}`
       )) as DriveItem;

--- a/connectors/src/connectors/microsoft/lib/utils.ts
+++ b/connectors/src/connectors/microsoft/lib/utils.ts
@@ -102,16 +102,18 @@ export const getCachedListColumns = cacheWithRedis(
 );
 
 export async function _getListColumns({
+  logger,
   client,
   siteId,
   listId,
 }: {
+  logger: LoggerInterface;
   client: Client;
   siteId: string;
   listId: string;
 }): Promise<ColumnDefinition[]> {
   const endpoint = `/sites/${siteId}/lists/${listId}/columns`;
-  const res = await clientApiGet(client, endpoint);
+  const res = await clientApiGet(logger, client, endpoint);
   return res.value.filter(isCustomColumn);
 }
 
@@ -139,6 +141,7 @@ export const getColumnsFromListItem = async (
   }
   try {
     const columns = await getCachedListColumns({
+      logger,
       client,
       listId: file.sharepointIds.listId,
       siteId: file.sharepointIds.siteId,

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -114,6 +114,7 @@ export async function syncOneFile({
     "@microsoft.graph.downloadUrl" in file
       ? file["@microsoft.graph.downloadUrl"]
       : await getFileDownloadURL(
+          localLogger,
           await getClient(connector.connectionId),
           documentId
         );

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -144,7 +144,7 @@ async function processSheet({
     return new Err(new Error("Worksheet has no id"));
   }
   const content = await wrapMicrosoftGraphAPIWithResult(() =>
-    getWorksheetContent(client, worksheetInternalId)
+    getWorksheetContent(localLogger, client, worksheetInternalId)
   );
 
   const loggerArgs = {
@@ -294,7 +294,7 @@ export async function handleSpreadSheet({
 
   const worksheetsRes = await wrapMicrosoftGraphAPIWithResult(() =>
     getAllPaginatedEntities((nextLink) =>
-      getWorksheets(client, documentId, nextLink)
+      getWorksheets(localLogger, client, documentId, nextLink)
     )
   );
 


### PR DESCRIPTION
## Description

- Add logs to monitor latency of MS graph api calls (request from a customer)
- Refactor the typeguard to unstuck github activity.

## Tests

Locally (forced a sync on both connectors)

## Risk

Low, should be safe thanks to type checking.

## Deploy Plan

Deploy `connectors`