### PR TITLE
Fix error message and simplify code.

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -233,10 +233,10 @@ export async function getUserConversations(
   const owner = auth.workspace();
   const user = auth.user();
   if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
+    throw new Error("Unexpected `auth` without a `workspace`.");
   }
   if (!user) {
-    throw new Error("Unexpected `auth` without `workspace`.");
+    throw new Error("Unexpected `auth` without a `user`.");
   }
 
   const participations = await ConversationParticipant.findAll({

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -111,10 +111,7 @@ export async function createConversation(
     visibility: ConversationVisibility;
   }
 ): Promise<ConversationType> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const conversation = await Conversation.create({
     sId: generateRandomModelSId(),
@@ -152,15 +149,12 @@ export async function updateConversation(
     visibility: ConversationVisibility;
   }
 ): Promise<Result<ConversationType, ConversationError>> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const conversation = await Conversation.findOne({
     where: {
       sId: conversationId,
-      workspaceId: auth.workspace()?.id,
+      workspaceId: owner.id,
       visibility: { [Op.ne]: "deleted" },
     },
   });
@@ -191,14 +185,12 @@ export async function deleteConversation(
     destroy?: boolean;
   }
 ): Promise<Result<{ success: true }, ConversationError>> {
-  if (!auth.workspace()) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const conversation = await Conversation.findOne({
     where: {
       sId: conversationId,
-      workspaceId: auth.workspace()?.id,
+      workspaceId: owner.id,
       visibility: { [Op.ne]: "deleted" },
     },
   });
@@ -230,14 +222,8 @@ export async function getUserConversations(
   includeDeleted?: boolean,
   includeTest?: boolean
 ): Promise<ConversationWithoutContentType[]> {
-  const owner = auth.workspace();
-  const user = auth.user();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without a `workspace`.");
-  }
-  if (!user) {
-    throw new Error("Unexpected `auth` without a `user`.");
-  }
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
 
   const participations = await ConversationParticipant.findAll({
     attributes: ["userId", "updatedAt", "conversationId"],
@@ -345,10 +331,7 @@ export async function getConversation(
   conversationId: string,
   includeDeleted?: boolean
 ): Promise<Result<ConversationType, ConversationError>> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const conversation = await Conversation.findOne({
     where: {
@@ -446,8 +429,7 @@ export async function getConversationMessageType(
   conversation: ConversationType | ConversationWithoutContentType,
   messageId: string
 ): Promise<"user_message" | "agent_message" | "content_fragment" | null> {
-  const owner = auth.workspace();
-  if (!owner) {
+  if (!auth.workspace()) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
@@ -483,10 +465,7 @@ export async function generateConversationTitle(
   auth: Authenticator,
   conversation: ConversationType
 ): Promise<Result<string, Error>> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const model = getSmallWhitelistedModel(owner);
   if (!model) {


### PR DESCRIPTION
## Description

We had an incorrect "Unexpected `auth` without `workspace" for user in getUserConversations().
Took the opportunity to use getNonNullableXX() instead of custom checks.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`