### PR TITLE
Stop transcripts workflows on relocation

### DIFF
--- a/front/lib/api/labs.ts
+++ b/front/lib/api/labs.ts
@@ -25,7 +25,7 @@ export async function pauseAllLabsWorkflows(auth: Authenticator) {
   allLabsConfigs.forEach(async (config) => {
     if (config) {
       logger.info(
-        `Stopping Labs workflow ${config.id} for workspace ${config.workspaceId} and provider ${config.provider}`
+        `Stopping Labs workflow for workspace ${config.workspaceId} and provider ${config.provider}`
       );
       await stopRetrieveTranscriptsWorkflow(config);
       await config.setIsActive(false);

--- a/front/lib/api/labs.ts
+++ b/front/lib/api/labs.ts
@@ -1,9 +1,8 @@
-import { concurrentExecutor } from "@connectors/lib/async_utils";
-
 import type { Authenticator } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import logger from "@app/logger/logger";
 import { stopRetrieveTranscriptsWorkflow } from "@app/temporal/labs/client";
+import { concurrentExecutor } from "@app/types";
 import { Ok } from "@app/types";
 import { labsTranscriptsProviders } from "@app/types/labs";
 
@@ -11,34 +10,35 @@ import { labsTranscriptsProviders } from "@app/types/labs";
  * Pauses all Labs transcripts temporal workflows and their schedules for a workspace
  */
 export async function pauseAllLabsWorkflows(auth: Authenticator) {
-  const executor = concurrentExecutor({ maxConcurrent: 3 });
-
-  const allLabsConfigs = await executor.run(
-    labsTranscriptsProviders.map((provider) => async () => {
+  const allLabsConfigs = await concurrentExecutor(
+    [...labsTranscriptsProviders],
+    async (provider) => {
       const config =
         await LabsTranscriptsConfigurationResource.findByWorkspaceAndProvider({
           auth,
           provider,
         });
       return config;
-    })
+    },
+    { concurrency: 3 }
   );
 
   let stoppedWorkflows = 0;
 
-  await executor.run(
-    allLabsConfigs.map(
-      (config: LabsTranscriptsConfigurationResource | null) => async () => {
-        if (config) {
-          logger.info(
-            `Stopping Labs workflow for workspace ${config.workspaceId} and provider ${config.provider}`
-          );
-          await stopRetrieveTranscriptsWorkflow(config);
-          await config.setIsActive(false);
-          stoppedWorkflows++;
-        }
-      }
-    )
+  await concurrentExecutor(
+    allLabsConfigs.filter(
+      (config): config is LabsTranscriptsConfigurationResource =>
+        config !== null
+    ),
+    async (config) => {
+      logger.info(
+        `Stopping Labs workflow for workspace ${config.workspaceId} and provider ${config.provider}`
+      );
+      await stopRetrieveTranscriptsWorkflow(config);
+      await config.setIsActive(false);
+      stoppedWorkflows++;
+    },
+    { concurrency: 3 }
   );
 
   return new Ok(stoppedWorkflows);

--- a/front/lib/api/labs.ts
+++ b/front/lib/api/labs.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
+import logger from "@app/logger/logger";
 import { stopRetrieveTranscriptsWorkflow } from "@app/temporal/labs/client";
 import { Ok } from "@app/types";
 import { labsTranscriptsProviders } from "@app/types/labs";
@@ -23,6 +24,9 @@ export async function pauseAllLabsWorkflows(auth: Authenticator) {
 
   allLabsConfigs.forEach(async (config) => {
     if (config) {
+      logger.info(
+        `Stopping Labs workflow ${config.id} for workspace ${config.workspaceId} and provider ${config.provider}`
+      );
       await stopRetrieveTranscriptsWorkflow(config);
       await config.setIsActive(false);
       stoppedWorkflows++;

--- a/front/lib/api/labs.ts
+++ b/front/lib/api/labs.ts
@@ -1,0 +1,33 @@
+import type { Authenticator } from "@app/lib/auth";
+import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
+import { stopRetrieveTranscriptsWorkflow } from "@app/temporal/labs/client";
+import { Ok } from "@app/types";
+import { labsTranscriptsProviders } from "@app/types/labs";
+
+/**
+ * Pauses all Labs transcripts temporal workflows and their schedules for a workspace
+ */
+export async function pauseAllLabsWorkflows(auth: Authenticator) {
+  const allLabsConfigs = await Promise.all(
+    labsTranscriptsProviders.map(async (provider) => {
+      const config =
+        await LabsTranscriptsConfigurationResource.findByWorkspaceAndProvider({
+          auth,
+          provider,
+        });
+      return config;
+    })
+  );
+
+  let stoppedWorkflows = 0;
+
+  allLabsConfigs.forEach(async (config) => {
+    if (config) {
+      await stopRetrieveTranscriptsWorkflow(config);
+      await config.setIsActive(false);
+      stoppedWorkflows++;
+    }
+  });
+
+  return new Ok(stoppedWorkflows);
+}

--- a/front/migrations/20250321_stop_relocated_transcripts_workflows.ts
+++ b/front/migrations/20250321_stop_relocated_transcripts_workflows.ts
@@ -33,14 +33,18 @@ async function pauseWorkflowsForWorkspace(
 
 makeScript(
   {
-    workspaceId: { type: "string", required: false },
+    workspaceIds: { type: "string", required: false },
   },
-  async ({ workspaceId, execute }, logger) => {
-    if (workspaceId) {
+  async ({ workspaceIds, execute }, logger) => {
+    if (!workspaceIds) {
+      logger.error("Usage: Workspace IDs are required (comma-separated)");
+      throw new Error("Workspace IDs are required");
+    }
+
+    const ids = workspaceIds.split(",").map((id) => id.trim());
+
+    for (const workspaceId of ids) {
       await pauseWorkflowsForWorkspace(workspaceId, logger, execute);
-    } else {
-      logger.error("Usage: Workspace ID is required");
-      throw new Error("Workspace ID is required");
     }
   }
 );

--- a/front/migrations/20250321_stop_relocated_transcripts_workflows.ts
+++ b/front/migrations/20250321_stop_relocated_transcripts_workflows.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env ts-node-script
 import type { Logger } from "pino";
 
 import { pauseAllLabsWorkflows } from "@app/lib/api/labs";

--- a/front/migrations/20250321_stop_relocated_transcripts_workflows.ts
+++ b/front/migrations/20250321_stop_relocated_transcripts_workflows.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env ts-node-script
+import type { Logger } from "pino";
+
+import { pauseAllLabsWorkflows } from "@app/lib/api/labs";
+import { Authenticator } from "@app/lib/auth";
+import { makeScript } from "@app/scripts/helpers";
+
+async function pauseWorkflowsForWorkspace(
+  workspaceId: string,
+  logger: Logger,
+  execute: boolean
+) {
+  logger.info(`Processing workspace ${workspaceId}`);
+
+  if (!execute) {
+    return;
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const pauseLabsRes = await pauseAllLabsWorkflows(auth);
+
+  if (pauseLabsRes.isErr()) {
+    logger.error(
+      `Failed to pause labs workflows for workspace ${workspaceId}: ${pauseLabsRes.error}`
+    );
+    throw new Error(`Failed to pause labs workflows: ${pauseLabsRes.error}`);
+  }
+
+  logger.info(
+    `Successfully paused labs workflows for workspace ${workspaceId}`
+  );
+}
+
+makeScript(
+  {
+    workspaceId: { type: "string", required: false },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    if (workspaceId) {
+      await pauseWorkflowsForWorkspace(workspaceId, logger, execute);
+    } else {
+      logger.error("Usage: Workspace ID is required");
+      throw new Error("Workspace ID is required");
+    }
+  }
+);

--- a/front/scripts/relocate_workspace.ts
+++ b/front/scripts/relocate_workspace.ts
@@ -3,6 +3,7 @@ import {
   pauseAllManagedDataSources,
   resumeAllManagedDataSources,
 } from "@app/lib/api/data_sources";
+import { pauseAllLabsWorkflows } from "@app/lib/api/labs";
 import type { RegionType } from "@app/lib/api/regions/config";
 import {
   config,
@@ -121,7 +122,15 @@ makeScript(
             return;
           }
 
-          // 3) Launch the relocation workflow.
+          // 3) Pause all labs workflows.
+          const pauseLabsRes = await pauseAllLabsWorkflows(auth);
+          if (pauseLabsRes.isErr()) {
+            logger.error(
+              `Failed to pause labs workflows: ${pauseLabsRes.error}`
+            );
+          }
+
+          // 4) Launch the relocation workflow.
           await launchWorkspaceRelocationWorkflow({
             workspaceId: owner.sId,
             sourceRegion,


### PR DESCRIPTION
## Description

This PR adds functionality to pause and manage Labs transcripts workflows during workspace relocation operations. Here's what the changes include:

1. New API module (`labs.ts`):
   - Adds a `pauseAllLabsWorkflows` function that stops all Labs transcripts temporal workflows and their schedules for a workspace
   - The function updates the active status of workflow configurations and returns the count of stopped workflows

2. A script to pause all workflows from already relocated workspaces

3. Updates to workspace relocation script:
   - Modifies `relocate_workspace.ts` to include Labs workflows management
   - Adds a new step to pause Labs workflows before launching the relocation workflow

The changes ensure that Labs transcripts workflows are properly handled during workspace relocations, preventing potential issues with workflow execution during the relocation process.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run the backfill script 
`npx tsx migrations/20250321_stop_relocated_transcripts_workflows.ts --workspaceIds="id1,id2,id3" --execute`