### PR TITLE
[Relocation] Fix: dust app relocation: create projects for dust apps

### DIFF
--- a/front/temporal/relocation/activities/destination_region/core/apps.ts
+++ b/front/temporal/relocation/activities/destination_region/core/apps.ts
@@ -1,5 +1,6 @@
 import config from "@app/lib/api/config";
 import type { RegionType } from "@app/lib/api/regions/config";
+import { AppModel } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
 import type { CoreAppAPIRelocationBlob } from "@app/temporal/relocation/activities/types";
 import { readFromRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
@@ -33,12 +34,21 @@ export async function processApp({
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
+  // Create new project for the app.
+  const projectRes = await coreAPI.createProject();
+
+  if (projectRes.isErr()) {
+    throw new Error(`Failed to create project: ${projectRes.error}`);
+  }
+
+  const newDustAPIProjectId = projectRes.value.project.project_id.toString();
+
   for (const app of data.blobs.apps) {
     await concurrentExecutor(
       app.datasets,
       async (dataset) => {
         const res = await coreAPI.createDataset({
-          projectId: dustAPIProjectId,
+          projectId: newDustAPIProjectId,
           datasetId: dataset.dataset_id,
           data: dataset.data,
         });
@@ -54,7 +64,7 @@ export async function processApp({
       Object.values(app.coreSpecifications),
       async (specification) => {
         const res = await coreAPI.saveSpecification({
-          projectId: dustAPIProjectId,
+          projectId: newDustAPIProjectId,
           specification: specification,
         });
 
@@ -65,4 +75,16 @@ export async function processApp({
       { concurrency: 10 }
     );
   }
+
+  // Update app with new project id.
+  await AppModel.update(
+    {
+      dustAPIProjectId: newDustAPIProjectId,
+    },
+    {
+      where: {
+        dustAPIProjectId: dustAPIProjectId,
+      },
+    }
+  );
 }


### PR DESCRIPTION
Description
---
Fixes issue described in [this
thread](https://dust4ai.slack.com/archives/C08GJ7PTW3E/p1742592866471579?thread_ts=1742578164.569179&cid=C08GJ7PTW3E)

```
Some(db error: ERROR: insert or update on table "datasets" violates foreign key constraint "datasets_project_fkey"
DETAIL: Key (project)=(32599) is not present in table "projects".

Caused by:
    ERROR: insert or update on table "datasets" violates foreign key constraint "datasets_project_fkey"
    DETAIL: Key (project)=(32599) is not present in table "projects".)
````

Dust apps need projects to be created in destination core before they can be migrated.

Then, corresponding front project ids must be updated.

This is done in activity, to avoid having to restart ongoing relocations.

Risks
---
Relocation issues. Require careful review

Deploy
---
front
