### PR TITLE
Salesforce url error and guide

### DIFF
--- a/front/components/data_source/SalesforceOAuthExtractConfig.tsx
+++ b/front/components/data_source/SalesforceOAuthExtractConfig.tsx
@@ -74,11 +74,16 @@ export function SalesforceOauthExtraConfig({
     );
   }, [extraConfig, setIsExtraConfigValid]);
 
+  const isErrorUrl =
+    typeof extraConfig.instance_url === "string" &&
+    extraConfig.instance_url.length > 0 &&
+    !isValidSalesforceDomain(extraConfig.instance_url);
+
   return (
     <>
       <Input
         label="Salesforce instance URL"
-        message="The URL of your Salesforce organization instance."
+        message="Must be a valid Salesforce domain in https and ending with .salesforce.com or .force.com"
         name="instance_url"
         value={extraConfig.instance_url ?? ""}
         placeholder="https://my-org.salesforce.com"
@@ -88,6 +93,8 @@ export function SalesforceOauthExtraConfig({
             instance_url: e.target.value,
           }));
         }}
+        isError={isErrorUrl}
+        messageStatus={isErrorUrl ? "error" : "default"}
       />
       <Input
         label="Client ID"

--- a/front/components/data_source/SalesforceOAuthExtractConfig.tsx
+++ b/front/components/data_source/SalesforceOAuthExtractConfig.tsx
@@ -13,52 +13,64 @@ export function SalesforceOauthExtraConfig({
   setExtraConfig,
   setIsExtraConfigValid,
 }: ConnectorOauthExtraConfigProps) {
-  const [pkceLoadingStatus, setPkceLoadingStatus] = useState<
-    "idle" | "loading" | "error"
-  >("idle");
+  const [pkceStatus, setPkceStatus] = useState<{
+    url: string;
+    status: "success" | "loading" | "error" | "idle";
+  }>({
+    url: "",
+    status: "idle",
+  });
 
   useEffect(() => {
     async function generatePKCE() {
-      if (
-        isValidSalesforceDomain(extraConfig.instance_url) &&
-        !extraConfig.code_verifier &&
-        pkceLoadingStatus === "idle"
-      ) {
-        setPkceLoadingStatus("loading");
-        try {
-          const response = await fetch(
-            `/api/oauth/pkce?domain=${extraConfig.instance_url}`,
-            {
-              method: "GET",
-              headers: {
-                "Content-Type": "application/json",
-              },
-            }
-          );
-          if (!response.ok) {
-            throw new Error("Failed to generate PKCE challenge");
+      try {
+        setPkceStatus({
+          url: extraConfig.instance_url,
+          status: "loading",
+        });
+        const response = await fetch(
+          `/api/oauth/pkce?domain=${extraConfig.instance_url}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
           }
-          const { code_verifier, code_challenge } = await response.json();
-          setExtraConfig((extraConfig) => ({
-            ...extraConfig,
-            code_verifier,
-            code_challenge,
-          }));
-          setPkceLoadingStatus("idle");
-        } catch (error) {
-          console.error("Error generating PKCE challenge:", error);
-          setPkceLoadingStatus("error");
+        );
+        if (!response.ok) {
+          throw new Error("Failed to generate PKCE challenge");
         }
+        const { code_verifier, code_challenge } = await response.json();
+        setExtraConfig((extraConfig) => ({
+          ...extraConfig,
+          code_verifier,
+          code_challenge,
+        }));
+        setPkceStatus({
+          url: extraConfig.instance_url,
+          status: "success",
+        });
+      } catch (error) {
+        console.error("Error generating PKCE challenge:", error);
+        setPkceStatus({
+          url: extraConfig.instance_url,
+          status: "error",
+        });
       }
     }
 
-    void generatePKCE();
+    if (
+      isValidSalesforceDomain(extraConfig.instance_url) &&
+      pkceStatus.url !== extraConfig.instance_url
+    ) {
+      void generatePKCE();
+    }
   }, [
     extraConfig.instance_url,
     extraConfig.code_verifier,
-    pkceLoadingStatus,
+    pkceStatus,
     setExtraConfig,
-    setPkceLoadingStatus,
+    setPkceStatus,
   ]);
 
   useEffect(() => {
@@ -79,11 +91,17 @@ export function SalesforceOauthExtraConfig({
     extraConfig.instance_url.length > 0 &&
     !isValidSalesforceDomain(extraConfig.instance_url);
 
+  const isPkceError = pkceStatus.status === "error";
+
   return (
     <>
       <Input
         label="Salesforce instance URL"
-        message="Must be a valid Salesforce domain in https and ending with .salesforce.com or .force.com"
+        message={
+          isPkceError
+            ? "Error loading Salesforce OAuth credentials. Check if your url is correct and try again or contact us at support@dust.tt."
+            : "Must be a valid Salesforce domain in https and ending with .salesforce.com or .force.com"
+        }
         name="instance_url"
         value={extraConfig.instance_url ?? ""}
         placeholder="https://my-org.salesforce.com"
@@ -93,8 +111,7 @@ export function SalesforceOauthExtraConfig({
             instance_url: e.target.value,
           }));
         }}
-        isError={isErrorUrl}
-        messageStatus={isErrorUrl ? "error" : "default"}
+        messageStatus={isErrorUrl || isPkceError ? "error" : "default"}
       />
       <Input
         label="Client ID"

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -355,7 +355,8 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       unselected: "none",
     },
     isDeletable: true,
-    guideLink: "https://docs.dust.tt/docs/salesforce-connection",
+    guideLink:
+      "https://www.notion.so/dust-tt/Dust-Salesforce-Connection-Admin-Guide-for-beta-testers-1b428599d94180508c17ed762af5ef90",
   },
   gong: {
     name: "Gong",


### PR DESCRIPTION
## Description

Salesforce create/edit Connection form: 
- Display error when url is not valid. 
- Display error if we cannot extract the pkce infos. 
- Make sure we do refetch the pkce if the url changes.
- Fix guide link.

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front.
