### PR TITLE
Fix content fragment rendering to align with list_conversation_files

### DIFF
--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -54,6 +54,8 @@ export function isConversationContentNodeType(
   return "contentFragmentId" in attachment;
 }
 
+// If updating this function, make sure to update `contentFragmentId` when we render the conversation
+// for the model. So there is a consistent way to reference content fragments across different actions.
 export function conversationAttachmentId(
   attachment: ConversationAttachmentType
 ): string {

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -5,6 +5,7 @@ import type {
   Transaction,
 } from "sequelize";
 
+import { conversationAttachmentId } from "@app/lib/actions/conversation/list_files";
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
@@ -584,7 +585,9 @@ export async function renderLightContentFragmentForModel(
           {
             type: "text",
             text: renderContentFragmentXml({
-              contentFragmentId: contentFragment.sId,
+              // Use fileId as contentFragmentId to provide a consistent identifier for the model
+              // to reference content fragments across different actions like include_file.
+              contentFragmentId: fileStringId,
               contentType,
               title,
               version: contentFragmentVersion,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -584,9 +584,7 @@ export async function renderLightContentFragmentForModel(
           {
             type: "text",
             text: renderContentFragmentXml({
-              // Use fileId as contentFragmentId to provide a consistent identifier for the model
-              // to reference content fragments across different actions like include_file.
-              contentFragmentId: fileStringId,
+              contentFragmentId: contentFragment.sId,
               contentType,
               title,
               version: contentFragmentVersion,
@@ -625,7 +623,9 @@ export async function renderLightContentFragmentForModel(
       {
         type: "text",
         text: renderContentFragmentXml({
-          contentFragmentId: contentFragment.sId,
+          // Use fileId as contentFragmentId to provide a consistent identifier for the model
+          // to reference content fragments across different actions like include_file.
+          contentFragmentId: fileStringId ?? contentFragment.sId,
           contentType,
           title,
           version: contentFragmentVersion,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -5,7 +5,6 @@ import type {
   Transaction,
 } from "sequelize";
 
-import { conversationAttachmentId } from "@app/lib/actions/conversation/list_files";
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes this issue: https://github.com/dust-tt/tasks/issues/2450.

We were exposing two distinct identifiers for the same file:
1. Content fragment ID when rendering conversations for models
2. File ID when returning list_conversation_files results

This inconsistency creates ambiguity and has led to instances where models incorrectly reference files using the wrong identifier.

This PR addresses the immediate issue, though a more comprehensive solution requiring a unified function to compute content fragment IDs will follow shortly.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
