### PR TITLE
Add 'filterable' info in field

### DIFF
--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -67,6 +67,7 @@ impl TryFrom<&gcp_bigquery_client::model::table_schema::TableSchema> for TableSc
                             | FieldType::Interval => TableSchemaFieldType::Text,
                         },
                         possible_values: None,
+                        filterable: true,
                     })
                     .collect(),
             )),

--- a/core/src/databases/remote_databases/salesforce/salesforce.rs
+++ b/core/src/databases/remote_databases/salesforce/salesforce.rs
@@ -405,6 +405,10 @@ impl SalesforceRemoteDatabase {
                     QueryDatabaseError::GenericError(anyhow!("Field `soapType` not found"))
                 })?;
 
+                let filterable = field["filterable"].as_bool().ok_or_else(|| {
+                    QueryDatabaseError::GenericError(anyhow!("Field `filterable` not found"))
+                })?;
+
                 let value_type = match soap_type.to_lowercase().as_str() {
                     "tns:id" => match field["relationshipName"].as_str() {
                         Some(rel_name) => TableSchemaFieldType::Reference(rel_name.to_string()),
@@ -449,6 +453,7 @@ impl SalesforceRemoteDatabase {
                     name,
                     value_type,
                     possible_values: possible_values,
+                    filterable,
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -68,6 +68,7 @@ impl TryFrom<SnowflakeSchemaColumn> for TableSchemaColumn {
             name: col.name,
             value_type: col_type,
             possible_values: None,
+            filterable: true,
         })
     }
 }

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -68,14 +68,16 @@ pub struct TableSchemaColumn {
     pub name: String,
     pub value_type: TableSchemaFieldType,
     pub possible_values: Option<Vec<String>>,
+    pub filterable: bool,
 }
 
 impl TableSchemaColumn {
-    pub fn new(name: &str, field_type: TableSchemaFieldType) -> Self {
+    pub fn new(name: &str, field_type: TableSchemaFieldType, filterable: bool) -> Self {
         Self {
             name: name.to_string(),
             value_type: field_type,
             possible_values: None,
+            filterable,
         }
     }
 
@@ -88,6 +90,11 @@ impl TableSchemaColumn {
                 dbml.push_str("']");
             }
         }
+
+        if !&self.filterable {
+            dbml.push_str(" [note: non filterable - this field cannot be used in a where clause]");
+        }
+
         dbml
     }
 }
@@ -219,6 +226,7 @@ impl TableSchema {
                             name: k.clone(),
                             value_type,
                             possible_values: Some(vec![]),
+                            filterable: true,
                         };
                         Self::accumulate_value(&mut column, v);
                         schema_map.insert(k.clone(), column);
@@ -472,26 +480,31 @@ mod tests {
                 name: "field1".to_string(),
                 value_type: TableSchemaFieldType::Int,
                 possible_values: Some(vec!["1".to_string(), "2".to_string()]),
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field2".to_string(),
                 value_type: TableSchemaFieldType::Float,
                 possible_values: Some(vec!["1.2".to_string(), "2.4".to_string()]),
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field3".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: None,
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field4".to_string(),
                 value_type: TableSchemaFieldType::Bool,
                 possible_values: Some(vec!["TRUE".to_string(), "FALSE".to_string()]),
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field5".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: Some(vec!["\"not null anymore\"".to_string()]),
+                filterable: true,
             },
         ]);
 
@@ -673,21 +686,25 @@ mod tests {
                 name: "field1".to_string(),
                 value_type: TableSchemaFieldType::Int,
                 possible_values: None,
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field2".to_string(),
                 value_type: TableSchemaFieldType::Float,
                 possible_values: None,
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field3".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: None,
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field4".to_string(),
                 value_type: TableSchemaFieldType::Bool,
                 possible_values: None,
+                filterable: true,
             },
         ])
     }
@@ -738,10 +755,12 @@ mod tests {
                 Some(TableSchemaColumn::new(
                     "no_possible_values",
                     TableSchemaFieldType::Text,
+                    true,
                 )),
                 Some(TableSchemaColumn::new(
                     "no_possible_values",
                     TableSchemaFieldType::Text,
+                    true,
                 )),
                 TableSchemaFieldType::Text,
                 None,
@@ -873,6 +892,7 @@ mod tests {
                 "2000-01-01 00:00:00".to_string(),
                 "2000-01-02 00:00:00".to_string(),
             ]),
+            filterable: true,
         }]);
 
         assert_eq!(schema, expected_schema);
@@ -925,6 +945,7 @@ mod tests {
             name: name.to_string(),
             value_type,
             possible_values: Some(possible_values),
+            filterable: true,
         }
     }
 }

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -131,7 +131,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "b4f205e453",
       appHash:
-        "ae042340a4c705b3cfcc3760a2ffde04c0b3fd246da8ca2e01dd01e2daebcce2",
+        "d6c762512b6d716f7e13151cf2c245bf51e1923f54859303ca7b144d4ac6dc3f",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

Add "filterable"  in TableSchemaColumn .  In salesforce some fields are not queryable and cannot be used in a where.
Also add "  // Never include a non filterable field in a WHERE clause " to the dust app to make it clear to the model these fields can't be used

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy core
deploy front

