### PR TITLE
[Google Drive] Permissions: catch ExternalOauthTokenError on oauth

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -247,21 +247,20 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
       );
     }
-    const authCredentials = (async () => {
-      try {
-        return await getAuthObject(c.connectionId);
-      } catch (e) {
-        if (e instanceof ExternalOAuthTokenError) {
-          return new Err(
-            new ConnectorManagerError(
-              "EXTERNAL_OAUTH_TOKEN_ERROR",
-              `Google Drive authorization error, please re-authorize. Error: ${e.message}`
-            )
-          );
-        }
-        throw e;
+    let authCredentials;
+    try {
+      authCredentials = await getAuthObject(c.connectionId);
+    } catch (e) {
+      if (e instanceof ExternalOAuthTokenError) {
+        return new Err(
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            `Google Drive authorization error, please re-authorize. Error: ${e.message}`
+          )
+        );
       }
-    })();
+      throw e;
+    }
 
     if (isTablesView && filterPermission !== "read") {
       return new Err(

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -247,20 +247,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
       );
     }
-    let authCredentials;
-    try {
-      authCredentials = await getAuthObject(c.connectionId);
-    } catch (e) {
-      if (e instanceof ExternalOAuthTokenError) {
-        return new Err(
-          new ConnectorManagerError(
-            "EXTERNAL_OAUTH_TOKEN_ERROR",
-            `Google Drive authorization error, please re-authorize. Error: ${e.message}`
-          )
-        );
-      }
-      throw e;
-    }
 
     if (isTablesView && filterPermission !== "read") {
       return new Err(
@@ -272,6 +258,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     }
 
     try {
+      const authCredentials = await getAuthObject(c.connectionId);
       const parentDriveId =
         parentInternalId && getDriveFileId(parentInternalId);
       if (filterPermission === "read") {
@@ -539,7 +526,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         return new Err(
           new ConnectorManagerError(
             "EXTERNAL_OAUTH_TOKEN_ERROR",
-            "Google Drive authorization error, please re-authorize."
+            `Google Drive authorization error, please re-authorize. Error: ${e.message}`
           )
         );
       }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -247,7 +247,21 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
       );
     }
-    const authCredentials = await getAuthObject(c.connectionId);
+    const authCredentials = (async () => {
+      try {
+        return await getAuthObject(c.connectionId);
+      } catch (e) {
+        if (e instanceof ExternalOAuthTokenError) {
+          return new Err(
+            new ConnectorManagerError(
+              "EXTERNAL_OAUTH_TOKEN_ERROR",
+              `Google Drive authorization error, please re-authorize. Error: ${e.message}`
+            )
+          );
+        }
+        throw e;
+      }
+    })();
 
     if (isTablesView && filterPermission !== "read") {
       return new Err(


### PR DESCRIPTION
Description
---
Fixes logs such as [this one](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZWtqXqKqiOouAAAABhBWld0cVl2d0FBQ3JzdmhIcEgzVHBnQUQAAAAkMDE5NWFkYWEtM2U2NS00ZDk2LWE5ZWEtYWQ3MGI0ZTUzZTM1AAAETg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1714135514324&to_ts=1714136414324)

ExternalOauthTokenError should be caught and not trigger an unhandled error. It is already the case for most calls, but in Google Drive retrievePermissions there was an uncaught one.

Risks
---
low

Deploy
---
connectors

