### PR TITLE
Add a static link to manage stripe subscription

### DIFF
--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -50,6 +50,11 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
       url = `/w/${selection.lastWorkspaceId}`;
     }
 
+    // This allows linking to the workspace subscription page from the documentation.
+    if (context.query.goto === "subscription") {
+      url = url + "/subscription/manage";
+    }
+
     if (context.query.inviteToken) {
       url = `/api/login?inviteToken=${inviteToken}`;
     }

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -168,27 +168,7 @@ export default function Subscription({
     submit: handleGoToStripePortal,
     isSubmitting: isGoingToStripePortal,
   } = useSubmitFunction(async () => {
-    const res = await fetch("/api/stripe/portal", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        workspaceId: owner.sId,
-      }),
-    });
-    if (!res.ok) {
-      sendNotification({
-        type: "error",
-        title: "Failed to open billing dashboard",
-        description: "Failed to open billing dashboard.",
-      });
-    } else {
-      const content = await res.json();
-      if (content.portalUrl) {
-        window.open(content.portalUrl, "_blank");
-      }
-    }
+    await router.push(`/w/${owner.sId}/subscription/manage`);
   });
 
   const { submit: skipFreeTrial, isSubmitting: skipFreeTrialIsSubmitting } =

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -168,7 +168,7 @@ export default function Subscription({
     submit: handleGoToStripePortal,
     isSubmitting: isGoingToStripePortal,
   } = useSubmitFunction(async () => {
-    await router.push(`/w/${owner.sId}/subscription/manage`);
+    window.open(`/w/${owner.sId}/subscription/manage`, "_blank");
   });
 
   const { submit: skipFreeTrial, isSubmitting: skipFreeTrialIsSubmitting } =

--- a/front/pages/w/[wId]/subscription/manage.tsx
+++ b/front/pages/w/[wId]/subscription/manage.tsx
@@ -1,0 +1,64 @@
+import { Spinner } from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import type { WorkspaceType } from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  owner: WorkspaceType;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  if (!owner || !auth.isAdmin()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+    },
+  };
+});
+
+export default function ManageSubscription({
+  owner,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+
+  useEffect(() => {
+    async function redirectToStripePortal() {
+      const res = await fetch("/api/stripe/portal", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          workspaceId: owner.sId,
+        }),
+      });
+
+      if (!res.ok) {
+        await router.push(`/w/${owner.sId}/subscription`);
+        return;
+      }
+
+      const content = await res.json();
+      if (content.portalUrl) {
+        window.location.href = content.portalUrl;
+      } else {
+        await router.push(`/w/${owner.sId}/subscription`);
+      }
+    }
+
+    void redirectToStripePortal();
+  }, [owner.sId, router]);
+
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <Spinner />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Users are complaining that they can't find their manage subscription link easily
On top of the change for visibility in the subscription management page, we also want to link from the documentation directly to the stripe portal. 
So we're adding a static link: `https://dust.tt?goto=subscription` that will redirect to the stripe portal of the last visited workspace.

When deployed we'll add the link to the documentation here: https://docs.dust.tt/docs/subscriptions

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
