### PR TITLE
Improve Intercom upsert collection error handling

### DIFF
--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -340,6 +340,7 @@ export async function syncLevel1CollectionWithChildrenActivity({
     region: intercomWorkspace.region,
     currentSyncMs,
   });
+
   return {
     collectionId,
     action: "upserted",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR improves error handling around upserting Intercom collections ([example](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZWo4boEWALU0gAAABhBWldvNGNtU0FBQXR1a3NXX1MzeUNBQUgAAAAkMDE5NWE4ZTEtY2EwNS00YTgxLThmNjItMjA3ZmI5NjY3NTA5AAAFxQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1742293558000&to_ts=1742294458000&live=true)). As the `Promise.all()` wraps all the errors being thrown under an array of object, making the errors not actionnable.  

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
