### PR TITLE
[front] - fix(search): correct searchSourceUrls field type in NodeIdSearchBody

### DIFF
--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -67,7 +67,7 @@ const NodeIdSearchBody = t.intersection([
   }),
   t.partial({
     query: t.undefined,
-    searchSourceUrls: t.undefined,
+    searchSourceUrls: t.boolean,
   }),
 ]);
 


### PR DESCRIPTION
## Description

This PR changes the type of searchSourceUrls from undefined to boolean to ensure proper type checking, following up this PR: https://github.com/dust-tt/dust/pull/11538

## Risk

Low

## Deploy Plan

Deploy front