### PR TITLE
[.github] - fix(build-image): disable provenance in image build

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -73,6 +73,7 @@ runs:
         depot build \
           --project 3vz0lnf16v \
           --platform linux/amd64 \
+          --provenance=false \
           --cache-from type=gha,scope=${{ inputs.component }} \
           --cache-to type=gha,mode=max,scope=${{ inputs.component }} \
           -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \


### PR DESCRIPTION
## Description

This PR aims at adding a `--provenance=false` flag to depot build to avoid pushing multiple duplicated images to the Google Artifact Registry. This issue was previously fixed in https://github.com/dust-tt/dust/pull/9242

## Risk

Low

## Deploy Plan

N/A