### PR TITLE
Add Poke plugin to delete users from Auth0

### DIFF
--- a/front/lib/api/poke/plugins/global/delete_auth0_user.ts
+++ b/front/lib/api/poke/plugins/global/delete_auth0_user.ts
@@ -1,0 +1,44 @@
+import { Err, Ok } from "@dust-tt/types";
+
+import {
+  getAuth0ManagemementClient,
+  getAuth0UsersFromEmail,
+} from "@app/lib/api/auth0";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { isEmailValid } from "@app/lib/utils";
+
+export const deleteAuth0UserPlugin = createPlugin({
+  manifest: {
+    id: "delete-auth0-user",
+    name: "Delete Auth0 User",
+    description: "Delete a user from Auth0.",
+    resourceTypes: ["global"],
+    args: {
+      email: {
+        type: "string",
+        label: "Email",
+        description: "The email of the user to delete",
+      },
+    },
+  },
+  execute: async (auth, _, args) => {
+    const email = args.email.trim();
+    if (isEmailValid(email) === false) {
+      return new Err(new Error("Email address is invalid."));
+    }
+
+    const [auth0User] = await getAuth0UsersFromEmail([email]);
+    if (!auth0User) {
+      return new Err(new Error("User not found in Auth0."));
+    }
+
+    await getAuth0ManagemementClient().users.delete({
+      id: auth0User.user_id,
+    });
+
+    return new Ok({
+      display: "text",
+      value: "User deleted from Auth0.",
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/global/index.ts
+++ b/front/lib/api/poke/plugins/global/index.ts
@@ -1,2 +1,3 @@
 export * from "./batch_downgrade";
 export * from "./create_workspace";
+export * from "./delete_auth0_user";

--- a/front/pages/poke/plugins/index.tsx
+++ b/front/pages/poke/plugins/index.tsx
@@ -14,7 +14,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<object>(
 
 export default function ListPokePlugins() {
   return (
-    <div className="mx-auto h-full flex-grow flex-col items-center justify-center p-8 pt-8">
+    <div className="h-full flex-grow flex-col items-center justify-center p-8 pt-8">
       <PluginList
         pluginResourceTarget={{
           resourceType: "global",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a Poke plugin to delete users from Auth0. When creating a workspace in a region different than the existing user region, which prevent sending invitation to existing users. In case, this is really what we need, we can use this plugin to delete the existing user in auth0.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
