### PR TITLE
[Webcrawler] Skip paused connector directly in activity

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -82,6 +82,12 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
     return;
   }
 
+  // The crawler scheduler may have scheduled a crawl before the connector was paused.
+  if (connector.isPaused()) {
+    logger.info({ connectorId }, "Connector is paused. Skipping crawl.");
+    return;
+  }
+
   const webCrawlerConfig =
     await WebCrawlerConfigurationResource.fetchByConnectorId(connectorId);
 


### PR DESCRIPTION
Description
---
The webcrawler scheduler does not schedule crawls for paused websites, but if the website is paused after it was scheduled, the crawl will start.

E.g. in relocations when we pause all connectors, this happens a lot, [example here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1742808150399699)

This PR performs the check in the activity.

Risks
---
low

Deploy
---
connectors
