### PR TITLE
refactor(extension): uniformize `MarkdownCitation` with `front`

### DIFF
--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -13,13 +13,14 @@ import {
   getCiteDirective,
 } from "@app/ui/components/markdown/CiteBlock";
 import type { MarkdownCitation } from "@app/ui/components/markdown/MarkdownCitation";
-import { citationIconMap } from "@app/ui/components/markdown/MarkdownCitation";
+import { getCitationIcon } from "@app/ui/components/markdown/MarkdownCitation";
 import {
   MentionBlock,
   mentionDirective,
 } from "@app/ui/components/markdown/MentionBlock";
 import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
 import { useEventSource } from "@app/ui/hooks/useEventSource";
+import { useTheme } from "@app/ui/hooks/useTheme";
 import type {
   AgentActionPublicType,
   AgentActionSpecificEvent,
@@ -112,10 +113,13 @@ export function visualizationDirective() {
 }
 
 export function makeDocumentCitation(
-  document: RetrievalDocumentPublicType
+  document: RetrievalDocumentPublicType,
+  isDark?: boolean
 ): MarkdownCitation {
-  const IconComponent =
-    citationIconMap[getProviderFromRetrievedDocument(document)];
+  const IconComponent = getCitationIcon(
+    getProviderFromRetrievedDocument(document),
+    isDark
+  );
   return {
     href: document.sourceUrl ?? undefined,
     title: getTitleFromRetrievedDocument(document),
@@ -161,6 +165,7 @@ export function AgentMessage({
 }: AgentMessageProps) {
   const platform = usePlatform();
   const sendNotification = useSendNotification();
+  const { theme } = useTheme();
 
   const [streamedAgentMessage, setStreamedAgentMessage] =
     useState<AgentMessagePublicType>(message);
@@ -436,7 +441,7 @@ export function AgentMessage({
     const allDocsReferences = allDocs.reduce<{
       [key: string]: MarkdownCitation;
     }>((acc, d) => {
-      acc[d.reference] = makeDocumentCitation(d);
+      acc[d.reference] = makeDocumentCitation(d, theme === "dark");
       return acc;
     }, {});
 

--- a/extension/ui/components/markdown/MarkdownCitation.tsx
+++ b/extension/ui/components/markdown/MarkdownCitation.tsx
@@ -12,7 +12,10 @@ export function getCitationIcon(
     case "image":
       return ImageIcon;
     default:
-      return CONNECTOR_CONFIGURATIONS[type].getLogoComponent(isDark);
+      return (
+        CONNECTOR_CONFIGURATIONS[type]?.getLogoComponent(isDark) ||
+        DocumentTextIcon
+      );
   }
 }
 

--- a/extension/ui/components/markdown/MarkdownCitation.tsx
+++ b/extension/ui/components/markdown/MarkdownCitation.tsx
@@ -1,56 +1,20 @@
-import {
-  BigQueryLogo,
-  ConfluenceLogo,
-  DocumentTextIcon,
-  DriveLogo,
-  GithubLogo,
-  GongLogo,
-  ImageIcon,
-  IntercomLogo,
-  MicrosoftLogo,
-  NotionLogo,
-  SalesforceLogo,
-  SlackLogo,
-  SnowflakeLogo,
-  ZendeskLogo,
-} from "@dust-tt/sparkle";
-import type { SVGProps } from "react";
+import { CONNECTOR_CONFIGURATIONS } from "@app/shared/lib/connector_providers";
+import type { ConnectorProvider } from "@dust-tt/client";
+import { DocumentTextIcon, ImageIcon } from "@dust-tt/sparkle";
 
-export type CitationIconType =
-  | "confluence"
-  | "document"
-  | "github"
-  | "google_drive"
-  | "intercom"
-  | "microsoft"
-  | "zendesk"
-  | "notion"
-  | "slack"
-  | "image"
-  | "snowflake"
-  | "bigquery"
-  | "salesforce"
-  | "gong";
-
-export const citationIconMap: Record<
-  CitationIconType,
-  (props: SVGProps<SVGSVGElement>) => React.JSX.Element
-> = {
-  confluence: ConfluenceLogo,
-  document: DocumentTextIcon,
-  github: GithubLogo,
-  google_drive: DriveLogo,
-  intercom: IntercomLogo,
-  microsoft: MicrosoftLogo,
-  zendesk: ZendeskLogo,
-  notion: NotionLogo,
-  slack: SlackLogo,
-  image: ImageIcon,
-  snowflake: SnowflakeLogo,
-  bigquery: BigQueryLogo,
-  salesforce: SalesforceLogo,
-  gong: GongLogo,
-};
+export function getCitationIcon(
+  type: ConnectorProvider | "document" | "image",
+  isDark?: boolean
+) {
+  switch (type) {
+    case "document":
+      return DocumentTextIcon;
+    case "image":
+      return ImageIcon;
+    default:
+      return CONNECTOR_CONFIGURATIONS[type].getLogoComponent(isDark);
+  }
+}
 
 export interface MarkdownCitation {
   description?: string;


### PR DESCRIPTION
## Description

- Direct follow up on https://github.com/dust-tt/dust/pull/11561, which refactored `MarkdownCitation` in front.
- This PR does the same for the extension, where `CONNECTOR_CONFIGURATIONS` is not the same but still contains the logo getter.
- It also naturally handles the icon switch depending on the theme.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- No deploy.