### PR TITLE
relocation: skip documents not found in SQL

### DIFF
--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -105,7 +105,7 @@ export async function getDataSourceDocuments({
 
     // Filter out the errors related to documents that are not found in SQL.
     const unknownFailures = failed.filter(
-      (r) => r.error.code !== "data_source_document_not_found"
+      (r) => r.isErr() && r.error.code !== "data_source_document_not_found"
     );
 
     // Explicitly fail if there are any other errors.

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -90,7 +90,7 @@ export async function getDataSourceDocuments({
   const documentBlobs = res
     .filter((r): r is Ok<CoreAPIDocumentBlob> => r.isOk())
     .map((r) => r.value);
-  let failed = res.filter((r) => r.isErr());
+  const failed = res.filter((r) => r.isErr());
   if (failed.length > 0) {
     localLogger.error(
       { count: failed.length, failed },
@@ -104,12 +104,12 @@ export async function getDataSourceDocuments({
     // relying on a procedure to upload fake blob in storage (see relocation runbook)
 
     // Filter out the errors related to documents that are not found in SQL.
-    failed = failed.filter(
+    const unknownFailures = failed.filter(
       (r) => r.error.code !== "data_source_document_not_found"
     );
 
     // Explicitly fail if there are any other errors.
-    if (failed.length > 0) {
+    if (unknownFailures.length > 0) {
       throw new Error("Failed to get data source document blobs");
     }
   }


### PR DESCRIPTION
## Description

If we land on documents that are not found in SQL in source region (ES/SQL discrepancy) we just ignore them since they were deleted.

Unblock current relocations

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `front`