### PR TITLE
[front] Use api route for finalize

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -104,7 +104,7 @@ export async function handleUpdatePermissions(
   if (connectionIdRes.isErr()) {
     sendNotification({
       type: "error",
-      title: "Failed to update the permissions of the Data Source",
+      title: "Failed to update the permissions",
       description: connectionIdRes.error.message,
     });
     return;
@@ -119,7 +119,7 @@ export async function handleUpdatePermissions(
   if (updateRes.error) {
     sendNotification({
       type: "error",
-      title: "Failed to update the permissions of the Data Source",
+      title: "Failed to update the permissions",
       description: updateRes.error,
     });
   } else {

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -1,0 +1,21 @@
+import type { OAuthProvider } from "@dust-tt/types";
+
+export const useFinalize = () => {
+  const doFinalize = async (
+    provider: OAuthProvider,
+    queryParams: Record<string, string | string[] | undefined>
+  ) => {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(queryParams)) {
+      if (Array.isArray(value)) {
+        value.forEach((v) => params.append(key, v));
+      } else if (value !== undefined) {
+        params.append(key, value);
+      }
+    }
+
+    return fetch(`/api/oauth/${provider}/finalize?${params.toString()}`);
+  };
+
+  return doFinalize;
+};

--- a/front/pages/api/oauth/[provider]/finalize.ts
+++ b/front/pages/api/oauth/[provider]/finalize.ts
@@ -11,7 +11,7 @@ async function handler(
     WithAPIErrorResponse<{ connection: OAuthConnectionType }>
   >
 ) {
-  const provider = req.query.provider as string;
+  const provider = req.query.provider;
   if (!isOAuthProvider(provider)) {
     res.status(404).end();
     return;

--- a/front/pages/api/oauth/[provider]/finalize.ts
+++ b/front/pages/api/oauth/[provider]/finalize.ts
@@ -19,7 +19,12 @@ async function handler(
 
   const cRes = await finalizeConnection(provider, req.query);
   if (!cRes.isOk()) {
-    res.status(400).end();
+    res.status(500).json({
+      error: {
+        type: "internal_server_error",
+        message: cRes.error.message,
+      },
+    });
     return;
   }
 

--- a/front/pages/api/oauth/[provider]/finalize.ts
+++ b/front/pages/api/oauth/[provider]/finalize.ts
@@ -1,0 +1,29 @@
+import type { OAuthConnectionType, WithAPIErrorResponse } from "@dust-tt/types";
+import { isOAuthProvider } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import { finalizeConnection } from "@app/lib/api/oauth";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<{ connection: OAuthConnectionType }>
+  >
+) {
+  const provider = req.query.provider as string;
+  if (!isOAuthProvider(provider)) {
+    res.status(404).end();
+    return;
+  }
+
+  const cRes = await finalizeConnection(provider, req.query);
+  if (!cRes.isOk()) {
+    res.status(400).end();
+    return;
+  }
+
+  res.status(200).json({ connection: cRes.value });
+}
+
+export default withSessionAuthentication(handler);

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -33,10 +33,9 @@ export default function Finalize({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [error, setError] = useState<string | null>(null);
 
+  // Finalize the connection on component mount.
   useEffect(() => {
     async function finalizeOAuth() {
-      // When the component mounts, send a message `connection_finalized` to the window that opened
-      // this one.
       if (!window.opener) {
         setError(
           "This URL was unexpectedly visited outside of the Dust Connections setup flow. " +
@@ -55,6 +54,8 @@ export default function Finalize({
         const res = await fetch(
           `/api/oauth/${provider}/finalize?${params.toString()}`
         );
+        // Send a message `connection_finalized` to the window that opened
+        // this one, with either an error or the connection data.
         if (!res.ok) {
           window.opener.postMessage(
             {

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -1,7 +1,5 @@
-import { Button, LogoutIcon } from "@dust-tt/sparkle";
 import { isOAuthProvider } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -22,7 +22,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   return {
     props: {
       queryParams,
-      provider: provider as string,
+      provider,
     },
   };
 });

--- a/types/src/oauth/client/setup.ts
+++ b/types/src/oauth/client/setup.ts
@@ -38,7 +38,7 @@ export async function setupOAuthConnection({
         const { error, connection } = event.data;
         if (error) {
           resolve(new Err(new Error(error)));
-        } else if (isOAuthConnectionType(connection)) {
+        } else if (connection && isOAuthConnectionType(connection)) {
           resolve(new Ok(connection));
         } else {
           resolve(

--- a/types/src/oauth/client/setup.ts
+++ b/types/src/oauth/client/setup.ts
@@ -35,8 +35,10 @@ export async function setupOAuthConnection({
 
       if (event.data.type === "connection_finalized") {
         authComplete = true;
-        const connection = event.data.connection;
-        if (isOAuthConnectionType(connection)) {
+        const { error, connection } = event.data;
+        if (error) {
+          resolve(new Err(new Error(error)));
+        } else if (isOAuthConnectionType(connection)) {
           resolve(new Ok(connection));
         } else {
           resolve(


### PR DESCRIPTION
## Description

Move the logic of finalization call to an api route instead of getServerSideProps, which can be called multiple times.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Breaks creation of new connection, can be rolled back

## Deploy Plan

deploy front
