### PR TITLE
Fix: do not fail when missing channel name

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -873,15 +873,19 @@ async function makeContentFragments(
     });
 
     if (channel.error) {
-      return new Err(
-        new Error(`Could not retrieve channel name: ${channel.error}`)
-      );
+      throw new Error(`Could not retrieve channel name: ${channel.error}`);
     }
     if (!channel.channel || !channel.channel.name) {
-      return new Err(new Error("Could not retrieve channel name"));
+      if (channel.channel?.is_im || channel.channel?.is_mpim) {
+        channelName = "Direct Message";
+      } else {
+        throw new Error(
+          "Could not retrieve channel name while the response was successful"
+        );
+      }
+    } else {
+      channelName = channel.channel.name;
     }
-
-    channelName = channel.channel.name;
   } catch (e) {
     // We were missing the "im:read" scope, so we fallback to the "Unknown" channel name
     // because we would trigger an oauth error otherwise.


### PR DESCRIPTION
## Description

In DM's, it's normal to not have a channel name so no more error.
Also, made the channel name optional just-in-case and added a log.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `connectors`