### PR TITLE
Modify response_format to take in JSON object instead of string

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -313,7 +313,7 @@ impl Block for Chat {
                 if let Some(Value::String(s)) = v.get("openai_organization_id") {
                     extras["openai_organization_id"] = json!(s.clone());
                 }
-                if let Some(Value::String(s)) = v.get("response_format") {
+                if let Some(Value::Object(s)) = v.get("response_format") {
                     extras["response_format"] = json!(s.clone());
                 }
                 if let Some(Value::String(s)) = v.get("reasoning_effort") {

--- a/core/src/providers/openai_compatible_helpers.rs
+++ b/core/src/providers/openai_compatible_helpers.rs
@@ -97,6 +97,8 @@ impl FromStr for OpenAIToolChoice {
     }
 }
 
+type ResponseFormat = serde_json::Map<String, serde_json::Value>;
+
 // Outputs types.
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -625,7 +627,7 @@ pub async fn openai_compatible_chat_completion(
                 _ => None,
             },
             match v.get("response_format") {
-                Some(Value::String(f)) => Some(f.to_string()),
+                Some(Value::Object(f)) => Some(f.clone()),
                 _ => None,
             },
             match v.get("reasoning_effort") {
@@ -868,7 +870,7 @@ async fn streamed_chat_completion(
     max_tokens: Option<i32>,
     presence_penalty: Option<f32>,
     frequency_penalty: Option<f32>,
-    response_format: Option<String>,
+    response_format: Option<ResponseFormat>,
     reasoning_effort: Option<String>,
     logprobs: Option<bool>,
     top_logprobs: Option<i32>,
@@ -963,9 +965,7 @@ async fn streamed_chat_completion(
         body["tool_choice"] = json!(tool_choice);
     }
     if let Some(response_format) = response_format {
-        body["response_format"] = json!({
-            "type": response_format,
-        });
+        body["response_format"] = json!(response_format);
     }
     if let Some(reasoning_effort) = reasoning_effort {
         body["reasoning_effort"] = json!(reasoning_effort);
@@ -1366,7 +1366,7 @@ async fn chat_completion(
     max_tokens: Option<i32>,
     presence_penalty: Option<f32>,
     frequency_penalty: Option<f32>,
-    response_format: Option<String>,
+    response_format: Option<ResponseFormat>,
     reasoning_effort: Option<String>,
     logprobs: Option<bool>,
     top_logprobs: Option<i32>,
@@ -1399,9 +1399,7 @@ async fn chat_completion(
     }
 
     if let Some(response_format) = response_format {
-        body["response_format"] = json!({
-            "type": response_format,
-        });
+        body["response_format"] = json!(response_format)
     }
     if tools.len() > 0 {
         body["tools"] = json!(tools);


### PR DESCRIPTION
## Description

* We already handle response_format input for openai. It currently assumed that the response_format would be a type, which is incorrect https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat&example=structured-data#how-to-use
* Changing the response_format config element to pass in the json object as opposed to extracting it as a json value
* Created a dedicated type in case we wanted to more specifically type the expected content of the object

## Tests

Ran against local endpoint:

Request:
```
{
      "specification_hash": "973a5fa849b584b384cdd87b70bd7e03ebf12227edf0ff50e9e7f08fa7a27c86",
      "config": {
        "MODEL": {
          "provider_id": "openai",
          "model_id": "gpt-4.5-preview-2025-02-27",
          "function_call": null,
          "use_cache": false,
          "response_format": {
            "type": "json_schema",
            "json_schema": {
              "name": "ABeautifulTest",
              "strict": true,
              "schema": {
              "type": "object",
              "properties": {
                "Name": {
                  "type": "string"
                },
                "Description": {
                    "type": "string"
                }
              },
              "required": ["Name", "Description"],
              "additionalProperties": false
              }
            }
          }
        }
      },
      "blocking": true,
      "inputs": [{"hello":"world"}]
    }
```

Output:
```
 {"run":{"run_id":"730bf651dfc1b78f54223084c300dc54339490bd1ed4fbb816b70b06b4d68560","created":1742578696878,"run_type":"deploy","config":{"blocks":{"MODEL":{"provider_id":"openai","model_id":"gpt-4.5-preview-2025-02-27","function_call":null,"use_cache":false,"response_format":{"type":"json_schema","json_schema":{"name":"ABeautifulTest","strict":true,"schema":{"type":"object","properties":{"Name":{"type":"string"},"Description":{"type":"string"}},"required":["Name","Description"],"additionalProperties":false}}}}}},"status":{"run":"succeeded","blocks":[{"block_type":"input","name":"INPUT","status":"succeeded","success_count":1,"error_count":0},{"block_type":"chat","name":"MODEL","status":"succeeded","success_count":1,"error_count":0}]},"traces":[[["input","INPUT"],[[{"value":{"hello":"world"},"error":null,"meta":null}]]],[["chat","MODEL"],[[{"value":{"message":{"content":"{\"Name\":\"Hello\",\"Description\":\"Hi! How can I assist you today?\"}","role":"assistant"}},"error":null,"meta":{"logs":[],"token_usage":{"prompt_tokens":52,"completion_tokens":18},"provider_request_id":"req_b75b23937184f73151094d25df79c036"}}]]]],"specification_hash":"973a5fa849b584b384cdd87b70bd7e03ebf12227edf0ff50e9e7f08fa7a27c86","results":[[{"value":{"message":{"content":"{\"Name\":\"Hello\",\"Description\":\"Hi! How can I assist you today?\"}","role":"assistant"}},"error":null,"meta":{"logs":[],"token_usage":{"prompt_tokens":52,"completion_tokens":18},"provider_request_id":"req_b75b23937184f73151094d25df79c036"}}]]}}
```

## Risk

N/A - I don't believe this is directly exposed to customers yet via the console. It should fix an existing issue.

## Deploy Plan

Deploy via Github