### PR TITLE
(fix) Poke sid link to agent was always going in the dust-apps workspace

### DIFF
--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -82,16 +82,18 @@ const UserMessageView = ({ message }: { message: UserMessageType }) => {
 const AgentMessageView = ({
   message,
   multiActionsApp,
+  workspaceId,
 }: {
   message: PokeAgentMessageType;
   multiActionsApp: Action;
+  workspaceId: string;
 }) => {
   return (
     <div className="ml-4 pt-2 text-sm text-element-700">
       <div className="font-bold">
         [agent] @{message.configuration.name} {"(sId="}
         <a
-          href={`/poke/${multiActionsApp.app.workspaceId}/assistants/${message.configuration.sId}`}
+          href={`/poke/${workspaceId}/assistants/${message.configuration.sId}`}
           target="_blank"
           className="text-action-500"
         >
@@ -220,6 +222,7 @@ const ConversationPage = ({
                             key={`message-${i}-${j}`}
                             multiActionsApp={multiActionsApp}
                             message={m}
+                            workspaceId={workspaceId}
                           />
                         );
                       }


### PR DESCRIPTION
## Description

Poke sid link to agent was always going in the dust-apps workspace

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
