### PR TITLE
enh(`api/v1`) - Trim titles on upserts to fallback correctly on "Untitled document"

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -19,12 +19,12 @@ import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { validateUrl } from "@app/types";
 import {
   CoreAPI,
   dustManagedCredentials,
   safeSubstring,
   sectionFullText,
+  validateUrl,
 } from "@app/types";
 
 export const config = {
@@ -568,7 +568,7 @@ async function handler(
         ?.substring(6);
 
       // Use titleInTags if no title is provided.
-      const title = r.data.title || titleInTags || "Untitled Document";
+      const title = r.data.title?.trim() || titleInTags || "Untitled Document";
 
       if (!titleInTags) {
         tags.push(`title:${title}`);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -301,18 +301,6 @@ async function handler(
         mimeType = r.data.mime_type;
         title = r.data.title.trim();
       } else {
-        // TODO(content-node): get rid of this once the use of timestamp columns in core has been rationalized
-        if (r.data.timestamp) {
-          logger.info(
-            {
-              workspaceId: owner.id,
-              dataSourceId: dataSource.sId,
-              timestamp: r.data.timestamp,
-              currentDate: Date.now(),
-            },
-            "[ContentNode] User-set timestamp."
-          );
-        }
         // If the request is from a regular API key, the request must not provide mimeType.
         if (r.data.mime_type) {
           return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -326,11 +326,11 @@ async function handler(
         mimeType = "application/vnd.dust.table";
 
         // If the request is from a regular API key, and the title is provided, we use it.
-        // Otherwise we default to either:
+        // Otherwise, we default to either:
         // - the title tag if any
         // - the name of the table
-        if (r.data.title) {
-          title = r.data.title;
+        if (r.data.title && r.data.title.trim()) {
+          title = r.data.title.trim();
         } else {
           const titleTag = tags?.find((t) => t.startsWith("title:"));
           if (titleTag) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -276,7 +276,6 @@ async function handler(
       } = r.data;
 
       let mimeType: string;
-      let title: string;
       if (auth.isSystemKey()) {
         // If the request is from a system key, the request must provide both title and mimeType.
         if (!r.data.mime_type) {
@@ -299,7 +298,6 @@ async function handler(
         }
 
         mimeType = r.data.mime_type;
-        title = r.data.title.trim();
       } else {
         // If the request is from a regular API key, the request must not provide mimeType.
         if (r.data.mime_type) {
@@ -312,16 +310,15 @@ async function handler(
           });
         }
         mimeType = "application/vnd.dust.table";
-
-        // If the request is from a regular API key, and the title is provided, we use it.
-        // Otherwise, we default to either:
-        // - the title tag if any
-        // - the name of the table
-        const titleInTags = tags
-          ?.find((t) => t.startsWith("title:"))
-          ?.substring(6);
-        title = r.data.title?.trim() || titleInTags || name;
       }
+      // If the title is provided, we use it.
+      // Otherwise, we default to either:
+      // - the title tag if any
+      // - the name of the table
+      const titleInTags = tags
+        ?.find((t) => t.startsWith("title:"))
+        ?.substring(6);
+      const title = r.data.title?.trim() || titleInTags || name;
 
       const tableId = maybeTableId || generateRandomModelSId();
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -299,7 +299,7 @@ async function handler(
         }
 
         mimeType = r.data.mime_type;
-        title = r.data.title;
+        title = r.data.title.trim();
       } else {
         // TODO(content-node): get rid of this once the use of timestamp columns in core has been rationalized
         if (r.data.timestamp) {
@@ -329,16 +329,10 @@ async function handler(
         // Otherwise, we default to either:
         // - the title tag if any
         // - the name of the table
-        if (r.data.title && r.data.title.trim()) {
-          title = r.data.title.trim();
-        } else {
-          const titleTag = tags?.find((t) => t.startsWith("title:"));
-          if (titleTag) {
-            title = titleTag.substring(6);
-          } else {
-            title = name;
-          }
-        }
+        const titleInTags = tags
+          ?.find((t) => t.startsWith("title:"))
+          ?.substring(6);
+        title = r.data.title?.trim() || titleInTags || name;
       }
 
       const tableId = maybeTableId || generateRandomModelSId();


### PR DESCRIPTION
## Description

- We have documents that have an empty title in the elasticsearch index `core.data_sources_nodes`.
- These empty titles break the pagination (the `search_after` cursor more specifically).
- Validation was added in `core` to reject these documents: https://github.com/dust-tt/dust/pull/11401.
- A document breaking the validation was observed [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1742234502100909), this PR addresses its case by adding a missing trim in `api/v1`.
- Note: mutating the title passed by the user of `api/v1` is not great, but we really want to sanitize the title and rely on the fallback if necessary.

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy front.
- Delete the upsert queue workflow, reupsert the document.