### PR TITLE
[extension] mcp: bump sdk and explicitely don't support mcp

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
-        "@dust-tt/client": "^1.0.33",
+        "@dust-tt/client": "^1.0.34",
         "@dust-tt/sparkle": "^0.2.449",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@tailwindcss/forms": "^0.5.9",
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.33.tgz",
-      "integrity": "sha512-g6R8YljzXdRfj02qBpJZyxHo+/+/y7P3uVO1i6pxXfZRsQL0JMpwJZTJruKNyFch9Pdwoff1VoY52SwG4KpHdw==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.34.tgz",
+      "integrity": "sha512-tYjmSr2J7TzbrJ6j8enHM3pHA2U4CD67jhXphj8MDzTHAx+t1nn25hoPB28FcbwpDXcWNldhWj36INXDVBo9fw==",
       "dependencies": {
         "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
-    "@dust-tt/client": "^1.0.33",
+    "@dust-tt/client": "^1.0.34",
     "@dust-tt/sparkle": "^0.2.449",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@tailwindcss/forms": "^0.5.9",

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -301,10 +301,14 @@ export function AgentMessage({
       }
       case "tool_approve_execution":
         setStreamedAgentMessage((m) => {
-          return { ...m, status: "failed", error: { 
-            message: "Tools are not available in the extension", 
-            code: "tool_not_available" 
-          }};
+          return {
+            ...m,
+            status: "failed",
+            error: {
+              message: "Tools are not available in the extension",
+              code: "tool_not_available",
+            },
+          };
         });
         setLastAgentStateClassification("done");
         break;

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -299,6 +299,15 @@ export function AgentMessage({
         setLastAgentStateClassification("done");
         break;
       }
+      case "tool_approve_execution":
+        setStreamedAgentMessage((m) => {
+          return { ...m, status: "failed", error: { 
+            message: "Tools are not available in the extension", 
+            code: "tool_not_available" 
+          }};
+        });
+        setLastAgentStateClassification("done");
+        break;
 
       case "generation_tokens": {
         switch (event.classification) {
@@ -331,7 +340,6 @@ export function AgentMessage({
         setLastAgentStateClassification("thinking");
         break;
       }
-
       default:
         // Log message and do nothing. Don't crash if a new event type is not handled here.
         assertNeverAndIgnore(event);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We need to handle the `tool_approve_execution` message in the extension => we explicitely say that we don't support tool usage in the extension yet.
This PR's main purpose is to avoid crashing the extension on messages, supporting the MCP in the extension will be doable in a next version imo.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
- Untested for the "don't support MCP side", no agent with MCP are creatable for the moment.
Will test it when it's ready.

- Tested regular messages, and they work.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
No risks, as for the moment MCPs are not even live.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Bump extension version.