### PR TITLE
[v1 API - tables] Use default title for tables

### DIFF
--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -37,6 +37,8 @@ export const FOLDERS_SELECTION_PREVENTED_MIME_TYPES = [
   MIME_TYPES.NOTION.SYNCING_FOLDER,
 ] as readonly string[];
 
+export const UNTITLED_TITLE = "Untitled Document";
+
 export function getContentNodeInternalIdFromTableId(
   dataSourceView: DataSourceViewResource | DataSourceViewType,
   tableId: string
@@ -93,9 +95,7 @@ export function getContentNodeFromCoreNode(
     parentInternalId: coreNode.parent_id ?? null,
     // TODO(2025-01-27 aubin): remove this once the corresponding titles are backfilled.
     title:
-      coreNode.title === "Untitled document"
-        ? coreNode.node_id
-        : coreNode.title,
+      coreNode.title === UNTITLED_TITLE ? coreNode.node_id : coreNode.title,
     sourceUrl: coreNode.source_url ?? null,
     permission: "read",
     lastUpdatedAt: coreNode.timestamp,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -7,6 +7,7 @@ import type { Transaction } from "sequelize";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { default as apiConfig, default as config } from "@app/lib/api/config";
+import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { sendGitHubDeletionEmail } from "@app/lib/api/email";
 import { upsertTableFromCsv } from "@app/lib/api/tables";
 import { getMembers } from "@app/lib/api/workspace";
@@ -635,18 +636,13 @@ export async function upsertTable({
 
   const titleEmpty = params.title.trim().length === 0;
   // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
-  if (
-    params.title &&
-    (params.title.length > MAX_NODE_TITLE_LENGTH || titleEmpty)
-  ) {
+  if (params.title && params.title.length > MAX_NODE_TITLE_LENGTH) {
     return new Err({
       name: "dust_error",
-      code: titleEmpty ? "title_is_empty" : "title_too_long",
+      code: "title_too_long",
       message:
         "Invalid title:" +
-        (titleEmpty
-          ? "title cannot be empty"
-          : `title too long (max ${MAX_NODE_TITLE_LENGTH} characters).`),
+        `title too long (max ${MAX_NODE_TITLE_LENGTH} characters).`,
     });
   }
 
@@ -686,6 +682,8 @@ export async function upsertTable({
     }
     standardizedSourceUrl = standardized;
   }
+
+  const title = titleEmpty ? UNTITLED_TITLE : params.title;
 
   if (async) {
     if (fileId) {
@@ -746,7 +744,7 @@ export async function upsertTable({
         csv: null,
         fileId: fileId ?? null,
         truncate,
-        title: params.title,
+        title,
         mimeType: params.mimeType,
         sourceUrl: standardizedSourceUrl,
       },
@@ -788,7 +786,7 @@ export async function upsertTable({
     tableParents,
     fileId: fileId ?? null,
     truncate,
-    title: params.title,
+    title,
     mimeType: params.mimeType,
     sourceUrl: standardizedSourceUrl,
   });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -9,6 +9,7 @@ import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
+import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes";
 import { runDocumentUpsertHooks } from "@app/lib/document_upsert_hooks/hooks";
@@ -569,7 +570,7 @@ async function handler(
         ?.trim();
 
       // Use titleInTags if no title is provided.
-      const title = r.data.title?.trim() || titleInTags || "Untitled Document";
+      const title = r.data.title?.trim() || titleInTags || UNTITLED_TITLE;
 
       if (!titleInTags) {
         tags.push(`title:${title}`);


### PR DESCRIPTION
Description
---

Fixes [this monitor](https://dust4ai.slack.com/archives/C05F84CFP0E/p1742553570819939)

Aligns with what was done for documents of providing a default title.

Risk
---
standard

Deploy
---
front
