### PR TITLE
[Agent Builder] Fix: prevent selecting dust app from unallowed space

### DIFF
--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -65,6 +65,10 @@ export function ActionDustAppRun({
 
   const noDustApp = dustApps.length === 0;
 
+  const hasNoDustAppsInAllowedSpaces = dustApps.every(
+    (app) => !allowedSpaces.some((space) => space.sId === app.space.sId)
+  );
+
   if (!action.configuration) {
     return null;
   }
@@ -141,7 +145,7 @@ export function ActionDustAppRun({
                 const appsInSpace = space
                   ? dustApps.filter((app) => app.space.sId === space.sId)
                   : dustApps;
-                if (appsInSpace.length === 0) {
+                if (appsInSpace.length === 0 || hasNoDustAppsInAllowedSpaces) {
                   return <>No Dust Apps available.</>;
                 }
 

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -65,9 +65,11 @@ export function ActionDustAppRun({
 
   const noDustApp = dustApps.length === 0;
 
-  const hasNoDustAppsInAllowedSpaces = dustApps.every(
-    (app) => !allowedSpaces.some((space) => space.sId === app.space.sId)
-  );
+  const hasNoDustAppsInAllowedSpaces = useMemo(() => {
+    // No n^2 complexity.
+    const allowedSet = new Set(allowedSpaces.map((space) => space.sId));
+    return dustApps.every((app) => !allowedSet.has(app.space.sId));
+  }, [dustApps, allowedSpaces]);
 
   if (!action.configuration) {
     return null;


### PR DESCRIPTION
Description
---
If there is only one space with dust apps, let's call it space A, existing code allows people to select e.g. retrieval actions from another space B, then dust apps from space A (see video).

Product-wise, we currently only allow people to select stuff from one space. Furthermore, this breaks other little parts of the code not yet ready for that (e.g. agent permissioning).

The PR fixes this.

[Screencast From 2025-03-24 19-16-16.webm](https://github.com/user-attachments/assets/1b614e61-c873-4574-a2a0-29a6245a03b8)



Risk
---
low

Deploy
---
front
