### PR TITLE
[Relocation] Fix empty titles

### DIFF
--- a/front/temporal/relocation/activities/destination_region/core/documents.ts
+++ b/front/temporal/relocation/activities/destination_region/core/documents.ts
@@ -76,7 +76,8 @@ export async function processDataSourceDocuments({
         parents = [d.document_id];
       }
 
-      const title = !d.title || d.title.length === 0 ? UNTITLED_TITLE : d.title;
+      const title =
+        !d.title || d.title.trim().length === 0 ? UNTITLED_TITLE : d.title;
 
       return coreAPI.upsertDataSourceDocument({
         // Override the project and data source ids to the ones in the destination region.

--- a/front/temporal/relocation/activities/destination_region/core/documents.ts
+++ b/front/temporal/relocation/activities/destination_region/core/documents.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import type { RegionType } from "@app/lib/api/regions/config";
 import logger from "@app/logger/logger";
 import type {
@@ -75,6 +76,8 @@ export async function processDataSourceDocuments({
         parents = [d.document_id];
       }
 
+      const title = !d.title || d.title.length === 0 ? UNTITLED_TITLE : d.title;
+
       return coreAPI.upsertDataSourceDocument({
         // Override the project and data source ids to the ones in the destination region.
         projectId: destIds.dustAPIProjectId,
@@ -88,7 +91,7 @@ export async function processDataSourceDocuments({
         section: d.section,
         credentials,
         lightDocumentOutput: true,
-        title: d.title,
+        title,
         mimeType: d.mime_type,
       });
     },


### PR DESCRIPTION
Description
---
Fixes issue described [here](https://dust4ai.slack.com/archives/C08GJ7PTW3E/p1742566146206369)
Core now rejects empty titles. We handle in v1 by passing a default title. But some legacy documents had empty titles.

This PR tweaks relocation to handle that

Risk
---
standard

Deploy
---
front

