### PR TITLE
Improve Gong error handling

### DIFF
--- a/connectors/src/connectors/gong/lib/errors.ts
+++ b/connectors/src/connectors/gong/lib/errors.ts
@@ -1,6 +1,21 @@
 import type { ModelId } from "@dust-tt/types";
+import { safeParseJSON } from "@dust-tt/types";
 
 type GongAPIErrorType = "validation_error" | "http_response_error";
+
+function isGongAPIErrorBody(body: unknown): body is {
+  errors: string[];
+  requestId: string;
+} {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "errors" in body &&
+    Array.isArray(body.errors) &&
+    "requestId" in body &&
+    typeof body.requestId === "string"
+  );
+}
 
 export class GongAPIError extends Error {
   readonly type: GongAPIErrorType;
@@ -45,18 +60,39 @@ export class GongAPIError extends Error {
   static fromAPIError(
     response: Response,
     {
+      body,
       connectorId,
       endpoint,
       pathErrors,
-    }: { connectorId: ModelId; endpoint: string; pathErrors?: string[] }
+    }: {
+      body: string;
+      connectorId: ModelId;
+      endpoint: string;
+      pathErrors?: string[];
+    }
   ) {
+    const bodyParsedRes = safeParseJSON(body);
+    let errors: string[] = [];
+    let requestId: string | undefined;
+
+    if (bodyParsedRes.isErr()) {
+      errors = [
+        `Failed to parse error response: ${bodyParsedRes.error.message}`,
+      ];
+    } else if (isGongAPIErrorBody(bodyParsedRes.value)) {
+      errors = bodyParsedRes.value.errors;
+      requestId = bodyParsedRes.value.requestId;
+    }
+
     return new this(
       `Gong API responded with status: ${response.status} on ${endpoint}`,
       {
         type: "http_response_error",
         connectorId,
         endpoint,
+        errors,
         pathErrors,
+        requestId,
         status: response.status,
       }
     );
@@ -77,5 +113,25 @@ export class GongAPIError extends Error {
       connectorId,
       pathErrors,
     });
+  }
+
+  toString(): string {
+    const errorDetails = [
+      `message: ${this.message}`,
+      `type: ${this.type}`,
+      `endpoint: ${this.endpoint}`,
+      `status: ${this.status || "N/A"}`,
+      `requestId: ${this.requestId || "N/A"}`,
+    ];
+
+    if (this.errors && this.errors.length > 0) {
+      errorDetails.push(`errors: [${this.errors.join(", ")}]`);
+    }
+
+    if (this.pathErrors && this.pathErrors.length > 0) {
+      errorDetails.push(`pathErrors: [${this.pathErrors.join(", ")}]`);
+    }
+
+    return `GongAPIError: {${errorDetails.join(", ")}}`;
   }
 }

--- a/connectors/src/connectors/gong/lib/errors.ts
+++ b/connectors/src/connectors/gong/lib/errors.ts
@@ -71,6 +71,7 @@ export class GongAPIError extends Error {
       pathErrors?: string[];
     }
   ) {
+    // Attempt to parse the body as JSON.
     const bodyParsedRes = safeParseJSON(body);
     let errors: string[] = [];
     let requestId: string | undefined;
@@ -82,6 +83,8 @@ export class GongAPIError extends Error {
     } else if (isGongAPIErrorBody(bodyParsedRes.value)) {
       errors = bodyParsedRes.value.errors;
       requestId = bodyParsedRes.value.requestId;
+    } else {
+      errors = [body];
     }
 
     return new this(

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -143,9 +143,12 @@ export class GongClient {
         throw new HTTPError(response.statusText, response.status);
       }
 
+      const body = await response.text();
+
       throw GongAPIError.fromAPIError(response, {
         endpoint,
         connectorId: this.connectorId,
+        body,
       });
     }
 

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -143,6 +143,7 @@ export class GongClient {
         throw new HTTPError(response.statusText, response.status);
       }
 
+      // Don't attempt to parse the body in JSON.
       const body = await response.text();
 
       throw GongAPIError.fromAPIError(response, {
@@ -240,7 +241,7 @@ export class GongClient {
         nextPageCursor: transcripts.records.cursor,
       };
     } catch (err) {
-      if (err instanceof HTTPError && err.statusCode === 404) {
+      if (isNotFoundError(err)) {
         return {
           transcripts: [],
           nextPageCursor: null,
@@ -316,7 +317,7 @@ export class GongClient {
         nextPageCursor: callsMetadata.records.cursor,
       };
     } catch (err) {
-      if (err instanceof HTTPError && err.statusCode === 404) {
+      if (isNotFoundError(err)) {
         return {
           callsMetadata: [],
           nextPageCursor: null,

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -80,9 +80,10 @@ export async function gongSyncTranscriptsActivity({
   const configuration = await fetchGongConfiguration(connector);
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
-    workspaceId: dataSourceConfig.workspaceId,
     dataSourceId: dataSourceConfig.dataSourceId,
     provider: "gong",
+    startTimestamp: configuration.lastSyncTimestamp,
+    workspaceId: dataSourceConfig.workspaceId,
   };
 
   const syncStartTs = Date.now();
@@ -95,6 +96,15 @@ export async function gongSyncTranscriptsActivity({
       startTimestamp: configuration.lastSyncTimestamp,
       pageCursor,
     });
+
+    if (transcripts.length === 0) {
+      logger.info(
+        { ...loggerArgs, pageCursor },
+        "[Gong] No more transcripts found."
+      );
+      break;
+    }
+
     const callsMetadata = await getTranscriptsMetadata({
       callIds: transcripts.map((t) => t.callId),
       connector,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR improves the Gong errors hygiene by leveraging all provided details. We currently have a few Gong workflows stuck because of invalid `callIds` on the `/extensive` endpoint.

Error is:
```
{"requestId":"1p0j3597h9ec92oozlm","errors":["filter.callIds: must not be empty but can be null or can be omitted"]}
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
