### PR TITLE
refactor: rename `MIME_TYPES` into `INTERNAL_MIME_TYPES`

### DIFF
--- a/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
+++ b/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
@@ -16,7 +16,7 @@ import {
   IntercomWorkspaceModel,
 } from "@connectors/lib/models/intercom";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 async function createFolderNodes(execute: boolean) {
   const connectors = await ConnectorResource.listByType("intercom", {});
@@ -35,7 +35,7 @@ async function createFolderNodes(execute: boolean) {
         parents: [getTeamsInternalId(connector.id)],
         parentId: null,
         title: "Conversations",
-        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+        mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     }
 
@@ -59,7 +59,7 @@ async function createFolderNodes(execute: boolean) {
             parents: [teamInternalId, getTeamsInternalId(connector.id)],
             parentId: getTeamsInternalId(connector.id),
             title: team.name,
-            mimeType: MIME_TYPES.INTERCOM.TEAM,
+            mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAM,
           });
         }
       },
@@ -113,7 +113,7 @@ async function createFolderNodes(execute: boolean) {
                 parents: collectionParents,
                 parentId: collectionParents[1] || null,
                 title: collection.name,
-                mimeType: MIME_TYPES.INTERCOM.COLLECTION,
+                mimeType: INTERNAL_MIME_TYPES.INTERCOM.COLLECTION,
               });
             }
           },

--- a/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
+++ b/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
@@ -8,7 +8,7 @@ import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const DRIVE_CONCURRENCY = 10;
 
@@ -58,7 +58,7 @@ async function upsertFoldersForConnector(
           parents,
           parentId: parents[1] || null,
           title: spreadsheetName,
-          mimeType: MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
+          mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
           sourceUrl: getSourceUrlForGoogleDriveSheet(driveFileId),
         });
         localLogger.info(

--- a/connectors/migrations/20250120_delete_zendesk_brand_folders.ts
+++ b/connectors/migrations/20250120_delete_zendesk_brand_folders.ts
@@ -13,7 +13,7 @@ import {
   ZendeskBrandResource,
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const FOLDER_CONCURRENCY = 10;
 
@@ -51,7 +51,7 @@ async function migrateConnector(
           parents: [helpCenterNode.internalId],
           parentId: null,
           title: helpCenterNode.title,
-          mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+          mimeType: INTERNAL_MIME_TYPES.ZENDESK.HELP_CENTER,
         });
 
         const ticketsNode = brand.getTicketsContentNode(connectorId, {
@@ -63,7 +63,7 @@ async function migrateConnector(
           parents: [ticketsNode.internalId],
           parentId: null,
           title: ticketsNode.title,
-          mimeType: MIME_TYPES.ZENDESK.TICKETS,
+          mimeType: INTERNAL_MIME_TYPES.ZENDESK.TICKETS,
         });
       },
       { concurrency: FOLDER_CONCURRENCY }
@@ -89,7 +89,7 @@ async function migrateConnector(
           parents,
           parentId: parents[1],
           title: category.name,
-          mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+          mimeType: INTERNAL_MIME_TYPES.ZENDESK.CATEGORY,
         });
       },
       { concurrency: FOLDER_CONCURRENCY }

--- a/connectors/migrations/20250122_gdrive_clean_parents.ts
+++ b/connectors/migrations/20250122_gdrive_clean_parents.ts
@@ -23,7 +23,7 @@ import type { DataSourceConfig } from "@connectors/types";
 import {
   concurrentExecutor,
   getGoogleSheetTableId,
-  MIME_TYPES,
+  INTERNAL_MIME_TYPES,
 } from "@connectors/types";
 
 async function migrateConnector(
@@ -156,8 +156,8 @@ async function processFilesBatch({
             title: file.name,
             mimeType:
               file.mimeType === "application/vnd.google-apps.folder"
-                ? MIME_TYPES.GOOGLE_DRIVE.FOLDER
-                : MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
+                ? INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER
+                : INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
             sourceUrl: getSourceUrlForGoogleDriveFiles(file),
           });
         } else {

--- a/connectors/migrations/20250122_microsoft_spreadsheets_folder.ts
+++ b/connectors/migrations/20250122_microsoft_spreadsheets_folder.ts
@@ -9,7 +9,7 @@ import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
-import { concurrentExecutor, MIME_TYPES } from "@connectors/types";
+import { concurrentExecutor, INTERNAL_MIME_TYPES } from "@connectors/types";
 
 async function migrateConnector(
   connector: ConnectorResource,
@@ -62,7 +62,7 @@ async function migrateConnector(
           title: parentSpreadsheet.name ?? "Untitled spreadsheet",
           parents,
           parentId: parents[1] ?? null,
-          mimeType: MIME_TYPES.MICROSOFT.SPREADSHEET,
+          mimeType: INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
           sourceUrl: parentSpreadsheet.webUrl ?? undefined,
         });
       }

--- a/connectors/migrations/20250125_microsoft_folder_parents_fix.ts
+++ b/connectors/migrations/20250125_microsoft_folder_parents_fix.ts
@@ -8,7 +8,7 @@ import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
-import { concurrentExecutor, MIME_TYPES } from "@connectors/types";
+import { concurrentExecutor, INTERNAL_MIME_TYPES } from "@connectors/types";
 
 async function backfillConnector(
   connector: ConnectorResource,
@@ -55,7 +55,7 @@ async function backfillConnector(
           title: folderResource.name ?? "Untitled folder",
           parents,
           parentId: parents[1] ?? null,
-          mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+          mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
           sourceUrl: folderResource.webUrl ?? undefined,
         });
       }

