### PR TITLE
Only list data source nodes when relocating

### DIFF
--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -41,7 +41,7 @@ export async function getDataSourceDocuments({
     data_source_views: [
       {
         data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
-        // Only paginate through documents.
+        // Only paginate through data source nodes.
         search_scope: "nodes_titles",
         // Leaving empty to get all documents.
         view_filter: [],

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -43,6 +43,7 @@ export async function getDataSourceDocuments({
         data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
         // Leaving empty to get all documents.
         view_filter: [],
+        search_scope: "nodes_titles",
       },
     ],
     node_types: ["document"],

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -41,9 +41,10 @@ export async function getDataSourceDocuments({
     data_source_views: [
       {
         data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
+        // Only paginate through documents.
+        search_scope: "nodes_titles",
         // Leaving empty to get all documents.
         view_filter: [],
-        search_scope: "nodes_titles",
       },
     ],
     node_types: ["document"],

--- a/front/temporal/relocation/activities/source_region/core/folders.ts
+++ b/front/temporal/relocation/activities/source_region/core/folders.ts
@@ -38,7 +38,7 @@ export async function getDataSourceFolders({
     data_source_views: [
       {
         data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
-        // Only paginate through documents.
+        // Only paginate through data source nodes.
         search_scope: "nodes_titles",
         // Leaving empty to get all folders.
         view_filter: [],

--- a/front/temporal/relocation/activities/source_region/core/folders.ts
+++ b/front/temporal/relocation/activities/source_region/core/folders.ts
@@ -38,6 +38,8 @@ export async function getDataSourceFolders({
     data_source_views: [
       {
         data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
+        // Only paginate through documents.
+        search_scope: "nodes_titles",
         // Leaving empty to get all folders.
         view_filter: [],
       },

--- a/front/temporal/relocation/activities/source_region/core/tables.ts
+++ b/front/temporal/relocation/activities/source_region/core/tables.ts
@@ -43,6 +43,8 @@ export async function getDataSourceTables({
     data_source_views: [
       {
         data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
+        // Only paginate through documents.
+        search_scope: "nodes_titles",
         // Leaving empty to get all tables.
         view_filter: [],
       },

--- a/front/temporal/relocation/activities/source_region/core/tables.ts
+++ b/front/temporal/relocation/activities/source_region/core/tables.ts
@@ -43,7 +43,7 @@ export async function getDataSourceTables({
     data_source_views: [
       {
         data_source_id: dataSourceCoreIds.dustAPIDataSourceId,
-        // Only paginate through documents.
+        // Only paginate through data source nodes.
         search_scope: "nodes_titles",
         // Leaving empty to get all tables.
         view_filter: [],


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Relocations surfaced that the recent changes around the search endpoint to list and paginate over the data source nodes was broken in the relocation script. Indeed, we only need the data source nodes to be returned.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
