### PR TITLE
Upg: use proxy for oauth

### DIFF
--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -54,7 +54,8 @@ impl Provider for ConfluenceConnectionProvider {
             "redirect_uri": redirect_uri,
         });
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://auth.atlassian.com/oauth/token")
             .header("Content-Type", "application/json")
             .json(&body);
@@ -117,7 +118,8 @@ impl Provider for ConfluenceConnectionProvider {
             "refresh_token": refresh_token,
         });
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://auth.atlassian.com/oauth/token")
             .header("Content-Type", "application/json")
             .json(&body);

--- a/core/src/oauth/providers/github.rs
+++ b/core/src/oauth/providers/github.rs
@@ -98,7 +98,8 @@ impl GithubConnectionProvider {
         code: &str,
     ) -> Result<(String, u64, serde_json::Value), ProviderError> {
         // https://github.com/octokit/auth-app.js/blob/main/src/get-installation-authentication.ts
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post(format!(
                 "https://api.github.com/app/installations/{}/access_tokens",
                 code

--- a/core/src/oauth/providers/gong.rs
+++ b/core/src/oauth/providers/gong.rs
@@ -55,7 +55,8 @@ impl Provider for GongConnectionProvider {
             ("redirect_uri", &redirect_uri),
         ];
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://app.gong.io/oauth2/generate-customer-token")
             .header("Content-Type", "application/json")
             .header("Authorization", authorization)
@@ -113,7 +114,8 @@ impl Provider for GongConnectionProvider {
             ("refresh_token", &refresh_token),
         ];
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://app.gong.io/oauth2/generate-customer-token")
             .header("Content-Type", "application/json")
             .header("Authorization", authorization)

--- a/core/src/oauth/providers/google_drive.rs
+++ b/core/src/oauth/providers/google_drive.rs
@@ -54,7 +54,8 @@ impl Provider for GoogleDriveConnectionProvider {
             "redirect_uri": redirect_uri,
         });
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://oauth2.googleapis.com/token")
             .header("Content-Type", "application/json")
             .json(&body);
@@ -124,7 +125,8 @@ impl Provider for GoogleDriveConnectionProvider {
             "refresh_token": refresh_token,
         });
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://oauth2.googleapis.com/token")
             .header("Content-Type", "application/json")
             .json(&body);

--- a/core/src/oauth/providers/intercom.rs
+++ b/core/src/oauth/providers/intercom.rs
@@ -46,7 +46,8 @@ impl Provider for IntercomConnectionProvider {
             "redirect_uri": redirect_uri,
         });
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://api.intercom.io/auth/eagle/token")
             .header("Content-Type", "application/json")
             .json(&body);

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -54,7 +54,8 @@ impl Provider for MicrosoftConnectionProvider {
             "scope": "User.Read Sites.Read.All Directory.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
         });
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://login.microsoftonline.com/common/oauth2/v2.0/token")
             .header("Content-Type", "application/x-www-form-urlencoded")
             .form(&body);
@@ -104,7 +105,8 @@ impl Provider for MicrosoftConnectionProvider {
             "scope": "User.Read Sites.Read.All Directory.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
         });
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://login.microsoftonline.com/common/oauth2/v2.0/token")
             .header("Content-Type", "application/x-www-form-urlencoded")
             .form(&body);

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -51,7 +51,8 @@ impl Provider for NotionConnectionProvider {
             "redirect_uri": redirect_uri,
         });
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://api.notion.com/v1/oauth/token")
             .header("Accept", "application/json")
             .header("Content-Type", "application/json")

--- a/core/src/oauth/providers/salesforce.rs
+++ b/core/src/oauth/providers/salesforce.rs
@@ -87,7 +87,8 @@ impl Provider for SalesforceConnectionProvider {
         form_data.insert("redirect_uri", redirect_uri);
         form_data.insert("code_verifier", code_verifier);
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post(format!("{}/services/oauth2/token", instance_url))
             .header("Content-Type", "application/x-www-form-urlencoded")
             .form(&form_data);
@@ -134,7 +135,8 @@ impl Provider for SalesforceConnectionProvider {
         form_data.insert("client_secret", &client_secret);
         form_data.insert("refresh_token", &refresh_token);
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post(format!("{}/services/oauth2/token", instance_url))
             .header("Content-Type", "application/x-www-form-urlencoded")
             .form(&form_data);

--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -49,7 +49,8 @@ impl Provider for SlackConnectionProvider {
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post("https://slack.com/api/oauth.v2.access")
             .header("Content-Type", "application/x-www-form-urlencoded")
             .header("Authorization", format!("Basic {}", self.basic_auth()))
@@ -98,7 +99,7 @@ impl Provider for SlackConnectionProvider {
         //     .unseal_refresh_token()?
         //     .ok_or_else(|| anyhow!("Missing `refresh_token` in Slack connection"))?;
 
-        // let req = reqwest::Client::new()
+        // let req = self.reqwest_client()
         //     .post("https://slack.com/api/oauth.v2.access")
         //     .header("Authorization", format!("Basic {}", self.basic_auth()))
         //     .header("Content-Type", "application/json; charset=utf-8")

--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -62,7 +62,8 @@ impl Provider for ZendeskConnectionProvider {
 
         let url = format!("https://{}.zendesk.com/oauth/tokens", subdomain);
 
-        let req = reqwest::Client::new()
+        let req = self
+            .reqwest_client()
             .post(url)
             .header("Content-Type", "application/json")
             .json(&body);


### PR DESCRIPTION
## Description

Use proxy if env var provided for oauth so our customers can whitelist a fixed ip.

## Tests

Green

## Risk

Low, will fallback to no proxy if some issue, can be reverted.

## Deploy Plan

deploy & add env vars to oauth pods.