--- a/connectors/migrations/20250127_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20250127_backfill_gdrive_shared_with_me.ts
@@ -9,7 +9,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 makeScript({}, async ({ execute }, logger) => {
   const connectors = await ConnectorResource.listByType("google_drive", {});
@@ -25,7 +25,7 @@ makeScript({}, async ({ execute }, logger) => {
           parents: [folderId],
           parentId: null,
           title: "Shared with me",
-          mimeType: MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
+          mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
           sourceUrl: GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
         });
         logger.info(

--- a/connectors/migrations/20250127_backfill_notion_syncing.ts
+++ b/connectors/migrations/20250127_backfill_notion_syncing.ts
@@ -4,7 +4,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 makeScript({}, async ({ execute }, logger) => {
   const connectors = await ConnectorResource.listByType("notion", {});
@@ -21,7 +21,7 @@ makeScript({}, async ({ execute }, logger) => {
           parents: [folderId],
           parentId: null,
           title: "Syncing",
-          mimeType: MIME_TYPES.NOTION.SYNCING_FOLDER,
+          mimeType: INTERNAL_MIME_TYPES.NOTION.SYNCING_FOLDER,
         });
         logger.info(
           `Upserted folder ${folderId} for connector ${connector.id}`

--- a/connectors/migrations/20250127_backfill_webcrawler_folder_titles.ts
+++ b/connectors/migrations/20250127_backfill_webcrawler_folder_titles.ts
@@ -9,7 +9,7 @@ import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { WebCrawlerFolder } from "@connectors/lib/models/webcrawler";
 import type Logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { concurrentExecutor, MIME_TYPES } from "@connectors/types";
+import { concurrentExecutor, INTERNAL_MIME_TYPES } from "@connectors/types";
 
 async function migrateConnector(
   connector: ConnectorResource,
@@ -57,7 +57,7 @@ async function migrateConnector(
           parents,
           parentId: parents[1] || null,
           title: getDisplayNameForFolder(folder),
-          mimeType: MIME_TYPES.WEBCRAWLER.FOLDER,
+          mimeType: INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
         });
       }
     },

--- a/connectors/migrations/20250128_backfill_provider_visibility.ts
+++ b/connectors/migrations/20250128_backfill_provider_visibility.ts
@@ -11,7 +11,7 @@ import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const FOLDER_CONCURRENCY = 16;
 
@@ -51,7 +51,7 @@ makeScript({}, async ({ execute }, logger) => {
             title: `#${channel.slackChannelName}`,
             parentId: null,
             parents: [internalId],
-            mimeType: MIME_TYPES.SLACK.CHANNEL,
+            mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
             providerVisibility: channel.private ? "private" : "public",
             sourceUrl: getSlackChannelSourceUrl(
               channel.slackChannelId,

--- a/connectors/migrations/20250129_backfill_notion_unkown_with_mimetype_unknown.ts
+++ b/connectors/migrations/20250129_backfill_notion_unkown_with_mimetype_unknown.ts
@@ -5,7 +5,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 makeScript({}, async ({ execute }, logger) => {
   const connectors = await ConnectorResource.listByType("notion", {});
@@ -21,7 +21,7 @@ makeScript({}, async ({ execute }, logger) => {
           parents: [folderId],
           parentId: null,
           title: "Orphaned Resources",
-          mimeType: MIME_TYPES.NOTION.UNKNOWN_FOLDER,
+          mimeType: INTERNAL_MIME_TYPES.NOTION.UNKNOWN_FOLDER,
         });
         logger.info(
           `Upserted folder ${folderId} for connector ${connector.id}`

--- a/connectors/migrations/20250205_reupsert_confluence_space.ts
+++ b/connectors/migrations/20250205_reupsert_confluence_space.ts
@@ -9,7 +9,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ConfluenceSpace } from "@connectors/lib/models/confluence";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 makeScript(
   {
@@ -41,7 +41,7 @@ makeScript(
         parents: [folderId],
         parentId: null,
         title: space.name,
-        mimeType: MIME_TYPES.CONFLUENCE.SPACE,
+        mimeType: INTERNAL_MIME_TYPES.CONFLUENCE.SPACE,
         sourceUrl: `${baseUrl}/wiki${space._links.webui}`,
       });
       const spaceInDb = await ConfluenceSpace.findOne({

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -30,7 +30,7 @@ import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 type SlackWebhookEventSubtype =
   | "message_changed"
@@ -390,7 +390,7 @@ const _webhookSlackAPIHandler = async (
                       ],
                       parentId: null,
                       title: `#${slackChannelName}`,
-                      mimeType: MIME_TYPES.SLACK.CHANNEL,
+                      mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
                       sourceUrl: getSlackChannelSourceUrl(slackChannelId, c),
                       providerVisibility: "public",
                     });

--- a/connectors/src/connectors/bigquery/lib/permissions.ts
+++ b/connectors/src/connectors/bigquery/lib/permissions.ts
@@ -24,7 +24,7 @@ import type {
   ContentNode,
 } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
-import { EXCLUDE_SCHEMAS, MIME_TYPES } from "@connectors/types";
+import { EXCLUDE_SCHEMAS, INTERNAL_MIME_TYPES } from "@connectors/types";
 
 /**
  * Retrieves the existing content nodes for a parent in the BigQuery account.
@@ -60,7 +60,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.BIGQUERY
+          INTERNAL_MIME_TYPES.BIGQUERY
         );
       })
     );
@@ -98,7 +98,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.BIGQUERY
+          INTERNAL_MIME_TYPES.BIGQUERY
         );
       })
     );
@@ -133,7 +133,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.BIGQUERY
+          INTERNAL_MIME_TYPES.BIGQUERY
         );
       })
     );
@@ -166,20 +166,24 @@ export const fetchReadNodes = async ({
 
   return new Ok([
     ...availableDatabases.map((db) =>
-      getContentNodeFromInternalId(db.internalId, "read", MIME_TYPES.BIGQUERY)
+      getContentNodeFromInternalId(
+        db.internalId,
+        "read",
+        INTERNAL_MIME_TYPES.BIGQUERY
+      )
     ),
     ...availableSchemas.map((schema) =>
       getContentNodeFromInternalId(
         schema.internalId,
         "read",
-        MIME_TYPES.BIGQUERY
+        INTERNAL_MIME_TYPES.BIGQUERY
       )
     ),
     ...availableTables.map((table) =>
       getContentNodeFromInternalId(
         table.internalId,
         "read",
-        MIME_TYPES.BIGQUERY
+        INTERNAL_MIME_TYPES.BIGQUERY
       )
     ),
   ]);
@@ -222,7 +226,7 @@ export const fetchSyncedChildren = async ({
         getContentNodeFromInternalId(
           schema.internalId,
           "read",
-          MIME_TYPES.BIGQUERY
+          INTERNAL_MIME_TYPES.BIGQUERY
         )
       );
       return new Ok(schemaContentNodes);
@@ -251,7 +255,7 @@ export const fetchSyncedChildren = async ({
       getContentNodeFromInternalId(
         schema.internalId,
         "read",
-        MIME_TYPES.BIGQUERY
+        INTERNAL_MIME_TYPES.BIGQUERY
       )
     );
     availableTables.forEach((table) => {
@@ -264,7 +268,7 @@ export const fetchSyncedChildren = async ({
           getContentNodeFromInternalId(
             schemaToAddInternalId,
             "none",
-            MIME_TYPES.BIGQUERY
+            INTERNAL_MIME_TYPES.BIGQUERY
           )
         );
       }
@@ -286,7 +290,7 @@ export const fetchSyncedChildren = async ({
       getContentNodeFromInternalId(
         table.internalId,
         "read",
-        MIME_TYPES.BIGQUERY
+        INTERNAL_MIME_TYPES.BIGQUERY
       )
     );
     return new Ok(tables);

--- a/connectors/src/connectors/bigquery/temporal/activities.ts
+++ b/connectors/src/connectors/bigquery/temporal/activities.ts
@@ -8,8 +8,8 @@ import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 import {
+  INTERNAL_MIME_TYPES,
   isBigQueryWithLocationCredentials,
-  MIME_TYPES,
 } from "@connectors/types";
 
 export async function syncBigQueryConnection(connectorId: ModelId) {
@@ -36,7 +36,11 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
   }
   const tree = treeRes.value;
 
-  await sync({ remoteDBTree: tree, mimeTypes: MIME_TYPES.BIGQUERY, connector });
+  await sync({
+    remoteDBTree: tree,
+    mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+    connector,
+  });
 
   await syncSucceeded(connectorId);
 }

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -19,7 +19,7 @@ import {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ConnectorPermission, ContentNode } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 function isConfluenceSpaceModel(
   confluenceSpace: unknown
@@ -52,7 +52,7 @@ export function createContentNodeFromSpace(
     expandable: isExpandable,
     permission,
     lastUpdatedAt: null,
-    mimeType: MIME_TYPES.CONFLUENCE.SPACE,
+    mimeType: INTERNAL_MIME_TYPES.CONFLUENCE.SPACE,
   };
 }
 
@@ -74,7 +74,7 @@ export function createContentNodeFromPage(
     expandable: isExpandable,
     permission: "read",
     lastUpdatedAt: null,
-    mimeType: MIME_TYPES.CONFLUENCE.PAGE,
+    mimeType: INTERNAL_MIME_TYPES.CONFLUENCE.PAGE,
   };
 }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -48,8 +48,8 @@ import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 import {
   ConfluenceClientError,
+  INTERNAL_MIME_TYPES,
   isConfluenceNotFoundError,
-  MIME_TYPES,
 } from "@connectors/types";
 
 /**
@@ -241,7 +241,7 @@ export async function confluenceUpsertSpaceFolderActivity({
     parents: [makeSpaceInternalId(spaceId)],
     parentId: null,
     title: spaceName,
-    mimeType: MIME_TYPES.CONFLUENCE.SPACE,
+    mimeType: INTERNAL_MIME_TYPES.CONFLUENCE.SPACE,
     sourceUrl: spaceInDb?.urlSuffix && `${baseUrl}/wiki${spaceInDb.urlSuffix}`,
   });
 
@@ -359,7 +359,7 @@ async function upsertConfluencePageToDataSource({
     timestampMs: lastPageVersionCreatedAt.getTime(),
     upsertContext: { sync_type: syncType },
     title: page.title,
-    mimeType: MIME_TYPES.CONFLUENCE.PAGE,
+    mimeType: INTERNAL_MIME_TYPES.CONFLUENCE.PAGE,
     async: true,
   });
 }

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -42,7 +42,7 @@ import type {
   ContentNodesViewType,
 } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const logger = mainLogger.child({ provider: "github" });
 
@@ -295,7 +295,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
             expandable: true,
             permission: "read",
             lastUpdatedAt: null,
-            mimeType: MIME_TYPES.GITHUB.REPOSITORY,
+            mimeType: INTERNAL_MIME_TYPES.GITHUB.REPOSITORY,
           }))
         );
       }
@@ -366,7 +366,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: false,
               permission: "read",
               lastUpdatedAt: latestIssue.updatedAt.getTime(),
-              mimeType: MIME_TYPES.GITHUB.ISSUES,
+              mimeType: INTERNAL_MIME_TYPES.GITHUB.ISSUES,
             });
           }
 
@@ -380,7 +380,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: false,
               permission: "read",
               lastUpdatedAt: latestDiscussion.updatedAt.getTime(),
-              mimeType: MIME_TYPES.GITHUB.DISCUSSIONS,
+              mimeType: INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
             });
           }
 
@@ -394,7 +394,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: true,
               permission: "read",
               lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
-              mimeType: MIME_TYPES.GITHUB.CODE_ROOT,
+              mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_ROOT,
             });
           }
 
@@ -436,7 +436,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: true,
               permission: "read",
               lastUpdatedAt: directory.codeUpdatedAt.getTime(),
-              mimeType: MIME_TYPES.GITHUB.CODE_DIRECTORY,
+              mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_DIRECTORY,
             });
           });
 
@@ -450,7 +450,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
               expandable: false,
               permission: "read",
               lastUpdatedAt: file.codeUpdatedAt.getTime(),
-              mimeType: MIME_TYPES.GITHUB.CODE_FILE,
+              mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_FILE,
             });
           });
 

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -66,7 +66,7 @@ import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 // Only allow documents up to 5mb to be processed.
 const MAX_DOCUMENT_TXT_LEN = 5000000;
@@ -329,7 +329,7 @@ export async function githubUpsertIssueActivity(
       sync_type: isBatchSync ? "batch" : "incremental",
     },
     title: issue.title,
-    mimeType: MIME_TYPES.GITHUB.ISSUE,
+    mimeType: INTERNAL_MIME_TYPES.GITHUB.ISSUE,
     async: true,
   });
 
@@ -544,7 +544,7 @@ export async function githubUpsertDiscussionActivity(
       sync_type: isBatchSync ? "batch" : "incremental",
     },
     title: discussion.title,
-    mimeType: MIME_TYPES.GITHUB.DISCUSSION,
+    mimeType: INTERNAL_MIME_TYPES.GITHUB.DISCUSSION,
     async: true,
   });
 
@@ -1012,7 +1012,7 @@ export async function githubCodeSyncActivity({
     title: "Code",
     parents: [getCodeRootInternalId(repoId), getRepositoryInternalId(repoId)],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: MIME_TYPES.GITHUB.CODE_ROOT,
+    mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_ROOT,
     sourceUrl: getRepoUrl(repoLogin, repoName),
   });
 
@@ -1232,7 +1232,7 @@ export async function githubCodeSyncActivity({
               sync_type: isBatchSync ? "batch" : "incremental",
             },
             title: f.fileName,
-            mimeType: MIME_TYPES.GITHUB.CODE_FILE,
+            mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_FILE,
             async: true,
           });
 
@@ -1276,7 +1276,7 @@ export async function githubCodeSyncActivity({
           parents,
           parentId: parents[1],
           title: d.dirName,
-          mimeType: MIME_TYPES.GITHUB.CODE_DIRECTORY,
+          mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_DIRECTORY,
           sourceUrl: d.sourceUrl,
         });
 
@@ -1420,7 +1420,7 @@ export async function githubUpsertRepositoryFolderActivity({
     parents: [getRepositoryInternalId(repoId)],
     parentId: null,
     sourceUrl: getRepoUrl(repoLogin, repoName),
-    mimeType: MIME_TYPES.GITHUB.REPOSITORY,
+    mimeType: INTERNAL_MIME_TYPES.GITHUB.REPOSITORY,
   });
 }
 
@@ -1445,7 +1445,7 @@ export async function githubUpsertIssuesFolderActivity({
     title: "Issues",
     parents: [getIssuesInternalId(repoId), getRepositoryInternalId(repoId)],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: MIME_TYPES.GITHUB.ISSUES,
+    mimeType: INTERNAL_MIME_TYPES.GITHUB.ISSUES,
     sourceUrl: getIssuesUrl(getRepoUrl(repoLogin, repoName)),
   });
 }
@@ -1474,7 +1474,7 @@ export async function githubUpsertDiscussionsFolderActivity({
       getRepositoryInternalId(repoId),
     ],
     parentId: getRepositoryInternalId(repoId),
-    mimeType: MIME_TYPES.GITHUB.DISCUSSIONS,
+    mimeType: INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
     sourceUrl: getDiscussionsUrl(getRepoUrl(repoLogin, repoName)),
   });
 }

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -33,7 +33,7 @@ import {
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ContentNode, DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const logger = mainLogger.child({ provider: "gong" });
 
@@ -81,7 +81,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       parents: [makeGongTranscriptFolderInternalId(connector)],
       parentId: null,
       title: TRANSCRIPTS_FOLDER_TITLE,
-      mimeType: MIME_TYPES.GONG.TRANSCRIPT_FOLDER,
+      mimeType: INTERNAL_MIME_TYPES.GONG.TRANSCRIPT_FOLDER,
     });
 
     const result = await createSchedule({

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -15,7 +15,7 @@ import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import { GongTranscriptResource } from "@connectors/resources/gong_resources";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 function formatDateNicely(date: Date) {
   const yyyy = date.getFullYear();
@@ -148,7 +148,7 @@ export async function syncGongTranscript({
     loggerArgs: { ...loggerArgs, callId },
     upsertContext: { sync_type: "batch" },
     title,
-    mimeType: MIME_TYPES.GONG.TRANSCRIPT,
+    mimeType: INTERNAL_MIME_TYPES.GONG.TRANSCRIPT,
     async: true,
   });
 }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -63,7 +63,7 @@ import type { GoogleDriveObjectType } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 import {
   getGoogleSheetContentNodeInternalId,
-  MIME_TYPES,
+  INTERNAL_MIME_TYPES,
 } from "@connectors/types";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types";
 
@@ -331,7 +331,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                 permission: "read",
                 mimeType:
                   type === "folder"
-                    ? MIME_TYPES.GOOGLE_DRIVE.FOLDER
+                    ? INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER
                     : f.mimeType,
               };
             },
@@ -407,7 +407,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                 }))
                   ? "read"
                   : "none",
-                mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+                mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
               };
             })
           );
@@ -423,7 +423,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
             lastUpdatedAt: null,
             expandable: true,
             permission: "none",
-            mimeType: MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
+            mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
           });
 
           nodes.sort((a, b) => {
@@ -502,7 +502,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                 }))
                   ? "read"
                   : "none",
-                mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+                mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
               };
             })
           );
@@ -877,7 +877,7 @@ async function getFoldersAsContentNodes({
           viewType,
         }),
         permission: "read",
-        mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+        mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
       };
     },
     { concurrency: 4 }

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -38,8 +38,8 @@ import {
   concurrentExecutor,
   getGoogleIdsFromSheetContentNodeInternalId,
   getGoogleSheetTableId,
+  INTERNAL_MIME_TYPES,
   isGoogleSheetContentNodeInternalId,
-  MIME_TYPES,
 } from "@connectors/types";
 
 export async function isDriveObjectExpandable({
@@ -178,7 +178,7 @@ export async function updateParentsField(
       parents: parentIds,
       parentId: parentIds[1] ?? null,
       title: file.name ?? "",
-      mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+      mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
       sourceUrl: getSourceUrlForGoogleDriveFiles(file),
     });
     const sheets = await GoogleDriveSheet.findAll({
@@ -350,7 +350,7 @@ export async function fixParentsConsistency({
                   parents: missingFolderParents,
                   parentId: missingFolderParents[1] || null,
                   title: missingFolder.name ?? "",
-                  mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+                  mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
                   sourceUrl: getSourceUrlForGoogleDriveFiles(missingFolder),
                 });
 

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -45,7 +45,7 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 import type { GoogleDriveObjectType } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types";
 
 const FILES_SYNC_CONCURRENCY = 10;
@@ -75,7 +75,7 @@ export async function upsertSharedWithMeFolder(connectorId: ModelId) {
     parents: [folderId],
     parentId: null,
     title: "Shared with me",
-    mimeType: MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
+    mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
     sourceUrl: GOOGLE_DRIVE_SHARED_WITH_ME_WEB_URL,
   });
 }
@@ -947,7 +947,7 @@ export async function markFolderAsVisited(
     parents,
     parentId: parents[1] || null,
     title: file.name ?? "",
-    mimeType: MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
     sourceUrl: getSourceUrlForGoogleDriveFiles(file),
   });
 

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -31,8 +31,8 @@ import type { ModelId } from "@connectors/types";
 import type { GoogleDriveObjectType } from "@connectors/types";
 import {
   getGoogleSheetTableId,
+  INTERNAL_MIME_TYPES,
   InvalidStructuredDataHeaderError,
-  MIME_TYPES,
   slugify,
 } from "@connectors/types";
 
@@ -528,7 +528,7 @@ export async function syncSpreadSheet(
         parents,
         parentId: parents[1] || null,
         title: spreadsheet.data.properties?.title ?? "Untitled Spreadsheet",
-        mimeType: MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
+        mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
         sourceUrl: getSourceUrlForGoogleDriveFiles(file),
       });
 

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -19,7 +19,7 @@ import type {
   ContentNodesViewType,
 } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 export async function allowSyncTeam({
   connectorId,
@@ -143,7 +143,7 @@ export async function retrieveIntercomConversationsPermissions({
         preventSelection: false,
         permission: isAllConversationsSynced ? "read" : "none",
         lastUpdatedAt: null,
-        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+        mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     } else if (isRootLevel && hasTeamsWithReadPermission) {
       nodes.push({
@@ -156,7 +156,7 @@ export async function retrieveIntercomConversationsPermissions({
         preventSelection: false,
         permission: "read",
         lastUpdatedAt: null,
-        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+        mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     }
 
@@ -171,7 +171,7 @@ export async function retrieveIntercomConversationsPermissions({
           expandable: false,
           permission: team.permission,
           lastUpdatedAt: null,
-          mimeType: MIME_TYPES.INTERCOM.TEAM,
+          mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAM,
         });
       });
     }
@@ -189,7 +189,7 @@ export async function retrieveIntercomConversationsPermissions({
         preventSelection: false,
         permission: isAllConversationsSynced ? "read" : "none",
         lastUpdatedAt: null,
-        mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+        mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
       });
     }
     if (parentInternalId === allTeamsInternalId) {
@@ -206,7 +206,7 @@ export async function retrieveIntercomConversationsPermissions({
           expandable: false,
           permission: isTeamInDb ? "read" : "none",
           lastUpdatedAt: null,
-          mimeType: MIME_TYPES.INTERCOM.TEAM,
+          mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAM,
         });
       });
     }

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -28,7 +28,7 @@ import type {
   ContentNodesViewType,
 } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 // A Help Center contains collections and articles:
 // - Level 1: Collections (parent_id is null)
@@ -374,7 +374,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         expandable: true,
         permission: helpCenter.permission,
         lastUpdatedAt: helpCenter.updatedAt.getTime(),
-        mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
+        mimeType: INTERNAL_MIME_TYPES.INTERCOM.HELP_CENTER,
       }));
     } else {
       const helpCenters = await fetchIntercomHelpCenters({ accessToken });
@@ -388,7 +388,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         preventSelection: true,
         permission: "none",
         lastUpdatedAt: null,
-        mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
+        mimeType: INTERNAL_MIME_TYPES.INTERCOM.HELP_CENTER,
       }));
     }
     nodes.sort((a, b) => {
@@ -435,7 +435,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         expandable: true,
         permission: collection.permission,
         lastUpdatedAt: collection.updatedAt.getTime() || null,
-        mimeType: MIME_TYPES.INTERCOM.COLLECTION,
+        mimeType: INTERNAL_MIME_TYPES.INTERCOM.COLLECTION,
       }));
     } else {
       const collectionsInIntercom = await fetchIntercomCollections({
@@ -464,7 +464,7 @@ export async function retrieveIntercomHelpCentersPermissions({
           expandable: false, // WE DO NOT LET EXPAND BELOW LEVEL 1 WHEN SELECTING NODES
           permission: matchingCollectionInDb ? "read" : "none",
           lastUpdatedAt: matchingCollectionInDb?.updatedAt.getTime() || null,
-          mimeType: MIME_TYPES.INTERCOM.COLLECTION,
+          mimeType: INTERNAL_MIME_TYPES.INTERCOM.COLLECTION,
         };
       });
     }
@@ -504,7 +504,7 @@ export async function retrieveIntercomHelpCentersPermissions({
           expandable: true,
           permission: collection.permission,
           lastUpdatedAt: collection.lastUpsertedTs?.getTime() || null,
-          mimeType: MIME_TYPES.INTERCOM.COLLECTION,
+          mimeType: INTERNAL_MIME_TYPES.INTERCOM.COLLECTION,
         })
       );
 
@@ -529,7 +529,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         expandable: false,
         permission: article.permission,
         lastUpdatedAt: article.updatedAt.getTime(),
-        mimeType: MIME_TYPES.INTERCOM.ARTICLE,
+        mimeType: INTERNAL_MIME_TYPES.INTERCOM.ARTICLE,
       }));
 
       collectionNodes.sort((a, b) => {

--- a/connectors/src/connectors/intercom/lib/permissions.ts
+++ b/connectors/src/connectors/intercom/lib/permissions.ts
@@ -13,7 +13,7 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ContentNode } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 /**
  * Retrieve all selected nodes by the admin when setting permissions.
@@ -65,7 +65,7 @@ export async function retrieveSelectedNodes({
       expandable,
       permission: collection.permission,
       lastUpdatedAt: collection.updatedAt.getTime() || null,
-      mimeType: MIME_TYPES.INTERCOM.COLLECTION,
+      mimeType: INTERNAL_MIME_TYPES.INTERCOM.COLLECTION,
     });
   });
 
@@ -87,7 +87,7 @@ export async function retrieveSelectedNodes({
       expandable: true,
       permission: "read",
       lastUpdatedAt: null,
-      mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+      mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
     });
   }
 
@@ -107,7 +107,7 @@ export async function retrieveSelectedNodes({
       expandable: false,
       permission: team.permission,
       lastUpdatedAt: team.updatedAt.getTime() || null,
-      mimeType: MIME_TYPES.INTERCOM.TEAM,
+      mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAM,
     });
   });
 

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -43,7 +43,7 @@ import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const INTERCOM_CONVO_BATCH_SIZE = 20;
 const INTERCOM_ARTICLE_BATCH_SIZE = 20;
@@ -179,7 +179,7 @@ export async function syncHelpCenterOnlyActivity({
     title: helpCenterOnIntercom.display_name || "Help Center",
     parents: [helpCenterInternalId],
     parentId: null,
-    mimeType: MIME_TYPES.INTERCOM.HELP_CENTER,
+    mimeType: INTERNAL_MIME_TYPES.INTERCOM.HELP_CENTER,
     timestampMs: currentSyncMs,
   });
 
@@ -555,7 +555,7 @@ export async function syncTeamOnlyActivity({
       ...(syncAllActivated ? [getTeamsInternalId(connectorId)] : []),
     ],
     parentId: syncAllActivated ? getTeamsInternalId(connectorId) : null,
-    mimeType: MIME_TYPES.INTERCOM.TEAM,
+    mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAM,
     timestampMs: currentSyncMs,
   });
 
@@ -685,7 +685,7 @@ export async function syncAllTeamsActivity({
       title: teamOnIntercom.name,
       parents: [folderId, getTeamsInternalId(connectorId)],
       parentId: getTeamsInternalId(connectorId),
-      mimeType: MIME_TYPES.INTERCOM.TEAM,
+      mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAM,
       timestampMs: currentSyncMs,
     });
 
@@ -870,6 +870,6 @@ export async function upsertIntercomTeamsFolderActivity({
     title: "Conversations",
     parents: [getTeamsInternalId(connectorId)],
     parentId: null,
-    mimeType: MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
   });
 }

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -30,7 +30,7 @@ import {
 import logger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();
 
@@ -341,7 +341,7 @@ export async function syncConversation({
       sync_type: syncType,
     },
     title: convoTitle,
-    mimeType: MIME_TYPES.INTERCOM.CONVERSATION,
+    mimeType: INTERNAL_MIME_TYPES.INTERCOM.CONVERSATION,
     async: true,
   });
 }

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -32,7 +32,7 @@ import {
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
-import { concurrentExecutor, MIME_TYPES } from "@connectors/types";
+import { concurrentExecutor, INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();
 
@@ -229,7 +229,7 @@ export async function upsertCollectionWithChildren({
     title: collection.name.trim() || "Untitled Collection",
     parents: collectionParents,
     parentId: collectionParents[1] || null,
-    mimeType: MIME_TYPES.INTERCOM.COLLECTION,
+    mimeType: INTERNAL_MIME_TYPES.INTERCOM.COLLECTION,
     sourceUrl: collection.url || fallbackCollectionUrl,
     timestampMs: currentSyncMs,
   });
@@ -426,7 +426,7 @@ export async function upsertArticle({
       sync_type: "batch",
     },
     title: article.title,
-    mimeType: MIME_TYPES.INTERCOM.ARTICLE,
+    mimeType: INTERNAL_MIME_TYPES.INTERCOM.ARTICLE,
     async: true,
   });
   await articleOnDb.update({

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -17,7 +17,7 @@ import {
 } from "@connectors/connectors/microsoft/lib/utils";
 import type { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
 import type { ContentNode, ContentNodeType } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 export function getRootNodes(): ContentNode[] {
   return [getSitesRootAsContentNode(), getTeamsRootAsContentNode()];
@@ -37,7 +37,7 @@ export function getSitesRootAsContentNode(): ContentNode {
     preventSelection: true,
     expandable: true,
     permission: "none",
-    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -55,7 +55,7 @@ export function getTeamsRootAsContentNode(): ContentNode {
     preventSelection: true,
     expandable: true,
     permission: "none",
-    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 export function getTeamAsContentNode(team: Team): ContentNode {
@@ -72,7 +72,7 @@ export function getTeamAsContentNode(team: Team): ContentNode {
     preventSelection: true,
     expandable: true,
     permission: "none",
-    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -97,7 +97,7 @@ export function getSiteAsContentNode(
     preventSelection: true,
     expandable: true,
     permission: "none",
-    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -126,7 +126,7 @@ export function getChannelAsContentNode(
     lastUpdatedAt: null,
     expandable: false,
     permission: "none",
-    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -147,7 +147,7 @@ export function getDriveAsContentNode(
     lastUpdatedAt: null,
     expandable: true,
     permission: "none",
-    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 export function getFolderAsContentNode(
@@ -163,7 +163,7 @@ export function getFolderAsContentNode(
     lastUpdatedAt: null,
     expandable: true,
     permission: "none",
-    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };
 }
 
@@ -200,9 +200,9 @@ export function getMicrosoftNodeAsContentNode(
     permission: "none",
     mimeType:
       type === "table"
-        ? MIME_TYPES.MICROSOFT.SPREADSHEET
+        ? INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET
         : type === "folder"
-          ? MIME_TYPES.MICROSOFT.FOLDER
-          : node.mimeType || MIME_TYPES.MICROSOFT.FOLDER,
+          ? INTERNAL_MIME_TYPES.MICROSOFT.FOLDER
+          : node.mimeType || INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };
 }

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -55,7 +55,7 @@ import {
 } from "@connectors/resources/microsoft_resource";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { cacheWithRedis, MIME_TYPES } from "@connectors/types";
+import { cacheWithRedis, INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const FILES_SYNC_CONCURRENCY = 10;
 const DELETE_CONCURRENCY = 5;
@@ -220,7 +220,7 @@ export async function getRootNodesToSyncFromResources(
         parents: [createdOrUpdatedResource.internalId],
         parentId: null,
         title: createdOrUpdatedResource.name ?? "",
-        mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+        mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
         sourceUrl: createdOrUpdatedResource.webUrl ?? undefined,
       }),
     { concurrency: 5 }
@@ -516,7 +516,7 @@ export async function syncFiles({
         parents: [createdOrUpdatedResource.internalId, ...parentsOfParent],
         parentId: parentsOfParent[0],
         title: createdOrUpdatedResource.name ?? "Untitled Folder",
-        mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+        mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
         sourceUrl: createdOrUpdatedResource.webUrl ?? undefined,
       }),
     { concurrency: 5 }
@@ -723,7 +723,7 @@ export async function syncDeltaForRootNodesInDrive({
           parents,
           parentId: parents[1] || null,
           title: blob.name ?? "Untitled Folder",
-          mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+          mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
           sourceUrl: blob.webUrl ?? undefined,
         });
 
@@ -938,7 +938,7 @@ async function updateDescendantsParentsInCore({
     parents,
     parentId: parents[1] || null,
     title: folder.name ?? "Untitled Folder",
-    mimeType: MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
     sourceUrl: folder.webUrl ?? undefined,
   });
 

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -30,7 +30,7 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES, slugify } from "@connectors/types";
+import { INTERNAL_MIME_TYPES, slugify } from "@connectors/types";
 
 const MAXIMUM_NUMBER_OF_EXCEL_SHEET_ROWS = 50000;
 
@@ -331,7 +331,7 @@ export async function handleSpreadSheet({
     title: file.name ?? "Untitled spreadsheet",
     parents,
     parentId: parentInternalId,
-    mimeType: MIME_TYPES.MICROSOFT.SPREADSHEET,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
     sourceUrl: file.webUrl ?? undefined,
   });
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -29,7 +29,10 @@ import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ContentNode, ContentNodesViewType } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { getOAuthConnectionAccessToken, MIME_TYPES } from "@connectors/types";
+import {
+  getOAuthConnectionAccessToken,
+  INTERNAL_MIME_TYPES,
+} from "@connectors/types";
 
 import { getOrphanedCount, hasChildren } from "./lib/parents";
 
@@ -127,7 +130,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       parents: [nodeIdFromNotionId("unknown")],
       parentId: null,
       title: "Orphaned Resources",
-      mimeType: MIME_TYPES.NOTION.UNKNOWN_FOLDER,
+      mimeType: INTERNAL_MIME_TYPES.NOTION.UNKNOWN_FOLDER,
     });
     // Upsert to data_sources_folders (core) a top-level folder for the syncing resources.
     await upsertDataSourceFolder({
@@ -136,7 +139,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       parents: [nodeIdFromNotionId("syncing")],
       parentId: null,
       title: "Syncing",
-      mimeType: MIME_TYPES.NOTION.SYNCING_FOLDER,
+      mimeType: INTERNAL_MIME_TYPES.NOTION.SYNCING_FOLDER,
     });
 
     try {
@@ -489,7 +492,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         expandable,
         permission: "read",
         lastUpdatedAt: page.lastUpsertedTs?.getTime() || null,
-        mimeType: MIME_TYPES.NOTION.PAGE,
+        mimeType: INTERNAL_MIME_TYPES.NOTION.PAGE,
       };
     };
 
@@ -512,7 +515,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         expandable: true,
         permission: "read",
         lastUpdatedAt: db.structuredDataUpsertedTs?.getTime() ?? null,
-        mimeType: MIME_TYPES.NOTION.DATABASE,
+        mimeType: INTERNAL_MIME_TYPES.NOTION.DATABASE,
       };
     };
 
@@ -534,7 +537,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
           expandable: true,
           permission: "read",
           lastUpdatedAt: null,
-          mimeType: MIME_TYPES.NOTION.UNKNOWN_FOLDER,
+          mimeType: INTERNAL_MIME_TYPES.NOTION.UNKNOWN_FOLDER,
         });
       }
     }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -78,7 +78,7 @@ import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 import {
   getNotionDatabaseTableId,
-  MIME_TYPES,
+  INTERNAL_MIME_TYPES,
   slugify,
 } from "@connectors/types";
 
@@ -1886,7 +1886,7 @@ export async function renderAndUpsertPageFromCache({
             parents: parents,
             parentId: parents[1] || null,
             title: parentDb.title ?? "Untitled Notion Database",
-            mimeType: MIME_TYPES.NOTION.DATABASE,
+            mimeType: INTERNAL_MIME_TYPES.NOTION.DATABASE,
             sourceUrl:
               parentDb.notionUrl ??
               `https://www.notion.so/${parentDb.notionDatabaseId.replace(/-/g, "")}`,
@@ -2116,7 +2116,7 @@ export async function renderAndUpsertPageFromCache({
       sync_type: isFullSync ? "batch" : "incremental",
     },
     title: title ?? "",
-    mimeType: MIME_TYPES.NOTION.PAGE,
+    mimeType: INTERNAL_MIME_TYPES.NOTION.PAGE,
     async: true,
   });
 
@@ -2611,7 +2611,7 @@ export async function upsertDatabaseStructuredDataFromCache({
       parents: parentIds,
       parentId: parentIds[1] || null,
       title: dbModel.title ?? "Untitled Notion Database",
-      mimeType: MIME_TYPES.NOTION.DATABASE,
+      mimeType: INTERNAL_MIME_TYPES.NOTION.DATABASE,
       sourceUrl:
         dbModel.notionUrl ??
         `https://www.notion.so/${dbModel.notionDatabaseId.replace(/-/g, "")}`,
@@ -2674,7 +2674,7 @@ export async function upsertDatabaseStructuredDataFromCache({
           sync_type: "batch",
         },
         title: databaseName,
-        mimeType: MIME_TYPES.NOTION.DATABASE,
+        mimeType: INTERNAL_MIME_TYPES.NOTION.DATABASE,
         async: true,
       });
     } else {

--- a/connectors/src/connectors/salesforce/lib/permissions.ts
+++ b/connectors/src/connectors/salesforce/lib/permissions.ts
@@ -22,7 +22,7 @@ import {
 } from "@connectors/lib/remote_databases/utils";
 import type { ContentNode } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 /**
  * Retrieves the existing content nodes for a parent in the Salesforce account.
@@ -58,7 +58,7 @@ export const fetchAvailableChildrenInSalesforce = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.SALESFORCE
+          INTERNAL_MIME_TYPES.SALESFORCE
         );
       })
     );
@@ -87,7 +87,7 @@ export const fetchAvailableChildrenInSalesforce = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.SALESFORCE
+          INTERNAL_MIME_TYPES.SALESFORCE
         );
       })
     );
@@ -120,7 +120,7 @@ export const fetchAvailableChildrenInSalesforce = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.SALESFORCE
+          INTERNAL_MIME_TYPES.SALESFORCE
         );
       })
     );
@@ -153,20 +153,24 @@ export const fetchReadNodes = async ({
 
   return new Ok([
     ...availableDatabases.map((db) =>
-      getContentNodeFromInternalId(db.internalId, "read", MIME_TYPES.SALESFORCE)
+      getContentNodeFromInternalId(
+        db.internalId,
+        "read",
+        INTERNAL_MIME_TYPES.SALESFORCE
+      )
     ),
     ...availableSchemas.map((schema) =>
       getContentNodeFromInternalId(
         schema.internalId,
         "read",
-        MIME_TYPES.SALESFORCE
+        INTERNAL_MIME_TYPES.SALESFORCE
       )
     ),
     ...availableTables.map((table) =>
       getContentNodeFromInternalId(
         table.internalId,
         "read",
-        MIME_TYPES.SALESFORCE
+        INTERNAL_MIME_TYPES.SALESFORCE
       )
     ),
   ]);
@@ -209,7 +213,7 @@ export const fetchSyncedChildren = async ({
         getContentNodeFromInternalId(
           schema.internalId,
           "read",
-          MIME_TYPES.SALESFORCE
+          INTERNAL_MIME_TYPES.SALESFORCE
         )
       );
       return new Ok(schemaContentNodes);
@@ -238,7 +242,7 @@ export const fetchSyncedChildren = async ({
       getContentNodeFromInternalId(
         schema.internalId,
         "read",
-        MIME_TYPES.SALESFORCE
+        INTERNAL_MIME_TYPES.SALESFORCE
       )
     );
     availableTables.forEach((table) => {
@@ -251,7 +255,7 @@ export const fetchSyncedChildren = async ({
           getContentNodeFromInternalId(
             schemaToAddInternalId,
             "none",
-            MIME_TYPES.SALESFORCE
+            INTERNAL_MIME_TYPES.SALESFORCE
           )
         );
       }
@@ -273,7 +277,7 @@ export const fetchSyncedChildren = async ({
       getContentNodeFromInternalId(
         table.internalId,
         "read",
-        MIME_TYPES.SALESFORCE
+        INTERNAL_MIME_TYPES.SALESFORCE
       )
     );
     return new Ok(tables);

--- a/connectors/src/connectors/salesforce/temporal/activities.ts
+++ b/connectors/src/connectors/salesforce/temporal/activities.ts
@@ -4,7 +4,7 @@ import { sync } from "@connectors/lib/remote_databases/activities";
 import { parseInternalId } from "@connectors/lib/remote_databases/utils";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 export async function syncSalesforceConnection(connectorId: ModelId) {
   const getConnectorAndCredentialsRes =
@@ -25,7 +25,7 @@ export async function syncSalesforceConnection(connectorId: ModelId) {
 
   await sync({
     remoteDBTree: tree,
-    mimeTypes: MIME_TYPES.SALESFORCE,
+    mimeTypes: INTERNAL_MIME_TYPES.SALESFORCE,
     connector,
     // Only keep the table name in the remote table id.
     internalTableIdToRemoteTableId: (internalTableId: string) =>

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -16,7 +16,7 @@ import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { SlackAutoReadPattern } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 function findMatchingChannelPatterns(
   remoteChannelName: string,
@@ -79,7 +79,7 @@ export async function autoReadChannel(
       title: `#${remoteChannelName}`,
       parentId: null,
       parents: [slackChannelInternalIdFromSlackChannelId(slackChannelId)],
-      mimeType: MIME_TYPES.SLACK.CHANNEL,
+      mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
       sourceUrl: getSlackChannelSourceUrl(slackChannelId, slackConfiguration),
       providerVisibility: remoteChannel.channel?.is_private
         ? "private"

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -42,8 +42,8 @@ import type {
 import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 import {
+  INTERNAL_MIME_TYPES,
   isSlackAutoReadPatterns,
-  MIME_TYPES,
   safeParseJSON,
 } from "@connectors/types";
 
@@ -403,7 +403,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         permission: ch.permission,
         lastUpdatedAt: null,
         providerVisibility: ch.private ? "private" : "public",
-        mimeType: MIME_TYPES.SLACK.CHANNEL,
+        mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
       }));
 
       resources.sort((a, b) => {

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -15,7 +15,7 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { ConnectorPermission } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 import { getSlackClient } from "./slack_client";
 
@@ -117,7 +117,7 @@ export async function updateSlackChannelInCoreDb(
     title: `#${channelOnDb.slackChannelName}`,
     parentId: null,
     parents: [folderId],
-    mimeType: MIME_TYPES.SLACK.CHANNEL,
+    mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
     sourceUrl: getSlackChannelSourceUrl(channelId, slackConfiguration),
     providerVisibility: channelOnDb.private ? "private" : "public",
     timestampMs,

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -19,7 +19,10 @@ import type {
   AdminSuccessResponseType,
   SlackCommandType,
 } from "@connectors/types";
-import { isSlackbotWhitelistType, MIME_TYPES } from "@connectors/types";
+import {
+  INTERNAL_MIME_TYPES,
+  isSlackbotWhitelistType,
+} from "@connectors/types";
 
 export async function maybeLaunchSlackSyncWorkflowForChannelId(
   connectorId: number,
@@ -276,7 +279,7 @@ export const slack = async ({
         title: `#${channel.name}`,
         parentId: null,
         parents: [slackChannelInternalIdFromSlackChannelId(args.channelId)],
-        mimeType: MIME_TYPES.SLACK.CHANNEL,
+        mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
         sourceUrl: getSlackChannelSourceUrl(args.channelId, slackConfiguration),
         providerVisibility: channel.private ? "private" : "public",
       });

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -53,7 +53,11 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { cacheWithRedis, MIME_TYPES, safeSubstring } from "@connectors/types";
+import {
+  cacheWithRedis,
+  INTERNAL_MIME_TYPES,
+  safeSubstring,
+} from "@connectors/types";
 
 const logger = mainLogger.child({ provider: "slack" });
 
@@ -257,7 +261,7 @@ export async function syncChannel(
       title: `#${channel.name}`,
       parentId: null,
       parents: [slackChannelInternalIdFromSlackChannelId(channelId)],
-      mimeType: MIME_TYPES.SLACK.CHANNEL,
+      mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
       sourceUrl: getSlackChannelSourceUrl(channelId, slackConfiguration),
       providerVisibility: channel.private ? "private" : "public",
     });
@@ -650,7 +654,7 @@ export async function syncNonThreaded(
         ?.split(":")
         .slice(1)
         .join(":") ?? "",
-    mimeType: MIME_TYPES.SLACK.MESSAGES,
+    mimeType: INTERNAL_MIME_TYPES.SLACK.MESSAGES,
     async: true,
   });
 }
@@ -869,7 +873,7 @@ export async function syncThread(
         ?.split(":")
         .slice(1)
         .join(":") ?? "",
-    mimeType: MIME_TYPES.SLACK.THREAD,
+    mimeType: INTERNAL_MIME_TYPES.SLACK.THREAD,
     async: true,
   });
 }

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -24,7 +24,7 @@ import type { ModelId } from "@connectors/types";
 import {
   EXCLUDE_DATABASES,
   EXCLUDE_SCHEMAS,
-  MIME_TYPES,
+  INTERNAL_MIME_TYPES,
 } from "@connectors/types";
 /**
  * Retrieves the existing content nodes for a parent in the Snowflake account.
@@ -68,7 +68,7 @@ export const fetchAvailableChildrenInSnowflake = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.SNOWFLAKE
+          INTERNAL_MIME_TYPES.SNOWFLAKE
         );
       })
     );
@@ -107,7 +107,7 @@ export const fetchAvailableChildrenInSnowflake = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.SNOWFLAKE
+          INTERNAL_MIME_TYPES.SNOWFLAKE
         );
       })
     );
@@ -140,7 +140,7 @@ export const fetchAvailableChildrenInSnowflake = async ({
         return getContentNodeFromInternalId(
           internalId,
           permission,
-          MIME_TYPES.SNOWFLAKE
+          INTERNAL_MIME_TYPES.SNOWFLAKE
         );
       })
     );
@@ -173,20 +173,24 @@ export const fetchSelectedNodes = async ({
 
   return new Ok([
     ...availableDatabases.map((db) =>
-      getContentNodeFromInternalId(db.internalId, "read", MIME_TYPES.SNOWFLAKE)
+      getContentNodeFromInternalId(
+        db.internalId,
+        "read",
+        INTERNAL_MIME_TYPES.SNOWFLAKE
+      )
     ),
     ...availableSchemas.map((schema) =>
       getContentNodeFromInternalId(
         schema.internalId,
         "read",
-        MIME_TYPES.SNOWFLAKE
+        INTERNAL_MIME_TYPES.SNOWFLAKE
       )
     ),
     ...availableTables.map((table) =>
       getContentNodeFromInternalId(
         table.internalId,
         "read",
-        MIME_TYPES.SNOWFLAKE
+        INTERNAL_MIME_TYPES.SNOWFLAKE
       )
     ),
   ]);
@@ -229,7 +233,7 @@ export const fetchSyncedChildren = async ({
         getContentNodeFromInternalId(
           schema.internalId,
           "read",
-          MIME_TYPES.SNOWFLAKE
+          INTERNAL_MIME_TYPES.SNOWFLAKE
         )
       );
       return new Ok(schemaContentNodes);
@@ -258,7 +262,7 @@ export const fetchSyncedChildren = async ({
       getContentNodeFromInternalId(
         schema.internalId,
         "read",
-        MIME_TYPES.SNOWFLAKE
+        INTERNAL_MIME_TYPES.SNOWFLAKE
       )
     );
     availableTables.forEach((table) => {
@@ -271,7 +275,7 @@ export const fetchSyncedChildren = async ({
           getContentNodeFromInternalId(
             schemaToAddInternalId,
             "none",
-            MIME_TYPES.SNOWFLAKE
+            INTERNAL_MIME_TYPES.SNOWFLAKE
           )
         );
       }
@@ -294,7 +298,7 @@ export const fetchSyncedChildren = async ({
       getContentNodeFromInternalId(
         table.internalId,
         "read",
-        MIME_TYPES.SNOWFLAKE
+        INTERNAL_MIME_TYPES.SNOWFLAKE
       )
     );
     return new Ok(tables);

--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -12,7 +12,7 @@ import {
 } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
-import { isSnowflakeCredentials, MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES, isSnowflakeCredentials } from "@connectors/types";
 
 export async function syncSnowflakeConnection(connectorId: ModelId) {
   const localLogger = logger.child({
@@ -55,7 +55,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
     localLogger.info("Connection is not read-only, garbage collecting");
     // We garbage collect everything that was synced as nothing will be marked as used.
     await sync({
-      mimeTypes: MIME_TYPES.SNOWFLAKE,
+      mimeTypes: INTERNAL_MIME_TYPES.SNOWFLAKE,
       connector,
     });
 
@@ -74,7 +74,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
 
     await sync({
       remoteDBTree: tree,
-      mimeTypes: MIME_TYPES.SNOWFLAKE,
+      mimeTypes: INTERNAL_MIME_TYPES.SNOWFLAKE,
       connector,
     });
 

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -32,8 +32,8 @@ import type {
 import type { DataSourceConfig } from "@connectors/types";
 import {
   DepthOptions,
+  INTERNAL_MIME_TYPES,
   isDepthOption,
-  MIME_TYPES,
   WEBCRAWLER_MAX_PAGES,
   WebCrawlerHeaderRedactedValue,
 } from "@connectors/types";
@@ -214,7 +214,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
             permission: "read",
             type: "folder",
             lastUpdatedAt: folder.updatedAt.getTime(),
-            mimeType: MIME_TYPES.WEBCRAWLER.FOLDER,
+            mimeType: INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
           };
         })
         .concat(

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -46,7 +46,7 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
 import type { ModelId } from "@connectors/types";
 import {
-  MIME_TYPES,
+  INTERNAL_MIME_TYPES,
   stripNullBytes,
   WEBCRAWLER_MAX_DEPTH,
   WEBCRAWLER_MAX_PAGES,
@@ -302,7 +302,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
             parents,
             parentId: parents[1] || null,
             title: getDisplayNameForFolder(webCrawlerFolder),
-            mimeType: MIME_TYPES.WEBCRAWLER.FOLDER,
+            mimeType: INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
             sourceUrl: webCrawlerFolder.url,
           });
 

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -26,7 +26,7 @@ import type {
   ContentNodesViewType,
 } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 /**
  * Retrieve all nodes selected by the admin when setting permissions.
@@ -102,7 +102,7 @@ async function getRootLevelContentNodes(
           expandable: true,
           permission: "none",
           lastUpdatedAt: null,
-          mimeType: MIME_TYPES.ZENDESK.BRAND,
+          mimeType: INTERNAL_MIME_TYPES.ZENDESK.BRAND,
         }
     );
   }
@@ -159,7 +159,7 @@ async function getBrandChildren(
       expandable: false,
       permission: "none",
       lastUpdatedAt: null,
-      mimeType: MIME_TYPES.ZENDESK.TICKETS,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.TICKETS,
     };
     nodes.push(ticketsNode);
 
@@ -179,7 +179,7 @@ async function getBrandChildren(
         expandable: true,
         permission: "none",
         lastUpdatedAt: null,
-        mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+        mimeType: INTERNAL_MIME_TYPES.ZENDESK.HELP_CENTER,
       };
       nodes.push(helpCenterNode);
     }
@@ -237,7 +237,7 @@ async function getHelpCenterChildren(
           expandable: false,
           permission: "none",
           lastUpdatedAt: null,
-          mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+          mimeType: INTERNAL_MIME_TYPES.ZENDESK.CATEGORY,
         }
     );
   }

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -17,7 +17,7 @@ import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_reso
 import { ZendeskArticleResource } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();
 
@@ -171,7 +171,7 @@ export async function syncArticle({
     loggerArgs: { ...loggerArgs, articleId: article.id },
     upsertContext: { sync_type: "batch" },
     title: article.title,
-    mimeType: MIME_TYPES.ZENDESK.ARTICLE,
+    mimeType: INTERNAL_MIME_TYPES.ZENDESK.ARTICLE,
     async: true,
   });
   await articleInDb.update({ lastUpsertedTs: new Date(currentSyncDateMs) });

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -16,7 +16,7 @@ import {
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 /**
  * Deletes all the data stored in the db and in the data source relative to a category (articles).
@@ -131,7 +131,7 @@ export async function syncCategory({
     parents,
     parentId: parentId,
     title: category.name,
-    mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+    mimeType: INTERNAL_MIME_TYPES.ZENDESK.CATEGORY,
     sourceUrl: category.html_url,
     timestampMs: currentSyncDateMs,
   });

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -18,7 +18,7 @@ import type { ZendeskConfigurationResource } from "@connectors/resources/zendesk
 import { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();
 
@@ -262,7 +262,7 @@ export async function syncTicket({
       loggerArgs: { ...loggerArgs, ticketId: ticket.id },
       upsertContext: { sync_type: "batch" },
       title: ticket.subject,
-      mimeType: MIME_TYPES.ZENDESK.TICKET,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.TICKET,
       async: true,
     });
     await ticketInDb.update({ lastUpsertedTs: new Date(currentSyncDateMs) });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -41,7 +41,7 @@ import {
   ZendeskConfigurationResource,
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 /**
  * This activity is responsible for updating the lastSyncStartTime of the connector to now.
@@ -153,7 +153,7 @@ export async function syncZendeskBrandActivity({
       parents: [helpCenterNode.internalId],
       parentId: null,
       title: helpCenterNode.title,
-      mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.HELP_CENTER,
       timestampMs: currentSyncDateMs,
     });
 
@@ -172,7 +172,7 @@ export async function syncZendeskBrandActivity({
         parents,
         parentId: parents[1],
         title: category.name,
-        mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+        mimeType: INTERNAL_MIME_TYPES.ZENDESK.CATEGORY,
         sourceUrl: category.url,
         timestampMs: currentSyncDateMs,
       });
@@ -218,7 +218,7 @@ export async function syncZendeskBrandActivity({
         parents: [folderId],
         parentId: null,
         title: category.name,
-        mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+        mimeType: INTERNAL_MIME_TYPES.ZENDESK.CATEGORY,
         sourceUrl: category.url,
         timestampMs: currentSyncDateMs,
       });
@@ -235,7 +235,7 @@ export async function syncZendeskBrandActivity({
       parents: [ticketsNode.internalId],
       parentId: null,
       title: ticketsNode.title,
-      mimeType: MIME_TYPES.ZENDESK.TICKETS,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.TICKETS,
       timestampMs: currentSyncDateMs,
     });
   } else {
@@ -485,7 +485,7 @@ export async function syncZendeskCategoryActivity({
     parents,
     parentId,
     title: fetchedCategory.name,
-    mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+    mimeType: INTERNAL_MIME_TYPES.ZENDESK.CATEGORY,
     sourceUrl: fetchedCategory.html_url,
     timestampMs: currentSyncDateMs,
   });

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -26,7 +26,7 @@ import {
   ZendeskConfigurationResource,
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 /**
  * Retrieves the timestamp cursor, which is the start date of the last successful incremental sync.
@@ -156,7 +156,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
               parents,
               parentId: parents[1],
               title: category.name,
-              mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+              mimeType: INTERNAL_MIME_TYPES.ZENDESK.CATEGORY,
               sourceUrl: category.url,
             });
           } else {

--- a/connectors/src/lib/remote_databases/activities.test.ts
+++ b/connectors/src/lib/remote_databases/activities.test.ts
@@ -13,7 +13,7 @@ import {
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { itInTransaction } from "@connectors/tests/utils";
 import type { DataSourceConfig } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 import { sync } from "./activities";
 
@@ -79,7 +79,7 @@ describe("sync remote databases", async () => {
       await sync({
         remoteDBTree,
         connector: connector,
-        mimeTypes: MIME_TYPES.BIGQUERY,
+        mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
       });
 
       const remoteDB = await RemoteDatabaseModel.findOne({
@@ -97,7 +97,7 @@ describe("sync remote databases", async () => {
         title: "test-db",
         parents: ["test-db"],
         parentId: null,
-        mimeType: MIME_TYPES.BIGQUERY.DATABASE,
+        mimeType: INTERNAL_MIME_TYPES.BIGQUERY.DATABASE,
       });
     }
   );
@@ -148,7 +148,7 @@ describe("sync remote databases", async () => {
       await sync({
         remoteDBTree,
         connector: connector,
-        mimeTypes: MIME_TYPES.BIGQUERY,
+        mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
       });
 
       const remoteDatabase = await RemoteDatabaseModel.findOne({
@@ -175,7 +175,7 @@ describe("sync remote databases", async () => {
         title: "test-schema",
         parents: ["test-db.test-schema", "test-db"],
         parentId: "test-db",
-        mimeType: MIME_TYPES.BIGQUERY.SCHEMA,
+        mimeType: INTERNAL_MIME_TYPES.BIGQUERY.SCHEMA,
       });
     }
   );
@@ -249,7 +249,7 @@ describe("sync remote databases", async () => {
       await sync({
         remoteDBTree,
         connector: connector,
-        mimeTypes: MIME_TYPES.BIGQUERY,
+        mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
         internalTableIdToRemoteTableId,
       });
 
@@ -276,7 +276,7 @@ describe("sync remote databases", async () => {
         ],
         parentId: "test-db.test-schema",
         title: "test-table",
-        mimeType: MIME_TYPES.BIGQUERY.TABLE,
+        mimeType: INTERNAL_MIME_TYPES.BIGQUERY.TABLE,
       });
     }
   );
@@ -321,7 +321,7 @@ describe("sync remote databases", async () => {
       await sync({
         remoteDBTree,
         connector: connector,
-        mimeTypes: MIME_TYPES.BIGQUERY,
+        mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
       });
 
       expect(deleteDataSourceFolder).toHaveBeenCalledWith({
@@ -363,7 +363,7 @@ describe("sync remote databases", async () => {
     await sync({
       remoteDBTree: undefined,
       connector: connector,
-      mimeTypes: MIME_TYPES.BIGQUERY,
+      mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
     });
 
     expect(await RemoteDatabaseModel.count()).toEqual(0);
@@ -426,7 +426,7 @@ describe("sync remote databases", async () => {
       await sync({
         remoteDBTree,
         connector: connector,
-        mimeTypes: MIME_TYPES.BIGQUERY,
+        mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
       });
 
       // Check database model
@@ -467,7 +467,7 @@ describe("sync remote databases", async () => {
         title: "test.db",
         parents: ["test__DUST_DOT__db"],
         parentId: null,
-        mimeType: MIME_TYPES.BIGQUERY.DATABASE,
+        mimeType: INTERNAL_MIME_TYPES.BIGQUERY.DATABASE,
       });
 
       expect(upsertDataSourceFolder).toHaveBeenCalledWith({
@@ -479,7 +479,7 @@ describe("sync remote databases", async () => {
           "test__DUST_DOT__db",
         ],
         parentId: "test__DUST_DOT__db",
-        mimeType: MIME_TYPES.BIGQUERY.SCHEMA,
+        mimeType: INTERNAL_MIME_TYPES.BIGQUERY.SCHEMA,
       });
 
       // Verify upsertDataSourceRemoteTable call
@@ -499,7 +499,7 @@ describe("sync remote databases", async () => {
         ],
         parentId: "test__DUST_DOT__db.test__DUST_DOT__schema",
         title: "test.table",
-        mimeType: MIME_TYPES.BIGQUERY.TABLE,
+        mimeType: INTERNAL_MIME_TYPES.BIGQUERY.TABLE,
       });
     }
   );
@@ -565,7 +565,7 @@ describe("sync remote databases", async () => {
       await sync({
         remoteDBTree,
         connector: connector,
-        mimeTypes: MIME_TYPES.BIGQUERY,
+        mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
         internalTableIdToRemoteTableId,
       });
 
@@ -583,7 +583,7 @@ describe("sync remote databases", async () => {
         ],
         parentId: "test-db.test-schema",
         title: "test-table",
-        mimeType: MIME_TYPES.BIGQUERY.TABLE,
+        mimeType: INTERNAL_MIME_TYPES.BIGQUERY.TABLE,
       });
     }
   );

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -20,7 +20,7 @@ import type {
 import { buildInternalId } from "@connectors/lib/remote_databases/utils";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { MIME_TYPES } from "@connectors/types";
+import type { INTERNAL_MIME_TYPES } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 
 const isDatabaseReadGranted = ({
@@ -46,9 +46,9 @@ const createDatabase = async ({
   allDatabases: RemoteDatabaseModel[];
   connector: ConnectorResource;
   mimeTypes:
-    | typeof MIME_TYPES.BIGQUERY
-    | typeof MIME_TYPES.SNOWFLAKE
-    | typeof MIME_TYPES.SALESFORCE;
+    | typeof INTERNAL_MIME_TYPES.BIGQUERY
+    | typeof INTERNAL_MIME_TYPES.SNOWFLAKE
+    | typeof INTERNAL_MIME_TYPES.SALESFORCE;
 }): Promise<{
   newDatabase: RemoteDatabaseModel | null;
   usedInternalIds: Set<string>;
@@ -132,9 +132,9 @@ const createSchemaAndHierarchy = async ({
   allSchemas: RemoteSchemaModel[];
   connector: ConnectorResource;
   mimeTypes:
-    | typeof MIME_TYPES.BIGQUERY
-    | typeof MIME_TYPES.SNOWFLAKE
-    | typeof MIME_TYPES.SALESFORCE;
+    | typeof INTERNAL_MIME_TYPES.BIGQUERY
+    | typeof INTERNAL_MIME_TYPES.SNOWFLAKE
+    | typeof INTERNAL_MIME_TYPES.SALESFORCE;
 }): Promise<{
   newDatabase: RemoteDatabaseModel | null;
   newSchema: RemoteSchemaModel | null;
@@ -248,9 +248,9 @@ const createTableAndHierarchy = async ({
   allDatabases: RemoteDatabaseModel[];
   connector: ConnectorResource;
   mimeTypes:
-    | typeof MIME_TYPES.BIGQUERY
-    | typeof MIME_TYPES.SNOWFLAKE
-    | typeof MIME_TYPES.SALESFORCE;
+    | typeof INTERNAL_MIME_TYPES.BIGQUERY
+    | typeof INTERNAL_MIME_TYPES.SNOWFLAKE
+    | typeof INTERNAL_MIME_TYPES.SALESFORCE;
   internalTableIdToRemoteTableId: (internalTableId: string) => string;
 }): Promise<{
   newDatabase: RemoteDatabaseModel | null;
@@ -351,9 +351,9 @@ export async function sync({
   remoteDBTree?: RemoteDBTree;
   connector: ConnectorResource;
   mimeTypes:
-    | typeof MIME_TYPES.BIGQUERY
-    | typeof MIME_TYPES.SNOWFLAKE
-    | typeof MIME_TYPES.SALESFORCE;
+    | typeof INTERNAL_MIME_TYPES.BIGQUERY
+    | typeof INTERNAL_MIME_TYPES.SNOWFLAKE
+    | typeof INTERNAL_MIME_TYPES.SALESFORCE;
   internalTableIdToRemoteTableId?: (internalTableId: string) => string;
 }) {
   const dataSourceConfig = dataSourceConfigFromConnector(connector);

--- a/connectors/src/lib/remote_databases/content_nodes.ts
+++ b/connectors/src/lib/remote_databases/content_nodes.ts
@@ -5,7 +5,7 @@ import {
 import type {
   ConnectorPermission,
   ContentNode,
-  MIME_TYPES,
+  INTERNAL_MIME_TYPES,
 } from "@connectors/types";
 /**
  * 3 types of nodes in a remote database content tree:
@@ -35,9 +35,9 @@ export const getContentNodeFromInternalId = (
   internalId: string,
   permission: ConnectorPermission = "none",
   mimeTypes:
-    | typeof MIME_TYPES.BIGQUERY
-    | typeof MIME_TYPES.SNOWFLAKE
-    | typeof MIME_TYPES.SALESFORCE
+    | typeof INTERNAL_MIME_TYPES.BIGQUERY
+    | typeof INTERNAL_MIME_TYPES.SNOWFLAKE
+    | typeof INTERNAL_MIME_TYPES.SALESFORCE
 ): ContentNode => {
   const type = getContentNodeTypeFromInternalId(internalId);
   const { databaseName, schemaName, tableName } = parseInternalId(internalId);

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -27,7 +27,7 @@ import { BaseResource } from "@connectors/resources/base_resource";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types"; // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 import type { ContentNode } from "@connectors/types";
-import { MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -324,7 +324,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrandModel> {
           ? "read"
           : "none",
       lastUpdatedAt: this.updatedAt.getTime(),
-      mimeType: MIME_TYPES.ZENDESK.BRAND,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.BRAND,
     };
   }
 
@@ -342,7 +342,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrandModel> {
       expandable: true,
       permission: this.helpCenterPermission,
       lastUpdatedAt: null,
-      mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.HELP_CENTER,
     };
   }
 
@@ -363,7 +363,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrandModel> {
       expandable: expandable,
       permission: this.ticketsPermission,
       lastUpdatedAt: null,
-      mimeType: MIME_TYPES.ZENDESK.TICKETS,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.TICKETS,
     };
   }
 }
@@ -615,7 +615,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategoryModel> 
       expandable: expandable,
       permission,
       lastUpdatedAt: this.updatedAt.getTime(),
-      mimeType: MIME_TYPES.ZENDESK.CATEGORY,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.CATEGORY,
     };
   }
 
@@ -700,7 +700,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicketModel> {
       permission: this.permission,
       lastUpdatedAt: this.updatedAt.getTime(),
       preventSelection: true,
-      mimeType: MIME_TYPES.ZENDESK.TICKET,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.TICKET,
     };
   }
 
@@ -904,7 +904,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticleModel> {
       permission: this.permission,
       lastUpdatedAt: this.updatedAt.getTime(),
       preventSelection: true,
-      mimeType: MIME_TYPES.ZENDESK.ARTICLE,
+      mimeType: INTERNAL_MIME_TYPES.ZENDESK.ARTICLE,
     };
   }
 

--- a/connectors/src/types/shared/internal_mime_types.ts
+++ b/connectors/src/types/shared/internal_mime_types.ts
@@ -52,7 +52,7 @@ function generateMimeTypes<
   );
 }
 
-export const MIME_TYPES = {
+export const INTERNAL_MIME_TYPES = {
   CONFLUENCE: generateMimeTypes({
     provider: "confluence",
     resourceTypes: ["SPACE", "PAGE"],
@@ -143,40 +143,40 @@ export const MIME_TYPES = {
 };
 
 export type BigQueryMimeType =
-  (typeof MIME_TYPES.BIGQUERY)[keyof typeof MIME_TYPES.BIGQUERY];
+  (typeof INTERNAL_MIME_TYPES.BIGQUERY)[keyof typeof INTERNAL_MIME_TYPES.BIGQUERY];
 
 export type ConfluenceMimeType =
-  (typeof MIME_TYPES.CONFLUENCE)[keyof typeof MIME_TYPES.CONFLUENCE];
+  (typeof INTERNAL_MIME_TYPES.CONFLUENCE)[keyof typeof INTERNAL_MIME_TYPES.CONFLUENCE];
 
 export type GithubMimeType =
-  (typeof MIME_TYPES.GITHUB)[keyof typeof MIME_TYPES.GITHUB];
+  (typeof INTERNAL_MIME_TYPES.GITHUB)[keyof typeof INTERNAL_MIME_TYPES.GITHUB];
 
 export type GoogleDriveMimeType =
-  (typeof MIME_TYPES.GOOGLE_DRIVE)[keyof typeof MIME_TYPES.GOOGLE_DRIVE];
+  (typeof INTERNAL_MIME_TYPES.GOOGLE_DRIVE)[keyof typeof INTERNAL_MIME_TYPES.GOOGLE_DRIVE];
 
 export type IntercomMimeType =
-  (typeof MIME_TYPES.INTERCOM)[keyof typeof MIME_TYPES.INTERCOM];
+  (typeof INTERNAL_MIME_TYPES.INTERCOM)[keyof typeof INTERNAL_MIME_TYPES.INTERCOM];
 
 export type MicrosoftMimeType =
-  (typeof MIME_TYPES.MICROSOFT)[keyof typeof MIME_TYPES.MICROSOFT];
+  (typeof INTERNAL_MIME_TYPES.MICROSOFT)[keyof typeof INTERNAL_MIME_TYPES.MICROSOFT];
 
 export type NotionMimeType =
-  (typeof MIME_TYPES.NOTION)[keyof typeof MIME_TYPES.NOTION];
+  (typeof INTERNAL_MIME_TYPES.NOTION)[keyof typeof INTERNAL_MIME_TYPES.NOTION];
 
 export type SlackMimeType =
-  (typeof MIME_TYPES.SLACK)[keyof typeof MIME_TYPES.SLACK];
+  (typeof INTERNAL_MIME_TYPES.SLACK)[keyof typeof INTERNAL_MIME_TYPES.SLACK];
 
 export type SnowflakeMimeType =
-  (typeof MIME_TYPES.SNOWFLAKE)[keyof typeof MIME_TYPES.SNOWFLAKE];
+  (typeof INTERNAL_MIME_TYPES.SNOWFLAKE)[keyof typeof INTERNAL_MIME_TYPES.SNOWFLAKE];
 
 export type WebcrawlerMimeType =
-  (typeof MIME_TYPES.WEBCRAWLER)[keyof typeof MIME_TYPES.WEBCRAWLER];
+  (typeof INTERNAL_MIME_TYPES.WEBCRAWLER)[keyof typeof INTERNAL_MIME_TYPES.WEBCRAWLER];
 
 export type ZendeskMimeType =
-  (typeof MIME_TYPES.ZENDESK)[keyof typeof MIME_TYPES.ZENDESK];
+  (typeof INTERNAL_MIME_TYPES.ZENDESK)[keyof typeof INTERNAL_MIME_TYPES.ZENDESK];
 
 export type SalesforceMimeType =
-  (typeof MIME_TYPES.SALESFORCE)[keyof typeof MIME_TYPES.SALESFORCE];
+  (typeof INTERNAL_MIME_TYPES.SALESFORCE)[keyof typeof INTERNAL_MIME_TYPES.SALESFORCE];
 
 export type DustMimeType =
   | BigQueryMimeType

--- a/extension/shared/lib/content_nodes.ts
+++ b/extension/shared/lib/content_nodes.ts
@@ -3,7 +3,7 @@ import type {
   ContentNodeType,
   DataSourceViewContentNodeType,
 } from "@dust-tt/client";
-import { MIME_TYPES } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import {
   assertNever,
   ChatBubbleLeftRightIcon,
@@ -19,27 +19,27 @@ import {
 export const MAX_NODE_TITLE_LENGTH = 512;
 
 // Mime types that should be represented with a Channel icon.
-export const CHANNEL_MIME_TYPES = [
-  MIME_TYPES.GITHUB.DISCUSSIONS,
-  MIME_TYPES.INTERCOM.TEAM,
-  MIME_TYPES.INTERCOM.TEAMS_FOLDER,
-  MIME_TYPES.SLACK.CHANNEL,
+export const CHANNEL_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
+  INTERNAL_MIME_TYPES.INTERCOM.TEAM,
+  INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+  INTERNAL_MIME_TYPES.SLACK.CHANNEL,
 ] as readonly string[];
 
 // Mime types that should be represented with a Database icon but are not of type "table".
-export const DATABASE_MIME_TYPES = [
-  MIME_TYPES.GITHUB.ISSUES,
+export const DATABASE_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GITHUB.ISSUES,
 ] as readonly string[];
 
 // Mime types that should be represented with a File icon but are not of type "document".
-export const FILE_MIME_TYPES = [
-  MIME_TYPES.WEBCRAWLER.FOLDER,
+export const FILE_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
 ] as readonly string[];
 
 // Mime types that should be represented with a Spreadsheet icon, despite being of type "folder".
-export const SPREADSHEET_MIME_TYPES = [
-  MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
-  MIME_TYPES.MICROSOFT.SPREADSHEET,
+export const SPREADSHEET_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
+  INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
 ] as readonly string[];
 
 // Mime type that represents a datasource.
@@ -78,26 +78,26 @@ export function getVisualForContentNode(node: ContentNodeType) {
   // Check mime type first for special icon handling.
   if (node.mimeType) {
     // Handle private channels with lock icon.
-    if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
+    if (CHANNEL_INTERNAL_MIME_TYPES.includes(node.mimeType)) {
       return node.providerVisibility === "private"
         ? LockIcon
         : ChatBubbleLeftRightIcon;
     }
 
     // Handle database-like content.
-    if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
+    if (DATABASE_INTERNAL_MIME_TYPES.includes(node.mimeType)) {
       return Square3Stack3DIcon;
     }
 
     // Handle file-like content that isn't a document type.
-    if (FILE_MIME_TYPES.includes(node.mimeType)) {
+    if (FILE_INTERNAL_MIME_TYPES.includes(node.mimeType)) {
       return getVisualForFileContentNode(
         node as ContentNodeType & { type: "document" }
       );
     }
 
     // Handle spreadsheets.
-    if (SPREADSHEET_MIME_TYPES.includes(node.mimeType)) {
+    if (SPREADSHEET_INTERNAL_MIME_TYPES.includes(node.mimeType)) {
       return FolderTableIcon;
     }
   }

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -10,14 +10,14 @@ import type {
 } from "@app/types";
 import { assertNever } from "@app/types";
 
-export const NON_EXPANDABLE_NODES_INTERNAL_MIME_TYPES = [
+export const NON_EXPANDABLE_NODES_MIME_TYPES = [
   INTERNAL_MIME_TYPES.SLACK.CHANNEL,
   INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
   INTERNAL_MIME_TYPES.GITHUB.ISSUES,
   INTERNAL_MIME_TYPES.INTERCOM.TEAM,
 ] as readonly string[];
 
-export const NON_SEARCHABLE_NODES_INTERNAL_MIME_TYPES = [
+export const NON_SEARCHABLE_NODES_MIME_TYPES = [
   INTERNAL_MIME_TYPES.GITHUB.DISCUSSION,
   INTERNAL_MIME_TYPES.GITHUB.ISSUE,
   INTERNAL_MIME_TYPES.INTERCOM.CONVERSATION,
@@ -25,7 +25,7 @@ export const NON_SEARCHABLE_NODES_INTERNAL_MIME_TYPES = [
   INTERNAL_MIME_TYPES.SLACK.THREAD,
 ] as readonly string[];
 
-export const FOLDERS_TO_HIDE_IF_EMPTY_INTERNAL_MIME_TYPES = [
+export const FOLDERS_TO_HIDE_IF_EMPTY_MIME_TYPES = [
   INTERNAL_MIME_TYPES.NOTION.UNKNOWN_FOLDER,
   INTERNAL_MIME_TYPES.NOTION.SYNCING_FOLDER,
   INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
@@ -33,7 +33,7 @@ export const FOLDERS_TO_HIDE_IF_EMPTY_INTERNAL_MIME_TYPES = [
   INTERNAL_MIME_TYPES.GITHUB.ISSUES,
 ] as readonly string[];
 
-export const FOLDERS_SELECTION_PREVENTED_INTERNAL_MIME_TYPES = [
+export const FOLDERS_SELECTION_PREVENTED_MIME_TYPES = [
   INTERNAL_MIME_TYPES.NOTION.SYNCING_FOLDER,
 ] as readonly string[];
 
@@ -76,7 +76,7 @@ function isExpandable(
   viewType: ContentNodesViewType
 ) {
   return (
-    !NON_EXPANDABLE_NODES_INTERNAL_MIME_TYPES.includes(node.mime_type) &&
+    !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
     node.children_count > 0 &&
     // if we aren't in tables/all view, spreadsheets are not expandable
     !(
@@ -105,9 +105,7 @@ export function getContentNodeFromCoreNode(
     expandable: isExpandable(coreNode, viewType),
     mimeType: coreNode.mime_type,
     preventSelection:
-      FOLDERS_SELECTION_PREVENTED_INTERNAL_MIME_TYPES.includes(
-        coreNode.mime_type
-      ) ||
+      FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(coreNode.mime_type) ||
       (viewType === "table" && coreNode.node_type !== "table"),
     parentTitle: coreNode.parent_title,
   };

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -1,6 +1,6 @@
-import { MIME_TYPES } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
-import { SPREADSHEET_MIME_TYPES } from "@app/lib/content_nodes";
+import { SPREADSHEET_INTERNAL_MIME_TYPES } from "@app/lib/content_nodes";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type {
   ContentNodesViewType,
@@ -10,31 +10,31 @@ import type {
 } from "@app/types";
 import { assertNever } from "@app/types";
 
-export const NON_EXPANDABLE_NODES_MIME_TYPES = [
-  MIME_TYPES.SLACK.CHANNEL,
-  MIME_TYPES.GITHUB.DISCUSSIONS,
-  MIME_TYPES.GITHUB.ISSUES,
-  MIME_TYPES.INTERCOM.TEAM,
+export const NON_EXPANDABLE_NODES_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.SLACK.CHANNEL,
+  INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
+  INTERNAL_MIME_TYPES.GITHUB.ISSUES,
+  INTERNAL_MIME_TYPES.INTERCOM.TEAM,
 ] as readonly string[];
 
-export const NON_SEARCHABLE_NODES_MIME_TYPES = [
-  MIME_TYPES.GITHUB.DISCUSSION,
-  MIME_TYPES.GITHUB.ISSUE,
-  MIME_TYPES.INTERCOM.CONVERSATION,
-  MIME_TYPES.SLACK.MESSAGES,
-  MIME_TYPES.SLACK.THREAD,
+export const NON_SEARCHABLE_NODES_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GITHUB.DISCUSSION,
+  INTERNAL_MIME_TYPES.GITHUB.ISSUE,
+  INTERNAL_MIME_TYPES.INTERCOM.CONVERSATION,
+  INTERNAL_MIME_TYPES.SLACK.MESSAGES,
+  INTERNAL_MIME_TYPES.SLACK.THREAD,
 ] as readonly string[];
 
-export const FOLDERS_TO_HIDE_IF_EMPTY_MIME_TYPES = [
-  MIME_TYPES.NOTION.UNKNOWN_FOLDER,
-  MIME_TYPES.NOTION.SYNCING_FOLDER,
-  MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
-  MIME_TYPES.GITHUB.DISCUSSIONS,
-  MIME_TYPES.GITHUB.ISSUES,
+export const FOLDERS_TO_HIDE_IF_EMPTY_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.NOTION.UNKNOWN_FOLDER,
+  INTERNAL_MIME_TYPES.NOTION.SYNCING_FOLDER,
+  INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SHARED_WITH_ME,
+  INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
+  INTERNAL_MIME_TYPES.GITHUB.ISSUES,
 ] as readonly string[];
 
-export const FOLDERS_SELECTION_PREVENTED_MIME_TYPES = [
-  MIME_TYPES.NOTION.SYNCING_FOLDER,
+export const FOLDERS_SELECTION_PREVENTED_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.NOTION.SYNCING_FOLDER,
 ] as readonly string[];
 
 export const UNTITLED_TITLE = "Untitled Document";
@@ -76,12 +76,12 @@ function isExpandable(
   viewType: ContentNodesViewType
 ) {
   return (
-    !NON_EXPANDABLE_NODES_MIME_TYPES.includes(node.mime_type) &&
+    !NON_EXPANDABLE_NODES_INTERNAL_MIME_TYPES.includes(node.mime_type) &&
     node.children_count > 0 &&
     // if we aren't in tables/all view, spreadsheets are not expandable
     !(
       !["table", "all"].includes(viewType) &&
-      SPREADSHEET_MIME_TYPES.includes(node.mime_type)
+      SPREADSHEET_INTERNAL_MIME_TYPES.includes(node.mime_type)
     )
   );
 }
@@ -105,7 +105,9 @@ export function getContentNodeFromCoreNode(
     expandable: isExpandable(coreNode, viewType),
     mimeType: coreNode.mime_type,
     preventSelection:
-      FOLDERS_SELECTION_PREVENTED_MIME_TYPES.includes(coreNode.mime_type) ||
+      FOLDERS_SELECTION_PREVENTED_INTERNAL_MIME_TYPES.includes(
+        coreNode.mime_type
+      ) ||
       (viewType === "table" && coreNode.node_type !== "table"),
     parentTitle: coreNode.parent_title,
   };

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -1,4 +1,4 @@
-import { MIME_TYPES } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import {
   ChatBubbleLeftRightIcon,
   DocumentIcon,
@@ -16,27 +16,27 @@ import { assertNever } from "@app/types";
 export const MAX_NODE_TITLE_LENGTH = 512;
 
 // Mime types that should be represented with a Channel icon.
-export const CHANNEL_MIME_TYPES = [
-  MIME_TYPES.GITHUB.DISCUSSIONS,
-  MIME_TYPES.INTERCOM.TEAM,
-  MIME_TYPES.INTERCOM.TEAMS_FOLDER,
-  MIME_TYPES.SLACK.CHANNEL,
+export const CHANNEL_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
+  INTERNAL_MIME_TYPES.INTERCOM.TEAM,
+  INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+  INTERNAL_MIME_TYPES.SLACK.CHANNEL,
 ] as readonly string[];
 
 // Mime types that should be represented with a Database icon but are not of type "table".
-export const DATABASE_MIME_TYPES = [
-  MIME_TYPES.GITHUB.ISSUES,
+export const DATABASE_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GITHUB.ISSUES,
 ] as readonly string[];
 
 // Mime types that should be represented with a File icon but are not of type "document".
-export const FILE_MIME_TYPES = [
-  MIME_TYPES.WEBCRAWLER.FOLDER,
+export const FILE_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
 ] as readonly string[];
 
 // Mime types that should be represented with a Spreadsheet icon, despite being of type "folder".
-export const SPREADSHEET_MIME_TYPES = [
-  MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
-  MIME_TYPES.MICROSOFT.SPREADSHEET,
+export const SPREADSHEET_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
+  INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
 ] as readonly string[];
 
 // Mime type that represents a datasource.
@@ -73,26 +73,26 @@ export function getVisualForContentNode(node: ContentNode) {
   // Check mime type first for special icon handling.
   if (node.mimeType) {
     // Handle private channels with lock icon.
-    if (CHANNEL_MIME_TYPES.includes(node.mimeType)) {
+    if (CHANNEL_INTERNAL_MIME_TYPES.includes(node.mimeType)) {
       return node.providerVisibility === "private"
         ? LockIcon
         : ChatBubbleLeftRightIcon;
     }
 
     // Handle database-like content.
-    if (DATABASE_MIME_TYPES.includes(node.mimeType)) {
+    if (DATABASE_INTERNAL_MIME_TYPES.includes(node.mimeType)) {
       return Square3Stack3DIcon;
     }
 
     // Handle file-like content that isn't a document type.
-    if (FILE_MIME_TYPES.includes(node.mimeType)) {
+    if (FILE_INTERNAL_MIME_TYPES.includes(node.mimeType)) {
       return getVisualForFileContentNode(
         node as ContentNode & { type: "document" }
       );
     }
 
     // Handle spreadsheets.
-    if (SPREADSHEET_MIME_TYPES.includes(node.mimeType)) {
+    if (SPREADSHEET_INTERNAL_MIME_TYPES.includes(node.mimeType)) {
       return FolderTableIcon;
     }
   }

--- a/front/migrations/20250113_backfill_github_mime_types.ts
+++ b/front/migrations/20250113_backfill_github_mime_types.ts
@@ -1,5 +1,5 @@
 import type { GithubMimeType } from "@dust-tt/client";
-import { MIME_TYPES } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 import type { Sequelize } from "sequelize";
 import { QueryTypes } from "sequelize";
@@ -55,11 +55,11 @@ function matchGithubInternalIdType(internalId: string): {
 function getMimeTypeForNodeId(nodeId: string): GithubMimeType {
   switch (matchGithubInternalIdType(nodeId).type) {
     case "REPO_CODE":
-      return MIME_TYPES.GITHUB.CODE_ROOT;
+      return INTERNAL_MIME_TYPES.GITHUB.CODE_ROOT;
     case "REPO_CODE_DIR":
-      return MIME_TYPES.GITHUB.CODE_DIRECTORY;
+      return INTERNAL_MIME_TYPES.GITHUB.CODE_DIRECTORY;
     case "REPO_CODE_FILE":
-      return MIME_TYPES.GITHUB.CODE_FILE;
+      return INTERNAL_MIME_TYPES.GITHUB.CODE_FILE;
     default:
       throw new Error(`Unreachable: unrecognized node_id: ${nodeId}`);
   }

--- a/front/migrations/20250113_backfill_zendesk_hc_mime_types.ts
+++ b/front/migrations/20250113_backfill_zendesk_hc_mime_types.ts
@@ -1,4 +1,4 @@
-import { MIME_TYPES } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 import type { Sequelize } from "sequelize";
 import { QueryTypes } from "sequelize";
@@ -56,7 +56,7 @@ async function backfillDataSource(
         `UPDATE data_sources_nodes SET mime_type = :mimeType WHERE id IN (:ids)`,
         {
           replacements: {
-            mimeType: MIME_TYPES.ZENDESK.HELP_CENTER,
+            mimeType: INTERNAL_MIME_TYPES.ZENDESK.HELP_CENTER,
             ids: rows.map((row) => row.id),
           },
         }

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -1,4 +1,4 @@
-import { MIME_TYPES_VALUES } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES_VALUES } from "@dust-tt/client";
 import * as t from "io-ts";
 
 import { getSupportedNonImageMimeTypes } from "../../files";
@@ -36,7 +36,7 @@ export const getSupportedInlinedContentType = () => {
 };
 
 const [first, second, ...rest] = [
-  ...MIME_TYPES_VALUES,
+  ...INTERNAL_MIME_TYPES_VALUES,
   ...getSupportedNonImageMimeTypes(),
 ];
 export const getSupportedContentNodeContentTypeSchema = () => {
@@ -59,7 +59,10 @@ export const isSupportedInlinedFragmentContentType = (
   contentType: string
 ): contentType is SupportedInlinedContentFragmentTypeSchema => {
   return (
-    [...MIME_TYPES_VALUES, ...getSupportedNonImageMimeTypes()] as string[]
+    [
+      ...INTERNAL_MIME_TYPES_VALUES,
+      ...getSupportedNonImageMimeTypes(),
+    ] as string[]
   ).includes(contentType);
 };
 
@@ -67,7 +70,10 @@ export const isSupportedContentNodeFragmentContentType = (
   contentType: string
 ): contentType is SupportedContentNodeContentType => {
   return (
-    [...MIME_TYPES_VALUES, ...getSupportedNonImageMimeTypes()] as string[]
+    [
+      ...INTERNAL_MIME_TYPES_VALUES,
+      ...getSupportedNonImageMimeTypes(),
+    ] as string[]
   ).includes(contentType);
 };
 

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -141,7 +141,7 @@ export const INTERNAL_MIME_TYPES = {
   }),
 };
 
-export const MIME_TYPES_VALUES = Object.values(INTERNAL_MIME_TYPES).flatMap((value) =>
+export const INTERNAL_MIME_TYPES_VALUES = Object.values(INTERNAL_MIME_TYPES).flatMap((value) =>
   Object.values(value).map((v) => v)
 );
 
@@ -200,5 +200,5 @@ export type DustMimeType =
   | GongMimeType;
 
 export function isDustMimeType(mimeType: string): mimeType is DustMimeType {
-  return (MIME_TYPES_VALUES as string[]).includes(mimeType);
+  return (INTERNAL_MIME_TYPES_VALUES as string[]).includes(mimeType);
 }

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -52,7 +52,7 @@ function generateMimeTypes<
   );
 }
 
-export const MIME_TYPES = {
+export const INTERNAL_MIME_TYPES = {
   CONFLUENCE: generateMimeTypes({
     provider: "confluence",
     resourceTypes: ["SPACE", "PAGE"],
@@ -141,48 +141,48 @@ export const MIME_TYPES = {
   }),
 };
 
-export const MIME_TYPES_VALUES = Object.values(MIME_TYPES).flatMap((value) =>
+export const MIME_TYPES_VALUES = Object.values(INTERNAL_MIME_TYPES).flatMap((value) =>
   Object.values(value).map((v) => v)
 );
 
 export type BigQueryMimeType =
-  (typeof MIME_TYPES.BIGQUERY)[keyof typeof MIME_TYPES.BIGQUERY];
+  (typeof INTERNAL_MIME_TYPES.BIGQUERY)[keyof typeof INTERNAL_MIME_TYPES.BIGQUERY];
 
 export type ConfluenceMimeType =
-  (typeof MIME_TYPES.CONFLUENCE)[keyof typeof MIME_TYPES.CONFLUENCE];
+  (typeof INTERNAL_MIME_TYPES.CONFLUENCE)[keyof typeof INTERNAL_MIME_TYPES.CONFLUENCE];
 
 export type GithubMimeType =
-  (typeof MIME_TYPES.GITHUB)[keyof typeof MIME_TYPES.GITHUB];
+  (typeof INTERNAL_MIME_TYPES.GITHUB)[keyof typeof INTERNAL_MIME_TYPES.GITHUB];
 
 export type GoogleDriveMimeType =
-  (typeof MIME_TYPES.GOOGLE_DRIVE)[keyof typeof MIME_TYPES.GOOGLE_DRIVE];
+  (typeof INTERNAL_MIME_TYPES.GOOGLE_DRIVE)[keyof typeof INTERNAL_MIME_TYPES.GOOGLE_DRIVE];
 
 export type IntercomMimeType =
-  (typeof MIME_TYPES.INTERCOM)[keyof typeof MIME_TYPES.INTERCOM];
+  (typeof INTERNAL_MIME_TYPES.INTERCOM)[keyof typeof INTERNAL_MIME_TYPES.INTERCOM];
 
 export type MicrosoftMimeType =
-  (typeof MIME_TYPES.MICROSOFT)[keyof typeof MIME_TYPES.MICROSOFT];
+  (typeof INTERNAL_MIME_TYPES.MICROSOFT)[keyof typeof INTERNAL_MIME_TYPES.MICROSOFT];
 
 export type NotionMimeType =
-  (typeof MIME_TYPES.NOTION)[keyof typeof MIME_TYPES.NOTION];
+  (typeof INTERNAL_MIME_TYPES.NOTION)[keyof typeof INTERNAL_MIME_TYPES.NOTION];
 
 export type SlackMimeType =
-  (typeof MIME_TYPES.SLACK)[keyof typeof MIME_TYPES.SLACK];
+  (typeof INTERNAL_MIME_TYPES.SLACK)[keyof typeof INTERNAL_MIME_TYPES.SLACK];
 
 export type SnowflakeMimeType =
-  (typeof MIME_TYPES.SNOWFLAKE)[keyof typeof MIME_TYPES.SNOWFLAKE];
+  (typeof INTERNAL_MIME_TYPES.SNOWFLAKE)[keyof typeof INTERNAL_MIME_TYPES.SNOWFLAKE];
 
 export type WebcrawlerMimeType =
-  (typeof MIME_TYPES.WEBCRAWLER)[keyof typeof MIME_TYPES.WEBCRAWLER];
+  (typeof INTERNAL_MIME_TYPES.WEBCRAWLER)[keyof typeof INTERNAL_MIME_TYPES.WEBCRAWLER];
 
 export type ZendeskMimeType =
-  (typeof MIME_TYPES.ZENDESK)[keyof typeof MIME_TYPES.ZENDESK];
+  (typeof INTERNAL_MIME_TYPES.ZENDESK)[keyof typeof INTERNAL_MIME_TYPES.ZENDESK];
 
 export type SalesforceMimeType =
-  (typeof MIME_TYPES.SALESFORCE)[keyof typeof MIME_TYPES.SALESFORCE];
+  (typeof INTERNAL_MIME_TYPES.SALESFORCE)[keyof typeof INTERNAL_MIME_TYPES.SALESFORCE];
 
 export type GongMimeType =
-  (typeof MIME_TYPES.GONG)[keyof typeof MIME_TYPES.GONG];
+  (typeof INTERNAL_MIME_TYPES.GONG)[keyof typeof INTERNAL_MIME_TYPES.GONG];
 
 export type DustMimeType =
   | BigQueryMimeType

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1,7 +1,7 @@
 import moment from "moment-timezone";
 import { z } from "zod";
 
-import { MIME_TYPES_VALUES } from "./internal_mime_types";
+import { INTERNAL_MIME_TYPES_VALUES } from "./internal_mime_types";
 
 type StringLiteral<T> = T extends string
   ? string extends T
@@ -204,7 +204,7 @@ const supportedUploadableContentType = [
 const SupportedContentFragmentTypeSchema = FlexibleEnumSchema<
   | keyof typeof supportedOtherFileFormats
   | keyof typeof supportedImageFileFormats
-  | (typeof MIME_TYPES_VALUES)[number]
+  | (typeof INTERNAL_MIME_TYPES_VALUES)[number]
   // Legacy content types still retuned by the API when rendering old messages.
   | "dust-application/slack"
 >();


### PR DESCRIPTION
## Description

- There is currently a potential confusion between `FILE_FORMATS`, which contains the regular mime types and `MIME_TYPES`, which contains the internal ones.
- This PR addresses this issue by renaming `MIME_TYPES` into `INTERNAL_MIME_TYPES`.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
- Deploy front.