### PR TITLE
Remove field `reasoning_content` from `AssistantChatMessage`

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -87,8 +87,6 @@ struct AnthropicImageContent {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum AnthropicContentType {
-    Thinking,
-    RedactedThinking,
     Text,
     Image,
     ToolUse,

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -590,7 +590,6 @@ impl TryFrom<ChatResponse> for AssistantChatMessage {
             role: ChatMessageRole::Assistant,
             name: None,
             content: text_content,
-            reasoning_content: None,
             function_call,
             function_calls,
         })

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -102,12 +102,6 @@ struct AnthropicContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     text: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    thinking: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    redacted_thinking: Option<String>,
-
     #[serde(skip_serializing_if = "Option::is_none", flatten)]
     tool_use: Option<AnthropicContentToolUse>,
 
@@ -309,8 +303,6 @@ impl<'a> TryFrom<&'a ChatMessageConversionInput<'a>> for AnthropicChatMessage {
                                 Ok(AnthropicContent {
                                     r#type: AnthropicContentType::ToolUse,
                                     text: None,
-                                    thinking: None,
-                                    redacted_thinking: None,
                                     tool_use: Some(AnthropicContentToolUse {
                                         name: function_call.name.clone(),
                                         id: function_call.id.clone(),
@@ -329,8 +321,6 @@ impl<'a> TryFrom<&'a ChatMessageConversionInput<'a>> for AnthropicChatMessage {
                 let text = assistant_msg.content.as_ref().map(|text| AnthropicContent {
                     r#type: AnthropicContentType::Text,
                     text: Some(text.clone()),
-                    thinking: None,
-                    redacted_thinking: None,
                     tool_result: None,
                     tool_use: None,
                     source: None,
@@ -358,8 +348,6 @@ impl<'a> TryFrom<&'a ChatMessageConversionInput<'a>> for AnthropicChatMessage {
                         content: Some(function_msg.content.clone()),
                     }),
                     text: None,
-                    thinking: None,
-                    redacted_thinking: None,
                     source: None,
                 };
 
@@ -376,8 +364,6 @@ impl<'a> TryFrom<&'a ChatMessageConversionInput<'a>> for AnthropicChatMessage {
                             MixedContent::TextContent(tc) => Ok(AnthropicContent {
                                 r#type: AnthropicContentType::Text,
                                 text: Some(tc.text.clone()),
-                                thinking: None,
-                                redacted_thinking: None,
                                 tool_result: None,
                                 tool_use: None,
                                 source: None,
@@ -388,8 +374,6 @@ impl<'a> TryFrom<&'a ChatMessageConversionInput<'a>> for AnthropicChatMessage {
                                         r#type: AnthropicContentType::Image,
                                         source: Some(base64_data.clone()),
                                         text: None,
-                                        thinking: None,
-                                        redacted_thinking: None,
                                         tool_use: None,
                                         tool_result: None,
                                     })
@@ -409,8 +393,6 @@ impl<'a> TryFrom<&'a ChatMessageConversionInput<'a>> for AnthropicChatMessage {
                     content: vec![AnthropicContent {
                         r#type: AnthropicContentType::Text,
                         text: Some(t.clone()),
-                        thinking: None,
-                        redacted_thinking: None,
                         tool_result: None,
                         tool_use: None,
                         source: None,
@@ -422,8 +404,6 @@ impl<'a> TryFrom<&'a ChatMessageConversionInput<'a>> for AnthropicChatMessage {
                 content: vec![AnthropicContent {
                     r#type: AnthropicContentType::Text,
                     text: Some(system_msg.content.clone()),
-                    thinking: None,
-                    redacted_thinking: None,
                     tool_result: None,
                     tool_use: None,
                     source: None,

--- a/core/src/providers/chat_messages.rs
+++ b/core/src/providers/chat_messages.rs
@@ -76,8 +76,6 @@ pub struct AssistantChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reasoning_content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub function_call: Option<ChatFunctionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_calls: Option<Vec<ChatFunctionCall>>,

--- a/core/src/providers/deepseek.rs
+++ b/core/src/providers/deepseek.rs
@@ -17,7 +17,7 @@ use parking_lot::RwLock;
 use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::helpers::strip_tools_fromn_chat_history;
+use super::helpers::strip_tools_from_chat_history;
 use super::openai_compatible_helpers::{
     openai_compatible_chat_completion, TransformSystemMessages,
 };
@@ -132,7 +132,7 @@ impl LLM for DeepseekLLM {
             self.api_key.clone().unwrap(),
             // Pre-process messages if model is deepseek-reasoner.
             match MODEL_IDS_WITH_TOOLS_SUPPORT.contains(&self.id.as_str()) {
-                false => Some(strip_tools_fromn_chat_history(messages)),
+                false => Some(strip_tools_from_chat_history(messages)),
                 true => None,
             }
             .as_ref()

--- a/core/src/providers/fireworks.rs
+++ b/core/src/providers/fireworks.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::helpers::strip_tools_fromn_chat_history;
+use super::helpers::strip_tools_from_chat_history;
 use super::openai_compatible_helpers::{
     openai_compatible_chat_completion, TransformSystemMessages,
 };
@@ -137,7 +137,7 @@ impl LLM for FireworksLLM {
             self.api_key.clone().unwrap(),
             // Pre-process messages if model is one of the supported models.
             match MODEL_IDS_WITH_TOOLS_SUPPORT.contains(&self.id.as_str()) {
-                false => Some(strip_tools_fromn_chat_history(messages)),
+                false => Some(strip_tools_from_chat_history(messages)),
                 true => None,
             }
             .as_ref()

--- a/core/src/providers/helpers.rs
+++ b/core/src/providers/helpers.rs
@@ -38,8 +38,6 @@ pub fn strip_tools_fromn_chat_history(messages: &Vec<ChatMessage>) -> Vec<ChatMe
                     content: Some(content),
                     name: message.name.clone(),
                     role: message.role.clone(),
-                    // Unused for r1:
-                    reasoning_content: None,
                     function_call: None,
                     function_calls: None,
                 }));

--- a/core/src/providers/helpers.rs
+++ b/core/src/providers/helpers.rs
@@ -6,7 +6,7 @@ use super::{
 // Useful for models that don't support tools.
 // For assistant messages, we remove function/tool calls (and we format them inside of the "content" field instead).
 // For function/tool result messages, we transform them into user messages.
-pub fn strip_tools_fromn_chat_history(messages: &Vec<ChatMessage>) -> Vec<ChatMessage> {
+pub fn strip_tools_from_chat_history(messages: &Vec<ChatMessage>) -> Vec<ChatMessage> {
     let mut new_messages = Vec::new();
     for message in messages {
         match message {

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -237,7 +237,6 @@ impl TryFrom<&MistralChatMessage> for AssistantChatMessage {
 
         Ok(AssistantChatMessage {
             content,
-            reasoning_content: None,
             role,
             name: None,
             function_call,

--- a/core/src/providers/togetherai.rs
+++ b/core/src/providers/togetherai.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::helpers::strip_tools_fromn_chat_history;
+use super::helpers::strip_tools_from_chat_history;
 use super::openai_compatible_helpers::{
     openai_compatible_chat_completion, TransformSystemMessages,
 };
@@ -138,7 +138,7 @@ impl LLM for TogetherAILLM {
             self.api_key.clone().unwrap(),
             // Pre-process messages if model is one of the supported models.
             match MODEL_IDS_WITH_TOOLS_SUPPORT.contains(&self.id.as_str()) {
-                false => Some(strip_tools_fromn_chat_history(messages)),
+                false => Some(strip_tools_from_chat_history(messages)),
                 true => None,
             }
             .as_ref()


### PR DESCRIPTION
## Description

- Reverts dust-tt/dust#10121.
- In the context of recent works on the thinking mode of Claude Sonnet 3.7, it was surfaced that do not currently have a clear view of how we want to handle the distinction between thinking and non-thinking tokens in `core` (delimiters for Sonnet 3.5 and Deepseek R1, AFAICT not passed for o3 and o1).
- This PR aims at nuking the `reasoning_content` field from `AssistantChatMessage`, which was specific to Deepseek's API (and inherited in Fireworks), and not used in `front`.
- This field is dropped in favor of sticking with delimiters for every current use.
- This PR also removes two unused fields in `AnthropicContent`.

## Risk

- None expected, unused field.

## Deploy Plan

- Deploy core.