### PR TITLE
[Search KB] Fix: remove transient filtering when searching

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -259,8 +259,7 @@ export const SpaceDataSourceViewContentList = ({
     [resetPagination, setViewType, viewType]
   );
 
-  const { searchTerm: dataSourceSearch, setIsSearchDisabled } =
-    useContext(SpaceSearchContext);
+  const { setIsSearchDisabled } = useContext(SpaceSearchContext);
 
   const columns = useMemo(
     () => getTableColumns(showSpaceUsage),
@@ -619,10 +618,6 @@ export const SpaceDataSourceViewContentList = ({
           <DataTable
             data={rows}
             columns={columns}
-            filter={dataSourceSearch}
-            filterColumn={
-              "title" // see todo above
-            }
             className="pb-4"
             totalRowCount={totalNodesCount}
             rowCountIsCapped={!totalNodesCountIsAccurate}


### PR DESCRIPTION
Description
---
Before: for ~1s we see a basic children filtering before seeing search results (unstable, moving)
[Screencast From 2025-03-05 22-22-55.webm](https://github.com/user-attachments/assets/5d92eda5-b0a1-4f4a-a078-30938d270311)

After: stays the same, stable

[Screencast From 2025-03-05 22-28-11.webm](https://github.com/user-attachments/assets/5ac80604-e6b5-44c9-8c7f-01f0b6aed1db)

Risk
---
low

Deploy
---
front
