### PR TITLE
[Github connector] Reduce repositories page size, from 100 to 25

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -56,6 +56,7 @@ import {
 } from "@connectors/types";
 
 const API_PAGE_SIZE = 100;
+const REPOSITORIES_API_PAGE_SIZE = 25;
 
 type GithubOrg = {
   id: number;
@@ -132,7 +133,7 @@ export async function getReposPage(
     return new Ok(
       (
         await octokit.request("GET /installation/repositories", {
-          per_page: API_PAGE_SIZE,
+          per_page: REPOSITORIES_API_PAGE_SIZE,
           page: page,
         })
       ).data.repositories.map((r) => ({


### PR DESCRIPTION
Description
---
Fixes [this monitor](https://dust4ai.slack.com/archives/C05F84CFP0E/p1742831863443639)

Some people have too many repositories. The request to grab a page of them takes too
long, that is more than 5 minutes---the activity start-to-close timeout.

Reducing page size by a factor 4 as an attempt to avoid that completely

Risks
---
low

Deploy
---
connectors
