### PR TITLE
Bump `sdk/js` version

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
-    "@dust-tt/client": "^1.0.31",
+    "@dust-tt/client": "^1.0.32",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@dust-tt/sparkle": "^0.2.446",
     "@tailwindcss/forms": "^0.5.9",

--- a/extension/package.json
+++ b/extension/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
-    "@dust-tt/client": "^1.0.32",
+    "@dust-tt/client": "^1.0.31",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@dust-tt/sparkle": "^0.2.446",
     "@tailwindcss/forms": "^0.5.9",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

- `MIME_TYPES` was renamed into `INTERNAL_MIME_TYPES` in a previous PR, which breaks retro-compatibility for users relying on an installed version of the sdk like the extension.
- This PR addresses this issue by bumping the version of the `sdk/js`.

## Tests

- N/A.

## Risk

- Low.

## Deploy Plan

- Publish sdk/js.