### PR TITLE
[front] mcp: create a MCP server and assign it to an agent

### DIFF
--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -2,8 +2,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuTrigger,
   DropdownMenuSeparator,
+  DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -37,9 +37,10 @@ export function ActionMCP({
     useState<(typeof AVAILABLE_INTERNAL_MCPSERVER_IDS)[number] | null>(
       actionConfiguration.internalMCPServerId
     );
-  const [selectedRemoteMCPServerId, setSelectedRemoteMCPServerId] =
-    useState<string | null>(actionConfiguration.remoteMCPServerId);
-  
+  const [selectedRemoteMCPServerId, setSelectedRemoteMCPServerId] = useState<
+    string | null
+  >(actionConfiguration.remoteMCPServerId);
+
   const space = allowedSpaces.length > 0 ? allowedSpaces[0] : null;
   const { servers, isServersLoading } = useRemoteMCPServers({
     disabled: !space,
@@ -48,10 +49,16 @@ export function ActionMCP({
   });
 
   const getDropdownLabel = () => {
-    if (actionConfiguration.serverType === "internal" && selectedInternalMCPServerId) {
+    if (
+      actionConfiguration.serverType === "internal" &&
+      selectedInternalMCPServerId
+    ) {
       return `${selectedInternalMCPServerId}`;
-    } else if (actionConfiguration.serverType === "remote" && selectedRemoteMCPServerId) {
-      const server = servers.find(s => s.id === selectedRemoteMCPServerId);
+    } else if (
+      actionConfiguration.serverType === "remote" &&
+      selectedRemoteMCPServerId
+    ) {
+      const server = servers.find((s) => s.id === selectedRemoteMCPServerId);
       return server ? `${server.name}` : "Unnamed Server";
     }
     return "Select a server";
@@ -61,19 +68,18 @@ export function ActionMCP({
     <>
       <div>Will expose all the tools available via an MCP Server.</div>
       <div>
-        You can choose from <b>internal</b>, Dust-developed MCP Servers, or from <b>Remote</b> MCP Servers.
-        You can setup Remote servers in your spaces of choice, in the Knowledge tab.
+        You can choose from <b>internal</b>, Dust-developed MCP Servers, or from{" "}
+        <b>Remote</b> MCP Servers. You can setup Remote servers in your spaces
+        of choice, in the Knowledge tab.
       </div>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button
-            isSelect
-            label={getDropdownLabel()}
-            className="w-48"
-          />
+          <Button isSelect label={getDropdownLabel()} className="w-48" />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="mt-1" align="start">
-          <div className="px-2 py-1 text-xs font-medium text-gray-500">Internal Servers</div>
+          <div className="px-2 py-1 text-xs font-medium text-gray-500">
+            Internal Servers
+          </div>
           {AVAILABLE_INTERNAL_MCPSERVER_IDS.map((id) => (
             <DropdownMenuItem
               key={id}
@@ -91,13 +97,15 @@ export function ActionMCP({
               }}
             />
           ))}
-          
+
           {servers.length > 0 && <DropdownMenuSeparator />}
-          
+
           {servers.length > 0 && (
-            <div className="px-2 py-1 text-xs font-medium text-gray-500">Remote Servers</div>
+            <div className="px-2 py-1 text-xs font-medium text-gray-500">
+              Remote Servers
+            </div>
           )}
-          
+
           {servers.map((server) => (
             <DropdownMenuItem
               key={server.id}
@@ -115,13 +123,17 @@ export function ActionMCP({
               }}
             />
           ))}
-          
+
           {isServersLoading && (
-            <div className="px-2 py-1 text-sm text-gray-500">Loading remote servers...</div>
+            <div className="px-2 py-1 text-sm text-gray-500">
+              Loading remote servers...
+            </div>
           )}
-          
+
           {!isServersLoading && servers.length === 0 && (
-            <div className="px-2 py-1 text-sm text-gray-500">No remote servers available</div>
+            <div className="px-2 py-1 text-sm text-gray-500">
+              No remote servers available
+            </div>
           )}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -3,6 +3,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownMenuSeparator,
 } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -12,9 +13,16 @@ import type {
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
 import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
+import { useRemoteMCPServers } from "@app/lib/swr/remote_mcp_servers";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
-type ActionMCPProps = {
+export function ActionMCP({
+  owner,
+  allowedSpaces,
+  actionConfiguration,
+  updateAction,
+  setEdited,
+}: {
   owner: LightWorkspaceType;
   allowedSpaces: SpaceType[];
   actionConfiguration: AssistantBuilderMCPServerConfiguration;
@@ -24,46 +32,97 @@ type ActionMCPProps = {
     ) => AssistantBuilderMCPServerConfiguration
   ) => void;
   setEdited: (edited: boolean) => void;
-};
-
-export function ActionMCP({
-  actionConfiguration,
-  updateAction,
-  setEdited,
-}: ActionMCPProps) {
+}) {
   const [selectedInternalMCPServerId, setSelectedInternalMCPServerId] =
     useState<(typeof AVAILABLE_INTERNAL_MCPSERVER_IDS)[number] | null>(
       actionConfiguration.internalMCPServerId
     );
+  const [selectedRemoteMCPServerId, setSelectedRemoteMCPServerId] =
+    useState<string | null>(actionConfiguration.remoteMCPServerId);
+  
+  const space = allowedSpaces.length > 0 ? allowedSpaces[0] : null;
+  const { servers, isServersLoading } = useRemoteMCPServers({
+    disabled: !space,
+    owner,
+    space: space!,
+  });
+
+  const getDropdownLabel = () => {
+    if (actionConfiguration.serverType === "internal" && selectedInternalMCPServerId) {
+      return `${selectedInternalMCPServerId}`;
+    } else if (actionConfiguration.serverType === "remote" && selectedRemoteMCPServerId) {
+      const server = servers.find(s => s.id === selectedRemoteMCPServerId);
+      return server ? `${server.name}` : "Unnamed Server";
+    }
+    return "Select a server";
+  };
 
   return (
     <>
       <div>Will expose all the tools available via an MCP Server.</div>
-      <div>For testing purposes, pick an internal server</div>
+      <div>
+        You can choose from <b>internal</b>, Dust-developed MCP Servers, or from <b>Remote</b> MCP Servers.
+        You can setup Remote servers in your spaces of choice, in the Knowledge tab.
+      </div>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             isSelect
-            label={selectedInternalMCPServerId ?? "Select a internal server"}
+            label={getDropdownLabel()}
             className="w-48"
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="mt-1" align="start">
+          <div className="px-2 py-1 text-xs font-medium text-gray-500">Internal Servers</div>
           {AVAILABLE_INTERNAL_MCPSERVER_IDS.map((id) => (
             <DropdownMenuItem
               key={id}
-              label={id}
+              label={`${id}`}
               onClick={() => {
                 setSelectedInternalMCPServerId(id);
+                setSelectedRemoteMCPServerId(null);
                 updateAction((previousAction) => ({
                   ...previousAction,
                   serverType: "internal",
                   internalMCPServerId: id,
+                  remoteMCPServerId: null,
                 }));
                 setEdited(true);
               }}
             />
           ))}
+          
+          {servers.length > 0 && <DropdownMenuSeparator />}
+          
+          {servers.length > 0 && (
+            <div className="px-2 py-1 text-xs font-medium text-gray-500">Remote Servers</div>
+          )}
+          
+          {servers.map((server) => (
+            <DropdownMenuItem
+              key={server.id}
+              label={`${server.name}`}
+              onClick={() => {
+                setSelectedInternalMCPServerId(null);
+                setSelectedRemoteMCPServerId(server.id || null);
+                updateAction((previousAction) => ({
+                  ...previousAction,
+                  serverType: "remote",
+                  internalMCPServerId: null,
+                  remoteMCPServerId: server.id!,
+                }));
+                setEdited(true);
+              }}
+            />
+          ))}
+          
+          {isServersLoading && (
+            <div className="px-2 py-1 text-sm text-gray-500">Loading remote servers...</div>
+          )}
+          
+          {!isServersLoading && servers.length === 0 && (
+            <div className="px-2 py-1 text-sm text-gray-500">No remote servers available</div>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </>

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -16,13 +16,7 @@ import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
 import { useRemoteMCPServers } from "@app/lib/swr/remote_mcp_servers";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
-export function ActionMCP({
-  owner,
-  allowedSpaces,
-  actionConfiguration,
-  updateAction,
-  setEdited,
-}: {
+type ActionMCPProps = {
   owner: LightWorkspaceType;
   allowedSpaces: SpaceType[];
   actionConfiguration: AssistantBuilderMCPServerConfiguration;
@@ -32,7 +26,15 @@ export function ActionMCP({
     ) => AssistantBuilderMCPServerConfiguration
   ) => void;
   setEdited: (edited: boolean) => void;
-}) {
+};
+
+export function ActionMCP({
+  owner,
+  allowedSpaces,
+  actionConfiguration,
+  updateAction,
+  setEdited,
+}: ActionMCPProps) {
   const [selectedInternalMCPServerId, setSelectedInternalMCPServerId] =
     useState<(typeof AVAILABLE_INTERNAL_MCPSERVER_IDS)[number] | null>(
       actionConfiguration.internalMCPServerId
@@ -53,13 +55,13 @@ export function ActionMCP({
       actionConfiguration.serverType === "internal" &&
       selectedInternalMCPServerId
     ) {
-      return `${selectedInternalMCPServerId}`;
+      return selectedInternalMCPServerId;
     } else if (
       actionConfiguration.serverType === "remote" &&
       selectedRemoteMCPServerId
     ) {
       const server = servers.find((s) => s.id === selectedRemoteMCPServerId);
-      return server ? `${server.name}` : "Unnamed Server";
+      return server ? server.name : "Unnamed Server";
     }
     return "Select a server";
   };
@@ -83,7 +85,7 @@ export function ActionMCP({
           {AVAILABLE_INTERNAL_MCPSERVER_IDS.map((id) => (
             <DropdownMenuItem
               key={id}
-              label={`${id}`}
+              label={id}
               onClick={() => {
                 setSelectedInternalMCPServerId(id);
                 setSelectedRemoteMCPServerId(null);
@@ -109,7 +111,7 @@ export function ActionMCP({
           {servers.map((server) => (
             <DropdownMenuItem
               key={server.id}
-              label={`${server.name}`}
+              label={server.name}
               onClick={() => {
                 setSelectedInternalMCPServerId(null);
                 setSelectedRemoteMCPServerId(server.id || null);

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -14,6 +14,7 @@ import {
   Icon,
   PlusIcon,
   RobotIcon,
+  ServerIcon,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { CellContext } from "@tanstack/react-table";
@@ -31,6 +32,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { DATA_SOURCE_VIEW_CATEGORIES, removeNulls } from "@app/types";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 type RowData = {
   category: string;
@@ -106,6 +108,9 @@ export const SpaceCategoriesList = ({
     workspaceId: owner.sId,
     spaceId: space.sId,
   });
+  const { hasFeature } = useFeatureFlags({
+    workspaceId: owner.sId
+  })
 
   const { setIsSearchDisabled } = React.useContext(SpaceSearchContext);
 
@@ -184,6 +189,14 @@ export const SpaceCategoriesList = ({
             icon={CommandLineIcon}
             label="Create a Dust App"
           />
+          {hasFeature("mcp_actions") && ( 
+            <DropdownMenuItem
+              disabled={!canWriteInSpace}
+              href={`/w/${owner.sId}/spaces/${space.sId}/categories/mcp`}
+              icon={ServerIcon}
+              label="Create an MCP"
+            />
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </>

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -26,13 +26,13 @@ import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHea
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   DataSourceWithAgentsUsageType,
   SpaceType,
   WorkspaceType,
 } from "@app/types";
 import { DATA_SOURCE_VIEW_CATEGORIES, removeNulls } from "@app/types";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 type RowData = {
   category: string;
@@ -109,8 +109,8 @@ export const SpaceCategoriesList = ({
     spaceId: space.sId,
   });
   const { hasFeature } = useFeatureFlags({
-    workspaceId: owner.sId
-  })
+    workspaceId: owner.sId,
+  });
 
   const { setIsSearchDisabled } = React.useContext(SpaceSearchContext);
 
@@ -189,7 +189,7 @@ export const SpaceCategoriesList = ({
             icon={CommandLineIcon}
             label="Create a Dust App"
           />
-          {hasFeature("mcp_actions") && ( 
+          {hasFeature("mcp_actions") && (
             <DropdownMenuItem
               disabled={!canWriteInSpace}
               href={`/w/${owner.sId}/spaces/${space.sId}/categories/mcp`}

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -237,7 +237,7 @@ interface SpaceResourcesListProps {
   canWriteInSpace: boolean;
   space: SpaceType;
   systemSpace: SpaceType;
-  category: Exclude<DataSourceViewCategory, "apps">;
+  category: Exclude<DataSourceViewCategory, "apps" | "mcp">;
   onSelect: (sId: string) => void;
   integrations: DataSourceIntegration[];
 }

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -45,6 +45,7 @@ import type {
 import { assertNever, DATA_SOURCE_VIEW_CATEGORIES } from "@app/types";
 import { useRemoteMCPServer, useRemoteMCPServers } from "@app/lib/swr/remote_mcp_servers";
 import { MCPResponse } from "@app/types/mcp";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface SpaceSideBarMenuProps {
   owner: LightWorkspaceType;
@@ -342,6 +343,9 @@ const SpaceMenuItem = ({
 }) => {
   const router = useRouter();
   const { setNavigationSelection } = usePersistedNavigationSelection();
+  const { hasFeature } = useFeatureFlags({
+    workspaceId: owner.sId
+  })
 
   const spacePath = `/w/${owner.sId}/spaces/${space.sId}`;
   const isAncestorToCurrentPage =
@@ -392,6 +396,9 @@ const SpaceMenuItem = ({
                   />
                 );
               } else if (c === "mcp") {
+                if (!hasFeature("mcp_actions")) {
+                  return null;
+                }
                 return (
                   <SpaceRemoteMCPServersSubMenu
                     key={c}

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -452,7 +452,7 @@ const DATA_SOURCE_OR_VIEW_SUB_ITEMS: {
   },
   mcp: {
     icon: SparklesIcon,
-    label: "Remote MCP Servers",
+    label: "MCP Servers",
   },
 };
 
@@ -741,7 +741,7 @@ const SpaceRemoteMCPServerItem = ({
     <Tree.Item
       type="leaf"
       label={server.name}
-      visual={CommandLineIcon}
+      visual={SparklesIcon}
       areActionsFading={false}
     />
   );

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -28,12 +28,14 @@ import {
 } from "@app/lib/spaces";
 import { useApps } from "@app/lib/swr/apps";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+import { useRemoteMCPServers } from "@app/lib/swr/remote_mcp_servers";
 import {
   useSpaceDataSourceViews,
   useSpaceInfo,
   useSpaces,
   useSpacesAsAdmin,
 } from "@app/lib/swr/spaces";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   AppType,
   DataSourceViewCategory,
@@ -43,9 +45,7 @@ import type {
   SpaceType,
 } from "@app/types";
 import { assertNever, DATA_SOURCE_VIEW_CATEGORIES } from "@app/types";
-import { useRemoteMCPServer, useRemoteMCPServers } from "@app/lib/swr/remote_mcp_servers";
-import { MCPResponse } from "@app/types/mcp";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { MCPResponse } from "@app/types/mcp";
 
 interface SpaceSideBarMenuProps {
   owner: LightWorkspaceType;
@@ -234,7 +234,9 @@ const SystemSpaceMenu = ({
     <Tree variant="navigator">
       {SYSTEM_SPACE_ITEMS.map((item) => (
         <SystemSpaceItem
-          category={item.category as Exclude<DataSourceViewCategory, "apps" | "mcp">}
+          category={
+            item.category as Exclude<DataSourceViewCategory, "apps" | "mcp">
+          }
           key={item.label}
           label={item.label}
           owner={owner}
@@ -344,8 +346,8 @@ const SpaceMenuItem = ({
   const router = useRouter();
   const { setNavigationSelection } = usePersistedNavigationSelection();
   const { hasFeature } = useFeatureFlags({
-    workspaceId: owner.sId
-  })
+    workspaceId: owner.sId,
+  });
 
   const spacePath = `/w/${owner.sId}/spaces/${space.sId}`;
   const isAncestorToCurrentPage =
@@ -730,7 +732,6 @@ const SpaceAppSubMenu = ({
   );
 };
 
-
 const SpaceRemoteMCPServerItem = ({
   server,
 }: {
@@ -797,7 +798,11 @@ const SpaceRemoteMCPServersSubMenu = ({
       {isExpanded && (
         <Tree isLoading={isServersLoading}>
           {sortBy(servers, "name").map((server) => (
-            <SpaceRemoteMCPServerItem server={server} key={server.id} owner={owner} />
+            <SpaceRemoteMCPServerItem
+              server={server}
+              key={server.id}
+              owner={owner}
+            />
           ))}
         </Tree>
       )}

--- a/front/components/spaces/mcp/SpaceMCPForm.tsx
+++ b/front/components/spaces/mcp/SpaceMCPForm.tsx
@@ -1,0 +1,202 @@
+import {
+  Button,
+  Input,
+  Label,
+  TextArea,
+  Spinner,
+  Page,
+} from "@dust-tt/sparkle";
+import { ChangeEvent, useEffect, useState } from "react";
+
+import { MCPFormAction, MCPFormState, MCPTool } from "@app/types/mcp";
+
+interface SpaceMCPFormProps {
+  state: MCPFormState;
+  dispatch: React.Dispatch<MCPFormAction>;
+  isConfigurationLoading: boolean;
+  onSynchronize: () => Promise<void>;
+  isSynchronized: boolean;
+  sharedSecret?: string;
+  isSynchronizing?: boolean;
+}
+
+export function SpaceMCPForm({
+  state,
+  dispatch,
+  isConfigurationLoading,
+  onSynchronize,
+  isSynchronized,
+  sharedSecret,
+  isSynchronizing = false,
+}: SpaceMCPFormProps) {
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [isSecretVisible, setIsSecretVisible] = useState(false);
+
+  useEffect(() => {
+    // Reset any error state when the URL changes
+    setSyncError(null);
+  }, [state.url]);
+
+  const handleSynchronize = async () => {
+    if (!state.url) {
+      setSyncError("Please enter a valid URL before synchronizing.");
+      return;
+    }
+
+    setSyncError(null);
+
+    try {
+      await onSynchronize();
+    } catch (error) {
+      console.error("Error synchronizing with MCP:", error);
+      setSyncError(error instanceof Error ? error.message : "Failed to synchronize with MCP server");
+    }
+  };
+
+  const toggleSecretVisibility = () => {
+    setIsSecretVisible(!isSecretVisible);
+  };
+
+  if (isConfigurationLoading) {
+    return (
+      <div className="flex justify-center items-center p-8">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {syncError && (
+        <div className="rounded-md bg-red-50 p-4">
+          <div className="flex">
+            <div className="flex-shrink-0">
+              <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+              </svg>
+            </div>
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-red-800">Synchronization Error</h3>
+              <div className="mt-2 text-sm text-red-700">
+                <p>{syncError}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="url">URL</Label>
+        <div className="flex space-x-2">
+          <div className="flex-grow">
+            <Input
+              id="url"
+              placeholder="https://example.com/api/mcp"
+              value={state.url}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                dispatch({ type: "SET_FIELD", field: "url", value: e.target.value })
+              }
+              isError={!!state.errors?.url}
+              message={state.errors?.url}
+            />
+          </div>
+          <Button
+            label={isSynchronizing ? "Synchronizing..." : "Synchronize"}
+            variant="tertiary"
+            onClick={handleSynchronize}
+            disabled={isSynchronizing || !state.url}
+          />
+        </div>
+      </div>
+
+      {isSynchronized && (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              placeholder="MCP Server Name"
+              value={state.name}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                dispatch({
+                  type: "SET_FIELD",
+                  field: "name",
+                  value: e.target.value,
+                })
+              }
+              isError={!!state.errors?.name}
+              message={state.errors?.name}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <TextArea
+              id="description"
+              placeholder="Description of the MCP Server"
+              value={state.description}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                dispatch({
+                  type: "SET_FIELD",
+                  field: "description",
+                  value: e.target.value,
+                })
+              }
+            />
+            {state.errors?.description && (
+              <p className="text-sm text-red-600 mt-1">{state.errors.description}</p>
+            )}
+          </div>
+
+          {sharedSecret && (
+            <div className="space-y-2">
+              <Label htmlFor="sharedSecret">Shared Secret</Label>
+              <div className="relative">
+                <Input
+                  id="sharedSecret"
+                  value={sharedSecret}
+                  readOnly
+                  type={isSecretVisible ? "text" : "password"}
+                />
+                <button
+                  type="button"
+                  onClick={toggleSecretVisibility}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                >
+                  {isSecretVisible ? (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+              <p className="text-xs text-gray-500">
+                This is the secret key used to authenticate your MCP server with Dust. Keep it secure.
+              </p>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label>Available Tools</Label>
+            <div className="border rounded-md p-4 space-y-4">
+              {state.tools && state.tools.length > 0 ? (
+                state.tools.map((tool: string, index: number) => (
+                  <div key={index} className="border-b pb-2 last:border-b-0 last:pb-0">
+                    <h4 className="font-medium text-sm">{tool}</h4>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-gray-500">No tools available</p>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/front/components/spaces/mcp/SpaceMCPForm.tsx
+++ b/front/components/spaces/mcp/SpaceMCPForm.tsx
@@ -185,9 +185,12 @@ export function SpaceMCPForm({
             <Label>Available Tools</Label>
             <div className="border rounded-md p-4 space-y-4">
               {state.tools && state.tools.length > 0 ? (
-                state.tools.map((tool: string, index: number) => (
-                  <div key={index} className="border-b pb-2 last:border-b-0 last:pb-0">
-                    <h4 className="font-medium text-sm">{tool}</h4>
+                state.tools.map((tool: { name: string, description: string }, index: number) => (
+                  <div key={index} className="border-b pb-4 last:border-b-0 last:pb-0">
+                    <h4 className="font-medium text-sm">{tool.name}</h4>
+                    {tool.description && (
+                      <p className="text-xs text-gray-500 mt-1">{tool.description}</p>
+                    )}
                   </div>
                 ))
               ) : (

--- a/front/components/spaces/mcp/SpaceMCPForm.tsx
+++ b/front/components/spaces/mcp/SpaceMCPForm.tsx
@@ -1,16 +1,16 @@
 import {
   Button,
+  EyeIcon,
+  EyeSlashIcon,
   Input,
   Label,
-  TextArea,
   Spinner,
-  Page,
-  EyeSlashIcon,
-  EyeIcon,
+  TextArea,
 } from "@dust-tt/sparkle";
-import { ChangeEvent, useEffect, useState } from "react";
+import type { ChangeEvent } from "react";
+import { useEffect, useState } from "react";
 
-import { MCPFormAction, MCPFormState, MCPTool } from "@app/types/mcp";
+import type { MCPFormAction, MCPFormState } from "@app/types/mcp";
 
 interface SpaceMCPFormProps {
   state: MCPFormState;
@@ -51,7 +51,11 @@ export function SpaceMCPForm({
       await onSynchronize();
     } catch (error) {
       console.error("Error synchronizing with MCP:", error);
-      setSyncError(error instanceof Error ? error.message : "Failed to synchronize with MCP server");
+      setSyncError(
+        error instanceof Error
+          ? error.message
+          : "Failed to synchronize with MCP server"
+      );
     }
   };
 
@@ -61,7 +65,7 @@ export function SpaceMCPForm({
 
   if (isConfigurationLoading) {
     return (
-      <div className="flex justify-center items-center p-8">
+      <div className="flex items-center justify-center p-8">
         <Spinner />
       </div>
     );
@@ -73,12 +77,22 @@ export function SpaceMCPForm({
         <div className="rounded-md bg-red-50 p-4">
           <div className="flex">
             <div className="flex-shrink-0">
-              <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+              <svg
+                className="h-5 w-5 text-red-400"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                  clipRule="evenodd"
+                />
               </svg>
             </div>
             <div className="ml-3">
-              <h3 className="text-sm font-medium text-red-800">Synchronization Error</h3>
+              <h3 className="text-sm font-medium text-red-800">
+                Synchronization Error
+              </h3>
               <div className="mt-2 text-sm text-red-700">
                 <p>{syncError}</p>
               </div>
@@ -96,7 +110,11 @@ export function SpaceMCPForm({
               placeholder="https://example.com/api/mcp"
               value={state.url}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                dispatch({ type: "SET_FIELD", field: "url", value: e.target.value })
+                dispatch({
+                  type: "SET_FIELD",
+                  field: "url",
+                  value: e.target.value,
+                })
               }
               isError={!!state.errors?.url}
               message={state.errors?.url}
@@ -146,7 +164,9 @@ export function SpaceMCPForm({
               }
             />
             {state.errors?.description && (
-              <p className="text-sm text-red-600 mt-1">{state.errors.description}</p>
+              <p className="mt-1 text-sm text-red-600">
+                {state.errors.description}
+              </p>
             )}
           </div>
 
@@ -163,33 +183,44 @@ export function SpaceMCPForm({
                 <button
                   type="button"
                   onClick={toggleSecretVisibility}
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                  className="absolute inset-y-0 right-0 flex items-center pr-3"
                 >
                   {isSecretVisible ? (
                     <EyeSlashIcon className="h-5 w-5 text-gray-400" />
                   ) : (
-                    <EyeIcon className="h-5 w-5 text-gray-400"/>
+                    <EyeIcon className="h-5 w-5 text-gray-400" />
                   )}
                 </button>
               </div>
               <p className="text-xs text-gray-500">
-                This is the secret key used to authenticate your MCP server with Dust. Keep it secure.
+                This is the secret key used to authenticate your MCP server with
+                Dust. Keep it secure.
               </p>
             </div>
           )}
 
           <div className="space-y-2">
             <Label>Available Tools</Label>
-            <div className="border rounded-md p-4 space-y-4">
+            <div className="space-y-4 rounded-md border p-4">
               {state.tools && state.tools.length > 0 ? (
-                state.tools.map((tool: { name: string, description: string }, index: number) => (
-                  <div key={index} className="border-b pb-4 last:border-b-0 last:pb-0">
-                    <h4 className="font-medium text-sm">{tool.name}</h4>
-                    {tool.description && (
-                      <p className="text-xs text-gray-500 mt-1">{tool.description}</p>
-                    )}
-                  </div>
-                ))
+                state.tools.map(
+                  (
+                    tool: { name: string; description: string },
+                    index: number
+                  ) => (
+                    <div
+                      key={index}
+                      className="border-b pb-4 last:border-b-0 last:pb-0"
+                    >
+                      <h4 className="text-sm font-medium">{tool.name}</h4>
+                      {tool.description && (
+                        <p className="mt-1 text-xs text-gray-500">
+                          {tool.description}
+                        </p>
+                      )}
+                    </div>
+                  )
+                )
               ) : (
                 <p className="text-sm text-gray-500">No tools available</p>
               )}

--- a/front/components/spaces/mcp/SpaceMCPForm.tsx
+++ b/front/components/spaces/mcp/SpaceMCPForm.tsx
@@ -5,6 +5,8 @@ import {
   TextArea,
   Spinner,
   Page,
+  EyeSlashIcon,
+  EyeIcon,
 } from "@dust-tt/sparkle";
 import { ChangeEvent, useEffect, useState } from "react";
 
@@ -164,14 +166,9 @@ export function SpaceMCPForm({
                   className="absolute inset-y-0 right-0 pr-3 flex items-center"
                 >
                   {isSecretVisible ? (
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                    </svg>
+                    <EyeSlashIcon className="h-5 w-5 text-gray-400" />
                   ) : (
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                    </svg>
+                    <EyeIcon className="h-5 w-5 text-gray-400"/>
                   )}
                 </button>
               </div>

--- a/front/components/spaces/mcp/SpaceMCPForm.tsx
+++ b/front/components/spaces/mcp/SpaceMCPForm.tsx
@@ -35,7 +35,6 @@ export function SpaceMCPForm({
   const [isSecretVisible, setIsSecretVisible] = useState(false);
 
   useEffect(() => {
-    // Reset any error state when the URL changes
     setSyncError(null);
   }, [state.url]);
 

--- a/front/components/spaces/mcp/SpaceMCPList.tsx
+++ b/front/components/spaces/mcp/SpaceMCPList.tsx
@@ -67,7 +67,7 @@ const getTableColumns = (): ColumnDef<RowData, string>[] => {
       ),
       accessorFn: (row: RowData) => row.name,
       meta: {
-        className: "w-full",
+        className: "w-1/3",
       },
     },
     {
@@ -76,7 +76,7 @@ const getTableColumns = (): ColumnDef<RowData, string>[] => {
       cell: (info: CellContext<RowData, string>) => {
         const { server } = info.row.original;
         return (
-          <div className="flex flex-wrap gap-1">
+          <div className="flex flex-wrap gap-1 items-center">
             {server.tools.length > 0 ? (
               <>
                 {server.tools.slice(0, 2).map((tool, i) => (
@@ -101,7 +101,7 @@ const getTableColumns = (): ColumnDef<RowData, string>[] => {
       },
       accessorFn: () => "",
       meta: {
-        className: "w-1/3",
+        className: "w-full",
       },
     },
     {

--- a/front/components/spaces/mcp/SpaceMCPList.tsx
+++ b/front/components/spaces/mcp/SpaceMCPList.tsx
@@ -36,7 +36,7 @@ type MCPServerDisplay = {
   id: string;
   name: string;
   description: string;
-  tools: string[];
+  tools: { name: string, description: string }[];
   url: string;
 };
 
@@ -78,14 +78,21 @@ const getTableColumns = (): ColumnDef<RowData, string>[] => {
         return (
           <div className="flex flex-wrap gap-1">
             {server.tools.length > 0 ? (
-              server.tools.map((tool, i) => (
-                <span 
-                  key={i} 
-                  className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-700 dark:text-blue-50"
-                >
-                  {tool}
-                </span>
-              ))
+              <>
+                {server.tools.slice(0, 2).map((tool, i) => (
+                  <span 
+                    key={i} 
+                    className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-700 dark:text-blue-50"
+                  >
+                    {tool.name}
+                  </span>
+                ))}
+                {server.tools.length > 2 && (
+                  <span className="text-xs text-gray-500">
+                    +{server.tools.length - 2} more
+                  </span>
+                )}
+              </>
             ) : (
               <span className="text-sm text-gray-500">No tools</span>
             )}

--- a/front/components/spaces/mcp/SpaceMCPList.tsx
+++ b/front/components/spaces/mcp/SpaceMCPList.tsx
@@ -1,0 +1,368 @@
+import {
+  Button,
+  CommandLineIcon,
+  DataTable,
+  PencilSquareIcon,
+  PlusIcon,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Spinner,
+  TrashIcon,
+  usePaginationFromUrl,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import type { MenuItem } from "@dust-tt/sparkle";
+import { sortBy } from "lodash";
+import type { ComponentType } from "react";
+import * as React from "react";
+import { useState } from "react";
+
+import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
+import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
+import { useQueryParams } from "@app/hooks/useQueryParams";
+import { useRemoteMCPServers, useDeleteRemoteMCPServer } from "@app/lib/swr/remote_mcp_servers";
+import type {
+  LightWorkspaceType,
+  SpaceType,
+} from "@app/types";
+import SpaceMCPModal from "./SpaceMCPModal";
+
+type MCPServerDisplay = {
+  id: string;
+  name: string;
+  description: string;
+  tools: string[];
+  url: string;
+};
+
+type RowData = {
+  server: MCPServerDisplay;
+  category: string;
+  name: string;
+  icon: ComponentType;
+  workspaceId: string;
+  menuItems?: MenuItem[];
+  onClick?: () => void;
+};
+
+interface SpaceMCPListProps {
+  canWriteInSpace: boolean;
+  owner: LightWorkspaceType;
+  space: SpaceType;
+}
+
+const getTableColumns = (): ColumnDef<RowData, string>[] => {
+  return [
+    {
+      id: "name",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent icon={info.row.original.icon}>
+          {info.getValue()}
+        </DataTable.CellContent>
+      ),
+      accessorFn: (row: RowData) => row.name,
+      meta: {
+        className: "w-full",
+      },
+    },
+    {
+      id: "tools",
+      header: "Tools",
+      cell: (info: CellContext<RowData, string>) => {
+        const { server } = info.row.original;
+        return (
+          <div className="flex flex-wrap gap-1">
+            {server.tools.length > 0 ? (
+              server.tools.map((tool, i) => (
+                <span 
+                  key={i} 
+                  className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-700 dark:text-blue-50"
+                >
+                  {tool}
+                </span>
+              ))
+            ) : (
+              <span className="text-sm text-gray-500">No tools</span>
+            )}
+          </div>
+        );
+      },
+      accessorFn: () => "",
+      meta: {
+        className: "w-1/3",
+      },
+    },
+    {
+      id: "actions",
+      header: "",
+      meta: {
+        className: "w-16 text-right",
+      },
+      cell: (info) => (
+        <DataTable.MoreButton menuItems={info.row.original.menuItems} />
+      ),
+    },
+  ];
+};
+
+export const SpaceMCPList = ({
+  owner,
+  canWriteInSpace,
+  space,
+}: SpaceMCPListProps) => {
+  const sendNotification = useSendNotification();
+  const [isCreateModalOpened, setIsCreateModalOpened] = useState(false);
+  const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [serverToDelete, setServerToDelete] = useState<MCPServerDisplay | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const { deleteServer } = useDeleteRemoteMCPServer();
+  
+  const { q: searchParam } = useQueryParams(["q"]);
+  const searchTerm = searchParam.value || "";
+
+  const { servers, isServersLoading, mutateServers } = useRemoteMCPServers({
+    owner,
+    space,
+  });
+
+  // Wrapper function for mutateServers to match the expected type
+  const handleRefreshServers = async () => {
+    await mutateServers();
+  };
+
+  const { pagination, setPagination } = usePaginationFromUrl({
+    urlPrefix: "table",
+  });
+
+  const handleDeleteServer = async (server: MCPServerDisplay) => {
+    setServerToDelete(server);
+    setIsDeleteConfirmOpen(true);
+  };
+
+  const confirmDeleteServer = async () => {
+    if (!serverToDelete) {
+      return;
+    }
+    
+    setIsDeleting(true);
+    try {
+      await deleteServer(owner, space, serverToDelete.id);
+      await mutateServers();
+      sendNotification({
+        title: "MCP server deleted",
+        type: "success",
+        description: "The MCP server has been successfully deleted.",
+      });
+      setIsDeleteConfirmOpen(false);
+    } catch (err) {
+      sendNotification({
+        title: "Error deleting MCP",
+        type: "error",
+        description: err instanceof Error ? err.message : "An error occurred",
+      });
+    } finally {
+      setIsDeleting(false);
+      setServerToDelete(null);
+    }
+  };
+
+  const handleEditServer = (server: MCPServerDisplay) => {
+    setSelectedServerId(server.id);
+    setIsEditMode(true);
+  };
+
+  const rows: RowData[] = React.useMemo(() => {
+    if (!servers || servers.length === 0) {
+      return [];
+    }
+    
+    return sortBy(servers, "name").map((server) => {
+      const menuItems: MenuItem[] = [];
+      
+      if (canWriteInSpace) {
+        menuItems.push({
+          label: "Edit",
+          kind: "item",
+          icon: PencilSquareIcon,
+          onClick: (e) => {
+            e.stopPropagation();
+            handleEditServer({
+              id: server.id || "",
+              name: server.name,
+              description: server.description,
+              tools: server.tools || [],
+              url: server.url || "",
+            });
+          },
+        });
+        
+        menuItems.push({
+          label: "Delete",
+          icon: TrashIcon,
+          kind: "item",
+          variant: "warning",
+          onClick: (e) => {
+            e.stopPropagation();
+            handleDeleteServer({
+              id: server.id || "",
+              name: server.name,
+              description: server.description,
+              tools: server.tools || [],
+              url: server.url || "",
+            });
+          },
+        });
+      }
+
+      return {
+        server: {
+          id: server.id || "",
+          name: server.name,
+          description: server.description,
+          tools: server.tools || [],
+          url: server.url || "",
+        },
+        category: "mcp",
+        name: server.name,
+        icon: CommandLineIcon,
+        workspaceId: owner.sId,
+        menuItems,
+        onClick: () => {
+          handleEditServer({
+            id: server.id || "",
+            name: server.name,
+            description: server.description,
+            tools: server.tools || [],
+            url: server.url || "",
+          });
+        },
+      };
+    });
+  }, [servers, owner.sId, canWriteInSpace]);
+
+  const { portalToHeader } = useActionButtonsPortal({
+    containerId: ACTION_BUTTONS_CONTAINER_ID,
+  });
+
+  if (isServersLoading) {
+    return (
+      <div className="mt-8 flex justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  const columns = getTableColumns();
+  const isEmpty = rows.length === 0;
+
+  const closeModal = () => {
+    setIsCreateModalOpened(false);
+    setSelectedServerId(null);
+    setIsEditMode(false);
+    // Refresh the server list when modal is closed
+    mutateServers();
+  };
+
+  const actionButtons = (
+    <>
+      {canWriteInSpace && (
+        <Button
+          label="New MCP Server"
+          variant="primary"
+          icon={PlusIcon}
+          size="sm"
+          onClick={() => {
+            setIsCreateModalOpened(true);
+          }}
+        />
+      )}
+    </>
+  );
+
+  return (
+    <>
+      {!isEmpty && portalToHeader(actionButtons)}
+      {isEmpty ? (
+        <div className="flex h-36 w-full max-w-4xl items-center justify-center gap-2 rounded-lg bg-structure-50 dark:bg-structure-50-night">
+          <Button
+            label="Add MCP Server"
+            disabled={!canWriteInSpace}
+            onClick={() => {
+              setIsCreateModalOpened(true);
+            }}
+          />
+        </div>
+      ) : (
+        <DataTable<RowData>
+          data={rows}
+          columns={columns}
+          className="pb-4"
+          filter={searchTerm}
+          filterColumn="name"
+          pagination={pagination}
+          setPagination={setPagination}
+        />
+      )}
+      
+      {/* Create/Edit Modal */}
+      {(isCreateModalOpened || isEditMode) && (
+        <SpaceMCPModal
+          owner={owner}
+          space={space}
+          isOpen={isCreateModalOpened || isEditMode}
+          onClose={closeModal}
+          serverId={selectedServerId || undefined}
+          canWriteInSpace={canWriteInSpace}
+          onSave={handleRefreshServers}
+        />
+      )}
+      
+      {/* Delete Confirmation Dialog */}
+      <Sheet
+        open={isDeleteConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsDeleteConfirmOpen(false);
+            setServerToDelete(null);
+          }
+        }}
+      >
+        <SheetContent size="md">
+          <SheetHeader>
+            <SheetTitle>Delete MCP Server</SheetTitle>
+          </SheetHeader>
+          <SheetContainer>
+            <div className="py-4">
+              <p>Are you sure you want to delete <strong>{serverToDelete?.name}</strong>?</p>
+              <p className="mt-2 text-red-600">This action cannot be undone.</p>
+            </div>
+          </SheetContainer>
+          <SheetFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: () => {
+                setIsDeleteConfirmOpen(false);
+                setServerToDelete(null);
+              },
+            }}
+            rightButtonProps={{
+              label: isDeleting ? "Deleting..." : "Delete",
+              variant: "warning",
+              onClick: confirmDeleteServer,
+              disabled: isDeleting,
+            }}
+          />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+};

--- a/front/components/spaces/mcp/SpaceMCPModal.tsx
+++ b/front/components/spaces/mcp/SpaceMCPModal.tsx
@@ -1,0 +1,396 @@
+import {
+  Button,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  TrashIcon,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import { useEffect, useReducer, useState } from "react";
+
+import { SpaceMCPForm } from "@app/components/spaces/mcp/SpaceMCPForm";
+import { 
+  useRemoteMCPServer, 
+  useSyncRemoteMCPServer, 
+  useUpdateRemoteMCPServer,
+  useDeleteRemoteMCPServer 
+} from "@app/lib/swr/remote_mcp_servers";
+import type {
+  SpaceType,
+  WorkspaceType,
+} from "@app/types";
+import { validateUrl } from "@app/types";
+import { MCPFormAction, MCPFormState } from "@app/types/mcp";
+
+function getInitialFormState(): MCPFormState {
+  return {
+    url: "",
+    name: "",
+    description: "",
+    tools: [],
+    errors: {},
+  };
+}
+
+type ValidationResult = {
+  isValid: boolean;
+  errors: MCPFormState["errors"];
+};
+
+function validateFormState(
+  state: MCPFormState
+): ValidationResult {
+  const urlValidation = validateUrl(state.url);
+  const errors: MCPFormState["errors"] = {
+    url: !urlValidation.valid
+      ? "Please provide a valid URL (e.g. https://example.com or https://example.com/a/b/c))."
+      : undefined,
+    name: !state.name ? "Name is required" : undefined,
+  };
+  return { isValid: urlValidation.valid && !!state.name, errors };
+}
+
+export interface SpaceMCPModalProps {
+  serverId?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  owner: WorkspaceType;
+  space: SpaceType;
+  canWriteInSpace: boolean;
+  onSave?: () => Promise<void>;
+}
+
+export default function SpaceMCPModal({
+  serverId,
+  isOpen,
+  onClose,
+  owner,
+  space,
+  canWriteInSpace,
+  onSave,
+}: SpaceMCPModalProps) {
+  const router = useRouter();
+  const sendNotification = useSendNotification();
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSynchronizing, setIsSynchronizing] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isSynchronized, setIsSynchronized] = useState(false);
+  const [sharedSecret, setSharedSecret] = useState<string | undefined>(undefined);
+  const [mcpServerId, setMcpServerId] = useState<string | undefined>(undefined);
+
+  // Fetch existing server data if serverId is provided
+  const { server, isServerLoading, mutateServer } = useRemoteMCPServer({
+    owner,
+    space,
+    serverId: serverId || "",
+    disabled: !serverId
+  });
+
+  // Get update, sync, and delete hooks
+  const { updateServer } = useUpdateRemoteMCPServer();
+  const { syncServer } = useSyncRemoteMCPServer();
+  const { deleteServer } = useDeleteRemoteMCPServer();
+
+  const formReducer = (
+    state: MCPFormState,
+    action: MCPFormAction
+  ): MCPFormState => {
+    switch (action.type) {
+      case "SET_FIELD": {
+        const newState = { ...state, [action.field]: action.value };
+        if (action.field === "url") {
+          validateUrl(action.value);
+        }
+        return newState;
+      }
+      case "SET_ERROR":
+        return {
+          ...state,
+          errors: { ...state.errors, [action.field]: action.value },
+        };
+      case "RESET":
+        return getInitialFormState();
+      case "VALIDATE": {
+        const result = validateFormState(state);
+        return { ...state, errors: result.errors };
+      }
+      default:
+        return state;
+    }
+  };
+
+  const [formState, dispatch] = useReducer(
+    formReducer,
+    getInitialFormState()
+  );
+
+  // Load data from existing server into form
+  useEffect(() => {
+    if (server) {
+      dispatch({ type: "SET_FIELD", field: "name", value: server.name });
+      dispatch({ type: "SET_FIELD", field: "description", value: server.description });
+      dispatch({ type: "SET_FIELD", field: "url", value: server.url || "" });
+      dispatch({ type: "SET_FIELD", field: "tools", value: server.tools });
+      
+      if (server.sharedSecret) {
+        setSharedSecret(server.sharedSecret);
+      }
+      
+      setIsSynchronized(true);
+      setMcpServerId(server.id);
+    }
+  }, [server]);
+
+  const handleSubmit = async () => {
+    dispatch({ type: "VALIDATE" });
+    const validation = validateFormState(formState);
+
+    if (!validation.isValid) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const serverIdToUse = serverId || mcpServerId;
+      
+      if (serverIdToUse) {
+        // Update existing MCP server using the hook
+        await updateServer(owner, space, serverIdToUse, {
+          name: formState.name,
+          url: formState.url,
+          description: formState.description,
+          tools: formState.tools,
+        });
+
+        if (serverId) {
+          await mutateServer();
+        }
+        
+        sendNotification({
+          title: "MCP updated",
+          type: "success",
+          description: "The MCP has been successfully updated.",
+        });
+      } else {
+        sendNotification({
+          title: "Error saving MCP",
+          type: "error",
+          description: "Missing MCP server ID. Please try synchronizing again.",
+        });
+        setIsSaving(false);
+        return;
+      }
+      
+      onClose();
+      dispatch({ type: "RESET" });
+      setIsSynchronized(false);
+      setSharedSecret(undefined);
+      setMcpServerId(undefined);
+      
+      // Call the onSave callback instead of refreshing the page
+      if (onSave) {
+        await onSave();
+      } else {
+        // Fallback to the old behavior if callback is not provided
+        router.push(router.asPath);
+      }
+    } catch (err) {
+      sendNotification({
+        title: "Error updating MCP",
+        type: "error",
+        description: err instanceof Error ? err.message : "An error occurred",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (): Promise<void> => {
+    if (!serverId) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await deleteServer(owner, space, serverId);
+      
+      sendNotification({
+        title: "MCP server deleted",
+        type: "success",
+        description: "The MCP server has been successfully deleted.",
+      });
+      
+      onClose();
+      
+      // Call the onSave callback instead of refreshing the page
+      if (onSave) {
+        await onSave();
+      } else {
+        // Fallback to the old behavior if callback is not provided
+        router.push(router.asPath);
+      }
+    } catch (err) {
+      sendNotification({
+        title: "Error deleting MCP",
+        type: "error",
+        description: err instanceof Error ? err.message : "An error occurred",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSynchronize = async () => {
+    if (!formState.url) {
+      sendNotification({
+        title: "Error",
+        type: "error",
+        description: "Please enter a valid URL before synchronizing.",
+      });
+      return;
+    }
+
+    setIsSynchronizing(true);
+    try {
+      // Use the syncServer hook instead of direct fetch
+      const result = await syncServer(owner, space, formState.url);
+      
+      if (result.success && result.data) {
+        // Populate form state with the received data
+        dispatch({ type: "SET_FIELD", field: "name", value: result.data.name });
+        dispatch({ type: "SET_FIELD", field: "description", value: result.data.description });
+        dispatch({ type: "SET_FIELD", field: "tools", value: result.data.tools });
+        
+        // Store the shared secret and server ID
+        setSharedSecret(result.data.sharedSecret);
+        setMcpServerId(result.data.id);
+        
+        setIsSynchronized(true);
+
+        sendNotification({
+          title: "Success",
+          type: "success",
+          description: "MCP server synchronized successfully.",
+        });
+      } else {
+        throw new Error("Failed to synchronize MCP server");
+      }
+    } catch (error) {
+      sendNotification({
+        title: "Error synchronizing MCP server",
+        type: "error",
+        description: error instanceof Error ? error.message : "An error occurred",
+      });
+    } finally {
+      setIsSynchronizing(false);
+    }
+  };
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <SheetContent size="xl">
+        <SheetHeader>
+          <SheetTitle>
+            {serverId ? "Edit MCP Server" : "Create MCP Server"}
+          </SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <SpaceMCPForm
+            state={formState}
+            dispatch={dispatch}
+            isConfigurationLoading={isServerLoading}
+            onSynchronize={handleSynchronize}
+            isSynchronized={isSynchronized || !!serverId}
+            sharedSecret={sharedSecret}
+            isSynchronizing={isSynchronizing}
+          />
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Save",
+            onClick: async (event: Event) => {
+              event.preventDefault();
+              if (isSynchronized || serverId) {
+                await handleSubmit();
+              } else {
+                await handleSynchronize();
+              }
+            },
+            disabled: !canWriteInSpace || (isSaving || isSynchronizing) || 
+                    ((!isSynchronized && !serverId)),
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+type DeleteConfirmationDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  serverName: string;
+};
+
+function DeleteConfirmationDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  serverName,
+}: DeleteConfirmationDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  
+  const handleConfirm = async () => {
+    setIsDeleting(true);
+    try {
+      await onConfirm();
+      onClose();
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+  
+  return (
+    <Sheet open={isOpen} onOpenChange={onClose}>
+      <SheetContent size="md">
+        <SheetHeader>
+          <SheetTitle>Delete MCP Server</SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <div className="py-4">
+            <p>Are you sure you want to delete <strong>{serverName}</strong>?</p>
+            <p className="mt-2 text-red-600">This action cannot be undone.</p>
+          </div>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: isDeleting ? "Deleting..." : "Delete",
+            variant: "warning",
+            onClick: handleConfirm,
+            disabled: isDeleting,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/spaces/mcp/SpaceMCPModal.tsx
+++ b/front/components/spaces/mcp/SpaceMCPModal.tsx
@@ -81,7 +81,6 @@ export default function SpaceMCPModal({
     disabled: !serverId,
   });
 
-  // Get update, sync hooks
   const { updateServer } = useUpdateRemoteMCPServer();
   const { syncById, syncByUrl } = useSyncRemoteMCPServer();
 
@@ -115,7 +114,6 @@ export default function SpaceMCPModal({
 
   const [formState, dispatch] = useReducer(formReducer, getInitialFormState());
 
-  // Load data from existing server into form
   useEffect(() => {
     if (server) {
       dispatch({ type: "SET_FIELD", field: "name", value: server.name });
@@ -149,7 +147,6 @@ export default function SpaceMCPModal({
       const serverIdToUse = serverId || mcpServerId;
 
       if (serverIdToUse) {
-        // Update existing MCP server using the hook
         await updateServer(owner, space, serverIdToUse, {
           name: formState.name,
           url: formState.url,
@@ -206,7 +203,6 @@ export default function SpaceMCPModal({
 
     setIsSynchronizing(true);
     try {
-      // Determine if we should sync by ID or URL
       const serverIdToUse = serverId || mcpServerId;
       let result: MCPApiResponse;
 
@@ -217,7 +213,6 @@ export default function SpaceMCPModal({
       }
 
       if (result.success && result.data) {
-        // Populate form state with the received data
         dispatch({ type: "SET_FIELD", field: "name", value: result.data.name });
         dispatch({
           type: "SET_FIELD",
@@ -230,7 +225,6 @@ export default function SpaceMCPModal({
           value: result.data.tools,
         });
 
-        // Store the shared secret and server ID
         setSharedSecret(result.data.sharedSecret);
         setMcpServerId(result.data.id);
 

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -2,18 +2,21 @@ import { Op } from "sequelize";
 
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { getMCPServerMetadata } from "@app/lib/actions/mcp_actions";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { ModelId } from "@app/types";
-import { Authenticator } from "@app/lib/auth";
 
-export async function fetchMCPServerActionConfigurations(auth: Authenticator, {
-  configurationIds,
-  variant,
-}: {
-  configurationIds: ModelId[];
-  variant: "light" | "full";
-}): Promise<Map<ModelId, MCPServerConfigurationType[]>> {
+export async function fetchMCPServerActionConfigurations(
+  auth: Authenticator,
+  {
+    configurationIds,
+    variant,
+  }: {
+    configurationIds: ModelId[];
+    variant: "light" | "full";
+  }
+): Promise<Map<ModelId, MCPServerConfigurationType[]>> {
   if (variant !== "full") {
     return new Map();
   }

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -3,10 +3,11 @@ import { Op } from "sequelize";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { getMCPServerMetadata } from "@app/lib/actions/mcp_actions";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
-import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { ModelId } from "@app/types";
+import { Authenticator } from "@app/lib/auth";
 
-export async function fetchMCPServerActionConfigurations({
+export async function fetchMCPServerActionConfigurations(auth: Authenticator, {
   configurationIds,
   variant,
 }: {
@@ -36,7 +37,8 @@ export async function fetchMCPServerActionConfigurations({
 
     let remoteMCPServerId: string | null = null;
     if (serverType === "remote" && config.remoteMCPServerId) {
-      const remoteMCPServer = await RemoteMCPServer.findByPk(
+      const remoteMCPServer = await RemoteMCPServerResource.findByPk(
+        auth,
         config.remoteMCPServerId
       );
       if (!remoteMCPServer) {
@@ -52,7 +54,7 @@ export async function fetchMCPServerActionConfigurations({
     }
 
     // Note: this won't attempt to connect to remote servers and will use the cached metadata.
-    const metadata = await getMCPServerMetadata(config);
+    const metadata = await getMCPServerMetadata(auth, config);
 
     const actions = actionsByConfigurationId.get(agentConfigurationId);
     if (actions) {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -271,6 +271,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
 
     // TODO(mcp): listen to sse events to provide live feedback to the user
     const r = await tryCallMCPTool({
+      auth,
       owner,
       actionConfiguration,
       rawInputs,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -164,18 +164,20 @@ function makeMCPConfigurations({
   });
 }
 
-const connectToMCPServer = async (auth: Authenticator,
+const connectToMCPServer = async (
+  auth: Authenticator,
   {
-  serverType,
-  internalMCPServerId,
-  remoteMCPServerId,
-}: {
-  serverType: MCPServerConfigurationType["serverType"];
-  internalMCPServerId?:
-    | MCPServerConfigurationType["internalMCPServerId"]
-    | null;
-  remoteMCPServerId?: MCPServerConfigurationType["remoteMCPServerId"] | null;
-}) => {
+    serverType,
+    internalMCPServerId,
+    remoteMCPServerId,
+  }: {
+    serverType: MCPServerConfigurationType["serverType"];
+    internalMCPServerId?:
+      | MCPServerConfigurationType["internalMCPServerId"]
+      | null;
+    remoteMCPServerId?: MCPServerConfigurationType["remoteMCPServerId"] | null;
+  }
+) => {
   //TODO(mcp): handle failure, timeout...
   // This is where we route the MCP client to the right server.
   const mcpClient = new Client({
@@ -205,7 +207,10 @@ const connectToMCPServer = async (auth: Authenticator,
         );
       }
 
-      const remoteMCPServer = await RemoteMCPServerResource.fetchById(auth, remoteMCPServerId);
+      const remoteMCPServer = await RemoteMCPServerResource.fetchById(
+        auth,
+        remoteMCPServerId
+      );
 
       if (!remoteMCPServer) {
         throw new Error(
@@ -238,11 +243,17 @@ function extractMetadataFromServerVersion(r: Implementation | undefined): {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function updateRemoteMCPServerMetadata(auth: Authenticator, config: {
-  serverType: "remote";
-  remoteMCPServerId: string;
-}) {
-  const remoteMCPServer = await RemoteMCPServerResource.fetchById(auth, config.remoteMCPServerId);
+async function updateRemoteMCPServerMetadata(
+  auth: Authenticator,
+  config: {
+    serverType: "remote";
+    remoteMCPServerId: string;
+  }
+) {
+  const remoteMCPServer = await RemoteMCPServerResource.fetchById(
+    auth,
+    config.remoteMCPServerId
+  );
 
   if (!remoteMCPServer) {
     throw new Error(

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -71,6 +71,8 @@ export async function getDataSourceViewsUsageByCategory({
       break;
     case "apps":
       return {};
+    case "mcp":
+      return {};
     default:
       assertNever(category);
   }

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -50,6 +50,7 @@ import {
 } from "@app/lib/models/assistant/agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TemplateResource } from "@app/lib/resources/template_resource";
@@ -483,7 +484,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     fetchWebsearchActionConfigurations({ configurationIds, variant }),
     fetchBrowseActionConfigurations({ configurationIds, variant }),
     fetchReasoningActionConfigurations({ configurationIds, variant }),
-    fetchMCPServerActionConfigurations({ configurationIds, variant }),
+    fetchMCPServerActionConfigurations(auth, { configurationIds, variant }),
     user
       ? getFavoriteStates(auth, { configurationIds: configurationSIds })
       : Promise.resolve(new Map<string, boolean>()),
@@ -1167,9 +1168,10 @@ export async function createAgentActionConfiguration(
     case "mcp_server_configuration": {
       let remoteMCPServerId = null;
       if (action.serverType === "remote" && action.remoteMCPServerId) {
-        const remoteMCPServer = await RemoteMCPServer.findOne({
-          where: { sId: action.remoteMCPServerId }
-        });
+        const remoteMCPServer = await RemoteMCPServerResource.fetchById(
+          auth,
+          action.remoteMCPServerId
+        );
         
         if (!remoteMCPServer) {
           throw new Error(`Remote MCP server with sId ${action.remoteMCPServerId} not found.`);

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -38,7 +38,6 @@ import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/brow
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
-import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
@@ -1172,9 +1171,11 @@ export async function createAgentActionConfiguration(
           auth,
           action.remoteMCPServerId
         );
-        
+
         if (!remoteMCPServer) {
-          throw new Error(`Remote MCP server with sId ${action.remoteMCPServerId} not found.`);
+          throw new Error(
+            `Remote MCP server with sId ${action.remoteMCPServerId} not found.`
+          );
         }
         remoteMCPServerId = remoteMCPServer.id;
       }

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -59,6 +59,10 @@ AgentMCPServerConfiguration.init(
         isIn: [AVAILABLE_INTERNAL_MCPSERVER_IDS],
       },
     },
+    remoteMCPServerId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     modelName: "agent_mcp_server_configuration",
@@ -90,6 +94,7 @@ AgentMCPServerConfiguration.init(
             }
             break;
           case "remote":
+            console.log(config);
             if (!config.remoteMCPServerId) {
               throw new Error(
                 "remoteMCPServerId is required for serverType remote"

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -94,7 +94,6 @@ AgentMCPServerConfiguration.init(
             }
             break;
           case "remote":
-            console.log(config);
             if (!config.remoteMCPServerId) {
               throw new Error(
                 "remoteMCPServerId is required for serverType remote"

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -17,7 +17,7 @@ export class RemoteMCPServer extends SoftDeletableWorkspaceAwareModel<RemoteMCPS
   declare url: string;
   declare name: string;
   declare description: string | null;
-  declare cachedTools: { name: string, description: string }[];
+  declare cachedTools: { name: string; description: string }[];
 
   declare lastSyncAt: Date | null;
   declare sharedSecret: string;

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -3,15 +3,15 @@ import { DataTypes } from "sequelize";
 
 import { frontSequelize } from "@app/lib/resources/storage";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
-import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 
-export class RemoteMCPServer extends WorkspaceAwareModel<RemoteMCPServer> {
+export class RemoteMCPServer extends SoftDeletableWorkspaceAwareModel<RemoteMCPServer> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare sId: string;
 
-  declare spaceId: ForeignKey<SpaceModel["id"]>;
+  declare vaultId: ForeignKey<SpaceModel["id"]>;
   declare space: NonAttribute<SpaceModel>;
 
   declare url: string;
@@ -34,6 +34,9 @@ RemoteMCPServer.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
     },
     sId: {
       type: DataTypes.STRING,
@@ -72,9 +75,9 @@ RemoteMCPServer.init(
 );
 
 SpaceModel.hasMany(RemoteMCPServer, {
-  foreignKey: { allowNull: false, name: "spaceId" },
+  foreignKey: { allowNull: false, name: "vaultId" },
   onDelete: "RESTRICT",
 });
 RemoteMCPServer.belongsTo(SpaceModel, {
-  foreignKey: { allowNull: false, name: "spaceId" },
+  foreignKey: { allowNull: false, name: "vaultId" },
 });

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -14,11 +14,10 @@ export class RemoteMCPServer extends WorkspaceAwareModel<RemoteMCPServer> {
   declare spaceId: ForeignKey<SpaceModel["id"]>;
   declare space: NonAttribute<SpaceModel>;
 
-  declare name: string;
   declare url: string;
-
+  declare name: string;
   declare description: string | null;
-  declare cachedTools: string[];
+  declare cachedTools: { name: string, description: string }[];
 
   declare lastSyncAt: Date | null;
   declare sharedSecret: string;
@@ -53,7 +52,7 @@ RemoteMCPServer.init(
       allowNull: true,
     },
     cachedTools: {
-      type: DataTypes.ARRAY(DataTypes.STRING),
+      type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: [],
     },

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -1,0 +1,205 @@
+import assert from "assert";
+import type { Attributes, CreationAttributes, ModelStatic, Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
+export interface RemoteMCPServerResource extends ReadonlyAttributesType<RemoteMCPServer> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class RemoteMCPServerResource extends ResourceWithSpace<RemoteMCPServer> {
+  static model: ModelStatic<RemoteMCPServer> = RemoteMCPServer;
+
+  constructor(
+    model: ModelStatic<RemoteMCPServer>,
+    blob: Attributes<RemoteMCPServer>,
+    public readonly space: SpaceResource
+  ) {
+    super(RemoteMCPServer, blob, space);
+  }
+
+  static async makeNew(
+    blob: Omit<CreationAttributes<RemoteMCPServer>, "spaceId" | "sId" >,
+    space: SpaceResource
+  ) {
+    const server = await RemoteMCPServer.create({
+      ...blob,
+      vaultId: space.id,
+      sId: generateRandomModelSId(),
+    });
+
+    return new this(RemoteMCPServer, server.get(), space);
+  }
+
+  // Fetching.
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<RemoteMCPServer>
+  ) {
+    const servers = await this.baseFetchWithAuthorization(auth, {
+        ...options,
+    })
+    return servers.filter((server) => auth.isAdmin() || server.canRead(auth)) 
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    ids: string[]
+  ): Promise<RemoteMCPServerResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        sId: ids,
+      },
+    });
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    id: string
+  ): Promise<RemoteMCPServerResource | null> {
+    const [server] = await this.fetchByIds(auth, [id]);
+    return server ?? null;
+  }
+
+  static async findByPk(
+    auth: Authenticator,
+    id: number,
+    options?: ResourceFindOptions<RemoteMCPServer>
+  ): Promise<RemoteMCPServerResource | null> {
+    const servers = await this.baseFetch(auth, {
+      where: {
+        id,
+      },
+      ...options,
+    });
+    return servers.length > 0 ? servers[0] : null;
+  }
+
+  static async listByWorkspace(
+    auth: Authenticator,
+    options?: { includeDeleted?: boolean }
+  ) {
+    return this.baseFetch(auth, {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+
+  static async listBySpace(
+    auth: Authenticator,
+    space: SpaceResource,
+    { includeDeleted }: { includeDeleted?: boolean } = {}
+  ) {
+    return this.baseFetch(auth, {
+      where: {
+        vaultId: space.id,
+      },
+      includeDeleted,
+    });
+  }
+
+  // Deletion.
+
+  async hardDelete(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<Result<number, Error>> {
+    assert(this.canWrite(auth), "Unauthorized delete attempt");
+    const deletedCount = await RemoteMCPServer.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: this.id,
+      },
+      transaction,
+      hardDelete: true,
+    });
+
+    return new Ok(deletedCount);
+  }
+
+  async softDelete(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<Result<number, Error>> {
+    assert(this.canWrite(auth), "Unauthorized delete attempt");
+    const deletedCount = await RemoteMCPServer.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: this.id,
+      },
+      transaction,
+      hardDelete: false,
+    });
+
+    return new Ok(deletedCount);
+  }
+
+  // Mutation.
+
+  async updateSettings(
+    auth: Authenticator,
+    {
+      name,
+      description,
+      url,
+      sharedSecret,
+    }: {
+      name?: string;
+      description?: string | null;
+      url?: string;
+      sharedSecret?: string;
+    }
+  ) {
+    assert(this.canWrite(auth), "Unauthorized write attempt");
+    await this.update({
+      name,
+      description,
+      url,
+      sharedSecret,
+    });
+  }
+
+  async updateTools(
+    auth: Authenticator,
+    {
+      cachedTools,
+      lastSyncAt,
+    }: {
+      cachedTools: { name: string; description: string }[];
+      lastSyncAt: Date;
+    }
+  ) {
+    assert(this.canWrite(auth), "Unauthorized write attempt");
+    await this.update({
+      cachedTools,
+      lastSyncAt,
+    });
+  }
+
+  // Serialization.
+  toJSON() {
+    return {
+      id: this.id,
+      sId: this.sId,
+      name: this.name,
+      description: this.description,
+      url: this.url,
+      cachedTools: this.cachedTools,
+      lastSyncAt: this.lastSyncAt,
+      space: this.space.toJSON(),
+    };
+  }
+}

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -1,22 +1,25 @@
 import assert from "assert";
-import type { Attributes, CreationAttributes, ModelStatic, Transaction } from "sequelize";
-import { Op } from "sequelize";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
-import { BaseResource } from "@app/lib/resources/base_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
+import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
-import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
+import { Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
-export interface RemoteMCPServerResource extends ReadonlyAttributesType<RemoteMCPServer> {}
+export interface RemoteMCPServerResource
+  extends ReadonlyAttributesType<RemoteMCPServer> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class RemoteMCPServerResource extends ResourceWithSpace<RemoteMCPServer> {
   static model: ModelStatic<RemoteMCPServer> = RemoteMCPServer;
@@ -30,7 +33,7 @@ export class RemoteMCPServerResource extends ResourceWithSpace<RemoteMCPServer> 
   }
 
   static async makeNew(
-    blob: Omit<CreationAttributes<RemoteMCPServer>, "spaceId" | "sId" >,
+    blob: Omit<CreationAttributes<RemoteMCPServer>, "spaceId" | "sId">,
     space: SpaceResource
   ) {
     const server = await RemoteMCPServer.create({
@@ -49,9 +52,9 @@ export class RemoteMCPServerResource extends ResourceWithSpace<RemoteMCPServer> 
     options?: ResourceFindOptions<RemoteMCPServer>
   ) {
     const servers = await this.baseFetchWithAuthorization(auth, {
-        ...options,
-    })
-    return servers.filter((server) => auth.isAdmin() || server.canRead(auth)) 
+      ...options,
+    });
+    return servers.filter((server) => auth.isAdmin() || server.canRead(auth));
   }
 
   static async fetchByIds(
@@ -95,6 +98,7 @@ export class RemoteMCPServerResource extends ResourceWithSpace<RemoteMCPServer> 
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
       },
+      ...options,
     });
   }
 

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -6,6 +6,7 @@ import {
   LockIcon,
   PlanetIcon,
   ServerIcon,
+  SparklesIcon,
 } from "@dust-tt/sparkle";
 import { groupBy } from "lodash";
 import type React from "react";
@@ -120,8 +121,8 @@ export const CATEGORY_DETAILS: {
     icon: CommandLineIcon,
   },
   mcp: {
-    label: "Remote MCP Servers",
-    icon: ServerIcon
+    label: "MCP Servers",
+    icon: SparklesIcon
   },
 };
 

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -122,7 +122,7 @@ export const CATEGORY_DETAILS: {
   },
   mcp: {
     label: "MCP Servers",
-    icon: SparklesIcon
+    icon: SparklesIcon,
   },
 };
 

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -119,6 +119,10 @@ export const CATEGORY_DETAILS: {
     label: "Apps",
     icon: CommandLineIcon,
   },
+  mcp: {
+    label: "Remote MCP Servers",
+    icon: ServerIcon
+  },
 };
 
 export const getSpaceAccessPriority = (space: SpaceType) => {

--- a/front/lib/swr/remote_mcp_servers.ts
+++ b/front/lib/swr/remote_mcp_servers.ts
@@ -151,7 +151,7 @@ export function useUpdateRemoteMCPServer() {
       name: string;
       url: string;
       description: string;
-      tools: string[];
+      tools: { name: string, description: string }[];
     }
   ): Promise<MCPApiResponse> => {
     const response = await fetch(

--- a/front/lib/swr/remote_mcp_servers.ts
+++ b/front/lib/swr/remote_mcp_servers.ts
@@ -64,6 +64,15 @@ export function useRemoteMCPServer({
     disabled,
   });
 
+  if (!serverId) {
+    return {
+      server: null,
+      isServerLoading: false,
+      isServerError: true,
+      mutateServer: () => {},
+    };
+  }
+
   return {
     server: data?.data || null,
     isServerLoading: !error && !data,
@@ -104,15 +113,19 @@ export function useDeleteRemoteMCPServer() {
  * This can either create a new server using a URL or sync an existing server by its ID
  */
 export function useSyncRemoteMCPServer() {
-  // Sync by URL - this will find existing servers with the same URL or create a new one
+  // Create a new server with the provided URL
   const syncByUrl = async (
     owner: LightWorkspaceType,
     space: SpaceType,
     url: string
   ): Promise<MCPApiResponse> => {
     const response = await fetch(
-      `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote?url=${encodeURIComponent(url)}`,
-      { method: "GET" }
+      `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+      }
     );
 
     if (!response.ok) {
@@ -125,14 +138,13 @@ export function useSyncRemoteMCPServer() {
     return response.json();
   };
 
-  // Sync an existing server by its ID
   const syncById = async (
     owner: LightWorkspaceType,
     space: SpaceType,
     serverId: string
   ): Promise<MCPApiResponse> => {
     const response = await fetch(
-      `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote/${serverId}?action=sync`,
+      `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote/${serverId}/sync`,
       { method: "POST" }
     );
 

--- a/front/lib/swr/remote_mcp_servers.ts
+++ b/front/lib/swr/remote_mcp_servers.ts
@@ -56,22 +56,13 @@ export function useRemoteMCPServer({
 }) {
   const serverFetcher: Fetcher<MCPApiResponse> = fetcher;
 
-  if (!serverId) {
-    return {
-      server: null,
-      isServerLoading: false,
-      isServerError: true,
-      mutateServer: () => Promise.resolve(),
-    };
-  }
+  const url = serverId
+    ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote/${serverId}`
+    : null;
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    serverId ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote/${serverId}` : null,
-    serverFetcher,
-    {
-      disabled,
-    }
-  );
+  const { data, error, mutate } = useSWRWithDefaults(url, serverFetcher, {
+    disabled,
+  });
 
   return {
     server: data?.data || null,
@@ -104,18 +95,8 @@ export function useDeleteRemoteMCPServer() {
 
     return response.json();
   };
-  
-  return { deleteServer };
-}
 
-// Keep the old function for backward compatibility
-export async function deleteRemoteMCPServer(
-  owner: LightWorkspaceType,
-  space: SpaceType,
-  serverId: string
-): Promise<MCPApiResponse> {
-  const { deleteServer } = useDeleteRemoteMCPServer();
-  return deleteServer(owner, space, serverId);
+  return { deleteServer };
 }
 
 /**
@@ -124,50 +105,48 @@ export async function deleteRemoteMCPServer(
  */
 export function useSyncRemoteMCPServer() {
   // Sync by URL - this will find existing servers with the same URL or create a new one
-  const syncByUrl = async (owner: LightWorkspaceType, space: SpaceType, url: string): Promise<MCPApiResponse> => {
+  const syncByUrl = async (
+    owner: LightWorkspaceType,
+    space: SpaceType,
+    url: string
+  ): Promise<MCPApiResponse> => {
     const response = await fetch(
       `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote?url=${encodeURIComponent(url)}`,
       { method: "GET" }
     );
-    
+
     if (!response.ok) {
       const error = await response.json();
-      throw new Error(error.api_error?.message || "Failed to synchronize server");
+      throw new Error(
+        error.api_error?.message || "Failed to synchronize server"
+      );
     }
-    
+
     return response.json();
   };
-  
+
   // Sync an existing server by its ID
-  const syncById = async (owner: LightWorkspaceType, space: SpaceType, serverId: string): Promise<MCPApiResponse> => {
+  const syncById = async (
+    owner: LightWorkspaceType,
+    space: SpaceType,
+    serverId: string
+  ): Promise<MCPApiResponse> => {
     const response = await fetch(
       `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote/${serverId}?action=sync`,
       { method: "POST" }
     );
-    
+
     if (!response.ok) {
       const error = await response.json();
-      throw new Error(error.api_error?.message || "Failed to synchronize server");
+      throw new Error(
+        error.api_error?.message || "Failed to synchronize server"
+      );
     }
-    
+
     return response.json();
   };
 
-  // Main sync function that determines which method to use
-  const syncServer = async (
-    owner: LightWorkspaceType, 
-    space: SpaceType, 
-    urlOrId: string, 
-    isUrl: boolean = true
-  ): Promise<MCPApiResponse> => {
-    if (isUrl) {
-      return syncByUrl(owner, space, urlOrId);
-    } else {
-      return syncById(owner, space, urlOrId);
-    }
-  };
-  
-  return { syncServer, syncByUrl, syncById };
+  return { syncByUrl, syncById };
 }
 
 /**
@@ -175,14 +154,14 @@ export function useSyncRemoteMCPServer() {
  */
 export function useUpdateRemoteMCPServer() {
   const updateServer = async (
-    owner: LightWorkspaceType, 
-    space: SpaceType, 
-    serverId: string, 
+    owner: LightWorkspaceType,
+    space: SpaceType,
+    serverId: string,
     data: {
       name: string;
       url: string;
       description: string;
-      tools: { name: string, description: string }[];
+      tools: { name: string; description: string }[];
     }
   ): Promise<MCPApiResponse> => {
     const response = await fetch(
@@ -193,14 +172,14 @@ export function useUpdateRemoteMCPServer() {
         body: JSON.stringify(data),
       }
     );
-    
+
     if (!response.ok) {
       const error = await response.json();
       throw new Error(error.api_error?.message || "Failed to update server");
     }
-    
+
     return response.json();
   };
-  
+
   return { updateServer };
 }

--- a/front/lib/swr/remote_mcp_servers.ts
+++ b/front/lib/swr/remote_mcp_servers.ts
@@ -1,0 +1,175 @@
+import { useMemo } from "react";
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
+import type { MCPApiResponse, MCPResponse } from "@app/types/mcp";
+
+// Type for the GetRemoteMCPServersResponseBody
+export type GetRemoteMCPServersResponseBody = {
+  servers: MCPResponse[];
+};
+
+/**
+ * Hook to fetch the list of remote MCP servers for a space
+ */
+export function useRemoteMCPServers({
+  disabled,
+  owner,
+  space,
+}: {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  space: SpaceType;
+}) {
+  const serversFetcher: Fetcher<GetRemoteMCPServersResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote`,
+    serversFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    servers: useMemo(() => (data ? data.servers : []), [data]),
+    isServersLoading: !error && !data,
+    isServersError: !!error,
+    mutateServers: mutate,
+  };
+}
+
+/**
+ * Hook to fetch a specific remote MCP server by ID
+ */
+export function useRemoteMCPServer({
+  disabled,
+  owner,
+  space,
+  serverId,
+}: {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  space: SpaceType;
+  serverId: string;
+}) {
+  const serverFetcher: Fetcher<MCPApiResponse> = fetcher;
+
+  if (!serverId) {
+    return {
+      server: null,
+      isServerLoading: false,
+      isServerError: true,
+      mutateServer: () => Promise.resolve(),
+    };
+  }
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    serverId ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote/${serverId}` : null,
+    serverFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    server: data?.data || null,
+    isServerLoading: !error && !data,
+    isServerError: !!error,
+    mutateServer: mutate,
+  };
+}
+
+/**
+ * Hook to delete a remote MCP server
+ */
+export function useDeleteRemoteMCPServer() {
+  const deleteServer = async (
+    owner: LightWorkspaceType,
+    space: SpaceType,
+    serverId: string
+  ): Promise<MCPApiResponse> => {
+    const response = await fetch(
+      `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote/${serverId}`,
+      {
+        method: "DELETE",
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.api_error?.message || "Failed to delete server");
+    }
+
+    return response.json();
+  };
+  
+  return { deleteServer };
+}
+
+// Keep the old function for backward compatibility
+export async function deleteRemoteMCPServer(
+  owner: LightWorkspaceType,
+  space: SpaceType,
+  serverId: string
+): Promise<MCPApiResponse> {
+  const { deleteServer } = useDeleteRemoteMCPServer();
+  return deleteServer(owner, space, serverId);
+}
+
+/**
+ * Hook to synchronize with a remote MCP server by URL
+ */
+export function useSyncRemoteMCPServer() {
+  const syncServer = async (owner: LightWorkspaceType, space: SpaceType, url: string): Promise<MCPApiResponse> => {
+    const response = await fetch(
+      `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote?url=${encodeURIComponent(url)}`,
+      { method: "GET" }
+    );
+    
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.api_error?.message || "Failed to synchronize server");
+    }
+    
+    return response.json();
+  };
+  
+  return { syncServer };
+}
+
+/**
+ * Hook to update a remote MCP server
+ */
+export function useUpdateRemoteMCPServer() {
+  const updateServer = async (
+    owner: LightWorkspaceType, 
+    space: SpaceType, 
+    serverId: string, 
+    data: {
+      name: string;
+      url: string;
+      description: string;
+      tools: string[];
+    }
+  ): Promise<MCPApiResponse> => {
+    const response = await fetch(
+      `/api/w/${owner.sId}/spaces/${space.sId}/mcp/remote/${serverId}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      }
+    );
+    
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.api_error?.message || "Failed to update server");
+    }
+    
+    return response.json();
+  };
+  
+  return { updateServer };
+}

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -150,7 +150,7 @@ export function useSpaceDataSourceViews({
   spaceId,
   workspaceId,
 }: {
-  category?: Exclude<DataSourceViewCategory, "apps">;
+  category?: Exclude<DataSourceViewCategory, "apps" | "mcp">;
   disabled?: boolean;
   spaceId: string;
   workspaceId: string;
@@ -191,7 +191,7 @@ export function useSpaceDataSourceViewsWithDetails({
   spaceId,
   workspaceId,
 }: {
-  category: Exclude<DataSourceViewCategory, "apps">;
+  category: Exclude<DataSourceViewCategory, "apps" | "mcp">;
   disabled?: boolean;
   spaceId: string;
   workspaceId: string;
@@ -342,7 +342,7 @@ export function useDeleteFolderOrWebsite({
 }: {
   owner: LightWorkspaceType;
   spaceId: string;
-  category: Exclude<DataSourceViewCategory, "apps">;
+  category: Exclude<DataSourceViewCategory, "apps" | "mcp">;
 }) {
   const sendNotification = useSendNotification();
   const { mutateRegardlessOfQueryParams: mutateSpaceDataSourceViews } =

--- a/front/migrations/db/migration_185.sql
+++ b/front/migrations/db/migration_185.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS "remote_mcp_servers" (
     "name" varchar(255) NOT NULL,
     "url" varchar(255) NOT NULL,
     "description" text,
-    "cachedTools" varchar(255)[] DEFAULT ARRAY[] ::varchar(255)[],
+    "cachedTools" JSONB NOT NULL DEFAULT '[]',
     "lastSyncAt" timestamp with time zone,
     "sharedSecret" varchar(255) NOT NULL,
     "workspaceId" bigint NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,

--- a/front/migrations/db/migration_185.sql
+++ b/front/migrations/db/migration_185.sql
@@ -2,16 +2,17 @@
 CREATE TABLE IF NOT EXISTS "remote_mcp_servers" (
     "createdAt" timestamp with time zone NOT NULL,
     "updatedAt" timestamp with time zone NOT NULL,
+    "deletedAt" timestamp with time zone,
     "sId" varchar(255) NOT NULL,
-    "name" varchar(255) NOT NULL,
     "url" varchar(255) NOT NULL,
+    "name" varchar(255) NOT NULL,
     "description" text,
     "cachedTools" JSONB NOT NULL DEFAULT '[]',
     "lastSyncAt" timestamp with time zone,
     "sharedSecret" varchar(255) NOT NULL,
     "workspaceId" bigint NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     "id" bigserial,
-    "spaceId" bigint NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "vaultId" bigint NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     PRIMARY KEY ("id")
 );
 

--- a/front/migrations/db/migration_188.sql
+++ b/front/migrations/db/migration_188.sql
@@ -1,0 +1,4 @@
+-- Migration created on Mar 23, 2025
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedTools" DROP NOT NULL;
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedTools" SET DEFAULT '[]';
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedTools" TYPE JSONB;

--- a/front/migrations/db/migration_188.sql
+++ b/front/migrations/db/migration_188.sql
@@ -1,4 +1,0 @@
--- Migration created on Mar 23, 2025
-ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedTools" DROP NOT NULL;
-ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedTools" SET DEFAULT '[]';
-ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedTools" TYPE JSONB;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -7,10 +7,12 @@ import { getDataSourceViewsUsageByCategory } from "@app/lib/api/agent_data_sourc
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import { softDeleteSpaceAndLaunchScrubWorkflow } from "@app/lib/api/spaces";
-import { getFeatureFlags, type Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -23,8 +25,6 @@ import {
   DATA_SOURCE_VIEW_CATEGORIES,
   PatchSpaceRequestBodySchema,
 } from "@app/types";
-import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 type SpaceCategoryInfo = {
   usage: DataSourceWithAgentsUsageType;
@@ -51,7 +51,7 @@ async function handler(
   { space }: { space: SpaceResource }
 ): Promise<void> {
   const workspace = auth.getNonNullableWorkspace();
-  const ff = await getFeatureFlags(workspace)
+  const ff = await getFeatureFlags(workspace);
 
   switch (req.method) {
     case "GET": {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/remote/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/remote/[serverId]/index.ts
@@ -1,0 +1,237 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
+import { MCPApiResponse } from "@app/types/mcp";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<MCPApiResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  const { method } = req;
+  const { wId, spaceId, serverId } = req.query;
+
+  if (typeof wId !== "string" || typeof spaceId !== "string" || typeof serverId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  // Check authentication
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only users that are `builders` for the current workspace can view MCP servers.",
+      },
+    });
+  }
+
+  // Ensure workspace ID matches authenticated workspace
+  if (auth.workspace()?.sId !== wId) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message: "You don't have access to this workspace.",
+      },
+    });
+  }
+
+  // Get the actual workspace and space database IDs
+  const workspace = auth.workspace();
+  const space = await SpaceResource.fetchById(auth, spaceId);
+
+  if (!workspace || !space) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "Workspace or space not found",
+      },
+    });
+  }
+
+  // Use the numeric IDs for database operations
+  const workspaceIdNum = workspace.id;
+  const spaceIdNum = space.id;
+
+  switch (method) {
+    case "GET": {
+      try {
+        // Find the specific remote MCP server
+        const server = await RemoteMCPServer.findOne({
+          where: { 
+            workspaceId: workspaceIdNum, 
+            spaceId: spaceIdNum,
+            sId: serverId 
+          },
+        });
+
+        if (!server) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "data_source_not_found",
+              message: "Remote MCP Server not found",
+            },
+          });
+        }
+
+        return res.status(200).json({
+          success: true,
+          data: {
+            id: server.sId,
+            workspaceId: wId,
+            name: server.name,
+            description: server.description || "",
+            tools: server.cachedTools,
+            url: server.url,
+            // Include shared secret in individual server response
+            sharedSecret: server.sharedSecret,
+          },
+        });
+      } catch (error) {
+        console.error("Error fetching remote MCP server:", error);
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Internal server error",
+          },
+        });
+      }
+    }
+
+    case "PATCH": {
+      try {
+        const { name, url, description, tools } = req.body;
+
+        // Validate required fields
+        if (!name || !url) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Name and URL are required fields",
+            },
+          });
+        }
+
+        // Find the specific MCP server
+        const server = await RemoteMCPServer.findOne({
+          where: { 
+            workspaceId: workspaceIdNum, 
+            spaceId: spaceIdNum,
+            sId: serverId 
+          },
+        });
+
+        if (!server) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "data_source_not_found",
+              message: "Remote MCP Server not found",
+            },
+          });
+        }
+
+        // Update the server
+        await server.update({
+          name,
+          url,
+          description: description || server.description,
+          cachedTools: tools || server.cachedTools,
+          lastSyncAt: new Date(),
+        });
+
+        return res.status(200).json({
+          success: true,
+          data: {
+            id: server.sId,
+            workspaceId: wId,
+            name: server.name,
+            description: server.description || "",
+            tools: server.cachedTools,
+            url: server.url,
+          },
+        });
+      } catch (error) {
+        console.error("Error updating remote MCP server:", error);
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Internal server error",
+          },
+        });
+      }
+    }
+
+    case "DELETE": {
+      try {
+        // Find and delete the specific remote MCP server
+        const server = await RemoteMCPServer.findOne({
+          where: { 
+            workspaceId: workspaceIdNum, 
+            spaceId: spaceIdNum,
+            sId: serverId 
+          },
+        });
+
+        if (!server) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "data_source_not_found",
+              message: "Remote MCP Server not found",
+            },
+          });
+        }
+
+        await server.destroy();
+
+        return res.status(200).json({
+          success: true,
+          data: {
+            id: serverId,
+            name: server.name,
+            description: server.description || "",
+            tools: server.cachedTools,
+          },
+        });
+      } catch (error) {
+        console.error("Error deleting remote MCP server:", error);
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Internal server error",
+          },
+        });
+      }
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET, PATCH, or DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler); 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/remote/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/remote/[serverId]/index.ts
@@ -1,5 +1,3 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -9,47 +7,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import type { MCPApiResponse } from "@app/types/mcp";
-
-/**
- * Synchronizes with an MCP server and retrieves its metadata and tools.
- * This function connects to the server and fetches the necessary information.
- */
-async function fetchServerMetadata(url: string) {
-  const mcpClient = new Client({
-    name: "dust-mcp-client",
-    version: "1.0.0",
-  });
-
-  try {
-    const sseTransport = new SSEClientTransport(new URL(url));
-    await mcpClient.connect(sseTransport);
-
-    const serverVersion = await mcpClient.getServerVersion();
-    const serverName = serverVersion?.name || "A Remote MCP Server";
-    const serverDescription =
-      serverVersion &&
-      "description" in serverVersion &&
-      typeof serverVersion.description === "string"
-        ? serverVersion.description
-        : "Remote MCP server description";
-
-    // Get available tools from the server
-    const toolsResult = await mcpClient.listTools();
-    const serverTools = toolsResult.tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description || "",
-    }));
-
-    return {
-      name: serverName,
-      description: serverDescription,
-      tools: serverTools,
-    };
-  } finally {
-    // Ensure client is closed even if there was an error
-    await mcpClient.close();
-  }
-}
 
 async function handler(
   req: NextApiRequest,
@@ -73,19 +30,17 @@ async function handler(
     });
   }
 
-  // Check authentication
   if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "data_source_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can view MCP servers.",
+          "Only users that are `builders` for the current workspace can manage MCP servers.",
       },
     });
   }
 
-  // Ensure workspace ID matches authenticated workspace
   if (auth.workspace()?.sId !== wId) {
     return apiError(req, res, {
       status_code: 403,
@@ -96,7 +51,6 @@ async function handler(
     });
   }
 
-  // Get the space resource
   const space = await SpaceResource.fetchById(auth, spaceId);
 
   if (!space) {
@@ -109,7 +63,6 @@ async function handler(
     });
   }
 
-  // Find the specific remote MCP server for all methods
   const server = await RemoteMCPServerResource.fetchById(auth, serverId);
 
   if (!server) {
@@ -134,7 +87,6 @@ async function handler(
             description: server.description || "",
             tools: server.cachedTools,
             url: server.url,
-            // Include shared secret in individual server response
             sharedSecret: server.sharedSecret,
           },
         });
@@ -150,81 +102,35 @@ async function handler(
       }
     }
 
-    case "POST": {
-      // Special route for synchronizing this specific server
-      if (req.query.action === "sync") {
-        try {
-          // Synchronize the server by fetching new metadata
-          const metadata = await fetchServerMetadata(server.url);
-
-          // Update the server settings with the new metadata
-          await server.updateSettings(auth, {
-            name: metadata.name,
-            description: metadata.description,
-          });
-
-          // Update tools with the new metadata
-          await server.updateTools(auth, {
-            cachedTools: metadata.tools,
-            lastSyncAt: new Date(),
-          });
-
-          return res.status(200).json({
-            success: true,
-            data: {
-              id: server.sId,
-              workspaceId: wId,
-              name: server.name,
-              description: server.description || "",
-              tools: server.cachedTools,
-              url: server.url,
-              sharedSecret: server.sharedSecret,
-            },
-          });
-        } catch (error) {
-          console.error("Error synchronizing MCP server:", error);
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Failed to synchronize MCP server",
-            },
-          });
-        }
-      } else {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Invalid action",
-          },
-        });
-      }
-    }
-
     case "PATCH": {
       try {
         const { name, url, description, tools } = req.body;
 
-        // Validate required fields
-        if (!name || !url) {
+        if (!name && !url && !description && !tools) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: "Name and URL are required fields",
+              message: "At least one field to update is required",
             },
           });
         }
 
-        // Update the server settings
-        await server.updateSettings(auth, {
-          name,
-          url,
-          description,
-        });
+        const updateSettingsData: any = {};
+        if (name) {
+          updateSettingsData.name = name;
+        }
+        if (url) {
+          updateSettingsData.url = url;
+        }
+        if (description !== undefined) {
+          updateSettingsData.description = description;
+        }
 
-        // Update tools if provided
+        if (Object.keys(updateSettingsData).length > 0) {
+          await server.updateSettings(auth, updateSettingsData);
+        }
+
         if (tools) {
           await server.updateTools(auth, {
             cachedTools: tools,
@@ -241,6 +147,7 @@ async function handler(
             description: server.description || "",
             tools: server.cachedTools,
             url: server.url,
+            sharedSecret: server.sharedSecret,
           },
         });
       } catch (error) {
@@ -286,7 +193,7 @@ async function handler(
         api_error: {
           type: "method_not_supported_error",
           message:
-            "The method passed is not supported, GET, POST, PATCH, or DELETE is expected.",
+            "The method passed is not supported, GET, PATCH, or DELETE is expected.",
         },
       });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/remote/[serverId]/sync.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/remote/[serverId]/sync.ts
@@ -1,0 +1,169 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import type { MCPApiResponse } from "@app/types/mcp";
+
+/**
+ * Synchronizes with an MCP server and retrieves its metadata and tools.
+ * This function connects to the server and fetches the necessary information.
+ */
+async function fetchServerMetadata(url: string) {
+  const mcpClient = new Client({
+    name: "dust-mcp-client",
+    version: "1.0.0",
+  });
+
+  try {
+    const sseTransport = new SSEClientTransport(new URL(url));
+    await mcpClient.connect(sseTransport);
+
+    const serverVersion = await mcpClient.getServerVersion();
+    const serverName = serverVersion?.name || "A Remote MCP Server";
+    const serverDescription =
+      serverVersion &&
+      "description" in serverVersion &&
+      typeof serverVersion.description === "string"
+        ? serverVersion.description
+        : "Remote MCP server description";
+
+    // Get available tools from the server
+    const toolsResult = await mcpClient.listTools();
+    const serverTools = toolsResult.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description || "",
+    }));
+
+    return {
+      name: serverName,
+      description: serverDescription,
+      tools: serverTools,
+    };
+  } finally {
+    // Ensure client is closed even if there was an error
+    await mcpClient.close();
+  }
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<MCPApiResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  const { method } = req;
+  const { wId, spaceId, serverId } = req.query;
+
+  if (
+    typeof wId !== "string" ||
+    typeof spaceId !== "string" ||
+    typeof serverId !== "string"
+  ) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only users that are `builders` for the current workspace can manage MCP servers.",
+      },
+    });
+  }
+
+  if (auth.workspace()?.sId !== wId) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message: "You don't have access to this workspace.",
+      },
+    });
+  }
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+
+  if (!space) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "Space not found",
+      },
+    });
+  }
+
+  // Find the specific remote MCP server
+  const server = await RemoteMCPServerResource.fetchById(auth, serverId);
+
+  if (!server) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "Remote MCP Server not found",
+      },
+    });
+  }
+
+  if (method === "POST") {
+    try {
+      const metadata = await fetchServerMetadata(server.url);
+
+      await server.updateSettings(auth, {
+        name: metadata.name,
+        description: metadata.description,
+      });
+
+      await server.updateTools(auth, {
+        cachedTools: metadata.tools,
+        lastSyncAt: new Date(),
+      });
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          id: server.sId,
+          workspaceId: wId,
+          name: server.name,
+          description: server.description || "",
+          tools: server.cachedTools,
+          url: server.url,
+          sharedSecret: server.sharedSecret,
+        },
+      });
+    } catch (error) {
+      console.error("Error synchronizing MCP server:", error);
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to synchronize MCP server",
+        },
+      });
+    }
+  } else {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/remote/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/remote/index.ts
@@ -1,0 +1,238 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
+import { MCPApiResponse } from "@app/types/mcp";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { randomBytes } from "crypto";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { GetRemoteMCPServersResponseBody } from "@app/lib/swr/remote_mcp_servers";
+
+// Function to generate a secure token
+function generateSecureToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<MCPApiResponse | GetRemoteMCPServersResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { method } = req;
+  const { wId, spaceId } = req.query;
+
+  if (typeof wId !== "string" || typeof spaceId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  // Check authentication
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only users that are `builders` for the current workspace can manage MCP servers.",
+      },
+    });
+  }
+
+  // Ensure workspace ID matches authenticated workspace
+  if (auth.workspace()?.sId !== wId) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message: "You don't have access to this workspace.",
+      },
+    });
+  }
+
+  // Get the actual workspace and space database IDs
+  const workspace = auth.workspace();
+  const space = await SpaceResource.fetchById(auth, spaceId);
+
+  if (!workspace || !space) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "Workspace or space not found",
+      },
+    });
+  }
+
+  // Use the numeric IDs for database operations
+  const workspaceIdNum = workspace.id;
+  const spaceIdNum = space.id;
+
+  switch (method) {
+    case "GET": {
+      // Check if we're listing servers or synchronizing with a specific URL
+      const { url } = req.query;
+
+      if (url) {
+        // Synchronize with a remote MCP server
+        try {
+          if (typeof url !== "string" || !url) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "URL parameter is required",
+              },
+            });
+          }
+
+          // Generate secure tokens
+          const sharedSecret = generateSecureToken();
+          const sId = generateSecureToken();
+
+          // In a real implementation, we would fetch the tools from the MCP server
+          // For now, use mock data
+          const mockTools = [
+            "Search Web",
+            "Generate Image" 
+          ];
+
+          // Create a new MCP server
+          const newMCPServer = await RemoteMCPServer.create({
+            workspaceId: workspaceIdNum,
+            spaceId: spaceIdNum,
+            name: "New MCP Server", // Default name
+            url: url,
+            description: "Fetched MCP Server", // Default description
+            cachedTools: mockTools,
+            lastSyncAt: new Date(),
+            sharedSecret,
+            sId,
+          });
+
+          return res.status(200).json({
+            success: true,
+            data: {
+              id: newMCPServer.sId,
+              workspaceId: wId,
+              name: newMCPServer.name,
+              description: newMCPServer.description ?? "",
+              tools: newMCPServer.cachedTools,
+              sharedSecret: newMCPServer.sharedSecret,
+            },
+          });
+        } catch (error) {
+          console.error("Error synchronizing MCP:", error);
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Internal server error",
+            },
+          });
+        }
+      } else {
+        // List all MCP servers for this space
+        try {
+          // Find all remote MCP servers for this space
+          const servers = await RemoteMCPServer.findAll({
+            where: { workspaceId: workspaceIdNum, spaceId: spaceIdNum },
+          });
+
+          // Map the server records to the expected response format
+          const serverResponses = servers.map((server) => ({
+            id: server.sId,
+            workspaceId: wId,
+            name: server.name,
+            description: server.description || "",
+            tools: server.cachedTools,
+            url: server.url,
+            // Don't include sharedSecret in the list response
+          }));
+
+          return res.status(200).json({
+            servers: serverResponses,
+          });
+        } catch (error) {
+          console.error("Error listing remote MCP servers:", error);
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Internal server error",
+            },
+          });
+        }
+      }
+    }
+
+    case "POST": {
+      try {
+        const { name, url, description, tools } = req.body;
+
+        // Validate required fields
+        if (!name || !url || !description) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Missing required fields",
+            },
+          });
+        }
+
+        // Generate a secure shared secret
+        const sharedSecret = generateSecureToken();
+
+        // Create the remote MCP server
+        const newRemoteMCPServer = await RemoteMCPServer.create({
+          workspaceId: workspaceIdNum,
+          spaceId: spaceIdNum,
+          name,
+          url,
+          description,
+          cachedTools: tools || [],
+          lastSyncAt: new Date(),
+          sharedSecret,
+          sId: generateSecureToken(),
+        });
+
+        return res.status(201).json({
+          success: true,
+          data: {
+            id: newRemoteMCPServer.sId,
+            workspaceId: wId,
+            name: newRemoteMCPServer.name,
+            description: newRemoteMCPServer.description ?? "",
+            tools: newRemoteMCPServer.cachedTools,
+          },
+        });
+      } catch (error) {
+        console.error("Error creating MCP:", error);
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Internal server error",
+          },
+        });
+      }
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler); 

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
@@ -29,14 +29,14 @@ import {
   removeNulls,
 } from "@app/types";
 
-type DataSourceViewCategoryWithoutApps = Exclude<
+type DataSourceViewCategoryWithoutAppsAndMCPs = Exclude<
   DataSourceViewCategory,
-  "apps"
+  "apps" | "mcp"
 >;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
   SpaceLayoutPageProps & {
-    category: DataSourceViewCategoryWithoutApps;
+    category: DataSourceViewCategoryWithoutAppsAndMCPs;
     isAdmin: boolean;
     canWriteInSpace: boolean;
     space: SpaceType;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/mcp/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/mcp/index.tsx
@@ -1,11 +1,13 @@
+import type { SpaceType } from "@dust-tt/client";
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react-markdown/lib/react-markdown";
+
 import { SpaceMCPList } from "@app/components/spaces/mcp/SpaceMCPList";
-import { SpaceLayout, SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
+import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
+import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { DataSourceViewCategory } from "@app/types";
-import { SpaceType } from "@dust-tt/client";
-import { InferGetServerSidePropsType } from "next";
-import { ReactElement } from "react-markdown/lib/react-markdown";
+import type { DataSourceViewCategory } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
   SpaceLayoutPageProps & {
@@ -58,11 +60,13 @@ export default function Space({
   owner,
   space,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  return <SpaceMCPList 
-    canWriteInSpace={canWriteInSpace}
-    owner={owner}
-    space={space}
-  />;
+  return (
+    <SpaceMCPList
+      canWriteInSpace={canWriteInSpace}
+      owner={owner}
+      space={space}
+    />
+  );
 }
 
 Space.getLayout = (page: ReactElement, pageProps: any) => {

--- a/front/types/api/public/spaces.ts
+++ b/front/types/api/public/spaces.ts
@@ -36,6 +36,7 @@ export const DATA_SOURCE_VIEW_CATEGORIES = [
   "folder",
   "website",
   "apps",
+  "mcp",
 ] as const;
 
 export type DataSourceViewCategory =
@@ -51,13 +52,13 @@ export function isValidDataSourceViewCategory(
 
 export type DataSourceViewCategoryWithoutApps = Exclude<
   DataSourceViewCategory,
-  "apps"
+  "apps" | "mcp"
 >;
 
 export function isDataSourceViewCategoryWithoutApps(
   category: unknown
 ): category is DataSourceViewCategoryWithoutApps {
-  return isValidDataSourceViewCategory(category) && category !== "apps";
+  return isValidDataSourceViewCategory(category) && category !== "apps" && category !== "mcp";
 }
 
 export function isWebsiteOrFolderCategory(

--- a/front/types/api/public/spaces.ts
+++ b/front/types/api/public/spaces.ts
@@ -58,7 +58,11 @@ export type DataSourceViewCategoryWithoutApps = Exclude<
 export function isDataSourceViewCategoryWithoutApps(
   category: unknown
 ): category is DataSourceViewCategoryWithoutApps {
-  return isValidDataSourceViewCategory(category) && category !== "apps" && category !== "mcp";
+  return (
+    isValidDataSourceViewCategory(category) &&
+    category !== "apps" &&
+    category !== "mcp"
+  );
 }
 
 export function isWebsiteOrFolderCategory(

--- a/front/types/mcp.ts
+++ b/front/types/mcp.ts
@@ -2,7 +2,7 @@ export type MCPFormState = {
   url: string;
   name: string;
   description: string;
-  tools: string[];
+  tools: { name: string, description: string }[];
   errors?: {
     url?: string;
     name?: string;
@@ -37,7 +37,7 @@ export interface MCPResponse {
   workspaceId?: string;
   name: string;
   description: string;
-  tools: string[];
+  tools: { name: string, description: string }[];
   url?: string;
   version?: string;
   sharedSecret?: string;

--- a/front/types/mcp.ts
+++ b/front/types/mcp.ts
@@ -2,7 +2,7 @@ export type MCPFormState = {
   url: string;
   name: string;
   description: string;
-  tools: { name: string, description: string }[];
+  tools: { name: string; description: string }[];
   errors?: {
     url?: string;
     name?: string;
@@ -37,7 +37,7 @@ export interface MCPResponse {
   workspaceId?: string;
   name: string;
   description: string;
-  tools: { name: string, description: string }[];
+  tools: { name: string; description: string }[];
   url?: string;
   version?: string;
   sharedSecret?: string;

--- a/front/types/mcp.ts
+++ b/front/types/mcp.ts
@@ -1,0 +1,56 @@
+export type MCPFormState = {
+  url: string;
+  name: string;
+  description: string;
+  tools: string[];
+  errors?: {
+    url?: string;
+    name?: string;
+    description?: string;
+  };
+};
+
+export type MCPFormAction =
+  | {
+      [K in keyof Omit<MCPFormState, "errors">]: {
+        type: "SET_FIELD";
+        field: K;
+        value: MCPFormState[K];
+      };
+    }[keyof Omit<MCPFormState, "errors">]
+  | {
+      type: "SET_ERROR";
+      field: keyof MCPFormState["errors"];
+      value: string | undefined;
+    }
+  | {
+      type: "RESET";
+      config?: null;
+      name?: string;
+    }
+  | { type: "VALIDATE" };
+
+export type MCPTool = string;
+
+export interface MCPResponse {
+  id?: string;
+  workspaceId?: string;
+  name: string;
+  description: string;
+  tools: string[];
+  url?: string;
+  version?: string;
+  sharedSecret?: string;
+}
+
+export interface MCPError {
+  message: string;
+  code: string;
+  details?: Record<string, unknown>;
+}
+
+export interface MCPApiResponse {
+  success: boolean;
+  data?: MCPResponse;
+  error?: MCPError;
+}

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -428,7 +428,7 @@ export interface LoggerInterface {
 }
 
 const DataSourceViewCategoriesSchema = FlexibleEnumSchema<
-  "managed" | "folder" | "website" | "apps"
+  "managed" | "folder" | "website" | "apps" | "mcp"
 >();
 
 const BlockTypeSchema = FlexibleEnumSchema<


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR enables, behind a feature flag, the ability to setup a remote MCP server and add it as a capability to an agent.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

I've set up locally some agents and tried them, with some composio.dev mcps. The feature flag works and has been tested.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Because it's behind a feature flag, it should not be a problem.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Block front.
Drop table remote_mcp_servers (it's empty in prod).
Apply migration 185 again.
Unblock.
Deploy front.

## Next steps 
Because the PR is already quite large, will be done in other PRs : 
- [ ] Allowing the real override of name and description for an MCP.
- [ ] Validating the action before the agent execution.