### PR TITLE
enh(Gong) - Temporal setup improvements

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -3,8 +3,8 @@ import { Err, MIME_TYPES, Ok } from "@dust-tt/types";
 
 import { makeGongTranscriptFolderInternalId } from "@connectors/connectors/gong/lib/internal_ids";
 import {
-  launchGongSyncWorkflow,
-  stopGongSyncWorkflow,
+  launchGongSync,
+  stopGongSync,
 } from "@connectors/connectors/gong/temporal/client";
 import type {
   ConnectorManagerError,
@@ -51,7 +51,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       mimeType: MIME_TYPES.GONG.TRANSCRIPT_FOLDER,
     });
 
-    const result = await launchGongSyncWorkflow(connector);
+    const result = await launchGongSync(connector);
     if (result.isErr()) {
       logger.error(
         { connectorId: connector.id, error: result.error },
@@ -96,7 +96,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       logger.error({ connectorId }, "[Gong] Connector not found.");
       throw new Error("[Gong] Connector not found.");
     }
-    const result = await stopGongSyncWorkflow(connector);
+    const result = await stopGongSync(connector);
     if (result.isErr()) {
       return result;
     }
@@ -111,7 +111,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const result = await launchGongSyncWorkflow(connector);
+    const result = await launchGongSync(connector);
     if (result.isErr()) {
       logger.error(
         { connectorId: this.connectorId, error: result.error },
@@ -148,7 +148,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const result = await launchGongSyncWorkflow(connector);
+    const result = await launchGongSync(connector);
     if (result.isErr()) {
       logger.error(
         { connectorId: this.connectorId, error: result.error },

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -17,10 +17,12 @@ import type {
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import logger from "@connectors/logger/logger";
+import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { GongConfigurationResource } from "@connectors/resources/gong_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
+
+const logger = mainLogger.child({ provider: "gong" });
 
 const TRANSCRIPTS_FOLDER_TITLE = "Transcripts";
 
@@ -55,10 +57,6 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
 
     const result = await createGongSyncSchedule(connector);
     if (result.isErr()) {
-      logger.error(
-        { connectorId: connector.id, error: result.error },
-        "[Gong] Error creating schedule and launching Gong sync."
-      );
       throw result.error;
     }
 
@@ -81,14 +79,6 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
 
     const scheduleResult = await deleteGongSyncSchedule(connector);
     if (scheduleResult.isErr()) {
-      logger.error(
-        {
-          connectorId,
-          provider: "gong",
-          error: scheduleResult.error,
-        },
-        "[Gong] Failed to delete schedule and terminate workflow."
-      );
       return scheduleResult;
     }
     const connectorResult = await connector.delete();
@@ -96,7 +86,6 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       logger.error(
         {
           connectorId,
-          provider: "gong",
           error: connectorResult.error,
         },
         "[Gong] Failed to delete connector."
@@ -162,7 +151,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       // If fromTs is set, we ignore it and sync from the last cursor; we cannot miss transcripts if we assume that
       // transcripts cannot be created in the past.
       logger.warn(
-        `[Gong] Ignoring the fromTs, syncing from ${configuration.lastSyncTimestamp}`
+        `[Gong] Ignoring the fromTs, syncing from ${configuration.lastSyncTimestamp}.`
       );
     }
 
@@ -170,7 +159,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
     if (result.isErr()) {
       logger.error(
         { connectorId: this.connectorId, error: result.error },
-        "[Gong] Error launching Gong sync workflow"
+        "[Gong] Error launching Gong sync."
       );
       throw result.error;
     }

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -3,7 +3,7 @@ import { Err, MIME_TYPES, Ok } from "@dust-tt/types";
 
 import { makeGongTranscriptFolderInternalId } from "@connectors/connectors/gong/lib/internal_ids";
 import {
-  launchGongSync,
+  startGongSync,
   stopGongSync,
 } from "@connectors/connectors/gong/temporal/client";
 import type {
@@ -51,7 +51,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       mimeType: MIME_TYPES.GONG.TRANSCRIPT_FOLDER,
     });
 
-    const result = await launchGongSync(connector);
+    const result = await startGongSync(connector);
     if (result.isErr()) {
       logger.error(
         { connectorId: connector.id, error: result.error },
@@ -111,7 +111,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const result = await launchGongSync(connector);
+    const result = await startGongSync(connector);
     if (result.isErr()) {
       logger.error(
         { connectorId: this.connectorId, error: result.error },
@@ -148,7 +148,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const result = await launchGongSync(connector);
+    const result = await startGongSync(connector);
     if (result.isErr()) {
       logger.error(
         { connectorId: this.connectorId, error: result.error },

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -41,7 +41,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       {}
     );
 
-    // Upsert a top-level folder that will contain all the transcripts (non selectable).
+    // Upsert a top-level folder that will contain all the transcripts (non-selectable).
     await upsertDataSourceFolder({
       dataSourceConfig: dataSourceConfigFromConnector(connector),
       folderId: makeGongTranscriptFolderInternalId(connector),

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -85,7 +85,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
     if (connectorResult.isErr()) {
       logger.error(
         {
-          connectorId,
+          connectorId: connector.id,
           error: connectorResult.error,
         },
         "[Gong] Failed to delete connector."
@@ -143,7 +143,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
     if (result.isErr()) {
       throw result.error;
     }
-    return new Ok(connectorId.toString());
+    return new Ok(connector.id.toString());
   }
 
   async retrievePermissions(): Promise<

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -1,18 +1,14 @@
-import type { ModelId, Result } from "@dust-tt/types";
-import { Err, getOAuthConnectionAccessToken, Ok } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
 import { GongAPIError } from "@connectors/connectors/gong/lib/errors";
-import { apiConfig } from "@connectors/lib/api/config";
 import {
   ExternalOAuthTokenError,
   HTTPError,
   isNotFoundError,
 } from "@connectors/lib/error";
-import logger from "@connectors/logger/logger";
-import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
 // Pass-through codec that is used to allow unknown properties.
 const CatchAllCodec = t.record(t.string, t.unknown);
@@ -115,27 +111,6 @@ const GongPaginatedResults = <C extends t.Mixed, F extends string>(
       [fieldName]: t.array(codec),
     } as Record<F, t.ArrayC<C>>),
   ]);
-
-export async function getGongAccessToken(
-  connector: ConnectorResource
-): Promise<Result<string, Error>> {
-  const tokenResult = await getOAuthConnectionAccessToken({
-    config: apiConfig.getOAuthAPIConfig(),
-    logger,
-    provider: "gong",
-    connectionId: connector.connectionId,
-  });
-  if (tokenResult.isErr()) {
-    logger.error(
-      { connectionId: connector.connectionId, error: tokenResult.error },
-      "Error retrieving Gong access token."
-    );
-
-    return new Err(new Error(tokenResult.error.message));
-  }
-
-  return new Ok(tokenResult.value.access_token);
-}
 
 export class GongClient {
   private readonly baseUrl = "https://api.gong.io/v2";

--- a/connectors/src/connectors/gong/lib/users.ts
+++ b/connectors/src/connectors/gong/lib/users.ts
@@ -36,11 +36,11 @@ export async function getGongUsers(
     return users;
   }
 
+  const gongClient = await getGongClient(connector);
+
   await concurrentExecutor(
     missingUsers,
     async (gongUserId) => {
-      const gongClient = await getGongClient(connector);
-
       // If the user does not exist yet, fetch it from the API and save it.
       const user = await gongClient.getUser({ userId: gongUserId });
       if (!user) {

--- a/connectors/src/connectors/gong/lib/utils.ts
+++ b/connectors/src/connectors/gong/lib/utils.ts
@@ -14,6 +14,7 @@ export async function fetchGongConnector({
 }): Promise<ConnectorResource> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
+    logger.error({ connectorId }, "[Gong] Connector not found.");
     throw new Error("[Gong] Connector not found.");
   }
   return connector;
@@ -25,6 +26,10 @@ export async function fetchGongConfiguration(
   const configuration =
     await GongConfigurationResource.fetchByConnector(connector);
   if (!configuration) {
+    logger.error(
+      { connectorId: connector.id },
+      "[Gong] Configuration not found."
+    );
     throw new Error("[Gong] Configuration not found.");
   }
   return configuration;

--- a/connectors/src/connectors/gong/lib/utils.ts
+++ b/connectors/src/connectors/gong/lib/utils.ts
@@ -1,7 +1,9 @@
-import type { ModelId } from "@dust-tt/types";
+import type { ModelId, Result } from "@dust-tt/types";
+import { Err, getOAuthConnectionAccessToken, Ok } from "@dust-tt/types";
 
 import { GongClient } from "@connectors/connectors/gong/lib/gong_api";
-import { getGongAccessToken } from "@connectors/connectors/gong/lib/gong_api";
+import { apiConfig } from "@connectors/lib/api/config";
+import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { GongConfigurationResource } from "@connectors/resources/gong_resources";
 
@@ -26,6 +28,27 @@ export async function fetchGongConfiguration(
     throw new Error("[Gong] Configuration not found.");
   }
   return configuration;
+}
+
+async function getGongAccessToken(
+  connector: ConnectorResource
+): Promise<Result<string, Error>> {
+  const tokenResult = await getOAuthConnectionAccessToken({
+    config: apiConfig.getOAuthAPIConfig(),
+    logger,
+    provider: "gong",
+    connectionId: connector.connectionId,
+  });
+  if (tokenResult.isErr()) {
+    logger.error(
+      { connectionId: connector.connectionId, error: tokenResult.error },
+      "Error retrieving Gong access token."
+    );
+
+    return new Err(new Error(tokenResult.error.message));
+  }
+
+  return new Ok(tokenResult.value.access_token);
 }
 
 export async function getGongClient(connector: ConnectorResource) {

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -12,7 +12,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
-function makeGongSyncWorkflowId(connector: ConnectorResource): string {
+function makeGongSyncScheduleId(connector: ConnectorResource): string {
   return `gong-sync-${connector.id}`;
 }
 
@@ -20,7 +20,7 @@ export async function launchGongSyncWorkflow(
   connector: ConnectorResource
 ): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
-  const workflowId = makeGongSyncWorkflowId(connector);
+  const workflowId = makeGongSyncScheduleId(connector);
 
   const action: ScheduleOptionsAction = {
     type: "startWorkflow",
@@ -36,7 +36,7 @@ export async function launchGongSyncWorkflow(
   try {
     await client.schedule.create({
       action,
-      scheduleId: makeGongSyncWorkflowId(connector),
+      scheduleId: makeGongSyncScheduleId(connector),
       policies: {
         // If Temporal Server is down or unavailable at the time when a Schedule should take an Action.
         // Backfill scheduled action up to the previous day.
@@ -63,7 +63,7 @@ export async function stopGongSyncWorkflow(
   connector: ConnectorResource
 ): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
-  const workflowId = makeGongSyncWorkflowId(connector);
+  const workflowId = makeGongSyncScheduleId(connector);
 
   try {
     const handle: WorkflowHandle<typeof gongSyncWorkflow> =

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -19,6 +19,10 @@ function makeGongSyncScheduleId(connector: ConnectorResource): string {
   return `gong-sync-${connector.id}`;
 }
 
+// Starts the sync of Gong data for the given connector.
+// - Creates a new schedule if it doesn't exist.
+// - Resumes the schedule if paused.
+// - Triggers the schedule to start the sync workflow immediately.
 export async function launchGongSync(
   connector: ConnectorResource
 ): Promise<Result<string, Error>> {
@@ -82,6 +86,9 @@ export async function launchGongSync(
   return new Ok(scheduleId);
 }
 
+// Stops the sync of Gong data for the given connector.
+// - Pauses the schedule.
+// - Terminates any running workflows for the schedule.
 export async function stopGongSync(
   connector: ConnectorResource
 ): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -41,8 +41,9 @@ export async function launchGongSyncWorkflow(
         // If Temporal Server is down or unavailable at the time when a Schedule should take an Action.
         // Backfill scheduled action up to the previous day.
         catchupWindow: "1 day",
-        // We allow only one workflow at a time.
-        overlap: ScheduleOverlapPolicy.SKIP,
+        // We buffer up to one workflow to make sure triggering a sync ensures having up-to-date data even if a very
+        // long-running workflow was running.
+        overlap: ScheduleOverlapPolicy.BUFFER_ONE,
       },
       spec: {
         intervals: [{ every: "1h" }],

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -20,7 +20,7 @@ function makeGongSyncScheduleId(connector: ConnectorResource): string {
   return `gong-sync-${connector.id}`;
 }
 
-export async function launchGongSyncWorkflow(
+export async function launchGongSync(
   connector: ConnectorResource
 ): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
@@ -83,7 +83,7 @@ export async function launchGongSyncWorkflow(
   return new Ok(scheduleId);
 }
 
-export async function stopGongSyncWorkflow(
+export async function stopGongSync(
   connector: ConnectorResource
 ): Promise<Result<void, Error>> {
   const client = await getTemporalClient();

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -12,7 +12,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
-function makeGongSyncScheduleId(connector: ConnectorResource): string {
+function makeGongSyncWorkflowId(connector: ConnectorResource): string {
   return `gong-sync-${connector.id}`;
 }
 
@@ -20,7 +20,7 @@ export async function launchGongSyncWorkflow(
   connector: ConnectorResource
 ): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
-  const workflowId = makeGongSyncScheduleId(connector);
+  const workflowId = makeGongSyncWorkflowId(connector);
 
   const action: ScheduleOptionsAction = {
     type: "startWorkflow",
@@ -36,7 +36,7 @@ export async function launchGongSyncWorkflow(
   try {
     await client.schedule.create({
       action,
-      scheduleId: makeGongSyncScheduleId(connector),
+      scheduleId: makeGongSyncWorkflowId(connector),
       policies: {
         // If Temporal Server is down or unavailable at the time when a Schedule should take an Action.
         // Backfill scheduled action up to the previous day.
@@ -63,7 +63,7 @@ export async function stopGongSyncWorkflow(
   connector: ConnectorResource
 ): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
-  const workflowId = makeGongSyncScheduleId(connector);
+  const workflowId = makeGongSyncWorkflowId(connector);
 
   try {
     const handle: WorkflowHandle<typeof gongSyncWorkflow> =

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -39,6 +39,7 @@ async function terminateWorkflowsForSchedule(
       await workflowHandle.terminate();
     } catch (error) {
       if (!(error instanceof WorkflowNotFoundError)) {
+        logger.error({ error }, "[Gong] Failed to terminate workflow.");
         throw error;
       }
     }

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -8,8 +8,10 @@ import {
 import { QUEUE_NAME } from "@connectors/connectors/gong/temporal/config";
 import { gongSyncWorkflow } from "@connectors/connectors/gong/temporal/workflows";
 import { getTemporalClient } from "@connectors/lib/temporal";
-import logger from "@connectors/logger/logger";
+import mainLogger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
+
+const logger = mainLogger.child({ provider: "gong" });
 
 // This function generates a connector-wise unique schedule ID for the Gong sync.
 // The IDs of the workflows spawned by this schedule will follow the pattern:
@@ -60,7 +62,6 @@ export async function createGongSyncSchedule(
     logger.error(
       {
         connectorId: connector.id,
-        provider: "gong",
         scheduleId,
         error,
       },
@@ -90,18 +91,17 @@ export async function deleteGongSyncSchedule(
     }
     // Delete the schedule.
     await scheduleHandle.delete();
-  } catch (e) {
-    if (!(e instanceof ScheduleNotFoundError)) {
+  } catch (error) {
+    if (!(error instanceof ScheduleNotFoundError)) {
       logger.error(
         {
           connectorId: connector.id,
-          provider: "gong",
           scheduleId,
-          error: e,
+          error,
         },
         "[Gong] Failed to delete schedule and terminate workflow."
       );
-      return new Err(e as Error);
+      return new Err(error as Error);
     }
   }
 
@@ -125,7 +125,6 @@ export async function startGongSync(
       logger.info(
         {
           connectorId: connector.id,
-          provider: "gong",
           scheduleId,
         },
         "[Gong] Resuming paused sync schedule."
@@ -140,7 +139,6 @@ export async function startGongSync(
       logger.error(
         {
           connectorId: connector.id,
-          provider: "gong",
           scheduleId,
           error,
         },
@@ -180,7 +178,6 @@ export async function stopGongSync(
       logger.error(
         {
           connectorId: connector.id,
-          provider: "gong",
           scheduleId,
           error,
         },

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -56,8 +56,6 @@ export async function launchGongSync(
       );
       await scheduleHandle.unpause();
     }
-    // Trigger the schedule to start the workflow immediately.
-    await scheduleHandle.trigger();
   } catch (err) {
     if (err instanceof ScheduleNotFoundError) {
       // Create the schedule if it doesn't exist.
@@ -82,6 +80,8 @@ export async function launchGongSync(
     }
     return new Err(err as Error);
   }
+  // Trigger the schedule to start the workflow immediately.
+  await scheduleHandle.trigger();
 
   return new Ok(scheduleId);
 }

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -48,7 +48,7 @@ export async function launchGongSyncWorkflow(
       spec: {
         // Adding a random offset to avoid all workflows starting at the same time and to take into account the fact
         // that many new transcripts will be made available roughly on the top of the hour.
-        jitter: 3600 * 1000, // 1 hour
+        jitter: 30 * 60 * 1000, // 30 minutes
         intervals: [{ every: "1h" }],
       },
     });

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -23,7 +23,7 @@ function makeGongSyncScheduleId(connector: ConnectorResource): string {
 // - Creates a new schedule if it doesn't exist.
 // - Resumes the schedule if paused.
 // - Triggers the schedule to start the sync workflow immediately.
-export async function launchGongSync(
+export async function startGongSync(
   connector: ConnectorResource
 ): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
@@ -40,10 +40,10 @@ export async function launchGongSync(
     taskQueue: QUEUE_NAME,
   };
 
+  const scheduleHandle = client.schedule.getHandle(
+    makeGongSyncScheduleId(connector)
+  );
   try {
-    const scheduleHandle = client.schedule.getHandle(
-      makeGongSyncScheduleId(connector)
-    );
     const scheduleDescription = await scheduleHandle.describe();
     if (scheduleDescription.state.paused) {
       logger.info(

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -1,5 +1,5 @@
 import type { Result } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, normalizeError, Ok } from "@dust-tt/types";
 import type { Client, ScheduleHandle } from "@temporalio/client";
 import {
   ScheduleNotFoundError,
@@ -94,7 +94,7 @@ export async function createGongSyncSchedule(
       },
       "[Gong] Failed to create schedule and launch Gong sync."
     );
-    return new Err(error as Error);
+    return new Err(normalizeError(error));
   }
 
   return new Ok(scheduleId);
@@ -123,7 +123,7 @@ export async function deleteGongSyncSchedule(
         },
         "[Gong] Failed to delete schedule and terminate workflow."
       );
-      return new Err(error as Error);
+      return new Err(normalizeError(error));
     }
   }
 
@@ -159,7 +159,7 @@ export async function startGongSync(
         },
         "[Gong] Failed to unpause and trigger schedule."
       );
-      return new Err(error as Error);
+      return new Err(normalizeError(error));
     }
   }
 
@@ -192,7 +192,7 @@ export async function stopGongSync(
         },
         "[Gong] Failed to stop schedule and terminate workflow."
       );
-      return new Err(error as Error);
+      return new Err(normalizeError(error));
     }
   }
 

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -46,6 +46,9 @@ export async function launchGongSyncWorkflow(
         overlap: ScheduleOverlapPolicy.BUFFER_ONE,
       },
       spec: {
+        // Adding a random offset to avoid all workflows starting at the same time and to take into account the fact
+        // that many new transcripts will be made available roughly on the top of the hour.
+        jitter: 3600 * 1000, // 1 hour
         intervals: [{ every: "1h" }],
       },
     });

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -28,9 +28,11 @@ async function terminateWorkflowsForSchedule(
   client: Client
 ) {
   const scheduleDescription = await scheduleHandle.describe();
-  for (const action of scheduleDescription.info.runningActions) {
+  // Terminate all the recent actions of the schedule,
+  // the running workflows are not available under scheduleDescription.info.runningActions.
+  for (const action of scheduleDescription.info.recentActions) {
     const workflowHandle = client.workflow.getHandle(
-      action.workflow.workflowId
+      action.action.workflow.workflowId
     );
     await workflowHandle.terminate();
   }


### PR DESCRIPTION
## Description

This PR improves the current Temporal setup with the following:
- Change the overlap policy from SKIP to BUFFER_ONE to ensure that triggering a sync will get the most up-to-date data, which can fail with SKIP if a long-running workflow is exhausting an outdated cursor.
- Add jitter to spread the start times over the hour.

This PR changes how schedules are managed by adding a pair of verbs `create/deleteGongSyncSchedule`, in addition to `start/stopGongSync`. The rationale behind it being that when using `stop` or `pause`, we can leverage the `pause` feature for schedules, which prevents future executions until unpaused. We therefore need a separate function to delete the schedule upon connector cleanup and we add a function for creating the schedule for symmetry.

- `startGongSync` is called by `ConnectorManager`.`sync`, `resume` and `unpause`, it resumes the schedule if paused and triggers the schedule to start the sync workflow immediately.
- `stopGongSync` is called by `ConnectorManager`.`stop` and `pause`, it pauses the schedule and terminates any running workflow for the schedule.
- `createGongSyncSchedule` is called by `ConnectorManager.create`, it creates the schedule and triggers it immediately.
- `deleteGongSyncSchedule` is called by `ConnectorManager.clean`, it terminates running workflows and deletes the schedule.

Relevant documentation:
  - https://docs.temporal.io/workflows#schedule
  - https://docs.temporal.io/develop/typescript/schedules#describe

This PR additionnaly handles a few minor refactoring tasks such as moving the `method` getGongAccessToken from `gong_api` to `utils`.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy `connectors`.