### PR TITLE
[Table upsert] Fix: refuse empty title

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -633,17 +633,18 @@ export async function upsertTable({
     });
   }
 
+  const titleEmpty = params.title.trim().length === 0;
   // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
   if (
     params.title &&
-    (params.title.length > MAX_NODE_TITLE_LENGTH || params.title.length === 0)
+    (params.title.length > MAX_NODE_TITLE_LENGTH || titleEmpty)
   ) {
     return new Err({
       name: "dust_error",
-      code: params.title.length === 0 ? "title_is_empty" : "title_too_long",
+      code: titleEmpty ? "title_is_empty" : "title_too_long",
       message:
         "Invalid title:" +
-        (params.title.length === 0
+        (titleEmpty
           ? "title cannot be empty"
           : `title too long (max ${MAX_NODE_TITLE_LENGTH} characters).`),
     });


### PR DESCRIPTION
Description
---
Fixes e.g. [this monitor](https://dust4ai.slack.com/archives/C05F84CFP0E/p1742474895975459)

A check that title is empty before sending to upsert queue was made, but didn't trim, while the core API in upsert queue does.

Risks
---
low

Deploy
---
front

