### PR TITLE
Do not sync bigquery dataset with too many tables

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -199,7 +199,9 @@ export const fetchTree = async ({
                     `[BigQuery] Skipping schema ${schema.name} with ${tables.length} tables because it has more than ${MAX_TABLES_PER_SCHEMA} tables.`
                   );
                   return {
-                    name: schema.name + " (not synced, too many tables)",
+                    name:
+                      schema.name +
+                      ` (sync skipped: exceeded ${MAX_TABLES_PER_SCHEMA} tables limit)`,
                     database_name: credentials.project_id,
                     tables: [],
                   };

--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -8,8 +8,10 @@ import type {
   RemoteDBTable,
   RemoteDBTree,
 } from "@connectors/lib/remote_databases/utils";
+import logger from "@connectors/logger/logger";
 import type { BigQueryCredentialsWithLocation } from "@connectors/types";
 
+const MAX_TABLES_PER_SCHEMA = 1000;
 type TestConnectionErrorCode = "INVALID_CREDENTIALS" | "UNKNOWN";
 
 export class TestConnectionError extends Error {
@@ -190,6 +192,18 @@ export const fetchTree = async ({
                   throw tablesRes.error;
                 }
                 const tables = tablesRes.value;
+
+                // Do not store if too many tables, the sync will be too long and it's quite likely that these are useless tables.
+                if (tables.length > MAX_TABLES_PER_SCHEMA) {
+                  logger.warn(
+                    `[BigQuery] Skipping schema ${schema.name} with ${tables.length} tables because it has more than ${MAX_TABLES_PER_SCHEMA} tables.`
+                  );
+                  return {
+                    name: schema.name + " (not synced, too many tables)",
+                    database_name: credentials.project_id,
+                    tables: [],
+                  };
+                }
 
                 return {
                   ...schema,


### PR DESCRIPTION
## Description

We have a user with a BQ connector that never succeed in the allowed 10 minutes.
After digging a bit: ~50 000 tables in a dataset (a/b experiment logs).

This PR skip dataset with more than 1000 tables (checked our stats, only 3 occurrences).

## Tests

Locally

## Risk

Very low

## Deploy Plan

Deploy `connector`