### PR TITLE
Use inputSchema for function call specifications

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -89,7 +89,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/front/lib/actions/browse.ts
+++ b/front/lib/actions/browse.ts
@@ -8,6 +8,7 @@ import type { BaseActionRunParams } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
@@ -138,19 +139,22 @@ export class BrowseConfigurationServerRunner extends BaseActionConfigurationServ
       throw new Error("Unexpected unauthenticated call to `runBrowseAction`");
     }
 
+    const inputs = [
+      {
+        name: "urls",
+        description: "List of urls to browse.",
+        type: "array" as const,
+        items: {
+          type: "string" as const,
+        },
+      },
+    ];
+
     return new Ok({
       name: name,
       description: description ?? "Get the content of a web page.",
-      inputs: [
-        {
-          name: "urls",
-          description: "List of urls to browse.",
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-      ],
+      inputs: inputs,
+      inputSchema: dustAppRunInputsToInputSchema(inputs),
     });
   }
 

--- a/front/lib/actions/conversation/include_file.ts
+++ b/front/lib/actions/conversation/include_file.ts
@@ -10,6 +10,7 @@ import type { BaseActionRunParams } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import { listFiles } from "@app/lib/api/assistant/jit_utils";
 import config from "@app/lib/api/config";
 import { getSupportedModelConfig } from "@app/lib/assistant";
@@ -236,18 +237,21 @@ export class ConversationIncludeFileConfigurationServerRunner extends BaseAction
       );
     }
 
+    const inputs = [
+      {
+        name: "fileId",
+        description:
+          "The fileId of the attachment to include in the conversation as returned by the `conversation_list_files_action`",
+        type: "string" as const,
+      },
+    ];
+
     return new Ok({
       name,
       description:
         description ?? DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_DESCRIPTION,
-      inputs: [
-        {
-          name: "fileId",
-          description:
-            "The fileId of the attachment to include in the conversation as returned by the `conversation_list_files_action`",
-          type: "string",
-        },
-      ],
+      inputs: inputs,
+      inputSchema: dustAppRunInputsToInputSchema(inputs),
     });
   }
 

--- a/front/lib/actions/dust_app_run.ts
+++ b/front/lib/actions/dust_app_run.ts
@@ -15,6 +15,10 @@ import type { BaseActionRunParams } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import {
+  dustAppRunInputsToInputSchema,
+  inputSchemaToDustAppRunInputs,
+} from "@app/lib/actions/types/agent";
 import { renderConversationForModel } from "@app/lib/api/assistant/generation";
 import config from "@app/lib/api/config";
 import { getDatasetSchema } from "@app/lib/api/datasets";
@@ -320,8 +324,9 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
 
     // Check that all inputs are accounted for.
     const params: DustAppParameters = {};
+    const inputs = inputSchemaToDustAppRunInputs(spec.inputSchema);
 
