### PR TITLE
Wrap Claude 3.7 thinking tokens in `<thinking>` tags

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1257,8 +1257,12 @@ impl AnthropicLLM {
                                     // Check if the stopping block is a thinking block
                                     match final_response.as_ref() {
                                         Some(response) => {
-                                            if let Some(content) = response.content.get(stop_event.index as usize) {
-                                                if let StreamContent::AnthropicStreamThinking(_) = content {
+                                            if let Some(content) =
+                                                response.content.get(stop_event.index as usize)
+                                            {
+                                                if let StreamContent::AnthropicStreamThinking(_) =
+                                                    content
+                                                {
                                                     // Send </thinking> tag at the end of a thinking block
                                                     let _ = event_sender.send(json!({
                                                         "type": "tokens",
@@ -1268,7 +1272,7 @@ impl AnthropicLLM {
                                                     }));
                                                 }
                                             }
-                                        },
+                                        }
                                         None => {}
                                     }
                                 }

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1127,6 +1127,14 @@ impl AnthropicLLM {
                                                 StreamContent::AnthropicStreamThinking(
                                                     thinking,
                                                 ) => {
+                                                    // Send <thinking> tag at the start of a thinking block
+                                                    let _ = event_sender.send(json!({
+                                                        "type": "tokens",
+                                                        "content": {
+                                                            "text": "<thinking>",
+                                                        },
+                                                    }));
+                                                    // Then send the actual thinking content
                                                     let _ = event_sender.send(json!({
                                                         "type": "tokens",
                                                         "content": {
@@ -1233,7 +1241,7 @@ impl AnthropicLLM {
                                 }
                                 }
                                 "content_block_stop" => {
-                                    let _: StreamContentBlockStop =
+                                    let stop_event: StreamContentBlockStop =
                                         match serde_json::from_str(event.data.as_str()) {
                                             Ok(event) => event,
                                             Err(error) => {
@@ -1245,6 +1253,24 @@ impl AnthropicLLM {
                                                 break 'stream;
                                             }
                                         };
+
+                                    // Check if the stopping block is a thinking block
+                                    match final_response.as_ref() {
+                                        Some(response) => {
+                                            if let Some(content) = response.content.get(stop_event.index as usize) {
+                                                if let StreamContent::AnthropicStreamThinking(_) = content {
+                                                    // Send </thinking> tag at the end of a thinking block
+                                                    let _ = event_sender.send(json!({
+                                                        "type": "tokens",
+                                                        "content": {
+                                                            "text": "</thinking>",
+                                                        },
+                                                    }));
+                                                }
+                                            }
+                                        },
+                                        None => {}
+                                    }
                                 }
                                 "message_delta" => {
                                     let event: StreamMessageDelta =


### PR DESCRIPTION
## Description

- Follow up on this comment https://github.com/dust-tt/dust/pull/11445#pullrequestreview-2699082090
- Follow up on: https://github.com/dust-tt/dust/pull/11445, which implemented thinking for Claude Sonnet 3.7 but output the thinking tokens directly as regular text.
- This PR addresses this issue by wrapping the thinking tokens in `<thinking>` tags in order to fallback on front's delimiter detection. It thus aligns the behavior of 3.5 and 3.7.

Before/After

<img width="288" alt="Screenshot 2025-03-19 at 6 08 37 PM" src="https://github.com/user-attachments/assets/c10a909f-cd98-4452-89ee-43f6e4f16a04" />
<img width="288" alt="Screenshot 2025-03-19 at 6 08 51 PM" src="https://github.com/user-attachments/assets/603f3c3e-a773-4845-8692-350b3ffdb937" />


## Tests

- Tested locally.

## Risk

- Risk of breaking the display of the CoTs.

## Deploy Plan

- Deploy core.
