### PR TITLE
Pass related credentials to finalize/refresh

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use std::{env, fmt};
 use tracing::{error, info};
 
-use super::providers::utils::ProviderHttpRequestError;
+use super::{credential::Credential, providers::utils::ProviderHttpRequestError};
 
 // We hold the lock for at most 15s. In case of panic preventing the lock from being released, this
 // is the maximum time the lock will be held.
@@ -144,11 +144,16 @@ pub trait Provider {
     async fn finalize(
         &self,
         connection: &Connection,
+        credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError>;
 
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError>;
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError>;
 
     // This method scrubs raw_json to remove information that should not exfill `oauth`, in
     // particular the `refresh_token`. By convetion the `access_token` should be scrubbed as well
@@ -558,8 +563,13 @@ impl Connection {
 
         let now = utils::now();
 
+        let credential = match self.related_credential_id() {
+            Some(id) => store.retrieve_credential(&id).await.ok(),
+            None => None,
+        };
+
         let finalize = provider(self.provider)
-            .finalize(self, code, redirect_uri)
+            .finalize(self, credential, code, redirect_uri)
             .await?;
 
         self.status = ConnectionStatus::Finalized;
@@ -704,7 +714,12 @@ impl Connection {
 
         let now = utils::now();
 
-        let refresh = provider(self.provider).refresh(self).await?;
+        let credential = match self.related_credential_id() {
+            Some(id) => store.retrieve_credential(&id).await.ok(),
+            None => None,
+        };
+
+        let refresh = provider(self.provider).refresh(self, credential).await?;
 
         self.access_token_expiry = refresh.access_token_expiry;
         self.encrypted_access_token = Some(seal_str(&refresh.access_token)?);

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -144,7 +144,7 @@ pub trait Provider {
     async fn finalize(
         &self,
         connection: &Connection,
-        credentials: Option<Credential>,
+        related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError>;
@@ -152,7 +152,7 @@ pub trait Provider {
     async fn refresh(
         &self,
         connection: &Connection,
-        credentials: Option<Credential>,
+        related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError>;
 
     // This method scrubs raw_json to remove information that should not exfill `oauth`, in

--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -42,7 +42,7 @@ impl Provider for ConfluenceConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -102,7 +102,7 @@ impl Provider for ConfluenceConnectionProvider {
     async fn refresh(
         &self,
         connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = match connection.unseal_refresh_token() {
             Ok(Some(token)) => token,

--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -4,6 +4,7 @@ use crate::{
             Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
             PROVIDER_TIMEOUT_SECONDS,
         },
+        credential::Credential,
         providers::utils::execute_request,
     },
     utils,
@@ -41,6 +42,7 @@ impl Provider for ConfluenceConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -97,7 +99,11 @@ impl Provider for ConfluenceConnectionProvider {
     /// Note: Confluence hard expires refresh_tokens after 360 days.
     ///       Confluence expires access_tokens after 1 hour.
     ///       Confluence expires refresh_tokens after 30 days of inactivity.
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = match connection.unseal_refresh_token() {
             Ok(Some(token)) => token,
             Ok(None) => Err(anyhow!("Missing `refresh_token` in Confluence connection"))?,

--- a/core/src/oauth/providers/github.rs
+++ b/core/src/oauth/providers/github.rs
@@ -3,6 +3,7 @@ use crate::{
         connection::{
             Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
         },
+        credential::Credential,
         providers::utils::execute_request,
     },
     utils,
@@ -145,6 +146,7 @@ impl Provider for GithubConnectionProvider {
     async fn finalize(
         &self,
         connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -171,7 +173,11 @@ impl Provider for GithubConnectionProvider {
         })
     }
 
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         let app_type = match connection.metadata()["use_case"].as_str() {
             Some(use_case) => match use_case {
                 "connection" => GithubUseCase::Connection,

--- a/core/src/oauth/providers/github.rs
+++ b/core/src/oauth/providers/github.rs
@@ -146,7 +146,7 @@ impl Provider for GithubConnectionProvider {
     async fn finalize(
         &self,
         connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -176,7 +176,7 @@ impl Provider for GithubConnectionProvider {
     async fn refresh(
         &self,
         connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         let app_type = match connection.metadata()["use_case"].as_str() {
             Some(use_case) => match use_case {

--- a/core/src/oauth/providers/gong.rs
+++ b/core/src/oauth/providers/gong.rs
@@ -4,6 +4,7 @@ use crate::{
             Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
             PROVIDER_TIMEOUT_SECONDS,
         },
+        credential::Credential,
         providers::utils::execute_request,
     },
     utils,
@@ -41,6 +42,7 @@ impl Provider for GongConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -93,7 +95,11 @@ impl Provider for GongConnectionProvider {
         })
     }
 
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = match connection.unseal_refresh_token() {
             Ok(Some(token)) => token,
             Ok(None) => Err(anyhow!("Missing `refresh_token` in Gong connection"))?,

--- a/core/src/oauth/providers/gong.rs
+++ b/core/src/oauth/providers/gong.rs
@@ -42,7 +42,7 @@ impl Provider for GongConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -98,7 +98,7 @@ impl Provider for GongConnectionProvider {
     async fn refresh(
         &self,
         connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = match connection.unseal_refresh_token() {
             Ok(Some(token)) => token,

--- a/core/src/oauth/providers/google_drive.rs
+++ b/core/src/oauth/providers/google_drive.rs
@@ -4,6 +4,7 @@ use crate::{
             Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
             PROVIDER_TIMEOUT_SECONDS,
         },
+        credential::Credential,
         providers::utils::execute_request,
     },
     utils,
@@ -41,6 +42,7 @@ impl Provider for GoogleDriveConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -102,7 +104,11 @@ impl Provider for GoogleDriveConnectionProvider {
     // Google Drive does not automatically expire refresh tokens for published apps,
     // unless they have been unused for six months.
     // Acess tokens expire after 1 hour.
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = match connection.unseal_refresh_token() {
             Ok(Some(token)) => token,
             Ok(None) => Err(anyhow!(

--- a/core/src/oauth/providers/google_drive.rs
+++ b/core/src/oauth/providers/google_drive.rs
@@ -42,7 +42,7 @@ impl Provider for GoogleDriveConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -107,7 +107,7 @@ impl Provider for GoogleDriveConnectionProvider {
     async fn refresh(
         &self,
         connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = match connection.unseal_refresh_token() {
             Ok(Some(token)) => token,

--- a/core/src/oauth/providers/intercom.rs
+++ b/core/src/oauth/providers/intercom.rs
@@ -34,7 +34,7 @@ impl Provider for IntercomConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -73,7 +73,7 @@ impl Provider for IntercomConnectionProvider {
     async fn refresh(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         Err(ProviderError::ActionNotSupportedError(
             "Intercom access tokens do not expire".to_string(),

--- a/core/src/oauth/providers/intercom.rs
+++ b/core/src/oauth/providers/intercom.rs
@@ -2,6 +2,7 @@ use crate::oauth::{
     connection::{
         Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
     },
+    credential::Credential,
     providers::utils::execute_request,
 };
 use anyhow::{anyhow, Result};
@@ -33,6 +34,7 @@ impl Provider for IntercomConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -68,7 +70,11 @@ impl Provider for IntercomConnectionProvider {
         })
     }
 
-    async fn refresh(&self, _connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        _connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         Err(ProviderError::ActionNotSupportedError(
             "Intercom access tokens do not expire".to_string(),
         ))?

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -41,7 +41,7 @@ impl Provider for MicrosoftConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -90,7 +90,7 @@ impl Provider for MicrosoftConnectionProvider {
     async fn refresh(
         &self,
         connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = connection
             .unseal_refresh_token()?

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -4,6 +4,7 @@ use crate::{
             Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
             PROVIDER_TIMEOUT_SECONDS,
         },
+        credential::Credential,
         providers::utils::execute_request,
     },
     utils,
@@ -40,6 +41,7 @@ impl Provider for MicrosoftConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -85,7 +87,11 @@ impl Provider for MicrosoftConnectionProvider {
         })
     }
 
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = connection
             .unseal_refresh_token()?
             .ok_or_else(|| anyhow!("Missing `refresh_token` in Microsoft connection"))?;

--- a/core/src/oauth/providers/mock.rs
+++ b/core/src/oauth/providers/mock.rs
@@ -1,7 +1,10 @@
 use crate::{
-    oauth::connection::{
-        Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
-        ACCESS_TOKEN_REFRESH_BUFFER_MILLIS, PROVIDER_TIMEOUT_SECONDS,
+    oauth::{
+        connection::{
+            Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
+            ACCESS_TOKEN_REFRESH_BUFFER_MILLIS, PROVIDER_TIMEOUT_SECONDS,
+        },
+        credential::Credential,
     },
     utils,
 };
@@ -26,6 +29,7 @@ impl Provider for MockConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -39,7 +43,11 @@ impl Provider for MockConnectionProvider {
         })
     }
 
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = connection
             .unseal_refresh_token()?
             .ok_or_else(|| anyhow!("Missing `refresh_token` in Mock connection"))?;

--- a/core/src/oauth/providers/mock.rs
+++ b/core/src/oauth/providers/mock.rs
@@ -29,7 +29,7 @@ impl Provider for MockConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -46,7 +46,7 @@ impl Provider for MockConnectionProvider {
     async fn refresh(
         &self,
         connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         let refresh_token = connection
             .unseal_refresh_token()?

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -41,7 +41,7 @@ impl Provider for NotionConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -80,7 +80,7 @@ impl Provider for NotionConnectionProvider {
     async fn refresh(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         Err(ProviderError::ActionNotSupportedError(
             "Notion access tokens do not expire".to_string(),

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -2,6 +2,7 @@ use crate::oauth::{
     connection::{
         Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
     },
+    credential::Credential,
     providers::utils::execute_request,
 };
 use anyhow::{anyhow, Result};
@@ -40,6 +41,7 @@ impl Provider for NotionConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -75,7 +77,11 @@ impl Provider for NotionConnectionProvider {
         })
     }
 
-    async fn refresh(&self, _connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        _connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         Err(ProviderError::ActionNotSupportedError(
             "Notion access tokens do not expire".to_string(),
         ))?

--- a/core/src/oauth/providers/salesforce.rs
+++ b/core/src/oauth/providers/salesforce.rs
@@ -1,13 +1,12 @@
 use crate::{
     oauth::{
-        client::OauthClient,
         connection::{
             Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
         },
-        credential::CredentialProvider,
+        credential::{Credential, CredentialProvider},
         providers::utils::execute_request,
     },
-    utils,
+    utils::{self},
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -28,14 +27,14 @@ impl SalesforceConnectionProvider {
     }
 
     /// Gets the Salesforce credentials (client_id and client_secret) from the related credential
-    pub async fn get_credentials(connection: &Connection) -> Result<(String, String)> {
-        // Get credential ID from connection
-        let credential_id = connection
-            .related_credential_id()
-            .ok_or_else(|| anyhow!("Missing related_credential_id for Salesforce connection"))?;
+    pub async fn get_credentials(credentials: Option<Credential>) -> Result<(String, String)> {
+        let credentials =
+            credentials.ok_or_else(|| anyhow!("Missing credentials for Salesforce connection"))?;
+
+        let content = credentials.unseal_encrypted_content()?;
+        let provider = credentials.provider();
 
         // Fetch credential
-        let (provider, content) = OauthClient::get_credential(&credential_id).await?;
         if provider != CredentialProvider::Salesforce {
             return Err(anyhow!(
                 "Invalid credential provider: {:?}, expected Salesforce",
@@ -67,6 +66,7 @@ impl Provider for SalesforceConnectionProvider {
     async fn finalize(
         &self,
         connection: &Connection,
+        credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -77,7 +77,7 @@ impl Provider for SalesforceConnectionProvider {
             .ok_or_else(|| anyhow!("Missing `code_verifier` in Salesforce connection"))?;
 
         // Get Salesforce client_id and client_secret using the helper
-        let (client_id, client_secret) = Self::get_credentials(connection).await?;
+        let (client_id, client_secret) = Self::get_credentials(credentials).await?;
 
         let body = json!({
             "grant_type": "authorization_code",
@@ -116,13 +116,17 @@ impl Provider for SalesforceConnectionProvider {
         })
     }
 
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         let instance_url = Self::get_instance_url(&connection.metadata())?;
         let refresh_token = connection
             .unseal_refresh_token()?
             .ok_or_else(|| anyhow!("Missing `refresh_token` in Salesforce connection"))?;
 
-        let (client_id, client_secret) = Self::get_credentials(connection).await?;
+        let (client_id, client_secret) = Self::get_credentials(credentials).await?;
 
         let body = json!({
             "grant_type": "refresh_token",

--- a/core/src/oauth/providers/salesforce.rs
+++ b/core/src/oauth/providers/salesforce.rs
@@ -6,7 +6,7 @@ use crate::{
         credential::{Credential, CredentialProvider},
         providers::utils::execute_request,
     },
-    utils::{self},
+    utils,
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;

--- a/core/src/oauth/providers/salesforce.rs
+++ b/core/src/oauth/providers/salesforce.rs
@@ -66,7 +66,7 @@ impl Provider for SalesforceConnectionProvider {
     async fn finalize(
         &self,
         connection: &Connection,
-        credentials: Option<Credential>,
+        related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -77,7 +77,7 @@ impl Provider for SalesforceConnectionProvider {
             .ok_or_else(|| anyhow!("Missing `code_verifier` in Salesforce connection"))?;
 
         // Get Salesforce client_id and client_secret using the helper
-        let (client_id, client_secret) = Self::get_credentials(credentials).await?;
+        let (client_id, client_secret) = Self::get_credentials(related_credentials).await?;
 
         let body = json!({
             "grant_type": "authorization_code",
@@ -119,14 +119,14 @@ impl Provider for SalesforceConnectionProvider {
     async fn refresh(
         &self,
         connection: &Connection,
-        credentials: Option<Credential>,
+        related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         let instance_url = Self::get_instance_url(&connection.metadata())?;
         let refresh_token = connection
             .unseal_refresh_token()?
             .ok_or_else(|| anyhow!("Missing `refresh_token` in Salesforce connection"))?;
 
-        let (client_id, client_secret) = Self::get_credentials(credentials).await?;
+        let (client_id, client_secret) = Self::get_credentials(related_credentials).await?;
 
         let body = json!({
             "grant_type": "refresh_token",

--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -45,7 +45,7 @@ impl Provider for SlackConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -89,7 +89,7 @@ impl Provider for SlackConnectionProvider {
     async fn refresh(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         Err(ProviderError::ActionNotSupportedError(
             "Slack access tokens do not expire.".to_string(),

--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -7,6 +7,7 @@ use crate::oauth::{
         ProviderError,
         RefreshResult, // PROVIDER_TIMEOUT_SECONDS,
     },
+    credential::Credential,
     providers::utils::execute_request,
 };
 use anyhow::{anyhow, Result};
@@ -44,6 +45,7 @@ impl Provider for SlackConnectionProvider {
     async fn finalize(
         &self,
         _connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -84,7 +86,11 @@ impl Provider for SlackConnectionProvider {
         })
     }
 
-    async fn refresh(&self, _connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        _connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         Err(ProviderError::ActionNotSupportedError(
             "Slack access tokens do not expire.".to_string(),
         ))?

--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -37,7 +37,7 @@ impl Provider for ZendeskConnectionProvider {
     async fn finalize(
         &self,
         connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -90,7 +90,7 @@ impl Provider for ZendeskConnectionProvider {
     async fn refresh(
         &self,
         _connection: &Connection,
-        _credentials: Option<Credential>,
+        _related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
         Err(ProviderError::ActionNotSupportedError(
             "Zendesk access tokens do not expire".to_string(),

--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -2,6 +2,7 @@ use crate::oauth::{
     connection::{
         Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
     },
+    credential::Credential,
     providers::utils::execute_request,
 };
 use anyhow::{anyhow, Result};
@@ -36,6 +37,7 @@ impl Provider for ZendeskConnectionProvider {
     async fn finalize(
         &self,
         connection: &Connection,
+        _credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -85,7 +87,11 @@ impl Provider for ZendeskConnectionProvider {
         })
     }
 
-    async fn refresh(&self, _connection: &Connection) -> Result<RefreshResult, ProviderError> {
+    async fn refresh(
+        &self,
+        _connection: &Connection,
+        _credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
         Err(ProviderError::ActionNotSupportedError(
             "Zendesk access tokens do not expire".to_string(),
         ))?


### PR DESCRIPTION
## Description

Pass the related credentials, if it exists, to finalize and refresh method which may need it (only salesforce for now uses this).
This avoid doing a reentrant http request to fetch credential, which may break and panic the once used in reqwest.


## Tests

locally

## Risk

none

## Deploy Plan

deploy core
