### PR TITLE
enh(Confluence) - log the `X-RateLimit` headers provided by Confluence API

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -602,7 +602,7 @@ export class ConfluenceClient {
     const params = new URLSearchParams({
       depth,
       sort,
-      limit: "100",
+      limit: "25",
       status: "current",
     });
 

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -591,7 +591,7 @@ export class ConfluenceClient {
     const params = new URLSearchParams({
       depth,
       sort,
-      limit: "25",
+      limit: "100",
       status: "current",
     });
 

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -333,6 +333,17 @@ export class ConfluenceClient {
           "provider:confluence",
           "status:rate_limited",
         ]);
+        const rateLimitHeaders: Record<string, string> = {};
+        response.headers.forEach((value, key) => {
+          if (key.toLowerCase().startsWith("x-ratelimit")) {
+            rateLimitHeaders[key] = value;
+          }
+        });
+
+        logger.info(
+          { rateLimitHeaders },
+          "[Confluence] Headers relative to the rate limit"
+        );
 
         if (retryCount < MAX_RATE_LIMIT_RETRY_COUNT) {
           const delayMs = getRetryAfterDuration(response);


### PR DESCRIPTION
## Description

- Confluence's API provides certain pieces of information relative to the rate limits enforced: https://developer.atlassian.com/cloud/confluence/rate-limiting/#introduction.
- This PR adds a log that will log every `X-RateLimit` header provided by the API whenever we get a 429 to help analyze the behavior of the API.

## Tests

- Header parsing logic tested locally.

## Risk

- n/a.

## Deploy Plan

- Deploy connectors.
