### PR TITLE
Improve Gong Connector Sync Resilience

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -238,7 +238,7 @@ export class GongClient {
       );
       return {
         transcripts: transcripts.callTranscripts,
-        nextPageCursor: transcripts.records.cursor,
+        nextPageCursor: transcripts.records.cursor ?? null,
       };
     } catch (err) {
       if (isNotFoundError(err)) {

--- a/connectors/src/connectors/gong/lib/internal_ids.ts
+++ b/connectors/src/connectors/gong/lib/internal_ids.ts
@@ -12,3 +12,9 @@ export function makeGongTranscriptInternalId(
 ) {
   return `gong-transcript-${connector.id}-${callId}`;
 }
+
+export function makeGongSyncTranscriptsWorkflowIdFromParentId(
+  workflowId: string
+): string | undefined {
+  return `${workflowId}-transcripts`;
+}

--- a/connectors/src/connectors/gong/temporal/workflows.ts
+++ b/connectors/src/connectors/gong/temporal/workflows.ts
@@ -1,6 +1,11 @@
 import type { ModelId } from "@dust-tt/types";
-import { proxyActivities } from "@temporalio/workflow";
+import {
+  executeChild,
+  proxyActivities,
+  workflowInfo,
+} from "@temporalio/workflow";
 
+import { makeGongSyncTranscriptsWorkflowIdFromParentId } from "@connectors/connectors/gong/lib/internal_ids";
 import type * as activities from "@connectors/connectors/gong/temporal/activities";
 
 const {
@@ -29,9 +34,52 @@ export async function gongSyncWorkflow({
     await gongListAndSaveUsersActivity({ connectorId });
   }
 
-  // Then, we save the transcripts.
-  await gongSyncTranscriptsActivity({ connectorId, forceResync });
+  const {
+    workflowId,
+    searchAttributes: parentSearchAttributes,
+    memo,
+  } = workflowInfo();
 
-  // Finally, we save the end of the sync.
-  await gongSaveSyncSuccessActivity({ connectorId });
+  // Record the start of the sync.
+  const syncStartTs = Date.now();
+
+  // Then, we start a child workflow to sync the transcripts.
+  await executeChild(gongSyncTranscriptsWorkflow, {
+    workflowId: makeGongSyncTranscriptsWorkflowIdFromParentId(workflowId),
+    searchAttributes: parentSearchAttributes,
+    args: [
+      {
+        connectorId,
+        forceResync,
+      },
+    ],
+    memo,
+  });
+
+  // Finally, we save the end of the sync and update the last sync timestamp.
+  await gongSaveSyncSuccessActivity({
+    connectorId,
+    lastSyncTimestamp: syncStartTs,
+  });
+}
+
+async function gongSyncTranscriptsWorkflow({
+  connectorId,
+  forceResync,
+}: {
+  connectorId: ModelId;
+  forceResync: boolean;
+}) {
+  let pageCursor: string | null = null;
+
+  // Do an outer loop to sync all the transcripts. To avoid hitting activity startToCloseTimeout.
+  do {
+    const { nextPageCursor } = await gongSyncTranscriptsActivity({
+      connectorId,
+      forceResync,
+      pageCursor,
+    });
+
+    pageCursor = nextPageCursor;
+  } while (pageCursor !== null);
 }

--- a/connectors/src/connectors/gong/temporal/workflows.ts
+++ b/connectors/src/connectors/gong/temporal/workflows.ts
@@ -63,7 +63,7 @@ export async function gongSyncWorkflow({
   });
 }
 
-async function gongSyncTranscriptsWorkflow({
+export async function gongSyncTranscriptsWorkflow({
   connectorId,
   forceResync,
 }: {

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -270,6 +270,7 @@ export class GongTranscriptResource extends BaseResource<GongTranscriptModel> {
     if (!transcript) {
       return null;
     }
+
     return new this(this.model, transcript.get());
   }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The current Gong call import process is experiencing performance issues where activities are taking excessive time to complete, occasionally reaching the `startToCloseTimeout` limit of Temporal. Even when not hitting this timeout, long-running activities are problematic since they need to be restarted during our frequent deployments.

This PR improves the architecture by:
- Creating a dedicated child workflow to handle transcript synchronization
- Moving the pagination logic out of the activity and into its own child workflow
- These changes will help break down the long-running operations into more manageable units and improve the overall reliability of the Gong connector sync process.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [ ] Will restart all Gong workflows