### PR TITLE
[front] - feat(hooks): implement custom hook for managing query params

### DIFF
--- a/front/hooks/useQueryParams.ts
+++ b/front/hooks/useQueryParams.ts
@@ -1,0 +1,95 @@
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type ParamValue = {
+  value: string | undefined;
+  setParam: (newValue: string | undefined) => void;
+};
+
+type UseQueryParamsResult<T extends string> = {
+  [K in T]: ParamValue;
+} & {
+  setParams: (updates: Partial<Record<T, string | undefined>>) => void;
+};
+
+export function useQueryParams<T extends string>(
+  paramNames: T[]
+): UseQueryParamsResult<T> {
+  const router = useRouter();
+  const [values, setValues] = useState<Record<string, string | undefined>>({});
+
+  useEffect(() => {
+    if (router.isReady) {
+      const newValues = paramNames.reduce(
+        (acc, name) => {
+          acc[name] = router.query[name] as string | undefined;
+          return acc;
+        },
+        {} as Record<string, string | undefined>
+      );
+
+      // Only update state if values actually changed
+      if (JSON.stringify(newValues) !== JSON.stringify(values)) {
+        setValues(newValues);
+      }
+    }
+  }, [router.isReady, paramNames, router.query, values]);
+
+  // Multi-parameter update function
+  const setParams = useCallback(
+    (updates: Partial<Record<T, string | undefined>>) => {
+      const updatedQuery = { ...router.query };
+      let hasChanges = false;
+
+      // Process all updates at once
+      Object.entries(updates).forEach(([paramName, newValue]) => {
+        if (paramNames.includes(paramName as T)) {
+          const currentValue = router.query[paramName] as string | undefined;
+
+          // Only update if value actually changed
+          if (currentValue !== newValue) {
+            hasChanges = true;
+            if (typeof newValue === "string") {
+              updatedQuery[paramName] = newValue;
+            } else {
+              delete updatedQuery[paramName];
+            }
+          }
+        }
+      });
+
+      // Only push router update if something actually changed
+      if (hasChanges) {
+        void router.push(
+          { pathname: router.pathname, query: updatedQuery },
+          undefined,
+          { shallow: true }
+        );
+      }
+    },
+    [router, paramNames]
+  );
+
+  const getters = useMemo(
+    () =>
+      paramNames.reduce(
+        (acc, paramName) => ({
+          ...acc,
+          [paramName]: {
+            value: values[paramName],
+            setParam: (newValue: string | undefined) =>
+              setParams({ [paramName]: newValue } as Partial<
+                Record<T, string | undefined>
+              >),
+          },
+        }),
+        {} as Record<T, ParamValue>
+      ),
+    [paramNames, values, setParams]
+  );
+
+  return {
+    ...getters,
+    setParams,
+  } as UseQueryParamsResult<T>;
+}

--- a/front/hooks/useQueryParams.ts
+++ b/front/hooks/useQueryParams.ts
@@ -6,59 +6,68 @@ type ParamValue = {
   setParam: (newValue: string | undefined) => void;
 };
 
