### PR TITLE
Salesforce domain must be ".salesforce.com" instead of ".force.com"

### DIFF
--- a/front/components/data_source/SalesforceOAuthExtractConfig.tsx
+++ b/front/components/data_source/SalesforceOAuthExtractConfig.tsx
@@ -100,7 +100,7 @@ export function SalesforceOauthExtraConfig({
         message={
           isPkceError
             ? "Error loading Salesforce OAuth credentials. Check if your url is correct and try again or contact us at support@dust.tt."
-            : "Must be a valid Salesforce domain in https and ending with .salesforce.com or .force.com"
+            : "Must be a valid Salesforce domain in https and ending with .salesforce.com"
         }
         name="instance_url"
         value={extraConfig.instance_url ?? ""}

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -153,9 +153,6 @@ const config = {
   getOAuthZendeskClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_ZENDESK_CLIENT_ID");
   },
-  getOAuthSalesforceClientId: (): string => {
-    return EnvironmentConfig.getEnvVariable("OAUTH_SALESFORCE_CLIENT_ID");
-  },
   // Text extraction.
   getTextExtractionUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -63,7 +63,7 @@ export function isValidSalesforceDomain(s: unknown): s is string {
   return (
     typeof s === "string" &&
     s.startsWith("https://") &&
-    (s.endsWith(".salesforce.com") || s.endsWith(".force.com"))
+    s.endsWith(".salesforce.com")
   );
 }
 


### PR DESCRIPTION
## Description

It seems that using .force urls are raising a "unsupported_grant_type" error. 
Also removing 'getOAuthSalesforceClientId` that is not used. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
