### PR TITLE
Fix filter ds for remote only in agent ds modal

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -168,14 +168,15 @@ export function DataSourceViewsSelector({
     }
 
     return orderDatasourceViewByImportance(dataSourceViews).filter((dsv) => {
+      const connectorId = dsv.dataSource.connectorId;
       if (!includesConnectorIDs.length && !excludesConnectorIDs.length) {
         return true;
       }
-      if (includesConnectorIDs.length && dsv.dataSource.connectorId) {
-        return includesConnectorIDs.includes(dsv.dataSource.connectorId);
+      if (includesConnectorIDs.length) {
+        return connectorId ? includesConnectorIDs.includes(connectorId) : false;
       }
-      if (excludesConnectorIDs.length && dsv.dataSource.connectorId) {
-        return !excludesConnectorIDs.includes(dsv.dataSource.connectorId);
+      if (excludesConnectorIDs.length && connectorId) {
+        return !excludesConnectorIDs.includes(connectorId);
       }
       return true;
     });


### PR DESCRIPTION
## Description

Following this PR: https://github.com/dust-tt/dust/pull/11520
Diff is line 176 -> if no connectorId (= if it's a folder) and we're in remote only, we should exclude. 

## Tests

Locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 