### PR TITLE
[core] Fix 'filterable' info in field schema

### DIFF
--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -67,6 +67,7 @@ impl TryFrom<&gcp_bigquery_client::model::table_schema::TableSchema> for TableSc
                             | FieldType::Interval => TableSchemaFieldType::Text,
                         },
                         possible_values: None,
+                        filterable: true,
                     })
                     .collect(),
             )),

--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -67,7 +67,7 @@ impl TryFrom<&gcp_bigquery_client::model::table_schema::TableSchema> for TableSc
                             | FieldType::Interval => TableSchemaFieldType::Text,
                         },
                         possible_values: None,
-                        filterable: None,
+                        non_filterable: None,
                     })
                     .collect(),
             )),

--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -67,7 +67,7 @@ impl TryFrom<&gcp_bigquery_client::model::table_schema::TableSchema> for TableSc
                             | FieldType::Interval => TableSchemaFieldType::Text,
                         },
                         possible_values: None,
-                        filterable: true,
+                        filterable: None,
                     })
                     .collect(),
             )),

--- a/core/src/databases/remote_databases/salesforce/salesforce.rs
+++ b/core/src/databases/remote_databases/salesforce/salesforce.rs
@@ -405,6 +405,10 @@ impl SalesforceRemoteDatabase {
                     QueryDatabaseError::GenericError(anyhow!("Field `soapType` not found"))
                 })?;
 
+                let filterable = field["filterable"].as_bool().ok_or_else(|| {
+                    QueryDatabaseError::GenericError(anyhow!("Field `filterable` not found"))
+                })?;
+
                 let value_type = match soap_type.to_lowercase().as_str() {
                     "tns:id" => match field["relationshipName"].as_str() {
                         Some(rel_name) => TableSchemaFieldType::Reference(rel_name.to_string()),
@@ -449,6 +453,7 @@ impl SalesforceRemoteDatabase {
                     name,
                     value_type,
                     possible_values: possible_values,
+                    filterable,
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/core/src/databases/remote_databases/salesforce/salesforce.rs
+++ b/core/src/databases/remote_databases/salesforce/salesforce.rs
@@ -453,7 +453,7 @@ impl SalesforceRemoteDatabase {
                     name,
                     value_type,
                     possible_values: possible_values,
-                    filterable: Some(filterable),
+                    non_filterable: Some(!filterable),
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/core/src/databases/remote_databases/salesforce/salesforce.rs
+++ b/core/src/databases/remote_databases/salesforce/salesforce.rs
@@ -453,7 +453,7 @@ impl SalesforceRemoteDatabase {
                     name,
                     value_type,
                     possible_values: possible_values,
-                    filterable,
+                    filterable: Some(filterable),
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -68,6 +68,7 @@ impl TryFrom<SnowflakeSchemaColumn> for TableSchemaColumn {
             name: col.name,
             value_type: col_type,
             possible_values: None,
+            filterable: true,
         })
     }
 }

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -68,7 +68,7 @@ impl TryFrom<SnowflakeSchemaColumn> for TableSchemaColumn {
             name: col.name,
             value_type: col_type,
             possible_values: None,
-            filterable: None,
+            non_filterable: None,
         })
     }
 }

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -68,7 +68,7 @@ impl TryFrom<SnowflakeSchemaColumn> for TableSchemaColumn {
             name: col.name,
             value_type: col_type,
             possible_values: None,
-            filterable: true,
+            filterable: None,
         })
     }
 }

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -68,14 +68,16 @@ pub struct TableSchemaColumn {
     pub name: String,
     pub value_type: TableSchemaFieldType,
     pub possible_values: Option<Vec<String>>,
+    pub filterable: bool,
 }
 
 impl TableSchemaColumn {
-    pub fn new(name: &str, field_type: TableSchemaFieldType) -> Self {
+    pub fn new(name: &str, field_type: TableSchemaFieldType, filterable: bool) -> Self {
         Self {
             name: name.to_string(),
             value_type: field_type,
             possible_values: None,
+            filterable,
         }
     }
 
@@ -88,6 +90,11 @@ impl TableSchemaColumn {
                 dbml.push_str("']");
             }
         }
+
+        if !&self.filterable {
+            dbml.push_str(" [note: non filterable - this field cannot be used in a where clause]");
+        }
+
         dbml
     }
 }
@@ -219,6 +226,7 @@ impl TableSchema {
                             name: k.clone(),
                             value_type,
                             possible_values: Some(vec![]),
+                            filterable: true,
                         };
                         Self::accumulate_value(&mut column, v);
                         schema_map.insert(k.clone(), column);
@@ -472,26 +480,31 @@ mod tests {
                 name: "field1".to_string(),
                 value_type: TableSchemaFieldType::Int,
                 possible_values: Some(vec!["1".to_string(), "2".to_string()]),
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field2".to_string(),
                 value_type: TableSchemaFieldType::Float,
                 possible_values: Some(vec!["1.2".to_string(), "2.4".to_string()]),
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field3".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: None,
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field4".to_string(),
                 value_type: TableSchemaFieldType::Bool,
                 possible_values: Some(vec!["TRUE".to_string(), "FALSE".to_string()]),
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field5".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: Some(vec!["\"not null anymore\"".to_string()]),
+                filterable: true,
             },
         ]);
 
