### PR TITLE
[Search KB] Fix: missing datasource title + wrong ordering

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -1037,8 +1037,13 @@ impl ElasticsearchSearchStore {
 
     fn build_relevance_sort(&self) -> Vec<Sort> {
         vec![
-            Sort::FieldSort(FieldSort::new("_score").order(SortOrder::Asc)),
-            Sort::FieldSort(FieldSort::new("node_id").order(SortOrder::Asc)),
+            Sort::FieldSort(FieldSort::new("_score").order(SortOrder::Desc)),
+            Sort::ScriptSort(
+                ScriptSort::ascending(Script::source(
+                    "doc['_index'].value.startsWith('data_source_nodes') ? doc['node_id'].value : doc['data_source_id'].value"
+                ))
+                .r#type(ScriptSortType::String)
+            ),
         ]
     }
 


### PR DESCRIPTION
Description
---
PR #11202  introduced infinite scrolling, with 2 issues:
- sort order was score ascending instead of descending;
- sort was using a field that does not exist on data sources, so data source names were missing.

This PR fixes that.

Risks
---
low

Deploy
---
core