### PR TITLE
[front] - enh(StatusBanner): prettify component

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -1,5 +1,6 @@
 import {
   classNames,
+  cn,
   CollapseButton,
   NavigationList,
   NavigationListItem,
@@ -166,6 +167,46 @@ export const NavigationSidebar = React.forwardRef<
   );
 });
 
+interface StatusBannerProps {
+  variant?: "info" | "warning";
+  title: string;
+  description: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+function StatusBanner({
+  variant = "info",
+  title,
+  description,
+  footer,
+}: StatusBannerProps) {
+  const colorClasses = {
+    info: cn(
+      "border-info-200 dark:border-info-200-night",
+      "bg-info-100 dark:bg-info-100-night",
+      "text-info-900 dark:text-info-900-night"
+    ),
+    warning: cn(
+      "border-warning-200 dark:border-warning-200-night",
+      "bg-warning-100 dark:bg-warning-100-night",
+      "text-warning-900 dark:text-warning-900-night"
+    ),
+  };
+
+  return (
+    <div
+      className={cn(
+        "space-y-2 border-y px-3 py-3 text-xs",
+        colorClasses[variant]
+      )}
+    >
+      <div className="font-bold">{title}</div>
+      <div className="font-normal">{description}</div>
+      {footer && <div>{footer}</div>}
+    </div>
+  );
+}
+
 function AppStatusBanner() {
   const { appStatus } = useAppStatus();
 
@@ -177,39 +218,28 @@ function AppStatusBanner() {
 
   if (dustStatus) {
     return (
-      <div
-        className={classNames(
-          "space-y-2 border-y px-3 py-3 text-xs",
-          "border-pink-200 dark:border-pink-200-night",
-          "bg-pink-100 dark:bg-pink-100-night",
-          "text-pink-900 dark:text-pink-900-night"
-        )}
-      >
-        <div className="font-bold">{dustStatus.name}</div>
-        <div className="font-normal">{dustStatus.description}</div>
-        <div>
-          Check our{" "}
-          <Link href={dustStatus.link} target="_blank" className="underline">
-            status page
-          </Link>{" "}
-          for updates.
-        </div>
-      </div>
+      <StatusBanner
+        title={dustStatus.name}
+        description={dustStatus.description}
+        footer={
+          <>
+            Check our{" "}
+            <Link href={dustStatus.link} target="_blank" className="underline">
+              status page
+            </Link>{" "}
+            for updates.
+          </>
+        }
+      />
     );
   }
+
   if (providersStatus) {
     return (
-      <div
-        className={classNames(
-          "space-y-2 border-y px-3 py-3 text-xs",
-          "border-pink-200 dark:border-pink-200-night",
-          "bg-pink-100 dark:bg-pink-100-night",
-          "text-pink-900 dark:text-pink-900-night"
-        )}
-      >
-        <div className="font-bold">{providersStatus.name}</div>
-        <div className="font-normal">{providersStatus.description}</div>
-      </div>
+      <StatusBanner
+        title={providersStatus.name}
+        description={providersStatus.description}
+      />
     );
   }
 
@@ -224,59 +254,51 @@ function SubscriptionEndBanner({ endDate }: { endDate: number }) {
   });
 
   return (
-    <div
-      className={classNames(
-        "border-y px-3 py-3 text-xs",
-        "border-pink-200 dark:border-pink-200-night",
-        "bg-pink-100 dark:bg-pink-100-night",
-        "text-pink-900 dark:text-pink-900-night"
-      )}
-    >
-      <div className="font-bold">Subscription ending on {formattedEndDate}</div>
-      <div className="font-normal">
-        Connections will be deleted and members will be revoked. Details{" "}
-        <Link
-          href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
-          target="_blank"
-          className="underline"
-        >
-          here
-        </Link>
-        .
-      </div>
-    </div>
+    <StatusBanner
+      variant="warning"
+      title={`Subscription ending on ${formattedEndDate}`}
+      description={
+        <>
+          Connections will be deleted and members will be revoked. Details{" "}
+          <Link
+            href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
+            target="_blank"
+            className="underline"
+          >
+            here
+          </Link>
+          .
+        </>
+      }
+    />
   );
 }
 
 function SubscriptionPastDueBanner() {
   return (
-    <div
-      className={classNames(
-        "border-y px-3 py-3 text-xs",
-        "border-warning-200 dark:border-warning-200-night",
-        "bg-warning-100 dark:bg-warning-100-night",
-        "text-warning-900 dark:text-warning-900-night"
-      )}
-    >
-      <div className="font-bold">Your payment has failed!</div>
-      <div className="font-normal">
-        <br />
-        Please make sure to update your payment method in the Admin section to
-        maintain access to your workspace. We will retry in a few days.
-        <br />
-        <br />
-        After 3 attempts, your workspace will be downgraded to the free plan.
-        Connections will be deleted and members will be revoked. Details{" "}
-        <Link
-          href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
-          target="_blank"
-          className="underline"
-        >
-          here
-        </Link>
-        .
-      </div>
-    </div>
+    <StatusBanner
+      variant="warning"
+      title="Your payment has failed!"
+      description={
+        <>
+          <br />
+          Please make sure to update your payment method in the Admin section to
+          maintain access to your workspace. We will retry in a few days.
+          <br />
+          <br />
+          After 3 attempts, your workspace will be downgraded to the free plan.
+          Connections will be deleted and members will be revoked. Details{" "}
+          <Link
+            href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
+            target="_blank"
+            className="underline"
+          >
+            here
+          </Link>
+          .
+        </>
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## Description

This PR introduces a generic `StatusBanner` component to standardize status banners.

Note: changes are directly ported from https://github.com/dust-tt/dust/pull/11437. I created a new branch because the original one still had `types/` which is a bit annoying to rebase.

## Risk

Low

## Deploy Plan

Deploy front