### PR TITLE
Make manage subscription button more visible

### DIFF
--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -9,11 +9,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  MoreIcon,
   Page,
   ShapesIcon,
   Spinner,
@@ -322,6 +317,7 @@ export default function Subscription({
                       <Button
                         label="Manage my subscription"
                         onClick={handleGoToStripePortal}
+                        variant="outline"
                       />
                     )}
                 </Page.Horizontal>

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -319,17 +319,10 @@ export default function Subscription({
                   <Chip size="sm" color={chipColor} label={planLabel} />
                   {!subscription.trialing &&
                     subscription.stripeSubscriptionId && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button icon={MoreIcon} variant="ghost" />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent>
-                          <DropdownMenuItem
-                            label="Manage my subscription"
-                            onClick={handleGoToStripePortal}
-                          />
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                      <Button
+                        label="Manage my subscription"
+                        onClick={handleGoToStripePortal}
+                      />
                     )}
                 </Page.Horizontal>
               </>


### PR DESCRIPTION
## Description

The manage subscription button on the subscription page is not visible enough, hidden in a dropdown button. 

Before: 
<kbd>
<img width="842" alt="Screenshot 2025-03-11 at 11 33 41" src="https://github.com/user-attachments/assets/16f2082f-f42c-4b86-a482-bf3b157d36a0" />
</kbd>

After:
<kbd>
<img width="712" alt="Screenshot 2025-03-11 at 11 34 32" src="https://github.com/user-attachments/assets/0bf49ca6-9820-461a-911b-20ce08a95504" />
</kbd>


## Tests

Locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 