### PR TITLE
Builder: Add a Select All buttons if all results comes from Salesforce in search results popover

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -89,11 +89,14 @@ export default function AssistantBuilderDataSourceModal({
     }
   }, [dataSourceViews, viewType]);
 
-  const selectedItemsCount = useMemo(() => {
+  const selectedTableCount = useMemo(() => {
+    if (viewType !== "table") {
+      return null;
+    }
     return Object.values(selectionConfigurations).reduce((acc, curr) => {
       return acc + curr.selectedResources.length;
     }, 0);
-  }, [selectionConfigurations]);
+  }, [selectionConfigurations, viewType]);
 
   return (
     <Sheet
@@ -125,9 +128,11 @@ export default function AssistantBuilderDataSourceModal({
             />
           </div>
         </SheetContainer>
-        <div className="flex flex-col border-t border-border/60 bg-background p-3 text-sm dark:border-border-night/60 dark:bg-background-night">
-          {selectedItemsCount} items selected.
-        </div>
+        {selectedTableCount && (
+          <div className="flex flex-col border-t border-border/60 bg-background p-3 text-sm dark:border-border-night/60 dark:bg-background-night">
+            {selectedTableCount} items selected.
+          </div>
+        )}
         <SheetFooter
           leftButtonProps={{
             label: "Cancel",

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -89,6 +89,12 @@ export default function AssistantBuilderDataSourceModal({
     }
   }, [dataSourceViews, viewType]);
 
+  const selectedItemsCount = useMemo(() => {
+    return Object.values(selectionConfigurations).reduce((acc, curr) => {
+      return acc + curr.selectedResources.length;
+    }, 0);
+  }, [selectionConfigurations]);
+
   return (
     <Sheet
       open={isOpen}
@@ -119,6 +125,9 @@ export default function AssistantBuilderDataSourceModal({
             />
           </div>
         </SheetContainer>
+        <div className="flex flex-col border-t border-border/60 bg-background p-3 text-sm dark:border-border-night/60 dark:bg-background-night">
+          {selectedItemsCount} items selected.
+        </div>
         <SheetFooter
           leftButtonProps={{
             label: "Cancel",

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -265,6 +265,32 @@ export function DataSourceViewsSelector({
     ? LimitedSearchContentMessage({ warningCode })
     : undefined;
 
+  // We want to allow a "Select all" results from the search results in the Assistant Builder.
+  // We think to make it a good XP we need to add some additional filters per data source.
+  // Since this is something that we really need for Salesforce, we will start with this.
+  const displaySelectAllButton = useMemo(() => {
+    if (useCase !== "assistantBuilder" || searchResultNodes.length === 0) {
+      return false;
+    }
+
+    const isAllSalesforce = searchResultNodes.every(
+      (r) => r.dataSourceView.dataSource.connectorProvider === "salesforce"
+    );
+    return isAllSalesforce;
+
+    // TODO: Replace with this once we are ready to select all from the search results for all data sources.
+    // if (viewType !== "table") {
+    //   return true;
+    // }
+    // const hasRemote = searchResultNodes.some((r) =>
+    //   isRemoteDatabase(r.dataSourceView.dataSource)
+    // );
+    // const hasNonRemote = searchResultNodes.some(
+    //   (r) => !isRemoteDatabase(r.dataSourceView.dataSource)
+    // );
+    // return hasRemote !== hasNonRemote;
+  }, [searchResultNodes, useCase]);
+
   return (
     <div>
       <SearchInputWithPopover
@@ -286,6 +312,20 @@ export function DataSourceViewsSelector({
             updateSelection(item, prevState)
           );
         }}
+        displayItemCount={useCase === "assistantBuilder"}
+        onSelectAll={
+          displaySelectAllButton
+            ? () => {
+                setSearchSpaceText("");
+                searchResultNodes.forEach((item) => {
+                  setSelectionConfigurations((prevState) =>
+                    updateSelection(item, prevState)
+                  );
+                });
+                setSearchResult(searchResultNodes[0]); // We scroll to the first item. Not perfect but no perfect solution here.
+              }
+            : undefined
+        }
         contentMessage={contentMessage}
         renderItem={(item, selected) => {
           return (


### PR DESCRIPTION
## Description

We want to be able to add a "Select All" button from the search results in the Assistant Builder. 
Figma is here: https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product?node-id=2389-13138&p=f&t=zpmjmIzpiXyO6Nei-0

To be perfectly usable we think it needs to come with some way to filter from a datasource. This is a bit more work then just allowing to Select all. To be able to ship this quickly for Salesforce for which it's a real pain point to not be able to select multiple items at the time, I gated this new button to salesforce only. 

Meaning this button appears only if all the results come from Salesforce and we're in the Builder. 

<img width="770" alt="Screenshot 2025-03-21 at 16 06 36" src="https://github.com/user-attachments/assets/73e25091-2b73-4eee-9fb9-fac3cb2e9b59" />

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