-type UseQueryParamsResult<T extends string> = {
-  [K in T]: ParamValue;
+type UseQueryParamsResult<T extends string[]> = {
+  [K in T[number]]: ParamValue;
 } & {
-  setParams: (updates: Partial<Record<T, string | undefined>>) => void;
+  setParams: (updates: Partial<Record<T[number], string | undefined>>) => void;
 };
 
-export function useQueryParams<T extends string>(
-  paramNames: T[]
+export function useQueryParams<T extends string[]>(
+  paramNames: T
 ): UseQueryParamsResult<T> {
   const router = useRouter();
   const [values, setValues] = useState<Record<string, string | undefined>>({});
 
   useEffect(() => {
     if (router.isReady) {
-      const newValues = paramNames.reduce(
+      const newValues = paramNames.reduce<Record<string, string | undefined>>(
         (acc, name) => {
-          acc[name] = router.query[name] as string | undefined;
+          const value = router.query[name];
+          acc[name] = typeof value === "string" ? value : undefined;
           return acc;
         },
-        {} as Record<string, string | undefined>
+        {}
       );
 
-      // Only update state if values actually changed
       if (JSON.stringify(newValues) !== JSON.stringify(values)) {
         setValues(newValues);
       }
     }
   }, [router.isReady, paramNames, router.query, values]);
 
-  // Multi-parameter update function
   const setParams = useCallback(
-    (updates: Partial<Record<T, string | undefined>>) => {
-      const updatedQuery = { ...router.query };
-      let hasChanges = false;
+    (updates: Partial<Record<T[number], string | undefined>>) => {
+      const initialQuery = { ...router.query };
 
-      // Process all updates at once
-      Object.entries(updates).forEach(([paramName, newValue]) => {
-        if (paramNames.includes(paramName as T)) {
-          const currentValue = router.query[paramName] as string | undefined;
-
-          // Only update if value actually changed
-          if (currentValue !== newValue) {
-            hasChanges = true;
-            if (typeof newValue === "string") {
-              updatedQuery[paramName] = newValue;
-            } else {
-              delete updatedQuery[paramName];
-            }
+      const [updatedQuery, hasChanges] = Object.entries(updates).reduce<
+        [Record<string, string | undefined | string[]>, boolean]
+      >(
+        ([currentQuery, changed], [paramName, newValue]) => {
+          // Skip if not in our param list
+          if (!paramNames.includes(paramName)) {
+            return [currentQuery, changed];
           }
-        }
-      });
 
-      // Only push router update if something actually changed
+          const currentValue = currentQuery[paramName];
+
+          // Skip if value hasn't changed
+          if (currentValue === newValue) {
+            return [currentQuery, changed];
+          }
+
+          if (typeof newValue === "string") {
+            // Add or update param with string value
+            return [{ ...currentQuery, [paramName]: newValue }, true];
+          } else {
+            // Remove param when value is undefined
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { [paramName]: _, ...restQuery } = currentQuery;
+            return [restQuery, true];
+          }
+        },
+        [initialQuery, false]
+      );
+
       if (hasChanges) {
         void router.push(
           { pathname: router.pathname, query: updatedQuery },
@@ -70,26 +79,24 @@ export function useQueryParams<T extends string>(
     [router, paramNames]
   );
 
-  const getters = useMemo(
-    () =>
-      paramNames.reduce(
-        (acc, paramName) => ({
-          ...acc,
-          [paramName]: {
-            value: values[paramName],
-            setParam: (newValue: string | undefined) =>
-              setParams({ [paramName]: newValue } as Partial<
-                Record<T, string | undefined>
-              >),
-          },
-        }),
-        {} as Record<T, ParamValue>
-      ),
-    [paramNames, values, setParams]
-  );
+  const getters = useMemo(() => {
+    return paramNames.reduce(
+      (acc, paramName) => {
+        acc[paramName as T[number]] = {
+          value: values[paramName],
+          setParam: (newValue: string | undefined) =>
+            setParams({
+              [paramName]: newValue,
+            } as Partial<Record<T[number], string | undefined>>),
+        };
+        return acc;
+      },
+      {} as Record<T[number], ParamValue>
+    );
+  }, [paramNames, values, setParams]);
 
   return {
     ...getters,
     setParams,
-  } as UseQueryParamsResult<T>;
+  };
 }


### PR DESCRIPTION
## Description

This PR implements a custom React hook `useQueryParams` to manage URL query parameters in a type-safe and efficient way. 
The hook provides individual getters and setters for each parameter along with a batch update function. It handles URL updates with shallow routing and prevents unnecessary state updates and router pushes.

Note: this is a `useHashParams` on steroid.

## Risk

None


## Deploy Plan

Deploy `front`