-    for (const k of spec.inputs) {
+    for (const k of inputs) {
       if (k.name in rawInputs && typeof rawInputs[k.name] === k.type) {
         // As defined in dustAppRunActionSpecification, type is either "string", "number" or "boolean"
         params[k.name] = rawInputs[k.name] as string | number | boolean;
@@ -764,6 +769,7 @@ async function dustAppRunActionSpecification({
       name,
       description,
       inputs: [],
+      inputSchema: dustAppRunInputsToInputSchema([]),
     });
   }
 
@@ -793,6 +799,7 @@ async function dustAppRunActionSpecification({
     name,
     description,
     inputs,
+    inputSchema: dustAppRunInputsToInputSchema(inputs),
   });
 }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -66,39 +66,6 @@ const Schema = z.union([
 
 export type MCPToolResultContent = z.infer<typeof Schema>;
 
-function isPropertyCompatibleType(value: unknown): value is {
-  title?: string;
-  description?: string;
-  type: "string" | "number" | "boolean" | "array" | "object";
-} {
-  return (
-    value != null &&
-    typeof value === "object" &&
-    "type" in value &&
-    (value.type === "string" ||
-      value.type === "number" ||
-      value.type === "boolean" ||
-      value.type === "array" ||
-      value.type === "object")
-  );
-}
-
-function isPropertyWithItemAndCompatibleItemType(value: unknown): value is {
-  items: { type: "string" | "number" | "boolean" };
-} {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "items" in value &&
-    typeof value.items === "object" &&
-    value.items !== null &&
-    "type" in value.items &&
-    (value.items.type === "string" ||
-      value.items.type === "number" ||
-      value.items.type === "boolean")
-  );
-}
-
 function makeMCPConfigurations({
   config,
   listToolsResult,
@@ -116,50 +83,7 @@ function makeMCPConfigurations({
       remoteMCPServerId: config.remoteMCPServerId,
       name: tool.name,
       description: tool.description ?? null,
-
-      inputs: Object.entries(tool.inputSchema.properties ?? {}).map(
-        ([propertyName, propertyValues]) => {
-          // Check if propertyValues is an object with a title and type property.
-          if (isPropertyCompatibleType(propertyValues)) {
-            if (propertyValues.type === "array") {
-              if (isPropertyWithItemAndCompatibleItemType(propertyValues)) {
-                return {
-                  name: propertyName,
-                  description:
-                    propertyValues.title ?? propertyValues.description ?? "",
-                  type: propertyValues.type,
-                  items: {
-                    type: propertyValues.items.type,
-                  },
-                };
-              } else {
-                return {
-                  name: propertyName,
-                  description:
-                    propertyValues.title ?? propertyValues.description ?? "",
-                  type: propertyValues.type,
-                  items: {
-                    type: "string", // fallback type
-                  },
-                };
-              }
-            } else {
-              return {
-                name: propertyName,
-                description:
-                  propertyValues.title ?? propertyValues.description ?? "",
-                type: propertyValues.type,
-              };
-            }
-          } else {
-            throw new Error(
-              `MCPConfigurationServerRunner: property ${propertyName} is not a valid property: ${JSON.stringify(
-                propertyValues
-              )}`
-            );
-          }
-        }
-      ),
+      inputSchema: tool.inputSchema,
     };
   });
 }

--- a/front/lib/actions/process.ts
+++ b/front/lib/actions/process.ts
@@ -19,6 +19,7 @@ import type { BaseActionRunParams } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -561,7 +562,7 @@ async function processActionSpecification({
   return {
     name,
     description,
-    inputs,
+    inputSchema: dustAppRunInputsToInputSchema(inputs),
   };
 }
 

--- a/front/lib/actions/reasoning.ts
+++ b/front/lib/actions/reasoning.ts
@@ -9,6 +9,7 @@ import {
   BaseActionConfigurationServerRunner,
 } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import { isReasoningConfiguration } from "@app/lib/actions/types/guards";
 import { AgentMessageContentParser } from "@app/lib/api/assistant/agent_message_content_parser";
 import { renderConversationForModel } from "@app/lib/api/assistant/generation";
@@ -157,6 +158,7 @@ export class ReasoningConfigurationServerRunner extends BaseActionConfigurationS
         description ||
         "Perform complex step-by-step reasoning using an advanced AI model.",
       inputs: [],
+      inputSchema: dustAppRunInputsToInputSchema([]),
     });
   }
 

