### PR TITLE
[front] - refacto: add `useDebounce` hook

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useDebounce } from "@app/hooks/useDebounce";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import {
@@ -134,9 +135,15 @@ export function DataSourceViewsSelector({
   const [searchResult, setSearchResult] = useState<
     DataSourceViewContentNode | undefined
   >();
-  const [searchSpaceText, setSearchSpaceText] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState<string>("");
-  const [isDebouncing, setIsDebouncing] = useState(false);
+  const {
+    inputValue: searchSpaceText,
+    debouncedValue: debouncedSearch,
+    isDebouncing,
+    setValue: setSearchSpaceText,
+  } = useDebounce("", {
+    delay: 300,
+    minLength: MIN_SEARCH_QUERY_SIZE,
+  });
 
   const { searchResultNodes, isSearchLoading, warningCode } = useSpaceSearch({
     dataSourceViews,
@@ -146,20 +153,6 @@ export function DataSourceViewsSelector({
     viewType,
     space,
   });
-
-  useEffect(() => {
-    setIsDebouncing(true);
-    const timeout = setTimeout(() => {
-      setDebouncedSearch(
-        searchSpaceText.length >= MIN_SEARCH_QUERY_SIZE ? searchSpaceText : ""
-      );
-      setIsDebouncing(false);
-    }, 300);
-    return () => {
-      clearTimeout(timeout);
-      setIsDebouncing(false);
-    };
-  }, [searchSpaceText]);
 
   useEffect(() => {
     if (searchResult) {

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -19,6 +19,7 @@ import type { SpaceSearchContextType } from "@app/components/spaces/search/Space
 import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { SpacePageHeader } from "@app/components/spaces/SpacePageHeaders";
 import { useCursorPaginationForDataTable } from "@app/hooks/useCursorPaginationForDataTable";
+import { useDebounce } from "@app/hooks/useDebounce";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import {
   DATA_SOURCE_MIME_TYPE,
@@ -161,7 +162,6 @@ function BackendSearch({
   parentId,
 }: FullBackendSearchProps) {
   const { q: searchParam } = useQueryParams(["q"]);
-  const searchTerm = searchParam.value || "";
 
   const [searchResultDataSourceView, setSearchResultDataSourceView] =
     React.useState<DataSourceViewType | null>(null);
@@ -180,16 +180,27 @@ function BackendSearch({
     setEffectiveContentNode(null);
   }, []);
 
-  // For backend search, we need to debounce the search term.
-  const [debouncedSearch, setDebouncedSearch] = React.useState<string>("");
   const [searchResults, setSearchResults] = React.useState<
     DataSourceViewContentNode[]
   >([]);
 
-  // Determine whether to show search results or children.
+  const {
+    inputValue: searchTerm,
+    debouncedValue: debouncedSearch,
+    isDebouncing,
+    setValue: setSearchValue,
+  } = useDebounce(searchParam.value || "", {
+    delay: 300,
+    minLength: MIN_SEARCH_QUERY_SIZE,
+  });
+
+  const handleSearchChange = (value: string) => {
+    searchParam.setParam(value);
+    setSearchValue(value);
+  };
+
   const shouldShowSearchResults = debouncedSearch.length > 0;
 
-  // Transition state.
   const [isChanging, setIsChanging] = React.useState(false);
   const [showSearch, setShowSearch] = React.useState(shouldShowSearchResults);
   const [searchHitCount, setSearchHitCount] = React.useState(0);
@@ -201,24 +212,12 @@ function BackendSearch({
     tablePagination,
   } = useCursorPaginationForDataTable(PAGE_SIZE);
 
-  // Debounce search term for backend search.
+  // Reset pagination when debounced search changes
   React.useEffect(() => {
-    const timeout = setTimeout(() => {
-      const newSearchTerm =
-        searchTerm.length >= MIN_SEARCH_QUERY_SIZE ? searchTerm : "";
-      if (newSearchTerm !== debouncedSearch) {
-        // Reset pagination when search term changes
-        resetPagination();
-        setDebouncedSearch(newSearchTerm);
-      }
-    }, 300);
+    resetPagination();
+  }, [debouncedSearch, resetPagination]);
 
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [searchTerm, debouncedSearch, resetPagination]);
-
-  // Use the space search hook for backend search.
+  // Use the space search hook for backend search
   const {
     isSearchLoading,
     isSearchValidating,
@@ -235,6 +234,9 @@ function BackendSearch({
     space,
     viewType,
   });
+
+  // Combined loading state
+  const isLoading = isDebouncing || isSearchLoading || isSearchValidating;
 
   React.useEffect(() => {
     if (tablePagination.pageIndex === 0) {
@@ -263,13 +265,13 @@ function BackendSearch({
     tablePagination.pageIndex,
   ]);
 
-  // Handle transition when search state changes.
+  // Handle transition when search state changes
   React.useEffect(() => {
     if (shouldShowSearchResults !== showSearch) {
       setIsChanging(true);
       const timer = setTimeout(() => {
         setShowSearch(shouldShowSearchResults);
-        // Small delay to start fade-in after content change.
+        // Small delay to start fade-in after content change
         setTimeout(() => setIsChanging(false), 50);
       }, 150);
 
@@ -278,22 +280,17 @@ function BackendSearch({
   }, [shouldShowSearchResults, showSearch]);
 
   React.useEffect(() => {
-    if (
-      totalNodesCount !== undefined &&
-      !isSearchValidating &&
-      !isSearchLoading
-    ) {
+    if (totalNodesCount !== undefined && !isSearchValidating && !isLoading) {
       setSearchHitCount(totalNodesCount);
     }
-  }, [isSearchLoading, isSearchValidating, totalNodesCount]);
-
+  }, [isLoading, isSearchValidating, totalNodesCount]);
   return (
     <SpaceSearchContext.Provider value={searchContextValue}>
       <SearchInput
         name="search"
         placeholder="Search (Name)"
         value={searchTerm}
-        onChange={searchParam.setParam}
+        onChange={handleSearchChange}
         disabled={isSearchDisabled}
       />
 

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -235,7 +235,6 @@ function BackendSearch({
     viewType,
   });
 
-  // Combined loading state
   const isLoading = isDebouncing || isSearchLoading || isSearchValidating;
 
   React.useEffect(() => {
@@ -271,7 +270,7 @@ function BackendSearch({
       setIsChanging(true);
       const timer = setTimeout(() => {
         setShowSearch(shouldShowSearchResults);
-        // Small delay to start fade-in after content change
+        // Small delay to start fade-in after content change.
         setTimeout(() => setIsChanging(false), 50);
       }, 150);
 

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -6,43 +6,34 @@ interface UseDebounceOptions {
   minLength?: number;
 }
 
-export function useDebounce<T>(
-  initialValue: T,
+export function useDebounce(
+  initialValue: string,
   options: UseDebounceOptions = {}
 ) {
   const { delay = 300, minLength = 0 } = options;
 
-  // Input value (immediate)
-  const [inputValue, setInputValue] = useState<T>(initialValue);
-  // Debounced value (delayed)
-  const [debouncedValue, setDebouncedValue] = useState<T>(initialValue);
-  // Loading state during debounce
+  const [inputValue, setInputValue] = useState<string>(initialValue);
+  const [debouncedValue, setDebouncedValue] = useState<string>(initialValue);
   const [isDebouncing, setIsDebouncing] = useState(false);
 
   // Create debounced function
   const debouncedUpdate = useRef(
-    debounce((value: T) => {
+    debounce((value: string) => {
       setDebouncedValue(value);
       setIsDebouncing(false);
     }, delay)
   ).current;
 
   // Update function
-  const setValue = (value: T) => {
+  const setValue = (value: string) => {
     setInputValue(value);
 
-    // String length check if applicable
-    if (
-      typeof value === "string" &&
-      minLength > 0 &&
-      value.length < minLength
-    ) {
-      setDebouncedValue("" as unknown as T);
+    if (minLength > 0 && value.length < minLength) {
+      setDebouncedValue("");
       setIsDebouncing(false);
       debouncedUpdate.cancel();
       return;
     }
-
     setIsDebouncing(true);
     debouncedUpdate(value);
   };
@@ -55,11 +46,11 @@ export function useDebounce<T>(
   }, [debouncedUpdate]);
 
   return {
-    inputValue, // Immediate value (for UI)
-    debouncedValue, // Delayed value (for operations)
-    isDebouncing, // Loading state
-    setValue, // Update function
-    flush: debouncedUpdate.flush, // Force update immediately
-    cancel: debouncedUpdate.cancel, // Cancel pending update
+    inputValue,
+    debouncedValue,
+    isDebouncing,
+    setValue,
+    flush: debouncedUpdate.flush,
+    cancel: debouncedUpdate.cancel,
   };
 }

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -1,0 +1,65 @@
+import { debounce } from "lodash";
+import { useEffect, useRef, useState } from "react";
+
+interface UseDebounceOptions {
+  delay?: number;
+  minLength?: number;
+}
+
+export function useDebounce<T>(
+  initialValue: T,
+  options: UseDebounceOptions = {}
+) {
+  const { delay = 300, minLength = 0 } = options;
+
+  // Input value (immediate)
+  const [inputValue, setInputValue] = useState<T>(initialValue);
+  // Debounced value (delayed)
+  const [debouncedValue, setDebouncedValue] = useState<T>(initialValue);
+  // Loading state during debounce
+  const [isDebouncing, setIsDebouncing] = useState(false);
+
+  // Create debounced function
+  const debouncedUpdate = useRef(
+    debounce((value: T) => {
+      setDebouncedValue(value);
+      setIsDebouncing(false);
+    }, delay)
+  ).current;
+
+  // Update function
+  const setValue = (value: T) => {
+    setInputValue(value);
+
+    // String length check if applicable
+    if (
+      typeof value === "string" &&
+      minLength > 0 &&
+      value.length < minLength
+    ) {
+      setDebouncedValue("" as unknown as T);
+      setIsDebouncing(false);
+      debouncedUpdate.cancel();
+      return;
+    }
+
+    setIsDebouncing(true);
+    debouncedUpdate(value);
+  };
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      debouncedUpdate.cancel();
+    };
+  }, [debouncedUpdate]);
+
+  return {
+    inputValue, // Immediate value (for UI)
+    debouncedValue, // Delayed value (for operations)
+    isDebouncing, // Loading state
+    setValue, // Update function
+    flush: debouncedUpdate.flush, // Force update immediately
+    cancel: debouncedUpdate.cancel, // Cancel pending update
+  };
+}


### PR DESCRIPTION
## Description

This PR introduces a reusable `useDebounce` hook to standardize debounce handling across search inputs. The hook encapsulates common debounce logic including minimum length checks, loading states, and cleanup. It replaces multiple custom debounce implementations with a single solution

## Risk

Moderate, breaking search across different places

## Deploy Plan

- Deploy front-edge
- Deploy front