### PR TITLE
fix: reduce cardinality of ratelimiter metrics to save 400 per month

### DIFF
--- a/types/src/shared/rate_limiter.ts
+++ b/types/src/shared/rate_limiter.ts
@@ -56,7 +56,7 @@ export async function rateLimiter({
 
   const now = new Date();
   const redisKey = makeRateLimiterKey(key);
-  const tags = [redisKey];
+  const tags: string[] = [];
 
   let redis: undefined | Awaited<ReturnType<typeof redisClient>> = undefined;
   try {


### PR DESCRIPTION
## Description

https://app.datadoghq.eu/billing/usage?category=custom-metrics&cost_summary_start_month=2025-03&cost_summary_time_unit=monthly&summary_month=2025-03&summary_view=billable&trends_start_date=2025-03-01&trends_time_frame=monthly

Only explanation for this metric to be top of our usage of custom metrics is that the cardinality is high (since percentiles are not activated), see: https://app.datadoghq.eu/metric/summary?filter=ratelimiter.latency.distribution&metric=ratelimiter.latency.distribution&from-usage=true

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `front`
- deploy `connectors`