### PR TITLE
Fix connector permission hierarchy rendering

### DIFF
--- a/connectors/src/connectors/bigquery/index.ts
+++ b/connectors/src/connectors/bigquery/index.ts
@@ -348,6 +348,19 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
+  /**
+   * Retrieves the parent IDs of a content node in hierarchical order.
+   * The first ID is the internal ID of the content node itself.
+   */
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    return new Ok([internalId]);
+  }
+
   async pause(): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -437,6 +437,15 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // Confluence only let you select spaces (root nodes).
+    return new Ok([internalId]);
+  }
+
   async setConfigurationKey(): Promise<Result<void, Error>> {
     throw new Error("Method not implemented.");
   }

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -465,6 +465,15 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     }
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // TODO: Implement this.
+    return new Ok([internalId]);
+  }
+
   async setConfigurationKey({
     configKey,
     configValue,

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -244,6 +244,15 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
     return new Ok([]);
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // Gong only let you select root nodes.
+    return new Ok([internalId]);
+  }
+
   async setPermissions(): Promise<Result<void, Error>> {
     throw new Error("Method not supported.");
   }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -14,13 +14,21 @@ import {
 import type { drive_v3 } from "googleapis";
 import type { GaxiosResponse, OAuth2Client } from "googleapis-common";
 import type { InferAttributes, WhereOptions } from "sequelize";
+import { v4 as uuidv4 } from "uuid";
 
-import { isDriveObjectExpandable } from "@connectors/connectors/google_drive/lib";
+import {
+  getLocalParents,
+  isDriveObjectExpandable,
+} from "@connectors/connectors/google_drive/lib";
 import {
   GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
   GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
 } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
+import {
+  getFileParents,
+  getFileParentsMemoized,
+} from "@connectors/connectors/google_drive/lib/hierarchy";
 import { getPermissionViewType } from "@connectors/connectors/google_drive/lib/permissions";
 import {
   folderHasChildren,
@@ -675,6 +683,55 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       default: {
         return new Err(new Error(`Invalid config key ${configKey}`));
       }
+    }
+  }
+
+  async retrieveContentNodeParents({
+    internalId,
+    memoizationKey,
+  }: {
+    internalId: string;
+    memoizationKey: string;
+  }): Promise<Result<string[], Error>> {
+    try {
+      const connector = await ConnectorResource.fetchById(this.connectorId);
+      if (!connector) {
+        return new Err(
+          new Error(`Connector not found with id ${this.connectorId}`)
+        );
+      }
+
+      if (
+        internalId === getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID)
+      ) {
+        return new Ok([]);
+      }
+
+      const authCredentials = await getAuthObject(connector.connectionId);
+
+      const driveObject = await getGoogleDriveObject({
+        authCredentials,
+        driveObjectId: getDriveFileId(internalId),
+        cacheKey: { connectorId: this.connectorId, ts: memoizationKey },
+      });
+
+      if (!driveObject) {
+        return new Err(
+          new Error(`Drive object not found with id ${internalId}`)
+        );
+      }
+
+      const parents = await getFileParentsMemoized(
+        this.connectorId,
+        authCredentials,
+        driveObject,
+        memoizationKey,
+        { includeAllRemoteParents: true }
+      );
+
+      return new Ok(parents.map((p) => getInternalId(p)));
+    } catch (err) {
+      return new Err(err as Error);
     }
   }
 

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -14,21 +14,14 @@ import {
 import type { drive_v3 } from "googleapis";
 import type { GaxiosResponse, OAuth2Client } from "googleapis-common";
 import type { InferAttributes, WhereOptions } from "sequelize";
-import { v4 as uuidv4 } from "uuid";
 
-import {
-  getLocalParents,
-  isDriveObjectExpandable,
-} from "@connectors/connectors/google_drive/lib";
+import { isDriveObjectExpandable } from "@connectors/connectors/google_drive/lib";
 import {
   GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
   GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
 } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
-import {
-  getFileParents,
-  getFileParentsMemoized,
-} from "@connectors/connectors/google_drive/lib/hierarchy";
+import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import { getPermissionViewType } from "@connectors/connectors/google_drive/lib/permissions";
 import {
   folderHasChildren,

--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -20,7 +20,8 @@ async function getFileParents(
   connectorId: ModelId,
   authCredentials: OAuth2Client,
   driveFile: GoogleDriveObjectType,
-  startSyncTs: number
+  startSyncTs: number | string,
+  { includeAllRemoteParents }: { includeAllRemoteParents?: boolean } = {}
 ): Promise<string[]> {
   const logger = mainLogger.child({
     provider: "google_drive",
@@ -45,6 +46,10 @@ async function getFileParents(
     }
     parents.push(parent.id);
     currentObject = parent;
+  }
+
+  if (includeAllRemoteParents) {
+    return parents;
   }
 
   // Avoid inserting parents outside of what we sync by checking GoogleDriveFolder.
@@ -90,9 +95,10 @@ export const getFileParentsMemoized = cacheWithRedis(
     connectorId: ModelId,
     authCredentials: OAuth2Client,
     driveFile: GoogleDriveObjectType,
-    startSyncTs: number
+    startSyncTs: number | string,
+    { includeAllRemoteParents }: { includeAllRemoteParents?: boolean } = {}
   ) => {
-    const cacheKey = `gdrive-parents-${connectorId}-${startSyncTs}-${driveFile.id}`;
+    const cacheKey = `gdrive-parents-${connectorId}-${startSyncTs}-${driveFile.id}-${includeAllRemoteParents}`;
 
     return cacheKey;
   },

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -359,6 +359,15 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     }
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // TODO: Implement this.
+    return new Ok([internalId]);
+  }
+
   async setPermissions({
     permissions,
   }: {

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -71,6 +71,15 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
     Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
   >;
 
+  /**
+   * Retrieves the parent IDs of a content node in hierarchical order.
+   * The first ID is the internal ID of the content node itself.
+   */
+  abstract retrieveContentNodeParents(params: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>>;
+
   abstract setPermissions(params: {
     permissions: Record<string, ConnectorPermission>;
   }): Promise<Result<void, Error>>;

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -360,6 +360,15 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     }
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // TODO: Implement this.
+    return new Ok([internalId]);
+  }
+
   async setPermissions({
     permissions,
   }: {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -551,6 +551,15 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     return new Ok(nodes.concat(folderNodes));
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // TODO: Implement this.
+    return new Ok([internalId]);
+  }
+
   async setPermissions(): Promise<Result<void, Error>> {
     return new Err(
       new Error(`Setting Notion connector permissions is not implemented yet.`)

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -287,6 +287,15 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
     return fetchRes;
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // TODO: Implement this.
+    return new Ok([internalId]);
+  }
+
   async setPermissions({
     permissions,
   }: {

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -439,6 +439,15 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     }
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // TODO: Implement this.
+    return new Ok([internalId]);
+  }
+
   async setPermissions({
     permissions,
   }: {

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -310,6 +310,15 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     return fetchRes;
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // TODO: Implement this.
+    return new Ok([internalId]);
+  }
+
   async setPermissions({
     permissions,
   }: {

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -250,6 +250,15 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     );
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // This isn't used for webcrawler.
+    return new Ok([internalId]);
+  }
+
   async pause(): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -341,6 +341,15 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     }
   }
 
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    // TODO: Implement this.
+    return new Ok([internalId]);
+  }
+
   /**
    * Updates the permissions stored in db,
    * then launches a sync workflow with the signals

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -58,11 +58,7 @@ export type UseResourcesHook = (parentId: string | null) => {
 export type ContentNodeTreeItemStatus<T extends ContentNode = ContentNode> = {
   isSelected: boolean;
   node: T;
-  // when setting permissions on a connector, nodes that are to be selected /
-  // unselected may not be synced yet so we cannot easily access their parents
-  // In that case parents is null
-  // It is not an issue for this component(see ConnectorPermissionsModal.tsx)
-  parents: string[] | null;
+  parents: string[];
 };
 
 export type TreeSelectionModelUpdater = (

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -55,9 +55,9 @@ export type UseResourcesHook = (parentId: string | null) => {
   resourcesError?: APIError | null;
 };
 
-export type ContentNodeTreeItemStatus = {
+export type ContentNodeTreeItemStatus<T extends ContentNode = ContentNode> = {
   isSelected: boolean;
-  node: ContentNode;
+  node: T;
   // when setting permissions on a connector, nodes that are to be selected /
   // unselected may not be synced yet so we cannot easily access their parents
   // In that case parents is null

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -612,8 +612,6 @@ export function ConnectorPermissionsModal({
           [r.internalId]: {
             isSelected: true,
             node: r,
-            // content nodes are not synced yet so we cannot access their parents via permissions
-            // this is not an issue for this component
             parents: r.parentInternalIds ?? [],
           },
         }),

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -31,6 +31,7 @@ import type {
   ConnectorProvider,
   ConnectorType,
   ContentNode,
+  ContentNodeWithParent,
   DataSourceType,
   DataSourceViewType,
   LightWorkspaceType,
@@ -603,7 +604,9 @@ export function ConnectorPermissionsModal({
 
   const initialTreeSelectionModel = useMemo(
     () =>
-      allSelectedResources.reduce<Record<string, ContentNodeTreeItemStatus>>(
+      allSelectedResources.reduce<
+        Record<string, ContentNodeTreeItemStatus<ContentNodeWithParent>>
+      >(
         (acc, r) => ({
           ...acc,
           [r.internalId]: {
@@ -611,7 +614,7 @@ export function ConnectorPermissionsModal({
             node: r,
             // content nodes are not synced yet so we cannot access their parents via permissions
             // this is not an issue for this component
-            parents: null,
+            parents: r.parentInternalIds ?? [],
           },
         }),
         {}

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { ContentNode, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
@@ -12,7 +12,7 @@ import { getManagedDataSourcePermissionsHandler } from "@app/pages/api/w/[wId]/d
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorResponse<GetDataSourcePermissionsResponseBody>
+    WithAPIErrorResponse<GetDataSourcePermissionsResponseBody<ContentNode>>
   >,
   session: SessionWithUser
 ): Promise<void> {

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
@@ -1,4 +1,4 @@
-import type { ContentNode, WithAPIErrorResponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
@@ -12,7 +12,7 @@ import { getManagedDataSourcePermissionsHandler } from "@app/pages/api/w/[wId]/d
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorResponse<GetDataSourcePermissionsResponseBody<ContentNode>>
+    WithAPIErrorResponse<GetDataSourcePermissionsResponseBody>
   >,
   session: SessionWithUser
 ): Promise<void> {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -1,6 +1,6 @@
 import type {
   ConnectorPermission,
-  ContentNode,
+  ContentNodeWithParent,
   DataSourceType,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
@@ -36,7 +36,7 @@ const SetConnectorPermissionsRequestBodySchema = t.type({
 });
 
 export type GetDataSourcePermissionsResponseBody = {
-  resources: ContentNode[];
+  resources: ContentNodeWithParent[];
 };
 
 export type SetDataSourcePermissionsResponseBody = {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectorPermission,
+  ContentNode,
   ContentNodeWithParent,
   DataSourceType,
   WithAPIErrorResponse,
@@ -35,8 +36,10 @@ const SetConnectorPermissionsRequestBodySchema = t.type({
   ),
 });
 
-export type GetDataSourcePermissionsResponseBody = {
-  resources: ContentNodeWithParent[];
+export type GetDataSourcePermissionsResponseBody<
+  T extends ConnectorPermission = ConnectorPermission,
+> = {
+  resources: (T extends "read" ? ContentNodeWithParent : ContentNode)[];
 };
 
 export type SetDataSourcePermissionsResponseBody = {

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -106,10 +106,6 @@ export interface ContentNodeWithParent extends ContentNode {
   parentTitle?: string;
 }
 
-type GetContentNodesReturnType<Key extends string> = ConnectorsAPIResponse<{
-  [K in Key]: ContentNodeWithParent[];
-}>;
-
 export type GoogleDriveFolderType = {
   id: string;
   name: string;
@@ -299,17 +295,23 @@ export class ConnectorsAPI {
     return this._resultFromResponse(res);
   }
 
-  async getConnectorPermissions({
+  async getConnectorPermissions<
+    T extends ConnectorPermission = ConnectorPermission
+  >({
     connectorId,
     filterPermission,
     parentId,
     viewType = "document",
   }: {
     connectorId: string;
-    filterPermission?: ConnectorPermission;
+    filterPermission?: T;
     parentId?: string;
     viewType?: ContentNodesViewType;
-  }): Promise<GetContentNodesReturnType<"resources">> {
+  }): Promise<
+    ConnectorsAPIResponse<{
+      resources: (T extends "read" ? ContentNodeWithParent : ContentNode)[];
+    }>
+  > {
     const queryParams = new URLSearchParams();
 
     if (parentId) {
@@ -331,9 +333,7 @@ export class ConnectorsAPI {
       headers: this.getDefaultHeaders(),
     });
 
-    const response = await this._resultFromResponse(res);
-
-    return response as GetContentNodesReturnType<"resources">;
+    return this._resultFromResponse(res);
   }
 
   async setConnectorPermissions({

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -107,7 +107,7 @@ export interface ContentNodeWithParent extends ContentNode {
 }
 
 type GetContentNodesReturnType<Key extends string> = ConnectorsAPIResponse<{
-  [K in Key]: ContentNode[];
+  [K in Key]: ContentNodeWithParent[];
 }>;
 
 export type GoogleDriveFolderType = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/2369.

This PR addresses visibility issues with connector permissions following the migration to core content nodes. While permission checks work correctly for root-level nodes, the current UI Tree implementation has a limitation: it doesn't show partially selected parent nodes when their children are selected. This forces users to manually expand all nodes to understand which data they can access in Dust.

To improve this UX issue, we're adding back the `retrieveContentNodeParents` method that fetches the parent hierarchy of selected nodes from the remote server. This helps provide better visibility of the permission structure. It's only implemented for Google Drive for now. A few other PRs will come to fix all connectors.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
