### PR TITLE
[sparkle] Allow to clik on the item  to select or expand

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.437",
+  "version": "0.2.438",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.437",
+      "version": "0.2.438",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.437",
+  "version": "0.2.438",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -145,6 +145,7 @@ Tree.Item = React.forwardRef<
       ? onChevronClick
       : () => setCollapsedState(!collapsedState);
 
+    const canExpand = effectiveOnChevronClick && type === "node";
     const getChildren = () => {
       if (effectiveCollapsed) {
         return [];
@@ -166,7 +167,9 @@ Tree.Item = React.forwardRef<
           id={id}
           className={cn(
             treeItemStyleClasses.base,
-            onItemClick ? "s-cursor-pointer" : "",
+            onItemClick || checkbox?.onCheckedChange || canExpand
+              ? "s-cursor-pointer"
+              : "",
             isNavigatable ? treeItemStyleClasses.isNavigatableBase : "",
             isNavigatable
               ? isSelected
@@ -177,13 +180,30 @@ Tree.Item = React.forwardRef<
             type,
             className
           )}
-          onClick={onItemClick}
+          onClick={
+            onItemClick ||
+            ((e) => {
+              // Skip if click on checkbox or any button
+              if (
+                e.target instanceof HTMLElement &&
+                e.target.tagName !== "BUTTON"
+              ) {
+                e.stopPropagation();
+                if (checkbox?.onCheckedChange) {
+                  checkbox.onCheckedChange?.(!checkbox.checked);
+                } else if (canExpand) {
+                  effectiveOnChevronClick();
+                }
+              }
+            })
+          }
         >
           {type === "node" && (
             <Button
               icon={isExpanded ? ArrowDownSIcon : ArrowRightSIcon}
               size="xs"
               variant="ghost-secondary"
+              disabled={!effectiveOnChevronClick}
               onClick={(e) => {
                 e.stopPropagation();
                 if (effectiveOnChevronClick) {

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react";
-import React from "react";
+import React, { useState } from "react";
 
 import {
   DriveLogo,
@@ -30,6 +30,14 @@ const meta = {
 export default meta;
 
 export const TreeExample = () => {
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const check = (id: string) => {
+    setChecked((prev) => ({
+      ...prev,
+      [id]: !prev[id],
+    }));
+  };
+
   return (
     <div className="s-flex s-flex-col s-gap-10">
       <div className="s-flex s-gap-10">
@@ -47,9 +55,9 @@ export const TreeExample = () => {
                     type="leaf"
                     label="Item 1"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 1"],
+                      onCheckedChange: () => {
+                        check("Item 1");
                       },
                     }}
                   />
@@ -57,9 +65,9 @@ export const TreeExample = () => {
                     label="Item 2"
                     type="leaf"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 2"],
+                      onCheckedChange: () => {
+                        check("Item 2");
                       },
                     }}
                   />
@@ -67,16 +75,16 @@ export const TreeExample = () => {
                     label="Item 3"
                     type="leaf"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 3"],
+                      onCheckedChange: () => {
+                        check("Item 3");
                       },
                     }}
                   />
                 </Tree>
               </Tree.Item>
               <Tree.Item
-                label="Item 4 (forced collapsed)"
+                label="Item 4 (forced expanded)"
                 visual={FolderIcon}
                 collapsed={false}
               >
@@ -84,7 +92,7 @@ export const TreeExample = () => {
                   <Tree.Item
                     label="Item 1"
                     visual={FolderIcon}
-                    collapsed={false}
+                    defaultCollapsed={false}
                   >
                     <Tree.Item
                       label="Item 3"
@@ -158,7 +166,7 @@ export const TreeExample = () => {
                 visual={FolderIcon}
                 checkbox={{
                   checked: "partial",
-                  onChange: () => {
+                  onCheckedChange: () => {
                     return;
                   },
                 }}
@@ -168,9 +176,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: true,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 2"],
+                  onCheckedChange: () => {
+                    check("Item 2");
                   },
                 }}
               />
@@ -179,9 +187,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 3"],
+                  onCheckedChange: () => {
+                    check("Item 3");
                   },
                 }}
               />
@@ -190,9 +198,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 4"],
+                  onCheckedChange: () => {
+                    check("Item 4");
                   },
                 }}
               />
@@ -201,9 +209,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 5"],
+                  onCheckedChange: () => {
+                    check("Item 5");
                   },
                 }}
               />
@@ -219,9 +227,9 @@ export const TreeExample = () => {
                 visual={IntercomLogo}
                 type="item"
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Intercom"],
+                  onCheckedChange: () => {
+                    check("Intercom");
                   },
                 }}
               />
@@ -230,9 +238,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={NotionLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Notion"],
+                  onCheckedChange: () => {
+                    check("Notion");
                   },
                 }}
               />
@@ -241,9 +249,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={SlackLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Slack"],
+                  onCheckedChange: () => {
+                    check("Slack");
                   },
                 }}
               />
