### PR TITLE
[front] - chore(attach): search through spaces

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -10,43 +10,52 @@ import {
   SearchInputWithPopover,
   Separator,
 } from "@dust-tt/sparkle";
+import type { DataSourceViewContentNode } from "@dust-tt/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@dust-tt/types";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
+import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
+import type { WorkspaceType } from "@dust-tt/client";
+import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 
 interface InputBarAttachmentsProps {
+  owner: WorkspaceType;
   fileUploaderService: FileUploaderService;
-  onConnectedFileSelect: (fileId: string) => void;
+  onNodeSelect: (node: DataSourceViewContentNode) => void;
   isLoading?: boolean;
 }
 
-// TODO(attach from input bar): use component with spaces wide search
 export const InputBarAttachments = ({
+  owner,
   fileUploaderService,
-  onConnectedFileSelect,
+  onNodeSelect,
   isLoading = false,
 }: InputBarAttachmentsProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState<string>("");
+  const [isDebouncing, setIsDebouncing] = useState(false);
 
-  const items = Array.from({ length: 50 }).map((_, i) => ({
-    id: `${i}`,
-    title: `Document ${i + 1}`,
-    path: "Github",
-  }));
-
-  const filteredItems = useMemo(() => {
-    return items.filter((item) => item.title.includes(debouncedSearch));
-  }, [debouncedSearch, items]);
+  const { spaces, isSpacesLoading } = useSpaces({ workspaceId: owner.sId });
+  const { searchResultNodes, isSearchLoading } = useSpacesSearch({
+    includeDataSources: true,
+    owner,
+    search: debouncedSearch,
+    viewType: "all",
+    disabled: isSpacesLoading,
+    spaceIds: spaces.map((s) => s.sId),
+  });
 
   useEffect(() => {
+    setIsDebouncing(true);
     const timeout = setTimeout(() => {
       setDebouncedSearch(search.length >= MIN_SEARCH_QUERY_SIZE ? search : "");
+      setIsDebouncing(false);
     }, 300);
     return () => {
       clearTimeout(timeout);
+      setIsDebouncing(false);
     };
   }, [search]);
 
@@ -54,7 +63,7 @@ export const InputBarAttachments = ({
     <PopoverRoot>
       <PopoverTrigger asChild>
         <Button
-          variant="ghost"
+          variant="ghost-secondary"
           icon={PlusIcon}
           size="xs"
           disabled={isLoading}
@@ -100,27 +109,38 @@ export const InputBarAttachments = ({
                 placeholder="Search connected files"
                 value={search}
                 onChange={setSearch}
+                isLoading={isSearchLoading || isDebouncing}
                 open={search.length >= MIN_SEARCH_QUERY_SIZE}
-                onOpenChange={() => {}}
-                items={filteredItems}
-                renderItem={(item, selected) => (
-                  <div
-                    className={cn(
-                      "flex cursor-pointer items-center gap-2 rounded-lg px-1 py-2 hover:bg-structure-50",
-                      selected && "bg-structure-50"
-                    )}
-                    onClick={() => {
-                      onConnectedFileSelect(item.id);
-                      setSearch("");
-                    }}
-                  >
-                    <Icon visual={AttachmentIcon} size="xs" />
-                    <span className="text-sm">{item.title}</span>
-                    <span className="ml-auto text-sm text-slate-500">
-                      {item.path}
-                    </span>
-                  </div>
-                )}
+                onOpenChange={() => {
+                  setSearch("");
+                }}
+                items={searchResultNodes}
+                renderItem={(item, selected) => {
+                  return (
+                    <div
+                      className={cn(
+                        "m-1 flex cursor-pointer items-center gap-2 rounded-lg px-2 py-2 hover:bg-structure-50 dark:hover:bg-structure-50-night",
+                        selected && "bg-structure-50 dark:bg-structure-50-night"
+                      )}
+                      onClick={() => {
+                        setSearch("");
+                        onNodeSelect(item);
+                      }}
+                    >
+                      {getVisualForDataSourceViewContentNode(item)({
+                        className: "min-w-4",
+                      })}
+                      <span className="flex-shrink truncate text-sm">
+                        {item.title}
+                      </span>
+                      {item.parentTitle && (
+                        <div className="ml-auto flex-none text-sm text-slate-500">
+                          {/*{getLocationForDataSourceViewContentNode(item)}*/}
+                        </div>
+                      )}
+                    </div>
+                  );
+                }}
                 noResults="No results found"
                 disabled={isLoading}
               />

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -10,17 +10,19 @@ import {
   SearchInputWithPopover,
   Separator,
 } from "@dust-tt/sparkle";
-import type { DataSourceViewContentNode } from "@dust-tt/types";
+import type {
+  DataSourceViewContentNode,
+  LightWorkspaceType,
+} from "@dust-tt/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@dust-tt/types";
 import { useEffect, useRef, useState } from "react";
 
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
-import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
-import type { WorkspaceType } from "@dust-tt/client";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
+import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 
 interface InputBarAttachmentsProps {
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   fileUploaderService: FileUploaderService;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   isLoading?: boolean;
@@ -69,7 +71,7 @@ export const InputBarAttachments = ({
           disabled={isLoading}
         />
       </PopoverTrigger>
-      <PopoverContent className="w-[400px]" fullWidth align="start">
+      <PopoverContent className="w-96" fullWidth align="start">
         <div className="flex flex-col gap-4">
           <div className="px-4 pt-4">
             <h2 className="text-lg font-semibold">Local file</h2>
@@ -111,9 +113,7 @@ export const InputBarAttachments = ({
                 onChange={setSearch}
                 isLoading={isSearchLoading || isDebouncing}
                 open={search.length >= MIN_SEARCH_QUERY_SIZE}
-                onOpenChange={() => {
-                  setSearch("");
-                }}
+                onOpenChange={() => {}}
                 items={searchResultNodes}
                 renderItem={(item, selected) => {
                   return (

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -7,6 +7,7 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   AgentMention,
+  DataSourceViewContentNode,
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -144,8 +145,8 @@ const InputBarContainer = ({
               {featureFlags.includes("attach_from_datasources") ? (
                 <InputBarAttachments
                   fileUploaderService={fileUploaderService}
-                  onConnectedFileSelect={(fileId: string) =>
-                    console.log(`Uploading ${fileId}`)
+                  onNodeSelect={(node: DataSourceViewContentNode) =>
+                    console.log(`Uploading ${node.title}`)
                   }
                   owner={owner}
                   isLoading={false}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,10 +1,4 @@
-import {
-  ArrowUpIcon,
-  AttachmentIcon,
-  Button,
-  FullscreenExitIcon,
-  FullscreenIcon,
-} from "@dust-tt/sparkle";
+import { ArrowUpIcon, AttachmentIcon, Button, FullscreenExitIcon, FullscreenIcon } from "@dust-tt/sparkle";
 import type {
   AgentMention,
   DataSourceViewContentNode,
@@ -20,11 +14,11 @@ import useAssistantSuggestions from "@app/components/assistant/conversation/inpu
 import type { CustomEditorProps } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import useCustomEditor from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import useHandleMentions from "@app/components/assistant/conversation/input_bar/editor/useHandleMentions";
+import { InputBarAttachments } from "@app/components/assistant/conversation/input_bar/InputBarAttachments";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
-import { classNames } from "@app/lib/utils";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import { InputBarAttachments } from "@app/components/assistant/conversation/input_bar/InputBarAttachments";
+import { classNames } from "@app/lib/utils";
 
 export const INPUT_BAR_ACTIONS = [
   "attachment",

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -22,6 +22,8 @@ import useHandleMentions from "@app/components/assistant/conversation/input_bar/
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { classNames } from "@app/lib/utils";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { InputBarAttachments } from "@app/components/assistant/conversation/input_bar/InputBarAttachments";
 
 export const INPUT_BAR_ACTIONS = [
   "attachment",
@@ -58,6 +60,7 @@ const InputBarContainer = ({
   fileUploaderService,
 }: InputBarContainerProps) => {
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
   const [isExpanded, setIsExpanded] = useState(false);
   function handleExpansionToggle() {
@@ -138,15 +141,26 @@ const InputBarContainer = ({
                 type="file"
                 multiple={true}
               />
-              <Button
-                variant="ghost-secondary"
-                icon={AttachmentIcon}
-                size="xs"
-                tooltip={`Add a document to the conversation (${getSupportedFileExtensions().join(", ")}).`}
-                onClick={() => {
-                  fileInputRef.current?.click();
-                }}
-              />
+              {featureFlags.includes("attach_from_datasources") ? (
+                <InputBarAttachments
+                  fileUploaderService={fileUploaderService}
+                  onConnectedFileSelect={(fileId: string) =>
+                    console.log(`Uploading ${fileId}`)
+                  }
+                  owner={owner}
+                  isLoading={false}
+                />
+              ) : (
+                <Button
+                  variant="ghost-secondary"
+                  icon={AttachmentIcon}
+                  size="xs"
+                  tooltip={`Add a document to the conversation (${getSupportedFileExtensions().join(", ")}).`}
+                  onClick={() => {
+                    fileInputRef.current?.click();
+                  }}
+                />
+              )}
             </>
           )}
           {(actions.includes("assistants-list") ||

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,4 +1,10 @@
-import { ArrowUpIcon, AttachmentIcon, Button, FullscreenExitIcon, FullscreenIcon } from "@dust-tt/sparkle";
+import {
+  ArrowUpIcon,
+  AttachmentIcon,
+  Button,
+  FullscreenExitIcon,
+  FullscreenIcon,
+} from "@dust-tt/sparkle";
 import type {
   AgentMention,
   DataSourceViewContentNode,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -15,9 +15,20 @@ import type { Fetcher, KeyedMutator } from "swr";
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { getSpaceName } from "@app/lib/spaces";
-import { fetcher, fetcherWithBody, getErrorFromResponse, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetSpacesResponseBody, PostSpacesResponseBody } from "@app/pages/api/w/[wId]/spaces";
-import type { GetSpaceResponseBody, PatchSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
+import {
+  fetcher,
+  fetcherWithBody,
+  getErrorFromResponse,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type {
+  GetSpacesResponseBody,
+  PostSpacesResponseBody,
+} from "@app/pages/api/w/[wId]/spaces";
+import type {
+  GetSpaceResponseBody,
+  PatchSpaceResponseBody,
+} from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { GetSpaceDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views";
 import type { GetDataSourceViewResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]";
 import type { PostSpaceDataSourceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -21,7 +21,10 @@ import {
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import { PostWorkspaceSearchResponseBody } from "@app/pages/api/w/[wId]/search";
+import {
+  DataSourceContentNode,
+  PostWorkspaceSearchResponseBody,
+} from "@app/pages/api/w/[wId]/search";
 import type {
   GetSpacesResponseBody,
   PostSpacesResponseBody,
@@ -704,7 +707,7 @@ export function useSpacesSearch({
   isSearchError: boolean;
   isSearchValidating: boolean;
   mutate: KeyedMutator<PostWorkspaceSearchResponseBody>;
-  searchResultNodes: DataSourceViewContentNode[];
+  searchResultNodes: DataSourceContentNode[];
   warningCode: SearchWarningCode | null;
   nextPageCursor: string | null;
 } {

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -21,6 +21,7 @@ import {
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import { PostWorkspaceSearchResponseBody } from "@app/pages/api/w/[wId]/search";
 import type {
   GetSpacesResponseBody,
   PostSpacesResponseBody,
@@ -36,7 +37,6 @@ import type {
   PostSpaceSearchRequestBody,
   PostSpaceSearchResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/search";
-import { PostWorkspaceSearchResponseBody } from "@app/pages/api/w/[wId]/search";
 
 export function useSpaces({
   workspaceId,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -21,7 +21,7 @@ import {
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import {
+import type {
   DataSourceContentNode,
   PostWorkspaceSearchResponseBody,
 } from "@app/pages/api/w/[wId]/search";

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -17,13 +17,13 @@ import {
   getContentNodeFromCoreNode,
   NON_SEARCHABLE_NODES_MIME_TYPES,
 } from "@app/lib/api/content_nodes";
+import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getSearchFilterFromDataSourceViews } from "@app/lib/search";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import { getCursorPaginationParams } from "@app/lib/api/pagination";
 
 const SearchRequestBody = t.type({
   query: t.string,

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -38,7 +38,7 @@ const SearchRequestBody = t.type({
   includeDataSources: t.boolean,
 });
 
-type DataSourceContentNode = ContentNodeWithParent & {
+export type DataSourceContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
   dataSourceViews: DataSourceViewType[];
 };

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -59,6 +59,11 @@ module.exports = {
       maxWidth: {
         48: "12rem",
       },
+      width: {
+        100: "400px",
+        125: "500px",
+        150: "600px",
+      },
       scale: {
         99: ".99",
       },


### PR DESCRIPTION
## Description

Implements search functionality in the attachment picker allowing users to search and select documents from their spaces. The search is performed across all user spaces and displays results with their respective space locations. Each document search result shows its title, space, and location path.

![Screenshot 2025-03-07 at 10 32 38](https://github.com/user-attachments/assets/c162b813-203e-42aa-979e-ade6dfa3159d)

## Risk

Low, behind FF

## Deploy Plan

- Deploy `front`