### PR TITLE
Record usage workklow stuck when worspace was deleted

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -12,8 +12,16 @@ export async function recordUsageActivity(workspaceId: string) {
       sId: workspaceId,
     },
   });
+
+  const logger = mainLogger.child({ workspaceId });
+  logger.info({}, "[UsageQueue] Recording usage for worskpace.");
+
   if (!workspace) {
-    throw new Error("Workspace not found.");
+    // The workspace likely deleted during the debouncing period of usage reporting.
+    logger.info(
+      "[UsageQueue] Cannot record usage of subscription: workspace not found."
+    );
+    return;
   }
 
   const subscription = await Subscription.findOne({
@@ -23,9 +31,6 @@ export async function recordUsageActivity(workspaceId: string) {
     },
     include: [Plan],
   });
-
-  const logger = mainLogger.child({ workspaceId });
-  logger.info({}, "[UsageQueue] Recording usage for worskpace.");
 
   if (!subscription) {
     // The workspace likely downgraded during the debouncing period of usage reporting.


### PR DESCRIPTION
## Description

Prevent record usage workflow to be stuck when the workspace was deleted. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 