### PR TITLE
[sparkle] - fix(AttachmentChip): paths

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.447",
+  "version": "0.2.448",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.447",
+      "version": "0.2.448",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.447",
+  "version": "0.2.448",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/rollup.config.mjs
+++ b/sparkle/rollup.config.mjs
@@ -10,7 +10,7 @@ import external from "rollup-plugin-peer-deps-external";
 import postcss from "rollup-plugin-postcss";
 import tailwindcss from "tailwindcss";
 import { fileURLToPath } from "url";
-import terser from '@rollup/plugin-terser';
+import terser from "@rollup/plugin-terser";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -60,17 +60,17 @@ const config = {
       compress: {
         passes: 2,
         drop_console: true,
-        keep_fnames: false
+        keep_fnames: false,
       },
       format: {
         comments: false,
-        preserve_annotations: false
+        preserve_annotations: false,
       },
       mangle: {
-        properties: false
+        properties: false,
       },
-      sourceMap: false
-    })
+      sourceMap: false,
+    }),
   ],
 };
 

--- a/sparkle/src/components/AttachmentChip.tsx
+++ b/sparkle/src/components/AttachmentChip.tsx
@@ -6,7 +6,7 @@ import { Icon } from "./Icon";
 
 interface AttachmentChipProps {
   label: string;
-  icon: React.ComponentType;
+  icon?: React.ComponentType;
   className?: string;
 }
 
@@ -22,7 +22,7 @@ export function AttachmentChip({
         "s-border-border s-bg-background",
         "dark:s-border-border-night dark:s-bg-background-night",
         "s-text-foreground dark:s-text-foreground-night",
-        "s-max-w-[180px]",
+        "s-max-w-44",
         className
       )}
     >

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -78,6 +78,7 @@ export {
   DropdownMenuTrigger,
 } from "./Dropdown";
 export { default as DropzoneOverlay } from "./DropzoneOverlay";
+export { AttachmentChip } from "./AttachmentChip";
 export type { EmojiMartData } from "./EmojiPicker";
 export { DataEmojiMart, EmojiPicker } from "./EmojiPicker";
 export { EmptyCTA, EmptyCTAButton } from "./EmptyCTA";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -5,6 +5,7 @@ export {
   AssistantCardMore,
   LargeAssistantCard,
 } from "./AssistantCard";
+export { AttachmentChip } from "./AttachmentChip";
 export { Avatar } from "./Avatar";
 export { BarHeader } from "./BarHeader";
 export { Breadcrumbs } from "./Breadcrumbs";
@@ -78,7 +79,6 @@ export {
   DropdownMenuTrigger,
 } from "./Dropdown";
 export { default as DropzoneOverlay } from "./DropzoneOverlay";
-export { AttachmentChip } from "./AttachmentChip";
 export type { EmojiMartData } from "./EmojiPicker";
 export { DataEmojiMart, EmojiPicker } from "./EmojiPicker";
 export { EmptyCTA, EmptyCTAButton } from "./EmptyCTA";

--- a/sparkle/src/stories/AttachmentChip.stories.tsx
+++ b/sparkle/src/stories/AttachmentChip.stories.tsx
@@ -3,8 +3,7 @@ import React from "react";
 
 import { DocumentIcon, DocumentTextIcon } from "@sparkle/icons";
 import { NotionLogo } from "@sparkle/logo";
-
-import { AttachmentChip } from "./AttachmentChip";
+import { AttachmentChip } from "@sparkle/components";
 
 const meta = {
   title: "Components/AttachmentChip",

--- a/sparkle/src/stories/AttachmentChip.stories.tsx
+++ b/sparkle/src/stories/AttachmentChip.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
+import { AttachmentChip } from "@sparkle/components";
 import { DocumentIcon, DocumentTextIcon } from "@sparkle/icons";
 import { NotionLogo } from "@sparkle/logo";
-import { AttachmentChip } from "@sparkle/components";
 
 const meta = {
   title: "Components/AttachmentChip",


### PR DESCRIPTION
## Description

Makes the AttachmentChip component more flexible by making the icon prop optional and adjusting its max width using the Tailwind utility class. The component is now also properly exported from the main index file 

## Risk

Low

## Deploy Plan

Publish sparkle