### PR TITLE
[Conversations - Fragment] Return 400 on image format not supported

### DIFF
--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -1,8 +1,5 @@
-import type {
-  ProcessAndStoreFileError} from "@app/lib/api/files/upload";
-import {
-  processAndStoreFile
-} from "@app/lib/api/files/upload";
+import type { ProcessAndStoreFileError } from "@app/lib/api/files/upload";
+import { processAndStoreFile } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -1,4 +1,8 @@
-import { processAndStoreFile } from "@app/lib/api/files/upload";
+import type {
+  ProcessAndStoreFileError} from "@app/lib/api/files/upload";
+import {
+  processAndStoreFile
+} from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -38,7 +42,9 @@ export async function toFileContentFragment(
     contentFragment: ContentFragmentInputWithContentType;
     fileName?: string;
   }
-): Promise<Result<ContentFragmentInputWithFileIdType, { message: string }>> {
+): Promise<
+  Result<ContentFragmentInputWithFileIdType, ProcessAndStoreFileError>
+> {
   const file = await FileResource.makeNew({
     contentType: contentFragment.contentType,
     fileName:
@@ -58,8 +64,10 @@ export async function toFileContentFragment(
 
   if (processRes.isErr()) {
     return new Err({
+      name: "dust_error",
       message:
         `Error creating file for content fragment: ` + processRes.error.message,
+      code: processRes.error.code,
     });
   }
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -114,7 +114,7 @@ async function handler(
         }
       }
       const { context, ...rest } = r.data;
-      let contentFragment = rest;
+      const contentFragment = rest;
 
       // If we receive a content fragment that is not file based, we transform it to a file-based
       // one.
@@ -123,9 +123,17 @@ async function handler(
           contentFragment,
         });
         if (contentFragmentRes.isErr()) {
+          if (contentFragmentRes.error.code === "file_type_not_supported") {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: contentFragmentRes.error.message,
+              },
+            });
+          }
           throw new Error(contentFragmentRes.error.message);
         }
-        contentFragment = contentFragmentRes.value;
       }
 
       const contentFragmentRes = await postNewContentFragment(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -114,7 +114,7 @@ async function handler(
         }
       }
       const { context, ...rest } = r.data;
-      const contentFragment = rest;
+      let contentFragment = rest;
 
       // If we receive a content fragment that is not file based, we transform it to a file-based
       // one.
@@ -134,6 +134,7 @@ async function handler(
           }
           throw new Error(contentFragmentRes.error.message);
         }
+        contentFragment = contentFragmentRes.value;
       }
 
       const contentFragmentRes = await postNewContentFragment(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -177,6 +177,15 @@ async function handler(
             contentFragment,
           });
           if (contentFragmentRes.isErr()) {
+            if (contentFragmentRes.error.code === "file_type_not_supported") {
+              return apiError(req, res, {
+                status_code: 400,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: contentFragmentRes.error.message,
+                },
+              });
+            }
             throw new Error(contentFragmentRes.error.message);
           }
           contentFragment = contentFragmentRes.value;


### PR DESCRIPTION
Description
---
Fixes issue from thread [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1742306443758049), so there is no unhandled api error.

Receiving a 3rd party message "Image format not supported", an unhandled api error is not warranted since not actionable by us. The best is to throw a 400.

Risks
---
low

Deploy
---
front
