### PR TITLE
[front] UI skeleton for MCP servers/actions

### DIFF
--- a/front/components/actions/mcp/ActionDetails.tsx
+++ b/front/components/actions/mcp/ActionDetails.tsx
@@ -1,0 +1,43 @@
+import {
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+
+import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
+import type { WorkspaceType } from "@app/types";
+
+type ActionDetailsProps = {
+  owner: WorkspaceType;
+  onClose: () => void;
+  mcpServer: MCPServerMetadata | null;
+};
+
+export function ActionDetails({
+  mcpServer,
+  onClose,
+  owner,
+}: ActionDetailsProps) {
+  return (
+    <Sheet open={!!mcpServer} onOpenChange={onClose}>
+      <SheetContent size="lg">
+        <SheetHeader className="flex flex-col gap-5 pb-0 text-sm text-foreground dark:text-foreground-night">
+          <VisuallyHidden>
+            <SheetTitle />
+          </VisuallyHidden>
+        </SheetHeader>
+        <SheetContainer className="flex flex-col gap-5 pt-6 text-sm text-foreground dark:text-foreground-night">
+          {mcpServer?.name}
+          {mcpServer?.tools.map((tool) => (
+            <div key={tool.name}>
+              {tool.name} {tool.description}
+            </div>
+          ))}
+        </SheetContainer>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/actions/mcp/ActionDetails.tsx
+++ b/front/components/actions/mcp/ActionDetails.tsx
@@ -16,10 +16,9 @@ type ActionDetailsProps = {
   mcpServer: MCPServerMetadata | null;
 };
 
-export function ActionDetails({
+export function InternalMCPServerDetails({
   mcpServer,
   onClose,
-  owner,
 }: ActionDetailsProps) {
   return (
     <Sheet open={!!mcpServer} onOpenChange={onClose}>

--- a/front/components/actions/mcp/ActionsList.tsx
+++ b/front/components/actions/mcp/ActionsList.tsx
@@ -4,9 +4,7 @@ import {
   Button,
   classNames,
   Cog6ToothIcon,
-  CommandLineIcon,
   DataTable,
-  Icon,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
@@ -30,7 +28,13 @@ type RowData = {
   actions: MenuItem[];
 };
 
-export const ActionsList = ({ owner }: { owner: LightWorkspaceType }) => {
+export const ActionsList = ({
+  owner,
+  setShowDetails,
+}: {
+  owner: LightWorkspaceType;
+  setShowDetails: (mcpServer: MCPServerMetadata) => void;
+}) => {
   const { spaces } = useSpacesAsAdmin({
     workspaceId: owner.sId,
     disabled: false,
@@ -191,7 +195,9 @@ export const ActionsList = ({ owner }: { owner: LightWorkspaceType }) => {
   const rows: RowData[] = mcpServers.map((mcpServer) => ({
     mcpServer,
     spaces: [],
-    onClick: () => {},
+    onClick: () => {
+      setShowDetails(mcpServer);
+    },
     moreActions: [
       {
         label: "Delete",

--- a/front/components/actions/mcp/ActionsList.tsx
+++ b/front/components/actions/mcp/ActionsList.tsx
@@ -28,13 +28,15 @@ type RowData = {
   actions: MenuItem[];
 };
 
-export const ActionsList = ({
-  owner,
-  setShowDetails,
-}: {
+type AdminActionsListProps = {
   owner: LightWorkspaceType;
   setShowDetails: (mcpServer: MCPServerMetadata) => void;
-}) => {
+};
+
+export const AdminActionsList = ({
+  owner,
+  setShowDetails,
+}: AdminActionsListProps) => {
   const { spaces } = useSpacesAsAdmin({
     workspaceId: owner.sId,
     disabled: false,

--- a/front/components/actions/mcp/ActionsList.tsx
+++ b/front/components/actions/mcp/ActionsList.tsx
@@ -1,3 +1,4 @@
+import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Avatar,
   Button,
@@ -5,32 +6,28 @@ import {
   Cog6ToothIcon,
   CommandLineIcon,
   DataTable,
-  RocketIcon,
+  Icon,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import React from "react";
 
+import { AddActionMenu } from "@app/components/actions/mcp/AddActionMenu";
 import { useMCPConnectionManagement } from "@app/hooks/useMCPConnectionManagement";
-import type {
-  AllowedIconType,
-  MCPServerMetadata,
-} from "@app/lib/actions/mcp_actions";
+import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
+import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
 import {
   useMCPServerConnections,
-  useMcpServers,
+  useMCPServerViews,
 } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
-import type { LightWorkspaceType } from "@app/types";
-
-const MCP_SERVER_ICONS: Record<AllowedIconType, React.ElementType> = {
-  command: CommandLineIcon,
-  rocket: RocketIcon,
-} as const;
+import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 type RowData = {
   mcpServer: MCPServerMetadata;
+  spaces: SpaceType[];
   onClick: () => void;
+  actions: MenuItem[];
 };
 
 export const ActionsList = ({ owner }: { owner: LightWorkspaceType }) => {
@@ -38,110 +35,212 @@ export const ActionsList = ({ owner }: { owner: LightWorkspaceType }) => {
     workspaceId: owner.sId,
     disabled: false,
   });
+  const systemSpace = (spaces ?? []).find((space) => space.kind === "system");
+  const availableSpaces = (spaces ?? []).filter((s) => s.kind !== "system");
   const { connections, isConnectionsLoading } = useMCPServerConnections({
     owner,
   });
-  const { mcpServers, isMCPServersLoading } = useMcpServers({
+  const { mcpServers, isMCPServersLoading } = useMCPServerViews({
     owner,
-    space: (spaces ?? []).find((space) => space.kind === "system"),
+    space: systemSpace,
     filter: "all",
   });
 
   const { createAndSaveMCPServerConnection, deleteMCPServerConnection } =
     useMCPConnectionManagement({ owner });
 
-  const getTableColumns = (): ColumnDef<RowData, MCPServerMetadata>[] => {
-    return [
-      {
-        id: "name",
-        cell: (info: CellContext<RowData, MCPServerMetadata>) => (
-          <DataTable.CellContent>
-            <div
-              className={classNames("flex flex-row items-center gap-2 py-3")}
-            >
-              <div>
-                <Avatar
-                  visual={React.createElement(
-                    MCP_SERVER_ICONS[info.getValue().icon || "Rocket"]
-                  )}
-                />
+  const getTableColumns = (): ColumnDef<RowData>[] => {
+    const columns: ColumnDef<RowData, any>[] = [];
+
+    columns.push({
+      id: "name",
+      header: "Name",
+      sortingFn: (a, b) =>
+        a.original.mcpServer.name.localeCompare(b.original.mcpServer.name),
+      cell: (info: CellContext<RowData, MCPServerMetadata>) => (
+        <DataTable.CellContent>
+          <div className={classNames("flex flex-row items-center gap-2 py-3")}>
+            <div>
+              <Avatar
+                visual={React.createElement(
+                  MCP_SERVER_ICONS[info.getValue().icon || "Rocket"]
+                )}
+              />
+            </div>
+            <div className="flex min-w-0 grow flex-col">
+              <div className="overflow-hidden truncate text-sm font-semibold text-foreground dark:text-foreground-night">
+                {info.getValue().name}
               </div>
-              <div className="flex min-w-0 grow flex-col">
-                <div className="overflow-hidden truncate text-sm font-semibold text-foreground dark:text-foreground-night">
-                  {info.getValue().name}
-                </div>
-                <div className="overflow-hidden truncate text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  {info.getValue().description}
-                </div>
+              <div className="overflow-hidden truncate text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {info.getValue().description}
               </div>
             </div>
+          </div>
+        </DataTable.CellContent>
+      ),
+      accessorKey: "mcpServer",
+    });
+
+    columns.push({
+      id: "spaces",
+      accessorKey: "spaces",
+      meta: {
+        className: "w-48",
+      },
+      header: () => {
+        return (
+          <div className="flex w-full justify-end">
+            <p>Available to</p>
+          </div>
+        );
+      },
+      cell: (info: CellContext<RowData, SpaceType[]>) => (
+        <DataTable.BasicCellContent
+          className="justify-end"
+          label={
+            info.getValue().length > 0
+              ? info
+                  .getValue()
+                  .map((v) => v.name)
+                  .join(", ")
+              : "-"
+          }
+          tooltip={
+            info.getValue().length > 0
+              ? info
+                  .getValue()
+                  .map((v) => v.name)
+                  .join(", ")
+              : "-"
+          }
+        />
+      ),
+    });
+
+    columns.push({
+      id: "connection",
+      header: "",
+      enableSorting: false,
+      cell: (info: CellContext<RowData, MCPServerMetadata>) => {
+        const { id, authorization } = info.getValue();
+        const connection = connections.find(
+          (c) => c.internalMCPServerId === id
+        );
+
+        if (!authorization) {
+          return null;
+        }
+
+        return connection ? (
+          <DataTable.CellContent>
+            <Button
+              variant="warning"
+              disabled={isConnectionsLoading}
+              icon={Cog6ToothIcon}
+              label={"Disconnect"}
+              size="xs"
+              onClick={() => {
+                void deleteMCPServerConnection({
+                  connectionId: connection.sId,
+                });
+              }}
+            />
+          </DataTable.CellContent>
+        ) : (
+          <DataTable.CellContent>
+            <Button
+              variant="outline"
+              disabled={isConnectionsLoading}
+              icon={Cog6ToothIcon}
+              label={"Connect"}
+              size="xs"
+              onClick={() => {
+                void createAndSaveMCPServerConnection({
+                  authorizationInfo: authorization,
+                  mcpServerId: id,
+                });
+              }}
+            />
+          </DataTable.CellContent>
+        );
+      },
+      accessorKey: "mcpServer",
+      meta: {
+        className: "w-36",
+      },
+    });
+
+    columns.push({
+      id: "actions",
+      accessorKey: "actions",
+      header: "",
+      enableSorting: false,
+      meta: {
+        className: "w-12",
+      },
+      cell: (info: CellContext<RowData, MenuItem[]>) =>
+        info.getValue() && (
+          <DataTable.CellContent>
+            <DataTable.MoreButton menuItems={info.getValue()} />
           </DataTable.CellContent>
         ),
-        accessorKey: "mcpServer",
-      },
-      {
-        id: "action",
-        cell: (info: CellContext<RowData, MCPServerMetadata>) => {
-          const { id, authorization } = info.getValue();
-          const connection = connections.find(
-            (c) => c.internalMCPServerId === id
-          );
+    });
 
-          if (!authorization) {
-            return null;
-          }
-
-          return connection ? (
-            <DataTable.CellContent>
-              <Button
-                variant="warning"
-                disabled={isConnectionsLoading}
-                icon={Cog6ToothIcon}
-                label={"Disconnect"}
-                size="xs"
-                onClick={() => {
-                  void deleteMCPServerConnection({
-                    connectionId: connection.sId,
-                  });
-                }}
-              />
-            </DataTable.CellContent>
-          ) : (
-            <DataTable.CellContent>
-              <Button
-                variant="outline"
-                disabled={isConnectionsLoading}
-                icon={Cog6ToothIcon}
-                label={"Connect"}
-                size="xs"
-                onClick={() => {
-                  void createAndSaveMCPServerConnection({
-                    authorizationInfo: authorization,
-                    mcpServerId: id,
-                  });
-                }}
-              />
-            </DataTable.CellContent>
-          );
-        },
-        accessorKey: "mcpServer",
-        meta: {
-          className: "w-36",
-        },
-      },
-    ];
+    return columns;
   };
   const rows: RowData[] = mcpServers.map((mcpServer) => ({
     mcpServer,
+    spaces: [],
     onClick: () => {},
+    moreActions: [
+      {
+        label: "Delete",
+        onClick: () => {},
+      },
+    ],
+    actions: [
+      {
+        disabled: availableSpaces.length === 0,
+        kind: "submenu",
+        label: "Add to space",
+        items: availableSpaces.map((s) => ({
+          id: s.sId,
+          name: s.name,
+        })),
+        onSelect: (spaceId) => {
+          console.log(spaceId);
+        },
+      },
+      {
+        disabled: availableSpaces.length === 0,
+        kind: "item",
+        label: "Disable",
+        onSelect: () => {
+          console.log("disable");
+        },
+      },
+    ],
   }));
   const columns = getTableColumns();
 
-  return isConnectionsLoading || isMCPServersLoading ? (
-    <div className="mt-16 flex justify-center">
-      <Spinner />
+  return (
+    <div>
+      <div className="mb-4 flex h-9 w-full items-center justify-between gap-2">
+        <div />
+        <AddActionMenu
+          owner={owner}
+          enabledMCPServers={mcpServers.map((mcpServer) => mcpServer.id)}
+        />
+      </div>
+
+      <div className="flex justify-end"></div>
+      {isConnectionsLoading || isMCPServersLoading ? (
+        <div className="mt-16 flex justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        <DataTable data={rows} columns={columns} className="pb-4" />
+      )}
     </div>
-  ) : (
-    <DataTable data={rows} columns={columns} className="pb-4" />
   );
 };

--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -1,0 +1,66 @@
+import {
+  Button,
+  CloudArrowLeftRightIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  PlusIcon,
+} from "@dust-tt/sparkle";
+
+import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import { useMCPServers } from "@app/lib/swr/mcp_servers";
+import type { ConnectorProvider, WorkspaceType } from "@app/types";
+
+export type DataSourceIntegration = {
+  connectorProvider: ConnectorProvider;
+  setupWithSuffix: string | null;
+};
+
+type AddActionMenuProps = {
+  owner: WorkspaceType;
+  enabledMCPServers: string[];
+};
+
+export const AddActionMenu = ({
+  owner,
+  enabledMCPServers,
+}: AddActionMenuProps) => {
+  const { mcpServers } = useMCPServers({
+    owner,
+    filter: "internal",
+  });
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          label="Add action"
+          variant="primary"
+          icon={PlusIcon}
+          size="sm"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel label="Default actions" />
+
+        {mcpServers
+          .filter((i) => !enabledMCPServers.includes(i.id))
+          .map((i) => (
+            <DropdownMenuItem
+              key={i.id}
+              label={i.name}
+              icon={MCP_SERVER_ICONS[i.icon || "Rocket"]}
+              onClick={() => {}}
+            />
+          ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          icon={CloudArrowLeftRightIcon}
+          label="Add Remote MCP Server"
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -16,7 +16,7 @@ import type {
 } from "@app/components/assistant_builder/types";
 import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
 import { serverRequiresInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import { useMcpServers } from "@app/lib/swr/mcp_servers";
+import { useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import type {
   DataSourceViewSelectionConfigurations,
@@ -48,7 +48,7 @@ export function ActionMCP({
     workspaceId: owner.sId,
     disabled: false,
   });
-  const { mcpServers } = useMcpServers({
+  const { mcpServers } = useMCPServerViews({
     owner,
     space: (spaces ?? []).find((space) => space.kind === "system"),
     filter: "all",

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -1,0 +1,8 @@
+import { CommandLineIcon, RocketIcon } from "@dust-tt/sparkle";
+
+import type { AllowedIconType } from "@app/lib/actions/mcp_actions";
+
+export const MCP_SERVER_ICONS: Record<AllowedIconType, React.ComponentType> = {
+  command: CommandLineIcon,
+  rocket: RocketIcon,
+} as const;

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -359,7 +359,30 @@ export function useDeleteMCPServerConnection({
   return { deleteMCPServerConnection };
 }
 
-export function useMcpServers({
+export function useMCPServers({
+  owner,
+  filter,
+}: {
+  owner: LightWorkspaceType;
+  filter: AllowedFilter;
+}) {
+  const configFetcher: Fetcher<GetMCPServersResponseBody> = fetcher;
+
+  const url = `/api/w/${owner.sId}/mcp?filter=${filter}`;
+
+  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher);
+
+  const mcpServers = useMemo(() => (data ? data.mcpServers : []), [data]);
+
+  return {
+    mcpServers,
+    isMCPServersLoading: !error && !data,
+    isError: error,
+    mutate,
+  };
+}
+
+export function useMCPServerViews({
   owner,
   space,
   filter,

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -5,9 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
 import { getAllMCPServersMetadataLocally } from "@app/lib/actions/mcp_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -33,21 +31,10 @@ export type GetMCPServersResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetMCPServersResponseBody>>,
-  auth: Authenticator,
-  { space }: { space: SpaceResource }
+  auth: Authenticator
 ): Promise<void> {
   const { method } = req;
   const r = QueryParamsSchema.decode(req.query);
-
-  if (!space.isSystem()) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Only system spaces support listing MCP servers.",
-      },
-    });
-  }
 
   if (isLeft(r)) {
     return apiError(req, res, {
@@ -64,9 +51,7 @@ async function handler(
       switch (r.right.filter) {
         case "internal":
           {
-            const mcpServers = [
-              (await getAllMCPServersMetadataLocally(auth))[0],
-            ];
+            const mcpServers = await getAllMCPServersMetadataLocally(auth);
             return res.status(200).json({
               success: true,
               mcpServers,
@@ -77,7 +62,7 @@ async function handler(
           throw new Error("Not implemented");
           break;
         case "all":
-          const mcpServers = [(await getAllMCPServersMetadataLocally(auth))[0]];
+          const mcpServers = await getAllMCPServersMetadataLocally(auth);
           return res.status(200).json({
             success: true,
             mcpServers,
@@ -87,8 +72,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(
-  withResourceFetchingFromRoute(handler, {
-    space: { requireCanAdministrate: true },
-  })
-);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/index.ts
@@ -64,9 +64,7 @@ async function handler(
       switch (r.right.filter) {
         case "internal":
           {
-            const mcpServers = [
-              (await getAllMCPServersMetadataLocally(auth))[0],
-            ];
+            const mcpServers = await getAllMCPServersMetadataLocally(auth);
             return res.status(200).json({
               success: true,
               mcpServers,
@@ -77,7 +75,7 @@ async function handler(
           throw new Error("Not implemented");
           break;
         case "all":
-          const mcpServers = [(await getAllMCPServersMetadataLocally(auth))[0]];
+          const mcpServers = await getAllMCPServersMetadataLocally(auth);
           return res.status(200).json({
             success: true,
             mcpServers,

--- a/front/pages/w/[wId]/actions.tsx
+++ b/front/pages/w/[wId]/actions.tsx
@@ -8,6 +8,8 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 
+export const ACTION_BUTTONS_CONTAINER_ID = "actions-buttons-container";
+
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -36,7 +38,7 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   };
 });
 
-export default function Capabilities({
+export default function Actions({
   owner,
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -52,6 +54,7 @@ export default function Capabilities({
           icon={CommandLineIcon}
           description="Actions let you connect tools and automate tasks. Find all available actions here and set up new ones."
         />
+        <div id={ACTION_BUTTONS_CONTAINER_ID} className="flex gap-2" />
         <Page.Vertical align="stretch" gap="md">
           <ActionsList owner={owner} />
         </Page.Vertical>

--- a/front/pages/w/[wId]/actions.tsx
+++ b/front/pages/w/[wId]/actions.tsx
@@ -1,14 +1,15 @@
 import { CommandLineIcon, Page } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
+import { useState } from "react";
 
+import { ActionDetails } from "@app/components/actions/mcp/ActionDetails";
 import { ActionsList } from "@app/components/actions/mcp/ActionsList";
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
-
-export const ACTION_BUTTONS_CONTAINER_ID = "actions-buttons-container";
 
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   owner: WorkspaceType;
@@ -42,21 +43,30 @@ export default function Actions({
   owner,
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [showDetails, setShowDetails] = useState<MCPServerMetadata | null>(
+    null
+  );
+
   return (
     <AppLayout
       subscription={subscription}
       owner={owner}
       subNavigation={subNavigationAdmin({ owner, current: "actions" })}
     >
+      <ActionDetails
+        owner={owner}
+        mcpServer={showDetails}
+        onClose={() => setShowDetails(null)}
+      />
+
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
           title="Actions"
           icon={CommandLineIcon}
           description="Actions let you connect tools and automate tasks. Find all available actions here and set up new ones."
         />
-        <div id={ACTION_BUTTONS_CONTAINER_ID} className="flex gap-2" />
         <Page.Vertical align="stretch" gap="md">
-          <ActionsList owner={owner} />
+          <ActionsList owner={owner} setShowDetails={setShowDetails} />
         </Page.Vertical>
       </Page.Vertical>
       <div className="h-12" />

--- a/front/pages/w/[wId]/actions.tsx
+++ b/front/pages/w/[wId]/actions.tsx
@@ -2,8 +2,8 @@ import { CommandLineIcon, Page } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import { useState } from "react";
 
-import { ActionDetails } from "@app/components/actions/mcp/ActionDetails";
-import { ActionsList } from "@app/components/actions/mcp/ActionsList";
+import { InternalMCPServerDetails } from "@app/components/actions/mcp/ActionDetails";
+import { AdminActionsList } from "@app/components/actions/mcp/ActionsList";
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import type { MCPServerMetadata } from "@app/lib/actions/mcp_actions";
@@ -39,13 +39,15 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   };
 });
 
-export default function Actions({
+export default function AdminActions({
   owner,
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [showDetails, setShowDetails] = useState<MCPServerMetadata | null>(
     null
   );
+  const serverType =
+    showDetails && showDetails.id.startsWith("ims_") ? "internal" : "remote";
 
   return (
     <AppLayout
@@ -53,9 +55,9 @@ export default function Actions({
       owner={owner}
       subNavigation={subNavigationAdmin({ owner, current: "actions" })}
     >
-      <ActionDetails
+      <InternalMCPServerDetails
         owner={owner}
-        mcpServer={showDetails}
+        mcpServer={serverType === "internal" ? showDetails : null}
         onClose={() => setShowDetails(null)}
       />
 
@@ -66,7 +68,7 @@ export default function Actions({
           description="Actions let you connect tools and automate tasks. Find all available actions here and set up new ones."
         />
         <Page.Vertical align="stretch" gap="md">
-          <ActionsList owner={owner} setShowDetails={setShowDetails} />
+          <AdminActionsList owner={owner} setShowDetails={setShowDetails} />
         </Page.Vertical>
       </Page.Vertical>
       <div className="h-12" />


### PR DESCRIPTION
## Description

This adds buttons/action to add mcp servers, add to space, show details . Nothing implemented so far, buttons do not do anything.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
