### PR TITLE
[front] - fix(ContentFragment): rendering

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -86,36 +86,6 @@ export function ActionValidationProvider({
   const [isProcessing, setIsProcessing] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (currentValidation) {
-      setIsDialogOpen(true);
-    }
-  }, [currentValidation]);
-
-  useEffect(() => {
-    if (!isDialogOpen && currentValidation && !isProcessing) {
-      void handleSubmit(false);
-    }
-  }, [isDialogOpen]);
-
-  useEffect(() => {
-    if (
-      !isProcessing &&
-      validationQueue.length > 0 &&
-      !currentValidation &&
-      !isDialogOpen
-    ) {
-      removeFromQueue();
-      setErrorMessage(null);
-    }
-  }, [
-    isProcessing,
-    validationQueue,
-    currentValidation,
-    isDialogOpen,
-    removeFromQueue,
-  ]);
-
   const sendCurrentValidation = async (approved: boolean) => {
     if (!currentValidation) {
       return;
@@ -146,13 +116,42 @@ export function ActionValidationProvider({
       return;
     }
   };
-
   const handleSubmit = async (approved: boolean) => {
     void sendCurrentValidation(approved);
     setIsProcessing(false);
     setIsDialogOpen(false);
     clearCurrentValidation();
   };
+
+  useEffect(() => {
+    if (currentValidation) {
+      setIsDialogOpen(true);
+    }
+  }, [currentValidation]);
+
+  useEffect(() => {
+    if (!isDialogOpen && currentValidation && !isProcessing) {
+      void handleSubmit(false);
+    }
+  }, [isDialogOpen, currentValidation, isProcessing, handleSubmit]);
+
+  useEffect(() => {
+    if (
+      !isProcessing &&
+      validationQueue.length > 0 &&
+      !currentValidation &&
+      !isDialogOpen
+    ) {
+      removeFromQueue();
+      setErrorMessage(null);
+    }
+  }, [
+    isProcessing,
+    validationQueue,
+    currentValidation,
+    isDialogOpen,
+    removeFromQueue,
+  ]);
 
   const showValidationDialog = (props: {
     workspaceId: string;

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -108,7 +108,13 @@ export function ActionValidationProvider({
       removeFromQueue();
       setErrorMessage(null);
     }
-  }, [isProcessing, validationQueue, currentValidation, isDialogOpen]);
+  }, [
+    isProcessing,
+    validationQueue,
+    currentValidation,
+    isDialogOpen,
+    removeFromQueue,
+  ]);
 
   const sendCurrentValidation = async (approved: boolean) => {
     if (!currentValidation) {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -215,129 +215,132 @@ export function AgentMessage({
 
   const { showValidationDialog } = useContext(ActionValidationContext);
 
-  const onEventCallback = useCallback((eventStr: string) => {
-    const eventPayload: {
-      eventId: string;
-      data:
-        | AgentErrorEvent
-        | AgentActionSpecificEvent
-        | AgentActionSuccessEvent
-        | GenerationTokensEvent
-        | AgentGenerationCancelledEvent
-        | AgentMessageSuccessEvent;
-    } = JSON.parse(eventStr);
+  const onEventCallback = useCallback(
+    (eventStr: string) => {
+      const eventPayload: {
+        eventId: string;
+        data:
+          | AgentErrorEvent
+          | AgentActionSpecificEvent
+          | AgentActionSuccessEvent
+          | GenerationTokensEvent
+          | AgentGenerationCancelledEvent
+          | AgentMessageSuccessEvent;
+      } = JSON.parse(eventStr);
 
-    const updateMessageWithAction = (
-      m: AgentMessageType,
-      action: AgentActionType
-    ): AgentMessageType => {
-      return {
-        ...m,
-        actions: m.actions
-          ? [...m.actions.filter((a) => a.id !== action.id), action]
-          : [action],
+      const updateMessageWithAction = (
+        m: AgentMessageType,
+        action: AgentActionType
+      ): AgentMessageType => {
+        return {
+          ...m,
+          actions: m.actions
+            ? [...m.actions.filter((a) => a.id !== action.id), action]
+            : [action],
+        };
       };
-    };
 
-    const event = eventPayload.data;
-    switch (event.type) {
-      case "agent_action_success":
-        setStreamedAgentMessage((m) => {
-          return { ...updateMessageWithAction(m, event.action) };
-        });
-        setLastAgentStateClassification("thinking");
-        break;
+      const event = eventPayload.data;
+      switch (event.type) {
+        case "agent_action_success":
+          setStreamedAgentMessage((m) => {
+            return { ...updateMessageWithAction(m, event.action) };
+          });
+          setLastAgentStateClassification("thinking");
+          break;
 
-      case "tool_approve_execution":
-        // Show the validation dialog when this event is received
-        showValidationDialog({
-          workspaceId: owner.sId,
-          messageId: message.sId,
-          conversationId: conversationId,
-          action: event.action,
-          inputs: event.inputs,
-          hash: event.hash,
-        });
-        break;
+        case "tool_approve_execution":
+          // Show the validation dialog when this event is received
+          showValidationDialog({
+            workspaceId: owner.sId,
+            messageId: message.sId,
+            conversationId: conversationId,
+            action: event.action,
+            inputs: event.inputs,
+            hash: event.hash,
+          });
+          break;
 
-      case "browse_params":
-      case "conversation_include_file_params":
-      case "dust_app_run_block":
-      case "dust_app_run_params":
-      case "process_params":
-      case "reasoning_started":
-      case "reasoning_thinking":
-      case "reasoning_tokens":
-      case "retrieval_params":
-      case "search_labels_params":
-      case "tables_query_model_output":
-      case "tables_query_output":
-      case "tables_query_started":
-      case "websearch_params":
-      case "tool_params":
-        setStreamedAgentMessage((m) => {
-          return updateMessageWithAction(m, event.action);
-        });
-        setLastAgentStateClassification("acting");
-        break;
-      case "agent_error":
-        setStreamedAgentMessage((m) => {
-          return { ...m, status: "failed", error: event.error };
-        });
-        setLastAgentStateClassification("done");
-        break;
+        case "browse_params":
+        case "conversation_include_file_params":
+        case "dust_app_run_block":
+        case "dust_app_run_params":
+        case "process_params":
+        case "reasoning_started":
+        case "reasoning_thinking":
+        case "reasoning_tokens":
+        case "retrieval_params":
+        case "search_labels_params":
+        case "tables_query_model_output":
+        case "tables_query_output":
+        case "tables_query_started":
+        case "websearch_params":
+        case "tool_params":
+          setStreamedAgentMessage((m) => {
+            return updateMessageWithAction(m, event.action);
+          });
+          setLastAgentStateClassification("acting");
+          break;
+        case "agent_error":
+          setStreamedAgentMessage((m) => {
+            return { ...m, status: "failed", error: event.error };
+          });
+          setLastAgentStateClassification("done");
+          break;
 
-      case "agent_generation_cancelled":
-        setStreamedAgentMessage((m) => {
-          return { ...m, status: "cancelled" };
-        });
-        setLastAgentStateClassification("done");
-        break;
-      case "agent_message_success": {
-        setStreamedAgentMessage((m) => {
-          return {
-            ...m,
-            ...event.message,
-          };
-        });
-        setLastAgentStateClassification("done");
-        break;
-      }
-
-      case "generation_tokens": {
-        switch (event.classification) {
-          case "closing_delimiter":
-            break;
-          case "opening_delimiter":
-            break;
-          case "tokens":
-            setLastTokenClassification("tokens");
-            setStreamedAgentMessage((m) => {
-              const previousContent = m.content || "";
-              return { ...m, content: previousContent + event.text };
-            });
-            break;
-          case "chain_of_thought":
-            setLastTokenClassification("chain_of_thought");
-            setStreamedAgentMessage((m) => {
-              const currentChainOfThought = m.chainOfThought ?? "";
-              return {
-                ...m,
-                chainOfThought: currentChainOfThought + event.text,
-              };
-            });
-            break;
-          default:
-            assertNever(event);
+        case "agent_generation_cancelled":
+          setStreamedAgentMessage((m) => {
+            return { ...m, status: "cancelled" };
+          });
+          setLastAgentStateClassification("done");
+          break;
+        case "agent_message_success": {
+          setStreamedAgentMessage((m) => {
+            return {
+              ...m,
+              ...event.message,
+            };
+          });
+          setLastAgentStateClassification("done");
+          break;
         }
-        setLastAgentStateClassification("thinking");
-        break;
-      }
 
-      default:
-        assertNever(event);
-    }
-  }, []);
+        case "generation_tokens": {
+          switch (event.classification) {
+            case "closing_delimiter":
+              break;
+            case "opening_delimiter":
+              break;
+            case "tokens":
+              setLastTokenClassification("tokens");
+              setStreamedAgentMessage((m) => {
+                const previousContent = m.content || "";
+                return { ...m, content: previousContent + event.text };
+              });
+              break;
+            case "chain_of_thought":
+              setLastTokenClassification("chain_of_thought");
+              setStreamedAgentMessage((m) => {
+                const currentChainOfThought = m.chainOfThought ?? "";
+                return {
+                  ...m,
+                  chainOfThought: currentChainOfThought + event.text,
+                };
+              });
+              break;
+            default:
+              assertNever(event);
+          }
+          setLastAgentStateClassification("thinking");
+          break;
+        }
+
+        default:
+          assertNever(event);
+      }
+    },
+    [conversationId, message.sId, owner.sId, showValidationDialog]
+  );
 
   useEventSource(
     buildEventSourceURL,

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -172,7 +172,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     <Icon visual={FolderIcon} />
                     <p>{contentFragment.contentNodeData.spaceName}</p>
                   </div>
-                  <div className="text-sm text-element-600">
+                  <div className="text-element-600 text-sm">
                     {contentFragment.sourceUrl || ""}
                   </div>
                 </div>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -170,7 +170,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     <Icon visual={FolderIcon} />
                     <p>{contentFragment.contentNodeData.spaceName}</p>
                   </div>
-                  <div className="text-sm text-element-600">
+                  <div className="text-element-600 text-sm">
                     {contentFragment.sourceUrl || ""}
                   </div>
                 </div>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -23,7 +23,6 @@ import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import type {
-  ConnectorProvider,
   MessageWithContentFragmentsType,
   UserType,
   WorkspaceType,

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -122,13 +122,12 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               if (contentFragment.contentNodeData) {
                 const { provider, nodeType } = contentFragment.contentNodeData;
                 const logo = getConnectorProviderLogoWithFallback({
-                  provider: provider as ConnectorProvider,
+                  provider,
                 });
 
                 // For websites or folders, show just the provider logo
-                const isWebsiteOrFolder = ["webcrawler", "folder"].includes(
-                  provider
-                );
+                const isWebsiteOrFolder =
+                  provider === "webcrawler" || provider === null;
                 if (isWebsiteOrFolder) {
                   visual = <Icon visual={logo} size="sm" />;
                 } else {
@@ -172,7 +171,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     <Icon visual={FolderIcon} />
                     <p>{contentFragment.contentNodeData.spaceName}</p>
                   </div>
-                  <div className="text-element-600 text-sm">
+                  <div className="text-sm text-element-600">
                     {contentFragment.sourceUrl || ""}
                   </div>
                 </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -192,6 +192,7 @@ const InputBarContainer = ({
     editorService,
     spacesMap,
     nodeOrUrlCandidate,
+    sendNotification,
   ]);
 
   // When input bar animation is requested it means the new button was clicked (removing focus from

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -40,9 +40,6 @@ import type {
   UserMessageType,
 } from "@app/types";
 import { ConversationError, Err, Ok, removeNulls } from "@app/types";
-import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
-import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 
 async function batchRenderUserMessages(
   messages: Message[]
@@ -386,25 +383,6 @@ async function fetchMessagesForPage(
         model: ContentFragmentModel,
         as: "contentFragment",
         required: false,
-        include: [
-          {
-            model: DataSourceViewModel,
-            required: false,
-            include: [
-              {
-                model: DataSourceModel,
-                as: "dataSourceForView",
-                required: false,
-                include: [
-                  {
-                    model: SpaceModel,
-                    required: false,
-                  },
-                ],
-              },
-            ],
-          },
-        ],
       },
     ],
   });

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -39,8 +39,10 @@ import type {
   Result,
   UserMessageType,
 } from "@app/types";
-import { ConversationError } from "@app/types";
-import { Err, Ok, removeNulls } from "@app/types";
+import { ConversationError, Err, Ok, removeNulls } from "@app/types";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 
 async function batchRenderUserMessages(
   messages: Message[]
@@ -384,9 +386,29 @@ async function fetchMessagesForPage(
         model: ContentFragmentModel,
         as: "contentFragment",
         required: false,
+        include: [
+          {
+            model: DataSourceViewModel,
+            required: false,
+            include: [
+              {
+                model: DataSourceModel,
+                as: "dataSourceForView",
+                required: false,
+                include: [
+                  {
+                    model: SpaceModel,
+                    required: false,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       },
     ],
   });
+
   return {
     hasMore,
     messages,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -303,6 +303,17 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       },
       contentFragmentId: this.sId,
       contentFragmentVersion: this.version,
+      contentNodeData: message.contentFragment
+        ? {
+            nodeId: message.contentFragment.nodeType,
+            nodeDataSourceViewId: message.contentFragment.nodeDataSourceViewId,
+            provider:
+              message.contentFragment.nodeDataSourceView?.dataSourceForView
+                .connectorProvider,
+            spaceName: message.contentFragment.nodeDataSourceView?.space,
+            nodeType: message.contentFragment.nodeType,
+          }
+        : null,
     };
   }
 }

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -15,6 +15,9 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
   generateRandomModelSId,
@@ -35,9 +38,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { CoreAPI, Err, isSupportedImageContentType, Ok } from "@app/types";
-import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
-import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
-import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
 export const CONTENT_OUTDATED_MSG =
   "Content is outdated. Please refer to the latest version of this content.";

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -285,15 +285,21 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
     // Add contentNodeData
     let contentNodeData: ContentFragmentNodeData | null = null;
     if (nodeId && this.nodeDataSourceViewId && nodeType) {
-      // Fetch the data source view directly
       const dsView = await DataSourceViewModel.findByPk(
         this.nodeDataSourceViewId,
         {
+          attributes: [],
           include: [
             {
               model: DataSourceModel,
               as: "dataSourceForView",
-              include: [SpaceModel],
+              attributes: ["connectorProvider"],
+              include: [
+                {
+                  model: SpaceModel,
+                  attributes: ["name"],
+                },
+              ],
             },
           ],
         }

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -1,4 +1,4 @@
-import type { CreationOptional, ForeignKey } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -37,6 +37,8 @@ export class ContentFragmentModel extends WorkspaceAwareModel<ContentFragmentMod
   declare nodeId: string | null;
   declare nodeDataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
   declare nodeType: ContentNodeType | null;
+
+  declare nodeDataSourceView: NonAttribute<DataSourceViewModel> | null;
 
   declare version: ContentFragmentVersion;
 }

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -1,4 +1,4 @@
-import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -37,8 +37,6 @@ export class ContentFragmentModel extends WorkspaceAwareModel<ContentFragmentMod
   declare nodeId: string | null;
   declare nodeDataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
   declare nodeType: ContentNodeType | null;
-
-  declare nodeDataSourceView: NonAttribute<DataSourceViewModel> | null;
 
   declare version: ContentFragmentVersion;
 }

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -5,6 +5,7 @@ import type { ContentNodeType } from "./core/content_node";
 import type { DataSourceViewContentNode } from "./data_source_view";
 import type { SupportedFileContentType } from "./files";
 import type { ModelId } from "./shared/model_id";
+
 export type ContentFragmentContextType = {
   username: string | null;
   fullName: string | null;
@@ -18,6 +19,14 @@ export type SupportedContentFragmentType =
   | SupportedFileContentType
   | DustMimeType
   | "dust-application/slack"; // Legacy
+
+export type ContentFragmentNodeData = {
+  nodeId: string;
+  nodeDataSourceViewId: string;
+  nodeType: ContentNodeType;
+  provider: string;
+  spaceName: string;
+};
 
 export type ContentFragmentType = {
   id: ModelId;
@@ -40,6 +49,7 @@ export type ContentFragmentType = {
   context: ContentFragmentContextType;
   contentFragmentId: string;
   contentFragmentVersion: ContentFragmentVersion;
+  contentNodeData: ContentFragmentNodeData | null;
 };
 
 export type UploadedContentFragment = {

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -1,4 +1,4 @@
-import type { DustMimeType } from "@dust-tt/client";
+import type { ConnectorProvider, DustMimeType } from "@dust-tt/client";
 
 import type { MessageType, MessageVisibility } from "./assistant/conversation";
 import type { ContentNodeType } from "./core/content_node";
@@ -24,7 +24,7 @@ export type ContentFragmentNodeData = {
   nodeId: string;
   nodeDataSourceViewId: string;
   nodeType: ContentNodeType;
-  provider: string;
+  provider: ConnectorProvider | null;
   spaceName: string;
 };
 


### PR DESCRIPTION
## Description

This PR enhances content fragment rendering by adding provider and space name information to content fragments from data sources. Adds visual differentiation between content types (table, document, folder) and their sources through appropriate icons and tooltips. The changes make attachments in messages consistent with how they appear in the input bar.

Note: a follow up PR will refactor the attachment logic to have it in one single place instead of both in InputBarAttachment and MessageItem. But it's a tiny bit annoying as we are not manipulating the same object.

**References:**
- https://github.com/dust-tt/tasks/issues/2406

## Risk

Low

## Deploy Plan

Deploy front