### PR TITLE
Fix: ms stuck and add logs for notion

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -330,7 +330,7 @@ async function isParentAlreadyInNodes({
       driveItem = await getItem(logger, client, parentAPIPath);
     } catch (error) {
       if (error instanceof GraphError && error.statusCode === 404) {
-        continue;
+        return false;
       }
       throw error;
     }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1919,6 +1919,7 @@ export async function renderAndUpsertPageFromCache({
   }
 
   localLogger.info("notionRenderAndUpsertPageFromCache: Rendering page.");
+
   const renderedPageSection = await renderPageSection({
     dsConfig,
     blocksByParentId,
@@ -2052,6 +2053,15 @@ export async function renderAndUpsertPageFromCache({
 
   const createdAt = new Date(pageCacheEntry.createdTime);
   const updatedAt = new Date(pageCacheEntry.lastEditedTime);
+
+  // From seb, debugging logs for a page we don't upsert to core
+  if (pageId === "3630244c-446e-475d-9323-55a264364b9e") {
+    localLogger.info(
+      "notionRenderAndUpsertPageFromCache: debug.",
+      blocksByParentId,
+      parsedProperties
+    );
+  }
 
   if (documentLength === 0 && propertiesContentLength < 128) {
     localLogger.info(


### PR DESCRIPTION
## Description

- Fix stuck MS connector (probably infinite loop due to continue)
- Add debug logs for a notion page that we don't upsert because of empty content

## Tests

None

## Risk

Low

## Deploy Plan

Deploy `connectors`