### PR TITLE
fix: correct `api/v1` doc section relative to the `timestamp` field in upserts

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -151,7 +151,7 @@ export const config = {
  *                 description: Tags to associate with the document.
  *               timestamp:
  *                 type: number
- *                 description: Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000).
+ *                 description: Unix timestamp (in milliseconds) for the document (e.g. 1736365559000).
  *               light_document_output:
  *                 type: boolean
  *                 description: If true, a lightweight version of the document will be returned in the response (excluding the text, chunks and vectors). Defaults to false.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -104,7 +104,7 @@ import { CoreAPI } from "@app/types";
  *                 description: Description of the table
  *               timestamp:
  *                 type: number
- *                 description: Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000).
+ *                 description: Unix timestamp (in milliseconds) for the table (e.g. 1736365559000).
  *               tags:
  *                 type: array
  *                 items:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2384,7 +2384,7 @@
                   },
                   "timestamp": {
                     "type": "number",
-                    "description": "Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000)."
+                    "description": "Unix timestamp (in milliseconds) for the document (e.g. 1736365559000)."
                   },
                   "light_document_output": {
                     "type": "boolean",
@@ -3552,7 +3552,7 @@
                   },
                   "timestamp": {
                     "type": "number",
-                    "description": "Reserved for internal use, should not be set. Unix timestamp (in seconds) of the time the document was last updated (e.g. 1698225000)."
+                    "description": "Unix timestamp (in milliseconds) for the table (e.g. 1736365559000)."
                   },
                   "tags": {
                     "type": "array",


### PR DESCRIPTION
## Description

- Addresses comments in https://github.com/dust-tt/dust/issues/11488.
- This PR corrects the unit mentioned for the `timestamps`: it is in milliseconds and not in seconds.
- This PR also removes the "Reserved for internal use, should not be set." guard.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy docs.