### PR TITLE
[front] - fix(templates): filtering

### DIFF
--- a/front/components/assistant_builder/TemplateGrid.tsx
+++ b/front/components/assistant_builder/TemplateGrid.tsx
@@ -1,30 +1,69 @@
-import { LargeAssistantCard } from "@dust-tt/sparkle";
+import { ContextItem, LargeAssistantCard } from "@dust-tt/sparkle";
+import type { TemplateTagCodeType, TemplateTagsType } from "@dust-tt/types";
+import _ from "lodash";
 
 import type { AssistantTemplateListType } from "@app/pages/api/templates";
 
 interface TemplateGridProps {
   templates: AssistantTemplateListType[];
   openTemplateModal: (templateId: string) => void;
+  templateTagsMapping: TemplateTagsType;
+  selectedTags: TemplateTagCodeType[];
 }
 
 export function TemplateGrid({
   templates,
   openTemplateModal,
+  templateTagsMapping,
+  selectedTags,
 }: TemplateGridProps) {
   if (!templates.length) {
     return null;
   }
+
+  const tags =
+    selectedTags.length > 0 ? selectedTags : getUniqueTags(templates);
+
   return (
-    <div className="grid grid-cols-2 gap-2">
-      {templates.map((t) => (
-        <LargeAssistantCard
-          key={t.sId}
-          title={t.handle}
-          pictureUrl={t.pictureUrl}
-          description={t.description ?? ""}
-          onClick={() => openTemplateModal(t.sId)}
-        />
-      ))}
+    <div className="flex flex-col gap-6">
+      {tags.map((tagName) => {
+        const templatesForTag = templates.filter((template) =>
+          template.tags.includes(tagName)
+        );
+
+        if (templatesForTag.length === 0) {
+          return null;
+        }
+
+        return (
+          <div key={tagName}>
+            <ContextItem.SectionHeader
+              title={templateTagsMapping[tagName].label}
+              hasBorder={false}
+            />
+            <div className="grid grid-cols-2 gap-2">
+              {templatesForTag.map((t) => (
+                <LargeAssistantCard
+                  key={t.sId}
+                  title={t.handle}
+                  pictureUrl={t.pictureUrl}
+                  description={t.description ?? ""}
+                  onClick={() => openTemplateModal(t.sId)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
     </div>
+  );
+}
+
+// Helper function to get unique tags from templates
+function getUniqueTags(
+  templates: AssistantTemplateListType[]
+): TemplateTagCodeType[] {
+  return _.uniq(templates.flatMap((template) => template.tags)).sort((a, b) =>
+    a.toLowerCase().localeCompare(b.toLowerCase())
   );
 }

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ContextItem,
   DocumentIcon,
   MagicIcon,
   Page,
@@ -71,7 +70,7 @@ export default function CreateAssistant({
   const [templateSearchTerm, setTemplateSearchTerm] = useState<string | null>(
     null
   );
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedTags, setSelectedTags] = useState<TemplateTagCodeType[]>([]);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
     router.query.templateId ? (router.query.templateId as string) : null
   );
@@ -149,12 +148,11 @@ export default function CreateAssistant({
     filterTemplates(searchTerm);
   };
 
-  const handleTagClick = (tagName: string) => {
-    setSelectedTags(
-      (prevTags) =>
-        prevTags.includes(tagName)
-          ? prevTags.filter((tag) => tag !== tagName) // Remove tag if already selected
-          : [...prevTags, tagName] // Add tag if not selected
+  const handleTagClick = (tagName: TemplateTagCodeType) => {
+    setSelectedTags((prevTags) =>
+      prevTags.includes(tagName)
+        ? prevTags.filter((tag) => tag !== tagName)
+        : [...prevTags, tagName]
     );
   };
 
@@ -209,7 +207,7 @@ export default function CreateAssistant({
                     <Button
                       label={templateTagsMapping[tagName].label}
                       variant={
-                        selectedTags.includes(tagName) ? "highlight" : "outline"
+                        selectedTags.includes(tagName) ? "primary" : "outline"
                       }
                       key={tagName}
                       size="xs"
@@ -220,34 +218,12 @@ export default function CreateAssistant({
             </div>
             <Page.Separator />
             <div className="flex flex-col pb-56">
-              {templateSearchTerm?.length || selectedTags.length > 0 ? (
-                <>
-                  <TemplateGrid
-                    templates={filteredTemplates.templates}
-                    openTemplateModal={openTemplateModal}
-                  />
-                </>
-              ) : (
-                <>
-                  {filteredTemplates.tags.map((tagName) => {
-                    const templatesForTag = filteredTemplates.templates.filter(
-                      (item) => item.tags.includes(tagName)
-                    );
-                    return (
-                      <div key={tagName}>
-                        <ContextItem.SectionHeader
-                          title={templateTagsMapping[tagName].label}
-                          hasBorder={false}
-                        />
-                        <TemplateGrid
-                          templates={templatesForTag}
-                          openTemplateModal={openTemplateModal}
-                        />
-                      </div>
-                    );
-                  })}
-                </>
-              )}
+              <TemplateGrid
+                templates={filteredTemplates.templates}
+                openTemplateModal={openTemplateModal}
+                templateTagsMapping={templateTagsMapping}
+                selectedTags={selectedTags}
+              />
             </div>
           </div>
         </Page>

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -18,7 +18,7 @@ import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { createRef, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { AssistantTemplateModal } from "@app/components/assistant_builder/AssistantTemplateModal";
 import { TemplateGrid } from "@app/components/assistant_builder/TemplateGrid";
@@ -71,6 +71,7 @@ export default function CreateAssistant({
   const [templateSearchTerm, setTemplateSearchTerm] = useState<string | null>(
     null
   );
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
     router.query.templateId ? (router.query.templateId as string) : null
   );
@@ -83,14 +84,42 @@ export default function CreateAssistant({
   }>({ templates: [], tags: [] });
 
   useEffect(() => {
+    filterTemplates();
+  }, [assistantTemplates, selectedTags]);
+
+  const filterTemplates = (searchTerm = templateSearchTerm) => {
     const templatesToDisplay = assistantTemplates.filter((template) => {
-      return isTemplateTagCodeArray(template.tags);
+      // Check if template has valid tags
+      if (!isTemplateTagCodeArray(template.tags)) {
+        return false;
+      }
+
+      // Filter by selected tags (show templates that match ANY selected tag)
+      if (
+        selectedTags.length > 0 &&
+        !selectedTags.some((tag) => template.tags.includes(tag))
+      ) {
+        return false;
+      }
+
+      // Filter by search term
+      if (searchTerm) {
+        const searchLower = searchTerm.toLowerCase();
+        return (
+          template.handle.toLowerCase().includes(searchLower) ||
+          template.description?.toLowerCase().includes(searchLower) ||
+          false
+        );
+      }
+
+      return true;
     });
+
     setFilteredTemplates({
       templates: templatesToDisplay,
-      tags: _.uniq(templatesToDisplay.map((template) => template.tags).flat()),
+      tags: _.uniq(assistantTemplates.map((template) => template.tags).flat()),
     });
-  }, [assistantTemplates]);
+  };
 
   const openTemplateModal = useCallback(
     async (templateId: string) => {
@@ -117,70 +146,16 @@ export default function CreateAssistant({
 
   const handleSearch = (searchTerm: string) => {
     setTemplateSearchTerm(searchTerm);
-    const templatesFilteredFromSearch =
-      searchTerm === ""
-        ? assistantTemplates
-        : assistantTemplates.filter(
-            (template) =>
-              template.handle
-                .toLowerCase()
-                .includes(searchTerm.toLowerCase()) ||
-              template.description
-                ?.toLowerCase()
-                .includes(searchTerm.toLowerCase())
-          );
-    const templatesToDisplay = templatesFilteredFromSearch.filter(
-      (template) => {
-        return isTemplateTagCodeArray(template.tags);
-      }
+    filterTemplates(searchTerm);
+  };
+
+  const handleTagClick = (tagName: string) => {
+    setSelectedTags(
+      (prevTags) =>
+        prevTags.includes(tagName)
+          ? prevTags.filter((tag) => tag !== tagName) // Remove tag if already selected
+          : [...prevTags, tagName] // Add tag if not selected
     );
-    setFilteredTemplates({
-      templates: templatesToDisplay,
-      tags: _.uniq(templatesToDisplay.map((template) => template.tags).flat()),
-    });
-  };
-
-  const tagsRefsMap = useRef<{
-    [key: string]: React.MutableRefObject<HTMLDivElement | null>;
-  }>({});
-
-  useEffect(() => {
-    Object.keys(templateTagsMapping).forEach((tag: string) => {
-      tagsRefsMap.current[tag] = tagsRefsMap.current[tag] || createRef();
-    });
-  }, [templateTagsMapping]);
-
-  const scrollToTag = (tagName: string) => {
-    const SCROLL_OFFSET = 64; // Header size
-    const scrollToElement = tagsRefsMap.current[tagName]?.current;
-    const scrollContainerElement = document.getElementById("main-content");
-
-    if (!scrollToElement || !scrollContainerElement) {
-      return;
-    }
-    const scrollToElementRect = scrollToElement.getBoundingClientRect();
-    const scrollContainerRect = scrollContainerElement.getBoundingClientRect();
-    const scrollTargetPosition =
-      scrollToElementRect.top -
-      scrollContainerRect.top +
-      scrollContainerElement.scrollTop -
-      SCROLL_OFFSET;
-
-    scrollContainerElement.scrollTo({
-      top: scrollTargetPosition,
-      behavior: "smooth",
-    });
-
-    setTimeout(() => {
-      triggerShakeAnimation(scrollToElement);
-    }, 1000);
-  };
-
-  const triggerShakeAnimation = (element: HTMLElement): void => {
-    element.classList.add("animate-shake");
-    setTimeout(() => {
-      element.classList.remove("animate-shake");
-    }, 500);
   };
 
   return (
@@ -233,17 +208,19 @@ export default function CreateAssistant({
                   .map((tagName) => (
                     <Button
                       label={templateTagsMapping[tagName].label}
-                      variant="outline"
+                      variant={
+                        selectedTags.includes(tagName) ? "highlight" : "outline"
+                      }
                       key={tagName}
                       size="xs"
-                      onClick={() => scrollToTag(tagName)}
+                      onClick={() => handleTagClick(tagName)}
                     />
                   ))}
               </div>
             </div>
             <Page.Separator />
             <div className="flex flex-col pb-56">
-              {templateSearchTerm?.length ? (
+              {templateSearchTerm?.length || selectedTags.length > 0 ? (
                 <>
                   <TemplateGrid
                     templates={filteredTemplates.templates}
@@ -257,7 +234,7 @@ export default function CreateAssistant({
                       (item) => item.tags.includes(tagName)
                     );
                     return (
-                      <div key={tagName} ref={tagsRefsMap.current[tagName]}>
+                      <div key={tagName}>
                         <ContextItem.SectionHeader
                           title={templateTagsMapping[tagName].label}
                           hasBorder={false}


### PR DESCRIPTION
## Description

This PR aims at fixing the template filtering view, when clicking on tags. We now properly filter templates based on their tags.

**References:** 
- https://github.com/dust-tt/tasks/issues/2316

## Risk

Low

## Deploy Plan

- Deploy front
