### PR TITLE
[front] - chore(search): support filtering by node_id

### DIFF
--- a/front/lib/search.ts
+++ b/front/lib/search.ts
@@ -55,10 +55,12 @@ export function getSearchFilterFromDataSourceViews(
     excludedNodeMimeTypes,
     includeDataSources,
     viewType,
+    nodeIds,
   }: {
     excludedNodeMimeTypes: readonly string[];
     includeDataSources: boolean;
     viewType: ContentNodesViewType;
+    nodeIds?: string[];
   }
 ) {
   const groupedPerDataSource = dataSourceViews.reduce(
@@ -111,5 +113,6 @@ export function getSearchFilterFromDataSourceViews(
     })),
     excluded_node_mime_types: excludedNodeMimeTypes,
     node_types: getCoreViewTypeFilter(viewType),
+    node_ids: nodeIds,
   };
 }

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -686,23 +686,39 @@ export function useSpaceSearch({
   };
 }
 
+type BaseSearchParams = {
+  disabled?: boolean;
+  includeDataSources: boolean;
+  owner: LightWorkspaceType;
+  spaceIds?: string[];
+  viewType: ContentNodesViewType;
+  pagination?: CursorPaginationParams;
+};
+
+// Text search variant
+type TextSearchParams = BaseSearchParams & {
+  search: string;
+  nodeIds?: undefined;
+};
+
+// Node ID search variant
+type NodeIdSearchParams = BaseSearchParams & {
+  search?: undefined;
+  nodeIds: string[];
+};
+
+type SpacesSearchParams = TextSearchParams | NodeIdSearchParams;
+
 export function useSpacesSearch({
   disabled = false,
   includeDataSources = false,
+  nodeIds,
   owner,
   search,
   spaceIds,
   viewType,
   pagination,
-}: {
-  disabled?: boolean;
-  includeDataSources: boolean;
-  owner: LightWorkspaceType;
-  search: string;
-  spaceIds?: string[];
-  viewType: ContentNodesViewType;
-  pagination?: CursorPaginationParams;
-}): {
+}: SpacesSearchParams): {
   isSearchLoading: boolean;
   isSearchError: boolean;
   isSearchValidating: boolean;
@@ -722,6 +738,7 @@ export function useSpacesSearch({
   const body = {
     query: search,
     viewType,
+    nodeIds,
     spaceIds,
     includeDataSources,
     limit: pagination?.limit ?? DEFAULT_SEARCH_LIMIT,
@@ -729,7 +746,7 @@ export function useSpacesSearch({
 
   // Only perform a query if we have a valid search
   const url =
-    search.length >= MIN_SEARCH_QUERY_SIZE
+    (search && search.length >= MIN_SEARCH_QUERY_SIZE) || nodeIds
       ? `/api/w/${owner.sId}/search?${params}`
       : null;
 


### PR DESCRIPTION
## Description

This PR adds a `nodeIds` parameter to filter on specific node, this parameter was already supported by the CoreAPI. 
It also modifies `useSpacesSearch` hook to accept a search term or node ids.

These changes are required for the URL pasting feature.

## Risk

Low

## Deploy Plan

- Deploy `front`