### PR TITLE
enh(Gong) - enrich tags on transcripts

### DIFF
--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -135,7 +135,7 @@ export async function syncGongTranscript({
       `media:${transcriptMetadata.metaData.media}`,
       `scope:${transcriptMetadata.metaData.scope}`,
       `direction:${transcriptMetadata.metaData.direction}`,
-      ...participants.map((p) => p.email),
+      ...participants.map((p) => `participant:${p.email}`),
     ],
     parents: [documentId, makeGongTranscriptFolderInternalId(connector)],
     parentId: makeGongTranscriptFolderInternalId(connector),

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -50,7 +50,7 @@ export async function syncGongTranscript({
 }) {
   const { callId } = transcript;
   const createdAtDate = new Date(transcriptMetadata.metaData.started);
-  const title = `${formatDateNicely(createdAtDate)}: ${transcriptMetadata.metaData.title || "Untitled transcript"}`;
+  const title = `${formatDateNicely(createdAtDate)} - ${transcriptMetadata.metaData.title || "Untitled transcript"}`;
   const documentUrl = transcriptMetadata.metaData.url;
 
   const transcriptInDb = await GongTranscriptResource.fetchByCallId(

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -19,6 +19,10 @@ import type { GongUserResource } from "@connectors/resources/gong_resources";
 import { GongTranscriptResource } from "@connectors/resources/gong_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
+function formatDateNicely(date: Date) {
+  return date.toISOString().split("T")[0];
+}
+
 /**
  * Syncs a transcript in the db and upserts it to the data sources.
  */
@@ -43,7 +47,7 @@ export async function syncGongTranscript({
 }) {
   const { callId } = transcript;
   const createdAtDate = new Date(transcriptMetadata.metaData.started);
-  const title = transcriptMetadata.metaData.title || "Untitled transcript";
+  const title = `${formatDateNicely(createdAtDate)}: ${transcriptMetadata.metaData.title || "Untitled transcript"}`;
   const documentUrl = transcriptMetadata.metaData.url;
 
   const transcriptInDb = await GongTranscriptResource.fetchByCallId(

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -20,7 +20,10 @@ import { GongTranscriptResource } from "@connectors/resources/gong_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 function formatDateNicely(date: Date) {
-  return date.toISOString().split("T")[0];
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}/${mm}/${dd}`;
 }
 
 /**


### PR DESCRIPTION
## Description

- On Gong transcripts, it is currently very hard to infer that a certain tag containing an email actually refers to the fact that the email is a participant's.
- This PR fixes that by prefixing participant's emails in tags with "participant:" (e.g. `participant:aubin@dust.tt`).
- This PR also adds the date of the call at the beginning of the title.

## Tests


## Risk

- n/a.

## Deploy Plan

- Deploy connectors.