### PR TITLE
Search result: Do not expand current node if not expandable

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -663,10 +663,21 @@ export function DataSourceViewSelector({
   const isExpanded = searchResult
     ? searchResult.dataSourceView.sId === dataSourceView.sId
     : false;
-  const defaultExpandedIds =
-    isExpanded && searchResult
-      ? removeNulls([...new Set(searchResult.parentInternalIds)])
-      : undefined;
+
+  const defaultExpandedIds = useMemo(
+    () =>
+      searchResult && isExpanded
+        ? removeNulls([
+            ...new Set(
+              searchResult.parentInternalIds?.filter(
+                (id) =>
+                  searchResult.expandable || id !== searchResult.internalId
+              )
+            ),
+          ])
+        : undefined,
+    [searchResult, isExpanded]
+  );
 
   return (
     <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.sId}`}>


### PR DESCRIPTION
## Description

When clicking on a result from the search in the agent datasource modal, all nodes are expanded even if not expandable. 
See screenshot. 

<img width="763" alt="Screenshot 2025-03-25 at 15 34 55" src="https://github.com/user-attachments/assets/d62a4352-1279-4976-ae30-68f64e2664a3" />


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 