### PR TITLE
Fix multi-db snowflake

### DIFF
--- a/connectors/src/connectors/snowflake/lib/cli.ts
+++ b/connectors/src/connectors/snowflake/lib/cli.ts
@@ -52,6 +52,9 @@ export const snowflake = async ({
     }
 
     case "fetch-schemas": {
+      if (args.database === undefined) {
+        throw new Error("Database is required for fetching schemas");
+      }
       const schemas = await fetchSchemas({
         credentials,
         fromDatabase: args.database,
@@ -63,6 +66,9 @@ export const snowflake = async ({
     }
 
     case "fetch-tables": {
+      if (args.database === undefined && args.schema === undefined) {
+        throw new Error("Database or Schema is required for fetching tables");
+      }
       const tables = await fetchTables({
         credentials,
         fromDatabase: args.database,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/2402

The whole story is in the issue above but the summary is the following: there is a notion of "default" DB (I suspect the `current` flag) which is the default DB used when querying tables and schemas. If there are more than 1 DB in snowflake then querying all schemas or all tables will only pull from that DB which means that our fetchTree implementation was incorrect leading to the issues seen by the user.

I checked that BigQuery is not subject to that. But Salesforce might?

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`