### PR TITLE
[front]- chore(attach): node in input bar

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -119,7 +119,7 @@ export const InputBarAttachments = ({
             disabled={isLoading}
           />
           <DropdownMenuSeparator />
-          <ScrollArea className="max-h-125 flex flex-col" hideScrollBar>
+          <ScrollArea className="flex max-h-96 flex-col" hideScrollBar>
             {showSearchResults ? (
               <div className="pt-2">
                 {unfoldedNodes.length > 0 ? (

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -46,6 +46,7 @@ export interface InputBarContainerProps {
   disableAutoFocus: boolean;
   disableSendButton: boolean;
   fileUploaderService: FileUploaderService;
+  onNodeSelect?: (node: DataSourceViewContentNode) => void;
 }
 
 const InputBarContainer = ({
@@ -59,10 +60,10 @@ const InputBarContainer = ({
   disableAutoFocus,
   disableSendButton,
   fileUploaderService,
+  onNodeSelect,
 }: InputBarContainerProps) => {
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
-
   const [isExpanded, setIsExpanded] = useState(false);
   function handleExpansionToggle() {
     setIsExpanded((currentExpanded) => !currentExpanded);
@@ -145,11 +146,12 @@ const InputBarContainer = ({
               {featureFlags.includes("attach_from_datasources") ? (
                 <InputBarAttachments
                   fileUploaderService={fileUploaderService}
-                  onNodeSelect={(node: DataSourceViewContentNode) =>
-                    console.log(`Uploading ${node.title}`)
-                  }
                   owner={owner}
                   isLoading={false}
+                  onNodeSelect={
+                    onNodeSelect ||
+                    ((node) => console.log(`Selected ${node.title}`))
+                  }
                 />
               ) : (
                 <Button

--- a/front/components/assistant/conversation/input_bar/InputBarNodeAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarNodeAttachments.tsx
@@ -1,0 +1,59 @@
+import {
+  Citation,
+  CitationClose,
+  CitationDescription,
+  CitationIcons,
+  CitationTitle,
+  Icon,
+} from "@dust-tt/sparkle";
+import type { DataSourceViewContentNode } from "@dust-tt/types";
+
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import {
+  getLocationForDataSourceViewContentNode,
+  getVisualForDataSourceViewContentNode,
+} from "@app/lib/content_nodes";
+
+interface InputBarNodeAttachmentsProps {
+  nodes: DataSourceViewContentNode[];
+  spacesMap: Record<string, string>;
+  onRemoveNode: (node: DataSourceViewContentNode) => void;
+}
+
+export function InputBarNodeAttachments({
+  nodes,
+  spacesMap,
+  onRemoveNode,
+}: InputBarNodeAttachmentsProps) {
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mr-3 flex gap-2 overflow-auto border-b border-separator pb-3 pt-3">
+      {nodes.map((node, index) => {
+        const logo = getConnectorProviderLogoWithFallback({
+          provider: node.dataSourceView.dataSource.connectorProvider,
+        });
+        return (
+          <Citation
+            key={`attached-node-${index}`}
+            className="w-40"
+            action={<CitationClose onClick={() => onRemoveNode(node)} />}
+          >
+            <CitationIcons>
+              {getVisualForDataSourceViewContentNode(node)({
+                className: "min-w-4",
+              })}
+              <Icon visual={logo} />
+            </CitationIcons>
+            <CitationTitle>{node.title}</CitationTitle>
+            <CitationDescription>
+              {`${spacesMap[node.dataSourceView.spaceId]} - ${getLocationForDataSourceViewContentNode(node)}`}
+            </CitationDescription>
+          </Citation>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

This PR aims at enabling visual data source attachments in `InputBar`. This is only visual for now.

Note: as we did not agree on design I went for a relatively simple option, very close to the citations we currently have.

<img width="738" alt="Screenshot 2025-03-10 at 20 05 24" src="https://github.com/user-attachments/assets/8c1c9a85-91ac-4e40-865b-45cec79d0ec9" />

## Risk

Low, behind FF

## Deploy Plan

Deploy `front`