### PR TITLE
Ensure content is set when generating last message

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -693,7 +693,7 @@ async function* runMultiActionsAgent(
   yield* contentParser.flushTokens();
 
   if (!output.actions.length) {
-    if (typeof output.generation === "string") {
+    if (typeof output.generation === "string" && contentParser.getContent()) {
       yield {
         type: "agent_message_content",
         created: Date.now(),


### PR DESCRIPTION
fixes https://github.com/dust-tt/tasks/issues/2279

## Description

Check that some parsed content exist before sending success event. If no tools are requested, the final message should always contains some text. If not we have an issue - send an error ("No action or generation found") instead of leaving the user with an empty response and successful state.

<img width="519" alt="Screenshot 2025-03-13 at 13 47 24" src="https://github.com/user-attachments/assets/1dec25ce-44c9-4bbb-8a35-40aca119013c" />

I don't think we need to modify AgentMessage model to handle warning differently. We can have a list of error types that would be displayed as warnings in the ErrorMessage component.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

have unexpected "No action or generation found" errors ?
## Deploy Plan

deploy front