@@ -673,21 +686,25 @@ mod tests {
                 name: "field1".to_string(),
                 value_type: TableSchemaFieldType::Int,
                 possible_values: None,
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field2".to_string(),
                 value_type: TableSchemaFieldType::Float,
                 possible_values: None,
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field3".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: None,
+                filterable: true,
             },
             TableSchemaColumn {
                 name: "field4".to_string(),
                 value_type: TableSchemaFieldType::Bool,
                 possible_values: None,
+                filterable: true,
             },
         ])
     }
@@ -738,10 +755,12 @@ mod tests {
                 Some(TableSchemaColumn::new(
                     "no_possible_values",
                     TableSchemaFieldType::Text,
+                    true,
                 )),
                 Some(TableSchemaColumn::new(
                     "no_possible_values",
                     TableSchemaFieldType::Text,
+                    true,
                 )),
                 TableSchemaFieldType::Text,
                 None,
@@ -873,6 +892,7 @@ mod tests {
                 "2000-01-01 00:00:00".to_string(),
                 "2000-01-02 00:00:00".to_string(),
             ]),
+            filterable: true,
         }]);
 
         assert_eq!(schema, expected_schema);
@@ -925,6 +945,7 @@ mod tests {
             name: name.to_string(),
             value_type,
             possible_values: Some(possible_values),
+            filterable: true,
         }
     }
 }

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -68,11 +68,12 @@ pub struct TableSchemaColumn {
     pub name: String,
     pub value_type: TableSchemaFieldType,
     pub possible_values: Option<Vec<String>>,
-    pub filterable: bool,
+    // Set to false if this field can't be used in a where clause. True by default
+    pub filterable: Option<bool>,
 }
 
 impl TableSchemaColumn {
-    pub fn new(name: &str, field_type: TableSchemaFieldType, filterable: bool) -> Self {
+    pub fn new(name: &str, field_type: TableSchemaFieldType, filterable: Option<bool>) -> Self {
         Self {
             name: name.to_string(),
             value_type: field_type,
@@ -91,7 +92,7 @@ impl TableSchemaColumn {
             }
         }
 
-        if !&self.filterable {
+        if !&self.filterable.unwrap_or(true) {
             dbml.push_str(" [note: non filterable - this field cannot be used in a where clause]");
         }
 
@@ -226,7 +227,7 @@ impl TableSchema {
                             name: k.clone(),
                             value_type,
                             possible_values: Some(vec![]),
-                            filterable: true,
+                            filterable: None,
                         };
                         Self::accumulate_value(&mut column, v);
                         schema_map.insert(k.clone(), column);
@@ -480,31 +481,31 @@ mod tests {
                 name: "field1".to_string(),
                 value_type: TableSchemaFieldType::Int,
                 possible_values: Some(vec!["1".to_string(), "2".to_string()]),
-                filterable: true,
+                filterable: None,
             },
             TableSchemaColumn {
                 name: "field2".to_string(),
                 value_type: TableSchemaFieldType::Float,
                 possible_values: Some(vec!["1.2".to_string(), "2.4".to_string()]),
-                filterable: true,
+                filterable: None,
             },
             TableSchemaColumn {
                 name: "field3".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: None,
-                filterable: true,
+                filterable: None,
             },
             TableSchemaColumn {
                 name: "field4".to_string(),
                 value_type: TableSchemaFieldType::Bool,
                 possible_values: Some(vec!["TRUE".to_string(), "FALSE".to_string()]),
-                filterable: true,
+                filterable: None,
             },
             TableSchemaColumn {
                 name: "field5".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: Some(vec!["\"not null anymore\"".to_string()]),
-                filterable: true,
+                filterable: None,
             },
         ]);
 
@@ -686,25 +687,25 @@ mod tests {
                 name: "field1".to_string(),
                 value_type: TableSchemaFieldType::Int,
                 possible_values: None,
-                filterable: true,
+                filterable: None,
             },
             TableSchemaColumn {
                 name: "field2".to_string(),
                 value_type: TableSchemaFieldType::Float,
                 possible_values: None,
-                filterable: true,
+                filterable: None,
             },
             TableSchemaColumn {
                 name: "field3".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: None,
-                filterable: true,
+                filterable: None,
             },
             TableSchemaColumn {
                 name: "field4".to_string(),
                 value_type: TableSchemaFieldType::Bool,
                 possible_values: None,
-                filterable: true,
+                filterable: None,
             },
         ])
     }
@@ -755,12 +756,12 @@ mod tests {
                 Some(TableSchemaColumn::new(
                     "no_possible_values",
                     TableSchemaFieldType::Text,
-                    true,
+                    None,
                 )),
                 Some(TableSchemaColumn::new(
                     "no_possible_values",
                     TableSchemaFieldType::Text,
-                    true,
+                    None,
                 )),
                 TableSchemaFieldType::Text,
                 None,
@@ -892,7 +893,7 @@ mod tests {
                 "2000-01-01 00:00:00".to_string(),
                 "2000-01-02 00:00:00".to_string(),
             ]),
