### PR TITLE
fix(local dev setup): disable auto ES index creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - xpack.license.self_generated.type=basic
       - xpack.ml.use_auto_machine_memory_percent=true
       - ES_JAVA_OPTS=-Xms${ES_LOCAL_HEAP_INIT} -Xmx${ES_LOCAL_HEAP_MAX}
+      - action.auto_create_index=false
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
## Description

We have observed issues with elasticsearch in local dev at several occasions.
The issue was identified a while back and was materialized as follows:
- Calls to the search_nodes endpoint fail.
- The index `core.data_sources_nodes_4` is correctly created, but `core.data_sources_nodes` is not an alias that points to it, it's an index that has a mapping different from `core.data_sources_nodes_4`.
- The root cause was that we tried to index documents before creating the index, letting elasticsearch create it (infers the mapping from the first document we index).

This PR addresses this issue by disabling this feature of auto-creating the index (will cause the upserts to get retried until we create the index and the alias).

## Tests

- Ongoing, will also try to find out why we don't have the alias created after running `init_dev_container`, which seems weird.

## Risk

- None, only affects local environment at setup time.

## Deploy Plan

- No deploy.
