### PR TITLE
Fix Salesforce oAuth finalize error

### DIFF
--- a/core/src/oauth/providers/salesforce.rs
+++ b/core/src/oauth/providers/salesforce.rs
@@ -79,19 +79,19 @@ impl Provider for SalesforceConnectionProvider {
         // Get Salesforce client_id and client_secret using the helper
         let (client_id, client_secret) = Self::get_credentials(related_credentials).await?;
 
-        let body = json!({
-            "grant_type": "authorization_code",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "code": code,
-            "redirect_uri": redirect_uri,
-            "code_verifier": code_verifier,
-        });
+        // Use a HashMap instead of json! for form data
+        let mut form_data = std::collections::HashMap::new();
+        form_data.insert("grant_type", "authorization_code");
+        form_data.insert("client_id", &client_id);
+        form_data.insert("client_secret", &client_secret);
+        form_data.insert("code", code);
+        form_data.insert("redirect_uri", redirect_uri);
+        form_data.insert("code_verifier", code_verifier);
 
         let req = reqwest::Client::new()
             .post(format!("{}/services/oauth2/token", instance_url))
             .header("Content-Type", "application/x-www-form-urlencoded")
-            .form(&body);
+            .form(&form_data);
 
         let raw_json = execute_request(ConnectionProvider::Salesforce, req)
             .await
@@ -128,17 +128,17 @@ impl Provider for SalesforceConnectionProvider {
 
         let (client_id, client_secret) = Self::get_credentials(related_credentials).await?;
 
-        let body = json!({
-            "grant_type": "refresh_token",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "refresh_token": refresh_token,
-        });
+        // Use a HashMap instead of json! for form data
+        let mut form_data = std::collections::HashMap::new();
+        form_data.insert("grant_type", "refresh_token");
+        form_data.insert("client_id", &client_id);
+        form_data.insert("client_secret", &client_secret);
+        form_data.insert("refresh_token", &refresh_token);
 
         let req = reqwest::Client::new()
             .post(format!("{}/services/oauth2/token", instance_url))
             .header("Content-Type", "application/x-www-form-urlencoded")
-            .form(&body);
+            .form(&form_data);
 
         let raw_json = execute_request(ConnectionProvider::Salesforce, req)
             .await


### PR DESCRIPTION
## Description

1. Replaced the json!({...}) objects with HashMap in both the finalize and refresh methods
2. Used proper form data structure with direct key-value pairs instead of JSON objects
3. Maintained the correct content type header (application/x-www-form-urlencoded)

The issue was that when using .form() with a JSON object created by json!({...}), the serialization wasn't producing proper form data. Using a HashMap ensures the parameters are properly encoded as form data.

This should resolve the "unsupported_grant_type" error you were encountering when trying to finalize the Salesforce OAuth flow.

## Tests

Locally.

## Risk

Salesforce only - Currently under feature flag and 

## Deploy Plan

Deploy oauth