-            filterable: true,
+            filterable: None,
         }]);
 
         assert_eq!(schema, expected_schema);
@@ -945,7 +946,7 @@ mod tests {
             name: name.to_string(),
             value_type,
             possible_values: Some(possible_values),
-            filterable: true,
+            filterable: None,
         }
     }
 }

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -68,17 +68,17 @@ pub struct TableSchemaColumn {
     pub name: String,
     pub value_type: TableSchemaFieldType,
     pub possible_values: Option<Vec<String>>,
-    // Set to false if this field can't be used in a where clause. True by default
-    pub filterable: Option<bool>,
+    // Set to true if this field can't be used in a where clause. False by default
+    pub non_filterable: Option<bool>,
 }
 
 impl TableSchemaColumn {
-    pub fn new(name: &str, field_type: TableSchemaFieldType, filterable: Option<bool>) -> Self {
+    pub fn new(name: &str, field_type: TableSchemaFieldType, non_filterable: Option<bool>) -> Self {
         Self {
             name: name.to_string(),
             value_type: field_type,
             possible_values: None,
-            filterable,
+            non_filterable,
         }
     }
 
@@ -92,7 +92,7 @@ impl TableSchemaColumn {
             }
         }
 
-        if !&self.filterable.unwrap_or(true) {
+        if self.non_filterable.unwrap_or(false) {
             dbml.push_str(" [note: non filterable - this field cannot be used in a where clause]");
         }
 
@@ -227,7 +227,7 @@ impl TableSchema {
                             name: k.clone(),
                             value_type,
                             possible_values: Some(vec![]),
-                            filterable: None,
+                            non_filterable: None,
                         };
                         Self::accumulate_value(&mut column, v);
                         schema_map.insert(k.clone(), column);
@@ -481,31 +481,31 @@ mod tests {
                 name: "field1".to_string(),
                 value_type: TableSchemaFieldType::Int,
                 possible_values: Some(vec!["1".to_string(), "2".to_string()]),
-                filterable: None,
+                non_filterable: None,
             },
             TableSchemaColumn {
                 name: "field2".to_string(),
                 value_type: TableSchemaFieldType::Float,
                 possible_values: Some(vec!["1.2".to_string(), "2.4".to_string()]),
-                filterable: None,
+                non_filterable: None,
             },
             TableSchemaColumn {
                 name: "field3".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: None,
-                filterable: None,
+                non_filterable: None,
             },
             TableSchemaColumn {
                 name: "field4".to_string(),
                 value_type: TableSchemaFieldType::Bool,
                 possible_values: Some(vec!["TRUE".to_string(), "FALSE".to_string()]),
-                filterable: None,
+                non_filterable: None,
             },
             TableSchemaColumn {
                 name: "field5".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: Some(vec!["\"not null anymore\"".to_string()]),
-                filterable: None,
+                non_filterable: None,
             },
         ]);
 
@@ -687,25 +687,25 @@ mod tests {
                 name: "field1".to_string(),
                 value_type: TableSchemaFieldType::Int,
                 possible_values: None,
-                filterable: None,
+                non_filterable: None,
             },
             TableSchemaColumn {
                 name: "field2".to_string(),
                 value_type: TableSchemaFieldType::Float,
                 possible_values: None,
-                filterable: None,
+                non_filterable: None,
             },
             TableSchemaColumn {
                 name: "field3".to_string(),
                 value_type: TableSchemaFieldType::Text,
                 possible_values: None,
-                filterable: None,
+                non_filterable: None,
             },
             TableSchemaColumn {
                 name: "field4".to_string(),
                 value_type: TableSchemaFieldType::Bool,
                 possible_values: None,
-                filterable: None,
+                non_filterable: None,
             },
         ])
     }
@@ -893,7 +893,7 @@ mod tests {
                 "2000-01-01 00:00:00".to_string(),
                 "2000-01-02 00:00:00".to_string(),
             ]),
-            filterable: None,
+            non_filterable: None,
         }]);
 
         assert_eq!(schema, expected_schema);
@@ -946,7 +946,7 @@ mod tests {
             name: name.to_string(),
             value_type,
             possible_values: Some(possible_values),
-            filterable: None,
+            non_filterable: None,
         }
     }
 }

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -131,7 +131,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "b4f205e453",
       appHash:
-        "ae042340a4c705b3cfcc3760a2ffde04c0b3fd246da8ca2e01dd01e2daebcce2",
+        "d6c762512b6d716f7e13151cf2c245bf51e1923f54859303ca7b144d4ac6dc3f",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
Reverts dust-tt/dust#11415 and restore https://github.com/dust-tt/dust/pull/11408

Now use an optional for non_filterable so that json deserialization does not crash when stored schema does / does not contain "non_filterable"

We have a few entries in db with "filterable:true", but these are safely ignored when deserializing, and will eventually be replaced when reupserting the table.

