### PR TITLE
Add data source configuration to MCP agent configuration

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -231,9 +231,9 @@ export default function ActionsScreen({
           break;
 
         case "MCP":
-          if (action.configuration.dataSourceConfigurations) {
+          if (action.configuration.resources.dataSourceConfigurations) {
             Object.values(
-              action.configuration.dataSourceConfigurations
+              action.configuration.resources.dataSourceConfigurations
             ).forEach((config) => {
               addActionToSpace(config.dataSourceView.spaceId);
             });

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -231,8 +231,13 @@ export default function ActionsScreen({
           break;
 
         case "MCP":
-          //TODO(mcp): add action to space when it leverage datasources configurations
-          // Iterate over the datasources configurations and add the action to the respective spaces
+          if (action.configuration.resources.dataSourceConfigurations) {
+            Object.values(
+              action.configuration.resources.dataSourceConfigurations
+            ).forEach((config) => {
+              addActionToSpace(config.dataSourceView.spaceId);
+            });
+          }
           break;
 
         case "WEB_NAVIGATION":

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -231,9 +231,9 @@ export default function ActionsScreen({
           break;
 
         case "MCP":
-          if (action.configuration.resources.dataSourceConfigurations) {
+          if (action.configuration.dataSourceConfigurations) {
             Object.values(
-              action.configuration.resources.dataSourceConfigurations
+              action.configuration.dataSourceConfigurations
             ).forEach((config) => {
               addActionToSpace(config.dataSourceView.spaceId);
             });

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -17,6 +17,7 @@ import {
 import type { RetrievalTimeframe } from "@app/lib/actions/retrieval";
 import type {
   AgentConfigurationType,
+  DataSourceViewSelectionConfigurations,
   LightAgentConfigurationType,
   ModelConfigurationType,
   PostOrPatchAgentConfigurationRequestBody,
@@ -28,6 +29,30 @@ import { assertNever, Err, Ok } from "@app/types";
 type SlackChannelLinkedWithAgent = SlackChannel & {
   agentConfigurationId: string;
 };
+
+function processDataSourceViewSelectionConfigurations({
+  owner,
+  dataSourceConfigurations,
+}: {
+  owner: WorkspaceType;
+  dataSourceConfigurations: DataSourceViewSelectionConfigurations;
+}) {
+  return Object.values(dataSourceConfigurations).map(
+    ({ dataSourceView, selectedResources, isSelectAll, tagsFilter }) => ({
+      dataSourceViewId: dataSourceView.sId,
+      workspaceId: owner.sId,
+      filter: {
+        parents: !isSelectAll
+          ? {
+              in: selectedResources.map((resource) => resource.internalId),
+              not: [],
+            }
+          : null,
+        tags: tagsFilter,
+      },
+    })
+  );
+}
 
 export async function submitAssistantBuilderForm({
   owner,
@@ -97,30 +122,11 @@ export async function submitAssistantBuilderForm({
             query: a.type === "RETRIEVAL_SEARCH" ? "auto" : "none",
             relativeTimeFrame: timeFrame,
             topK: "auto",
-            dataSources: Object.values(
-              a.configuration.dataSourceConfigurations
-            ).map(
-              ({
-                dataSourceView,
-                selectedResources,
-                isSelectAll,
-                tagsFilter,
-              }) => ({
-                dataSourceViewId: dataSourceView.sId,
-                workspaceId: owner.sId,
-                filter: {
-                  parents: !isSelectAll
-                    ? {
-                        in: selectedResources.map(
-                          (resource) => resource.internalId
-                        ),
-                        not: [],
-                      }
-                    : null,
-                  tags: tagsFilter,
-                },
-              })
-            ),
+            dataSources: processDataSourceViewSelectionConfigurations({
+              owner,
+              dataSourceConfigurations:
+                a.configuration.dataSourceConfigurations,
+            }),
           },
         ];
 
@@ -176,7 +182,6 @@ export async function submitAssistantBuilderForm({
         ];
 
       case "MCP":
-        //TODO(mcp): handle configuration of datasources
         return [
           {
             type: "mcp_server_configuration",
@@ -185,6 +190,15 @@ export async function submitAssistantBuilderForm({
             serverType: a.configuration.serverType,
             internalMCPServerId: a.configuration.internalMCPServerId,
             remoteMCPServerId: a.configuration.remoteMCPServerId,
+            resources: {
+              dataSources:
+                a.configuration.resources.dataSourceConfigurations &&
+                processDataSourceViewSelectionConfigurations({
+                  owner,
+                  dataSourceConfigurations:
+                    a.configuration.resources.dataSourceConfigurations,
+                }),
+            },
           },
         ];
 

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -190,13 +190,13 @@ export async function submitAssistantBuilderForm({
             serverType: a.configuration.serverType,
             internalMCPServerId: a.configuration.internalMCPServerId,
             remoteMCPServerId: a.configuration.remoteMCPServerId,
-            dataSources:
-              a.configuration.dataSourceConfigurations &&
-              processDataSourceViewSelectionConfigurations({
-                owner,
-                dataSourceConfigurations:
-                  a.configuration.dataSourceConfigurations,
-              }),
+            dataSources: a.configuration.dataSourceConfigurations
+              ? processDataSourceViewSelectionConfigurations({
+                  owner,
+                  dataSourceConfigurations:
+                    a.configuration.dataSourceConfigurations,
+                })
+              : null,
           },
         ];
 

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -190,15 +190,13 @@ export async function submitAssistantBuilderForm({
             serverType: a.configuration.serverType,
             internalMCPServerId: a.configuration.internalMCPServerId,
             remoteMCPServerId: a.configuration.remoteMCPServerId,
-            resources: {
-              dataSources:
-                a.configuration.resources.dataSourceConfigurations &&
-                processDataSourceViewSelectionConfigurations({
-                  owner,
-                  dataSourceConfigurations:
-                    a.configuration.resources.dataSourceConfigurations,
-                }),
-            },
+            dataSources:
+              a.configuration.dataSourceConfigurations &&
+              processDataSourceViewSelectionConfigurations({
+                owner,
+                dataSourceConfigurations:
+                  a.configuration.dataSourceConfigurations,
+              }),
           },
         ];
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -1,7 +1,6 @@
 import { CircleIcon, SquareIcon, TriangleIcon } from "@dust-tt/sparkle";
 import { uniqueId } from "lodash";
-import type { SVGProps } from "react";
-import type React from "react";
+import type React, { SVGProps } from "react";
 
 import {
   DEFAULT_MCP_ACTION_DESCRIPTION,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -30,10 +30,10 @@ import type {
   TimeframeUnit,
   WorkspaceType,
 } from "@app/types";
-import { DEFAULT_MAX_STEPS_USE_PER_RUN } from "@app/types";
 import {
   assertNever,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
+  DEFAULT_MAX_STEPS_USE_PER_RUN,
 } from "@app/types";
 
 export const ACTION_MODES = [
@@ -130,6 +130,9 @@ export type AssistantBuilderMCPServerConfiguration = {
   serverType: MCPServerConfigurationType["serverType"];
   internalMCPServerId: MCPServerConfigurationType["internalMCPServerId"];
   remoteMCPServerId: MCPServerConfigurationType["remoteMCPServerId"];
+  resources: {
+    dataSourceConfigurations?: DataSourceViewSelectionConfigurations;
+  };
 };
 
 // Builder State
@@ -366,6 +369,7 @@ export function getDefaultMCPServerActionConfiguration(): AssistantBuilderAction
       serverType: "internal",
       internalMCPServerId: null,
       remoteMCPServerId: null,
+      resources: {},
     },
     name: DEFAULT_MCP_ACTION_NAME,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -130,9 +130,8 @@ export type AssistantBuilderMCPServerConfiguration = {
   serverType: MCPServerConfigurationType["serverType"];
   internalMCPServerId: MCPServerConfigurationType["internalMCPServerId"];
   remoteMCPServerId: MCPServerConfigurationType["remoteMCPServerId"];
-  resources: {
-    dataSourceConfigurations?: DataSourceViewSelectionConfigurations;
-  };
+
+  dataSourceConfigurations?: DataSourceViewSelectionConfigurations;
 };
 
 // Builder State
@@ -369,7 +368,6 @@ export function getDefaultMCPServerActionConfiguration(): AssistantBuilderAction
       serverType: "internal",
       internalMCPServerId: null,
       remoteMCPServerId: null,
-      resources: {},
     },
     name: DEFAULT_MCP_ACTION_NAME,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -1,6 +1,7 @@
 import { CircleIcon, SquareIcon, TriangleIcon } from "@dust-tt/sparkle";
 import { uniqueId } from "lodash";
-import type React, { SVGProps } from "react";
+import type { SVGProps } from "react";
+import type React from "react";
 
 import {
   DEFAULT_MCP_ACTION_DESCRIPTION,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -131,7 +131,7 @@ export type AssistantBuilderMCPServerConfiguration = {
   internalMCPServerId: MCPServerConfigurationType["internalMCPServerId"];
   remoteMCPServerId: MCPServerConfigurationType["remoteMCPServerId"];
 
-  dataSourceConfigurations?: DataSourceViewSelectionConfigurations;
+  dataSourceConfigurations: DataSourceViewSelectionConfigurations | null;
 };
 
 // Builder State
@@ -368,6 +368,7 @@ export function getDefaultMCPServerActionConfiguration(): AssistantBuilderAction
       serverType: "internal",
       internalMCPServerId: null,
       remoteMCPServerId: null,
+      dataSourceConfigurations: null,
     },
     name: DEFAULT_MCP_ACTION_NAME,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1,4 +1,4 @@
-import type { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
+import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
 import type { MCPToolResultContent } from "@app/lib/actions/mcp_actions";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
 import type {
@@ -26,15 +26,27 @@ import type {
 } from "@app/types";
 import { Ok } from "@app/types";
 
+export function validateInternalMCPServerId(
+  serverId: string
+): serverId is InternalMCPServerIdType {
+  return AVAILABLE_INTERNAL_MCPSERVER_IDS.some(
+    (validServerId) => validServerId === serverId
+  );
+}
+
+export type InternalMCPServerIdType =
+  (typeof AVAILABLE_INTERNAL_MCPSERVER_IDS)[number];
+
 export type MCPServerConfigurationType = {
   id: ModelId;
   sId: string;
 
   //TODO(mcp): handle hosted and client
   serverType: "internal" | "remote";
-  internalMCPServerId: (typeof AVAILABLE_INTERNAL_MCPSERVER_IDS)[number] | null;
+  internalMCPServerId: InternalMCPServerIdType | null;
   remoteMCPServerId: string | null; // Hold the sId of the remote MCP server.
 
+  // TODO(mcp): add dataSourceConfigurationId fk here
   type: "mcp_server_configuration";
 
   name: string;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -52,7 +52,7 @@ export type MCPServerConfigurationType = {
   name: string;
   description: string | null;
 
-  dataSources: DataSourceConfiguration[];
+  dataSources: DataSourceConfiguration[] | null;
   // TODO(mcp): add other kind of configurations here such as table query.
 };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1,6 +1,7 @@
 import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
 import type { MCPToolResultContent } from "@app/lib/actions/mcp_actions";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
+import type { DataSourceConfiguration } from "@app/lib/actions/retrieval";
 import type {
   BaseActionRunParams,
   ExtractActionBlob,
@@ -46,11 +47,13 @@ export type MCPServerConfigurationType = {
   internalMCPServerId: InternalMCPServerIdType | null;
   remoteMCPServerId: string | null; // Hold the sId of the remote MCP server.
 
-  // TODO(mcp): add dataSourceConfigurationId fk here
   type: "mcp_server_configuration";
 
   name: string;
   description: string | null;
+
+  dataSources: DataSourceConfiguration[];
+  // TODO(mcp): add other kind of configurations here such as table query.
 };
 
 export type MCPToolConfigurationType = Omit<

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -25,7 +25,7 @@ import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_se
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType, Result } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { assertNever, Err, normalizeError, Ok } from "@app/types";
 
 // Redeclared here to avoid an issue with the zod types in the @modelcontextprotocol/sdk
 // See https://github.com/colinhacks/zod/issues/2938
@@ -320,7 +320,7 @@ export async function tryCallMCPTool({
       },
       `Error calling MCP tool, returning error.`
     );
-    return new Err(error as Error);
+    return new Err(normalizeError(error));
   }
 }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -84,6 +84,7 @@ function makeMCPConfigurations({
       name: tool.name,
       description: tool.description ?? null,
       inputSchema: tool.inputSchema,
+      dataSources: config.dataSources,
     };
   });
 }

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1181,6 +1181,7 @@ export async function createAgentActionConfiguration(
         serverType: action.serverType,
         internalMCPServerId: action.internalMCPServerId,
         remoteMCPServerId: action.remoteMCPServerId,
+        dataSources: action.dataSources,
       });
     }
     default:

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -135,6 +135,15 @@ AgentProcessConfiguration.hasMany(AgentDataSourceConfiguration, {
 });
 AgentDataSourceConfiguration.belongsTo(AgentProcessConfiguration, {
   foreignKey: { name: "processConfigurationId", allowNull: true },
+});
+
+// MCP server config <> Data source config
+AgentMCPServerConfiguration.hasMany(AgentDataSourceConfiguration, {
+  foreignKey: { name: "mcpServerConfigurationId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+AgentDataSourceConfiguration.belongsTo(AgentMCPServerConfiguration, {
+  foreignKey: { name: "mcpServerConfigurationId", allowNull: true },
 });
 
 // Data source config <> Data source

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -1,6 +1,7 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import type { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -25,13 +26,16 @@ export class AgentDataSourceConfiguration extends WorkspaceAwareModel<AgentDataS
   declare dataSourceId: ForeignKey<DataSourceModel["id"]>;
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
 
-  // AgentDataSourceConfiguration can be used by both the retrieval and the process actions'
-  // configurations.
+  // AgentDataSourceConfiguration can be used by both the retrieval, the process
+  // and the MCP actions' configurations.
   declare retrievalConfigurationId: ForeignKey<
     AgentRetrievalConfiguration["id"]
   > | null;
   declare processConfigurationId: ForeignKey<
     AgentRetrievalConfiguration["id"]
+  > | null;
+  declare mcpServerConfigurationId: ForeignKey<
+    AgentMCPServerConfiguration["id"]
   > | null;
 
   declare dataSource: NonAttribute<DataSourceModel>;
@@ -75,6 +79,7 @@ AgentDataSourceConfiguration.init(
     indexes: [
       { fields: ["retrievalConfigurationId"] },
       { fields: ["processConfigurationId"] },
+      { fields: ["mcpServerConfigurationId"] },
       { fields: ["dataSourceId"] },
       { fields: ["dataSourceViewId"] },
     ],

--- a/front/migrations/db/migration_190.sql
+++ b/front/migrations/db/migration_190.sql
@@ -1,0 +1,4 @@
+-- Migration created on Mar 26, 2025
+ALTER TABLE "public"."agent_data_source_configurations"
+    ADD COLUMN "mcpServerConfigurationId" BIGINT REFERENCES "agent_mcp_server_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+CREATE INDEX "agent_data_source_configurations_mcp_server_configuration_id" ON "agent_data_source_configurations" ("mcpServerConfigurationId");

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -490,6 +490,7 @@ export async function createOrUpgradeAgentConfiguration({
           remoteMCPServerId: action.remoteMCPServerId,
           name: action.name,
           description: action.description ?? DEFAULT_MCP_ACTION_DESCRIPTION,
+          dataSources: action.dataSources,
         },
         agentConfigurationRes.value
       );

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -140,18 +140,17 @@ const MCPServerActionConfigurationSchema = t.type({
     t.null,
   ]),
   remoteMCPServerId: t.union([t.string, t.null]),
-  resources: t.type({
-    dataSources: t.union([
-      t.undefined,
-      t.array(
-        t.type({
-          dataSourceViewId: t.string,
-          workspaceId: t.string,
-          filter: DataSourceFilterCodec,
-        })
-      ),
-    ]),
-  }),
+
+  dataSources: t.union([
+    t.undefined,
+    t.array(
+      t.type({
+        dataSourceViewId: t.string,
+        workspaceId: t.string,
+        filter: DataSourceFilterCodec,
+      })
+    ),
+  ]),
 });
 
 const ProcessActionConfigurationSchema = t.type({

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -133,8 +133,25 @@ const ReasoningActionConfigurationSchema = t.type({
 const MCPServerActionConfigurationSchema = t.type({
   type: t.literal("mcp_server_configuration"),
   serverType: t.union([t.literal("internal"), t.literal("remote")]),
-  internalMCPServerId: t.union([t.literal("helloworld"), t.null]),
+  internalMCPServerId: t.union([
+    // TODO(mcp): find a correct way to reuse AVAILABLE_INTERNAL_MCPSERVER_IDS here.
+    t.literal("helloworld"),
+    t.literal("data-source-utils"),
+    t.null,
+  ]),
   remoteMCPServerId: t.union([t.string, t.null]),
+  resources: t.type({
+    dataSources: t.union([
+      t.undefined,
+      t.array(
+        t.type({
+          dataSourceViewId: t.string,
+          workspaceId: t.string,
+          filter: DataSourceFilterCodec,
+        })
+      ),
+    ]),
+  }),
 });
 
 const ProcessActionConfigurationSchema = t.type({

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -136,13 +136,12 @@ const MCPServerActionConfigurationSchema = t.type({
   internalMCPServerId: t.union([
     // TODO(mcp): find a correct way to reuse AVAILABLE_INTERNAL_MCPSERVER_IDS here.
     t.literal("helloworld"),
-    t.literal("data-source-utils"),
     t.null,
   ]),
   remoteMCPServerId: t.union([t.string, t.null]),
 
   dataSources: t.union([
-    t.undefined,
+    t.null,
     t.array(
       t.type({
         dataSourceViewId: t.string,


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2364.
- This PR adds the types required to have a `dataSourceConfiguration` in the Assistant builder state for an MCP action configuration.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Run `migration_190.sql`.
- Deploy front.
