### PR TITLE
Fix: prevent large doc to upsert (and failures) for github connector

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -182,7 +182,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "Dust gathers data from issues, discussions, and pull-requests (top-level discussion, but not in-code comments). It synchronizes your code only if enabled.",
     mismatchError: `You cannot select another GitHub Organization.\nPlease contact us at support@dust.tt if you initially selected a wrong Organization or if you completely uninstalled the GitHub app.`,
     guideLink: "https://docs.dust.tt/docs/github-connection",
-    selectLabel: "Synchronized content",
+    selectLabel: "Authorized content",
     getLogoComponent: (isDark?: boolean) => {
       return isDark ? GithubWhiteLogo : GithubLogo;
     },


### PR DESCRIPTION
## Description

Github activities stuck because we return a 413 when trying to upsert a large doc.
Add a limit of 5mb (copied from gdrive) and check before trying to upsert.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `connectors`