### PR TITLE
[core] Cache schema in database

### DIFF
--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -303,6 +303,10 @@ impl RemoteDatabase for BigQueryRemoteDatabase {
         SqlDialect::Bigquery
     }
 
+    fn schema_expiration_time(&self) -> u64 {
+        1000 * 60 * 10
+    }
+
     async fn authorize_and_execute_query(
         &self,
         tables: &Vec<Table>,

--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -23,6 +23,8 @@ use super::{
 pub trait RemoteDatabase {
     fn dialect(&self) -> SqlDialect;
 
+    fn schema_expiration_time(&self) -> u64;
+
     // Checks that the query only uses tables from the passed vector of tables and
     // then executes the query.
     async fn authorize_and_execute_query(

--- a/core/src/databases/remote_databases/salesforce/salesforce.rs
+++ b/core/src/databases/remote_databases/salesforce/salesforce.rs
@@ -625,6 +625,9 @@ impl RemoteDatabase for SalesforceRemoteDatabase {
     fn dialect(&self) -> SqlDialect {
         SqlDialect::SalesforceSoql
     }
+    fn schema_expiration_time(&self) -> u64 {
+        1000 * 60 * 60 * 24
+    }
 
     async fn authorize_and_execute_query(
         &self,

--- a/core/src/databases/remote_databases/salesforce/salesforce.rs
+++ b/core/src/databases/remote_databases/salesforce/salesforce.rs
@@ -31,7 +31,7 @@ use super::sandbox::structured_query::{StructuredQuery, Validator};
 
 pub const MAX_QUERY_RESULT_ROWS: usize = 25_000;
 pub const GET_SESSION_MAX_TRIES: usize = 3;
-pub const REDIS_CACHE_TTL_SECONDS: u64 = 60 * 60; // 1 hour
+pub const SCHEMA_EXPIRATION_MILLIS: u64 = 1000 * 60 * 60 * 24; // 1 day
 
 pub struct SalesforceRemoteDatabase {
     client: reqwest::Client,
@@ -596,7 +596,7 @@ impl RemoteDatabase for SalesforceRemoteDatabase {
         SqlDialect::SalesforceSoql
     }
     fn schema_expiration_time(&self) -> u64 {
-        1000 * 60 * 60 * 24
+        SCHEMA_EXPIRATION_MILLIS
     }
 
     async fn authorize_and_execute_query(

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -50,6 +50,8 @@ pub const FORBIDDEN_OPERATIONS: [&str; 3] = ["UPDATE", "DELETE", "INSERT"];
 
 pub const GET_SESSION_MAX_TRIES: usize = 3;
 
+pub const SCHEMA_EXPIRATION_MILLIS: u64 = 1000 * 60 * 10; // 10 minutes
+
 impl TryFrom<SnowflakeSchemaColumn> for TableSchemaColumn {
     type Error = anyhow::Error;
 
@@ -348,7 +350,7 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
     }
 
     fn schema_expiration_time(&self) -> u64 {
-        1000 * 60 * 10
+        SCHEMA_EXPIRATION_MILLIS
     }
 
     async fn authorize_and_execute_query(

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -347,6 +347,10 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
         SqlDialect::Snowflake
     }
 
+    fn schema_expiration_time(&self) -> u64 {
+        1000 * 60 * 10
+    }
+
     async fn authorize_and_execute_query(
         &self,
         tables: &Vec<Table>,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -287,6 +287,7 @@ pub trait Store {
         data_source_id: &str,
         table_id: &str,
         schema: &TableSchema,
+        schema_stale_at: Option<u64>,
     ) -> Result<()>;
     async fn invalidate_data_source_table_schema(
         &self,


### PR DESCRIPTION
## Description

This replace redis cache with schema storage in "tables" table. We already have columns in database that are loaded with schema and stale_at data, which are not currently used for remote db. This leverage usage of the information contained in the table, make schema caching more generic (not specific to a remoteDb provider).

## Tests


## Risk



## Deploy Plan

deploy core
