### PR TITLE
[microsoft] Support for service accounts

### DIFF
--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -66,7 +66,7 @@ async fn connections_create(
         // Create credential
         match Credential::create(
             state.store.clone(),
-            crate::oauth::credential::CredentialProvider::Salesforce,
+            crate::oauth::credential::CredentialProvider::from(payload.provider),
             credential_metadata,
             credential_content,
         )

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -7,6 +7,7 @@ use crate::oauth::store::OAuthStore;
 use crate::utils::{self, ParseError};
 use anyhow::Result;
 
+use super::connection::ConnectionProvider;
 use super::encryption::{seal_str, unseal_str};
 
 pub static CREDENTIAL_ID_PREFIX: &str = "cred";
@@ -18,6 +19,17 @@ pub enum CredentialProvider {
     Modjo,
     Bigquery,
     Salesforce,
+    Microsoft,
+}
+
+impl From<ConnectionProvider> for CredentialProvider {
+    fn from(provider: ConnectionProvider) -> Self {
+        match provider {
+            ConnectionProvider::Microsoft => CredentialProvider::Microsoft,
+            ConnectionProvider::Salesforce => CredentialProvider::Salesforce,
+            _ => panic!("Unsupported provider: {:?}", provider),
+        }
+    }
 }
 
 impl fmt::Display for CredentialProvider {
@@ -132,6 +144,9 @@ impl Credential {
                 ]
             }
             CredentialProvider::Salesforce => {
+                vec!["client_id", "client_secret"]
+            }
+            CredentialProvider::Microsoft => {
                 vec!["client_id", "client_secret"]
             }
         };

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -141,9 +141,9 @@ impl Provider for MicrosoftConnectionProvider {
     async fn refresh(
         &self,
         connection: &Connection,
-        _related_credentials: Option<Credential>,
+        related_credentials: Option<Credential>,
     ) -> Result<RefreshResult, ProviderError> {
-        let (url, body) = match _related_credentials {
+        let (url, body) = match related_credentials {
             Some(credential) => {
                 self.handle_service_principal_credentials(&credential, connection)?
             }

--- a/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
+++ b/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
@@ -33,6 +33,18 @@ export function MicrosoftOAuthExtraConfig({
         )}
       >
         <Input
+          label="Tenant ID"
+          disabled={!useServicePrincipal}
+          name="tenant_id"
+          value={extraConfig.tenant_id ?? ""}
+          onChange={(e) => {
+            setExtraConfig((prev: Record<string, string>) => ({
+              ...prev,
+              tenant_id: e.target.value,
+            }));
+          }}
+        />
+        <Input
           label="Client ID"
           disabled={!useServicePrincipal}
           name="client_id"

--- a/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
+++ b/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
@@ -33,7 +33,7 @@ export function MicrosoftOAuthExtraConfig({
         )}
       >
         <Input
-          label="Service Principal ID"
+          label="Client ID"
           disabled={!useServicePrincipal}
           name="client_id"
           value={extraConfig.client_id ?? ""}

--- a/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
+++ b/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
@@ -1,0 +1,62 @@
+import { classNames, Input, SliderToggle } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers";
+
+export function MicrosoftOAuthExtraConfig({
+  extraConfig,
+  setExtraConfig,
+  setIsExtraConfigValid,
+}: ConnectorOauthExtraConfigProps) {
+  const [useServicePrincipal, setUseServicePrincipal] = useState(false);
+
+  useEffect(() => {
+    setIsExtraConfigValid(
+      !useServicePrincipal ||
+        (!!extraConfig.client_id && !!extraConfig.client_secret)
+    );
+  }, [useServicePrincipal, extraConfig, setIsExtraConfigValid]);
+
+  return (
+    <>
+      <div className="flex justify-between">
+        <div>Use a Service Principal</div>
+        <SliderToggle
+          selected={useServicePrincipal}
+          onClick={() => setUseServicePrincipal(!useServicePrincipal)}
+        />
+      </div>
+      <div
+        className={classNames(
+          "flex flex-col gap-2",
+          !useServicePrincipal ? "opacity-50" : ""
+        )}
+      >
+        <Input
+          label="Service Principal ID"
+          disabled={!useServicePrincipal}
+          name="client_id"
+          value={extraConfig.client_id ?? ""}
+          onChange={(e) => {
+            setExtraConfig((prev: Record<string, string>) => ({
+              ...prev,
+              client_id: e.target.value,
+            }));
+          }}
+        />
+        <Input
+          label="Service Account secret"
+          disabled={!useServicePrincipal}
+          name="client_secret"
+          value={extraConfig.client_secret ?? ""}
+          onChange={(e) => {
+            setExtraConfig((prev: Record<string, string>) => ({
+              ...prev,
+              client_secret: e.target.value,
+            }));
+          }}
+        />
+      </div>
+    </>
+  );
+}

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -316,7 +316,11 @@ const PROVIDER_STRATEGIES: Record<
     isExtraConfigValid: (extraConfig) => {
       return (
         Object.keys(extraConfig).length === 0 ||
-        !!(extraConfig.client_id && extraConfig.client_secret)
+        !!(
+          extraConfig.client_id &&
+          extraConfig.client_secret &&
+          extraConfig.tenant_id
+        )
       );
     },
     getRelatedCredential: (extraConfig, workspaceId, userId) => {

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -21,6 +21,7 @@ import type { ComponentType } from "react";
 import { GithubCodeEnableView } from "@app/components/data_source/GithubCodeEnableView";
 import { GongOptionComponent } from "@app/components/data_source/gong/GongOptionComponent";
 import { IntercomConfigView } from "@app/components/data_source/IntercomConfigView";
+import { MicrosoftOAuthExtraConfig } from "@app/components/data_source/MicrosoftOAuthExtraConfig";
 import { SalesforceOauthExtraConfig } from "@app/components/data_source/SalesforceOAuthExtractConfig";
 import { SlackBotEnableView } from "@app/components/data_source/SlackBotEnableView";
 import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
@@ -247,6 +248,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       return MicrosoftLogo;
     },
     isNested: true,
+    oauthExtraConfigComponent: MicrosoftOAuthExtraConfig,
     permissions: {
       selected: "read",
       unselected: "none",


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/2526

## Description

This allows connection through a service principal account. Additional form is displayed in Microsoft connect :

<img width="558" alt="Screenshot 2025-04-01 at 15 38 42" src="https://github.com/user-attachments/assets/60a6a400-1d24-4f62-b874-ba29607da341" />


setupUri bypass the code flow if a credentials is provided, and directly go to finalize which will use a client_credentials flow with the provided credentials.

## Tests

I was able to test the flow but still have some permission issues on our tenant

## Risk


## Deploy Plan

deploy oauth
deploy front