### PR TITLE
Fixing remaining dark mode colors on Dust App CodeEditor

### DIFF
--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -368,7 +368,6 @@ export default function Chat({
                 minHeight={80}
                 className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
                 style={{
-                  color: "rgb(55 65 81)",
                   fontSize: 13,
                   fontFamily:
                     "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -266,7 +266,6 @@ export default function DataSource({
                 minHeight={80}
                 className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
                 style={{
-                  color: "rgb(55 65 81)",
                   fontSize: 13,
                   fontFamily:
                     "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",

--- a/front/components/app/blocks/Database.tsx
+++ b/front/components/app/blocks/Database.tsx
@@ -260,7 +260,6 @@ export default function Database({
               minHeight={80}
               className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
               style={{
-                color: "rgb(55 65 81)",
                 fontSize: 13,
                 fontFamily:
                   "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",

--- a/front/components/app/blocks/LLM.tsx
+++ b/front/components/app/blocks/LLM.tsx
@@ -448,11 +448,9 @@ export default function LLM({
                 minHeight={80}
                 className="rounded-lg bg-slate-100 dark:bg-slate-100-night"
                 style={{
-                  color: "rgb(55 65 81)",
                   fontSize: 13,
                   fontFamily:
                     "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                  backgroundColor: "rgb(241 245 249)",
                 }}
               />
             </div>


### PR DESCRIPTION
## Description

Some blocks were not properly updated for dark mode, we need to remove the forced colors to rely on the theme. 


## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 