### PR TITLE
[core] Return the executed query from database block

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3727,13 +3727,14 @@ async fn databases_query_run(
                         "Failed to run query",
                         Some(e.into()),
                     ),
-                    Ok((results, schema)) => (
+                    Ok((results, schema, query)) => (
                         StatusCode::OK,
                         Json(APIResponse {
                             error: None,
                             response: Some(json!({
                                 "schema": schema,
                                 "results": results,
+                                "query": query,
                             })),
                         }),
                     ),

--- a/core/src/blocks/database.rs
+++ b/core/src/blocks/database.rs
@@ -106,10 +106,11 @@ impl Block for Database {
         let tables = load_tables_from_identifiers(&table_identifiers, env).await?;
 
         match execute_query(tables, &query, env.store.clone()).await {
-            Ok((results, schema)) => Ok(BlockResult {
+            Ok((results, schema, query)) => Ok(BlockResult {
                 value: json!({
                     "results": results,
                     "schema": schema,
+                    "query": query,
                 }),
                 meta: None,
             }),

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -56,7 +56,7 @@ pub async fn execute_query(
     tables: Vec<Table>,
     query: &str,
     store: Box<dyn Store + Sync + Send>,
-) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
+) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError> {
     match get_table_type_for_tables(tables.iter().collect()) {
         Err(e) => Err(QueryDatabaseError::GenericError(anyhow!(
             "Failed to get table type for tables: {}",

--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -94,7 +94,7 @@ impl BigQueryRemoteDatabase {
     pub async fn execute_query(
         &self,
         query: &str,
-    ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
+    ) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError> {
         let job = Job {
             configuration: Some(JobConfiguration {
                 query: Some(JobConfigurationQuery {
@@ -226,7 +226,7 @@ impl BigQueryRemoteDatabase {
             })
             .collect::<Result<Vec<QueryResult>>>()?;
 
-        Ok((parsed_rows, schema))
+        Ok((parsed_rows, schema, query.to_string()))
     }
 
     pub async fn get_query_plan(
@@ -307,7 +307,7 @@ impl RemoteDatabase for BigQueryRemoteDatabase {
         &self,
         tables: &Vec<Table>,
         query: &str,
-    ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
+    ) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError> {
         // Ensure that query is a SELECT query and only uses tables that are allowed.
         let plan = self.get_query_plan(query).await?;
 

--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -29,7 +29,7 @@ pub trait RemoteDatabase {
         &self,
         tables: &Vec<Table>,
         query: &str,
-    ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError>;
+    ) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError>;
     async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<TableSchema>>;
 }
 

--- a/core/src/databases/remote_databases/salesforce/salesforce.rs
+++ b/core/src/databases/remote_databases/salesforce/salesforce.rs
@@ -190,7 +190,7 @@ impl SalesforceRemoteDatabase {
     async fn execute_query(
         &self,
         query: &str,
-    ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
+    ) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError> {
         let mut all_records = Vec::new();
         let mut next_url = None;
         let mut query_result_rows = 0;
@@ -282,7 +282,7 @@ impl SalesforceRemoteDatabase {
         // For now, return an empty schema since Salesforce's schema is dynamic
         let schema = TableSchema::empty();
 
-        Ok((all_records, schema))
+        Ok((all_records, schema, query.to_string()))
     }
 
     /// Describes a Salesforce object and returns its schema
@@ -630,7 +630,7 @@ impl RemoteDatabase for SalesforceRemoteDatabase {
         &self,
         tables: &Vec<Table>,
         query: &str,
-    ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
+    ) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError> {
         // Parse the JSON query
         let parsed_query = serde_json::from_str::<StructuredQuery>(query).map_err(|e| {
             QueryDatabaseError::ExecutionError(format!("Failed to parse JSON query: {}", e))

--- a/core/src/databases/transient_database.rs
+++ b/core/src/databases/transient_database.rs
@@ -68,7 +68,7 @@ pub async fn execute_query_on_transient_database(
     tables: &Vec<LocalTable>,
     store: Box<dyn Store + Sync + Send>,
     query: &str,
-) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
+) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError> {
     let table_ids_hash = tables
         .iter()
         .map(|lt| lt.table.unique_id())
@@ -121,7 +121,7 @@ pub async fn execute_query_on_transient_database(
         ))?,
     };
 
-    Ok((result_rows, table_schema))
+    Ok((result_rows, table_schema, query.to_string()))
 }
 
 pub fn get_transient_database_unique_table_names(


### PR DESCRIPTION
## Description

Return the executed query from database block - change all the way down to remote database execution to get the query in case if it has be transformed. In salesforce, the query passed to execute_query is actually soql .

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None, adding a new output to database block and core databases_query_run call

## Deploy Plan

deploy core
