### PR TITLE
enh(Confluence) - redirect requests to Confluence API through a proxy

### DIFF
--- a/connectors/migrations/20250331_switch_use_proxy_confluence.ts
+++ b/connectors/migrations/20250331_switch_use_proxy_confluence.ts
@@ -18,7 +18,7 @@ makeScript(
 
     if (execute) {
       for (const connector of connectors) {
-        await connector.update({ useProxy: value });
+        await connector.setUseProxy(value);
       }
       logger.info(
         `Set useProxy to ${value} for ${connectors.length} ${provider} connectors`

--- a/connectors/migrations/20250331_switch_use_proxy_confluence.ts
+++ b/connectors/migrations/20250331_switch_use_proxy_confluence.ts
@@ -1,0 +1,32 @@
+import { isConnectorProvider } from "@dust-tt/client";
+import { makeScript } from "scripts/helpers";
+
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+makeScript(
+  {
+    provider: { type: "string", required: true },
+    value: { type: "boolean", required: true },
+  },
+  async ({ execute, provider, value }, logger) => {
+    if (!isConnectorProvider(provider) || provider === "salesforce") {
+      logger.error(`Invalid provider: ${provider}`);
+      return;
+    }
+
+    const connectors = await ConnectorResource.listByType(provider, {});
+
+    if (execute) {
+      for (const connector of connectors) {
+        await connector.update({ useProxy: value });
+      }
+      logger.info(
+        `Set useProxy to ${value} for ${connectors.length} ${provider} connectors`
+      );
+    } else {
+      logger.info(
+        `Would set useProxy to ${value} for ${connectors.length} ${provider} connectors`
+      );
+    }
+  }
+);

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -78,6 +78,7 @@ export async function listConfluenceSpaces(
 
   const client = new ConfluenceClient(confluenceAccessTokenRes.value, {
     cloudId: config?.cloudId,
+    useProxy: connector.useProxy ?? false,
   });
 
   const allSpaces = new Map<string, ConfluenceSpaceType>();

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -409,6 +409,7 @@ export class ConfluenceClient {
           body: JSON.stringify(data),
           // Timeout after 30 seconds.
           signal: AbortSignal.timeout(30000),
+          ...(this.proxyAgent ? { agent: this.proxyAgent } : {}),
         });
       } catch (e) {
         statsDClient.increment("external.api.calls", 1, [

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -1,11 +1,12 @@
 import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
 
+import { ProxyAgent } from "undici";
 import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
-import { ConfluenceClientError } from "@connectors/types";
+import { ConfluenceClientError, EnvironmentConfig } from "@connectors/types";
 
 const CatchAllCodec = t.record(t.string, t.unknown); // Catch-all for unknown properties.
 
@@ -228,13 +229,21 @@ export class ConfluenceClient {
   private readonly apiUrl = "https://api.atlassian.com";
   private readonly restApiBaseUrl: string;
   private readonly legacyRestApiBaseUrl: string;
+  private readonly useProxy: boolean;
 
   constructor(
     private readonly authToken: string,
-    { cloudId }: { cloudId?: string } = {}
+    {
+      cloudId,
+      useProxy = false,
+    }: {
+      cloudId?: string;
+      useProxy?: boolean;
+    } = {}
   ) {
     this.restApiBaseUrl = `/ex/confluence/${cloudId}/wiki/api/v2`;
     this.legacyRestApiBaseUrl = `/ex/confluence/${cloudId}/wiki/rest/api`;
+    this.useProxy = useProxy;
   }
 
   private async request<T>(

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -44,8 +44,7 @@ import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
 import {
   ConfluenceClientError,
   INTERNAL_MIME_TYPES,
@@ -121,7 +120,10 @@ export async function getConfluenceClient(
     effectiveConnector.connectionId
   );
 
-  return new ConfluenceClient(accessToken, { cloudId });
+  return new ConfluenceClient(accessToken, {
+    cloudId,
+    useProxy: effectiveConnector.useProxy ?? false,
+  });
 }
 
 export async function getSpaceIdsToSyncActivity(connectorId: ModelId) {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -40,8 +40,8 @@ import type {
   ConnectorPermission,
   ContentNode,
   ContentNodesViewType,
+  DataSourceConfig,
 } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const logger = mainLogger.child({ provider: "github" });
@@ -527,9 +527,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
 
       case "useProxy": {
-        await connector.update({
-          useProxy: configValue === "true",
-        });
+        await connector.setUseProxy(configValue === "true");
         return new Ok(void 0);
       }
 

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -20,8 +20,7 @@ import { getConnectorProviderStrategy } from "@connectors/resources/connector/st
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
-import type { ConnectorType } from "@connectors/types";
-import type { ModelId } from "@connectors/types";
+import type { ConnectorType, ModelId } from "@connectors/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -248,5 +247,9 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
       pausedAt: this.pausedAt?.getTime(),
       updatedAt: this.updatedAt.getTime(),
     };
+  }
+
+  async setUseProxy(useProxy: boolean) {
+    await this.update({ useProxy });
   }
 }


### PR DESCRIPTION
## Description

- This PR adds a script that turns on (or off) the `useProxy` column for all Confluence connectors.
- This PR updates the `ConfluenceClient` to rely on the proxy we already have whenever `useProxy` is enabled.

## Tests

- N/A.

## Risk

- Could momentarily crash Confluence connectors, easily rollbackable (by setting rerunning the script to set `useProxy` to false).

## Deploy Plan

- Deploy connectors.
- Run the script to switch on `useProxy` for all Confluence connectors.
- Monitor rate limits on the dd dashboard.