### PR TITLE
fixing team at alias

### DIFF
--- a/extension/ui/pages/LoginPage.tsx
+++ b/extension/ui/pages/LoginPage.tsx
@@ -161,7 +161,7 @@ export const LoginPage = () => {
   // Should never happen.
   return (
     <div className="flex h-screen items-center justify-center text-center">
-      <Page.SectionHeader title="Something unexpected occured, please contact us at team@dust.tt!" />
+      <Page.SectionHeader title="Something unexpected occured, please contact us at support@dust.tt!" />
     </div>
   );
 };

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -198,11 +198,11 @@ export function EnterpriseConnectionDetails({
         <Popup
           show={showNoVerifiedDomainPopup}
           chipLabel="Domain Verification Required"
-          description="Single Sign-On (SSO) is not available because your domain isn't verified yet. Contact us at team@dust.tt for assistance."
+          description="Single Sign-On (SSO) is not available because your domain isn't verified yet. Contact us at support@dust.tt for assistance."
           buttonLabel="Get Help"
           buttonClick={() => {
             window.location.href =
-              "mailto:team@dust.tt?subject=Help with Domain Verification for SSO";
+              "mailto:support@dust.tt?subject=Help with Domain Verification for SSO";
           }}
           className="absolute bottom-8 right-8"
           onClose={() => setShowNoVerifiedDomainPopup(false)}

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -281,7 +281,7 @@ export async function triggerFromEmail({
     return new Err({
       type: "unexpected_error",
       message:
-        "An unexpected error occurred. Please try again or contact us at team@dust.tt.",
+        "An unexpected error occurred. Please try again or contact us at support@dust.tt.",
     });
   }
 

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -125,7 +125,7 @@ async function handler(
             const errRes = await testCountTokens.json();
             const errType = errRes.error?.type ?? "unknown error";
             const errMessage =
-              errRes.error?.message ?? "contact us at team@dust.tt";
+              errRes.error?.message ?? "contact us at support@dust.tt";
             res
               .status(400)
               .json({ ok: false, error: `[${errType}] ${errMessage}` });


### PR DESCRIPTION
## Description
We want to deprecate team@dust.tt, replacing it with support@dust.

Note: I did not change the previous emails which were sent as they are not supposed to happen again.