### PR TITLE
[sparkle] - chore(Chip): add "white" variant

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.440",
+  "version": "0.2.441",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.440",
+      "version": "0.2.441",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.440",
+  "version": "0.2.441",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/AnimatedText.tsx
+++ b/sparkle/src/components/AnimatedText.tsx
@@ -1,6 +1,5 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { ReactNode } from "react";
-import React from "react";
+import React, { ReactNode } from "react";
 
 import { cn } from "@sparkle/lib/utils";
 
@@ -15,6 +14,7 @@ const ANIMATED_TEXT_VARIANTS = [
   "sky",
   "pink",
   "red",
+  "white",
 ] as const;
 
 type AnimatedTextVariantType = (typeof ANIMATED_TEXT_VARIANTS)[number];
@@ -35,6 +35,10 @@ const animatedVariants: Record<AnimatedTextVariantType, string> = {
   amber: cn(
     "s-from-amber-800 s-via-amber-950 s-via-50% s-to-amber-800",
     "dark:s-from-amber-800-night dark:s-via-amber-950-night dark:s-via-50% dark:s-to-amber-800-night"
+  ),
+  white: cn(
+    "s-from-slate-600 s-via-slate-950 s-via-50% s-to-slate-600",
+    "dark:s-from-slate-600-night dark:s-via-slate-950-night dark:s-via-50% dark:s-to-slate-600-night"
   ),
   slate: cn(
     "s-from-slate-600 s-via-slate-950 s-via-50% s-to-slate-600",
@@ -80,6 +84,7 @@ const animatedTextVariants: Record<AnimatedTextVariantType, string> = {
   emerald: "s-text-emerald-800 dark:s-text-emerald-800-night",
   amber: "s-text-amber-800 dark:s-text-amber-800-night",
   slate: "s-text-muted-foreground dark:s-text-muted-foreground-night",
+  white: "s-text-muted-foreground dark:s-text-muted-foreground-night",
   purple: "s-text-purple-800 dark:s-text-purple-800-night",
   warning: "s-text-warning-800 dark:s-text-warning-800-night",
   sky: "s-text-sky-800 dark:s-text-sky-800-night",

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -20,6 +20,7 @@ export const CHIP_COLORS = [
   "sky",
   "pink",
   "red",
+  "white",
 ] as const;
 
 type ChipColorType = (typeof CHIP_COLORS)[number];
@@ -57,6 +58,10 @@ const backgroundVariants: Record<ChipColorType, string> = {
     "s-bg-purple-100 s-border-purple-200",
     "dark:s-bg-purple-100-night dark:s-border-purple-200-night"
   ),
+  white: cn(
+    "s-bg-background s-border-border",
+    "dark:s-bg-muted-background-night dark:s-border-border-night"
+  ),
   warning: cn(
     "s-bg-warning-100 s-border-warning-200",
     "dark:s-bg-warning-100-night dark:s-border-warning-200-night"
@@ -84,6 +89,7 @@ const textVariants: Record<ChipColorType, string> = {
   sky: "s-text-sky-900 dark:s-text-sky-900-night",
   pink: "s-text-pink-900 dark:s-text-pink-900-night",
   red: "s-text-red-900 dark:s-text-red-900-night",
+  white: "s-text-foreground dark:s-text-foreground-night",
 };
 
 const chipVariants = cva("s-inline-flex s-box-border s-items-center", {


### PR DESCRIPTION
## Description

This PR aims at adding a "white" variant to the `Chip` component in sparkle.

## Risk

Low

## Deploy Plan

- Publish sparkle