### PR TITLE
[front] - feat(InputBar): paste Intercom URLs

### DIFF
--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -230,7 +230,10 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
       return url.hostname.endsWith("zendesk.com");
     },
     urlNormalizer: (url: URL): UrlCandidate => {
-      return { url: url.toString() };
+      const path = url.pathname.endsWith("/")
+        ? url.pathname.slice(0, -1)
+        : url.pathname;
+      return { url: `${url.origin}${path}` };
     },
   },
   intercom: {
@@ -243,7 +246,10 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
       );
     },
     urlNormalizer: (url: URL): UrlCandidate => {
-      return { url: url.toString() };
+      const path = url.pathname.endsWith("/")
+        ? url.pathname.slice(0, -1)
+        : url.pathname;
+      return { url: `${url.origin}${path}` };
     },
   },
 };

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -233,6 +233,19 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
       return { url: url.toString() };
     },
   },
+  intercom: {
+    matcher: (url: URL): boolean => {
+      return (
+        (url.hostname.includes("intercom.com") &&
+          url.hostname.startsWith("app")) ||
+        // custom help center domains (websiteTurnedOn is true)
+        url.hostname.startsWith("help")
+      );
+    },
+    urlNormalizer: (url: URL): UrlCandidate => {
+      return { url: url.toString() };
+    },
+  },
 };
 
 // Extract a channel node ID from a Slack client URL


### PR DESCRIPTION
## Description

This PR enables pasting Intercom URLs in the `InputBar`, we are also leveraging the search by url here.

Note: we have roughly 0.1% of the nodes without `sourceUrl`.

## Risk

Low

## Deploy Plan

Deploy front