### PR TITLE
Fix safeSubstring

### DIFF
--- a/connectors/src/types/shared/utils/string_utils.ts
+++ b/connectors/src/types/shared/utils/string_utils.ts
@@ -14,10 +14,14 @@ import { Err, Ok } from "@dust-tt/client";
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters
  */
 export function safeSubstring(
-  str: string,
+  str: string | undefined,
   start: number,
   end?: number
 ): string {
+  if (!str) {
+    return "";
+  }
+
   while (isTrailingLoneSurrogate(str.charCodeAt(start))) {
     start++;
   }

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -14,10 +14,14 @@ import { Err, Ok } from "../result";
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters
  */
 export function safeSubstring(
-  str: string,
+  str: string | undefined,
   start: number,
   end?: number
 ): string {
+  if (!str) {
+    return "";
+  }
+
   while (isTrailingLoneSurrogate(str.charCodeAt(start))) {
     start++;
   }


### PR DESCRIPTION
## Description

We have an error when trying to use an undefined string in safeTruncate. Root cause is that some typing about intercom entities that we get in connector is wrong.
This PR forces us to handle undefined string in safeTruncate.

## Tests

None

## Risk

Low

## Deploy Plan

Deploy `connectors` and `front`