### PR TITLE
Fix error log on CSV snippet when empty array from table query

### DIFF
--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -593,7 +593,8 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
 
     if (
       "results" in sanitizedOutput &&
-      Array.isArray(sanitizedOutput.results)
+      Array.isArray(sanitizedOutput.results) &&
+      sanitizedOutput.results.length > 0
     ) {
       const results = sanitizedOutput.results;
       const queryTitle = getTablesQueryResultsFileTitle({


### PR DESCRIPTION
## Description

Fixes this: https://app.datadoghq.eu/logs?query=%22Error%20Posting%20message%22%20service%3Afront%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZWTxGuSI9s8OQAAABhBWldUeEhMbEFBQ2tRR3Z4MkxNc013Q0MAAAAkMDE5NTkzYzYtNDcyNy00ZGEzLTk1MzYtMGQ0MTA2NTg1NzEzAAZDVA&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1741940323000&to_ts=1741940923000&live=false

Here's the action output: 

<img width="935" alt="Screenshot 2025-03-14 at 11 44 26" src="https://github.com/user-attachments/assets/84622f2e-758e-4261-9513-796e6392ae0e" />

## Tests

/ 

## Risk

/ 

## Deploy Plan

Deploy front. 
