### PR TITLE
Deduplicate Group Ids on Conversation

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2032,15 +2032,20 @@ export async function updateConversationRequestedGroupIds(
   conversation: ConversationType,
   t: Transaction
 ): Promise<void> {
-  const newRequirements = mentionedAgents.flatMap(
-    (agent) => agent.requestedGroupIds
+  // Sort and deduplicate new requirements.
+  const newRequirements = _.uniqWith(
+    mentionedAgents.flatMap((agent) =>
+      agent.requestedGroupIds.map((req) => sortBy(req))
+    ),
+    isEqual
   );
   const currentRequirements = conversation.requestedGroupIds;
 
   // Check if each new requirement already exists in current requirements.
   const areAllRequirementsPresent = newRequirements.every((newReq) =>
-    currentRequirements.some((currentReq) =>
-      isEqual(sortBy(newReq), sortBy(currentReq))
+    currentRequirements.some(
+      // newReq was sorted, so we need to sort currentReq as well.
+      (currentReq) => isEqual(newReq, sortBy(currentReq))
     )
   );
 
@@ -2053,7 +2058,8 @@ export async function updateConversationRequestedGroupIds(
   const requirementsToAdd = newRequirements.filter(
     (newReq) =>
       !currentRequirements.some((currentReq) =>
-        isEqual(sortBy(newReq), sortBy(currentReq))
+        // newReq was sorted, so we need to sort currentReq as well.
+        isEqual(newReq, sortBy(currentReq))
       )
   );
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When multiple agents with the same group requirements are mentioned in a single message, we were storing duplicate group requirements in the conversation's `requestedGroupIds`. While this didn't affect permissions or functionality (since duplicate requirements don't change the permission logic), it could potentially lead to unnecessary growth of the `requestedGroupIds` array in the database.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
