### PR TITLE
[front] - feat(attach): paste doc urls

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,10 +1,4 @@
-import {
-  ArrowUpIcon,
-  AttachmentIcon,
-  Button,
-  FullscreenExitIcon,
-  FullscreenIcon,
-} from "@dust-tt/sparkle";
+import { ArrowUpIcon, AttachmentIcon, Button, FullscreenExitIcon, FullscreenIcon } from "@dust-tt/sparkle";
 import type {
   AgentMention,
   DataSourceViewContentNode,
@@ -75,11 +69,18 @@ const InputBarContainer = ({
     setIsExpanded(false);
   }
 
+  const handleUrlDetected = (url: string, nodeId: string | null) => {
+    console.log("Detected URL:", url, "Node ID:", nodeId);
+  };
+
   const { editor, editorService } = useCustomEditor({
     suggestions,
     onEnterKeyDown,
     resetEditorContainerSize,
     disableAutoFocus,
+    ...(featureFlags.includes("attach_from_datasources") && {
+      onUrlDetected: handleUrlDetected,
+    }),
   });
 
   // When input bar animation is requested it means the new button was clicked (removing focus from

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,4 +1,10 @@
-import { ArrowUpIcon, AttachmentIcon, Button, FullscreenExitIcon, FullscreenIcon } from "@dust-tt/sparkle";
+import {
+  ArrowUpIcon,
+  AttachmentIcon,
+  Button,
+  FullscreenExitIcon,
+  FullscreenIcon,
+} from "@dust-tt/sparkle";
 import type {
   AgentMention,
   DataSourceViewContentNode,
@@ -7,7 +13,13 @@ import type {
 } from "@dust-tt/types";
 import { getSupportedFileExtensions } from "@dust-tt/types";
 import { EditorContent } from "@tiptap/react";
-import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import useAssistantSuggestions from "@app/components/assistant/conversation/input_bar/editor/useAssistantSuggestions";

--- a/front/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension.ts
@@ -1,7 +1,9 @@
 import { Extension, markPasteRule } from "@tiptap/core";
 
+import { nodeIdFromUrl } from "@app/lib/connectors";
+
 type URLFormatOptions = {
-  onUrlDetected?: (url: string) => void;
+  onUrlDetected?: (url: string, nodeId?: string | null) => void;
 };
 
 const URL_REGEX = /(https?:\/\/[^\s]+)/gi;
@@ -22,9 +24,12 @@ export const URLDetectionExtension = Extension.create<URLFormatOptions>({
         type: this.editor.schema.marks.bold,
         // Use getAttributes to trigger the callback
         getAttributes: (match) => {
-          // Call the callback with the detected URL
+          const url = match[0];
+          const nodeId = nodeIdFromUrl(url);
+
+          // Call the callback with the URL and extracted nodeId
           if (this.options.onUrlDetected) {
-            this.options.onUrlDetected(match[0]);
+            this.options.onUrlDetected(url, nodeId);
           }
           return {};
         },

--- a/front/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension.ts
@@ -1,9 +1,10 @@
-import { Extension, markPasteRule } from "@tiptap/core";
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
 
 import { nodeIdFromUrl } from "@app/lib/connectors";
 
 type URLFormatOptions = {
-  onUrlDetected?: (url: string, nodeId?: string | null) => void;
+  onUrlDetected?: (url: string, nodeId: string | null) => void;
 };
 
 const URL_REGEX = /(https?:\/\/[^\s]+)/gi;
@@ -17,21 +18,38 @@ export const URLDetectionExtension = Extension.create<URLFormatOptions>({
     };
   },
 
-  addPasteRules() {
-    return [
-      markPasteRule({
-        find: URL_REGEX,
-        type: this.editor.schema.marks.bold,
-        // Use getAttributes to trigger the callback
-        getAttributes: (match) => {
-          const url = match[0];
-          const nodeId = nodeIdFromUrl(url);
+  addProseMirrorPlugins() {
+    const { onUrlDetected } = this.options;
 
-          // Call the callback with the URL and extracted nodeId
-          if (this.options.onUrlDetected) {
-            this.options.onUrlDetected(url, nodeId);
-          }
-          return {};
+    return [
+      new Plugin({
+        key: new PluginKey("urlDetection"),
+        props: {
+          // Handle paste events to detect URLs
+          handlePaste: (view, event) => {
+            if (!onUrlDetected) {
+              return false;
+            }
+
+            // Get pasted text
+            const text = event.clipboardData?.getData("text/plain");
+            if (!text) {
+              return false;
+            }
+
+            // Check for URLs in pasted content
+            const urls = text.match(URL_REGEX);
+            if (urls) {
+              // For each URL found, check if it has a node ID
+              urls.forEach((url) => {
+                const nodeId = nodeIdFromUrl(url);
+                onUrlDetected(url, nodeId || null);
+              });
+            }
+
+            // Return false to allow normal paste handling
+            return false;
+          },
         },
       }),
     ];

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -5,25 +5,15 @@ import { useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { useEffect, useMemo } from "react";
 
-import {
-  MarkdownStyleExtension,
-} from "@app/components/assistant/conversation/input_bar/editor/extensions/MarkdownStyleExtension";
-import {
-  MentionStorageExtension,
-} from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionStorageExtension";
-import {
-  MentionWithPasteExtension,
-} from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionWithPasteExtension";
-import {
-  ParagraphExtension,
-} from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
+import { MarkdownStyleExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MarkdownStyleExtension";
+import { MentionStorageExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionStorageExtension";
+import { MentionWithPasteExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionWithPasteExtension";
+import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
 import { createMarkdownSerializer } from "@app/components/assistant/conversation/input_bar/editor/markdownSerializer";
 import type { EditorSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { makeGetAssistantSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { isMobile } from "@app/lib/utils";
-import {
-  URLDetectionExtension,
-} from "@app/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension";
+import { URLDetectionExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension";
 
 export interface EditorMention {
   id: string;

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -228,7 +228,9 @@ const useCustomEditor = ({
     extensions.push(
       URLDetectionExtension.configure({
         onUrlDetected: (url, nodeId) => {
-          onUrlDetected(url, nodeId ?? null);
+          if (nodeId) {
+            onUrlDetected(url, nodeId);
+          }
         },
       })
     );

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -9,11 +9,11 @@ import { MarkdownStyleExtension } from "@app/components/assistant/conversation/i
 import { MentionStorageExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionStorageExtension";
 import { MentionWithPasteExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionWithPasteExtension";
 import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
+import { URLDetectionExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension";
 import { createMarkdownSerializer } from "@app/components/assistant/conversation/input_bar/editor/markdownSerializer";
 import type { EditorSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { makeGetAssistantSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { isMobile } from "@app/lib/utils";
-import { URLDetectionExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension";
 
 export interface EditorMention {
   id: string;

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -5,14 +5,25 @@ import { useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { useEffect, useMemo } from "react";
 
-import { MarkdownStyleExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MarkdownStyleExtension";
-import { MentionStorageExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionStorageExtension";
-import { MentionWithPasteExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionWithPasteExtension";
-import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
+import {
+  MarkdownStyleExtension,
+} from "@app/components/assistant/conversation/input_bar/editor/extensions/MarkdownStyleExtension";
+import {
+  MentionStorageExtension,
+} from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionStorageExtension";
+import {
+  MentionWithPasteExtension,
+} from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionWithPasteExtension";
+import {
+  ParagraphExtension,
+} from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
 import { createMarkdownSerializer } from "@app/components/assistant/conversation/input_bar/editor/markdownSerializer";
 import type { EditorSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { makeGetAssistantSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { isMobile } from "@app/lib/utils";
+import {
+  URLDetectionExtension,
+} from "@app/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension";
 
 export interface EditorMention {
   id: string;
@@ -191,6 +202,7 @@ export interface CustomEditorProps {
   suggestions: EditorSuggestions;
   resetEditorContainerSize: () => void;
   disableAutoFocus: boolean;
+  onUrlDetected?: (url: string, nodeId: string | null) => void;
 }
 
 const useCustomEditor = ({
@@ -198,37 +210,42 @@ const useCustomEditor = ({
   resetEditorContainerSize,
   suggestions,
   disableAutoFocus,
+  onUrlDetected,
 }: CustomEditorProps) => {
+  const extensions = [
+    StarterKit.configure({
+      hardBreak: false, // Disable the built-in Shift+Enter.
+      paragraph: false,
+      strike: false,
+    }),
+    MentionStorageExtension,
+    MentionWithPasteExtension.configure({
+      HTMLAttributes: {
+        class:
+          "min-w-0 px-0 py-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-brand font-medium",
+      },
+      suggestion: makeGetAssistantSuggestions(),
+    }),
+    Placeholder.configure({
+      placeholder: "Ask a question or get some @help",
+      emptyNodeClass:
+        "first:before:text-gray-400 first:before:float-left first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:h-0",
+    }),
+    MarkdownStyleExtension,
+    ParagraphExtension,
+  ];
+  if (onUrlDetected) {
+    extensions.push(
+      URLDetectionExtension.configure({
+        onUrlDetected: (url, nodeId) => {
+          onUrlDetected(url, nodeId ?? null);
+        },
+      })
+    );
+  }
   const editor = useEditor({
     autofocus: disableAutoFocus ? false : "end",
-    extensions: [
-      StarterKit.configure({
-        hardBreak: false, // Disable the built-in Shift+Enter.
-        paragraph: false,
-        strike: false,
-      }),
-      // TODO(attach): uncomment for url detection
-      // URLDetectionExtension.configure({
-      //   onUrlDetected: (url) => {
-      //     console.log("URL detected", url);
-      //   }
-      // }),
-      MentionStorageExtension,
-      MentionWithPasteExtension.configure({
-        HTMLAttributes: {
-          class:
-            "min-w-0 px-0 py-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-brand font-medium",
-        },
-        suggestion: makeGetAssistantSuggestions(),
-      }),
-      Placeholder.configure({
-        placeholder: "Ask a question or get some @help",
-        emptyNodeClass:
-          "first:before:text-gray-400 first:before:float-left first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:h-0",
-      }),
-      MarkdownStyleExtension,
-      ParagraphExtension,
-    ],
+    extensions,
   });
 
   // Sync the extension's MentionStorage suggestions whenever the local suggestions state updates.

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -86,38 +86,46 @@ export function orderDatasourceViewSelectionConfigurationByImportance<
   });
 }
 
-// Extracts a nodeId from a given url
-// Currently supports Google Drive documents and Notion pages
-export function nodeIdFromUrl(url: string): string | null {
-  try {
-    const urlObj = new URL(url);
+interface Provider {
+  matcher: (url: URL) => boolean;
+  extractor: (url: URL) => string | null;
+}
 
-    // Google Drive URL handling
-    if (
-      urlObj.hostname.includes("drive.google.com") ||
-      urlObj.hostname.includes("docs.google.com")
-    ) {
+const providers: Record<string, Provider> = {
+  googleDrive: {
+    matcher: (url: URL): boolean => {
+      return (
+        url.hostname.includes("drive.google.com") ||
+        url.hostname.includes("docs.google.com")
+      );
+    },
+    extractor: (url: URL): string | null => {
       // Extract from /d/ID format (common in all Google Drive URLs)
-      const driveMatch = urlObj.pathname.match(/\/d\/([^/]+)/);
+      const driveMatch = url.pathname.match(/\/d\/([^/]+)/);
       if (driveMatch && driveMatch[1]) {
         return `gdrive-${driveMatch[1]}`;
       }
 
       // Extract from URL parameters (some older Drive formats)
-      const idParam = urlObj.searchParams.get("id");
+      const idParam = url.searchParams.get("id");
       if (idParam) {
         return `gdrive-${idParam}`;
       }
-    }
 
-    // Notion URL handling
-    if (urlObj.hostname.includes("notion.so")) {
+      return null;
+    },
+  },
+
+  notion: {
+    matcher: (url: URL): boolean => {
+      return url.hostname.includes("notion.so");
+    },
+    extractor: (url: URL): string | null => {
       // Get the last part of the path, which contains the ID
-      const pathParts = urlObj.pathname.split("/");
+      const pathParts = url.pathname.split("/");
       const lastPart = pathParts[pathParts.length - 1];
 
       // Notion IDs are 32 characters, often at the end of the URL path
-      // Sometimes they include hyphens in the URL which we need to handle
       if (lastPart) {
         // Extract the ID part (after the last dash in the page title if present)
         const parts = lastPart.split("-");
@@ -127,6 +135,22 @@ export function nodeIdFromUrl(url: string): string | null {
         if (idCandidate && idCandidate.replace(/-/g, "").length === 32) {
           return idCandidate;
         }
+      }
+
+      return null;
+    },
+  },
+};
+
+// Extracts a nodeId from a given url
+// Currently supports Google Drive documents and Notion pages
+export function nodeIdFromUrl(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+
+    for (const provider of Object.values(providers)) {
+      if (provider.matcher(urlObj)) {
+        return provider.extractor(urlObj);
       }
     }
 

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -85,3 +85,54 @@ export function orderDatasourceViewSelectionConfigurationByImportance<
     );
   });
 }
+
+// Extracts a nodeId from a given url
+// Currently supports Google Drive documents and Notion pages
+export function nodeIdFromUrl(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+
+    // Google Drive URL handling
+    if (
+      urlObj.hostname.includes("drive.google.com") ||
+      urlObj.hostname.includes("docs.google.com")
+    ) {
+      // Extract from /d/ID format (common in all Google Drive URLs)
+      const driveMatch = urlObj.pathname.match(/\/d\/([^/]+)/);
+      if (driveMatch && driveMatch[1]) {
+        return `gdrive-${driveMatch[1]}`;
+      }
+
+      // Extract from URL parameters (some older Drive formats)
+      const idParam = urlObj.searchParams.get("id");
+      if (idParam) {
+        return `gdrive-${idParam}`;
+      }
+    }
+
+    // Notion URL handling
+    if (urlObj.hostname.includes("notion.so")) {
+      // Get the last part of the path, which contains the ID
+      const pathParts = urlObj.pathname.split("/");
+      const lastPart = pathParts[pathParts.length - 1];
+
+      // Notion IDs are 32 characters, often at the end of the URL path
+      // Sometimes they include hyphens in the URL which we need to handle
+      if (lastPart) {
+        // Extract the ID part (after the last dash in the page title if present)
+        const parts = lastPart.split("-");
+        const idCandidate = parts[parts.length - 1];
+
+        // If we have a 32-character ID (with or without hyphens)
+        if (idCandidate && idCandidate.replace(/-/g, "").length === 32) {
+          return idCandidate;
+        }
+      }
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error parsing URL:", error);
+    return null;
+  }
+}

--- a/front/lib/search.ts
+++ b/front/lib/search.ts
@@ -55,10 +55,12 @@ export function getSearchFilterFromDataSourceViews(
     excludedNodeMimeTypes,
     includeDataSources,
     viewType,
+    nodeIds,
   }: {
     excludedNodeMimeTypes: readonly string[];
     includeDataSources: boolean;
     viewType: ContentNodesViewType;
+    nodeIds?: string[];
   }
 ) {
   const groupedPerDataSource = dataSourceViews.reduce(
@@ -111,5 +113,6 @@ export function getSearchFilterFromDataSourceViews(
     })),
     excluded_node_mime_types: excludedNodeMimeTypes,
     node_types: getCoreViewTypeFilter(viewType),
+    node_ids: nodeIds,
   };
 }

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -119,3 +119,13 @@ export const CATEGORY_DETAILS: {
     icon: CommandLineIcon,
   },
 };
+
+export const getSpaceAccessPriority = (space: SpaceType) => {
+  if (space.kind === "global") {
+    return 2;
+  }
+  if (!space.isRestricted) {
+    return 1;
+  }
+  return 0;
+};

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -686,23 +686,39 @@ export function useSpaceSearch({
   };
 }
 
+type BaseSearchParams = {
+  disabled?: boolean;
+  includeDataSources: boolean;
+  owner: LightWorkspaceType;
+  spaceIds?: string[];
+  viewType: ContentNodesViewType;
+  pagination?: CursorPaginationParams;
+};
+
+// Text search variant
+type TextSearchParams = BaseSearchParams & {
+  search: string;
+  nodeIds?: undefined;
+};
+
+// Node ID search variant
+type NodeIdSearchParams = BaseSearchParams & {
+  search?: undefined;
+  nodeIds: string[];
+};
+
+type SpacesSearchParams = TextSearchParams | NodeIdSearchParams;
+
 export function useSpacesSearch({
   disabled = false,
   includeDataSources = false,
+  nodeIds,
   owner,
   search,
   spaceIds,
   viewType,
   pagination,
-}: {
-  disabled?: boolean;
-  includeDataSources: boolean;
-  owner: LightWorkspaceType;
-  search: string;
-  spaceIds?: string[];
-  viewType: ContentNodesViewType;
-  pagination?: CursorPaginationParams;
-}): {
+}: SpacesSearchParams): {
   isSearchLoading: boolean;
   isSearchError: boolean;
   isSearchValidating: boolean;
@@ -722,6 +738,7 @@ export function useSpacesSearch({
   const body = {
     query: search,
     viewType,
+    nodeIds,
     spaceIds,
     includeDataSources,
     limit: pagination?.limit ?? DEFAULT_SEARCH_LIMIT,
@@ -729,7 +746,7 @@ export function useSpacesSearch({
 
   // Only perform a query if we have a valid search
   const url =
-    search.length >= MIN_SEARCH_QUERY_SIZE
+    (search && search.length >= MIN_SEARCH_QUERY_SIZE) || nodeIds
       ? `/api/w/${owner.sId}/search?${params}`
       : null;
 


### PR DESCRIPTION
## Description

This PR implements URL detection in the input bar to extract node IDs from pasted document URLs (Google Drive and Notion), allowing users to attach documents directly from their knowledge base by pasting URLs. When a supported URL is detected, the system extracts the node ID and attempts to attach the corresponding document to the conversation

**References:**
- https://github.com/dust-tt/tasks/issues/2352
- https://github.com/dust-tt/tasks/issues/2354

## Risk

Low, behind FF

## Deploy Plan

Deploy front