--- a/front/lib/actions/retrieval.ts
+++ b/front/lib/actions/retrieval.ts
@@ -11,6 +11,7 @@ import type {
   ActionConfigurationType,
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
+import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
@@ -825,7 +826,7 @@ function retrievalActionSpecification({
   return {
     name,
     description,
-    inputs,
+    inputSchema: dustAppRunInputsToInputSchema(inputs),
   };
 }
 

--- a/front/lib/actions/search_labels.ts
+++ b/front/lib/actions/search_labels.ts
@@ -6,6 +6,7 @@ import type { BaseActionRunParams } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSearchLabelsAction } from "@app/lib/models/assistant/actions/search_labels";
@@ -146,6 +147,17 @@ export class SearchLabelsConfigurationServerRunner extends BaseActionConfigurati
       name: string;
     }
   ): Promise<Result<AgentActionSpecification, Error>> {
+    const inputs = [
+      {
+        name: "searchText",
+        description:
+          "The text to search for in existing labels using edge ngram matching (case-insensitive). " +
+          "Matches labels that start with any word in the search text. " +
+          "The returned labels can be used in tagsIn/tagsNot parameters to restrict or exclude content " +
+          "based on the user request and conversation context.",
+        type: "string" as const,
+      },
+    ];
     return new Ok({
       name,
       description:
@@ -153,17 +165,8 @@ export class SearchLabelsConfigurationServerRunner extends BaseActionConfigurati
         `Find exact matching labels before using them in the tool ${this.actionConfiguration.parentTool}. ` +
           "Restricting or excluding content succeeds only with existing labels. " +
           "Searching without verifying labels first typically returns no results.",
-      inputs: [
-        {
-          name: "searchText",
-          description:
-            "The text to search for in existing labels using edge ngram matching (case-insensitive). " +
-            "Matches labels that start with any word in the search text. " +
-            "The returned labels can be used in tagsIn/tagsNot parameters to restrict or exclude content " +
-            "based on the user request and conversation context.",
-          type: "string",
-        },
-      ],
+      inputs: inputs,
+      inputSchema: dustAppRunInputsToInputSchema(inputs),
     });
   }
 

--- a/front/lib/actions/tables_query.ts
+++ b/front/lib/actions/tables_query.ts
@@ -15,6 +15,7 @@ import type { BaseActionRunParams } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import { renderConversationForModel } from "@app/lib/api/assistant/generation";
 import type { CSVRecord } from "@app/lib/api/csv";
 import { getSupportedModelConfig } from "@app/lib/assistant";
@@ -344,7 +345,7 @@ async function tablesQueryActionSpecification({
   return {
     name,
     description,
-    inputs: [],
+    inputSchema: dustAppRunInputsToInputSchema([]),
   };
 }
 

--- a/front/lib/actions/types/agent.test.ts
+++ b/front/lib/actions/types/agent.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import type { DustAppRunInputType, InputSchemaType } from "./agent";
+import {
+  dustAppRunInputsToInputSchema,
+  inputSchemaToDustAppRunInputs,
+} from "./agent";
+
+describe("Agent Type Utilities", () => {
+  describe("dustAppRunInputsToInputSchema", () => {
+    it("should convert basic inputs to schema", () => {
+      const inputs: DustAppRunInputType[] = [
+        {
+          name: "query",
+          type: "string",
+          description: "Search query",
+        },
+        {
+          name: "count",
+          type: "number",
+          description: "Number of results",
+        },
+      ];
+
+      const expected: InputSchemaType = {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query",
+          },
+          count: {
+            type: "number",
+            description: "Number of results",
+          },
+        },
+        required: ["query", "count"],
+      };
+
+      expect(dustAppRunInputsToInputSchema(inputs)).toEqual(expected);
+    });
+
+    it("should handle array type inputs", () => {
+      const inputs: DustAppRunInputType[] = [
+        {
+          name: "tags",
+          type: "array",
+          description: "List of tags",
+          items: {
+            type: "string",
+          },
+        },
+      ];
+
+      const expected: InputSchemaType = {
+        type: "object",
+        properties: {
+          tags: {
+            type: "array",
+            description: "List of tags",
+            items: {
+              type: "string",
+            },
+          },
+        },
+        required: ["tags"],
+      };
+
+      expect(dustAppRunInputsToInputSchema(inputs)).toEqual(expected);
+    });
+  });
+
+  describe("inputSchemaToDustAppRunInputs", () => {
+    it("should convert schema to basic inputs", () => {
+      const schema: InputSchemaType = {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query",
+          },
+          count: {
+            type: "number",
+            description: "Number of results",
+          },
+        },
+        required: ["query", "count"],
+      };
+
+      const expected: DustAppRunInputType[] = [
+        {
+          name: "query",
+          type: "string",
+          description: "Search query",
+        },
+        {
+          name: "count",
+          type: "number",
+          description: "Number of results",
+        },
+      ];
+
+      expect(inputSchemaToDustAppRunInputs(schema)).toEqual(expected);
+    });
+
+    it("should handle array type properties", () => {
+      const schema: InputSchemaType = {
+        type: "object",
+        properties: {
+          tags: {
+            type: "array",
+            description: "List of tags",
+            items: {
+              type: "string",
+            },
+          },
+        },
+        required: ["tags"],
+      };
+
+      const expected: DustAppRunInputType[] = [
+        {
+          name: "tags",
+          type: "array",
+          description: "List of tags",
+        },
+      ];
+
+      expect(inputSchemaToDustAppRunInputs(schema)).toEqual(expected);
+    });
+
+    it("should handle missing or invalid properties", () => {
+      const schema: InputSchemaType = {
+        type: "object",
+        properties: {
+          valid: {
+            type: "string",
+            description: "Valid property",
+          },
+          invalid: null,
+          missingType: {
+            description: "Missing type",
+          },
+        },
+        required: ["valid", "invalid", "missingType"],
+      };
+
+      const expected: DustAppRunInputType[] = [
+        {
+          name: "valid",
+          type: "string",
+          description: "Valid property",
+        },
+        {
+          name: "invalid",
+          type: "string",
+          description: "",
+        },
+        {
+          name: "missingType",
+          type: "string",
+          description: "Missing type",
+        },
+      ];
+
+      expect(inputSchemaToDustAppRunInputs(schema)).toEqual(expected);
+    });
+
+    it("should handle empty properties object", () => {
+      const schema: InputSchemaType = {
+        type: "object",
+        properties: {},
+        required: [],
+      };
+
+      expect(inputSchemaToDustAppRunInputs(schema)).toEqual([]);
+    });
+  });
+});

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -99,10 +99,7 @@ export interface BaseActionRunParams {
   agentConfiguration: AgentConfigurationType;
   conversation: ConversationType;
   agentMessage: AgentMessageType;
-  rawInputs: Record<
-    string,
-    string | boolean | number | string[] | boolean[] | number[]
-  >;
+  rawInputs: Record<string, unknown>;
   functionCallId: string | null;
   step: number;
 }

