### PR TITLE
Skip Relocating Large Tables

### DIFF
--- a/front/temporal/relocation/activities/source_region/core/tables.ts
+++ b/front/temporal/relocation/activities/source_region/core/tables.ts
@@ -8,6 +8,7 @@ import type {
 import {
   CORE_API_CONCURRENCY_LIMIT,
   CORE_API_LIST_NODES_BATCH_SIZE,
+  isStringTooLongError,
 } from "@app/temporal/relocation/activities/types";
 import { writeToRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
 import type {
@@ -16,7 +17,7 @@ import type {
   CoreAPITableBlob,
   Ok,
 } from "@app/types";
-import { concurrentExecutor, CoreAPI } from "@app/types";
+import { concurrentExecutor, CoreAPI, removeNulls } from "@app/types";
 
 export async function getDataSourceTables({
   dataSourceCoreIds,
@@ -79,19 +80,39 @@ export async function getDataSourceTables({
   // 2) Get the table blobs.
   const res = await concurrentExecutor(
     nodes,
-    async (n) =>
-      coreAPI.getDataSourceTableBlob({
-        projectId: dataSourceCoreIds.dustAPIProjectId,
-        dataSourceId: dataSourceCoreIds.dustAPIDataSourceId,
-        tableId: n.node_id,
-      }),
+    async (n) => {
+      try {
+        return await coreAPI.getDataSourceTableBlob({
+          projectId: dataSourceCoreIds.dustAPIProjectId,
+          dataSourceId: dataSourceCoreIds.dustAPIDataSourceId,
+          tableId: n.node_id,
+        });
+      } catch (err) {
+        // If the table is too large to be processed, log and skip.
+        if (isStringTooLongError(err)) {
+          logger.info(
+            {
+              tableId: n.node_id,
+              error: err,
+            },
+            "[Core] Failed to get data source table blob. Table is too large to be processed."
+          );
+
+          return null;
+        }
+
+        throw err;
+      }
+    },
     { concurrency: CORE_API_CONCURRENCY_LIMIT }
   );
 
-  const tableBlobs = res
+  const nonNullTableResults = removeNulls(res);
+
+  const tableBlobs = nonNullTableResults
     .filter((r): r is Ok<CoreAPITableBlob> => r.isOk())
     .map((r) => r.value);
-  const failed = res.filter((r) => r.isErr());
+  const failed = nonNullTableResults.filter((r) => r.isErr());
   if (failed.length > 0) {
     localLogger.error(
       { failed },

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -79,3 +79,14 @@ export function isArrayOfPlainObjects(value: unknown) {
     value.every((element) => isPlainObject(element))
   );
 }
+
+export function isStringTooLongError(
+  err: unknown
+): err is { code: "ERR_STRING_TOO_LONG" } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    err.code === "ERR_STRING_TOO_LONG"
+  );
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See context [here](https://dust4ai.slack.com/archives/C08GJ7PTW3E/p1742566146206369).

We have some table blobs that are ~ 512 MB, this reaches Node.js/V8 maximum string length limit. We handle this specific error code `ERR_STRING_TOO_LONG`. We log and skip the table.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
