### PR TITLE
[oauth] Use correct contentType for slack finalize

### DIFF
--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -51,7 +51,7 @@ impl Provider for SlackConnectionProvider {
     ) -> Result<FinalizeResult, ProviderError> {
         let req = reqwest::Client::new()
             .post("https://slack.com/api/oauth.v2.access")
-            .header("Content-Type", "application/json; charset=utf-8")
+            .header("Content-Type", "application/x-www-form-urlencoded")
             .header("Authorization", format!("Basic {}", self.basic_auth()))
             // Very important, this will *not* work with JSON body.
             .form(&[("code", code), ("redirect_uri", redirect_uri)]);


### PR DESCRIPTION
## Description

We're sending url-encoded body but declaring application/json . Must send application/x-www-form-urlencoded 

## Tests

tested locally 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy oauth
