### PR TITLE
[Attach] Ability to include tables from knowledge in conversation

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -164,7 +164,7 @@ export const InputBarAttachmentsPicker = ({
                       })}
                       disabled={
                         attachedNodeIds.includes(item.internalId) ||
-                        item.type !== "document"
+                        item.type === "folder"
                       }
                       description={`${spacesMap[item.dataSourceView.spaceId]} - ${getLocationForDataSourceViewContentNode(item)}`}
                       onClick={() => {

--- a/front/lib/actions/conversation/include_file.ts
+++ b/front/lib/actions/conversation/include_file.ts
@@ -17,7 +17,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentConversationIncludeFileAction } from "@app/lib/models/assistant/actions/conversation/include_file";
 import {
   CONTENT_OUTDATED_MSG,
-  renderFromAttachmentId as renderFromAttachmentId,
+  renderFromAttachmentId,
 } from "@app/lib/resources/content_fragment_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";

--- a/front/lib/actions/conversation/include_file.ts
+++ b/front/lib/actions/conversation/include_file.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
   DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
+import { conversationAttachmentId } from "@app/lib/actions/conversation/list_files";
 import type { ExtractActionBlob } from "@app/lib/actions/types";
 import type { BaseActionRunParams } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
@@ -16,7 +17,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentConversationIncludeFileAction } from "@app/lib/models/assistant/actions/conversation/include_file";
 import {
   CONTENT_OUTDATED_MSG,
-  renderFromResourceId,
+  renderFromAttachmentId as renderFromAttachmentId,
 } from "@app/lib/resources/content_fragment_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -116,7 +117,7 @@ export class ConversationIncludeFileActionType extends BaseAction {
     // message).
     const files = listFiles(conversation);
     for (const f of files) {
-      if (f.resourceId === fileId && f.isIncludable) {
+      if (conversationAttachmentId(f) === fileId && f.isIncludable) {
         if (f.contentFragmentVersion === "superseded") {
           return new Ok({
             fileId,
@@ -125,10 +126,10 @@ export class ConversationIncludeFileActionType extends BaseAction {
           });
         }
 
-        const r = await renderFromResourceId(conversation.owner, {
+        const r = await renderFromAttachmentId(conversation.owner, {
           contentType: f.contentType,
           excludeImages: true,
-          resourceId: f.resourceId,
+          conversationAttachmentId: conversationAttachmentId(f),
           model,
           title: f.title,
           contentFragmentVersion: f.contentFragmentVersion,

--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -53,7 +53,9 @@ export function isConversationContentNodeType(
   return "contentFragmentId" in attachment;
 }
 
-function resourceId(attachment: ConversationAttachmentType): string {
+export function conversationAttachmentId(
+  attachment: ConversationAttachmentType
+): string {
   if (isConversationFileType(attachment)) {
     return attachment.fileId;
   }
@@ -100,7 +102,7 @@ export class ConversationListFilesActionType extends BaseAction {
       `// searchable: content can be searched alongside other searchable files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
       `\n`;
     for (const f of this.files) {
-      content += `<file id="${resourceId(f)}" name="${_.escape(f.title)}" type="${f.contentType}" includable="${f.isIncludable}" queryable="${f.isQueryable}" searchable="${f.isSearchable}"`;
+      content += `<file id="${conversationAttachmentId(f)}" name="${_.escape(f.title)}" type="${f.contentType}" includable="${f.isIncludable}" queryable="${f.isQueryable}" searchable="${f.isSearchable}"`;
 
       if (f.snippet) {
         content += ` snippet="${_.escape(f.snippet)}"`;

--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -22,6 +22,8 @@ export type ConversationFileType = {
   title: string;
   contentType: SupportedContentFragmentType;
   contentFragmentVersion: ContentFragmentVersion;
+  // If the file is a content node, we set the node's data source view id.
+  nodeDataSourceViewId: string | null;
   snippet: string | null;
   generatedTables: string[];
   isIncludable: boolean;

--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -17,7 +17,7 @@ import type {
   SupportedContentFragmentType,
 } from "@app/types";
 
-export type ConversationFileType = {
+export type ConversationAttachmentType = {
   resourceId: string;
   title: string;
   contentType: SupportedContentFragmentType;
@@ -37,7 +37,7 @@ type ConversationListFilesActionBlob =
 export class ConversationListFilesActionType extends BaseAction {
   readonly id: ModelId = -1;
   readonly agentMessageId: ModelId;
-  readonly files: ConversationFileType[];
+  readonly files: ConversationAttachmentType[];
   readonly functionCallId: string | null;
   readonly functionCallName: string | null;
   readonly step: number = -1;
@@ -95,7 +95,7 @@ export function makeConversationListFilesAction({
   files,
 }: {
   agentMessage: AgentMessageType;
-  files: ConversationFileType[];
+  files: ConversationAttachmentType[];
 }): ConversationListFilesActionType | null {
   if (files.length === 0) {
     return null;

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -99,7 +99,7 @@ async function getJITActions(
           tables: filesUsableAsTableQuery.flatMap((f) =>
             f.generatedTables.map((tableId) => ({
               workspaceId: auth.getNonNullableWorkspace().sId,
-              dataSourceViewId: dataSourceView.sId,
+              dataSourceViewId: f.nodeDataSourceViewId ?? dataSourceView.sId,
               tableId: tableId,
             }))
           ),

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -21,12 +21,12 @@ import { listFiles } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import {
-  assertNever,
-  type AgentActionType,
-  type AgentMessageType,
-  type ConversationType,
+import type {
+  AgentActionType,
+  AgentMessageType,
+  ConversationType,
 } from "@app/types";
+import { assertNever } from "@app/types";
 
 async function getJITActions(
   auth: Authenticator,
@@ -121,7 +121,7 @@ async function getJITActions(
           relativeTimeFrame: "auto",
           dataSources: [
             {
-              workspaceId: auth.getNonNullableWorkspace().sId,
+              workspaceId: conversation.owner.sId,
               dataSourceViewId: dataSourceView.sId,
               filter: { parents: null, tags: null },
             },

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -84,7 +84,7 @@ async function getJITActions(
             if (isConversationFileType(f)) {
               assert(
                 dataSourceView,
-                "No datasource view found for table when trying to get JIT actions"
+                "No conversation datasource view found for table when trying to get JIT actions"
               );
               return f.generatedTables.map((tableId) => ({
                 workspaceId: auth.getNonNullableWorkspace().sId,
@@ -104,10 +104,13 @@ async function getJITActions(
         actions.push(action);
       }
 
-      if (filesUsableAsRetrievalQuery.length > 0) {
+      if (
+        filesUsableAsRetrievalQuery.filter((f) => isConversationFileType(f))
+          .length > 0
+      ) {
         assert(
           dataSourceView,
-          "No datasource view found for retrieval when trying to get JIT actions"
+          "No conversation datasource view found for retrieval when trying to get JIT actions"
         );
         const action: RetrievalConfigurationType = {
           description: DEFAULT_CONVERSATION_SEARCH_ACTION_DATA_DESCRIPTION,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -72,7 +72,6 @@ async function getJITActions(
       );
 
       if (filesUsableAsTableQuery.length > 0) {
-        // TODO(JIT) Shall we look for an existing table query action and update it instead of creating a new one? This would allow join between the tables.
         const action: TablesQueryConfigurationType = {
           // The description here is the description of the data, a meta description of the action is prepended automatically.
           description:

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
 import { makeConversationIncludeFileConfiguration } from "@app/lib/actions/conversation/include_file";
-import type { ConversationFileType } from "@app/lib/actions/conversation/list_files";
+import type { ConversationAttachmentType } from "@app/lib/actions/conversation/list_files";
 import { makeConversationListFilesAction } from "@app/lib/actions/conversation/list_files";
 import type { RetrievalConfigurationType } from "@app/lib/actions/retrieval";
 import { getRunnerForActionConfiguration } from "@app/lib/actions/runners";
@@ -32,7 +32,7 @@ async function getJITActions(
   }: {
     availableActions: ActionConfigurationType[];
     conversation: ConversationType;
-    files: ConversationFileType[];
+    files: ConversationAttachmentType[];
   }
 ): Promise<ActionConfigurationType[]> {
   const actions: ActionConfigurationType[] = [];

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -1,4 +1,4 @@
-import type { ConversationFileType } from "@app/lib/actions/conversation/list_files";
+import type { ConversationAttachmentType } from "@app/lib/actions/conversation/list_files";
 import type {
   ConversationType,
   SupportedContentFragmentType,
@@ -53,8 +53,8 @@ function isListableContentType(
 // Moved to a separate file to avoid circular dependency issue.
 export function listFiles(
   conversation: ConversationType
-): ConversationFileType[] {
-  const files: ConversationFileType[] = [];
+): ConversationAttachmentType[] {
+  const files: ConversationAttachmentType[] = [];
   for (const versions of conversation.content) {
     const m = versions[versions.length - 1];
 

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -70,11 +70,19 @@ export function listFiles(
         // in JIT. But for content node fragments, with a node id rather than a
         // file id, we don't care about the snippet.
         const canDoJIT = m.snippet !== null || !!m.nodeId;
-        const isIncludable = isConversationIncludableFileContentType(
-          m.contentType
-        );
+
         const isQueryable = canDoJIT && isQueryableContentType(m.contentType);
-        const isSearchable = canDoJIT && isSearchableContentType(m.contentType);
+        const isIncludable =
+          isConversationIncludableFileContentType(m.contentType) &&
+          // Tables from knowledge are not materialized as raw content. As such, they
+          // cannot be included.
+          !(!!m.nodeId && isQueryable);
+        const isSearchable =
+          canDoJIT &&
+          isSearchableContentType(m.contentType) &&
+          // Tables from knowledge are not materialized as raw content. As such, they
+          // cannot be searched.
+          !(!!m.nodeId && isQueryable);
 
         files.push({
           resourceId: m.contentFragmentId,

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -1,7 +1,6 @@
 import type {
   BaseConversationAttachmentType,
   ConversationAttachmentType,
-  ConversationFileType,
 } from "@app/lib/actions/conversation/list_files";
 import type {
   ConversationType,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -376,35 +376,41 @@ async function getSignedUrlForProcessedContent(
   return getPrivateUploadBucket().getSignedUrl(fileCloudStoragePath);
 }
 
-export async function renderFromResourceId(
+export async function renderFromAttachmentId(
   workspace: WorkspaceType,
   {
     contentType,
     excludeImages,
-    resourceId,
+    conversationAttachmentId,
     model,
     title,
     contentFragmentVersion,
   }: {
     contentType: SupportedContentFragmentType;
     excludeImages: boolean;
-    resourceId: string;
+    conversationAttachmentId: string;
     model: ModelConfigurationType;
     title: string;
     contentFragmentVersion: ContentFragmentVersion;
   }
 ): Promise<Result<ContentFragmentMessageTypeModel, Error>> {
   // At time of writing, passed resourceId can be either a file or a content fragment.
-  const { resourceName } = getResourceNameAndIdFromSId(resourceId) ?? {
+  const { resourceName } = getResourceNameAndIdFromSId(
+    conversationAttachmentId
+  ) ?? {
     resourceName: "content_fragment",
   };
 
   const { fileStringId, nodeId, nodeDataSourceViewId } =
     resourceName === "file"
-      ? { fileStringId: resourceId, nodeId: null, nodeDataSourceViewId: null }
+      ? {
+          fileStringId: conversationAttachmentId,
+          nodeId: null,
+          nodeDataSourceViewId: null,
+        }
       : await getIncludeFileIdsFromContentFragmentResourceId(
           workspace,
-          resourceId
+          conversationAttachmentId
         );
 
   if (isSupportedImageContentType(contentType)) {
@@ -493,7 +499,7 @@ export async function renderFromResourceId(
         {
           type: "text",
           text: renderContentFragmentXml({
-            contentFragmentId: resourceId,
+            contentFragmentId: conversationAttachmentId,
             contentType,
             title,
             version: contentFragmentVersion,
@@ -524,7 +530,7 @@ export async function renderFromResourceId(
         {
           type: "text",
           text: renderContentFragmentXml({
-            contentFragmentId: resourceId,
+            contentFragmentId: conversationAttachmentId,
             contentType,
             title,
             version: contentFragmentVersion,

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -93,7 +93,7 @@ ContentFragmentModel.init(
       defaultValue: "latest",
     },
     nodeId: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(512),
       allowNull: true,
     },
   },

--- a/front/migrations/db/migration_186.sql
+++ b/front/migrations/db/migration_186.sql
@@ -1,0 +1,2 @@
+-- Migration created on 2025-03-19 -- "nodeId" accepts 512 characters
+ALTER TABLE "content_fragments" ALTER COLUMN "nodeId" TYPE VARCHAR(512);

--- a/front/migrations/db/migration_186.sql
+++ b/front/migrations/db/migration_186.sql
@@ -1,2 +1,2 @@
 -- Migration created on 2025-03-19 -- "nodeId" accepts 512 characters
-ALTER TABLE "content_fragments" ALTER COLUMN "nodeId" TYPE VARCHAR(512);
+ALTER TABLE "content_fragments" ALTER COLUMN "nodeId" TYPE TEXT;

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -55,3 +55,18 @@ export function isContentFragmentType(
 ): arg is ContentFragmentType {
   return arg.type === "content_fragment";
 }
+
+export function isFileAttachment(
+  arg: ContentFragmentType
+): arg is ContentFragmentType & { fileId: string } {
+  return !!arg.fileId;
+}
+
+export function isContentNodeAttachment(
+  arg: ContentFragmentType
+): arg is ContentFragmentType & {
+  nodeId: string;
+  nodeDataSourceViewId: string;
+} {
+  return !!arg.nodeId && !!arg.nodeDataSourceViewId;
+}

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -100,6 +100,7 @@ const FILE_FORMATS = {
   "text/tsv": { cat: "delimited", exts: [".tsv"] },
   "text/tab-separated-values": { cat: "delimited", exts: [".tsv"] },
   "application/vnd.ms-excel": { cat: "delimited", exts: [".xls"] },
+  "application/vnd.google-apps.spreadsheet": { cat: "delimited", exts: [] },
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
     cat: "delimited",
     exts: [".xlsx"],

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -130,6 +130,7 @@ export const supportedOtherFileFormats = {
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
     ".xlsx",
   ],
+  "application/vnd.google-apps.spreadsheet": [],
   "application/vnd.ms-excel": [".xls"],
   "application/pdf": [".pdf"],
   "application/vnd.dust.section.json": [".json"],

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -606,14 +606,27 @@ const ConversationIncludeFileActionTypeSchema = BaseActionSchema.extend({
   type: z.literal("conversation_include_file_action"),
 });
 
-const ConversationFileTypeSchema = z.object({
-  resourceId: z.string(),
-  title: z.string(),
-  contentType: SupportedContentFragmentTypeSchema,
-});
+const ConversationAttachmentTypeSchema = z.union([
+  // File case
+  z.object({
+    fileId: z.string(),
+    contentFragmentId: z.undefined(),
+    nodeDataSourceViewId: z.undefined(),
+    title: z.string(),
+    contentType: SupportedContentFragmentTypeSchema,
+  }),
+  // Node case
+  z.object({
+    fileId: z.undefined(),
+    contentFragmentId: z.string(),
+    nodeDataSourceViewId: z.string(),
+    title: z.string(),
+    contentType: SupportedContentFragmentTypeSchema,
+  }),
+]);
 
 const ConversationListFilesActionTypeSchema = BaseActionSchema.extend({
-  files: z.array(ConversationFileTypeSchema),
+  files: z.array(ConversationAttachmentTypeSchema),
   functionCallId: z.string().nullable(),
   functionCallName: z.string().nullable(),
   agentMessageId: ModelIdSchema,


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2344

Allows adding queryable tables from input bar, and documents via global semantic search:
- adds content node tables to the table query action for the conversation
- prevents inclusion of content node tables using `conversation_include_file`,  or search using `retrieval` tool (contrarily to uploaded tables, we don't have their raw content)
- content fragment nodeid boosted to length 512 because of some very long ids
- also adds "application/vnd.google-apps.spreadsheet" as possible mime type

Risk
---
semi-high, touches JIT action generation

## Deploy Plan
migration 186
front

