### PR TITLE
[front] - fix(InputBarAttachmentsPicker): prevent duplicated attached nodes

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -232,7 +232,12 @@ export function AssistantInputBar({
   };
 
   const handleNodesAttachmentSelect = (node: DataSourceViewContentNode) => {
-    setAttachedNodes((prev) => [...prev, node]);
+    const isNodeAlreadyAttached = attachedNodes.some(
+      (attachedNode) => attachedNode.internalId === node.internalId
+    );
+    if (!isNodeAlreadyAttached) {
+      setAttachedNodes((prev) => [...prev, node]);
+    }
   };
 
   const handleNodesAttachmentRemove = (node: DataSourceViewContentNode) => {


### PR DESCRIPTION
## Description

This PR prevents from attaching multiple times the same node, this is especially relevant when pasting urls.

## Risk

Low

## Deploy Plan

Deploy front
