### PR TITLE
Bump `sdk/js` version used in the extension

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
-        "@dust-tt/client": "^1.0.31",
+        "@dust-tt/client": "^1.0.32",
         "@dust-tt/sparkle": "^0.2.446",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@tailwindcss/forms": "^0.5.9",
@@ -314,9 +314,10 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.31.tgz",
-      "integrity": "sha512-Bd9bJJaWp4OH/yRbqkrLZl5QDs5fIEcjn/WlyZvYHsdrLEFEEEc1J7LT6CraMFPHouZ2MfHTlQu0JNgAW+IYQw==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.32.tgz",
+      "integrity": "sha512-jipGZkgvC+2T+FiHFoFGjev6gmwAHy9D9rEDGM15RVeA7h0jY2dFS00DxKgR5g6C5jBwP7bhosYwLRlkIyf68A==",
+      "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
-    "@dust-tt/client": "^1.0.31",
+    "@dust-tt/client": "^1.0.32",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@dust-tt/sparkle": "^0.2.446",
     "@tailwindcss/forms": "^0.5.9",


### PR DESCRIPTION
## Description

- Direct follow up on https://github.com/dust-tt/dust/pull/11617.
- This PR bumps the version of the sdk/js used in the extension to fix a missing reference to `INTERNAL_MIME_TYPES` (renamed from `MIME_TYPES`).

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- TBD.