### PR TITLE
[Upsert] Prevent empty title in v1

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -656,7 +656,7 @@ export async function upsertTable({
   ) {
     return new Err({
       name: "dust_error",
-      code: "title_too_long",
+      code: params.title.length === 0 ? "title_is_empty" : "title_too_long",
       message:
         "Invalid title:" +
         (params.title.length === 0

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -650,11 +650,18 @@ export async function upsertTable({
   }
 
   // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
-  if (params.title && params.title.length > MAX_NODE_TITLE_LENGTH) {
+  if (
+    params.title &&
+    (params.title.length > MAX_NODE_TITLE_LENGTH || params.title.length === 0)
+  ) {
     return new Err({
       name: "dust_error",
       code: "title_too_long",
-      message: `Invalid title: title too long (max ${MAX_NODE_TITLE_LENGTH} characters).`,
+      message:
+        "Invalid title:" +
+        (params.title.length === 0
+          ? "title cannot be empty"
+          : `title too long (max ${MAX_NODE_TITLE_LENGTH} characters).`),
     });
   }
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -569,7 +569,8 @@ async function handler(
         ?.trim();
 
       // Use titleInTags if no title is provided.
-      const title = r.data.title?.trim() || titleInTags || "Untitled Document";
+      const title =
+        r.data.title?.trim() || titleInTags?.trim() || "Untitled Document";
 
       if (!titleInTags) {
         tags.push(`title:${title}`);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -569,8 +569,7 @@ async function handler(
         ?.trim();
 
       // Use titleInTags if no title is provided.
-      const title =
-        r.data.title?.trim() || titleInTags?.trim() || "Untitled Document";
+      const title = r.data.title?.trim() || titleInTags || "Untitled Document";
 
       if (!titleInTags) {
         tags.push(`title:${title}`);


### PR DESCRIPTION
Description
---
Fixes [this monitor](https://dust4ai.slack.com/archives/C05F84CFP0E/p1742347875208749)

Empty titles cause a bunch of issues and are now rejected by core. This ensures they are also rejected before that, to avoid invalid docs entering the upsert queue

Risk
---
normal

Deploy
---
front