@@ -252,9 +260,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={DustIcon}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Dust"],
+                  onCheckedChange: () => {
+                    check("Dust");
                   },
                 }}
               />
@@ -330,9 +338,9 @@ export const TreeExample = () => {
                         visual={FolderIcon}
                         type="leaf"
                         checkbox={{
-                          checked: false,
-                          onChange: () => {
-                            return;
+                          checked: checked["Item 1"],
+                          onCheckedChange: () => {
+                            check("Item 1");
                           },
                         }}
                       />
@@ -340,9 +348,9 @@ export const TreeExample = () => {
                         label="Item 2"
                         visual={FolderIcon}
                         checkbox={{
-                          checked: false,
-                          onChange: () => {
-                            return;
+                          checked: checked["Item 2"],
+                          onCheckedChange: () => {
+                            check("Item 2");
                           },
                         }}
                       />
@@ -350,9 +358,9 @@ export const TreeExample = () => {
                         label="Item 3"
                         visual={FolderIcon}
                         checkbox={{
-                          checked: false,
-                          onChange: () => {
-                            return;
+                          checked: checked["Item 3"],
+                          onCheckedChange: () => {
+                            check("Item 3");
                           },
                         }}
                       />
@@ -397,9 +405,9 @@ export const TreeExample = () => {
                     type="leaf"
                     label="Item 1"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 1"],
+                      onCheckedChange: () => {
+                        check("Item 1");
                       },
                     }}
                   />
@@ -407,9 +415,9 @@ export const TreeExample = () => {
                     label="Item 2"
                     type="leaf"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 2"],
+                      onCheckedChange: () => {
+                        check("Item 2");
                       },
                     }}
                   />
@@ -417,9 +425,9 @@ export const TreeExample = () => {
                     label="Item 3"
                     type="leaf"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 3"],
+                      onCheckedChange: () => {
+                        check("Item 3");
                       },
                     }}
                   />
@@ -440,12 +448,12 @@ export const TreeExample = () => {
                 collapsed={false}
               >
                 <Tree>
-                  <Tree.Item label="Item 1" collapsed={false}>
+                  <Tree.Item label="Item 1" defaultCollapsed={false}>
                     <Tree>
                       <Tree.Empty label="No documents" />
                     </Tree>
                   </Tree.Item>
-                  <Tree.Item label="Item 2" collapsed={false}>
+                  <Tree.Item label="Item 2" defaultCollapsed={false}>
                     <Tree>
                       <Tree.Empty
                         label="Empty tree can be clickable"
@@ -465,7 +473,7 @@ export const TreeExample = () => {
                     label="Item 1"
                     checkbox={{
                       checked: "partial",
-                      onChange: () => {
+                      onCheckedChange: () => {
                         return;
                       },
                     }}
@@ -473,36 +481,36 @@ export const TreeExample = () => {
                   <Tree.Item
                     label="Item 2"
                     checkbox={{
-                      checked: true,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 2"],
+                      onCheckedChange: () => {
+                        check("Item 2");
                       },
                     }}
                   />
                   <Tree.Item
                     label="Item 3"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 3"],
+                      onCheckedChange: () => {
+                        check("Item 3");
                       },
                     }}
                   />
                   <Tree.Item
                     label="Item 4"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 4"],
+                      onCheckedChange: () => {
+                        check("Item 4");
                       },
                     }}
                   />
                   <Tree.Item
                     label="Item 5"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 5"],
+                      onCheckedChange: () => {
+                        check("Item 5");
                       },
                     }}
                   />
@@ -519,7 +527,7 @@ export const TreeExample = () => {
                     label="Item 1"
                     checkbox={{
                       checked: "partial",
-                      onChange: () => {
+                      onCheckedChange: () => {
                         return;
                       },
                     }}
@@ -527,9 +535,9 @@ export const TreeExample = () => {
                   <Tree.Item
                     label="Item 2"
                     checkbox={{
-                      checked: true,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 2"],
+                      onCheckedChange: () => {
+                        check("Item 2");
                       },
                     }}
                   />
@@ -538,7 +546,7 @@ export const TreeExample = () => {
                     type="leaf"
                     checkbox={{
                       checked: "partial",
-                      onChange: () => {
+                      onCheckedChange: () => {
                         return;
                       },
                     }}
@@ -557,9 +565,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: true,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 1"],
+                  onCheckedChange: () => {
+                    check("Item 1");
                   },
                 }}
               />
@@ -568,9 +576,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: true,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 2"],
+                  onCheckedChange: () => {
+                    check("Item 2");
                   },
                 }}
               />
@@ -579,9 +587,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 3"],
+                  onCheckedChange: () => {
+                    check("Item 3");
                   },
                 }}
               />
