### PR TITLE
[.github] - chore: enforce main branch deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,17 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if deployment is from main branch
+        if: ${{ github.ref != 'refs/heads/main' && inputs.component != 'front-edge' && inputs.component != 'front-qa' }}
+        run: |
+          echo "Error: Deployments for ${{ inputs.component }} are only allowed from the main branch"
+          exit 1
+
   prepare:
+    needs: [ check-branch ]
     runs-on: ubuntu-latest
     outputs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}


### PR DESCRIPTION
## Description

This PR aims at blocking deployments if they are not from the main branch, except for 'front-edge' and 'front-qa'

## Risk

Low, breaking CI

## Deploy Plan

N/A