### PR TITLE
fix(`api/v1`) - Add trimming on title in tags

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -565,7 +565,8 @@ async function handler(
       const tags = r.data.tags || [];
       const titleInTags = tags
         .find((t) => t.startsWith("title:"))
-        ?.substring(6);
+        ?.substring(6)
+        ?.trim();
 
       // Use titleInTags if no title is provided.
       const title = r.data.title?.trim() || titleInTags || "Untitled Document";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -317,7 +317,8 @@ async function handler(
       // - the name of the table
       const titleInTags = tags
         ?.find((t) => t.startsWith("title:"))
-        ?.substring(6);
+        ?.substring(6)
+        ?.trim();
       const title = r.data.title?.trim() || titleInTags || name;
 
       const tableId = maybeTableId || generateRandomModelSId();


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/11422.
- Context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1742292306879319).
- A google drive document is stuck in the upsert queue due to having an empty title.
- We get a the following title from Google's API: " ", we then pass it in the tags, where it is read and passed as is to the upsert-queue document.
- This PR adds trimming on the title found in the tags.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
- Terminate upsert-queue workflow.
- Run CLI command to reupsert the document.