### PR TITLE
enh(Gong) - Pass all participants' email addresses in tags

### DIFF
--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -15,7 +15,6 @@ import {
 } from "@connectors/lib/data_sources";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { GongUserResource } from "@connectors/resources/gong_resources";
 import { GongTranscriptResource } from "@connectors/resources/gong_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
@@ -32,7 +31,7 @@ function formatDateNicely(date: Date) {
 export async function syncGongTranscript({
   transcript,
   transcriptMetadata,
-  participants,
+  participantEmails,
   speakerToEmailMap,
   connector,
   dataSourceConfig,
@@ -41,7 +40,7 @@ export async function syncGongTranscript({
 }: {
   transcript: GongCallTranscript;
   transcriptMetadata: GongTranscriptMetadata;
-  participants: GongUserResource[];
+  participantEmails: string[];
   speakerToEmailMap: Record<string, string>;
   connector: ConnectorResource;
   dataSourceConfig: DataSourceConfig;
@@ -123,7 +122,7 @@ export async function syncGongTranscript({
       media: transcriptMetadata.metaData.media,
       scope: transcriptMetadata.metaData.scope,
       direction: transcriptMetadata.metaData.direction,
-      participants: participants.map((p) => p.email).join(", ") || "none",
+      participants: participantEmails.join(", ") || "none",
     },
   });
 
@@ -142,7 +141,7 @@ export async function syncGongTranscript({
       `media:${transcriptMetadata.metaData.media}`,
       `scope:${transcriptMetadata.metaData.scope}`,
       `direction:${transcriptMetadata.metaData.direction}`,
-      ...participants.map((p) => `participant:${p.email}`),
+      ...participantEmails.map((email) => `participant:${email}`),
     ],
     parents: [documentId, makeGongTranscriptFolderInternalId(connector)],
     parentId: makeGongTranscriptFolderInternalId(connector),

--- a/connectors/src/connectors/gong/lib/users.ts
+++ b/connectors/src/connectors/gong/lib/users.ts
@@ -47,7 +47,11 @@ export async function getGongUsers(
         return null;
       }
 
-      return GongUserResource.makeNew(connector, getUserBlobFromGongAPI(user));
+      const newUser = await GongUserResource.makeNew(
+        connector,
+        getUserBlobFromGongAPI(user)
+      );
+      users.push(newUser);
     },
     { concurrency: 10 }
   );

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -117,6 +117,15 @@ export async function gongSyncTranscriptsActivity({
             .map((p) => p.userId)
             .filter((id): id is string => Boolean(id)),
         });
+
+        const participantEmails = transcriptMetadata.parties
+          .map(
+            (party) =>
+              participants.find((p) => party.userId === p.gongId)?.email ||
+              party.emailAddress
+          )
+          .filter((email): email is string => Boolean(email));
+
         const speakerToEmailMap = Object.fromEntries(
           transcriptMetadata.parties.map((party) => [
             party.speakerId,
@@ -132,7 +141,7 @@ export async function gongSyncTranscriptsActivity({
           dataSourceConfig,
           speakerToEmailMap,
           loggerArgs,
-          participants,
+          participantEmails,
           connector,
           forceResync,
         });

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -34,7 +34,6 @@ export const FOLDERS_TO_HIDE_IF_EMPTY_MIME_TYPES = [
 
 export const FOLDERS_SELECTION_PREVENTED_MIME_TYPES = [
   MIME_TYPES.NOTION.SYNCING_FOLDER,
-  MIME_TYPES.GONG.TRANSCRIPT_FOLDER,
 ] as readonly string[];
 
 export function getContentNodeInternalIdFromTableId(


### PR DESCRIPTION
## Description

Last few fixes for the Gong connector:
- Pass all participants' email addresses in tags.
- Make the top level Transcripts folder selectable (the Select All button is too hidden).

## Tests

- Tested locally.

## Risk

- n/a.

## Deploy Plan

- Deploy front.
- Deploy connectors.