### PR TITLE
feat(Gong) - allow setting the retention period in `GongOptionComponent`

### DIFF
--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -15,7 +15,8 @@ import type { DataSourceType, WorkspaceType } from "@app/types";
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 
 function checkIsPositiveInteger(value: string) {
-  return /^[0-9]+$/.test(value);
+  const integerValue = parseInt(value, 10);
+  return Number.isFinite(integerValue) && integerValue >= 0;
 }
 
 interface GongOptionComponentProps {

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -1,12 +1,134 @@
-import { ContentMessage } from "@dust-tt/sparkle";
+import {
+  Button,
+  ContentMessage,
+  ContextItem,
+  GongLogo,
+  Input,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import { useState } from "react";
 
-export function GongOptionComponent() {
+import { useConnectorConfig } from "@app/lib/swr/connectors";
+
+function checkIsPositiveInteger(value: string) {
+  return /^[0-9]+$/.test(value);
+}
+
+export function GongOptionComponent({
+  owner,
+  readOnly,
+  isAdmin,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+}) {
+  const configKey = "gongRetentionPeriodDays";
+
+  const { configValue, mutateConfig } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey,
+  });
+
+  const [retentionPeriod, setRetentionPeriod] = useState<string>(
+    configValue || ""
+  );
+  const [loading, setLoading] = useState(false);
+  const sendNotification = useSendNotification();
+
+  const handleSetNewConfig = async (newValue: string) => {
+    // Validate that the value is either empty or a positive integer
+    if (newValue !== "" && !checkIsPositiveInteger(newValue)) {
+      sendNotification({
+        type: "error",
+        title: "Invalid retention period",
+        description:
+          "Retention period must be a positive integer or empty for no limit.",
+      });
+      return;
+    }
+
+    setLoading(true);
+    const res = await fetch(
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
+      {
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+        body: JSON.stringify({ configValue: newValue }),
+      }
+    );
+    if (res.ok) {
+      await mutateConfig();
+      setLoading(false);
+      sendNotification({
+        type: "success",
+        title: "Gong configuration updated",
+        description: "Retention period successfully updated.",
+      });
+    } else {
+      setLoading(false);
+      const err = await res.json();
+      sendNotification({
+        type: "error",
+        title: "Failed to update Gong configuration",
+        description: err.error?.message || "An unknown error occurred",
+      });
+    }
+  };
+
   return (
-    <div className="flex flex-col py-2">
+    <div className="flex flex-col space-y-4 py-2">
       <ContentMessage title="All Gong data will sync automatically" size="lg">
         All your Gong resources will sync automatically. Selecting items
         individually is not available.
       </ContentMessage>
+
+      <ContextItem.List>
+        <ContextItem
+          title="Retention Period"
+          visual={<ContextItem.Visual visual={GongLogo} />}
+          action={
+            <div className="flex flex-row space-x-3 pt-6">
+              <Input
+                name="retentionPeriod"
+                placeholder="unlimited"
+                value={retentionPeriod}
+                onChange={(e) => {
+                  // Only allow positive integer values.
+                  const value = e.target.value;
+                  if (value === "" || checkIsPositiveInteger(value)) {
+                    setRetentionPeriod(value);
+                  }
+                }}
+                disabled={readOnly || !isAdmin || loading}
+                className="w-32"
+              />
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => handleSetNewConfig(retentionPeriod)}
+                disabled={readOnly || !isAdmin || loading}
+                className="w-full"
+                label="Save"
+              />
+            </div>
+          }
+        >
+          <ContextItem.Description>
+            <div className="text-element-700">
+              Set the number of days to retain Gong transcripts.
+              <br />
+              Leave empty to disable retention (no limit).
+              <br />
+              Outdated transcripts will be deleted on a daily basis.
+            </div>
+          </ContextItem.Description>
+        </ContextItem>
+      </ContextItem.List>
     </div>
   );
 }

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -11,6 +11,9 @@ import { useState } from "react";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
+// TODO(2025-03-17): share this variable between connectors and front.
+const RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
+
 function checkIsPositiveInteger(value: string) {
   return /^[0-9]+$/.test(value);
 }
