### PR TITLE
Upg add links and titles to make poke navigation easier

### DIFF
--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import React from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
@@ -11,11 +12,16 @@ export interface PokeLayoutProps {
 
 export default function PokeLayout({
   children,
+  title,
 }: {
   children: React.ReactNode;
+  title: string;
 }) {
   return (
     <ThemeProvider>
+      <Head>
+        <title>{"Poke - " + title}</title>
+      </Head>
       <PokeLayoutContent>{children}</PokeLayoutContent>
     </ThemeProvider>
   );

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -43,7 +43,7 @@ export async function dataSourceViewToPokeJSON(
     link: workspace
       ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/spaces/${dataSourceView.space.sId}/data_source_views/${dataSourceView.sId}`
       : null,
-    name: `Data Source (${dataSourceView.dataSource.name})`,
+    name: `Data Source View (${dataSourceView.dataSource.name})`,
     space: spaceToPokeJSON(dataSourceView.space),
   };
 }

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -1,5 +1,5 @@
 import { ContextItem, Page, TextArea } from "@dust-tt/sparkle";
-import type { AgentConfigurationType } from "@dust-tt/types";
+import type { AgentConfigurationType, WorkspaceType } from "@dust-tt/types";
 import { SUPPORTED_MODEL_CONFIGS } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
 import type { InferGetServerSidePropsType } from "next";
@@ -12,6 +12,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   agentConfigurations: AgentConfigurationType[];
+  workspace: WorkspaceType;
 }>(async (context, auth) => {
   const aId = context.params?.aId;
   if (!aId || typeof aId !== "string") {
@@ -29,16 +30,24 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       agentConfigurations,
+      workspace: auth.getNonNullableWorkspace(),
     },
   };
 });
 
 const AssistantDetailsPage = ({
   agentConfigurations,
+  workspace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { isDark } = useTheme();
   return (
     <div className="mx-auto max-w-4xl pt-8">
+      <h3 className="text-xl font-bold">
+        Assistant of workspace:{" "}
+        <a href={`/poke/${workspace.sId}`} className="text-action-500">
+          {workspace.name}
+        </a>
+      </h3>
       <Page.Vertical align="stretch">
         <ContextItem.List>
           {agentConfigurations.map((a) => (
@@ -108,8 +117,13 @@ const AssistantDetailsPage = ({
   );
 };
 
-AssistantDetailsPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+AssistantDetailsPage.getLayout = (
+  page: ReactElement,
+  { workspace }: { workspace: WorkspaceType }
+) => {
+  return (
+    <PokeLayout title={`${workspace.name} - Assistants`}>{page}</PokeLayout>
+  );
 };
 
 export default AssistantDetailsPage;

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -3,6 +3,7 @@ import type {
   ContentFragmentType,
   PokeAgentMessageType,
   UserMessageType,
+  WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
@@ -17,6 +18,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { usePokeConversation } from "@app/poke/swr";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
+  workspace: WorkspaceType;
   workspaceId: string;
   conversationId: string;
   conversationDataSourceId: string | null;
@@ -56,6 +58,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       conversationId: cId,
       conversationDataSourceId: conversationDataSource?.sId ?? null,
       multiActionsApp,
+      workspace: auth.getNonNullableWorkspace(),
     },
   };
 });
@@ -171,6 +174,7 @@ const ContentFragmentView = ({ message }: { message: ContentFragmentType }) => {
 
 const ConversationPage = ({
   workspaceId,
+  workspace,
   conversationId,
   conversationDataSourceId,
   multiActionsApp,
@@ -181,6 +185,12 @@ const ConversationPage = ({
     <>
       {conversation && (
         <div className="mx-auto max-w-4xl pt-8">
+          <h3 className="text-xl font-bold">
+            Conversation of workspace:{" "}
+            <a href={`/poke/${workspaceId}`} className="text-action-500">
+              {workspace.name}
+            </a>
+          </h3>
           <Page.Vertical align="stretch">
             <div className="flex space-x-2">
               <Button
@@ -243,8 +253,13 @@ const ConversationPage = ({
   );
 };
 
-ConversationPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+ConversationPage.getLayout = (
+  page: ReactElement,
+  { workspace }: { workspace: WorkspaceType }
+) => {
+  return (
+    <PokeLayout title={`${workspace.name} - Conversation`}>{page}</PokeLayout>
+  );
 };
 
 export default ConversationPage;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -394,327 +394,344 @@ const DataSourcePage = ({
   };
 
   return (
-    <div className="flex flex-row gap-x-6">
-      <ViewDataSourceTable
-        dataSource={dataSource}
-        temporalWorkspace={temporalWorkspace}
-        coreDataSource={coreDataSource}
-        connector={connector}
-        temporalRunningWorkflows={temporalRunningWorkflows}
-      />
-      <div className="mt-4 flex grow flex-col gap-y-4">
-        <PluginList
-          pluginResourceTarget={{
-            resourceId: dataSource.sId,
-            resourceType: "data_sources",
-            workspace: owner,
-          }}
-        />
-        <div className="flex w-full items-center gap-3 p-4">
-          <Button
-            variant="outline"
-            onClick={() => {
-              if (
-                window.confirm(
-                  "Are you sure you want to access this sensible user data? (Access will be logged)"
-                )
-              ) {
-                void router.push(
-                  `/poke/${owner.sId}/data_sources/${dataSource.sId}/search`
-                );
-              }
-            }}
-            label="Search Data"
-            icon={LockIcon}
-          />
-          {dataSource.connectorProvider === "slack" && (
-            <ConfigToggle
-              title="Slackbot enabled?"
-              owner={owner}
-              features={features}
-              dataSource={dataSource}
-              configKey="botEnabled"
-              featureKey="slackBotEnabled"
-            />
-          )}
-          {dataSource.connectorProvider === "notion" && (
-            <NotionUrlCheckOrFind owner={owner} dsId={dataSource.sId} />
-          )}
-          {dataSource.connectorProvider === "zendesk" && (
-            <ZendeskTicketCheck owner={owner} dsId={dataSource.sId} />
-          )}
-          {dataSource.connectorProvider === "google_drive" && (
-            <>
-              <ConfigToggle
-                title="PDF syncing enabled?"
-                owner={owner}
-                features={features}
-                dataSource={dataSource}
-                configKey="pdfEnabled"
-                featureKey="googleDrivePdfEnabled"
-              />
-              <ConfigToggle
-                title="CSV syncing enabled?"
-                owner={owner}
-                features={features}
-                dataSource={dataSource}
-                configKey="csvEnabled"
-                featureKey="googleDriveCsvEnabled"
-              />
+    <>
+      <h3 className="text-xl font-bold">
+        Data Source: {dataSource.name} of workspace:{" "}
+        <a href={`/poke/${owner.sId}`} className="text-action-500">
+          {owner.name}
+        </a>
+      </h3>
+      <p>
+        The content source of truth is <b>connectors</b>.
+      </p>
 
+      <div className="flex flex-row gap-x-6">
+        <ViewDataSourceTable
+          dataSource={dataSource}
+          temporalWorkspace={temporalWorkspace}
+          coreDataSource={coreDataSource}
+          connector={connector}
+          temporalRunningWorkflows={temporalRunningWorkflows}
+        />
+        <div className="mt-4 flex grow flex-col gap-y-4">
+          <PluginList
+            pluginResourceTarget={{
+              resourceId: dataSource.sId,
+              resourceType: "data_sources",
+              workspace: owner,
+            }}
+          />
+          <div className="flex w-full items-center gap-3 p-4">
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (
+                  window.confirm(
+                    "Are you sure you want to access this sensible user data? (Access will be logged)"
+                  )
+                ) {
+                  void router.push(
+                    `/poke/${owner.sId}/data_sources/${dataSource.sId}/search`
+                  );
+                }
+              }}
+              label="Search Data"
+              icon={LockIcon}
+            />
+            {dataSource.connectorProvider === "slack" && (
               <ConfigToggle
-                title="Large Files enabled?"
+                title="Slackbot enabled?"
                 owner={owner}
                 features={features}
                 dataSource={dataSource}
-                configKey="largeFilesEnabled"
-                featureKey="googleDriveLargeFilesEnabled"
+                configKey="botEnabled"
+                featureKey="slackBotEnabled"
               />
+            )}
+            {dataSource.connectorProvider === "notion" && (
+              <NotionUrlCheckOrFind owner={owner} dsId={dataSource.sId} />
+            )}
+            {dataSource.connectorProvider === "zendesk" && (
+              <ZendeskTicketCheck owner={owner} dsId={dataSource.sId} />
+            )}
+            {dataSource.connectorProvider === "google_drive" && (
+              <>
+                <ConfigToggle
+                  title="PDF syncing enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="pdfEnabled"
+                  featureKey="googleDrivePdfEnabled"
+                />
+                <ConfigToggle
+                  title="CSV syncing enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="csvEnabled"
+                  featureKey="googleDriveCsvEnabled"
+                />
+
+                <ConfigToggle
+                  title="Large Files enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="largeFilesEnabled"
+                  featureKey="googleDriveLargeFilesEnabled"
+                />
+              </>
+            )}
+            {dataSource.connectorProvider === "microsoft" && (
+              <>
+                <ConfigToggle
+                  title="Pdf syncing enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="pdfEnabled"
+                  featureKey="microsoftPdfEnabled"
+                />
+                <ConfigToggle
+                  title="CSV syncing enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="csvEnabled"
+                  featureKey="microsoftCsvEnabled"
+                />
+                <ConfigToggle
+                  title="Large Files enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="largeFilesEnabled"
+                  featureKey="microsoftLargeFilesEnabled"
+                />
+              </>
+            )}
+            {dataSource.connectorProvider === "github" && (
+              <>
+                <ConfigToggle
+                  title="Code sync enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="codeSyncEnabled"
+                  featureKey="githubCodeSyncEnabled"
+                />
+                <ConfigToggle
+                  title="Use proxy?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="useProxy"
+                  featureKey="githubUseProxyEnabled"
+                />
+              </>
+            )}
+          </div>
+          {dataSource.connectorProvider === "slack" && (
+            <>
+              <SlackWhitelistBot
+                owner={owner}
+                connectorId={connector?.id}
+                groups={groupsForSlackBot}
+              />
+              <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
+                <SlackChannelPatternInput
+                  initialValues={features.autoReadChannelPatterns || ""}
+                  owner={owner}
+                  dataSource={dataSource}
+                />
+              </div>
             </>
           )}
-          {dataSource.connectorProvider === "microsoft" && (
+          {!dataSource.connectorId ? (
             <>
-              <ConfigToggle
-                title="Pdf syncing enabled?"
-                owner={owner}
-                features={features}
-                dataSource={dataSource}
-                configKey="pdfEnabled"
-                featureKey="microsoftPdfEnabled"
-              />
-              <ConfigToggle
-                title="CSV syncing enabled?"
-                owner={owner}
-                features={features}
-                dataSource={dataSource}
-                configKey="csvEnabled"
-                featureKey="microsoftCsvEnabled"
-              />
-              <ConfigToggle
-                title="Large Files enabled?"
-                owner={owner}
-                features={features}
-                dataSource={dataSource}
-                configKey="largeFilesEnabled"
-                featureKey="microsoftLargeFilesEnabled"
-              />
+              <div className="mt-4 flex flex-row">
+                <div className="flex flex-1">
+                  <div className="flex flex-col">
+                    <div className="flex flex-row">
+                      <div className="flex flex-initial gap-x-2">
+                        <Button
+                          variant="ghost"
+                          disabled={offsetDocument < limit}
+                          onClick={() => {
+                            if (offsetDocument >= limit) {
+                              setOffsetDocument(offsetDocument - limit);
+                            } else {
+                              setOffsetDocument(0);
+                            }
+                          }}
+                          label="Previous"
+                        />
+                        <Button
+                          variant="ghost"
+                          label="Next"
+                          disabled={offsetDocument + limit >= totalDocuments}
+                          onClick={() => {
+                            if (offsetDocument + limit < totalDocuments) {
+                              setOffsetDocument(offsetDocument + limit);
+                            }
+                          }}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
+                      {totalDocuments > 0 && (
+                        <span>
+                          Showing documents {offsetDocument + 1} -{" "}
+                          {lastDocument} of {totalDocuments} documents
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
+                {documents.length > 0 ? (
+                  <ContextItem.List>
+                    {documents.map((d) => (
+                      <ContextItem
+                        key={d.document_id}
+                        title={displayNameByDocId[d.document_id]}
+                        visual={
+                          <ContextItem.Visual
+                            visual={({ className }) =>
+                              DocumentTextIcon({
+                                className: className + " text-element-600",
+                              })
+                            }
+                          />
+                        }
+                        action={
+                          <div className="flex gap-2">
+                            <Button
+                              variant="outline"
+                              icon={EyeIcon}
+                              onClick={() =>
+                                onDisplayDocumentSource(d.document_id)
+                              }
+                              tooltip="View"
+                            />
+                          </div>
+                        }
+                      >
+                        <ContextItem.Description>
+                          <div className="pt-2 text-sm text-element-700">
+                            {Math.floor(d.text_size / 1024)} kb,{" "}
+                            {timeAgoFrom(d.timestamp)} ago
+                          </div>
+                        </ContextItem.Description>
+                      </ContextItem>
+                    ))}
+                  </ContextItem.List>
+                ) : (
+                  <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
+                    <p>Empty</p>
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-4 flex flex-row">
+                <div className="flex flex-1">
+                  <div className="flex flex-col">
+                    <div className="flex flex-row">
+                      <div className="flex flex-initial gap-x-2">
+                        <Button
+                          variant="ghost"
+                          disabled={offsetTable < limit}
+                          onClick={() => {
+                            if (offsetTable >= limit) {
+                              setOffsetTable(offsetTable - limit);
+                            } else {
+                              setOffsetTable(0);
+                            }
+                          }}
+                          label="Previous"
+                        />
+                        <Button
+                          variant="ghost"
+                          label="Next"
+                          disabled={offsetTable + limit >= totalTables}
+                          onClick={() => {
+                            if (offsetTable + limit < totalTables) {
+                              setOffsetTable(offsetTable + limit);
+                            }
+                          }}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
+                      {totalDocuments > 0 && (
+                        <span>
+                          Showing tables {offsetTable + 1} - {lastTable} of{" "}
+                          {totalTables} tables
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
+                {tables.length > 0 ? (
+                  <ContextItem.List>
+                    {tables.map((t) => (
+                      <ContextItem
+                        key={t.table_id}
+                        title={t.name}
+                        visual={
+                          <ContextItem.Visual
+                            visual={({ className }) =>
+                              TableIcon({
+                                className: className + " text-element-600",
+                              })
+                            }
+                          />
+                        }
+                      >
+                        <ContextItem.Description>
+                          <div className="pt-2 text-sm text-element-700">
+                            {timeAgoFrom(t.timestamp)} ago
+                          </div>
+                        </ContextItem.Description>
+                      </ContextItem>
+                    ))}
+                  </ContextItem.List>
+                ) : (
+                  <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
+                    <p>Empty</p>
+                  </div>
+                )}
+              </div>
             </>
-          )}
-          {dataSource.connectorProvider === "github" && (
-            <>
-              <ConfigToggle
-                title="Code sync enabled?"
-                owner={owner}
-                features={features}
-                dataSource={dataSource}
-                configKey="codeSyncEnabled"
-                featureKey="githubCodeSyncEnabled"
-              />
-              <ConfigToggle
-                title="Use proxy?"
-                owner={owner}
-                features={features}
-                dataSource={dataSource}
-                configKey="useProxy"
-                featureKey="githubUseProxyEnabled"
-              />
-            </>
+          ) : (
+            <PokePermissionTree
+              owner={owner}
+              dataSource={dataSource}
+              onDocumentViewClick={onDisplayDocumentSource}
+              permissionFilter="read"
+            />
           )}
         </div>
-        {dataSource.connectorProvider === "slack" && (
-          <>
-            <SlackWhitelistBot
-              owner={owner}
-              connectorId={connector?.id}
-              groups={groupsForSlackBot}
-            />
-            <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
-              <SlackChannelPatternInput
-                initialValues={features.autoReadChannelPatterns || ""}
-                owner={owner}
-                dataSource={dataSource}
-              />
-            </div>
-          </>
-        )}
-        {!dataSource.connectorId ? (
-          <>
-            <div className="mt-4 flex flex-row">
-              <div className="flex flex-1">
-                <div className="flex flex-col">
-                  <div className="flex flex-row">
-                    <div className="flex flex-initial gap-x-2">
-                      <Button
-                        variant="ghost"
-                        disabled={offsetDocument < limit}
-                        onClick={() => {
-                          if (offsetDocument >= limit) {
-                            setOffsetDocument(offsetDocument - limit);
-                          } else {
-                            setOffsetDocument(0);
-                          }
-                        }}
-                        label="Previous"
-                      />
-                      <Button
-                        variant="ghost"
-                        label="Next"
-                        disabled={offsetDocument + limit >= totalDocuments}
-                        onClick={() => {
-                          if (offsetDocument + limit < totalDocuments) {
-                            setOffsetDocument(offsetDocument + limit);
-                          }
-                        }}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
-                    {totalDocuments > 0 && (
-                      <span>
-                        Showing documents {offsetDocument + 1} - {lastDocument}{" "}
-                        of {totalDocuments} documents
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
-              {documents.length > 0 ? (
-                <ContextItem.List>
-                  {documents.map((d) => (
-                    <ContextItem
-                      key={d.document_id}
-                      title={displayNameByDocId[d.document_id]}
-                      visual={
-                        <ContextItem.Visual
-                          visual={({ className }) =>
-                            DocumentTextIcon({
-                              className: className + " text-element-600",
-                            })
-                          }
-                        />
-                      }
-                      action={
-                        <div className="flex gap-2">
-                          <Button
-                            variant="outline"
-                            icon={EyeIcon}
-                            onClick={() =>
-                              onDisplayDocumentSource(d.document_id)
-                            }
-                            tooltip="View"
-                          />
-                        </div>
-                      }
-                    >
-                      <ContextItem.Description>
-                        <div className="pt-2 text-sm text-element-700">
-                          {Math.floor(d.text_size / 1024)} kb,{" "}
-                          {timeAgoFrom(d.timestamp)} ago
-                        </div>
-                      </ContextItem.Description>
-                    </ContextItem>
-                  ))}
-                </ContextItem.List>
-              ) : (
-                <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
-                  <p>Empty</p>
-                </div>
-              )}
-            </div>
-
-            <div className="mt-4 flex flex-row">
-              <div className="flex flex-1">
-                <div className="flex flex-col">
-                  <div className="flex flex-row">
-                    <div className="flex flex-initial gap-x-2">
-                      <Button
-                        variant="ghost"
-                        disabled={offsetTable < limit}
-                        onClick={() => {
-                          if (offsetTable >= limit) {
-                            setOffsetTable(offsetTable - limit);
-                          } else {
-                            setOffsetTable(0);
-                          }
-                        }}
-                        label="Previous"
-                      />
-                      <Button
-                        variant="ghost"
-                        label="Next"
-                        disabled={offsetTable + limit >= totalTables}
-                        onClick={() => {
-                          if (offsetTable + limit < totalTables) {
-                            setOffsetTable(offsetTable + limit);
-                          }
-                        }}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
-                    {totalDocuments > 0 && (
-                      <span>
-                        Showing tables {offsetTable + 1} - {lastTable} of{" "}
-                        {totalTables} tables
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
-              {tables.length > 0 ? (
-                <ContextItem.List>
-                  {tables.map((t) => (
-                    <ContextItem
-                      key={t.table_id}
-                      title={t.name}
-                      visual={
-                        <ContextItem.Visual
-                          visual={({ className }) =>
-                            TableIcon({
-                              className: className + " text-element-600",
-                            })
-                          }
-                        />
-                      }
-                    >
-                      <ContextItem.Description>
-                        <div className="pt-2 text-sm text-element-700">
-                          {timeAgoFrom(t.timestamp)} ago
-                        </div>
-                      </ContextItem.Description>
-                    </ContextItem>
-                  ))}
-                </ContextItem.List>
-              ) : (
-                <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
-                  <p>Empty</p>
-                </div>
-              )}
-            </div>
-          </>
-        ) : (
-          <PokePermissionTree
-            owner={owner}
-            dataSource={dataSource}
-            onDocumentViewClick={onDisplayDocumentSource}
-            permissionFilter="read"
-          />
-        )}
       </div>
-    </div>
+    </>
   );
 };
 
-DataSourcePage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+DataSourcePage.getLayout = (
+  page: ReactElement,
+  { owner, dataSource }: { owner: WorkspaceType; dataSource: DataSourceType }
+) => {
+  return (
+    <PokeLayout title={`${owner.name} - ${dataSource.name}`}>{page}</PokeLayout>
+  );
 };
 
 async function handleCheckOrFindNotionUrl(

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -264,6 +264,13 @@ export default function DataSourceView({
   );
 }
 
-DataSourceView.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+DataSourceView.getLayout = (
+  page: ReactElement,
+  { owner, dataSource }: { owner: WorkspaceType; dataSource: DataSourceType }
+) => {
+  return (
+    <PokeLayout title={`${owner.name} - Search ${dataSource.name}`}>
+      {page}
+    </PokeLayout>
+  );
 };

--- a/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
@@ -127,5 +127,5 @@ export default function DataSourceUpsert({
 }
 
 DataSourceUpsert.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+  return <PokeLayout title="View Document">{page}</PokeLayout>;
 };

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -405,8 +405,11 @@ export function DeleteWorkspaceModal({
   );
 }
 
-WorkspacePage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+WorkspacePage.getLayout = (
+  page: ReactElement,
+  { owner }: { owner: WorkspaceType }
+) => {
+  return <PokeLayout title={`${owner.name}`}>{page}</PokeLayout>;
 };
 
 export default WorkspacePage;

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -48,20 +48,33 @@ const MembershipsPage = ({
   owner,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   return (
-    <div className="flex-grow p-6">
-      <h1 className="mb-8 text-2xl font-bold">{owner.name}</h1>
-      <div className="flex justify-center">
-        <MembersDataTable members={members} owner={owner} />
+    <>
+      <h3 className="text-xl font-bold">
+        Members of workspace:{" "}
+        <a href={`/poke/${owner.sId}`} className="text-action-500">
+          {owner.name}
+        </a>
+      </h3>
+      <div className="flex-grow p-6">
+        <div className="flex justify-center">
+          <MembersDataTable members={members} owner={owner} />
+        </div>
+        <div className="flex justify-center">
+          <InvitationsDataTable
+            invitations={pendingInvitations}
+            owner={owner}
+          />
+        </div>
       </div>
-      <div className="flex justify-center">
-        <InvitationsDataTable invitations={pendingInvitations} owner={owner} />
-      </div>
-    </div>
+    </>
   );
 };
 
-MembershipsPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+MembershipsPage.getLayout = (
+  page: ReactElement,
+  { owner }: { owner: WorkspaceType }
+) => {
+  return <PokeLayout title={`${owner.name} - Memberships`}>{page}</PokeLayout>;
 };
 
 export default MembershipsPage;

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -9,6 +9,7 @@ import type {
   AppType,
   LightWorkspaceType,
   SpecificationType,
+  WorkspaceType,
 } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
@@ -232,6 +233,9 @@ function AppSpecification({
   );
 }
 
-AppPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+AppPage.getLayout = (
+  page: ReactElement,
+  { owner, app }: { owner: WorkspaceType; app: AppType }
+) => {
+  return <PokeLayout title={`${owner.name} - ${app.name}`}>{page}</PokeLayout>;
 };

--- a/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
@@ -54,34 +54,67 @@ export default function DataSourceViewPage({
   };
 
   return (
-    <div className="flex flex-row gap-x-6">
-      <ViewDataSourceViewTable dataSourceView={dataSourceView} owner={owner} />
-      <div className="mt-4 flex grow flex-col">
-        <PluginList
-          pluginResourceTarget={{
-            resourceId: dataSourceView.sId,
-            resourceType: "data_source_views",
-            workspace: owner,
-          }}
+    <>
+      <h3 className="text-xl font-bold">
+        {dataSourceView.name} in space:{" "}
+        <a
+          href={`/poke/${owner.sId}/spaces/${dataSourceView.space.sId}`}
+          className="text-action-500"
+        >
+          {dataSourceView.space.name}
+        </a>{" "}
+        of workspace:{" "}
+        <a href={`/poke/${owner.sId}`} className="text-action-500">
+          {owner.name}
+        </a>
+      </h3>
+      <p>
+        The content source of truth is <b>core</b>.
+      </p>
+      <div className="flex flex-row gap-x-6">
+        <ViewDataSourceViewTable
+          dataSourceView={dataSourceView}
+          owner={owner}
         />
-        <div className="border-material-200 my-4 rounded-lg border p-4">
-          <DataSourceViewSelector
-            owner={owner}
-            readonly
-            selectionConfiguration={defaultSelectionConfiguration(
-              dataSourceView
-            )}
-            setSelectionConfigurations={() => {}}
-            useContentNodes={useContentNodes}
-            viewType="all"
-            isRootSelectable={true}
+        <div className="mt-4 flex grow flex-col">
+          <PluginList
+            pluginResourceTarget={{
+              resourceId: dataSourceView.sId,
+              resourceType: "data_source_views",
+              workspace: owner,
+            }}
           />
+          <div className="border-material-200 my-4 rounded-lg border p-4">
+            <DataSourceViewSelector
+              owner={owner}
+              readonly
+              selectionConfiguration={defaultSelectionConfiguration(
+                dataSourceView
+              )}
+              setSelectionConfigurations={() => {}}
+              useContentNodes={useContentNodes}
+              viewType="all"
+              isRootSelectable={true}
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 
-DataSourceViewPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+DataSourceViewPage.getLayout = (
+  page: ReactElement,
+  {
+    owner,
+    dataSourceView,
+  }: { owner: WorkspaceType; dataSourceView: PokeDataSourceViewType }
+) => {
+  return (
+    <PokeLayout
+      title={`${owner.name} - ${dataSourceView.name} in ${dataSourceView.space.name}`}
+    >
+      {page}
+    </PokeLayout>
+  );
 };

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -2,6 +2,7 @@ import type {
   LightWorkspaceType,
   PokeSpaceType,
   UserTypeWithWorkspaces,
+  WorkspaceType,
 } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
@@ -75,23 +76,36 @@ export default function SpacePage({
   space,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
-    <div className="flex flex-row gap-x-6">
-      <ViewSpaceViewTable space={space} />
-      <div className="flex grow flex-col">
-        <MembersDataTable members={members} owner={owner} readonly />
-        <PluginList
-          pluginResourceTarget={{
-            resourceId: space.sId,
-            resourceType: "spaces",
-            workspace: owner,
-          }}
-        />
-        <DataSourceViewsDataTable owner={owner} spaceId={space.sId} />
+    <>
+      <h3 className="text-xl font-bold">
+        Space: {space.name} ({space.kind}) of workspace:{" "}
+        <a href={`/poke/${owner.sId}`} className="text-action-500">
+          {owner.name}
+        </a>
+      </h3>
+      <div className="flex flex-row gap-x-6">
+        <ViewSpaceViewTable space={space} />
+        <div className="flex grow flex-col">
+          <MembersDataTable members={members} owner={owner} readonly />
+          <PluginList
+            pluginResourceTarget={{
+              resourceId: space.sId,
+              resourceType: "spaces",
+              workspace: owner,
+            }}
+          />
+          <DataSourceViewsDataTable owner={owner} spaceId={space.sId} />
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 
-SpacePage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+SpacePage.getLayout = (
+  page: ReactElement,
+  { owner, space }: { owner: WorkspaceType; space: PokeSpaceType }
+) => {
+  return (
+    <PokeLayout title={`${owner.name} - ${space.name}`}>{page}</PokeLayout>
+  );
 };

--- a/front/pages/poke/[wId]/trackers/[tId]/index.tsx
+++ b/front/pages/poke/[wId]/trackers/[tId]/index.tsx
@@ -79,6 +79,9 @@ export default function TrackerDetailPage({
   );
 }
 
-TrackerDetailPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+TrackerDetailPage.getLayout = (
+  page: ReactElement,
+  { owner, trackerId }: { owner: WorkspaceType; trackerId: string }
+) => {
+  return <PokeLayout title={`${owner.name} - ${trackerId}`}>{page}</PokeLayout>;
 };

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -160,7 +160,7 @@ const Dashboard = () => {
 };
 
 Dashboard.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+  return <PokeLayout title="Home">{page}</PokeLayout>;
 };
 
 export default Dashboard;

--- a/front/pages/poke/kill.tsx
+++ b/front/pages/poke/kill.tsx
@@ -143,7 +143,7 @@ const KillPage = () => {
 };
 
 KillPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+  return <PokeLayout title="Kill Switches">{page}</PokeLayout>;
 };
 
 export default KillPage;

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -211,7 +211,7 @@ const PlansPage = () => {
 };
 
 PlansPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+  return <PokeLayout title="Plans">{page}</PokeLayout>;
 };
 
 export default PlansPage;

--- a/front/pages/poke/plugins/index.tsx
+++ b/front/pages/poke/plugins/index.tsx
@@ -25,5 +25,5 @@ export default function ListPokePlugins() {
 }
 
 ListPokePlugins.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+  return <PokeLayout title="Plugins">{page}</PokeLayout>;
 };

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -759,8 +759,11 @@ function TemplatesPage({
   );
 }
 
-TemplatesPage.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+TemplatesPage.getLayout = (
+  page: ReactElement,
+  { templateId }: { templateId: string }
+) => {
+  return <PokeLayout title={`Templates ${templateId}`}>{page}</PokeLayout>;
 };
 
 export default TemplatesPage;

--- a/front/pages/poke/templates/index.tsx
+++ b/front/pages/poke/templates/index.tsx
@@ -29,5 +29,5 @@ export default function ListTemplates({
 }
 
 ListTemplates.getLayout = (page: ReactElement) => {
-  return <PokeLayout>{page}</PokeLayout>;
+  return <PokeLayout title="Templates">{page}</PokeLayout>;
 };


### PR DESCRIPTION
## Description

- Added poke page titles (as in html titles) to make it easier to identify what i'm looking at.
- Added titles within poke pages with links to make navigation easier.

## Tests

Locally

## Risk

Low.

## Deploy Plan

Deploy `front`