### PR TITLE
Support Confluence & GitHub url in the Input Bar

### DIFF
--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -129,7 +129,6 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
       return { url: url.toString() };
     },
   },
-
   google_drive: {
     matcher: (url: URL): boolean => {
       return (
@@ -153,7 +152,14 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
       return null;
     },
   },
-
+  github: {
+    matcher: (url: URL): boolean => {
+      return url.hostname.endsWith("github.com");
+    },
+    urlNormalizer: (url: URL): UrlCandidate => {
+      return { url: url.toString() };
+    },
+  },
   notion: {
     matcher: (url: URL): boolean => {
       return url.hostname.includes("notion.so");

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -118,6 +118,18 @@ type ProviderWithExtractor = BaseProvider & {
 type Provider = ProviderWithExtractor | ProviderWithNormalizer;
 
 const providers: Partial<Record<ConnectorProvider, Provider>> = {
+  confluence: {
+    matcher: (url: URL): boolean => {
+      return (
+        url.hostname.endsWith("atlassian.net") &&
+        url.pathname.startsWith("/wiki")
+      );
+    },
+    urlNormalizer: (url: URL): UrlCandidate => {
+      return { url: url.toString() };
+    },
+  },
+
   google_drive: {
     matcher: (url: URL): boolean => {
       return (


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR solves this: https://github.com/dust-tt/tasks/issues/2455.

It adds support to replace Confluence and GitHub URLs pasted in the `InputBar` to link the associated content nodes. Spend sometimes reviewing URL construction in our connectors and ES and they those two connectors normalized very well the URLs.  

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
