### PR TITLE
Viz SVG download + improvements

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -6,7 +6,7 @@ const CONTENT_SECURITY_POLICIES = [
   `style-src 'self' 'unsafe-inline' *.typekit.net;`,
   `img-src 'self' data: https:;`,
   `connect-src 'self' blob: *.google-analytics.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com;`,
-  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net;`,
+  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt localhost:3007 *.hsforms.net;`,
   `font-src 'self' data: *.typekit.net;`,
   `object-src 'none';`,
   `form-action 'self';`,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -6,7 +6,7 @@ const CONTENT_SECURITY_POLICIES = [
   `style-src 'self' 'unsafe-inline' *.typekit.net;`,
   `img-src 'self' data: https:;`,
   `connect-src 'self' blob: *.google-analytics.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com;`,
-  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt localhost:3007 *.hsforms.net;`,
+  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net;`,
   `font-src 'self' data: *.typekit.net;`,
   `object-src 'none';`,
   `form-action 'self';`,

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -282,17 +282,14 @@ export function VisualizationWrapper({
   return (
     <div className="relative font-sans group/viz">
       <div className="flex flex-row gap-2 absolute top-2 right-2 bg-white rounded transition opacity-0 group-hover/viz:opacity-100 z-50">
-        <button
-          onClick={handleScreenshotDownload}
-          className="hover:bg-slate-200 rounded p-2 border border-slate-200"
-        >
-          <Download size={20} />
+        <button onClick={handleScreenshotDownload} className="">
+          <Download size={17} className="text-slate-500 hover:text-slate-900" />
         </button>
-        <button
-          className="hover:bg-slate-200 rounded p-2 border border-slate-200"
-          onClick={handleDisplayCode}
-        >
-          <SquareTerminal size={20} />
+        <button className="" onClick={handleDisplayCode}>
+          <SquareTerminal
+            size={17}
+            className="text-slate-500 hover:text-slate-900"
+          />
         </button>
       </div>
       <div ref={ref}>

--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "dd-trace": "^5.1.0",
         "html-to-image": "^1.11.11",
-        "lucide-react": "^0.446.0",
+        "lucide-react": "^0.483.0",
         "next": "^14.2.5",
         "papaparse": "^5.4.1",
         "react": "^18",
@@ -3926,11 +3926,11 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/lucide-react": {
-      "version": "0.446.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.446.0.tgz",
-      "integrity": "sha512-BU7gy8MfBMqvEdDPH79VhOXSEgyG8TSPOKWaExWGCQVqnGH7wGgDngPbofu+KdtVjPQBWbEmnfMTq90CTiiDRg==",
+      "version": "0.483.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.483.0.tgz",
+      "integrity": "sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {

--- a/viz/package.json
+++ b/viz/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "dd-trace": "^5.1.0",
     "html-to-image": "^1.11.11",
-    "lucide-react": "^0.446.0",
+    "lucide-react": "^0.483.0",
     "next": "^14.2.5",
     "papaparse": "^5.4.1",
     "react": "^18",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/2384

- Add support for download SVG (new icon)
- Added title on button so that we get a hover
- Simplified the design of the buttons

Building a dropdown will be terribly ugly since we don't have any design system available. 3  buttons is not great. But SVG download is pretty useful for exploiting these things. I think it strikes a decent trade-off let's see how it goes.

![Screenshot from 2025-03-18 14-09-37](https://github.com/user-attachments/assets/c8fb1737-f447-4ec8-9c0e-090816f9d5f5)
![Screenshot from 2025-03-18 14-09-27](https://github.com/user-attachments/assets/371580ee-b81c-4038-8fd4-0c958777c51a)
![Screenshot from 2025-03-18 14-09-16](https://github.com/user-attachments/assets/0a0fceff-2782-4369-99bd-1c11ad4560a8)


## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `viz`