### PR TITLE
Add an endpoint to fetch metadata for an internal MCP server

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -74,6 +74,16 @@ const Schema = z.union([
   EmbeddedResourceSchema,
 ]);
 
+export type ToolType = ListToolsResult["tools"][number];
+
+export interface MCPServerConnectionDetails {
+  serverType: MCPServerConfigurationType["serverType"];
+  internalMCPServerId?:
+    | MCPServerConfigurationType["internalMCPServerId"]
+    | null;
+  remoteMCPServerId?: MCPServerConfigurationType["remoteMCPServerId"] | null;
+}
+
 export type MCPToolResultContent = z.infer<typeof Schema>;
 
 export type MCPToolMetadata = {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -304,7 +304,7 @@ export async function getMCPServerMetadataLocally(
         internalMCPServerId: config.internalMCPServerId,
       });
 
-      const r = await mcpClient.getServerVersion();
+      const r = mcpClient.getServerVersion();
       const tools = await mcpClient.listTools();
       await mcpClient.close();
 
@@ -333,7 +333,7 @@ export async function getMCPServerMetadataLocally(
 }
 
 /**
- * Try to call a MCP tool.
+ * Try to call an MCP tool.
  *
  * This function will potentially fail if the server is remote as it will try to connect to it.
  */

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -117,9 +117,9 @@ function makeMCPConfigurations({
   listToolsResult,
 }: {
   config: MCPServerConfigurationType;
-  listToolsResult: ListToolsResult;
+  listToolsResult: ToolType[];
 }): MCPToolConfigurationType[] {
-  return listToolsResult.tools.map((tool) => {
+  return listToolsResult.map((tool) => {
     return {
       id: config.id,
       sId: generateRandomModelSId(),
@@ -400,13 +400,11 @@ export async function tryGetMCPTools(
   const configurations = await Promise.all(
     agentActions.filter(isMCPServerConfiguration).map(async (action) => {
       try {
-        // Connect to the MCP server.
-        const mcpClient = await connectToMCPServer(action);
-
-        const r: ListToolsResult = await mcpClient.listTools();
-
-        // Close immediately after listing tools.
-        await mcpClient.close();
+        const r: ToolType[] = await listMCPServerTools({
+          serverType: action.serverType,
+          internalMCPServerId: action.internalMCPServerId,
+          remoteMCPServerId: action.remoteMCPServerId,
+        });
 
         return makeMCPConfigurations({
           config: action,
@@ -427,4 +425,22 @@ export async function tryGetMCPTools(
   );
 
   return configurations.flat();
+}
+
+export async function listMCPServerTools(
+  connectionDetails: MCPServerConnectionDetails
+): Promise<ToolType[]> {
+  const mcpClient = await connectToMCPServer(connectionDetails);
+
+  let allTools: ToolType[] = [];
+  let nextPageCursor;
+  do {
+    const { tools, nextCursor } = await mcpClient.listTools();
+    nextPageCursor = nextCursor;
+    allTools = [...allTools, ...tools];
+  } while (nextPageCursor);
+
+  await mcpClient.close();
+
+  return allTools;
 }

--- a/front/lib/swr/mcp.ts
+++ b/front/lib/swr/mcp.ts
@@ -19,10 +19,10 @@ export function useInternalMcpServerMetadata({
     configFetcher
   );
 
-  const tools = useMemo(() => (data ? data.metadata : null), [data]);
+  const metadata = useMemo(() => (data ? data.metadata : null), [data]);
 
   return {
-    tools,
+    metadata,
     isLoading: !error && !data,
     isError: error,
     mutate,

--- a/front/lib/swr/mcp.ts
+++ b/front/lib/swr/mcp.ts
@@ -2,24 +2,24 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetMCPServerToolsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools";
+import type { GetMCPServerMetadataResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]";
 import type { LightWorkspaceType } from "@app/types";
 
-export function useInternalMcpServerTools({
+export function useInternalMcpServerMetadata({
   owner,
   serverId,
 }: {
   owner: LightWorkspaceType;
   serverId: string | null;
 }) {
-  const configFetcher: Fetcher<GetMCPServerToolsResponseBody> = fetcher;
+  const configFetcher: Fetcher<GetMCPServerMetadataResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    serverId ? `/api/w/${owner.sId}/mcp/${serverId}/tools` : null,
+    serverId ? `/api/w/${owner.sId}/mcp/${serverId}` : null,
     configFetcher
   );
 
-  const tools = useMemo(() => (data ? data.tools : null), [data]);
+  const tools = useMemo(() => (data ? data.metadata : null), [data]);
 
   return {
     tools,

--- a/front/lib/swr/mcp.ts
+++ b/front/lib/swr/mcp.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetMCPServerToolsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools";
+import type { LightWorkspaceType } from "@app/types";
+
+export function useInternalMcpServerTools({
+  owner,
+  serverId,
+}: {
+  owner: LightWorkspaceType;
+  serverId: string | null;
+}) {
+  const configFetcher: Fetcher<GetMCPServerToolsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    serverId ? `/api/w/${owner.sId}/mcp/${serverId}/tools` : null,
+    configFetcher
+  );
+
+  const tools = useMemo(() => (data ? data.tools : null), [data]);
+
+  return {
+    tools,
+    isLoading: !error && !data,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -1,26 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { validateInternalMCPServerId } from "@app/lib/actions/mcp";
-import type { ToolType } from "@app/lib/actions/mcp_actions";
-import {
-  listMCPServerTools,
-  normalizeInputSchemaProperties,
-} from "@app/lib/actions/mcp_actions";
+import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
+import { getMCPServerMetadataLocally } from "@app/lib/actions/mcp_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
-// TODO(mcp): Share this type with InputSchemaType.
-export type GetMCPServerToolsResponseBody = {
-  tools: (Pick<ToolType, "name" | "description"> & {
-    inputSchema: { [key: string]: string | number | boolean | object };
-  })[];
+export type GetMCPServerMetadataResponseBody = {
+  metadata: MCPServerMetadata;
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetMCPServerToolsResponseBody>>,
+  res: NextApiResponse<WithAPIErrorResponse<GetMCPServerMetadataResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
   const { serverId } = req.query;
@@ -48,15 +42,6 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      if (!serverId) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_mcp_server_id",
-            message: "MCP server id is required.",
-          },
-        });
-      }
       if (!validateInternalMCPServerId(serverId)) {
         return apiError(req, res, {
           status_code: 400,
@@ -67,17 +52,12 @@ async function handler(
         });
       }
 
-      const tools = await listMCPServerTools({
+      const metadata = await getMCPServerMetadataLocally({
         serverType: "internal",
         internalMCPServerId: serverId,
       });
 
-      return res.status(200).json({
-        tools: tools.map((tool) => ({
-          ...tool,
-          inputSchema: normalizeInputSchemaProperties(tool.inputSchema),
-        })),
-      });
+      return res.status(200).json({ metadata });
     default:
       return apiError(req, res, {
         status_code: 405,

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools.ts
@@ -1,0 +1,92 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { validateInternalMCPServerId } from "@app/lib/actions/mcp";
+import type { ToolType } from "@app/lib/actions/mcp_actions";
+import {
+  listMCPServerTools,
+  normalizeInputSchemaProperties,
+} from "@app/lib/actions/mcp_actions";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+// TODO(mcp): Share this type with InputSchemaType.
+export type GetMCPServerToolsResponseBody = {
+  tools: (Pick<ToolType, "name" | "description"> & {
+    inputSchema: { [key: string]: string | number | boolean | object };
+  })[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMCPServerToolsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { serverId } = req.query;
+
+  if (typeof serverId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "mcp_auth_error",
+        message:
+          "You are not authorized to make request to inspect an MCP server.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      if (!serverId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_mcp_server_id",
+            message: "MCP server id is required.",
+          },
+        });
+      }
+      if (!validateInternalMCPServerId(serverId)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_mcp_server_id",
+            message: "Only internal MCP server ids are supported.",
+          },
+        });
+      }
+
+      const tools = await listMCPServerTools({
+        serverType: "internal",
+        internalMCPServerId: serverId,
+      });
+
+      return res.status(200).json({
+        tools: tools.map((tool) => ({
+          ...tool,
+          inputSchema: normalizeInputSchemaProperties(tool.inputSchema),
+        })),
+      });
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -111,6 +111,9 @@ const API_ERROR_TYPES = [
   "mcp_server_connection_not_found",
   // Conversation:
   ...CONVERSATION_ERROR_TYPES,
+  // MCP:
+  "mcp_auth_error",
+  "invalid_mcp_server_id",
 ] as const;
 
 export type APIErrorType = (typeof API_ERROR_TYPES)[number];


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2364.
- This PR adds an endpoint an a hook to get the metadata for an internal MCP server.
- Minor improvements to typing in MCP sdk outputs.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.