### PR TITLE
enh(front): Pass the theme when selecting the icon in `Citations` 2

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -514,6 +514,7 @@ export function AgentMessage({
     agentMessageToRender.actions,
     agentMessageToRender.status,
     agentMessageToRender.sId,
+    isDark,
   ]);
   const { configuration: agentConfiguration } = agentMessageToRender;
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -53,6 +53,7 @@ import {
   sanitizeVisualizationContent,
   visualizationDirective,
 } from "@app/components/markdown/VisualizationBlock";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useEventSource } from "@app/hooks/useEventSource";
 import type { RetrievalActionType } from "@app/lib/actions/retrieval";
 import type { AgentActionSpecificEvent } from "@app/lib/actions/types/agent";
@@ -143,6 +144,7 @@ export function AgentMessage({
   owner,
   user,
 }: AgentMessageProps) {
+  const { isDark } = useTheme();
   const [streamedAgentMessage, setStreamedAgentMessage] =
     useState<AgentMessageType>(message);
 
@@ -488,7 +490,7 @@ export function AgentMessage({
     const allDocsReferences = allDocs.reduce<{
       [key: string]: MarkdownCitation;
     }>((acc, d) => {
-      acc[d.reference] = makeDocumentCitation(d);
+      acc[d.reference] = makeDocumentCitation(d, isDark);
       return acc;
     }, {});
 


### PR DESCRIPTION
## Description

- Direct follow up on https://github.com/dust-tt/dust/pull/11567.
- Turns out we also show the logo in `AgentMessage` so adding it there as well.

## Tests

- Tested locally.

<img width="722" alt="Screenshot 2025-03-24 at 10 49 22 PM" src="https://github.com/user-attachments/assets/581fa125-9913-4640-ae0c-4cc13a802fd8" />

<img width="722" alt="Screenshot 2025-03-24 at 10 49 35 PM" src="https://github.com/user-attachments/assets/49266140-0176-4ff7-b076-fc8765e7c9dc" />

## Risk

- N/A.

## Deploy Plan

- Deploy front.