### PR TITLE
Make conversation deletion more resilient

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -3,10 +3,7 @@ import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
-import {
-  hardDeleteDataSource,
-  softDeleteDataSourceAndLaunchScrubWorkflow,
-} from "@app/lib/api/data_sources";
+import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { AgentConversationIncludeFileAction } from "@app/lib/models/assistant/actions/conversation/include_file";

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -3,7 +3,10 @@ import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
-import { softDeleteDataSourceAndLaunchScrubWorkflow } from "@app/lib/api/data_sources";
+import {
+  hardDeleteDataSource,
+  softDeleteDataSourceAndLaunchScrubWorkflow,
+} from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { AgentConversationIncludeFileAction } from "@app/lib/models/assistant/actions/conversation/include_file";
@@ -148,15 +151,8 @@ async function destroyConversationDataSource(
   );
 
   if (dataSource) {
-    // Perform a soft delete and initiate a workflow for permanent deletion of the data source.
-    const r = await softDeleteDataSourceAndLaunchScrubWorkflow(
-      auth,
-      dataSource
-    );
-
-    if (r.isErr()) {
-      throw new Error(`Failed to delete data source: ${r.error.message}`);
-    }
+    // Directly delete the data source.
+    await hardDeleteDataSource(auth, dataSource);
   }
 }
 

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -54,9 +54,6 @@ const config = {
   getStripeSecretWebhookKey: (): string => {
     return EnvironmentConfig.getEnvVariable("STRIPE_SECRET_WEBHOOK_KEY");
   },
-  getDustDataSourcesBucket: (): string => {
-    return EnvironmentConfig.getEnvVariable("DUST_DATA_SOURCES_BUCKET");
-  },
   getServiceAccount: (): string => {
     return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
   },

--- a/front/lib/file_storage/config.ts
+++ b/front/lib/file_storage/config.ts
@@ -13,6 +13,9 @@ const config = {
   getGcsUpsertQueueBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_UPSERT_QUEUE_BUCKET");
   },
+  getDustDataSourcesBucket: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_DATA_SOURCES_BUCKET");
+  },
 };
 
 export default config;

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -107,6 +107,12 @@ export class FileStorage {
     return this.bucket.file(filename);
   }
 
+  async getFiles({ prefix }: { prefix?: string } = {}) {
+    const [files] = await this.bucket.getFiles({ prefix });
+
+    return files;
+  }
+
   get name() {
     return this.bucket.name;
   }
@@ -151,3 +157,6 @@ export const getPublicUploadBucket = (options?: FileStorageOptions) =>
 
 export const getUpsertQueueBucket = (options?: FileStorageOptions) =>
   getBucketInstance(config.getGcsUpsertQueueBucket(), options);
+
+export const getDustDataSourcesBucket = (options?: FileStorageOptions) =>
+  getBucketInstance(config.getDustDataSourcesBucket(), options);

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -98,34 +98,6 @@ export async function scrubDataSourceActivity({
     throw new Error("Data source is not soft deleted.");
   }
 
-  const { dustAPIProjectId } = dataSource;
-
-  const storage = new Storage({ keyFilename: config.getServiceAccount() });
-
-  const [files] = await storage
-    .bucket(config.getDustDataSourcesBucket())
-    .getFiles({ prefix: dustAPIProjectId });
-
-  const chunkSize = 32;
-  const chunks = [];
-  for (let i = 0; i < files.length; i += chunkSize) {
-    chunks.push(files.slice(i, i + chunkSize));
-  }
-
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i];
-    if (!chunk) {
-      continue;
-    }
-    await Promise.all(
-      chunk.map((f) => {
-        return (async () => {
-          await f.delete();
-        })();
-      })
-    );
-  }
-
   await hardDeleteDataSource(auth, dataSource);
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Recent implementation of data retention destroy conversation based on their age. Conversation can have associated data sources, those need to be deleted before deleting the conversation. Current implementation was relying on the soft deletion path where it triggers a temporal workflow which make this deletion path not resilient as this workflow can take a few minutes to run. This PR makes sure that we hard delete directly the data source with all their associated data.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
