### PR TITLE
Fix autoReadChannelPatterns relocation

### DIFF
--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -117,10 +117,7 @@ export async function processFrontTableChunk({
     for (const { sql, params } of statements) {
       await frontSequelize.transaction(async (transaction) =>
         frontSequelize.query(sql, {
-          // TODO(2025-01-31): Remove this once current batch of data is processed.
-          bind: params.map((p) =>
-            isArrayOfPlainObjects(p) ? JSON.stringify(p) : p
-          ),
+          bind: params,
           type: QueryTypes.INSERT,
           transaction,
         })

--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -32,6 +32,12 @@ export function generateParameterizedInsertStatements(
       for (const col of columns) {
         rowPlaceholders.push(`$${paramIndex++}`);
 
+        // Special case: `autoReadChannelPatterns` is a JSONB column that needs to be stringified.
+        if (col === "autoReadChannelPatterns") {
+          params.push(JSON.stringify(row[col]));
+          continue;
+        }
+
         // Array of plain objects are serialized to JSON strings.
         const serialized = isArrayOfPlainObjects(row[col])
           ? JSON.stringify(row[col])


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/2299.

The `autoReadChannelPatterns` is a JSONB and does not support `[]` as a valid empty array, instead it interprets it as an empty object. This causes issue in the relocation pipeline. This is implemented as a small hack since we can't access the column type at this point.  

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
