### PR TITLE
Check for table's name uniquess in core instead of fetching all tables in front when upserting

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2684,6 +2684,26 @@ impl Store for PostgresStore {
             _ => unreachable!(),
         };
 
+        // Check if there is already a table with that name in the data source.
+        let stmt = tx
+            .prepare("SELECT id FROM tables WHERE data_source = $1 AND name = $2 AND table_id != $3 LIMIT 1")
+            .await?;
+        let r = tx
+            .query(
+                &stmt,
+                &[
+                    &data_source_row_id,
+                    &upsert_params.name,
+                    &upsert_params.table_id,
+                ],
+            )
+            .await?;
+
+        if !r.is_empty() {
+            // We already have a table with that name but a different table id, it is not allowed
+            return Err(anyhow!("Tables names must be unique within a data source."));
+        }
+
         let stmt = tx
             .prepare(
                 "INSERT INTO tables \

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -323,41 +323,6 @@ async function handler(
 
       const tableId = maybeTableId || generateRandomModelSId();
 
-      const tRes = await coreAPI.getTables({
-        projectId: dataSource.dustAPIProjectId,
-        dataSourceId: dataSource.dustAPIDataSourceId,
-      });
-
-      if (tRes.isErr()) {
-        logger.error(
-          {
-            dataSourceId: dataSource.sId,
-            workspaceId: owner.id,
-            error: tRes.error,
-          },
-          "Failed to retrieve tables."
-        );
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to retrieve tables.",
-            data_source_error: tRes.error,
-          },
-        });
-      }
-
-      const tableWithSameName = tRes.value.tables.find((t) => t.name === name);
-      if (tableWithSameName && tableWithSameName.table_id !== tableId) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Tables names must be unique within a data source.",
-          },
-        });
-      }
-
       // Prohibit passing parents when not coming from connectors.
       if (!auth.isSystemKey() && parents) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

When we upsert a table we were fetching all the tables to check for uniqueness of datasource & name which is computationnaly intensive.
This PR move the check to core in a much more efficient way.

## Tests

Local

## Risk

Low, very low usage of this endpoint outside of controlled `connectors` code.

## Deploy Plan

Deploy `core` & `front`