### PR TITLE
[Relocation] Users with multiple memberships: relocate by default

### DIFF
--- a/front/admin/relocate_users.ts
+++ b/front/admin/relocate_users.ts
@@ -93,12 +93,12 @@ export async function updateAllWorkspaceUsersRegionMetadata(
     execute,
     newRegion,
     rateLimitThreshold,
-    skipUsersWithMultipleMemberships,
+    forceUsersWithMultipleMemberships,
   }: {
     execute: boolean;
     newRegion: RegionType;
     rateLimitThreshold: number;
-    skipUsersWithMultipleMemberships: boolean;
+    forceUsersWithMultipleMemberships: boolean;
   }
 ): Promise<Result<void, Error>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -123,15 +123,10 @@ export async function updateAllWorkspaceUsersRegionMetadata(
         })),
       },
       "Some users have multiple memberships. Can be ignored by setting the " +
-        "skipUsersWithMultipleMemberships flag."
+        "forceUsersWithMultipleMemberships flag."
     );
 
-    // Filter out the users with multiple memberships if option is set.
-    if (skipUsersWithMultipleMemberships) {
-      userIds = userIds.filter(
-        (id) => !externalMemberships.some((m) => m.userId === id)
-      );
-    } else {
+    if (!forceUsersWithMultipleMemberships) {
       return new Err(new Error("Some users have mutiple memberships"));
     }
   }
@@ -183,7 +178,7 @@ if (require.main === module) {
         required: false,
         default: 3,
       },
-      skipUsersWithMultipleMemberships: {
+      forceUsersWithMultipleMemberships: {
         type: "boolean",
         required: false,
         default: false,
@@ -194,7 +189,7 @@ if (require.main === module) {
         destinationRegion,
         workspaceId,
         rateLimitThreshold,
-        skipUsersWithMultipleMemberships,
+        forceUsersWithMultipleMemberships,
         execute,
       },
       logger
@@ -205,7 +200,7 @@ if (require.main === module) {
         execute,
         newRegion: destinationRegion as RegionType,
         rateLimitThreshold,
-        skipUsersWithMultipleMemberships,
+        forceUsersWithMultipleMemberships,
       });
 
       if (res.isErr()) {

--- a/front/scripts/relocate_workspace.ts
+++ b/front/scripts/relocate_workspace.ts
@@ -62,7 +62,7 @@ makeScript(
       choices: RELOCATION_STEPS,
       demandOption: true,
     },
-    skipUsersWithMultipleMemberships: {
+    forceUsersWithMultipleMemberships: {
       type: "boolean",
       required: false,
       default: false,
@@ -75,7 +75,7 @@ makeScript(
       step,
       workspaceId,
       execute,
-      skipUsersWithMultipleMemberships,
+      forceUsersWithMultipleMemberships,
     },
     logger
   ) => {
@@ -147,7 +147,7 @@ makeScript(
               execute,
               newRegion: destinationRegion,
               rateLimitThreshold: AUTH0_DEFAULT_RATE_LIMIT_THRESHOLD,
-              skipUsersWithMultipleMemberships,
+              forceUsersWithMultipleMemberships,
             });
           if (updateUsersRegionToDestRes.isErr()) {
             logger.error(
@@ -217,7 +217,7 @@ makeScript(
               execute,
               newRegion: sourceRegion,
               rateLimitThreshold: AUTH0_DEFAULT_RATE_LIMIT_THRESHOLD,
-              skipUsersWithMultipleMemberships: false,
+              forceUsersWithMultipleMemberships: false,
             });
           if (updateUsersRegionToSrcRes.isErr()) {
             logger.error(


### PR DESCRIPTION
Description
---
PR renames "skip" to "force" and relocates auth0 for users who have multiple memberships if the flag is set.

Option formerly did not relocate auth0 for users who had multiple memberships.

It turns out the most sensible default is to relocate them. Every time the issue happened, the other membership in source region was dummy and the user only cared about the relocated workspace

Risk
---
low

Deploy
---
front

