### PR TITLE
Agent Table Query select all: scroll to the last item instead of first

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -292,6 +292,29 @@ export function DataSourceViewsSelector({
     // return hasRemote !== hasNonRemote;
   }, [searchResultNodes, useCase]);
 
+  const handleSelectAll = useCallback(() => {
+    setSearchSpaceText("");
+
+    // Update all selections in a single state update.
+    setSelectionConfigurations((prevState) => {
+      const newState = searchResultNodes.reduce(
+        (acc, item) => updateSelection(item, acc),
+        prevState
+      );
+      return newState;
+    });
+
+    // Scroll to last item if there are results. Not perfect but no perfect solution here.
+    if (searchResultNodes.length > 0) {
+      setSearchResult(searchResultNodes[searchResultNodes.length - 1]);
+    }
+  }, [
+    setSearchSpaceText,
+    setSelectionConfigurations,
+    updateSelection,
+    searchResultNodes,
+  ]);
+
   return (
     <div>
       <SearchInputWithPopover
@@ -314,19 +337,7 @@ export function DataSourceViewsSelector({
           );
         }}
         displayItemCount={useCase === "assistantBuilder"}
-        onSelectAll={
-          displaySelectAllButton
-            ? () => {
-                setSearchSpaceText("");
-                searchResultNodes.forEach((item) => {
-                  setSelectionConfigurations((prevState) =>
-                    updateSelection(item, prevState)
-                  );
-                });
-                setSearchResult(searchResultNodes[0]); // We scroll to the first item. Not perfect but no perfect solution here.
-              }
-            : undefined
-        }
+        onSelectAll={displaySelectAllButton ? handleSelectAll : undefined}
         contentMessage={contentMessage}
         renderItem={(item, selected) => {
           return (


### PR DESCRIPTION
## Description

When we use the new "Select All" button from the search result in the agent datasource modal (in Table Query mode), instead of scrolling to the first item we scroll to the last, so that we can see all selected items. 
-> Was asked by @pinotalexandre 


I also refactored a bit the code to make it more efficient. 


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 