### PR TITLE
[front] - feat: implement URL detection in editor extension

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension.ts
@@ -1,0 +1,34 @@
+import { Extension, markPasteRule } from "@tiptap/core";
+
+type URLFormatOptions = {
+  onUrlDetected?: (url: string) => void;
+};
+
+const URL_REGEX = /(https?:\/\/[^\s]+)/gi;
+
+export const URLDetectionExtension = Extension.create<URLFormatOptions>({
+  name: "urlDetection",
+
+  addOptions() {
+    return {
+      onUrlDetected: undefined,
+    };
+  },
+
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: URL_REGEX,
+        type: this.editor.schema.marks.bold,
+        // Use getAttributes to trigger the callback
+        getAttributes: (match) => {
+          // Call the callback with the detected URL
+          if (this.options.onUrlDetected) {
+            this.options.onUrlDetected(match[0]);
+          }
+          return {};
+        },
+      }),
+    ];
+  },
+});

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -207,6 +207,12 @@ const useCustomEditor = ({
         paragraph: false,
         strike: false,
       }),
+      // TODO(attach): uncomment for url detection
+      // URLDetectionExtension.configure({
+      //   onUrlDetected: (url) => {
+      //     console.log("URL detected", url);
+      //   }
+      // }),
       MentionStorageExtension,
       MentionWithPasteExtension.configure({
         HTMLAttributes: {


### PR DESCRIPTION
## Description

This PR at implementing URL detection when pasting in the `InputBar`.

 - Added a new extension to the editor for detecting URLs during paste actions
 - Configured a dummy callback to log detected URLs for future implementation of URL handling

**References:**
- https://github.com/dust-tt/tasks/issues/2350

## Risk

None, not used 

## Deploy Plan

N/A