### PR TITLE
Use sqids for internal servers as well as remote servers

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -91,7 +91,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.29",
+      "version": "1.0.32",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/front/components/actions/mcp/CapabilitiesList.tsx
+++ b/front/components/actions/mcp/CapabilitiesList.tsx
@@ -15,7 +15,6 @@ import type {
   AllowedIconType,
   MCPServerMetadata,
 } from "@app/lib/actions/mcp_actions";
-import type { InternalMCPServerId } from "@app/lib/actions/mcp_internal_actions";
 import { useMCPServerConnections } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types";
 
@@ -24,7 +23,7 @@ const MCP_SERVER_ICONS: Record<AllowedIconType, React.ElementType> = {
   rocket: RocketIcon,
 } as const;
 
-type Capability = MCPServerMetadata & { id: InternalMCPServerId };
+type Capability = MCPServerMetadata;
 
 type RowData = {
   capability: Capability;
@@ -112,7 +111,7 @@ export const CapabilitiesList = ({
                 onClick={() => {
                   void createAndSaveMCPServerConnection({
                     authorizationInfo: authorization,
-                    serverId: id,
+                    mcpServerId: id,
                   });
                 }}
               />

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -127,7 +127,9 @@ export function ActionMCP({
           <Button
             isSelect
             label={
-              selectedMCPServer ? selectedMCPServer.name : "Select a MCP server"
+              selectedMCPServer
+                ? selectedMCPServer.name
+                : "Select an MCP server"
             }
             className="w-48"
           />

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
@@ -14,10 +14,10 @@ import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
-import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
-import type { InternalMCPServerIdType } from "@app/lib/actions/mcp";
+import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
 import { serverRequiresInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import { useInternalMcpServerMetadata } from "@app/lib/swr/mcp";
+import { useMcpServers } from "@app/lib/swr/mcp_servers";
+import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import type {
   DataSourceViewSelectionConfigurations,
   LightWorkspaceType,
@@ -43,34 +43,50 @@ export function ActionMCP({
   updateAction,
   setEdited,
 }: ActionMCPProps) {
-  const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
-
-  const { metadata } = useInternalMcpServerMetadata({
-    owner,
-    serverId: actionConfiguration.internalMCPServerId,
+  // Hack for now, we'll use the space based on the allowedSpaces once we have the object representing the join
+  const { spaces } = useSpacesAsAdmin({
+    workspaceId: owner.sId,
+    disabled: false,
   });
+  const { mcpServers } = useMcpServers({
+    owner,
+    space: (spaces ?? []).find((space) => space.kind === "system"),
+    filter: "all",
+  });
+
+  const defaultMCPServer = useMemo(
+    () =>
+      mcpServers.find(
+        (mcpServer) => mcpServer.id === actionConfiguration.mcpServerId
+      ),
+    [mcpServers, actionConfiguration.mcpServerId]
+  );
+
+  const [selectedMCPServer, setSelectedMCPServer] =
+    useState<MCPServerMetadata | null>(defaultMCPServer ?? null);
+  const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
 
   useEffect(() => {
     updateAction((previousAction) => ({
       ...previousAction,
       dataSourceConfigurations:
-        metadata &&
+        selectedMCPServer &&
         serverRequiresInternalConfiguration({
-          serverMetadata: metadata,
+          serverMetadata: selectedMCPServer,
           mimeType: INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE,
         })
           ? previousAction.dataSourceConfigurations || {}
           : null,
     }));
-  }, [metadata, setEdited, updateAction]);
+  }, [selectedMCPServer, updateAction]);
 
   const handleServerSelection = useCallback(
-    (serverId: InternalMCPServerIdType) => {
+    (mcpServer: MCPServerMetadata) => {
       setEdited(true);
+      setSelectedMCPServer(mcpServer);
       updateAction((previousAction) => ({
         ...previousAction,
-        serverType: "internal",
-        internalMCPServerId: serverId,
+        mcpServerId: mcpServer.id,
       }));
     },
     [setEdited, updateAction]
@@ -111,18 +127,17 @@ export function ActionMCP({
           <Button
             isSelect
             label={
-              actionConfiguration.internalMCPServerId ??
-              "Select a internal server"
+              selectedMCPServer ? selectedMCPServer.name : "Select a MCP server"
             }
             className="w-48"
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="mt-1" align="start">
-          {AVAILABLE_INTERNAL_MCPSERVER_IDS.map((id) => (
+          {mcpServers.map((mcpServer) => (
             <DropdownMenuItem
-              key={id}
-              label={id}
-              onClick={() => handleServerSelection(id)}
+              key={mcpServer.id}
+              label={mcpServer.name}
+              onClick={() => handleServerSelection(mcpServer)}
             />
           ))}
         </DropdownMenuContent>

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -233,9 +233,7 @@ async function getMCPServerActionConfiguration(
     throw new Error("MCP action configuration is not valid");
   }
 
-  builderAction.configuration.serverType = action.serverType;
-  builderAction.configuration.internalMCPServerId = action.internalMCPServerId;
-  builderAction.configuration.remoteMCPServerId = action.remoteMCPServerId;
+  builderAction.configuration.mcpServerId = action.mcpServerId;
 
   builderAction.name = action.name + "_" + generateRandomModelSId();
   builderAction.description =

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -187,9 +187,7 @@ export async function submitAssistantBuilderForm({
             type: "mcp_server_configuration",
             name: a.name,
             description: a.description,
-            serverType: a.configuration.serverType,
-            internalMCPServerId: a.configuration.internalMCPServerId,
-            remoteMCPServerId: a.configuration.remoteMCPServerId,
+            mcpServerId: a.configuration.mcpServerId,
             dataSources: a.configuration.dataSourceConfigurations
               ? processDataSourceViewSelectionConfigurations({
                   owner,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -14,7 +14,6 @@ import {
   DEFAULT_TABLES_QUERY_ACTION_NAME,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
-import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { ProcessSchemaPropertyType } from "@app/lib/actions/process";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type {
@@ -127,9 +126,7 @@ export type AssistantBuilderReasoningConfiguration = {
 
 // MCP configuration
 export type AssistantBuilderMCPServerConfiguration = {
-  serverType: MCPServerConfigurationType["serverType"];
-  internalMCPServerId: MCPServerConfigurationType["internalMCPServerId"];
-  remoteMCPServerId: MCPServerConfigurationType["remoteMCPServerId"];
+  mcpServerId: string;
 
   dataSourceConfigurations: DataSourceViewSelectionConfigurations | null;
 };
@@ -365,9 +362,7 @@ export function getDefaultMCPServerActionConfiguration(): AssistantBuilderAction
   return {
     type: "MCP",
     configuration: {
-      serverType: "internal",
-      internalMCPServerId: null,
-      remoteMCPServerId: null,
+      mcpServerId: "not-a-valid-mcp-server-id",
       dataSourceConfigurations: null,
     },
     name: DEFAULT_MCP_ACTION_NAME,

--- a/front/hooks/useMCPConnectionManagement.ts
+++ b/front/hooks/useMCPConnectionManagement.ts
@@ -2,7 +2,6 @@ import { useSendNotification } from "@dust-tt/sparkle";
 import { useCallback } from "react";
 
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_actions";
-import type { InternalMCPServerId } from "@app/lib/actions/mcp_internal_actions";
 import {
   useCreateMCPServerConnection,
   useDeleteMCPServerConnection,
@@ -22,10 +21,10 @@ export const useMCPConnectionManagement = ({
   const createAndSaveMCPServerConnection = useCallback(
     async ({
       authorizationInfo,
-      serverId,
+      mcpServerId,
     }: {
       authorizationInfo: AuthorizationInfo;
-      serverId: InternalMCPServerId;
+      mcpServerId: string;
     }) => {
       const cRes = await setupOAuthConnection({
         dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
@@ -45,7 +44,7 @@ export const useMCPConnectionManagement = ({
       }
       return createMCPServerConnection({
         connectionId: cRes.value.connection_id,
-        internalMCPServerId: serverId,
+        mcpServerId,
       });
     },
     [owner, sendNotification, createMCPServerConnection]

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -4,11 +4,6 @@
 // future based on user feedback.
 export const PROCESS_ACTION_TOP_K = 768;
 
-export const AVAILABLE_INTERNAL_MCPSERVER_IDS = [
-  "helloworld",
-  "data-source-utils",
-] as const;
-
 export const DEFAULT_BROWSE_ACTION_NAME = "browse";
 export const DEFAULT_BROWSE_ACTION_DESCRIPTION =
   "Browse the content of a web page";

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1,4 +1,3 @@
-import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
 import type { MCPToolResultContent } from "@app/lib/actions/mcp_actions";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
 import type { DataSourceConfiguration } from "@app/lib/actions/retrieval";
@@ -27,25 +26,11 @@ import type {
 } from "@app/types";
 import { Ok } from "@app/types";
 
-export function validateInternalMCPServerId(
-  serverId: string
-): serverId is InternalMCPServerIdType {
-  return AVAILABLE_INTERNAL_MCPSERVER_IDS.some(
-    (validServerId) => validServerId === serverId
-  );
-}
-
-export type InternalMCPServerIdType =
-  (typeof AVAILABLE_INTERNAL_MCPSERVER_IDS)[number];
-
 export type MCPServerConfigurationType = {
   id: ModelId;
   sId: string;
 
-  //TODO(mcp): handle hosted and client
-  serverType: "internal" | "remote";
-  internalMCPServerId: InternalMCPServerIdType | null;
-  remoteMCPServerId: string | null; // Hold the sId of the remote MCP server.
+  mcpServerId: string; // Hold the sId of the MCP server.
 
   type: "mcp_server_configuration";
 
@@ -103,11 +88,7 @@ export class MCPActionType extends BaseAction {
     | "allowed_explicitely"
     | "allowed_implicitely"
     | "denied" = "pending";
-  readonly serverType: MCPServerConfigurationType["serverType"] = "internal";
-  readonly internalMCPServerId: MCPServerConfigurationType["internalMCPServerId"] =
-    null;
-  readonly remoteMCPServerId: MCPServerConfigurationType["remoteMCPServerId"] =
-    null;
+  readonly mcpServerId: string = "not-valid";
   readonly mcpServerConfigurationId: string;
   readonly params: Record<string, unknown>; // Hold the inputs for the action.
   readonly output: MCPToolResultContent[] | null;
@@ -221,9 +202,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       workspaceId: owner.id,
       isError: false,
       executionState: "pending",
-      serverType: actionConfiguration.serverType,
-      internalMCPServerId: actionConfiguration.internalMCPServerId,
-      remoteMCPServerId: actionConfiguration.remoteMCPServerId,
+      mcpServerId: actionConfiguration.mcpServerId,
     });
 
     yield {
@@ -239,9 +218,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         functionCallName: actionConfiguration.name,
         agentMessageId: agentMessage.agentMessageId,
         step,
-        serverType: actionConfiguration.serverType,
-        internalMCPServerId: actionConfiguration.internalMCPServerId,
-        remoteMCPServerId: actionConfiguration.remoteMCPServerId,
+        mcpServerId: actionConfiguration.mcpServerId,
         mcpServerConfigurationId: `${actionConfiguration.id}`,
         executionState: "pending",
         isError: false,
@@ -302,9 +279,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         functionCallName: actionConfiguration.name,
         agentMessageId: agentMessage.agentMessageId,
         step,
-        serverType: actionConfiguration.serverType,
-        internalMCPServerId: actionConfiguration.internalMCPServerId,
-        remoteMCPServerId: actionConfiguration.remoteMCPServerId,
+        mcpServerId: actionConfiguration.mcpServerId,
         mcpServerConfigurationId: `${actionConfiguration.id}`,
         executionState: "allowed_explicitely",
         isError: false,
@@ -348,9 +323,7 @@ export async function mcpActionTypesFromAgentMessageIds(
       functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,
       step: action.step,
-      serverType: action.serverType,
-      internalMCPServerId: action.internalMCPServerId,
-      remoteMCPServerId: action.remoteMCPServerId,
+      mcpServerId: action.mcpServerId,
       mcpServerConfigurationId: action.mcpServerConfigurationId,
       executionState: action.executionState,
       isError: action.isError,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -174,12 +174,6 @@ const connectToMCPServer = async ({
 
     switch (serverType) {
       case "internal":
-        if (!id) {
-          throw new Error(
-            "Internal MCP server ID is required for internal server type."
-          );
-        }
-
         // Create a pair of linked in-memory transports
         // And connect the client to the server.
         const [client, server] = InMemoryTransport.createLinkedPair();
@@ -188,12 +182,6 @@ const connectToMCPServer = async ({
         break;
 
       case "remote":
-        if (!id) {
-          throw new Error(
-            `Remote MCP server ID or URL is required for remote server type.`
-          );
-        }
-
         const remoteMCPServer = await RemoteMCPServer.findOne({
           where: {
             id,
@@ -270,7 +258,7 @@ function extractMetadataFromTools(tools: ListToolsResult): MCPToolMetadata[] {
 
 export async function fetchRemoteServerMetaDataByURL(
   url: string
-): Promise<MCPServerMetadata> {
+): Promise<Omit<MCPServerMetadata, "id">> {
   const mcpClient = await connectToMCPServer({
     remoteMCPServerUrl: url,
   });
@@ -283,7 +271,6 @@ export async function fetchRemoteServerMetaDataByURL(
     const serverTools = extractMetadataFromTools(toolsResult);
 
     return {
-      id: generateRandomModelSId(),
       ...metadata,
       tools: serverTools,
     };

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -17,16 +17,20 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
+import {
+  connectToInternalMCPServer,
+  getInternalMCPServerSId,
+} from "@app/lib/actions/mcp_internal_actions";
+import { AVAILABLE_INTERNAL_MCPSERVER_NAMES } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import { isMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
-import type { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import {
   generateRandomModelSId,
-  getResourceIdFromSId,
+  getResourceNameAndIdFromSId,
 } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type {
@@ -76,14 +80,6 @@ const Schema = z.union([
 
 export type ToolType = ListToolsResult["tools"][number];
 
-export interface MCPServerConnectionDetails {
-  serverType: MCPServerConfigurationType["serverType"];
-  internalMCPServerId?:
-    | MCPServerConfigurationType["internalMCPServerId"]
-    | null;
-  remoteMCPServerId?: MCPServerConfigurationType["remoteMCPServerId"] | null;
-}
-
 export type MCPToolResultContent = z.infer<typeof Schema>;
 
 export type MCPToolMetadata = {
@@ -104,6 +100,7 @@ export type AuthorizationInfo = {
 };
 
 export type MCPServerMetadata = {
+  id: string;
   name: string;
   version: string;
   description: string;
@@ -124,9 +121,7 @@ function makeMCPConfigurations({
       id: config.id,
       sId: generateRandomModelSId(),
       type: "mcp_configuration",
-      serverType: config.serverType,
-      internalMCPServerId: config.internalMCPServerId,
-      remoteMCPServerId: config.remoteMCPServerId,
+      mcpServerId: config.mcpServerId,
       name: tool.name,
       description: tool.description ?? null,
       inputSchema: tool.inputSchema,
@@ -135,17 +130,36 @@ function makeMCPConfigurations({
   });
 }
 
+export const getServerTypeAndIdFromSId = (
+  mcpServerId: string
+): {
+  serverType: "internal" | "remote";
+  id: number;
+} => {
+  const sIdParts = getResourceNameAndIdFromSId(mcpServerId);
+  if (!sIdParts) {
+    throw new Error(`Invalid MCP server ID: ${mcpServerId}`);
+  }
+
+  const { resourceName, resourceId } = sIdParts;
+
+  switch (resourceName) {
+    case "internal_mcp_server":
+      return { serverType: "internal" as const, id: resourceId };
+    case "remote_mcp_server":
+      return { serverType: "remote" as const, id: resourceId };
+    default:
+      throw new Error(
+        `Invalid MCP server ID: ${mcpServerId} resourceName: ${resourceName}`
+      );
+  }
+};
+
 const connectToMCPServer = async ({
-  serverType,
-  internalMCPServerId,
-  remoteMCPServerId,
+  mcpServerId,
   remoteMCPServerUrl,
 }: {
-  serverType: MCPServerConfigurationType["serverType"];
-  internalMCPServerId?:
-    | MCPServerConfigurationType["internalMCPServerId"]
-    | null;
-  remoteMCPServerId?: MCPServerConfigurationType["remoteMCPServerId"] | null;
+  mcpServerId?: string;
   remoteMCPServerUrl?: string | null;
 }) => {
   //TODO(mcp): handle failure, timeout...
@@ -155,58 +169,57 @@ const connectToMCPServer = async ({
     version: "1.0.0",
   });
 
-  switch (serverType) {
-    case "internal":
-      if (!internalMCPServerId) {
-        throw new Error(
-          "Internal MCP server ID is required for internal server type."
-        );
-      }
+  if (mcpServerId) {
+    const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
 
-      // Create a pair of linked in-memory transports
-      // And connect the client to the server.
-      const [client, server] = InMemoryTransport.createLinkedPair();
-      await connectToInternalMCPServer(internalMCPServerId, server);
-      await mcpClient.connect(client);
-      break;
+    switch (serverType) {
+      case "internal":
+        if (!id) {
+          throw new Error(
+            "Internal MCP server ID is required for internal server type."
+          );
+        }
 
-    case "remote":
-      const url = remoteMCPServerUrl
-        ? new URL(remoteMCPServerUrl)
-        : await (async () => {
-            if (!remoteMCPServerId) {
-              throw new Error(
-                `Remote MCP server ID or URL is required for remote server type.`
-              );
-            }
-            const id = getResourceIdFromSId(remoteMCPServerId);
-            if (!id) {
-              throw new Error(
-                `Remote MCP server ID is invalid for remote server type.`
-              );
-            }
+        // Create a pair of linked in-memory transports
+        // And connect the client to the server.
+        const [client, server] = InMemoryTransport.createLinkedPair();
+        await connectToInternalMCPServer(mcpServerId, server);
+        await mcpClient.connect(client);
+        break;
 
-            const remoteMCPServer = await RemoteMCPServer.findOne({
-              where: {
-                id,
-              },
-            });
+      case "remote":
+        if (!id) {
+          throw new Error(
+            `Remote MCP server ID or URL is required for remote server type.`
+          );
+        }
 
-            if (!remoteMCPServer) {
-              throw new Error(
-                `Remote MCP server with remoteMCPServerId ${remoteMCPServerId} not found for remote server type.`
-              );
-            }
+        const remoteMCPServer = await RemoteMCPServer.findOne({
+          where: {
+            id,
+          },
+        });
 
-            return new URL(remoteMCPServer.url);
-          })();
+        if (!remoteMCPServer) {
+          throw new Error(
+            `Remote MCP server with remoteMCPServerId ${id} not found for remote server type.`
+          );
+        }
 
-      const sseTransport = new SSEClientTransport(url);
-      await mcpClient.connect(sseTransport);
-      break;
+        const url = new URL(remoteMCPServer.url);
+        const sseTransport = new SSEClientTransport(url);
+        await mcpClient.connect(sseTransport);
+        break;
 
-    default:
-      assertNever(serverType);
+      default:
+        assertNever(serverType);
+    }
+  } else if (remoteMCPServerUrl) {
+    const url = new URL(remoteMCPServerUrl);
+    const sseTransport = new SSEClientTransport(url);
+    await mcpClient.connect(sseTransport);
+  } else {
+    throw new Error("MCP server ID or URL is required.");
   }
 
   return mcpClient;
@@ -214,7 +227,7 @@ const connectToMCPServer = async ({
 
 function extractMetadataFromServerVersion(
   r: Implementation | undefined
-): Omit<MCPServerMetadata, "tools"> {
+): Omit<MCPServerMetadata, "tools" | "id"> {
   if (r) {
     return {
       name: r.name ?? DEFAULT_MCP_ACTION_NAME,
@@ -259,7 +272,6 @@ export async function fetchRemoteServerMetaDataByURL(
   url: string
 ): Promise<MCPServerMetadata> {
   const mcpClient = await connectToMCPServer({
-    serverType: "remote",
     remoteMCPServerUrl: url,
   });
 
@@ -271,6 +283,7 @@ export async function fetchRemoteServerMetaDataByURL(
     const serverTools = extractMetadataFromTools(toolsResult);
 
     return {
+      id: generateRandomModelSId(),
       ...metadata,
       tools: serverTools,
     };
@@ -285,51 +298,84 @@ export async function fetchRemoteServerMetaDataByURL(
  * This function is safe to call even if the server is remote as it will not connect to the server and use the cached metadata.
  */
 export async function getMCPServerMetadataLocally(
-  config:
-    | {
-        serverType: "internal";
-        internalMCPServerId: MCPServerConfigurationType["internalMCPServerId"];
-      }
-    | {
-        serverType: "remote";
-        remoteMCPServer: RemoteMCPServerResource;
-      }
+  auth: Authenticator,
+  {
+    mcpServerId,
+    remoteMCPServer,
+  }: {
+    mcpServerId: string;
+    remoteMCPServer?: RemoteMCPServerResource;
+  }
 ): Promise<MCPServerMetadata> {
-  const { serverType } = config;
+  const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
   switch (serverType) {
     case "internal":
       // For internal servers, we can connect to the server directly as it's an in-memory communication in the same process.
-      const mcpClient = await connectToMCPServer({
-        serverType: config.serverType,
-        internalMCPServerId: config.internalMCPServerId,
-      });
+      const mcpClient = await connectToMCPServer({ mcpServerId });
 
       const r = mcpClient.getServerVersion();
       const tools = await mcpClient.listTools();
       await mcpClient.close();
 
       return {
+        id: mcpServerId,
         ...extractMetadataFromServerVersion(r),
         tools: extractMetadataFromTools(tools),
       };
 
     case "remote":
       // TODO(mcp): add a background job to update the metadata by calling updateRemoteMCPServerMetadata.
-      const { remoteMCPServer } = config;
+
+      let server: RemoteMCPServerResource | null = null;
+      if (!remoteMCPServer) {
+        server = await RemoteMCPServerResource.fetchById(auth, mcpServerId);
+      } else {
+        server = remoteMCPServer;
+      }
+
+      if (!server) {
+        throw new Error(
+          `Remote MCP server with remoteMCPServerId ${id} not found for remote server type.`
+        );
+      }
+      if (server.id !== id) {
+        throw new Error(
+          `Remote MCP server id do not match ${id} !== ${server.id}`
+        );
+      }
+
       return {
-        name: remoteMCPServer.name,
+        id: server.sId,
+        name: server.name,
         // TODO(mcp): add version on remoteMCPServer
         version: DEFAULT_MCP_ACTION_VERSION,
-        description:
-          remoteMCPServer.description ?? DEFAULT_MCP_ACTION_DESCRIPTION,
+        description: server.description ?? DEFAULT_MCP_ACTION_DESCRIPTION,
         // TODO(mcp): add icon on remoteMCPServer
         icon: DEFAULT_MCP_ACTION_ICON,
-        tools: remoteMCPServer.cachedTools,
+        tools: server.cachedTools,
       };
 
     default:
       assertNever(serverType);
   }
+}
+
+export async function getAllMCPServersMetadataLocally(
+  auth: Authenticator
+): Promise<MCPServerMetadata[]> {
+  const mcpServers = await Promise.all(
+    AVAILABLE_INTERNAL_MCPSERVER_NAMES.map(async (internalMCPServerName) => {
+      const mcpServerId = getInternalMCPServerSId(auth, {
+        internalMCPServerName,
+      });
+      const metadata = await getMCPServerMetadataLocally(auth, {
+        mcpServerId,
+      });
+      return metadata;
+    })
+  );
+
+  return mcpServers;
 }
 
 /**
@@ -400,11 +446,7 @@ export async function tryGetMCPTools(
   const configurations = await Promise.all(
     agentActions.filter(isMCPServerConfiguration).map(async (action) => {
       try {
-        const r: ToolType[] = await listMCPServerTools({
-          serverType: action.serverType,
-          internalMCPServerId: action.internalMCPServerId,
-          remoteMCPServerId: action.remoteMCPServerId,
-        });
+        const r: ToolType[] = await listMCPServerTools(action.mcpServerId);
 
         return makeMCPConfigurations({
           config: action,
@@ -428,9 +470,9 @@ export async function tryGetMCPTools(
 }
 
 export async function listMCPServerTools(
-  connectionDetails: MCPServerConnectionDetails
+  mcpServerId: string
 ): Promise<ToolType[]> {
-  const mcpClient = await connectToMCPServer(connectionDetails);
+  const mcpClient = await connectToMCPServer({ mcpServerId });
 
   let allTools: ToolType[] = [];
   let nextPageCursor;

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,0 +1,4 @@
+export const AVAILABLE_INTERNAL_MCPSERVER_NAMES = [
+  "helloworld",
+  "data-source-utils",
+] as const;

--- a/front/lib/actions/mcp_internal_actions/data_source_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/data_source_utils.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
 import { DataSourceConfigurationInputSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 
-const serverInfo: Omit<MCPServerMetadata, "tools"> = {
+const serverInfo: Omit<MCPServerMetadata, "tools" | "id"> = {
   name: "data-source-utils",
   version: "1.0.0",
   description:

--- a/front/lib/actions/mcp_internal_actions/helloworld.ts
+++ b/front/lib/actions/mcp_internal_actions/helloworld.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
 
-const serverInfo: Omit<MCPServerMetadata, "tools"> = {
+const serverInfo: Omit<MCPServerMetadata, "tools" | "id"> = {
   name: "hello-world-server",
   version: "1.0.0",
   description: "You are a helpful server that can say hello to the user.",

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -1,22 +1,85 @@
 import type { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import type { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
+import type { AVAILABLE_INTERNAL_MCPSERVER_NAMES } from "@app/lib/actions/mcp_internal_actions/constants";
 import { createServer as dataSourceUtilsServer } from "@app/lib/actions/mcp_internal_actions/data_source_utils";
 import { createServer as helloWorldServer } from "@app/lib/actions/mcp_internal_actions/helloworld";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getResourceNameAndIdFromSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
+import { assertNever } from "@app/types";
 
-export type InternalMCPServerId =
-  (typeof AVAILABLE_INTERNAL_MCPSERVER_IDS)[number];
+const INTERNAL_MCPSERVER_NAMES_TO_ID: Record<
+  InternalMCPServerNameType,
+  number
+> = {
+  helloworld: 1,
+  "data-source-utils": 2,
+} as const;
+
+export type InternalMCPServerNameType =
+  (typeof AVAILABLE_INTERNAL_MCPSERVER_NAMES)[number];
+
+export const getInternalMCPServerSId = (
+  auth: Authenticator,
+  {
+    internalMCPServerName,
+  }: { internalMCPServerName: InternalMCPServerNameType }
+): string =>
+  makeSId("internal_mcp_server", {
+    id: INTERNAL_MCPSERVER_NAMES_TO_ID[internalMCPServerName],
+    workspaceId: auth.getNonNullableWorkspace().id,
+  });
+
+export const getInternalMCPServerId = (
+  sId: string
+): InternalMCPServerNameType => {
+  const sIdParts = getResourceNameAndIdFromSId(sId);
+
+  if (!sIdParts) {
+    throw new Error(`Invalid internal MCPServer sId: ${sId}`);
+  }
+
+  if (sIdParts.resourceName !== "internal_mcp_server") {
+    throw new Error(`Invalid internal MCPServer sId: ${sId}`);
+  }
+
+  // Swap keys and values.
+  const details = Object.entries(INTERNAL_MCPSERVER_NAMES_TO_ID).find(
+    ([, id]) => id === sIdParts.resourceId
+  );
+
+  if (!details) {
+    throw new Error(`Invalid internal MCPServer sId: ${sId}`);
+  }
+
+  return details[0] as InternalMCPServerNameType;
+};
 
 export const connectToInternalMCPServer = async (
-  internalMCPServerId: InternalMCPServerId,
+  mcpServerId: string,
   transport: InMemoryTransport
 ): Promise<McpServer> => {
-  const server: McpServer = internalMCPServers[internalMCPServerId]();
+  let server: McpServer | undefined;
+
+  const internalMCPServerName = getInternalMCPServerId(mcpServerId);
+
+  switch (internalMCPServerName) {
+    case "helloworld":
+      server = helloWorldServer();
+      break;
+    case "data-source-utils":
+      server = dataSourceUtilsServer();
+      break;
+    default:
+      assertNever(internalMCPServerName);
+  }
 
   if (!server) {
     throw new Error(
-      `Internal MCPServer not found for id ${internalMCPServerId}`
+      `Internal MCPServer not found for id ${internalMCPServerName}`
     );
   }
 
@@ -24,9 +87,3 @@ export const connectToInternalMCPServer = async (
 
   return server;
 };
-
-export const internalMCPServers: Record<InternalMCPServerId, () => McpServer> =
-  {
-    helloworld: helloWorldServer,
-    "data-source-utils": dataSourceUtilsServer,
-  };

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -33,9 +33,7 @@ export const getInternalMCPServerSId = (
     workspaceId: auth.getNonNullableWorkspace().id,
   });
 
-export const getInternalMCPServerId = (
-  sId: string
-): InternalMCPServerNameType => {
+const getInternalMCPServerName = (sId: string): InternalMCPServerNameType => {
   const sIdParts = getResourceNameAndIdFromSId(sId);
 
   if (!sIdParts) {
@@ -64,7 +62,7 @@ export const connectToInternalMCPServer = async (
 ): Promise<McpServer> => {
   let server: McpServer | undefined;
 
-  const internalMCPServerName = getInternalMCPServerId(mcpServerId);
+  const internalMCPServerName = getInternalMCPServerName(mcpServerId);
 
   switch (internalMCPServerName) {
     case "helloworld":

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -1,8 +1,6 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
-import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { MCPToolResultContent } from "@app/lib/actions/mcp_actions";
 import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
@@ -22,10 +20,10 @@ export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPSer
 
   declare serverType: "internal" | "remote";
 
-  declare internalMCPServerId:
-    | MCPServerConfigurationType["internalMCPServerId"]
-    | null;
+  // SId of the internal MCP server.
+  declare internalMCPServerId: string | null;
 
+  // ModelId of the remote MCP server.
   declare remoteMCPServerId: ForeignKey<RemoteMCPServer["id"]> | null;
 }
 
@@ -55,9 +53,6 @@ AgentMCPServerConfiguration.init(
     internalMCPServerId: {
       type: DataTypes.STRING,
       allowNull: true,
-      validate: {
-        isIn: [AVAILABLE_INTERNAL_MCPSERVER_IDS],
-      },
     },
     remoteMCPServerId: {
       type: DataTypes.BIGINT,
@@ -136,10 +131,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare serverType: MCPServerConfigurationType["serverType"];
-  declare internalMCPServerId: MCPServerConfigurationType["internalMCPServerId"];
-  declare remoteMCPServerId: MCPServerConfigurationType["remoteMCPServerId"];
-  // TODO(mcp): With client actions, we will likely add a way to reference an object representing the client-side server.
+  declare mcpServerId: string;
   declare mcpServerConfigurationId: string;
 
   declare params: Record<string, unknown>;
@@ -171,6 +163,10 @@ AgentMCPAction.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    mcpServerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
     mcpServerConfigurationId: {
       type: DataTypes.STRING,

--- a/front/lib/models/assistant/actions/mcp_server_connection.ts
+++ b/front/lib/models/assistant/actions/mcp_server_connection.ts
@@ -1,8 +1,6 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
-import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { RemoteMCPServer } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -19,9 +17,7 @@ export class MCPServerConnection extends WorkspaceAwareModel<MCPServerConnection
 
   declare serverType: "internal" | "remote";
 
-  declare internalMCPServerId:
-    | MCPServerConfigurationType["internalMCPServerId"]
-    | null;
+  declare internalMCPServerId: string | null;
 
   declare remoteMCPServerId: ForeignKey<RemoteMCPServer["id"]> | null;
 
@@ -58,9 +54,6 @@ MCPServerConnection.init(
     internalMCPServerId: {
       type: DataTypes.STRING,
       allowNull: true,
-      validate: {
-        isIn: [AVAILABLE_INTERNAL_MCPSERVER_IDS],
-      },
     },
     remoteMCPServerId: {
       type: DataTypes.BIGINT,

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -8,7 +8,6 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
-import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerConnection } from "@app/lib/models/assistant/actions/mcp_server_connection";
@@ -142,14 +141,14 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       }
     | {
         auth: Authenticator;
-        internalMCPServerId: MCPServerConfigurationType["internalMCPServerId"];
+        internalMCPServerId: string;
         remoteMCPServerId: undefined;
       }): Promise<Result<MCPServerConnectionResource, DustError>> {
     const connections = await this.baseFetch(auth, {
       where: {
         ...(remoteMCPServerId
-          ? { remoteMCPServerId, serverType: "remote" }
-          : { internalMCPServerId, serverType: "internal" }),
+          ? { remoteMCPServerId }
+          : { internalMCPServerId }),
       },
     });
 

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -31,6 +31,7 @@ const RESOURCES_PREFIX = {
   extension: "ext",
   mcp_server_connection: "msc",
   remote_mcp_server: "rms",
+  internal_mcp_server: "ims",
 };
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;
@@ -109,9 +110,12 @@ export function isResourceSId(
   return sId.startsWith(`${RESOURCES_PREFIX[resourceName]}_`);
 }
 
-export function getResourceNameAndIdFromSId(
-  sId: string
-): { resourceName: ResourceNameType; sId: string } | null {
+export function getResourceNameAndIdFromSId(sId: string): {
+  resourceName: ResourceNameType;
+  sId: string;
+  workspaceId: ModelId;
+  resourceId: ModelId;
+} | null {
   const resourceName = (
     Object.keys(RESOURCES_PREFIX) as ResourceNameType[]
   ).find((name) => isResourceSId(name, sId));
@@ -126,7 +130,7 @@ export function getResourceNameAndIdFromSId(
     return null;
   }
 
-  return { resourceName, sId };
+  return { resourceName, sId, ...sIdRes.value };
 }
 
 // Legacy behavior.

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -7,7 +7,10 @@ import type {
   GetConnectionsResponseBody,
   PostConnectionResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/connections";
-import type { GetMCPServersResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/mcp";
+import type {
+  AllowedFilter,
+  GetMCPServersResponseBody,
+} from "@app/pages/api/w/[wId]/spaces/[spaceId]/mcp";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 import type { MCPApiResponse, MCPResponse } from "@app/types/mcp";
 
@@ -363,7 +366,7 @@ export function useMcpServers({
 }: {
   owner: LightWorkspaceType;
   space?: SpaceType;
-  filter: "internal" | "remote" | "all";
+  filter: AllowedFilter;
 }) {
   const configFetcher: Fetcher<GetMCPServersResponseBody> = fetcher;
 

--- a/front/migrations/db/migration_193.sql
+++ b/front/migrations/db/migration_193.sql
@@ -1,0 +1,12 @@
+-- Migration created on Mar 27, 2025
+ALTER TABLE "public"."agent_mcp_actions"
+ADD COLUMN "mcpServerId" VARCHAR(255);
+
+UPDATE "public"."agent_mcp_actions"
+SET
+    "mcpServerId" = 'missing-id';
+
+ALTER TABLE "public"."agent_mcp_actions"
+ALTER COLUMN "mcpServerId"
+SET
+    NOT NULL;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -485,9 +485,7 @@ export async function createOrUpgradeAgentConfiguration({
         auth,
         {
           type: "mcp_server_configuration",
-          serverType: action.serverType,
-          internalMCPServerId: action.internalMCPServerId,
-          remoteMCPServerId: action.remoteMCPServerId,
+          mcpServerId: action.mcpServerId,
           name: action.name,
           description: action.description ?? DEFAULT_MCP_ACTION_DESCRIPTION,
           dataSources: action.dataSources,

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -1,6 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { validateInternalMCPServerId } from "@app/lib/actions/mcp";
 import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
 import { getMCPServerMetadataLocally } from "@app/lib/actions/mcp_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -42,19 +41,8 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      if (!validateInternalMCPServerId(serverId)) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_mcp_server_id",
-            message: "Only internal MCP server ids are supported.",
-          },
-        });
-      }
-
-      const metadata = await getMCPServerMetadataLocally({
-        serverType: "internal",
-        internalMCPServerId: serverId,
+      const metadata = await getMCPServerMetadataLocally(auth, {
+        mcpServerId: serverId,
       });
 
       return res.status(200).json({ metadata });

--- a/front/pages/api/w/[wId]/mcp/connections/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/index.ts
@@ -3,39 +3,34 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { AVAILABLE_INTERNAL_MCPSERVER_IDS } from "@app/lib/actions/constants";
+import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { ioTsEnum } from "@app/types";
 
-export type AvailableInternalMcpServerId =
-  (typeof AVAILABLE_INTERNAL_MCPSERVER_IDS)[number];
+const PostConnectionBodySchema = t.type({
+  connectionId: t.string,
+  mcpServerId: t.string,
+});
+export type PostConnectionBodyType = t.TypeOf<typeof PostConnectionBodySchema>;
 
-export const PostConnectionBodySchema = t.union([
-  t.type({
-    connectionId: t.string,
-    internalMCPServerId: ioTsEnum<AvailableInternalMcpServerId>(
-      AVAILABLE_INTERNAL_MCPSERVER_IDS
-    ),
-    remoteMCPServerId: t.undefined,
-  }),
-  t.type({
-    connectionId: t.string,
-    remoteMCPServerId: t.number,
-    internalMCPServerId: t.undefined,
-  }),
-]);
+export type PostConnectionResponseBody = {
+  success: boolean;
+  connection: MCPServerConnectionType;
+};
+
+export type GetConnectionsResponseBody = {
+  connections: MCPServerConnectionType[];
+};
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
-      | { success: boolean; connection: MCPServerConnectionType }
-      | { connections: MCPServerConnectionType[] }
+      PostConnectionResponseBody | GetConnectionsResponseBody
     >
   >,
   auth: Authenticator
@@ -63,17 +58,18 @@ async function handler(
       }
 
       const validatedBody = bodyValidation.right;
-      const { connectionId, internalMCPServerId, remoteMCPServerId } =
-        validatedBody;
+      const { connectionId, mcpServerId } = validatedBody;
+
+      const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
 
       const connectionResource = await MCPServerConnectionResource.makeNew(
         auth,
         {
           connectionId,
           connectionType: "workspace",
-          serverType: internalMCPServerId ? "internal" : "remote",
-          internalMCPServerId,
-          remoteMCPServerId,
+          serverType,
+          internalMCPServerId: serverType === "internal" ? mcpServerId : null,
+          remoteMCPServerId: serverType === "remote" ? id : null,
         }
       );
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/index.ts
@@ -1,0 +1,86 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
+import { getAllMCPServersMetadataLocally } from "@app/lib/actions/mcp_actions";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QueryParamsSchema = t.type({
+  filter: t.union([
+    t.literal("internal"),
+    t.literal("remote"),
+    t.literal("all"),
+  ]),
+});
+
+export type GetMCPServersResponseBody = {
+  success: boolean;
+  mcpServers: MCPServerMetadata[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMCPServersResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  const { method } = req;
+  const r = QueryParamsSchema.decode(req.query);
+
+  if (!space.isSystem()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Only system spaces support listing MCP servers.",
+      },
+    });
+  }
+
+  if (isLeft(r)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters.",
+      },
+    });
+  }
+
+  switch (method) {
+    case "GET": {
+      switch (r.right.filter) {
+        case "internal":
+          {
+            const mcpServers = await getAllMCPServersMetadataLocally(auth);
+            return res.status(200).json({
+              success: true,
+              mcpServers,
+            });
+          }
+          break;
+        case "remote":
+          throw new Error("Not implemented");
+          break;
+        case "all":
+          const mcpServers = await getAllMCPServersMetadataLocally(auth);
+          return res.status(200).json({
+            success: true,
+            mcpServers,
+          });
+      }
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanAdministrate: true },
+  })
+);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/index.ts
@@ -11,13 +11,19 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
+const allowedFiltersSchema = t.union([
+  t.literal("internal"),
+  t.literal("remote"),
+  t.literal("all"),
+]);
+
+export type AllowedFilter = t.TypeOf<typeof allowedFiltersSchema>;
+
 const QueryParamsSchema = t.type({
-  filter: t.union([
-    t.literal("internal"),
-    t.literal("remote"),
-    t.literal("all"),
-  ]),
+  filter: allowedFiltersSchema,
 });
+
+export type GetMCPServersQueryParams = t.TypeOf<typeof QueryParamsSchema>;
 
 export type GetMCPServersResponseBody = {
   success: boolean;

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -132,14 +132,7 @@ const ReasoningActionConfigurationSchema = t.type({
 
 const MCPServerActionConfigurationSchema = t.type({
   type: t.literal("mcp_server_configuration"),
-  serverType: t.union([t.literal("internal"), t.literal("remote")]),
-  internalMCPServerId: t.union([
-    // TODO(mcp): find a correct way to reuse AVAILABLE_INTERNAL_MCPSERVER_IDS here.
-    t.literal("helloworld"),
-    t.literal("data-source-utils"),
-    t.null,
-  ]),
-  remoteMCPServerId: t.union([t.string, t.null]),
+  mcpServerId: t.string,
 
   dataSources: t.union([
     t.null,


### PR DESCRIPTION
## Description

Switch from using the triplet : serverType + internalServerId? (hardcoded names) and remoteServerId? (number because FK) to using sqids that hold the type and the resource id.
Database models still reference the triplet.

That way methods api are simplified and we can unify the endpoints, hiding the specificity of the serverType from the external interfaces.

There is some cleanup to do (endpoints, hooks) but I didn't want to touch too many files at once and we can do it at the end when every subparts is done.

## Tests

Tested locally : edit agent, run mcp action, list capabliities, connect and disconnect (auth)

## Risk

Low, behind FF.

## Deploy Plan

Must run the migration first and then deploy `front`