### PR TITLE
[front] - enh(InputBarAttachments): UI 

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -85,7 +85,6 @@ export const InputBarAttachments = ({
   );
 
   const showSearchResults = search.length >= MIN_SEARCH_QUERY_SIZE;
-  const showLocalFile = !showSearchResults;
 
   const searchbarRef = (element: HTMLInputElement) => {
     if (element) {
@@ -121,30 +120,7 @@ export const InputBarAttachments = ({
           />
           <DropdownMenuSeparator />
           <ScrollArea className="max-h-125 flex flex-col" hideScrollBar>
-            {showLocalFile && (
-              <div className="flex flex-col items-end gap-4 pr-1">
-                <Input
-                  type="file"
-                  ref={fileInputRef}
-                  style={{ display: "none" }}
-                  onChange={async (e) => {
-                    await fileUploaderService.handleFileChange(e);
-                    if (fileInputRef.current) {
-                      fileInputRef.current.value = "";
-                    }
-                  }}
-                  multiple={true}
-                />
-                <Button
-                  onClick={() => fileInputRef.current?.click()}
-                  disabled={isLoading}
-                  icon={CloudArrowUpIcon}
-                  label="Upload file"
-                />
-              </div>
-            )}
-
-            {showSearchResults && (
+            {showSearchResults ? (
               <div className="pt-2">
                 {unfoldedNodes.length > 0 ? (
                   unfoldedNodes.map((item, index) => (
@@ -172,6 +148,27 @@ export const InputBarAttachments = ({
                     No results found
                   </div>
                 )}
+              </div>
+            ) : (
+              <div className="flex flex-col items-end gap-4 pr-1">
+                <Input
+                  type="file"
+                  ref={fileInputRef}
+                  style={{ display: "none" }}
+                  onChange={async (e) => {
+                    await fileUploaderService.handleFileChange(e);
+                    if (fileInputRef.current) {
+                      fileInputRef.current.value = "";
+                    }
+                  }}
+                  multiple={true}
+                />
+                <Button
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isLoading}
+                  icon={CloudArrowUpIcon}
+                  label="Upload file"
+                />
               </div>
             )}
             <ScrollBar className="py-0" />

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -1,14 +1,16 @@
 import {
   AttachmentIcon,
   Button,
-  cn,
-  Icon,
-  PlusIcon,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
-  SearchInputWithPopover,
-  Separator,
+  CloudArrowUpIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuTrigger,
+  Input,
+  ScrollArea,
+  ScrollBar,
+  Spinner,
 } from "@dust-tt/sparkle";
 import type {
   DataSourceViewContentNode,
@@ -47,8 +49,8 @@ export const InputBarAttachments = ({
     includeDataSources: true,
     owner,
     search: debouncedSearch,
-    viewType: "all",
-    disabled: isSpacesLoading,
+    viewType: "document",
+    disabled: isSpacesLoading || !debouncedSearch,
     spaceIds: spaces.map((s) => s.sId),
   });
 
@@ -81,96 +83,90 @@ export const InputBarAttachments = ({
     [searchResultNodes]
   );
 
+  const showSearchResults = search.length >= MIN_SEARCH_QUERY_SIZE;
+  const showLocalFile = !showSearchResults;
+
   return (
-    <PopoverRoot>
-      <PopoverTrigger asChild>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         <Button
           variant="ghost-secondary"
-          icon={PlusIcon}
+          icon={AttachmentIcon}
           size="xs"
           disabled={isLoading}
         />
-      </PopoverTrigger>
-      <PopoverContent className="w-125" fullWidth align="start" side="left">
-        <div className="flex flex-col gap-4">
-          <div className="px-4 pt-4">
-            <h2 className="text-lg font-semibold">Local file</h2>
-            <div className="mt-2">
-              <input
-                type="file"
-                ref={fileInputRef}
-                style={{ display: "none" }}
-                onChange={async (e) => {
-                  await fileUploaderService.handleFileChange(e);
-                  if (fileInputRef.current) {
-                    fileInputRef.current.value = "";
-                  }
-                }}
-                multiple={true}
-              />
-              <button
-                className="flex w-fit items-center gap-2 rounded-lg border border-structure-200 px-4 py-2 text-sm text-primary-800 hover:bg-structure-50"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={isLoading}
-              >
-                <Icon
-                  visual={AttachmentIcon}
-                  size="xs"
-                  className="text-element-600"
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-125" align="start" side="top">
+        <div className="items-end pb-2 pt-4">
+          <DropdownMenuSearchbar
+            name="search-files"
+            placeholder="Search knowledge or attach files"
+            value={search}
+            onChange={setSearch}
+            disabled={isLoading}
+          />
+
+          <ScrollArea
+            className="mt-2 flex max-h-[300px] flex-col"
+            hideScrollBar
+          >
+            {showLocalFile && (
+              <div className="flex flex-col items-end gap-4 pr-1">
+                <Input
+                  type="file"
+                  ref={fileInputRef}
+                  style={{ display: "none" }}
+                  onChange={async (e) => {
+                    await fileUploaderService.handleFileChange(e);
+                    if (fileInputRef.current) {
+                      fileInputRef.current.value = "";
+                    }
+                  }}
+                  multiple={true}
                 />
-                Attach local file
-              </button>
-            </div>
-          </div>
-          <Separator />
-          <div className="px-4 pb-2">
-            <h2 className="text-lg font-semibold">From knowledge</h2>
-            <div className="mt-2">
-              <SearchInputWithPopover
-                name="search-files"
-                placeholder="Search connected files"
-                value={search}
-                onChange={setSearch}
-                isLoading={isSearchLoading || isDebouncing}
-                open={search.length >= MIN_SEARCH_QUERY_SIZE}
-                onOpenChange={() => {}}
-                items={unfoldedNodes}
-                renderItem={(item, selected) => {
-                  return (
-                    <div
-                      className={cn(
-                        "m-1 flex cursor-pointer items-center gap-2 rounded-lg px-2 py-2 hover:bg-structure-50 dark:hover:bg-structure-50-night",
-                        selected && "bg-structure-50 dark:bg-structure-50-night"
-                      )}
+                <Button
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isLoading}
+                  icon={CloudArrowUpIcon}
+                  label="Upload file"
+                />
+              </div>
+            )}
+
+            {showSearchResults && (
+              <div className="pt-2">
+                {unfoldedNodes.length > 0 ? (
+                  unfoldedNodes.map((item, index) => (
+                    <DropdownMenuItem
+                      key={index}
+                      label={item.title}
+                      icon={() =>
+                        getVisualForDataSourceViewContentNode(item)({
+                          className: "min-w-4",
+                        })
+                      }
+                      description={`${spacesMap[item.dataSourceView.spaceId]} • ${getLocationForDataSourceViewContentNode(item)}`}
                       onClick={() => {
                         setSearch("");
                         onNodeSelect(item);
                       }}
-                    >
-                      {getVisualForDataSourceViewContentNode(item)({
-                        className: "min-w-4",
-                      })}
-                      <div className="flex min-w-0 flex-1 flex-col">
-                        <div className="flex items-center justify-between gap-2">
-                          <span className="truncate text-sm">{item.title}</span>
-                          <div className="flex-none text-sm text-slate-500">
-                            {spacesMap[item.dataSourceView.spaceId]}
-                          </div>
-                        </div>
-                        <div className="truncate text-xs text-slate-400">
-                          {getLocationForDataSourceViewContentNode(item)}
-                        </div>
-                      </div>
-                    </div>
-                  );
-                }}
-                noResults="No results found"
-                disabled={isLoading}
-              />
-            </div>
-          </div>
+                    />
+                  ))
+                ) : isSearchLoading || isDebouncing ? (
+                  <div className="flex justify-center py-4">
+                    <Spinner variant="dark" size="sm" />
+                  </div>
+                ) : (
+                  <div className="p-2 text-sm text-gray-500">
+                    No results found
+                  </div>
+                )}
+              </div>
+            )}
+            <ScrollBar className="py-0" />
+          </ScrollArea>
         </div>
-      </PopoverContent>
-    </PopoverRoot>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -50,7 +50,7 @@ export const InputBarAttachments = ({
     includeDataSources: true,
     owner,
     search: debouncedSearch,
-    viewType: "document",
+    viewType: "all",
     disabled: isSpacesLoading || !debouncedSearch,
     spaceIds: spaces.map((s) => s.sId),
   });

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSearchbar,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
   ScrollArea,
@@ -86,8 +87,20 @@ export const InputBarAttachments = ({
   const showSearchResults = search.length >= MIN_SEARCH_QUERY_SIZE;
   const showLocalFile = !showSearchResults;
 
+  const searchbarRef = (element: HTMLInputElement) => {
+    if (element) {
+      element.focus();
+    }
+  };
+
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (!open) {
+          setSearch("");
+        }
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost-secondary"
@@ -96,20 +109,18 @@ export const InputBarAttachments = ({
           disabled={isLoading}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-125" align="start" side="top">
-        <div className="items-end pb-2 pt-4">
+      <DropdownMenuContent className="w-125" side="bottom">
+        <div className="items-end pb-2">
           <DropdownMenuSearchbar
+            ref={searchbarRef}
             name="search-files"
             placeholder="Search knowledge or attach files"
             value={search}
             onChange={setSearch}
             disabled={isLoading}
           />
-
-          <ScrollArea
-            className="mt-2 flex max-h-[300px] flex-col"
-            hideScrollBar
-          >
+          <DropdownMenuSeparator />
+          <ScrollArea className="max-h-125 flex flex-col" hideScrollBar>
             {showLocalFile && (
               <div className="flex flex-col items-end gap-4 pr-1">
                 <Input
@@ -145,7 +156,7 @@ export const InputBarAttachments = ({
                           className: "min-w-4",
                         })
                       }
-                      description={`${spacesMap[item.dataSourceView.spaceId]} • ${getLocationForDataSourceViewContentNode(item)}`}
+                      description={`${spacesMap[item.dataSourceView.spaceId]} - ${getLocationForDataSourceViewContentNode(item)}`}
                       onClick={() => {
                         setSearch("");
                         onNodeSelect(item);


### PR DESCRIPTION
## Description

This PR aims at revamping the `InputBarAttachments` component. It now follows the same pattern as the `AssistantPicker`.

Search state:
![Screenshot 2025-03-10 at 09 17 00](https://github.com/user-attachments/assets/7b4ea7bf-5bc2-4428-8304-dd4b72842a04)

Default state:
![Screenshot 2025-03-10 at 10 01 21](https://github.com/user-attachments/assets/89722480-834f-429a-af2b-641fa873dfd0)

Note: selecting a node currently doesn't have any effect.

## Risk

Low: behind FF

## Deploy Plan

Deploy front