### PR TITLE
[Slack bot answers] Reconnect on errors and stream closing

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -21,6 +21,7 @@ import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_clien
 import type { SlackChatBotMessage } from "@connectors/lib/models/slack";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import { setTimeoutAsync } from "@connectors/lib/async_utils";
 
 // Copied from front/hooks/useEventSource.ts
 const RECONNECT_DELAY = 5000; // 5 seconds.
@@ -85,7 +86,7 @@ export async function streamConversationToSlack(
         },
         "Retryable error in Slack answer stream."
       );
-      await new Promise((resolve) => setTimeout(resolve, RECONNECT_DELAY));
+      await setTimeoutAsync(RECONNECT_DELAY);
       reconnectAttempts++;
     } else {
       return streamRes;

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -183,11 +183,11 @@ async function streamAgentAnswerToSlack(
         );
       }
       case "error": {
-        return new Err(
-          new SlackAnswerRetryableError(
-            `Error: code: ${event.content.code} message: ${event.content.message}`
-          )
-        );
+        const message = `Error: code: ${event.content.code} message: ${event.content.message}`;
+        if (event.content.code === "stream_error") {
+          return new Err(new SlackAnswerRetryableError(message));
+        }
+        return new Err(new Error(message));
       }
 
       case "agent_action_success": {

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 
 const RECONNECT_DELAY = 5000; // 5 seconds.
+const MAX_RECONNECT_ATTEMPTS = 10;
 
 /**
  * Stable EventSource Manager
@@ -139,7 +140,7 @@ export function useEventSource(
 
       reconnectAttempts.current++;
 
-      if (reconnectAttempts.current >= 10) {
+      if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
         console.log(
           "Too many errors, not reconnecting. Please refresh the page."
         );


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2447
Fixes https://github.com/dust-tt/tasks/issues/2448
Fixes https://github.com/dust-tt/tasks/issues/2421
Fixes https://github.com/dust-tt/tasks/issues/2446

Description
---
Most of the investigation context is in issue https://github.com/dust-tt/tasks/issues/2447

A regression was introduced 2 weeks ago when adding a timeout of 60s to the getMessageEvents() function, causing all agents whose multi action loop is > 60s to exit the event consumption loop before receiving the final event.

Only affects streams to slack because in front, we use an event source which reconnects on errors, and does not explicitly fails when the last event is not received swiftly.

This PR replicates the logic from front: on error or missing event, attempt reconnects after delay:
- extracts the `postSlackMessageUpdate` fn (required for the below)
- creates and extracts a `streamAgentAnswerToSlack` fn
- wraps retrying logic around `streamAgentAnswerToSlack`

Risks
---
medium high. affects all conversations on slack. tested locally. asking for 2 reviews.

Deploy
---
- connectors
- front