@@ -590,9 +598,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 4"],
+                  onCheckedChange: () => {
+                    check("Item 4");
                   },
                 }}
               />
@@ -601,9 +609,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={FolderIcon}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Item 5"],
+                  onCheckedChange: () => {
+                    check("Item 5");
                   },
                 }}
               />
@@ -619,9 +627,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={IntercomLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Intercom"],
+                  onCheckedChange: () => {
+                    check("Intercom");
                   },
                 }}
               />
@@ -630,9 +638,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={NotionLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Notion"],
+                  onCheckedChange: () => {
+                    check("Notion");
                   },
                 }}
               />
@@ -641,9 +649,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={SlackLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Slack"],
+                  onCheckedChange: () => {
+                    check("Slack");
                   },
                 }}
               />
@@ -652,9 +660,9 @@ export const TreeExample = () => {
                 type="item"
                 visual={DustIcon}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Dust"],
+                  onCheckedChange: () => {
+                    check("Dust");
                   },
                 }}
               />
@@ -707,6 +715,14 @@ export const TreeExample = () => {
 };
 
 export const SelectDataSourceExample = () => {
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const check = (id: string) => {
+    setChecked((prev) => ({
+      ...prev,
+      [id]: !prev[id],
+    }));
+  };
+
   return (
     <div className="s-flex s-w-full s-flex-col s-gap-10">
       <div className="s-flex s-grow s-gap-10">
@@ -735,7 +751,7 @@ export const SelectDataSourceExample = () => {
               />
               <Tree.Item
                 label="Slack"
-                collapsed={true}
+                defaultCollapsed={true}
                 visual={SlackLogo}
                 areActionsFading={false}
                 actions={
@@ -771,7 +787,7 @@ export const SelectDataSourceExample = () => {
                     />
                   </div>
                 }
-                collapsed={false}
+                defaultCollapsed={false}
               >
                 <Tree>
                   <Tree.Item label="Item 1" />
@@ -810,23 +826,23 @@ export const SelectDataSourceExample = () => {
           <div>
             <Tree>
               <Tree.Item
-                label="Intercom"
+                label="Intercoxxm"
                 visual={IntercomLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Intercom"],
+                  onCheckedChange: () => {
+                    check("Intercom");
                   },
                 }}
               />
               <Tree.Item
                 label="Slack"
-                collapsed={true}
+                defaultCollapsed={true}
                 visual={SlackLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Slack"],
+                  onCheckedChange: () => {
+                    check("Slack");
                   },
                 }}
               />
@@ -834,47 +850,47 @@ export const SelectDataSourceExample = () => {
                 label="Notion"
                 visual={NotionLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Notion"],
+                  onCheckedChange: () => {
+                    check("Notion");
                   },
                 }}
-                collapsed={false}
+                defaultCollapsed={false}
               >
                 <Tree>
                   <Tree.Item
                     label="Item 1"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 1"],
+                      onCheckedChange: () => {
+                        check("Item 1");
                       },
                     }}
                   />
                   <Tree.Item
                     label="Item 2"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 2"],
+                      onCheckedChange: () => {
+                        check("Item 2");
                       },
                     }}
                   />
                   <Tree.Item
                     label="Item 3"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 3"],
+                      onCheckedChange: () => {
+                        check("Item 3");
                       },
                     }}
                   />
                   <Tree.Item
                     label="Item 4"
                     checkbox={{
-                      checked: false,
-                      onChange: () => {
-                        return;
+                      checked: checked["Item 4"],
+                      onCheckedChange: () => {
+                        check("Item 4");
                       },
                     }}
                   />
@@ -884,9 +900,9 @@ export const SelectDataSourceExample = () => {
                 label="Google Drive"
                 visual={DriveLogo}
                 checkbox={{
-                  checked: false,
-                  onChange: () => {
-                    return;
+                  checked: checked["Google Drive"],
+                  onCheckedChange: () => {
+                    check("Google Drive");
                   },
                 }}
                 defaultCollapsed={true}


### PR DESCRIPTION
## Description

Makes it possible to click on the row to do a default action :
- If no onItemClick is already defined
- If item is selectable, selects it
- If not selectable by expandable, expan/collapse it

![Mar-14-2025 12-08-28](https://github.com/user-attachments/assets/8f25c037-84b6-4585-9365-a1628be97391)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
