### PR TITLE
Make the table name uniqness check optional

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2397,6 +2397,7 @@ struct DatabasesTablesUpsertPayload {
     parent_id: Option<String>,
     parents: Vec<String>,
     source_url: Option<String>,
+    check_name_uniqueness: Option<bool>,
 
     // Remote DB specifics
     remote_database_table_id: Option<String>,
@@ -2474,6 +2475,7 @@ async fn tables_upsert(
                 title: payload.title,
                 mime_type: payload.mime_type,
                 provider_visibility: payload.provider_visibility,
+                check_name_uniqueness: payload.check_name_uniqueness,
             },
         )
         .await

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -74,6 +74,7 @@ pub struct TableUpsertParams {
     pub title: String,
     pub mime_type: String,
     pub provider_visibility: Option<ProviderVisibility>,
+    pub check_name_uniqueness: Option<bool>,
 }
 
 pub struct FolderUpsertParams {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -397,6 +397,7 @@ async function handler(
         title,
         mimeType,
         sourceUrl: sourceUrl ?? null,
+        checkNameUniqueness: true,
       });
 
       if (upsertRes.isErr()) {

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -328,6 +328,25 @@ function formatDataSourceDisplayName(name: string) {
     .join(" ");
 }
 
+// Counter-part of `DatabasesTablesUpsertPayload` in `core/bin/core_api.rs`.
+type UpsertTableParams = {
+  projectId: string;
+  dataSourceId: string;
+  tableId: string;
+  name: string;
+  description: string;
+  timestamp: number | null;
+  tags: string[];
+  parentId: string | null;
+  parents: string[];
+  remoteDatabaseTableId?: string | null;
+  remoteDatabaseSecretId?: string | null;
+  title: string;
+  mimeType: string;
+  sourceUrl: string | null;
+  checkNameUniqueness?: boolean;
+};
+
 export class CoreAPI {
   _url: string;
   declare _logger: LoggerInterface;
@@ -1388,22 +1407,8 @@ export class CoreAPI {
     title,
     mimeType,
     sourceUrl,
-  }: {
-    projectId: string;
-    dataSourceId: string;
-    tableId: string;
-    name: string;
-    description: string;
-    timestamp: number | null;
-    tags: string[];
-    parentId: string | null;
-    parents: string[];
-    remoteDatabaseTableId?: string | null;
-    remoteDatabaseSecretId?: string | null;
-    title: string;
-    mimeType: string;
-    sourceUrl: string | null;
-  }): Promise<CoreAPIResponse<{ table: CoreAPITable }>> {
+    checkNameUniqueness,
+  }: UpsertTableParams): Promise<CoreAPIResponse<{ table: CoreAPITable }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
@@ -1426,6 +1431,7 @@ export class CoreAPI {
           title,
           mime_type: mimeType,
           source_url: sourceUrl,
+          check_name_uniqueness: checkNameUniqueness ?? false,
         }),
       }
     );


### PR DESCRIPTION
## Description

Following yesterday move of name uniquess check, I overlooked that all table upserts (even csv) ended up in the same place in core.
This PR makes the check optional and do it only were it was before.

## Tests

Green but we don't really cover this use case.

## Risk

Low as the default behavior is to ignore the uniqueness check like before.

## Deploy Plan

Deploy `core` and `front`