### PR TITLE
[Attach] Ability to attach datasources in inputbar (Folders (capital F) & Websites)

### DIFF
--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -219,6 +219,8 @@ pub struct CoreContentNode {
     pub parent_title: Option<String>,
 }
 
+pub const DATA_SOURCE_NODE_ID: &str = "datasource_node_id";
+
 impl CoreContentNode {
     pub fn new(base: NodeESDocument, children_count: u64, parent_title: Option<String>) -> Self {
         CoreContentNode {
@@ -233,7 +235,7 @@ impl CoreContentNode {
             base: NodeESDocument {
                 data_source_id: data_source.data_source_id.clone(),
                 data_source_internal_id: data_source.data_source_internal_id,
-                node_id: data_source.data_source_id.clone(),
+                node_id: DATA_SOURCE_NODE_ID.to_string(),
                 node_type: NodeType::Folder,
                 text_size: None,
                 timestamp: data_source.timestamp,

--- a/extension/package.json
+++ b/extension/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
-    "@dust-tt/client": "^1.0.34",
+    "@dust-tt/client": "^1.0.35",
     "@dust-tt/sparkle": "^0.2.449",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@tailwindcss/forms": "^0.5.9",

--- a/extension/shared/lib/content_nodes.ts
+++ b/extension/shared/lib/content_nodes.ts
@@ -3,7 +3,7 @@ import type {
   ContentNodeType,
   DataSourceViewContentNodeType,
 } from "@dust-tt/client";
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { DATA_SOURCE_MIME_TYPE, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import {
   assertNever,
   ChatBubbleLeftRightIcon,
@@ -41,9 +41,6 @@ export const SPREADSHEET_INTERNAL_MIME_TYPES = [
   INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
   INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
 ] as readonly string[];
-
-// Mime type that represents a datasource.
-export const DATA_SOURCE_MIME_TYPE = "application/vnd.dust.datasource";
 
 function getVisualForFileContentNode(
   node: ContentNodeType & { type: "document" }

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -24,7 +24,6 @@ import { useDebounce } from "@app/hooks/useDebounce";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { orderDatasourceViewByImportance } from "@app/lib/connectors";
 import {
-  DATA_SOURCE_MIME_TYPE,
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
@@ -54,6 +53,7 @@ import {
   MIN_SEARCH_QUERY_SIZE,
   removeNulls,
 } from "@app/types";
+import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -1,3 +1,4 @@
+import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 import {
   Button,
   CloudArrowLeftRightIcon,
@@ -53,7 +54,6 @@ import {
   MIN_SEARCH_QUERY_SIZE,
   removeNulls,
 } from "@app/types";
-import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -22,7 +22,6 @@ import { useCursorPaginationForDataTable } from "@app/hooks/useCursorPaginationF
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import {
-  DATA_SOURCE_MIME_TYPE,
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
@@ -39,6 +38,7 @@ import type {
   SpaceType,
 } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
+import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 
 const DEFAULT_VIEW_TYPE = "all";
 

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -1,3 +1,4 @@
+import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
   cn,
@@ -38,7 +39,6 @@ import type {
   SpaceType,
 } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
-import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 
 const DEFAULT_VIEW_TYPE = "all";
 

--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -37,7 +37,7 @@ export type ConversationFileType = BaseConversationAttachmentType & {
 
 export type ConversationContentNodeType = BaseConversationAttachmentType & {
   contentFragmentId: string;
-  contentNodeId: string;
+  nodeId: string;
   nodeDataSourceViewId: string;
   nodeType: ContentNodeType;
 };
@@ -61,9 +61,9 @@ export function isConversationContentNodeType(
 export function isContentFragmentDataSourceNode(
   attachment: ConversationContentNodeType | ContentFragmentInputWithContentNode
 ): attachment is ConversationContentNodeType & {
-  contentNodeId: typeof DATA_SOURCE_NODE_ID;
+  nodeId: typeof DATA_SOURCE_NODE_ID;
 } {
-  return attachment.contentNodeId === DATA_SOURCE_NODE_ID;
+  return attachment.nodeId === DATA_SOURCE_NODE_ID;
 }
 
 // If updating this function, make sure to update `contentFragmentId` when we render the conversation

--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -8,14 +8,15 @@ import {
 } from "@app/lib/actions/constants";
 import type { ExtractActionBlob } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
-import type {
-  AgentMessageType,
-  ContentFragmentVersion,
-  ContentNodeType,
-  FunctionCallType,
-  FunctionMessageTypeModel,
-  ModelId,
-  SupportedContentFragmentType,
+import {
+  DATA_SOURCE_NODE_ID,
+  type AgentMessageType,
+  type ContentFragmentVersion,
+  type ContentNodeType,
+  type FunctionCallType,
+  type FunctionMessageTypeModel,
+  type ModelId,
+  type SupportedContentFragmentType,
 } from "@app/types";
 
 export type BaseConversationAttachmentType = {
@@ -54,6 +55,14 @@ export function isConversationContentNodeType(
   attachment: ConversationAttachmentType
 ): attachment is ConversationContentNodeType {
   return "contentFragmentId" in attachment;
+}
+
+export function isConversationDataSourceNode(
+  attachment: ConversationContentNodeType
+): attachment is ConversationContentNodeType & {
+  contentFragmentId: typeof DATA_SOURCE_NODE_ID;
+} {
+  return attachment.contentFragmentId === DATA_SOURCE_NODE_ID;
 }
 
 // If updating this function, make sure to update `contentFragmentId` when we render the conversation

--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -8,16 +8,17 @@ import {
 } from "@app/lib/actions/constants";
 import type { ExtractActionBlob } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
-import {
-  DATA_SOURCE_NODE_ID,
-  type AgentMessageType,
-  type ContentFragmentVersion,
-  type ContentNodeType,
-  type FunctionCallType,
-  type FunctionMessageTypeModel,
-  type ModelId,
-  type SupportedContentFragmentType,
+import type {
+  AgentMessageType,
+  ContentFragmentInputWithContentNode,
+  ContentFragmentVersion,
+  ContentNodeType,
+  FunctionCallType,
+  FunctionMessageTypeModel,
+  ModelId,
+  SupportedContentFragmentType,
 } from "@app/types";
+import { DATA_SOURCE_NODE_ID } from "@app/types";
 
 export type BaseConversationAttachmentType = {
   title: string;
@@ -57,12 +58,12 @@ export function isConversationContentNodeType(
   return "contentFragmentId" in attachment;
 }
 
-export function isConversationDataSourceNode(
-  attachment: ConversationContentNodeType
+export function isContentFragmentDataSourceNode(
+  attachment: ConversationContentNodeType | ContentFragmentInputWithContentNode
 ): attachment is ConversationContentNodeType & {
-  contentFragmentId: typeof DATA_SOURCE_NODE_ID;
+  contentNodeId: typeof DATA_SOURCE_NODE_ID;
 } {
-  return attachment.contentFragmentId === DATA_SOURCE_NODE_ID;
+  return attachment.contentNodeId === DATA_SOURCE_NODE_ID;
 }
 
 // If updating this function, make sure to update `contentFragmentId` when we render the conversation

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -24,6 +24,7 @@ import type {
 } from "@app/types";
 import {
   CoreAPI,
+  DATA_SOURCE_NODE_ID,
   Err,
   extensionsForContentType,
   isContentFragmentInputWithContentNode,
@@ -146,7 +147,7 @@ export async function getContentFragmentBlob(
       coreContentNode = {
         data_source_id: dsView.dataSource.dustAPIDataSourceId,
         data_source_internal_id: "unavailable",
-        node_id: dsView.dataSource.dustAPIDataSourceId,
+        node_id: DATA_SOURCE_NODE_ID,
         node_type: "folder",
         title: dsView.dataSource.name,
         mime_type: DATA_SOURCE_MIME_TYPE,
@@ -172,13 +173,17 @@ export async function getContentFragmentBlob(
       });
       if (searchRes.isErr()) {
         return new Err(
-          new Error("Content node not found for content fragment input")
+          new Error(
+            `Content node not found for content fragment node id: ${cf.nodeId}`
+          )
         );
       }
       [coreContentNode] = searchRes.value.nodes;
       if (!coreContentNode) {
         return new Err(
-          new Error("Content node not found for content fragment input")
+          new Error(
+            `Content node not found for content fragment node id: ${cf.nodeId}`
+          )
         );
       }
     }

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -1,6 +1,7 @@
-import type { DustMimeType} from "@dust-tt/client";
+import type { DustMimeType } from "@dust-tt/client";
 import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 
+import { isContentFragmentDataSourceNode } from "@app/lib/actions/conversation/list_files";
 import config from "@app/lib/api/config";
 import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";
 import type { ProcessAndStoreFileError } from "@app/lib/api/files/upload";
@@ -139,8 +140,7 @@ export async function getContentFragmentBlob(
 
     let coreContentNode: CoreAPIContentNode | null = null;
 
-    // This means the content node is actually the full data source.
-    if (cf.nodeId === dsView.dataSource.dustAPIDataSourceId) {
+    if (isContentFragmentDataSourceNode(cf)) {
       // Follows CoreContentNode.from_es_data_source_document, see
       // core/src/data_sources/node.rs
       coreContentNode = {

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -1,4 +1,5 @@
-import type { DustMimeType } from "@dust-tt/client";
+import type { DustMimeType} from "@dust-tt/client";
+import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 
 import config from "@app/lib/api/config";
 import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";
@@ -29,7 +30,6 @@ import {
   isSupportedContentNodeFragmentContentType,
   Ok,
 } from "@app/types";
-import { DATA_SOURCE_MIME_TYPE } from "@app/lib/content_nodes";
 
 interface ContentFragmentBlob {
   contentType: DustMimeType | SupportedFileContentType;

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -173,7 +173,7 @@ async function getJITActions(
             .nodeDataSourceViewId,
           filter: {
             parents: {
-              in: [(f as ConversationContentNodeType).contentNodeId],
+              in: [(f as ConversationContentNodeType).nodeId],
               not: [],
             },
             tags: null,
@@ -214,7 +214,7 @@ async function getJITActions(
             parents: isContentFragmentDataSourceNode(folder)
               ? null
               : {
-                  in: [folder.contentNodeId],
+                  in: [folder.nodeId],
                   not: [],
                 },
             tags: null,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -13,8 +13,8 @@ import type {
   ConversationContentNodeType,
 } from "@app/lib/actions/conversation/list_files";
 import {
+  isContentFragmentDataSourceNode,
   isConversationContentNodeType,
-  isConversationDataSourceNode,
   isConversationFileType,
   makeConversationListFilesAction,
 } from "@app/lib/actions/conversation/list_files";
@@ -211,7 +211,7 @@ async function getJITActions(
           dataSourceViewId: folder.nodeDataSourceViewId,
           filter: {
             // Do not filter on parent if the folder is a data source node.
-            parents: isConversationDataSourceNode(folder)
+            parents: isContentFragmentDataSourceNode(folder)
               ? null
               : {
                   in: [folder.contentNodeId],

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -128,7 +128,7 @@ export function listFiles(
             ...baseAttachment,
             nodeDataSourceViewId: m.nodeDataSourceViewId,
             contentFragmentId: m.contentFragmentId,
-            contentNodeId: m.nodeId,
+            nodeId: m.nodeId,
             nodeType: m.nodeType,
           });
         }

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -1,4 +1,8 @@
-import { CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
+import {
+  CONTENT_NODE_MIME_TYPES,
+  isDustMimeType,
+  isIncludableInternalMimeType,
+} from "@dust-tt/client";
 
 import type {
   BaseConversationAttachmentType,
@@ -25,7 +29,9 @@ function isConversationIncludableFileContentType(
   if (isSupportedImageContentType(contentType)) {
     return false;
   }
-  // TODO(attach-ds): Filter out content Types that are folders
+  if (isDustMimeType(contentType)) {
+    return isIncludableInternalMimeType(contentType);
+  }
   return true;
 }
 
@@ -83,6 +89,7 @@ export function listFiles(
           (isQueryableContentType(m.contentType) || m.nodeType === "table");
         const isContentNodeTable = isContentNodeAttachment(m) && isQueryable;
         const isIncludable =
+          m.nodeType !== "folder" &&
           isConversationIncludableFileContentType(m.contentType) &&
           // Tables from knowledge are not materialized as raw content. As such, they cannot be
           // included.

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { DATA_SOURCE_MIME_TYPE, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import {
   ChatBubbleLeftRightIcon,
   DocumentIcon,
@@ -38,9 +38,6 @@ export const SPREADSHEET_INTERNAL_MIME_TYPES = [
   INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
   INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
 ] as readonly string[];
-
-// Mime type that represents a datasource.
-export const DATA_SOURCE_MIME_TYPE = "application/vnd.dust.datasource";
 
 function getVisualForFileContentNode(node: ContentNode & { type: "document" }) {
   if (node.expandable) {

--- a/front/types/core/content_node.ts
+++ b/front/types/core/content_node.ts
@@ -1,5 +1,7 @@
 import type { ProviderVisibility } from "../connectors/connectors_api";
 
+export const DATA_SOURCE_NODE_ID = "datasource_node_id";
+
 export type ContentNodeType = "document" | "table" | "folder";
 
 export type CoreAPIContentNode = {

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -147,6 +147,34 @@ export const CONTENT_NODE_MIME_TYPES = {
   }),
 };
 
+export const INCLUDABLE_INTERNAL_CONTENT_NODE_MIME_TYPES = {
+  CONFLUENCE: [CONTENT_NODE_MIME_TYPES.CONFLUENCE.PAGE],
+  GITHUB: [
+    CONTENT_NODE_MIME_TYPES.GITHUB.ISSUE,
+    CONTENT_NODE_MIME_TYPES.GITHUB.DISCUSSION,
+  ],
+  GOOGLE_DRIVE: [],
+  INTERCOM: [
+    CONTENT_NODE_MIME_TYPES.INTERCOM.CONVERSATION,
+    CONTENT_NODE_MIME_TYPES.INTERCOM.ARTICLE,
+  ],
+  MICROSOFT: [],
+  NOTION: [CONTENT_NODE_MIME_TYPES.NOTION.PAGE],
+  SLACK: [
+    CONTENT_NODE_MIME_TYPES.SLACK.THREAD,
+    CONTENT_NODE_MIME_TYPES.SLACK.MESSAGES,
+  ],
+  SNOWFLAKE: [],
+  WEBCRAWLER: [],
+  ZENDESK: [
+    CONTENT_NODE_MIME_TYPES.ZENDESK.TICKET,
+    CONTENT_NODE_MIME_TYPES.ZENDESK.ARTICLE,
+  ],
+  BIGQUERY: [],
+  SALESFORCE: [],
+  GONG: [],
+};
+
 const TOOL_INPUT_MIME_TYPES = {
   // If we get other similar mime types we'll add an util function just like above.
   CONFIGURATION: {
@@ -161,6 +189,10 @@ export const INTERNAL_MIME_TYPES = {
 
 export const INTERNAL_MIME_TYPES_VALUES = Object.values(
   CONTENT_NODE_MIME_TYPES
+).flatMap((value) => Object.values(value).map((v) => v));
+
+export const INCLUDABLE_INTERNAL_MIME_TYPES_VALUES = Object.values(
+  INCLUDABLE_INTERNAL_CONTENT_NODE_MIME_TYPES
 ).flatMap((value) => Object.values(value).map((v) => v));
 
 export type BigQueryMimeType =
@@ -205,6 +237,9 @@ export type GongMimeType =
 export type InternalConfigurationMimeType =
   (typeof INTERNAL_MIME_TYPES.CONFIGURATION)[keyof typeof INTERNAL_MIME_TYPES.CONFIGURATION];
 
+export type IncludableInternalMimeType =
+  (typeof INCLUDABLE_INTERNAL_MIME_TYPES_VALUES)[number];
+
 export type DustMimeType =
   | BigQueryMimeType
   | ConfluenceMimeType
@@ -223,4 +258,10 @@ export type DustMimeType =
 
 export function isDustMimeType(mimeType: string): mimeType is DustMimeType {
   return (INTERNAL_MIME_TYPES_VALUES as string[]).includes(mimeType);
+}
+
+export function isIncludableInternalMimeType(
+  mimeType: string
+): mimeType is IncludableInternalMimeType {
+  return (INCLUDABLE_INTERNAL_MIME_TYPES_VALUES as string[]).includes(mimeType);
 }


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2416

Description
---
As per title;  folders and websites can be searched. Paves the way for searching whole connections if needed.

Also:
- introduces INTERNAL_INCLUDABLE_MIME_TYPES, and prevent internal mime types that are *not* includable to be considered from inclusion by the model;
- also prevent any "folder" to be considered for inclusion.

Risks
---
standard

Deploy
---
front
