### PR TITLE
[Attach] Fix: ability to select multiple datasources

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -234,7 +234,10 @@ export function AssistantInputBar({
 
   const handleNodesAttachmentSelect = (node: DataSourceViewContentNode) => {
     const isNodeAlreadyAttached = attachedNodes.some(
-      (attachedNode) => attachedNode.internalId === node.internalId
+      (attachedNode) =>
+        attachedNode.internalId === node.internalId &&
+        attachedNode.dataSourceView.dataSource.sId ===
+          node.dataSourceView.dataSource.sId
     );
     if (!isNodeAlreadyAttached) {
       setAttachedNodes((prev) => [...prev, node]);

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -88,13 +88,12 @@ export function InputBarAttachments({
           provider: node.dataSourceView.dataSource.connectorProvider,
         });
 
-        const nodeId = node.internalId ?? `node-${node.internalId}`;
         const spaceName =
           nodes.spacesMap[node.dataSourceView.spaceId].name ?? "Unknown Space";
         const { dataSource } = node.dataSourceView;
         return {
           type: "node",
-          id: nodeId,
+          id: `${node.dataSourceView.dataSource.sId}-${node.internalId}`,
           url: node.sourceUrl,
           title: node.title,
           spaceName,

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -91,10 +91,6 @@ export const InputBarAttachmentsPicker = ({
     searchSourceUrls: true,
   });
 
-  const attachedNodeIds = useMemo(() => {
-    return attachedNodes.map((node) => node.internalId);
-  }, [attachedNodes]);
-
   const spacesMap = useMemo(
     () => Object.fromEntries(spaces.map((space) => [space.sId, space.name])),
     [spaces]
@@ -190,7 +186,12 @@ export const InputBarAttachmentsPicker = ({
                       provider:
                         item.dataSourceView.dataSource.connectorProvider,
                     })}
-                    disabled={attachedNodeIds.includes(item.internalId)}
+                    disabled={attachedNodes.some(
+                      (attachedNode) =>
+                        attachedNode.internalId === item.internalId &&
+                        attachedNode.dataSourceView.dataSource.sId ===
+                          item.dataSourceView.dataSource.sId
+                    )}
                     description={`${spacesMap[item.dataSourceView.spaceId]} - ${getLocationForDataSourceViewContentNode(item)}`}
                     onClick={() => {
                       setSearch("");


### PR DESCRIPTION
Description
---
PR #11695 allowed attaching datasources, and in so gave them all a special node id "datasource_node_id"

Code distinguished attachments only by node id (wrong since not global unicity guarantee).

So only one datasource could be selected, then others were shown disabled.

This PR fixes by using also datasource sid to distinguish attachments

Risks
---
standard

Deploy
---
front
