### PR TITLE
Fix Salesforce Config table connectorId should be BIGINT

### DIFF
--- a/connectors/migrations/db/migration_63.sql
+++ b/connectors/migrations/db/migration_63.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."salesforce_configurations"
+ALTER COLUMN "connectorId" TYPE BIGINT;


### PR DESCRIPTION
## Description

Table in migration_51 was created as is: 

```sql
CREATE TABLE IF NOT EXISTS "public"."salesforce_configurations" (
  "id" BIGSERIAL,
  "connectorId" INTEGER NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
  PRIMARY KEY ("id")
);
CREATE UNIQUE INDEX IF NOT EXISTS "salesforce_configurations_connector_id" ON "public"."salesforce_configurations" ("connectorId"); 
```

It needs to be BIGINT not integer. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

We have currently no entry on EU for this table, and 2 in US.

## Deploy Plan

Merge, run migration both on US & EU.
