### PR TITLE
Handle empty table title when relocating

### DIFF
--- a/front/temporal/relocation/activities/destination_region/core/tables.ts
+++ b/front/temporal/relocation/activities/destination_region/core/tables.ts
@@ -71,6 +71,8 @@ export async function processDataSourceTables({
         parents = [d.table_id];
       }
 
+      const title = d.title.trim() || d.name;
+
       // 1) Upsert the table.
       const upsertRes = await coreAPI.upsertTable({
         projectId: destIds.dustAPIProjectId,
@@ -84,7 +86,7 @@ export async function processDataSourceTables({
         parents,
         remoteDatabaseTableId: d.remote_database_table_id,
         remoteDatabaseSecretId: d.remote_database_secret_id,
-        title: d.title,
+        title,
         mimeType: d.mime_type,
         sourceUrl: sourceUrl ?? null,
       });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the relocation pipeline for tables, as some tables seems to have not been backfilled correctly, and have an empty title. This PR uses the same implementation as what's done in front:

https://github.com/dust-tt/dust/blob/3a0020c751238477238dd750d33c36cf8eb8349a/front/pages/api/v1/w/%5BwId%5D/spaces/%5BspaceId%5D/data_sources/%5BdsId%5D/tables/index.ts#L318-L321

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
