### PR TITLE
Tmp: disable trying to fetch gdrive labels until we have the scope approved

### DIFF
--- a/connectors/migrations/20231214_find_non_shared_drives.ts
+++ b/connectors/migrations/20231214_find_non_shared_drives.ts
@@ -51,6 +51,7 @@ async function main() {
 
           for (const f of selectedFolders) {
             const gDriveObject = await getGoogleDriveObject({
+              connectorId: c.id,
               authCredentials,
               driveObjectId: f.folderId,
             });

--- a/connectors/migrations/20240422_fix_gdrive_errorType.ts
+++ b/connectors/migrations/20240422_fix_gdrive_errorType.ts
@@ -24,6 +24,7 @@ async function main() {
     try {
       const auth = await getAuthObject(connector.connectionId);
       const gDriveObject = await getGoogleDriveObject({
+        connectorId: connector.id,
         authCredentials: auth,
         driveObjectId: "root",
       });

--- a/connectors/migrations/20240529_clean_gdrive_folders.ts
+++ b/connectors/migrations/20240529_clean_gdrive_folders.ts
@@ -82,6 +82,7 @@ async function main() {
     }
 
     const file = await getGoogleDriveObject({
+      connectorId,
       authCredentials,
       driveObjectId: folderId,
     });

--- a/connectors/migrations/20250219_upsert_google_drive_spreadsheet.ts
+++ b/connectors/migrations/20250219_upsert_google_drive_spreadsheet.ts
@@ -19,6 +19,7 @@ makeScript(
 
     // Fetch spreadsheet metadata.
     const spreadsheetData = await getGoogleDriveObject({
+      connectorId,
       authCredentials,
       driveObjectId: spreadsheetId,
     });

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -377,6 +377,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
           const nodes: ContentNode[] = await Promise.all(
             drives.map(async (d): Promise<ContentNode> => {
               const driveObject = await getGoogleDriveObject({
+                connectorId: c.id,
                 authCredentials,
                 driveObjectId: d.id,
               });
@@ -476,6 +477,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
           const nodes: ContentNode[] = await Promise.all(
             remoteFolders.map(async (rf): Promise<ContentNode> => {
               const driveObject = await driveObjectToDustType(
+                this.connectorId,
                 rf,
                 authCredentials
               );
@@ -701,6 +703,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       const authCredentials = await getAuthObject(connector.connectionId);
 
       const driveObject = await getGoogleDriveObject({
+        connectorId: this.connectorId,
         authCredentials,
         driveObjectId: getDriveFileId(internalId),
         cacheKey: { connectorId: this.connectorId, ts: memoizationKey },
@@ -852,6 +855,7 @@ async function getFoldersAsContentNodes({
     folders,
     async (f): Promise<ContentNode | null> => {
       const fd = await getGoogleDriveObject({
+        connectorId: f.connectorId,
         authCredentials,
         driveObjectId: f.folderId,
       });

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -258,6 +258,7 @@ export async function fixParentsConsistency({
         files,
         async (file) =>
           getGoogleDriveObject({
+            connectorId: connector.id,
             authCredentials,
             driveObjectId: file.driveFileId,
             cacheKey: {
@@ -329,6 +330,7 @@ export async function fixParentsConsistency({
           if (execute) {
             for (const missingFolderId of missing) {
               const missingFolder = await getGoogleDriveObject({
+                connectorId: connector.id,
                 authCredentials,
                 driveObjectId: getDriveFileId(missingFolderId),
               });

--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -91,7 +91,7 @@ export const google_drive = async ({
     case "list-labels": {
       const connector = await getConnector(args);
       const authCredentials = await getAuthObject(connector.connectionId);
-      const labels = await _getLabels(authCredentials);
+      const labels = await _getLabels(connector.id, authCredentials);
       return { status: 200, content: labels, type: typeof labels };
     }
     case "check-file": {
@@ -128,6 +128,7 @@ export const google_drive = async ({
       const now = Date.now();
       const authCredentials = await getAuthObject(connector.connectionId);
       const driveObject = await getGoogleDriveObject({
+        connectorId: connector.id,
         authCredentials,
         driveObjectId: getDriveFileId(fileId),
         cacheKey: { connectorId: connector.id, ts: now },
@@ -145,6 +146,7 @@ export const google_drive = async ({
       const now = Date.now();
       const authCredentials = await getAuthObject(connector.connectionId);
       const driveObject = await getGoogleDriveObject({
+        connectorId: connector.id,
         authCredentials,
         driveObjectId: getDriveFileId(fileId),
         cacheKey: { connectorId: connector.id, ts: now },
@@ -172,6 +174,7 @@ export const google_drive = async ({
         });
         if (!file) {
           const parentDriveObject = await getGoogleDriveObject({
+            connectorId: connector.id,
             authCredentials,
             driveObjectId: getDriveFileId(parent),
             cacheKey: { connectorId: connector.id, ts: now },
@@ -204,6 +207,7 @@ export const google_drive = async ({
       const now = Date.now();
       const authCredentials = await getAuthObject(connector.connectionId);
       const driveObject = await getGoogleDriveObject({
+        connectorId: connector.id,
         authCredentials,
         driveObjectId: getDriveFileId(fileId),
         cacheKey: { connectorId: connector.id, ts: now },

--- a/connectors/src/connectors/google_drive/lib/google_drive_api.ts
+++ b/connectors/src/connectors/google_drive/lib/google_drive_api.ts
@@ -6,7 +6,7 @@ import {
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
-import type { GoogleDriveObjectType } from "@connectors/types";
+import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 import { cacheWithRedis } from "@connectors/types";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types";
 
@@ -16,9 +16,11 @@ interface CacheKey {
 }
 
 async function _getGoogleDriveObject({
+  connectorId,
   authCredentials,
   driveObjectId,
 }: {
+  connectorId: ModelId;
   authCredentials: OAuth2Client;
   driveObjectId: string;
 }): Promise<GoogleDriveObjectType | null> {
@@ -37,7 +39,7 @@ async function _getGoogleDriveObject({
     }
     const file = res.data;
 
-    return await driveObjectToDustType(file, authCredentials);
+    return await driveObjectToDustType(connectorId, file, authCredentials);
   } catch (e) {
     if ((e as GaxiosError).response?.status === 401) {
       throw new ExternalOAuthTokenError();
@@ -53,6 +55,7 @@ const cachedGetGoogleDriveObject = cacheWithRedis<
   GoogleDriveObjectType | null,
   [
     {
+      connectorId: ModelId;
       authCredentials: OAuth2Client;
       driveObjectId: string;
       cacheKey: CacheKey;
@@ -67,20 +70,23 @@ const cachedGetGoogleDriveObject = cacheWithRedis<
 );
 
 export async function getGoogleDriveObject({
+  connectorId,
   authCredentials,
   driveObjectId,
   cacheKey,
 }: {
+  connectorId: ModelId;
   authCredentials: OAuth2Client;
   driveObjectId: string;
   cacheKey?: CacheKey;
 }): Promise<GoogleDriveObjectType | null> {
   if (cacheKey) {
     return cachedGetGoogleDriveObject({
+      connectorId,
       authCredentials,
       driveObjectId,
       cacheKey,
     });
   }
-  return _getGoogleDriveObject({ authCredentials, driveObjectId });
+  return _getGoogleDriveObject({ connectorId, authCredentials, driveObjectId });
 }

--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -32,6 +32,7 @@ async function getFileParents(
   let currentObject = driveFile;
   while (currentObject.parent) {
     const parent = await getGoogleDriveObject({
+      connectorId,
       authCredentials,
       driveObjectId: currentObject.parent,
       cacheKey: { connectorId, ts: startSyncTs },

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -7,7 +7,7 @@ import { OAuth2Client } from "googleapis-common";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
-import type { GoogleDriveObjectType } from "@connectors/types";
+import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 import { cacheWithRedis } from "@connectors/types";
 
 export function getInternalId(driveFileId: string): string {
@@ -54,6 +54,7 @@ export const getMyDriveIdCached = cacheWithRedis(
 
 // Turn the labels into a string array of formatted string such as labelTitle:labelValue
 const getLabelsNamesFromLabels = async (
+  connectorId: ModelId,
   file: drive_v3.Schema$File,
   authCredentials: OAuth2Client
 ) => {
@@ -61,7 +62,7 @@ const getLabelsNamesFromLabels = async (
   if (!labelInfo) {
     return [];
   }
-  const labels = await getCachedLabels(authCredentials);
+  const labels = await getCachedLabels(connectorId, authCredentials);
 
   return removeNulls(
     labelInfo.labels?.flatMap((l) => {
@@ -114,6 +115,7 @@ const getLabelsNamesFromLabels = async (
 };
 
 export async function driveObjectToDustType(
+  connectorId: ModelId,
   file: drive_v3.Schema$File,
   authCredentials: OAuth2Client
 ): Promise<GoogleDriveObjectType> {
@@ -129,7 +131,11 @@ export async function driveObjectToDustType(
 
   const drive = await getDriveClient(authCredentials);
 
-  const labels = await getLabelsNamesFromLabels(file, authCredentials);
+  const labels = await getLabelsNamesFromLabels(
+    connectorId,
+    file,
+    authCredentials
+  );
 
   if (!file.driveId) {
     // There is no driveId, the object is stored in "My Drive".
@@ -251,17 +257,22 @@ export async function getDriveClient(
 
 export const getCachedLabels = cacheWithRedis(
   _getLabels,
-  (authCredentials) => {
+  (connectorId, authCredentials) => {
     if (!authCredentials.credentials.access_token) {
       throw new Error("No access token in auth credentials");
     }
-    return authCredentials.credentials.access_token;
+    return `${connectorId}-labels`;
   },
   60 * 10 * 1000 // 10 minutes
 );
 
 // Get the list of published labels
-export async function _getLabels(authCredentials: OAuth2Client) {
+export async function _getLabels(
+  connectorId: ModelId,
+  authCredentials: OAuth2Client
+) {
+  // For now, return empty array until we have the new scope approved.
+  return [];
   try {
     const driveLabels = google.drivelabels({
       version: "v2",


### PR DESCRIPTION
## Description

Stop trying to fetch labels until we have the new scope approved.
Stop using the access token as the cache key.

## Tests

Locally + typechecking

## Risk

Low

## Deploy Plan

Deploy `connectors`