@@ -26,12 +29,10 @@ export function GongOptionComponent({
   isAdmin: boolean;
   dataSource: DataSourceType;
 }) {
-  const configKey = "gongRetentionPeriodDays";
-
   const { configValue, mutateConfig } = useConnectorConfig({
     owner,
     dataSource,
-    configKey,
+    configKey: RETENTION_PERIOD_CONFIG_KEY,
   });
 
   const [retentionPeriod, setRetentionPeriod] = useState<string>(
@@ -54,7 +55,7 @@ export function GongOptionComponent({
 
     setLoading(true);
     const res = await fetch(
-      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${RETENTION_PERIOD_CONFIG_KEY}`,
       {
         headers: { "Content-Type": "application/json" },
         method: "POST",

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -12,7 +12,7 @@ import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
 // TODO(2025-03-17): share this variable between connectors and front.
-const RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
+const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 
 function checkIsPositiveInteger(value: string) {
   return /^[0-9]+$/.test(value);
@@ -32,7 +32,7 @@ export function GongOptionComponent({
   const { configValue, mutateConfig } = useConnectorConfig({
     owner,
     dataSource,
-    configKey: RETENTION_PERIOD_CONFIG_KEY,
+    configKey: GONG_RETENTION_PERIOD_CONFIG_KEY,
   });
 
   const [retentionPeriod, setRetentionPeriod] = useState<string>(
@@ -55,7 +55,7 @@ export function GongOptionComponent({
 
     setLoading(true);
     const res = await fetch(
-      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${RETENTION_PERIOD_CONFIG_KEY}`,
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${GONG_RETENTION_PERIOD_CONFIG_KEY}`,
       {
         headers: { "Content-Type": "application/json" },
         method: "POST",

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -18,17 +18,19 @@ function checkIsPositiveInteger(value: string) {
   return /^[0-9]+$/.test(value);
 }
 
+interface GongOptionComponentProps {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+}
+
 export function GongOptionComponent({
   owner,
   readOnly,
   isAdmin,
   dataSource,
-}: {
-  owner: WorkspaceType;
-  readOnly: boolean;
-  isAdmin: boolean;
-  dataSource: DataSourceType;
-}) {
+}: GongOptionComponentProps) {
   const { configValue, mutateConfig } = useConnectorConfig({
     owner,
     dataSource,

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -14,7 +14,7 @@ import type { DataSourceType, WorkspaceType } from "@app/types";
 // TODO(2025-03-17): share this variable between connectors and front.
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 
-function checkIsNonNegativeInteger(value: string) {
+function checkIsPositiveInteger(value: string) {
   const integerValue = parseInt(value, 10);
   return Number.isFinite(integerValue) && integerValue >= 0;
 }
@@ -46,7 +46,7 @@ export function GongOptionComponent({
 
   const handleSetNewConfig = async (newValue: string) => {
     // Validate that the value is either empty or a positive integer
-    if (newValue !== "" && !checkIsNonNegativeInteger(newValue)) {
+    if (newValue !== "" && !checkIsPositiveInteger(newValue)) {
       sendNotification({
         type: "error",
         title: "Invalid retention period",
@@ -104,7 +104,7 @@ export function GongOptionComponent({
                 onChange={(e) => {
                   // Only allow positive integer values.
                   const value = e.target.value;
-                  if (value === "" || checkIsNonNegativeInteger(value)) {
+                  if (value === "" || checkIsPositiveInteger(value)) {
                     setRetentionPeriod(value);
                   }
                 }}

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -6,10 +6,10 @@ import {
   Input,
   useSendNotification,
 } from "@dust-tt/sparkle";
-import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import { useState } from "react";
 
 import { useConnectorConfig } from "@app/lib/swr/connectors";
+import type { DataSourceType, WorkspaceType } from "@app/types";
 
 function checkIsPositiveInteger(value: string) {
   return /^[0-9]+$/.test(value);

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -14,7 +14,7 @@ import type { DataSourceType, WorkspaceType } from "@app/types";
 // TODO(2025-03-17): share this variable between connectors and front.
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 
-function checkIsPositiveInteger(value: string) {
+function checkIsNonNegativeInteger(value: string) {
   const integerValue = parseInt(value, 10);
   return Number.isFinite(integerValue) && integerValue >= 0;
 }
@@ -46,7 +46,7 @@ export function GongOptionComponent({
 
   const handleSetNewConfig = async (newValue: string) => {
     // Validate that the value is either empty or a positive integer
-    if (newValue !== "" && !checkIsPositiveInteger(newValue)) {
+    if (newValue !== "" && !checkIsNonNegativeInteger(newValue)) {
       sendNotification({
         type: "error",
         title: "Invalid retention period",
@@ -104,7 +104,7 @@ export function GongOptionComponent({
                 onChange={(e) => {
                   // Only allow positive integer values.
                   const value = e.target.value;
-                  if (value === "" || checkIsPositiveInteger(value)) {
+                  if (value === "" || checkIsNonNegativeInteger(value)) {
                     setRetentionPeriod(value);
                   }
                 }}

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -15,8 +15,7 @@ import type { DataSourceType, WorkspaceType } from "@app/types";
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 
 function checkIsPositiveInteger(value: string) {
-  const integerValue = parseInt(value, 10);
-  return Number.isFinite(integerValue) && integerValue >= 0;
+  return /^[0-9]+$/.test(value);
 }
 
 interface GongOptionComponentProps {

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -14,7 +14,7 @@ import type { DataSourceType, WorkspaceType } from "@app/types";
 // TODO(2025-03-17): share this variable between connectors and front.
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 
-function checkIsPositiveInteger(value: string) {
+function checkIsNonNegativeInteger(value: string) {
   return /^[0-9]+$/.test(value);
 }
 
@@ -45,7 +45,7 @@ export function GongOptionComponent({
 
   const handleSetNewConfig = async (newValue: string) => {
     // Validate that the value is either empty or a positive integer
-    if (newValue !== "" && !checkIsPositiveInteger(newValue)) {
+    if (newValue !== "" && !checkIsNonNegativeInteger(newValue)) {
       sendNotification({
         type: "error",
         title: "Invalid retention period",
@@ -103,7 +103,7 @@ export function GongOptionComponent({
                 onChange={(e) => {
                   // Only allow positive integer values.
                   const value = e.target.value;
-                  if (value === "" || checkIsPositiveInteger(value)) {
+                  if (value === "" || checkIsNonNegativeInteger(value)) {
                     setRetentionPeriod(value);
                   }
                 }}


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/11264.
- This PR augments the `GongOptionComponent` to allow setting the desired retention period (in number of days).
- The additions include an Input and a Button that calls the connector manager's `setConfigurationKey` to update the retention period (backend already implemented).

<img width="603" alt="Screenshot 2025-03-17 at 10 40 54 AM" src="https://github.com/user-attachments/assets/9b185a3b-7475-4105-9630-c7a1d94f07bf" />



## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
