### PR TITLE
enh(core) - Add non empty titles validation on upserts

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1885,7 +1885,7 @@ async fn data_sources_documents_upsert(
         }
     }
 
-    if payload.title.is_empty() {
+    if payload.title.trim().is_empty() {
         return error_response(
             StatusCode::BAD_REQUEST,
             "invalid_title",
@@ -2463,7 +2463,7 @@ async fn tables_upsert(
         }
     }
 
-    if payload.title.is_empty() {
+    if payload.title.trim().is_empty() {
         return error_response(
             StatusCode::BAD_REQUEST,
             "invalid_title",
@@ -3310,7 +3310,7 @@ async fn folders_upsert(
         }
     }
 
-    if payload.title.is_empty() {
+    if payload.title.trim().is_empty() {
         return error_response(
             StatusCode::BAD_REQUEST,
             "invalid_title",

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1853,6 +1853,7 @@ async fn data_sources_documents_upsert(
         None => false,
     };
 
+    // TODO(2025-03-17 aubin) - Add generic validation on node upserts instead of duplicating it for folders, tables, documents.
     if payload.parents.get(0) != Some(&payload.document_id) {
         return error_response(
             StatusCode::BAD_REQUEST,

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1888,7 +1888,7 @@ async fn data_sources_documents_upsert(
     if payload.title.trim().is_empty() {
         return error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_title",
+            "title_is_empty",
             "Failed to upsert document - title is empty",
             None,
         );
@@ -2466,7 +2466,7 @@ async fn tables_upsert(
     if payload.title.trim().is_empty() {
         return error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_title",
+            "title_is_empty",
             "Failed to upsert table - title is empty",
             None,
         );
@@ -3313,7 +3313,7 @@ async fn folders_upsert(
     if payload.title.trim().is_empty() {
         return error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_title",
+            "title_is_empty",
             "Failed to upsert folder - title is empty",
             None,
         );

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1885,6 +1885,15 @@ async fn data_sources_documents_upsert(
         }
     }
 
+    if payload.title.is_empty() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_title",
+            "Failed to upsert document - title is empty",
+            None,
+        );
+    }
+
     match state
         .store
         .load_data_source(&project, &data_source_id)
@@ -2452,6 +2461,15 @@ async fn tables_upsert(
                     );
             }
         }
+    }
+
+    if payload.title.is_empty() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_title",
+            "Failed to upsert table - title is empty",
+            None,
+        );
     }
 
     match state
@@ -3290,6 +3308,15 @@ async fn folders_upsert(
                     );
             }
         }
+    }
+
+    if payload.title.is_empty() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_title",
+            "Failed to upsert folder - title is empty",
+            None,
+        );
     }
 
     match state

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -606,6 +606,7 @@ export async function upsertTable({
         | "table_not_found"
         | "file_not_found"
         | "title_too_long"
+        | "title_is_empty"
         | "invalid_parent_id"
         | "invalid_parents"
         | "internal_error";

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -598,18 +598,18 @@ export async function upsertTable({
       },
     Omit<DustError, "code"> & {
       code:
-        | "invalid_csv_and_file"
-        | "missing_csv"
         | "data_source_error"
-        | "invalid_csv_content"
-        | "invalid_url"
-        | "table_not_found"
         | "file_not_found"
-        | "title_too_long"
-        | "title_is_empty"
+        | "internal_error"
+        | "invalid_csv_and_file"
+        | "invalid_csv_content"
         | "invalid_parent_id"
         | "invalid_parents"
-        | "internal_error";
+        | "invalid_url"
+        | "missing_csv"
+        | "table_not_found"
+        | "title_is_empty"
+        | "title_too_long";
     }
   >
 > {

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -1,28 +1,28 @@
 export type DustErrorCode =
-  | "resource_not_found"
-  | "unauthorized"
-  | "invalid_id"
   | "core_api_error"
   | "internal_error"
+  | "invalid_id"
   | "limit_reached"
+  | "resource_not_found"
+  | "unauthorized"
   // Data source
   | "data_source_error"
   | "data_source_quota_error"
-  | "text_or_section_required"
-  | "invalid_url"
-  | "invalid_parents"
   | "invalid_parent_id"
+  | "invalid_parents"
+  | "invalid_title_in_tags"
+  | "invalid_url"
+  | "text_or_section_required"
   | "title_is_empty"
   | "title_too_long"
-  | "invalid_title_in_tags"
   // Table
-  | "missing_csv"
   | "invalid_rows"
+  | "missing_csv"
   // Group errors
+  | "system_or_global_group"
+  | "user_already_member"
   | "user_not_found"
   | "user_not_member"
-  | "user_already_member"
-  | "system_or_global_group"
   // Space errors
   | "space_already_exists";
 

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -12,6 +12,7 @@ export type DustErrorCode =
   | "invalid_url"
   | "invalid_parents"
   | "invalid_parent_id"
+  | "title_is_empty"
   | "title_too_long"
   | "invalid_title_in_tags"
   // Table

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -114,10 +114,10 @@ async function handler(
       if (upsertRes.isErr()) {
         switch (upsertRes.error.code) {
           case "invalid_csv_and_file":
-          case "invalid_parents":
           case "invalid_parent_id":
-          case "title_is_empty":
+          case "invalid_parents":
           case "invalid_url":
+          case "title_is_empty":
           case "title_too_long":
           case "missing_csv":
             return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -116,6 +116,7 @@ async function handler(
           case "invalid_csv_and_file":
           case "invalid_parents":
           case "invalid_parent_id":
+          case "title_is_empty":
           case "invalid_url":
           case "title_too_long":
           case "missing_csv":


### PR DESCRIPTION
## Description

Context:
- We need to validate that we do not upsert empty titles for data source nodes.
- Empty titles break the pagination by affecting how the `search_after` is deserialized (we get 2 values instead of 3).

This PR adds validation in `core` to return a 400 when attempting to upsert a node with an empty title.
A fallback title ("Untitled Document") is provided in `api/v1`, following this change we will be able to check whether there are still existing code paths that lead to having empty titles.

## Tests

- Tested locally.

## Risk

- Low, the goal here is to follow up on the newly returned errors if any.

## Deploy Plan

- Deploy `core`.
- Deploy `front`.
