### PR TITLE
[Conversations sort] Fix: broken sort

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -290,7 +290,7 @@ export async function getUserConversations(
       ({
         id: c.id,
         created: c.createdAt.getTime(),
-        updated: conversationUpdated(c),
+        updated: conversationUpdated(c) ?? c.updatedAt.getTime(),
         sId: c.sId,
         owner,
         title: c.title,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -265,6 +265,18 @@ export async function getUserConversations(
     includedConversationVisibilities.push("test");
   }
 
+  const participationsByConversationId = _.groupBy(
+    participations,
+    "conversationId"
+  );
+  const conversationUpdated = (c: Conversation) => {
+    const participations = participationsByConversationId[c.id];
+    if (!participations) {
+      return undefined;
+    }
+    return _.sortBy(participations, "updatedAt", "desc")[0].updatedAt.getTime();
+  };
+
   const conversations = (
     await Conversation.findAll({
       where: {
@@ -278,7 +290,7 @@ export async function getUserConversations(
       ({
         id: c.id,
         created: c.createdAt.getTime(),
-        updated: c.updatedAt.getTime(),
+        updated: conversationUpdated(c),
         sId: c.sId,
         owner,
         title: c.title,


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2441

Description
---
Fix regression introduced in https://github.com/dust-tt/dust/pull/10880 sorting conversations by convo.updatedAt rather than participant.updatedAt. See related issue: sorting by participant.updatedAt allows for better sorting.

Risks
---
standard

Deploy
---
front
