### PR TITLE
[front] - feat(attachments): paste Zendesk URLs

### DIFF
--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -232,7 +232,7 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
     urlNormalizer: (url: URL): UrlCandidate => {
       return { url: url.toString() };
     },
-  }
+  },
 };
 
 // Extract a channel node ID from a Slack client URL

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -225,6 +225,14 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
       return { url: url.toString() };
     },
   },
+  zendesk: {
+    matcher: (url: URL): boolean => {
+      return url.hostname.endsWith("zendesk.com");
+    },
+    urlNormalizer: (url: URL): UrlCandidate => {
+      return { url: url.toString() };
+    },
+  }
 };
 
 // Extract a channel node ID from a Slack client URL


### PR DESCRIPTION
## Description

This PR aims at enabling pasting Zendesk URLs in the InputBar. We rely on the search by url as the `nodeIds` are formatted with the connector id.

Note: I checked and there are very few (~100) nodes without source url.

## Risk

Low

## Deploy Plan

Deploy front