### PR TITLE
Fix csv snippet error

### DIFF
--- a/front/lib/api/csv.ts
+++ b/front/lib/api/csv.ts
@@ -132,14 +132,18 @@ export function generateCSVSnippet({
   // Max number of characters in the snippet.
   const MAX_SNIPPET_CHARS = 16384;
 
+  if (!content || content.trim() === "" || totalRecords === 0) {
+    return "TOTAL_LINES: 0\n(empty result set)\n";
+  }
+
   const records = parse(content, {
     columns: true,
-    skip_empty_lines: true,
+    skip_empty_lines: false,
     trim: true,
     to: 256, // Limit the number of records to parse
   });
 
-  if (totalRecords === 0) {
+  if (!records || !records.length) {
     return "TOTAL_LINES: 0\n(empty result set)\n";
   }
 


### PR DESCRIPTION
## Description

New attempt at fixing this error: [Log](https://app.datadoghq.eu/logs?query=%22Error%20Posting%20message%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZWy9gosWyYg6gAAABhBWld5OWh6TkFBQ0NQMWdyUVdvSnpnQVEAAAAkMDE5NWIyZjctNTNjMC00YjQ1LTgxOWUtMWNkZDBhZGIyOTg3AADugw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1697617448427&to_ts=1697631848427&live=true). 

The error occurred because the output of the table query action is: 

```
{
  thinking: "Some thinking",
  query: "The query",
  query_title: "The query title",
  results: [
    {
      'GROUP_CONCAT(DISTINCT "owner")': null,
    },
  ],
}
```

The fact that the value is null somehow breaks the snippet generation. 
I fixed it by keeping the empty line.
Tested locally and now the snippet looks like this: 

```
TOTAL_LINES: 1
"GROUP_CONCAT(DISTINCT ""owner"")"


(end of file)
```


This means that for an output as is: 
```
{
  thinking: "Some thinking",
  query: "The query",
  query_title: "The query title",
  results: results: [
      {
        DS: "20161",
      },
      {
        DS: "20160",
      },
      {
        DS: "20159",
      },
      {
        DS: null,
      },
      {
        DS: "20157",
      },
    ],
}
```

Instead of getting: 
```
TOTAL_LINES: 5
DS
20161
20160
20159
20157

(1 lines omitted)
```

We will get: 
```
TOTAL_LINES: 5
DS
20161
20160
20159

20157

(end of file)
```

## Tests

Locally. 

## Risk

I'm not sure why we were skipping empty lines and I think it's fine to keep them but I'll confirm with Seb who wrote the code + this is safe to rollback. 

## Deploy Plan

Deploy front. 
