### PR TITLE
enh(Confluence) - log the endpoint when hitting a rate limit

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -341,7 +341,10 @@ export class ConfluenceClient {
         });
 
         logger.info(
-          { rateLimitHeaders },
+          {
+            rateLimitHeaders,
+            endpoint,
+          },
           "[Confluence] Headers relative to the rate limit"
         );
 


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/11689.
- This PR adds the endpoint to the logs on the headers.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.