### PR TITLE
Fix: scroll to the input bar

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -1,7 +1,6 @@
 import { Page, useSendNotification } from "@dust-tt/sparkle";
 import type {
   AgentMention,
-  LightAgentConfigurationType,
   MentionType,
   Result,
   SubscriptionType,
@@ -11,7 +10,7 @@ import type {
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { useRouter } from "next/router";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { AssistantBrowserContainer } from "@app/components/assistant/conversation/AssistantBrowserContainer";
@@ -56,7 +55,6 @@ export function ConversationContainer({
   const { animate, setAnimate, setSelectedAssistant } =
     useContext(InputBarContext);
 
-  const assistantToMention = useRef<LightAgentConfigurationType | null>(null);
   const { scrollConversationsToTop } = useConversationsNavigation();
 
   const router = useRouter();
@@ -256,32 +254,6 @@ export function ConversationContainer({
     ]
   );
 
-  useEffect(() => {
-    const scrollContainerElement = document.getElementById(
-      "assistant-input-header"
-    );
-
-    if (scrollContainerElement) {
-      const observer = new IntersectionObserver(
-        () => {
-          if (assistantToMention.current) {
-            setInputbarMention(assistantToMention.current.sId);
-            assistantToMention.current = null;
-          }
-        },
-        { threshold: 0.8 }
-      );
-      observer.observe(scrollContainerElement);
-    }
-    const handleRouteChange = (url: string) => {
-      if (url.endsWith("/new")) {
-        setSelectedAssistant(null);
-        assistantToMention.current = null;
-      }
-    };
-    router.events.on("routeChangeComplete", handleRouteChange);
-  }, [setAnimate, setInputbarMention, router, setSelectedAssistant]);
-
   const [greeting, setGreeting] = useState<string>("");
   useEffect(() => {
     setGreeting(getRandomGreetingForName(user.firstName));
@@ -333,9 +305,9 @@ export function ConversationContainer({
       {!activeConversationId && (
         <AssistantBrowserContainer
           onAgentConfigurationClick={setInputbarMention}
-          setAssistantToMention={(assistant) => {
-            assistantToMention.current = assistant;
-          }}
+          setAssistantToMention={(assistant) =>
+            setSelectedAssistant({ configurationId: assistant.sId })
+          }
           owner={owner}
           isBuilder={isBuilder}
         />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -178,11 +178,12 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
     ? groupConversationsByDate(conversations)
     : ({} as Record<GroupLabel, ConversationWithoutContentType[]>);
 
-  const { setAnimate } = useContext(InputBarContext);
+  const { setAnimate, setSelectedAssistant } = useContext(InputBarContext);
 
-  const triggerInputAnimation = () => {
+  const newConversationAnimation = useCallback(() => {
     setAnimate(true);
-  };
+    setSelectedAssistant(null);
+  }, [setAnimate, setSelectedAssistant]);
 
   return (
     <>
@@ -237,15 +238,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                   tooltip="Create a new conversation"
                   onClick={() => {
                     setSidebarOpen(false);
-                    const { cId } = router.query;
-                    const isNewConversation =
-                      router.pathname === "/w/[wId]/assistant/[cId]" &&
-                      typeof cId === "string" &&
-                      cId === "new";
-
-                    if (isNewConversation && triggerInputAnimation) {
-                      triggerInputAnimation();
-                    }
+                    newConversationAnimation();
                   }}
                 />
                 <DropdownMenu>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -171,9 +171,7 @@ export function AssistantInputBar({
   useEffect(() => {
     if (animate) {
       if (!scrollAndAnimate(router.route)) {
-        router.events.on("routeChangeComplete", (url) => {
-          scrollAndAnimate(url);
-        });
+        router.events.on("routeChangeComplete", scrollAndAnimate);
       }
     }
 

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -147,7 +147,6 @@ export default function AppLayout({
         />
         <div className="relative h-full w-full flex-1 flex-col overflow-x-hidden overflow-y-hidden dark:bg-slate-950 dark:text-slate-50">
           <main
-            id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
             className={classNames(
               "flex h-full w-full flex-col items-center overflow-y-auto",
               hasTopPadding ?? !titleChildren ? "lg:pt-8" : ""
@@ -167,7 +166,10 @@ export default function AppLayout({
               </div>
             </div>
 
-            <div className="flex h-full w-full flex-col items-center overflow-y-auto px-4 sm:px-8">
+            <div
+              id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
+              className="flex h-full w-full flex-col items-center overflow-y-auto px-4 sm:px-8"
+            >
               {isWideMode ? (
                 loaded && children
               ) : (

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -8,7 +8,6 @@ import { ConversationContainer } from "@app/components/assistant/conversation/Co
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import ConversationLayout from "@app/components/assistant/conversation/ConversationLayout";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
-import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
@@ -84,15 +83,6 @@ export default function AssistantConversation({
     } else if (!activeConversationId) {
       // Force re-render by setting a new key with a random number.
       setConversationKey(`new_${Math.random() * 1000}`);
-
-      // Scroll to the top of the conversation container when clicking on "new".
-      const mainTag = document.getElementById(
-        CONVERSATION_PARENT_SCROLL_DIV_ID["page"]
-      );
-
-      if (mainTag) {
-        mainTag.scrollTo(0, 0);
-      }
     }
 
     const agentId = assistant ?? null;


### PR DESCRIPTION
## Description

Fix scrolling to the input bar:
- Move the id to the right element
- Remove duplicated system "assistantToMention = useRef<LightAgentConfigurationType | null>(null)" and only use setSelectedAssistant() from InputBarContext
- Handle scrolling and animation in the inputbar itself, immediately if we are already in the new page, or wait for route change complete.

## Tests

Locally

## Risk

Medium, but I tested all use cases I could think of.

## Deploy Plan

Deploy `front`