### PR TITLE
enh(Poke) - Add a column "Kind" to `DataSourceViewsDataTable`

### DIFF
--- a/front/components/poke/data_source_views/columns.tsx
+++ b/front/components/poke/data_source_views/columns.tsx
@@ -67,6 +67,10 @@ export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
       header: "Last edited by",
     },
     {
+      accessorKey: "kind",
+      header: "Kind",
+    },
+    {
       accessorKey: "editedAt",
       header: "Last edited at",
       cell: ({ row }) => {


### PR DESCRIPTION
## Description

- When debugging pages that are not found in Notion, we often need to compare the permissions tree (poke data source) to the data source view tree (poke default data source view).
- This PR simplifies this process by adding a column to show the data source view kind.
- This is not reasonable readable for non-eng as is, the key information here is that kind = default means that it's everything that was selected, as the user can see when adding it to a Space.

## Tests

- Checked locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.