### PR TITLE
Fix responseFormat set logic

### DIFF
--- a/front/components/assistant_builder/AdvancedSettings.tsx
+++ b/front/components/assistant_builder/AdvancedSettings.tsx
@@ -69,8 +69,8 @@ const isInvalidJson = (value: string | null | undefined): boolean => {
     return false;
   }
   try {
-    JSON.parse(value);
-    return false;
+    const parsed = JSON.parse(value);
+    return !parsed || typeof parsed !== "object";
   } catch {
     return true;
   }

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -118,24 +118,14 @@ AgentConfiguration.init(
       type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: null,
-      set(value) {
-        if (!value) {
-          this.setDataValue("responseFormat", undefined);
-          return;
-        }
-        // If it's already a string, parse it first
-        const parsed = typeof value === "string" ? JSON.parse(value) : value;
-        // Store the parsed object directly
-        this.setDataValue("responseFormat", parsed);
-      },
       validate: {
         isValidJSON(value: string) {
           if (value) {
-            if (typeof value !== "object") {
-              throw new Error("Response format is not a JSON object");
-            }
             try {
-              JSON.parse(JSON.stringify(value));
+              const parsed = JSON.parse(value);
+              if (parsed && typeof parsed !== "object") {
+                throw new Error("Response format is invalid JSON");
+              }
             } catch (e) {
               throw new Error("Response format is invalid JSON");
             }


### PR DESCRIPTION
## Description

* Fixing responseFormat type setting logic. No longer required to override serialization now that it is JSONB.
* Fixing issue where json wasn't properly presented as string after saving

## Tests

* Validated able to save / view response format via agent configuration

## Risk

* Safe to rollback
* 
## Deploy Plan

Github action