### PR TITLE
Preparation work for supporting "folder" content node based content fragments

### DIFF
--- a/extension/shared/lib/conversation.ts
+++ b/extension/shared/lib/conversation.ts
@@ -175,9 +175,8 @@ export async function postConversation(
       ...contentFragments.contentNodes.map((contentNode) => ({
         title: contentNode.title,
         nodeId: contentNode.internalId,
-        fileId: undefined,
         nodeDataSourceViewId: contentNode.dataSourceView.sId,
-        contentType: contentNode.mimeType,
+        fileId: undefined,
         context: {
           username: user.username,
           email: user.email,
@@ -200,7 +199,7 @@ export async function postConversation(
     });
   }
 
-  const conversationData = await cRes.value;
+  const conversationData = cRes.value;
 
   return new Ok(conversationData.conversation);
 }
@@ -275,7 +274,6 @@ export async function postMessage(
             title: file.title,
             nodeId: file.internalId,
             nodeDataSourceViewId: file.dataSourceView.sId,
-            contentType: file.mimeType,
             context: {
               username: user.username,
               email: user.email,

--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -125,7 +125,7 @@ export const InputBarAttachmentsPicker = ({
           <DropdownMenuSearchbar
             ref={searchbarRef}
             name="search-files"
-            placeholder="Search knowledge or attach files"
+            placeholder="Search knowledge"
             value={search}
             onChange={setSearch}
             disabled={isLoading}

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -54,7 +54,7 @@ function addItem(items: string[], newItem: string) {
 ### [GEN6] Comments must be sentences wrapped at 100 characters
 
 Comments must be full sentences (starting with a capital letter and ending with a period) and must
-be wrapped at 100 characters. Wrapping at a lower
+be wrapped at 100 characters. Wrapping at a lower characer count should be avoided.
 
 Example:
 

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -30,23 +30,46 @@ therefore acceptable.
 
 ### [GEN5] No mutation of function parameters
 
-Never mutate arrays or objects passed as parameters to functions. Create and return new instances instead. This includes avoiding methods like `splice` that mutate arrays in place.
+Never mutate arrays or objects passed as parameters to functions. Create and return new instances
+instead. This includes avoiding methods like `splice` that mutate arrays in place.
 
-Reviewer: If you detect parameter mutation in the code (including array methods like `splice`), request the author to refactor the code to create and return new instances instead.
+Reviewer: If you detect parameter mutation in the code (including array methods like `splice`),
+request the author to refactor the code to create and return new instances instead.
 
 Example:
 
 ```
 // BAD
 function addItem(items: string[], newItem: string) {
-items.push(newItem);
-return items;
+  items.push(newItem);
+  return items;
 }
 
 // GOOD
 function addItem(items: string[], newItem: string) {
-return [...items, newItem];
+  return [...items, newItem];
 }
+```
+
+### [GEN6] Comments must be sentences wrapped at 100 characters
+
+Comments must be full sentences (starting with a capital letter and ending with a period) and must
+be wrapped at 100 characters. Wrapping at a lower
+
+Example:
+
+```
+// BAD
+// this is a comment that is neither a full sentence nor wrapped at 100 characers / it should be wrapped because otherwise it's really hard to read
+
+// BAD
+// This comment is a valid sentence but it
+// is wrapped at a lower character count than
+// 100. It should be wrapped at 100 characters.
+
+// GOOD
+// This is a comment that is a full sentence and is wrapped at 100 characters. It is easy to read
+// and supports consistency of our code style.
 ```
 
 ## SECURITY

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -112,10 +112,9 @@ export function ConversationContainer({
     const messageData = { input, mentions, contentFragments };
 
     try {
-      // Update the local state immediately and fire the
-      // request. Since the API will return the updated
-      // data, there is no need to start a new revalidation
-      // and we can directly populate the cache.
+      // Update the local state immediately and fire the request. Since the API will return the
+      // updated data, there is no need to start a new revalidation and we can directly populate the
+      // cache.
       await mutateMessages(
         async (currentMessagePages) => {
           const result = await submitMessage({
@@ -173,8 +172,7 @@ export function ConversationContainer({
       await mutateConversations();
       scrollConversationsToTop();
     } catch (err) {
-      // If the API errors, the original data will be
-      // rolled back by SWR automatically.
+      // If the API errors, the original data will be rolled back by SWR automatically.
       console.error("Failed to post message:", err);
       return new Err({
         code: "internal_error",

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -172,7 +172,11 @@ export const InputBarAttachmentsPicker = ({
                         provider:
                           item.dataSourceView.dataSource.connectorProvider,
                       })}
-                      disabled={attachedNodeIds.includes(item.internalId)}
+                      disabled={
+                        attachedNodeIds.includes(item.internalId) ||
+                        // TODO(attac-ds): remove this condition
+                        item.type === "folder"
+                      }
                       description={`${spacesMap[item.dataSourceView.spaceId]} - ${getLocationForDataSourceViewContentNode(item)}`}
                       onClick={() => {
                         setSearch("");

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -139,7 +139,7 @@ export const InputBarAttachmentsPicker = ({
         <DropdownMenuSearchbar
           ref={searchbarRef}
           name="search-files"
-          placeholder="Search knowledge or attach files"
+          placeholder="Search knowledge"
           value={search}
           onChange={setSearch}
           disabled={isLoading}
@@ -172,10 +172,7 @@ export const InputBarAttachmentsPicker = ({
                         provider:
                           item.dataSourceView.dataSource.connectorProvider,
                       })}
-                      disabled={
-                        attachedNodeIds.includes(item.internalId) ||
-                        item.type === "folder"
-                      }
+                      disabled={attachedNodeIds.includes(item.internalId)}
                       description={`${spacesMap[item.dataSourceView.spaceId]} - ${getLocationForDataSourceViewContentNode(item)}`}
                       onClick={() => {
                         setSearch("");

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -124,8 +124,6 @@ export async function submitMessage({
               title: contentFragment.title,
               nodeId: contentFragment.internalId,
               nodeDataSourceViewId: contentFragment.dataSourceView.sId,
-              contentType: contentFragment.mimeType,
-              sourceUrl: contentFragment.sourceUrl,
               context: {
                 timezone:
                   Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
@@ -277,8 +275,6 @@ export async function createConversationWithMessage({
             profilePictureUrl: user.image,
           },
           nodeId: cf.internalId,
-          contentType,
-          sourceUrl: cf.sourceUrl,
           nodeDataSourceViewId: cf.dataSourceView.sId,
         };
       }),

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -14,6 +14,7 @@ import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentInputWithFileIdType,
   ContentFragmentInputWithInlinedContent,
+  ContentNodeType,
   ModelId,
   Result,
   SupportedFileContentType,
@@ -33,6 +34,7 @@ interface ContentFragmentBlob {
   fileId: ModelId | null;
   nodeId: string | null;
   nodeDataSourceViewId: ModelId | null;
+  nodeType: ContentNodeType | null;
   sourceUrl: string | null;
   textBytes: number | null;
   title: string;
@@ -116,6 +118,7 @@ export async function getContentFragmentBlob(
       textBytes: file.fileSize,
       nodeId: null,
       nodeDataSourceViewId: null,
+      nodeType: null,
       title,
     });
   } else if (isContentFragmentInputWithContentNode(cf)) {
@@ -168,14 +171,10 @@ export async function getContentFragmentBlob(
       );
     }
 
-    console.log(
-      ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> HERE",
-      cf,
-      contentNode
-    );
     return new Ok({
       nodeId: contentNode.internalId,
       nodeDataSourceViewId: getResourceIdFromSId(cf.nodeDataSourceViewId),
+      nodeType: contentNode.type,
       contentType: contentNode.mimeType,
       sourceUrl: contentNode.sourceUrl,
       textBytes: null,

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -152,13 +152,13 @@ export async function getContentFragmentBlob(
     });
     if (searchRes.isErr()) {
       return new Err(
-        new Error("Unknown content node for content fragment input")
+        new Error("Content node not found for content fragment input")
       );
     }
     const [coreContentNode] = searchRes.value.nodes;
     if (!coreContentNode) {
       return new Err(
-        new Error("Unknown content node for content fragment input")
+        new Error("Content node not found for content fragment input")
       );
     }
     const contentNode = getContentNodeFromCoreNode(coreContentNode, "all");

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -18,7 +18,7 @@ import {
 function isConversationIncludableFileContentType(
   contentType: SupportedContentFragmentType
 ): boolean {
-  // We allow including everything except images.and content node folders.
+  // We allow including everything except images.
   if (isSupportedImageContentType(contentType)) {
     return false;
   }

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -23,10 +23,6 @@ function isConversationIncludableFileContentType(
     return false;
   }
   // TODO(attach-ds): Filter out content Types that are folders
-  console.log(
-    "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< HERE 2",
-    contentType
-  );
   return true;
 }
 

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -18,10 +18,15 @@ import {
 function isConversationIncludableFileContentType(
   contentType: SupportedContentFragmentType
 ): boolean {
-  // We allow including everything except images.
+  // We allow including everything except images.and content node folders.
   if (isSupportedImageContentType(contentType)) {
     return false;
   }
+  // TODO(attach-ds): Filter out content Types that are folders
+  console.log(
+    "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< HERE 2",
+    contentType
+  );
   return true;
 }
 
@@ -69,24 +74,23 @@ export function listFiles(
       m.contentFragmentVersion === "latest"
     ) {
       if (isFileAttachment(m) || isContentNodeAttachment(m)) {
-        // Here, snippet not null is actually to detect file attachments that
-        // are prior to the JIT actions, and differentiate them from the newer
-        // file attachments that do have a snippet. Former ones cannot be used
-        // in JIT. But for content node fragments, with a node id rather than a
-        // file id, we don't care about the snippet.
+        // Here, snippet not null is actually to detect file attachments that are prior to the JIT
+        // actions, and differentiate them from the newer file attachments that do have a snippet.
+        // Former ones cannot be used in JIT. But for content node fragments, with a node id rather
+        // than a file id, we don't care about the snippet.
         const canDoJIT = m.snippet !== null || isContentNodeAttachment(m);
         const isQueryable = canDoJIT && isQueryableContentType(m.contentType);
         const isContentNodeTable = isContentNodeAttachment(m) && isQueryable;
         const isIncludable =
           isConversationIncludableFileContentType(m.contentType) &&
-          // Tables from knowledge are not materialized as raw content. As such, they
-          // cannot be included.
+          // Tables from knowledge are not materialized as raw content. As such, they cannot be
+          // included.
           !isContentNodeTable;
         const isSearchable =
           canDoJIT &&
           isSearchableContentType(m.contentType) &&
-          // Tables from knowledge are not materialized as raw content. As such, they
-          // cannot be searched.
+          // Tables from knowledge are not materialized as raw content. As such, they cannot be
+          // searched.
           !isContentNodeTable;
 
         const baseAttachment: BaseConversationAttachmentType = {
@@ -94,7 +98,8 @@ export function listFiles(
           contentType: m.contentType,
           snippet: m.snippet,
           contentFragmentVersion: m.contentFragmentVersion,
-          // Backward compatibility: we fallback to the fileId if no generated tables are mentionned but the file is queryable.
+          // Backward compatibility: we fallback to the fileId if no generated tables are mentionned
+          // but the file is queryable.
           generatedTables:
             m.generatedTables.length > 0
               ? m.generatedTables

--- a/front/lib/api/assistant/permissions.ts
+++ b/front/lib/api/assistant/permissions.ts
@@ -128,6 +128,10 @@ export async function getContentFragmentGroupIds(
     auth,
     contentFragment.nodeDataSourceViewId
   );
+  if (!dsView) {
+    throw new Error(`Unexpected dataSourceView not found`);
+  }
+
   const groups = groupsFromRequestedPermissions(dsView.requestedPermissions());
 
   return [groups].filter((arr) => arr.length > 0);

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -1,6 +1,7 @@
 import * as t from "io-ts";
 import type { NextApiRequest } from "next";
 
+import config from "@app/lib/api/config";
 import {
   getContentNodeFromCoreNode,
   NON_SEARCHABLE_NODES_MIME_TYPES,
@@ -20,8 +21,6 @@ import type {
   SearchWarningCode,
 } from "@app/types";
 import { CoreAPI, Err, Ok, removeNulls } from "@app/types";
-
-import config from "./config";
 
 export type DataSourceContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
@@ -132,7 +131,7 @@ export async function handleSearch(
 
   const excludedNodeMimeTypes = nodeIds ? [] : NON_SEARCHABLE_NODES_MIME_TYPES;
 
-  const searchFilterResult = getSearchFilterFromDataSourceViews(
+  const searchFilter = getSearchFilterFromDataSourceViews(
     auth.getNonNullableWorkspace(),
     allDatasourceViews,
     {
@@ -157,7 +156,7 @@ export async function handleSearch(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const searchRes = await coreAPI.searchNodes({
     query,
-    filter: searchFilterResult,
+    filter: searchFilter,
     options: {
       cursor: paginationRes.value?.cursor ?? undefined,
       limit: paginationRes.value?.limit,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -280,7 +280,7 @@ export async function searchContenNodesInSpace(
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-  const searchFilterResult = getSearchFilterFromDataSourceViews(
+  const searchFilter = getSearchFilterFromDataSourceViews(
     auth.getNonNullableWorkspace(),
     dataSourceViews,
     {
@@ -292,7 +292,7 @@ export async function searchContenNodesInSpace(
 
   const searchRes = await coreAPI.searchNodes({
     query,
-    filter: searchFilterResult,
+    filter: searchFilter,
     options,
   });
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -357,7 +357,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       FetchDataSourceViewOptions,
       "limit" | "order"
     >
-  ) {
+  ): Promise<DataSourceViewResource | null> {
     const [dataSourceView] = await DataSourceViewResource.fetchByIds(
       auth,
       [id],
@@ -389,7 +389,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       }
     );
 
-    return dataSourceViews ?? null;
+    return dataSourceViews ?? [];
   }
 
   static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {
@@ -405,7 +405,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       }
     );
 
-    return dataSourceViews ?? null;
+    return dataSourceViews ?? [];
   }
 
   static async fetchByConversation(

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -8,6 +8,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   ContentFragmentVersion,
+  ContentNodeType,
   SupportedContentFragmentType,
 } from "@app/types";
 
@@ -35,6 +36,7 @@ export class ContentFragmentModel extends WorkspaceAwareModel<ContentFragmentMod
 
   declare nodeId: string | null;
   declare nodeDataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
+  declare nodeType: ContentNodeType | null;
 
   declare version: ContentFragmentVersion;
 }
@@ -94,6 +96,10 @@ ContentFragmentModel.init(
     },
     nodeId: {
       type: DataTypes.STRING(512),
+      allowNull: true,
+    },
+    nodeType: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
   },

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -91,6 +91,11 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
             auth,
             m.dataSourceViewId
           );
+          if (!dataSourceView) {
+            throw new Error(
+              `Data source view not found: ${m.dataSourceViewId}`
+            );
+          }
           return TrackerDataSourceConfigurationModel.create(
             {
               scope: "maintained",
@@ -112,6 +117,11 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
             auth,
             w.dataSourceViewId
           );
+          if (!dataSourceView) {
+            throw new Error(
+              `Data source view not found: ${w.dataSourceViewId}`
+            );
+          }
           return TrackerDataSourceConfigurationModel.create(
             {
               scope: "watched",
@@ -192,6 +202,11 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
           auth,
           m.dataSourceViewId
         );
+        if (!dataSourceView) {
+          return new Err(
+            new Error(`Data source view not found: ${m.dataSourceViewId}`)
+          );
+        }
         await TrackerDataSourceConfigurationModel.create(
           {
             scope: "maintained",
@@ -211,6 +226,11 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
           auth,
           w.dataSourceViewId
         );
+        if (!dataSourceView) {
+          return new Err(
+            new Error(`Data source view not found: ${w.dataSourceViewId}`)
+          );
+        }
         await TrackerDataSourceConfigurationModel.create(
           {
             scope: "watched",

--- a/front/migrations/db/migration_189.sql
+++ b/front/migrations/db/migration_189.sql
@@ -1,3 +1,12 @@
 -- Migration created on Mar 25, 2025
 ALTER TABLE "public"."content_fragments" ADD COLUMN "nodeType" VARCHAR(255);
-UPDATE "public"."content_fragments" SET "nodeType" = 'document' WHERE "nodeId" IS NOT NULL;
+UPDATE "public"."content_fragments"
+SET "nodeType" = CASE
+  WHEN "contentType" IN (
+    'application/vnd.google-apps.spreadsheet',
+    'text/csv',
+    'application/vnd.dust.notion.database'
+  ) THEN 'table'
+  ELSE 'document'
+END
+WHERE "nodeId" IS NOT NULL;

--- a/front/migrations/db/migration_189.sql
+++ b/front/migrations/db/migration_189.sql
@@ -1,0 +1,3 @@
+-- Migration created on Mar 25, 2025
+ALTER TABLE "public"."content_fragments" ADD COLUMN "nodeType" VARCHAR(255);
+UPDATE "public"."content_fragments" SET "nodeType" = 'document' WHERE "nodeId" IS NOT NULL;

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -88,8 +88,6 @@ const ContentFragmentInputWithContentNodeSchema = t.intersection([
   t.type({
     nodeId: t.string,
     nodeDataSourceViewId: t.string,
-    contentType: getSupportedContentNodeContentTypeSchema(),
-    sourceUrl: t.union([t.string, t.null]),
   }),
 ]);
 
@@ -144,15 +142,9 @@ export function isContentFragmentInputWithFileId(
 }
 
 export function isContentFragmentInputWithContentNode(
-  fragment: Omit<ContentFragmentInputType, "contentType"> & {
-    contentType?: string | undefined | null;
-  }
+  fragment: Omit<ContentFragmentInputType, "contentType">
 ): fragment is ContentFragmentInputWithContentNode {
-  return (
-    "nodeId" in fragment &&
-    !!fragment.contentType &&
-    isSupportedContentNodeFragmentContentType(fragment.contentType)
-  );
+  return "nodeId" in fragment && "nodeDataSourceViewId" in fragment;
 }
 
 export const InternalPostContentFragmentRequestBodySchema = t.intersection([

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -76,9 +76,8 @@ export const MIME_TYPES = {
   }),
   GOOGLE_DRIVE: generateMimeTypes({
     provider: "google_drive",
-    // Spreadsheets may contain many sheets, thus resemble folders and are
-    // stored as such, but with the special mimeType below.
-    // For files and sheets, we keep Google's mime types.
+    // Spreadsheets may contain many sheets, thus resemble folders and are stored as such, but with
+    // the special mimeType below.  For files and sheets, we keep Google's mime types.
     resourceTypes: ["SHARED_WITH_ME", "FOLDER", "SPREADSHEET"],
   }),
   INTERCOM: generateMimeTypes({


### PR DESCRIPTION
## Description

We stop sending contentType and sourceUrl to the API when attaching a content node as content fragment and only send the nodeId and nodeDataSourceViewId. Instead we pull the content node as we create the blob to store the content fragment and pull the contentType and sourceUrl from there. This has the value of:
- Not trusting the client for these valus
- Checking that we do have access to the dataSoureView and 400 otherwise (we do have defense in depths at multiple layer if such a request was forged today)
- Allowing us to storing the nodeType to allow the future logic in list_files for handling folders.

For https://github.com/dust-tt/tasks/issues/2345
For https://github.com/dust-tt/tasks/issues/2456

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- run migration
- deploy `front`
- publish sdk/js
- check if some fixes are needed on the extension