### PR TITLE
Attach from Knowledge: permissions

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2017,15 +2017,15 @@ async function isMessagesLimitReached({
 }
 
 /**
- * Update the conversation requestedGroupIds based on the mentioned agents.
- * This function is purely additive - requirements are never removed.
+ * Update the conversation requestedGroupIds based on the mentioned agents. This function is purely
+ * additive - requirements are never removed.
  *
- * Each agent's requestedGroupIds represents a set of requirements that must be
- * satisfied. When an agent is mentioned in a conversation, its requirements are
- * added to the conversation's requirements.
+ * Each agent's requestedGroupIds represents a set of requirements that must be satisfied. When an
+ * agent is mentioned in a conversation, its requirements are added to the conversation's
+ * requirements.
  *
- * Within each requirement (sub-array), groups are combined with OR logic.
- * Different requirements (different sub-arrays) are combined with AND logic.
+ * - Within each requirement (sub-array), groups are combined with OR logic.
+ * - Different requirements (different sub-arrays) are combined with AND logic.
  */
 export async function updateConversationRequestedGroupIds(
   mentionedAgents: LightAgentConfigurationType[],
@@ -2083,9 +2083,8 @@ export async function updateConversationRequestedGroupIds(
 
   // Hotfix: Postgres requires all subarrays to be of the same length
   //
-  // since a requirement (subarray) is a set of groups that are linked with OR
-  // logic we can just repeat the last element of each requirement until all
-  // requirements have the maximal length.
+  // since a requirement (subarray) is a set of groups that are linked with OR logic we can just
+  // repeat the last element of each requirement until all requirements have the maximal length.
   const longestRequirement = allRequirements.reduce(
     (max, req) => Math.max(max, req.length),
     0

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -921,7 +921,7 @@ export async function* postUserMessage(
         m: AgentMessageWithRankType;
       }[];
 
-      await updateConversationRequestedGroupIds({
+      await updateConversationRequestedGroupIds(auth, {
         agents: nonNullResults.map(({ m }) => m.configuration),
         conversation,
         t,
@@ -1406,7 +1406,7 @@ export async function* editUserMessage(
         m: AgentMessageWithRankType;
       }[];
 
-      await updateConversationRequestedGroupIds({
+      await updateConversationRequestedGroupIds(auth, {
         agents: nonNullResults.map(({ m }) => m.configuration),
         conversation,
         t,
@@ -1618,7 +1618,7 @@ export async function* retryAgentMessage(
         }
       );
 
-      await updateConversationRequestedGroupIds({
+      await updateConversationRequestedGroupIds(auth, {
         agents: [message.configuration],
         conversation,
         t,
@@ -1828,7 +1828,7 @@ export async function postNewContentFragment(
       );
 
       if (isContentFragmentInputWithContentNode(cf)) {
-        await updateConversationRequestedGroupIds({
+        await updateConversationRequestedGroupIds(auth, {
           contentFragment: cf,
           conversation,
           t,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -23,6 +23,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { launchUpdateSpacePermissionsWorkflow } from "@app/temporal/permissions_queue/client";
 import type {
+  CombinedResourcePermissions,
   ModelId,
   ResourcePermission,
   Result,
@@ -533,7 +534,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    *
    * @returns Array of ResourcePermission objects based on space type
    */
-  requestedPermissions(): ResourcePermission[] {
+  requestedPermissions(): CombinedResourcePermissions[] {
     const globalGroup = this.isRegular()
       ? this.groups.find((group) => group.isGlobal())
       : undefined;
@@ -589,11 +590,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       ];
     }
 
-    // Open space:
-    // Currently only using global group for simplicity
-    // TODO(2024-10-25 flav): Refactor to store a list of ResourcePermission on conversations
-    // and agent_configurations. This will allow proper handling of multiple groups instead
-    // of only using the global group as a temporary solution.
+    // Open space.
+    // Currently only using global group for simplicity.
+    // TODO(2024-10-25 flav): Refactor to store a list of ResourcePermission on conversations and
+    // agent_configurations. This will allow proper handling of multiple groups instead of only
+    // using the global group as a temporary solution.
     if (globalGroup) {
       return [
         {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -25,7 +25,6 @@ import { launchUpdateSpacePermissionsWorkflow } from "@app/temporal/permissions_
 import type {
   CombinedResourcePermissions,
   ModelId,
-  ResourcePermission,
   Result,
   SpaceKind,
   SpaceType,


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/2356

## Description

- Add support for ContentFragmentInputWithContentNode to permissions utils in `front/lib/api/assistant/permissions.ts`
- Leverage that centralized logic to add ContentFragment related requestedGroupIds to the `conversation.requestedGroupIds`.
- Specialized a type in SpaceResource, because we can.

This is a bit of a tricky one but it was after all a nice and natural extension of the existing. Nice original design!

@philipperolet && @flvndvd: It did raise 2 questions (brace brace this is quite specific):
- In `front/lib/api/assistant/conversation.ts` we don't make sure that the requestGroupIds are unique as they are flatMapped across agents. Which means we can have doubles? Is that expected?
- in `front/lib/api/assistant/permissions.ts` we do add to requestedGroupIds the non restricted spaces groups (aka we don't filter out the CombinedResourcePermissions that have a user role read permission. Shouldn't we do it.

## Tests

Attempted to write tests but it's too involved.
Fully tested locally + re-tested agent addition with data from spaces another user does not have access to.

## Risk

Won't break free any existing authorization, but high risk because this is critical authorization code moving forward. Not used yet.

## Deploy Plan

- deploy `front`