### PR TITLE
Backfill empty titles

### DIFF
--- a/core/src/search_stores/migrations/20250331_backfill_empty_titles.http
+++ b/core/src/search_stores/migrations/20250331_backfill_empty_titles.http
@@ -1,0 +1,14 @@
+POST core.data_sources_nodes/_update_by_query
+{
+  "query": {
+    "term": {
+      "title.keyword": {
+        "value": ""
+      }
+    }
+  },
+  "script": {
+    "source": "if (ctx._source.containsKey('title') && ctx._source.title == '') { ctx._source.title = 'Untitled document'; }",
+    "lang": "painless"
+  }
+}

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -45,7 +45,6 @@ import type {
   WithConnector,
   WorkspaceType,
 } from "@app/types";
-import { validateUrl } from "@app/types";
 import {
   assertNever,
   ConnectorsAPI,
@@ -58,6 +57,7 @@ import {
   isDataSourceNameValid,
   Ok,
   sectionFullText,
+  validateUrl,
 } from "@app/types";
 
 export async function getDataSources(
@@ -634,7 +634,6 @@ export async function upsertTable({
     });
   }
 
-  const titleEmpty = params.title.trim().length === 0;
   // Enforce a max size on the title: since these will be synced in ES we don't support arbitrarily large titles.
   if (params.title && params.title.length > MAX_NODE_TITLE_LENGTH) {
     return new Err({
@@ -683,7 +682,7 @@ export async function upsertTable({
     standardizedSourceUrl = standardized;
   }
 
-  const title = titleEmpty ? UNTITLED_TITLE : params.title;
+  const title = params.title.trim() || name.trim() || UNTITLED_TITLE;
 
   if (async) {
     if (fileId) {

--- a/front/migrations/20250331_backfill_empty_nodes_titles.ts
+++ b/front/migrations/20250331_backfill_empty_nodes_titles.ts
@@ -1,0 +1,67 @@
+import { QueryTypes } from "sequelize";
+
+import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 1024;
+
+async function migrateNodes({
+  execute,
+  logger,
+}: {
+  execute: boolean;
+  logger: typeof Logger;
+}) {
+  const coreSequelize = getCorePrimaryDbConnection();
+  let nextId = 0;
+  let nodes: { id: number }[];
+
+  do {
+    nodes = (await coreSequelize.query(
+      `SELECT id, title
+       FROM data_sources_nodes
+       WHERE id > :nextId
+         AND TRIM(title) = ''
+       ORDER BY id
+       LIMIT :batchSize`,
+      {
+        replacements: { nextId, batchSize: BATCH_SIZE },
+        type: QueryTypes.SELECT,
+      }
+    )) as { id: number }[];
+
+    if (nodes.length === 0) {
+      break;
+    }
+
+    logger.info(
+      `Processing ${nodes.length} nodes, ids ranging from ${nodes[0].id} to ${nodes[nodes.length - 1].id}`
+    );
+
+    if (execute) {
+      await coreSequelize.query(
+        `UPDATE data_sources_nodes dsn
+         SET title = :fallbackName
+         FROM (
+                SELECT UNNEST(ARRAY [:ids]::bigint[]) AS id
+              ) ids
+         WHERE dsn.id = ids.id`,
+        {
+          replacements: {
+            ids: nodes.map((n) => n.id),
+            fallbackName: UNTITLED_TITLE,
+          },
+          type: QueryTypes.UPDATE,
+        }
+      );
+    }
+
+    nextId = nodes[nodes.length - 1].id;
+  } while (nodes.length === BATCH_SIZE);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  await migrateNodes({ execute, logger });
+});

--- a/front/migrations/20250331_backfill_empty_nodes_titles.ts
+++ b/front/migrations/20250331_backfill_empty_nodes_titles.ts
@@ -19,7 +19,7 @@ async function migrateNodes({
   let nodes: { id: number }[];
 
   do {
-    nodes = (await coreSequelize.query(
+    nodes = await coreSequelize.query<{ id: number }>(
       `SELECT id, title
        FROM data_sources_nodes
        WHERE id > :nextId
@@ -30,7 +30,7 @@ async function migrateNodes({
         replacements: { nextId, batchSize: BATCH_SIZE },
         type: QueryTypes.SELECT,
       }
-    )) as { id: number }[];
+    );
 
     if (nodes.length === 0) {
       break;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -382,19 +382,6 @@ async function handler(
         });
       }
 
-      // TODO(content-node): get rid of this once the use of timestamp columns in core has been rationalized
-      if (!auth.isSystemKey() && r.data.timestamp) {
-        logger.info(
-          {
-            workspaceId: owner.id,
-            dataSourceId: dataSource.sId,
-            timestamp: r.data.timestamp,
-            currentDate: Date.now(),
-          },
-          "[ContentNode] User-set timestamp."
-        );
-      }
-
       let sourceUrl: string | null = null;
       if (r.data.source_url) {
         const { valid: isSourceUrlValid, standardized: standardizedSourceUrl } =

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -8,6 +8,7 @@ import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -319,7 +320,8 @@ async function handler(
         ?.find((t) => t.startsWith("title:"))
         ?.substring(6)
         ?.trim();
-      const title = r.data.title?.trim() || titleInTags || name;
+      const title =
+        r.data.title?.trim() || titleInTags || name.trim() || UNTITLED_TITLE;
 
       const tableId = maybeTableId || generateRandomModelSId();
 

--- a/front/temporal/relocation/activities/destination_region/core/tables.ts
+++ b/front/temporal/relocation/activities/destination_region/core/tables.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -58,7 +59,7 @@ export async function processDataSourceTables({
       // There are some issues with the parents field.
       // parents[0] should be the table_id, but it's not always the case.
       // If we change the parents[0] to the table_id, then parents[1] should be the parent_id.
-      let parents: string[] = [];
+      let parents: string[];
       let parentId: string | null = d.parent_id ?? null;
       if (d.parents.length > 0) {
         if (d.parents[0] !== d.table_id) {
@@ -71,7 +72,7 @@ export async function processDataSourceTables({
         parents = [d.table_id];
       }
 
-      const title = d.title.trim() || d.name;
+      const title = d.title.trim() || d.name.trim() || UNTITLED_TITLE;
 
       // 1) Upsert the table.
       const upsertRes = await coreAPI.upsertTable({


### PR DESCRIPTION
## Description

- Nonempty titles are enforced in core on upserts, which has caused the relocation to fail before special handling was added to circumvent it.
- This PR adds backfill scripts to backfill the DB and the ES index (already run on the index [here](https://dust4ai.slack.com/archives/C08GJ7PTW3E/p1742289112951439), adding the script to this PR for bookkeeping).
- This PR also uniformizes the handling of titles for tables by adding `UNTITLED_TITLE` as a fallback is the name is empty.
- Some work is planned to check whether we can share the code paths between `api/v1` and `lib/api/data_sources`.


## Tests

- Tested locally.

## Risk

- A bit touchy but the dry run will tell.

## Deploy Plan

- Run `front/migrations/20250331_backfill_empty_nodes_titles.ts`.
- Deploy front.