### PR TITLE
[front] - fix(attachment): source url

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -7,8 +7,8 @@ import {
   DocumentTextIcon,
   Icon,
   SlackLogo,
+  useSendNotification,
 } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
 import React from "react";
 import { useSWRConfig } from "swr";
 

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -39,6 +39,7 @@ type NodeAttachment = {
   visual: React.ReactNode;
   path: string;
   onRemove: () => void;
+  url: string | null;
 };
 
 type Attachment = FileAttachment | NodeAttachment;
@@ -94,6 +95,7 @@ export function InputBarAttachments({
         return {
           type: "node",
           id: nodeId,
+          url: node.sourceUrl,
           title: node.title,
           spaceName,
           spaceIcon: nodes.spacesMap[node.dataSourceView.spaceId].icon,
@@ -133,6 +135,7 @@ export function InputBarAttachments({
             trigger={
               <Citation
                 className="w-40"
+                href={!isFile && attachment.url ? attachment.url : undefined}
                 isLoading={attachment.type === "file" && attachment.isUploading}
                 action={
                   <CitationClose

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -125,6 +125,7 @@ export async function submitMessage({
               nodeId: contentFragment.internalId,
               nodeDataSourceViewId: contentFragment.dataSourceView.sId,
               contentType: contentFragment.mimeType,
+              sourceUrl: contentFragment.sourceUrl,
               context: {
                 timezone:
                   Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -253,6 +253,7 @@ export async function createConversationWithMessage({
     contentFragments: [
       ...contentFragments.uploaded.map((cf) => ({
         title: cf.title,
+
         context: {
           profilePictureUrl: user.image,
         },
@@ -277,6 +278,7 @@ export async function createConversationWithMessage({
           },
           nodeId: cf.internalId,
           contentType,
+          sourceUrl: cf.sourceUrl,
           nodeDataSourceViewId: cf.dataSourceView.sId,
         };
       }),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,5 +1,4 @@
-import { isEqual, sortBy } from "lodash";
-import _ from "lodash";
+import _, { isEqual, sortBy } from "lodash";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -116,7 +116,7 @@ export async function getContentFragmentBlob(
       contentType: cf.contentType,
       nodeId: cf.nodeId,
       nodeDataSourceViewId: getResourceIdFromSId(cf.nodeDataSourceViewId),
-      sourceUrl: null,
+      sourceUrl: cf.sourceUrl,
       textBytes: null,
       fileId: null,
       title,

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -85,7 +85,7 @@ const ContentFragmentInputWithContentNodeSchema = t.intersection([
     nodeId: t.string,
     nodeDataSourceViewId: t.string,
     contentType: getSupportedContentNodeContentTypeSchema(),
-    sourceUrl: t.string,
+    sourceUrl: t.union([t.string, t.null]),
   }),
 ]);
 

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -85,6 +85,7 @@ const ContentFragmentInputWithContentNodeSchema = t.intersection([
     nodeId: t.string,
     nodeDataSourceViewId: t.string,
     contentType: getSupportedContentNodeContentTypeSchema(),
+    sourceUrl: t.string,
   }),
 ]);
 


### PR DESCRIPTION
## Description

This PR fixes a bug where content node attachments in messages did not properly display their source URL. The fix propagates the sourceUrl from the content node through the content fragment flow, enabling clickable links in the Citation component

**References:**
- https://github.com/dust-tt/tasks/issues/2442

## Risk

Low

## Deploy Plan

Deploy front