--- a/front/lib/actions/websearch.ts
+++ b/front/lib/actions/websearch.ts
@@ -11,6 +11,7 @@ import type {
   ActionConfigurationType,
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
+import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import {
   actionRefsOffset,
   getWebsearchNumResults,
@@ -170,18 +171,20 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
       );
     }
 
+    const inputs = [
+      {
+        name: "query",
+        description:
+          "The query used to perform the google search. If requested by the user, use the google syntax `site:` to restrict the the search to a particular website or domain.",
+        type: "string" as const,
+      },
+    ];
     return new Ok({
       name,
       description:
         description || "Perform a google search and return the top results.",
-      inputs: [
-        {
-          name: "query",
-          description:
-            "The query used to perform the google search. If requested by the user, use the google syntax `site:` to restrict the the search to a particular website or domain.",
-          type: "string",
-        },
-      ],
+      inputs: inputs,
+      inputSchema: dustAppRunInputsToInputSchema(inputs),
     });
   }
 

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -19,7 +19,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "0e9889c787",
       appHash:
-        "4e896f08ef6c2c69c97610c861cd444e3d34c839eab44f9b4fd7dd1d166c40a2",
+        "4ca72349dd72e1140d47efe96eda954e0e7b2cea2c36088b6da0ca083b23c3e2",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

"inputs" in the function call specifications was turned into a json schema in the multi-actions-v2 app.

This PR directly pass the json schema in the specifications as we are getting it directly from the MCP servers and remove the translation layer. It also move the generation of the JSON schema for the existing actions in `front`.

The new FUNCTIONS code block in the multi-actions-v2 is:

```ts
_fun = (env) => {
  let functions = []
  const NO_PARAMETERS = { type: "object", properties: {}, required: [] }
  
  for (const spec of env.state.INPUT.specifications) {
    let properties = {};
   
    functions.push({
      name: spec.name,
      description: spec.description,
      parameters: spec.inputSchema ?? NO_PARAMETERS
    })
  }
  
  return functions
}
```

## Tests

Local testing with various kind of actions.

## Risk

High, could break actions but easily revertable.

## Deploy Plan

Deploy `front-edge`, test, deploy `front`