### PR TITLE
[v1 conversations] Return 401 when auth doesn't have a user

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -307,6 +307,16 @@ async function handler(
       });
       return;
     case "GET":
+      if (!auth.user()) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "user_not_found",
+            message:
+              "Getting conversations is only available when authenticated as a user.",
+          },
+        });
+      }
       const conversations = await getUserConversations(auth);
       res.status(200).json({ conversations });
       return;


### PR DESCRIPTION
Fixes [this kind of monitor](https://dust4ai.slack.com/archives/C05F84CFP0E/p1742490463951319)

Description
---
If there's no user, it's not possible to know which conversations to list.

Risks
---
low

Deploy
---
front
