### PR TITLE
Agent Table Query select all: scroll to the last item instead of first t -> prevent re-render

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -219,48 +219,52 @@ export function DataSourceViewsSelector({
     filteredGroups.managedDsv.length > 0 &&
     (useCase === "assistantBuilder" || useCase === "trackerBuilder");
 
-  function updateSelection(
-    item: DataSourceViewContentNode,
-    prevState: DataSourceViewSelectionConfigurations
-  ): DataSourceViewSelectionConfigurations {
-    const { dataSourceView: dsv } = item;
-    const prevConfig = prevState[dsv.sId] ?? defaultSelectionConfiguration(dsv);
+  const updateSelection = useCallback(
+    (
+      item: DataSourceViewContentNode,
+      prevState: DataSourceViewSelectionConfigurations
+    ): DataSourceViewSelectionConfigurations => {
+      const { dataSourceView: dsv } = item;
+      const prevConfig =
+        prevState[dsv.sId] ?? defaultSelectionConfiguration(dsv);
 
-    const exists = prevConfig.selectedResources.some(
-      (r) => r.internalId === item.internalId
-    );
+      const exists = prevConfig.selectedResources.some(
+        (r) => r.internalId === item.internalId
+      );
 
-    if (item.mimeType === DATA_SOURCE_MIME_TYPE) {
+      if (item.mimeType === DATA_SOURCE_MIME_TYPE) {
+        return {
+          ...prevState,
+          [dsv.sId]: {
+            ...prevConfig,
+            selectedResources: [],
+            isSelectAll: true,
+          },
+        };
+      }
+
+      const newResources = exists
+        ? prevConfig.selectedResources
+        : [
+            ...prevConfig.selectedResources,
+            {
+              ...item,
+              dataSourceView: dsv,
+              parentInternalIds: item.parentInternalIds || [],
+            },
+          ];
+
       return {
         ...prevState,
         [dsv.sId]: {
           ...prevConfig,
-          selectedResources: [],
-          isSelectAll: true,
+          selectedResources: newResources,
+          isSelectAll: false,
         },
       };
-    }
-
-    const newResources = exists
-      ? prevConfig.selectedResources
-      : [
-          ...prevConfig.selectedResources,
-          {
-            ...item,
-            dataSourceView: dsv,
-            parentInternalIds: item.parentInternalIds || [],
-          },
-        ];
-
-    return {
-      ...prevState,
-      [dsv.sId]: {
-        ...prevConfig,
-        selectedResources: newResources,
-        isSelectAll: false,
-      },
-    };
-  }
+    },
+    []
+  );
 
   const contentMessage = warningCode
     ? LimitedSearchContentMessage({ warningCode })


### PR DESCRIPTION
## Description

Follow up from https://github.com/dust-tt/dust/pull/11577

I had a warning: 
> The 'updateSelection' function makes the dependencies of useCallback Hook (at line 311) change on every render. To fix this, wrap the definition of 'updateSelection' in its own useCallback() Hook.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
