### PR TITLE
Fix: fetch tags if missing from delta query

### DIFF
--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -96,7 +96,12 @@ export const microsoft = async ({
           : ""
       )) as DriveItem;
 
-      const columns = await getColumnsFromListItem(driveItem, client, logger);
+      const columns = await getColumnsFromListItem(
+        driveItem,
+        driveItem.listItem?.fields,
+        client,
+        logger
+      );
 
       const microsoftNodeResource =
         await MicrosoftNodeResource.fetchByInternalId(

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -426,28 +426,12 @@ export async function getAllPaginatedEntities<T extends Entity>(
   return allItems;
 }
 
-export async function getItem(
+export async function getItem<T extends Entity>(
   logger: LoggerInterface,
   client: Client,
   itemApiPath: string
-): Promise<Entity> {
+): Promise<T> {
   return clientApiGet(logger, client, itemApiPath);
-}
-
-export async function getFileDownloadURL(
-  logger: LoggerInterface,
-  client: Client,
-  internalId: string
-) {
-  const { nodeType, itemAPIPath } = typeAndPathFromInternalId(internalId);
-
-  if (nodeType !== "file") {
-    throw new Error(`Invalid node type: ${nodeType} for getFileDownloadURL`);
-  }
-
-  const res = await clientApiGet(logger, client, `${itemAPIPath}`);
-
-  return res["@microsoft.graph.downloadUrl"];
 }
 
 type MicrosoftEntity = {

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -17,11 +17,12 @@ export type DriveItem = Pick<
   | "size"
   | "sharepointIds"
   | "listItem" // This must be expanded to get the fields
->;
+> & { "@microsoft.graph.downloadUrl": string | undefined };
 
 // This must match the type above and be used when using the graph API
+// Note: for some reason, $select do not work for @microsoft.graph.downloadUrl but select does.
 export const DRIVE_ITEM_EXPANDS_AND_SELECTS =
-  "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds&$expand=listItem($expand=fields)";
+  "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds&$expand=listItem($expand=fields)&select=@microsoft.graph.downloadUrl";
 
 export const MICROSOFT_NODE_TYPES = [
   "sites-root",

--- a/connectors/src/connectors/microsoft/lib/utils.ts
+++ b/connectors/src/connectors/microsoft/lib/utils.ts
@@ -1,7 +1,11 @@
 import type { LoggerInterface } from "@dust-tt/client";
 import { cacheWithRedis } from "@dust-tt/types";
 import type { Client } from "@microsoft/microsoft-graph-client";
-import type { ColumnDefinition } from "@microsoft/microsoft-graph-types";
+import type {
+  ColumnDefinition,
+  FieldValueSet,
+  NullableOption,
+} from "@microsoft/microsoft-graph-types";
 
 import { clientApiGet } from "@connectors/connectors/microsoft/lib/graph_api";
 
@@ -120,16 +124,12 @@ export async function _getListColumns({
 // Turn the labels into a string array of formatted string such as column.displayName:value
 export const getColumnsFromListItem = async (
   file: DriveItem,
+  fields: NullableOption<FieldValueSet> | undefined,
   client: Client,
   logger: LoggerInterface
 ) => {
   const listItem = file.listItem;
-  if (
-    !file.sharepointIds?.listId ||
-    !file.sharepointIds?.siteId ||
-    !listItem ||
-    !listItem.fields
-  ) {
+  if (!file.sharepointIds?.listId || !file.sharepointIds?.siteId || !fields) {
     logger.info(
       {
         file,
@@ -149,8 +149,7 @@ export const getColumnsFromListItem = async (
 
     const columnsList: string[] = [];
 
-    const fields = listItem.fields as Record<string, unknown>;
-    for (const [k, v] of Object.entries(fields)) {
+    for (const [k, v] of Object.entries(fields as Record<string, unknown>)) {
       const column = columns.find((column) => column.name === k);
       if (column) {
         columnsList.push(`${column.displayName}:${v}`);

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -205,8 +205,13 @@ async function processSheet({
       })),
     ];
 
+    if (!spreadsheet.listItem?.fields) {
+      localLogger.warn("Unexpected missing fields for spreadsheet");
+    }
+
     const tags = await getColumnsFromListItem(
       spreadsheet,
+      spreadsheet.listItem?.fields,
       await getClient(connector.connectionId),
       localLogger
     );


### PR DESCRIPTION
## Description

Fix the missing tags from the delta query by fetching the information for the item if they are missing.

## Tests

Tested locally.

## Risk

Increase of graph api query, added a metric to monitor.

## Deploy Plan

Deploy `connectors`