### PR TITLE
enh(front): Pass the theme when selecting the icon in `Citations`

### DIFF
--- a/front/components/actions/retrieval/RetrievalActionDetails.tsx
+++ b/front/components/actions/retrieval/RetrievalActionDetails.tsx
@@ -10,13 +10,18 @@ import {
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import { makeDocumentCitations } from "@app/components/actions/retrieval/utils";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { RetrievalActionType } from "@app/lib/actions/retrieval";
 
 export function RetrievalActionDetails({
   action,
   defaultOpen,
 }: ActionDetailsComponentBaseProps<RetrievalActionType>) {
-  const documentCitations = makeDocumentCitations(action.documents ?? []);
+  const { isDark } = useTheme();
+  const documentCitations = makeDocumentCitations(
+    action.documents ?? [],
+    isDark
+  );
 
   const isIncludeAction = !action.params.query;
 


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/11561.
- This PR passes the theme when computing the icon in `makeDocumentCitations`.
- There are a few connectors for which we have a different icon in dark mode than in light mode (GitHub, Zendesk). This behavior is implemented in `CONNECTOR_CONFIGURATIONS` and is now directly reused in `makeDocumentCitations`.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.