### PR TITLE
Add fallback on titles for `data_sources_folders`

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -31,8 +31,7 @@ import {
 } from "@connectors/lib/models/intercom";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
 import {
   concurrentExecutor,
   MIME_TYPES,
@@ -231,7 +230,7 @@ export async function upsertCollectionWithChildren({
   await upsertDataSourceFolder({
     dataSourceConfig,
     folderId: internalCollectionId,
-    title: collection.name,
+    title: collection.name.trim() || "Untitled Collection",
     parents: collectionParents,
     parentId: collectionParents[1] || null,
     mimeType: MIME_TYPES.INTERCOM.COLLECTION,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -174,7 +174,7 @@ async function handler(
         timestamp: timestamp || null,
         parentId: parentId || null,
         parents: parents || [fId],
-        title: title,
+        title: title.trim() || "Untitled Folder",
         mimeType: mime_type,
         sourceUrl: source_url ?? null,
         providerVisibility: provider_visibility,


### PR DESCRIPTION
## Description

- Follow up on https://dust4ai.slack.com/archives/C050SM8NSPK/p1742297811847259.
- Follow up on https://github.com/dust-tt/dust/pull/11422.
- This PR adds a fallback for Intercom collection without a title ("Untitled Collection", similarly to what we do in Google Drive, Notion, etc...).
- This PR also adds a global fallback in `api/v1` for any folder without a title.

## Tests

## Risk

## Deploy Plan

- Deploy `connectors`.
- Deploy `front`.
