### PR TITLE
[API v1 - Conversations] Require non-empty user messages

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -53,12 +53,7 @@ import type {
   UserMessageType,
   WorkspaceType,
 } from "@app/types";
-import {
-  assertNever,
-  isTextContent,
-  isUserMessageTypeModel,
-  SUPPORTED_MODEL_CONFIGS,
-} from "@app/types";
+import { assertNever, SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_ACTIONS_PER_STEP = 16;

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -511,27 +511,13 @@ async function* runMultiActionsAgent(
     runConfig.MODEL.anthropic_beta_flags = anthropicBetaFlags;
   }
 
-  const renderedConversation = modelConversationRes.value.modelConversation;
-  // Anthropic does not accept empty user message.
-  if (model.providerId === "anthropic") {
-    renderedConversation.messages.forEach((m) => {
-      if (isUserMessageTypeModel(m)) {
-        m.content.forEach((c) => {
-          if (isTextContent(c) && c.text.length === 0) {
-            c.text = "Answer according to provided context and instructions.";
-          }
-        });
-      }
-    });
-  }
-
   const res = await runActionStreamed(
     auth,
     "assistant-v2-multi-actions-agent",
     runConfig,
     [
       {
-        conversation: renderedConversation,
+        conversation: modelConversationRes.value.modelConversation,
         specifications,
         prompt,
       },

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -327,7 +327,7 @@
  *       properties:
  *         content:
  *           type: string
- *           description: The content of the message
+ *           description: The content of the message. Should not be empty.
  *           example: "This is my message"
  *         mentions:
  *           type: array

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -4,7 +4,11 @@ import { getSupportedNonImageMimeTypes } from "../../files";
 import { MIME_TYPES_VALUES } from "../../shared/internal_mime_types";
 
 export const InternalPostMessagesRequestBodySchema = t.type({
-  content: t.string,
+  content: t.refinement(
+    t.string,
+    (s): s is string => s.length > 0,
+    "NonEmptyString"
+  ),
   mentions: t.array(t.type({ configurationId: t.string })),
   context: t.type({
     timezone: t.string,

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -81,12 +81,6 @@ export function isContentFragmentMessageTypeModel(
   return contentFragment.role === "content_fragment";
 }
 
-export function isUserMessageTypeModel(
-  userMessage: ModelMessageTypeMultiActions
-): userMessage is UserMessageTypeModel {
-  return userMessage.role === "user";
-}
-
 export type ModelConversationTypeMultiActions = {
   messages: ModelMessageTypeMultiActions[];
 };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1787,7 +1787,7 @@ export type GetWorkspaceFeatureFlagsResponseType = z.infer<
 
 export const PublicPostMessagesRequestBodySchema = z.intersection(
   z.object({
-    content: z.string(),
+    content: z.string().min(1),
     mentions: z.array(
       z.object({
         configurationId: z.string(),
@@ -1873,7 +1873,7 @@ export const PublicPostConversationsRequestBodySchema = z.intersection(
     message: z.union([
       z.intersection(
         z.object({
-          content: z.string(),
+          content: z.string().min(1),
           mentions: z.array(
             z.object({
               configurationId: z.string(),


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2123 (see also slack thread in issue)

Reverts #10650 . Throws 400 if empty string is passed as message

Risks
---
We are slightly changing the API v1 contract.

Risk: pissed off clients that used to send empty messages to non-anthropic clients and don't want to send " " instead.

Also, if we ever send empty messages internally, we'll soon know (but doubt we do, there's always the mention at least)

Deploy
---
- warn spendesk
- warn customer success team & user runner
- deploy front

