### PR TITLE
[front] - fix: disable attachment picker items when already attached

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -356,6 +356,7 @@ export function AssistantInputBar({
                   disableSendButton || fileUploaderService.isProcessingFiles
                 }
                 onNodeSelect={handleNodesAttachmentSelect}
+                attachedNodes={attachedNodes}
               />
             </div>
           </div>

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -32,12 +32,14 @@ interface InputBarAttachmentsPickerProps {
   fileUploaderService: FileUploaderService;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   isLoading?: boolean;
+  attachedNodes: DataSourceViewContentNode[];
 }
 
 export const InputBarAttachmentsPicker = ({
   owner,
   fileUploaderService,
   onNodeSelect,
+  attachedNodes,
   isLoading = false,
 }: InputBarAttachmentsPickerProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -55,6 +57,10 @@ export const InputBarAttachmentsPicker = ({
     disabled: isSpacesLoading || !debouncedSearch,
     spaceIds: spaces.map((s) => s.sId),
   });
+
+  const atachedNodeIds = useMemo(() => {
+    return attachedNodes.map((node) => node.internalId);
+  }, [attachedNodes]);
 
   useEffect(() => {
     setIsDebouncing(true);
@@ -139,6 +145,7 @@ export const InputBarAttachmentsPicker = ({
                           className: "min-w-4",
                         })
                       }
+                      disabled={atachedNodeIds.includes(item.internalId)}
                       description={`${spacesMap[item.dataSourceView.spaceId]} - ${getLocationForDataSourceViewContentNode(item)}`}
                       onClick={() => {
                         setSearch("");

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -56,6 +56,7 @@ export interface InputBarContainerProps {
   disableSendButton: boolean;
   fileUploaderService: FileUploaderService;
   onNodeSelect?: (node: DataSourceViewContentNode) => void;
+  attachedNodes: DataSourceViewContentNode[];
 }
 
 const InputBarContainer = ({
@@ -70,6 +71,7 @@ const InputBarContainer = ({
   disableSendButton,
   fileUploaderService,
   onNodeSelect,
+  attachedNodes,
 }: InputBarContainerProps) => {
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
@@ -232,6 +234,7 @@ const InputBarContainer = ({
                     onNodeSelect ||
                     ((node) => console.log(`Selected ${node.title}`))
                   }
+                  attachedNodes={attachedNodes}
                 />
               ) : (
                 <Button


### PR DESCRIPTION
## Description

This PR implements logic to disable items in the attachment picker if they are already attached to the input bar

## Risk

Low

## Deploy Plan

- Deploy front