### PR TITLE
Only display active workspace members in the Space group

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -395,7 +395,20 @@ export class GroupResource extends BaseResource<GroupModel> {
       });
     }
 
-    return UserResource.fetchByModelIds(memberships.map((m) => m.userId));
+    const users = await UserResource.fetchByModelIds(
+      memberships.map((m) => m.userId)
+    );
+
+    const { memberships: workspaceMemberships } =
+      await MembershipResource.getActiveMemberships({
+        users,
+        workspace: owner,
+      });
+
+    // Only return users that have an active membership in the workspace.
+    return users.filter((user) =>
+      workspaceMemberships.some((m) => m.userId === user.id)
+    );
   }
 
   async addMembers(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes this: https://github.com/dust-tt/tasks/issues/2460.

Revoked workspace members were still being listed as Space members and could not be removed from the Space because we don't remove the group membership when revocating someone. This is done on purpose as given that this scenario happens pretty often we want to ensure users can re-gain access to their agents (access which is based on group membership).

This PR ensures we only return active workspace members.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
