### PR TITLE
[extension] - fix(inputBar): conditional picker rendering

### DIFF
--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -36,12 +36,14 @@ interface InputBarAttachmentsPickerProps {
   onNodeSelect: (node: DataSourceViewContentNodeType) => void;
   isLoading?: boolean;
   attachedNodes: DataSourceViewContentNodeType[];
+  isAttachedFromDataSourceActivated: boolean;
 }
 
 export const InputBarAttachmentsPicker = ({
   fileUploaderService,
   onNodeSelect,
   attachedNodes,
+  isAttachedFromDataSourceActivated,
   isLoading = false,
 }: InputBarAttachmentsPickerProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -96,7 +98,7 @@ export const InputBarAttachmentsPicker = ({
     }
   };
 
-  return (
+  return isAttachedFromDataSourceActivated ? (
     <DropdownMenu
       open={isOpen}
       onOpenChange={(open) => {
@@ -203,5 +205,28 @@ export const InputBarAttachmentsPicker = ({
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+  ) : (
+    <>
+      <Input
+        type="file"
+        ref={fileInputRef}
+        style={{ display: "none" }}
+        onChange={async (e) => {
+          setIsOpen(false);
+          await fileUploaderService.handleFileChange(e);
+          if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+          }
+        }}
+        multiple={true}
+      />
+      <Button
+        size="xs"
+        variant="ghost-secondary"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={isLoading}
+        icon={AttachmentIcon}
+      />
+    </>
   );
 };

--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -73,7 +73,7 @@ export const InputBarContainer = ({
     []
   );
 
-  const isAttachedFromDataSourceActivated: boolean = true;
+  const isAttachedFromDataSourceActivated: boolean = false;
 
   const { editor, editorService } = useCustomEditor({
     suggestions,
@@ -227,6 +227,9 @@ export const InputBarContainer = ({
               onNodeSelect || ((node) => console.log(`Selected ${node.title}`))
             }
             attachedNodes={attachedNodes}
+            isAttachedFromDataSourceActivated={
+              isAttachedFromDataSourceActivated
+            }
           />
           <AssistantPicker
             owner={owner}


### PR DESCRIPTION
## Description

This PR fixes a bug where the extension's attachment picker component was rendering regardless of the `isAttachedFromDataSourceActivated` flag value. Now correctly shows either the full attachment picker UI or a simple file upload button based on the flag.

## Risk

Low

## Deploy Plan

N/A