### PR TITLE
relocation: fix if there is 0 apps in source region

### DIFF
--- a/front/temporal/relocation/activities/source_region/core/apps.ts
+++ b/front/temporal/relocation/activities/source_region/core/apps.ts
@@ -24,7 +24,7 @@ export async function retrieveAppsCoreIdsBatch({
 }): Promise<{
   dustAPIProjectIds: string[];
   hasMore: boolean;
-  lastId: ModelId;
+  lastId: ModelId | undefined;
 }> {
   const localLogger = logger.child({
     lastId,
@@ -57,7 +57,7 @@ export async function retrieveAppsCoreIdsBatch({
   return {
     dustAPIProjectIds: apps.map((a) => a.dustAPIProjectId),
     hasMore: apps.length === BATCH_SIZE,
-    lastId: apps[apps.length - 1].id,
+    lastId: apps.length > 0 ? apps[apps.length - 1].id : undefined,
   };
 }
 


### PR DESCRIPTION
## Description

Fix for: https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZXedLESQKtbQAAAABhBWlhlZExxb0FBQ2JjWHZoNnVLcEtRQXoAAAAkMDE5NWRlNzQtZDBlNi00YmNiLTg2NWMtYzIwOTVkOWU1ZDNhAAAXlA&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1743179566786&to_ts=1743193966786&live=true

Code did not handle the case where there is 0 apps retrieved.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`