### PR TITLE
[front] - fix(AssistantBuilderRightPanel): remove bg

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -111,7 +111,7 @@ export default function AssistantBuilderRightPanel({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="shrink-0 bg-white pt-5">
+      <div className="shrink-0 pt-5">
         <Tabs
           value={rightPanelStatus.tab ?? "Preview"}
           onValueChange={(t) =>


### PR DESCRIPTION
## Description

This PR fixes the assistant drawer background colour which was hardcoded to white, leading to unwanted behaviour in dakr mode.

**References:**
- [Slack thread](https://dust4ai.slack.com/archives/C07R26W00MD/p1742319619238849)

## Risk

None

## Deploy Plan

Deploy front