### PR TITLE
Folders improvements post title

### DIFF
--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -51,7 +51,7 @@ function isCoreAPIDocumentType(
 }
 
 interface Document {
-  name: string;
+  title: string;
   text: string;
   tags: string[];
   sourceUrl: string;
@@ -79,7 +79,7 @@ export const DocumentUploadOrEditModal = ({
   const sendNotification = useSendNotification();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [documentState, setDocumentState] = useState<Document>({
-    name: "",
+    title: "",
     text: "",
     tags: [],
     sourceUrl: "",
@@ -91,7 +91,7 @@ export const DocumentUploadOrEditModal = ({
   });
 
   const [editionStatus, setEditionStatus] = useState({
-    name: false,
+    title: false,
     content: false,
   });
 
@@ -151,12 +151,11 @@ export const DocumentUploadOrEditModal = ({
     async (document: Document) => {
       setIsUpsertingDocument(true);
       const body = {
-        name: initialId ?? document.name,
-        title: initialId ?? document.name,
+        title: initialId ?? document.title,
         mime_type: document.mimeType ?? "text/plain",
         timestamp: null,
         parent_id: null,
-        parents: [initialId ?? document.name],
+        parents: [initialId ?? document.title],
         section: { prefix: null, content: document.text, sections: [] },
         text: null,
         source_url: document.sourceUrl || undefined,
@@ -178,7 +177,7 @@ export const DocumentUploadOrEditModal = ({
       if (upsertRes) {
         onClose(true);
         setDocumentState({
-          name: "",
+          title: "",
           text: "",
           tags: [],
           sourceUrl: "",
@@ -186,7 +185,7 @@ export const DocumentUploadOrEditModal = ({
         });
         setEditionStatus({
           content: false,
-          name: false,
+          title: false,
         });
         setHasChanged(false);
       }
@@ -213,11 +212,11 @@ export const DocumentUploadOrEditModal = ({
   // We don't disable the save button, we show an error message instead.
   const onSave = useCallback(async () => {
     if (!isValidDocument) {
-      if (documentState.name.trim() === "") {
+      if (documentState.title.trim() === "") {
         sendNotification({
           type: "error",
-          title: "Missing document name",
-          description: "You must provide a name for the document.",
+          title: "Missing document title",
+          description: "You must provide a title for the document.",
         });
         return;
       }
@@ -279,7 +278,7 @@ export const DocumentUploadOrEditModal = ({
         setFileId(fileBlobs[0].fileId);
         setDocumentState((prev) => ({
           ...prev,
-          name: prev.name.length > 0 ? prev.name : selectedFile.name,
+          title: prev.title.length > 0 ? prev.title : selectedFile.name,
           mimeType: selectedFile.type,
           sourceUrl:
             prev.sourceUrl.length > 0
@@ -302,7 +301,7 @@ export const DocumentUploadOrEditModal = ({
   useEffect(() => {
     if (!initialId) {
       setDocumentState({
-        name: "",
+        title: "",
         text: "",
         tags: [],
         sourceUrl: "",
@@ -311,7 +310,7 @@ export const DocumentUploadOrEditModal = ({
     } else if (document && isCoreAPIDocumentType(document)) {
       setDocumentState((prev) => ({
         ...prev,
-        name: initialId,
+        title: initialId,
         text: document.text ?? "",
         tags: document.tags,
         sourceUrl: document.source_url ?? "",
@@ -322,9 +321,9 @@ export const DocumentUploadOrEditModal = ({
 
   // Effect: Validate the document state
   useEffect(() => {
-    const isNameValid = documentState.name.trim().length > 0;
+    const isTitleValid = documentState.title.trim().length > 0;
     const isContentValid = documentState.text.trim().length > 0;
-    setIsValidDocument(isNameValid && isContentValid);
+    setIsValidDocument(isTitleValid && isContentValid);
   }, [documentState]);
 
   return (
@@ -357,21 +356,21 @@ export const DocumentUploadOrEditModal = ({
                     <Page.SectionHeader title="Document title" />
                     <Input
                       placeholder="Document title"
-                      name="name"
+                      name="title"
                       maxLength={MAX_NAME_CHARS}
-                      value={documentState.name}
+                      value={documentState.title}
                       disabled={!!initialId}
                       onChange={(e) => {
-                        setEditionStatus((prev) => ({ ...prev, name: true }));
+                        setEditionStatus((prev) => ({ ...prev, title: true }));
                         setDocumentState((prev) => ({
                           ...prev,
-                          name: e.target.value,
+                          title: e.target.value,
                         }));
                         setHasChanged(true);
                       }}
                       message={
-                        !documentState.name && editionStatus.name
-                          ? "You must provide a name."
+                        !documentState.title && editionStatus.title
+                          ? "You must provide a title."
                           : null
                       }
                       messageStatus="error"

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -378,19 +378,6 @@ export async function upsertDocument({
     );
   }
 
-  // Add selection of tags as prefix to the section if they are present.
-  let tagsPrefix = "";
-  ["title", "author"].forEach((t) => {
-    nonNullTags.forEach((tag) => {
-      if (tag.startsWith(t + ":") && tag.length > t.length + 1) {
-        tagsPrefix += `$${t} : ${tag.slice(t.length + 1)}\n`;
-      }
-    });
-  });
-  if (tagsPrefix && generatedSection) {
-    generatedSection.prefix = tagsPrefix;
-  }
-
   if (!generatedSection) {
     return new Err(
       new DustError(

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -364,13 +364,10 @@ export async function upsertDocument({
       : section || null;
 
   const nonNullTags = tags || [];
+
   const titleInTags = nonNullTags
     .find((t) => t.startsWith("title:"))
     ?.substring(6);
-  if (!titleInTags) {
-    nonNullTags.push(`title:${title}`);
-  }
-
   if (titleInTags && titleInTags !== title) {
     logger.warn(
       { dataSourceId: dataSource.sId, documentId, titleInTags, title },

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -13,8 +13,8 @@ import type { PatchDocumentResponseBody } from "@app/pages/api/w/[wId]/spaces/[s
 import type {
   DataSourceViewType,
   LightWorkspaceType,
-  PatchDataSourceWithNameDocumentRequestBody,
-  PostDataSourceWithNameDocumentRequestBody,
+  PatchDataSourceDocumentRequestBody,
+  PostDataSourceDocumentRequestBody,
 } from "@app/types";
 
 export function useDataSourceViewDocument({
@@ -32,7 +32,8 @@ export function useDataSourceViewDocument({
     fetcher;
   const url =
     dataSourceView && documentId
-      ? `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/documents/${encodeURIComponent(documentId)}`
+      ? `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/` +
+        `${dataSourceView.sId}/documents/${encodeURIComponent(documentId)}`
       : null;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -54,7 +55,7 @@ export function useDataSourceViewDocument({
 export function useUpdateDataSourceViewDocument(
   owner: LightWorkspaceType,
   dataSourceView: DataSourceViewType,
-  documentName: string
+  documentId: string
 ) {
   const { mutateRegardlessOfQueryParams: mutateContentNodes } =
     useDataSourceViewContentNodes({
@@ -67,14 +68,16 @@ export function useUpdateDataSourceViewDocument(
   const { mutateDocument } = useDataSourceViewDocument({
     owner,
     dataSourceView,
-    documentId: documentName,
+    documentId,
     disabled: true, // Needed just to create
   });
 
   const sendNotification = useSendNotification();
 
-  const doUpdate = async (body: PatchDataSourceWithNameDocumentRequestBody) => {
-    const patchUrl = `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_sources/${dataSourceView.dataSource.sId}/documents/${encodeURIComponent(documentName)}`;
+  const doUpdate = async (body: PatchDataSourceDocumentRequestBody) => {
+    const patchUrl =
+      `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/` +
+      `data_sources/${dataSourceView.dataSource.sId}/documents/${encodeURIComponent(documentId)}`;
     const res = await fetch(patchUrl, {
       method: "PATCH",
       headers: {
@@ -121,8 +124,10 @@ export function useCreateDataSourceViewDocument(
 
   const sendNotification = useSendNotification();
 
-  const doCreate = async (body: PostDataSourceWithNameDocumentRequestBody) => {
-    const createUrl = `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_sources/${dataSourceView.dataSource.sId}/documents`;
+  const doCreate = async (body: PostDataSourceDocumentRequestBody) => {
+    const createUrl =
+      `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/` +
+      `data_sources/${dataSourceView.dataSource.sId}/documents`;
     const res = await fetch(createUrl, {
       method: "POST",
       headers: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -14,7 +14,7 @@ import type {
   DocumentType,
   WithAPIErrorResponse,
 } from "@app/types";
-import { PostDataSourceWithNameDocumentRequestBodySchema } from "@app/types";
+import { PostDataSourceDocumentRequestBodySchema } from "@app/types";
 
 export const config = {
   api: {
@@ -82,8 +82,9 @@ async function handler(
         });
       }
 
-      const bodyValidation =
-        PostDataSourceWithNameDocumentRequestBodySchema.decode(req.body);
+      const bodyValidation = PostDataSourceDocumentRequestBodySchema.decode(
+        req.body
+      );
 
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -97,7 +98,6 @@ async function handler(
       }
 
       const {
-        name,
         source_url,
         text,
         section,
@@ -111,7 +111,10 @@ async function handler(
       } = bodyValidation.right;
 
       const upsertResult = await upsertDocument({
-        document_id: name, // using the name as the document_id since we don't have one here
+        // For folders documents created from the app (this endpoint) we use the document title as
+        // ID. This is inherited behavior that is perfectly valid but we might want to move to
+        // generating IDs in the future.
+        document_id: title,
         source_url,
         text,
         section,

--- a/front/types/api/public/data_sources.ts
+++ b/front/types/api/public/data_sources.ts
@@ -46,20 +46,9 @@ export type PostDataSourceDocumentRequestBody = t.TypeOf<
   typeof PostDataSourceDocumentRequestBodySchema
 >;
 
-export const PostDataSourceWithNameDocumentRequestBodySchema = t.intersection([
-  t.type({
-    name: t.string,
-  }),
-  PostDataSourceDocumentRequestBodySchema,
-]);
-
-export type PostDataSourceWithNameDocumentRequestBody = t.TypeOf<
-  typeof PostDataSourceWithNameDocumentRequestBodySchema
->;
-
 // Post and Patch require the same request body
-export type PatchDataSourceWithNameDocumentRequestBody = t.TypeOf<
-  typeof PostDataSourceWithNameDocumentRequestBodySchema
+export type PatchDataSourceDocumentRequestBody = t.TypeOf<
+  typeof PostDataSourceDocumentRequestBodySchema
 >;
 
 export const PatchDataSourceTableRequestBodySchema = t.type({


### PR DESCRIPTION
## Description

FIxes: https://github.com/dust-tt/tasks/issues/2420

In the context of folders manual uploads:

- Stop injecting `title:X` tags since we have titles now
- Stop injecting `$title: X` as prefix because it's not idempotent so if you re-edit your doc it piles up. It's a bit of a loss but it wasn't really principled. Also we we're not doing it in api/v1 so it's better aligned this way.
- Remove references to `name` in the font-end which don't make any sense now that we have title.

I kept documentId at creation to be equal to title. We could generate an sId but it's not required so leaving as is.

## Tests

Tested locally. Covered to some extent by tests.

## Risk

Low

## Deploy Plan

- deploy `front`