### PR TITLE
[front] - refacto(Attachment): centralize logic

### DIFF
--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -98,7 +98,6 @@ export function AttachmentCitation({
 
   return (
     <Tooltip
-      tooltipTriggerAsChild
       trigger={
         <Citation
           className={className}

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -72,13 +72,11 @@ export type AttachmentCitation =
 type AttachmentCitationProps = {
   attachmentCitation: AttachmentCitation;
   onRemove?: () => void;
-  className?: string;
 };
 
 export function AttachmentCitation({
   attachmentCitation,
   onRemove,
-  className = "w-40",
 }: AttachmentCitationProps) {
   const tooltipContent =
     attachmentCitation.type === "file" ? (
@@ -100,7 +98,7 @@ export function AttachmentCitation({
     <Tooltip
       trigger={
         <Citation
-          className={className}
+          className="w-40"
           href={attachmentCitation.sourceUrl ?? undefined}
           isLoading={
             attachmentCitation.type === "file" && attachmentCitation.isUploading
@@ -125,9 +123,7 @@ export function AttachmentCitation({
           </CitationTitle>
           {attachmentCitation.type === "node" && (
             <CitationDescription className="truncate text-ellipsis">
-              <div className="flex items-center gap-1">
-                <span>{attachmentCitation.spaceName}</span>
-              </div>
+              <span>{attachmentCitation.spaceName}</span>
             </CitationDescription>
           )}
         </Citation>
@@ -146,10 +142,10 @@ export function contentFragmentToAttachmentCitation(
 
     const visual =
       provider && ["webcrawler", "folder"].includes(provider) ? (
-        <Icon visual={logo} size="sm" />
+        <Icon visual={logo} />
       ) : (
         <>
-          <Icon visual={logo} size="sm" />
+          <Icon visual={logo} />
           <Icon
             visual={
               nodeType === "table"
@@ -158,7 +154,6 @@ export function contentFragmentToAttachmentCitation(
                   ? FolderIcon
                   : DocumentIcon
             }
-            size="sm"
           />
         </>
       );
@@ -179,7 +174,7 @@ export function contentFragmentToAttachmentCitation(
     id: contentFragment.sId,
     title: contentFragment.title,
     sourceUrl: contentFragment.sourceUrl,
-    visual: <Icon visual={isImageType ? ImageIcon : DocumentIcon} size="sm" />,
+    visual: <Icon visual={isImageType ? ImageIcon : DocumentIcon} />,
   };
 }
 

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -1,0 +1,214 @@
+import {
+  Citation,
+  CitationClose,
+  CitationDescription,
+  CitationIcons,
+  CitationImage,
+  CitationTitle,
+  DocumentIcon,
+  FolderIcon,
+  Icon,
+  ImageIcon,
+  TableIcon,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import type { ContentFragmentType } from "@app/types";
+
+export type FileAttachment = {
+  type: "file";
+  id: string;
+  title: string;
+  preview?: string;
+  isUploading: boolean;
+  onRemove: () => void;
+};
+
+export type NodeAttachment = {
+  type: "node";
+  id: string;
+  title: string;
+  spaceName: string;
+  spaceIcon: React.ComponentType;
+  visual: React.ReactNode;
+  path: string;
+  onRemove: () => void;
+  url: string | null;
+};
+
+export type Attachment = FileAttachment | NodeAttachment;
+
+interface BaseAttachmentCitation {
+  id: string;
+  title: string;
+  sourceUrl?: string | null;
+  visual: React.ReactNode;
+}
+
+interface FileAttachmentCitation extends BaseAttachmentCitation {
+  type: "file";
+  preview?: string;
+  isUploading?: boolean;
+  spaceName?: never;
+  path?: never;
+  spaceIcon?: never;
+}
+
+interface NodeAttachmentCitation extends BaseAttachmentCitation {
+  type: "node";
+  spaceName: string;
+  path: string;
+  spaceIcon: React.ComponentType;
+  preview?: never;
+  isUploading?: never;
+}
+
+export type AttachmentCitation =
+  | FileAttachmentCitation
+  | NodeAttachmentCitation;
+
+type AttachmentCitationProps = {
+  attachmentCitation: AttachmentCitation;
+  onRemove?: () => void;
+  className?: string;
+};
+
+export function AttachmentCitation({
+  attachmentCitation,
+  onRemove,
+  className = "w-40",
+}: AttachmentCitationProps) {
+  const tooltipContent =
+    attachmentCitation.type === "file" ? (
+      attachmentCitation.title
+    ) : (
+      <div className="flex flex-col gap-1">
+        <div className="font-bold">{attachmentCitation.title}</div>
+        <div className="flex gap-1 pt-1 text-sm">
+          <Icon visual={attachmentCitation.spaceIcon} />
+          <p>{attachmentCitation.spaceName}</p>
+        </div>
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {attachmentCitation.path}
+        </div>
+      </div>
+    );
+
+  return (
+    <Tooltip
+      tooltipTriggerAsChild
+      trigger={
+        <Citation
+          className={className}
+          href={attachmentCitation.sourceUrl ?? undefined}
+          isLoading={
+            attachmentCitation.type === "file" && attachmentCitation.isUploading
+          }
+          action={
+            onRemove && (
+              <CitationClose
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove();
+                }}
+              />
+            )
+          }
+        >
+          {attachmentCitation.type === "file" && attachmentCitation.preview && (
+            <CitationImage imgSrc={attachmentCitation.preview} />
+          )}
+          <CitationIcons>{attachmentCitation.visual}</CitationIcons>
+          <CitationTitle className="truncate text-ellipsis">
+            {attachmentCitation.title}
+          </CitationTitle>
+          {attachmentCitation.type === "node" && (
+            <CitationDescription className="truncate text-ellipsis">
+              <div className="flex items-center gap-1">
+                <span>{attachmentCitation.spaceName}</span>
+              </div>
+            </CitationDescription>
+          )}
+        </Citation>
+      }
+      label={tooltipContent}
+    />
+  );
+}
+
+export function contentFragmentToAttachmentCitation(
+  contentFragment: ContentFragmentType
+): AttachmentCitation {
+  if (contentFragment.contentNodeData) {
+    const { provider, nodeType } = contentFragment.contentNodeData;
+    const logo = getConnectorProviderLogoWithFallback({ provider });
+
+    const visual =
+      provider && ["webcrawler", "folder"].includes(provider) ? (
+        <Icon visual={logo} size="sm" />
+      ) : (
+        <>
+          <Icon
+            visual={
+              nodeType === "table"
+                ? TableIcon
+                : nodeType === "folder"
+                  ? FolderIcon
+                  : DocumentIcon
+            }
+            className="h-5 w-5"
+          />
+          <Icon visual={logo} size="sm" />
+        </>
+      );
+
+    return {
+      type: "node",
+      id: contentFragment.sId,
+      title: contentFragment.title,
+      sourceUrl: contentFragment.sourceUrl,
+      visual,
+      spaceName: contentFragment.contentNodeData.spaceName,
+    };
+  }
+
+  const isImageType = contentFragment.contentType.startsWith("image/");
+  return {
+    type: "file",
+    id: contentFragment.sId,
+    title: contentFragment.title,
+    sourceUrl: contentFragment.sourceUrl,
+    visual: <Icon visual={isImageType ? ImageIcon : DocumentIcon} />,
+  };
+}
+
+export function attachmentToAttachmentCitation(
+  attachment: Attachment
+): AttachmentCitation {
+  if (attachment.type === "file") {
+    return {
+      type: "file",
+      id: attachment.id,
+      title: attachment.title,
+      preview: attachment.preview,
+      isUploading: attachment.isUploading,
+      visual: attachment.preview || (
+        <Icon visual={attachment.preview ? ImageIcon : DocumentIcon} />
+      ),
+      sourceUrl: null,
+    };
+  } else {
+    return {
+      type: "node",
+      id: attachment.id,
+      title: attachment.title,
+      spaceName: attachment.spaceName,
+      spaceIcon: attachment.spaceIcon,
+      path: attachment.path,
+      visual: attachment.visual,
+      sourceUrl: attachment.url,
+    };
+  }
+}

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -59,8 +59,8 @@ interface FileAttachmentCitation extends BaseAttachmentCitation {
 interface NodeAttachmentCitation extends BaseAttachmentCitation {
   type: "node";
   spaceName: string;
-  path: string;
-  spaceIcon: React.ComponentType;
+  path?: string;
+  spaceIcon?: React.ComponentType;
   preview?: never;
   isUploading?: never;
 }

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -149,6 +149,7 @@ export function contentFragmentToAttachmentCitation(
         <Icon visual={logo} size="sm" />
       ) : (
         <>
+          <Icon visual={logo} size="sm" />
           <Icon
             visual={
               nodeType === "table"
@@ -157,9 +158,8 @@ export function contentFragmentToAttachmentCitation(
                   ? FolderIcon
                   : DocumentIcon
             }
-            className="h-5 w-5"
+            size="sm"
           />
-          <Icon visual={logo} size="sm" />
         </>
       );
 
@@ -179,7 +179,7 @@ export function contentFragmentToAttachmentCitation(
     id: contentFragment.sId,
     title: contentFragment.title,
     sourceUrl: contentFragment.sourceUrl,
-    visual: <Icon visual={isImageType ? ImageIcon : DocumentIcon} />,
+    visual: <Icon visual={isImageType ? ImageIcon : DocumentIcon} size="sm" />,
   };
 }
 
@@ -193,9 +193,7 @@ export function attachmentToAttachmentCitation(
       title: attachment.title,
       preview: attachment.preview,
       isUploading: attachment.isUploading,
-      visual: attachment.preview || (
-        <Icon visual={attachment.preview ? ImageIcon : DocumentIcon} />
-      ),
+      visual: <Icon visual={attachment.preview ? ImageIcon : DocumentIcon} />,
       sourceUrl: null,
     };
   } else {

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -1,27 +1,16 @@
-import {
-  Citation,
-  CitationDescription,
-  CitationIcons,
-  CitationImage,
-  CitationTitle,
-  DocumentIcon,
-  FolderIcon,
-  Icon,
-  ImageIcon,
-  SlackLogo,
-  TableIcon,
-  Tooltip,
-  useSendNotification,
-} from "@dust-tt/sparkle";
+import { useSendNotification } from "@dust-tt/sparkle";
 import React from "react";
 import { useSWRConfig } from "swr";
 
 import { AgentMessage } from "@app/components/assistant/conversation/AgentMessage";
+import {
+  AttachmentCitation,
+  contentFragmentToAttachmentCitation,
+} from "@app/components/assistant/conversation/AttachmentCitation";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import type {
   MessageWithContentFragmentsType,
   UserType,
@@ -117,99 +106,13 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       case "user_message":
         const citations = message.contenFragments
           ? message.contenFragments.map((contentFragment) => {
-              let visual;
-              if (contentFragment.contentNodeData) {
-                const { provider, nodeType } = contentFragment.contentNodeData;
-                const logo = getConnectorProviderLogoWithFallback({
-                  provider,
-                });
-
-                // For websites or folders, show just the provider logo
-                const isWebsiteOrFolder =
-                  provider === "webcrawler" || provider === null;
-                if (isWebsiteOrFolder) {
-                  visual = <Icon visual={logo} size="sm" />;
-                } else {
-                  // For other types, show both node type icon and provider logo
-                  const nodeIcon =
-                    nodeType === "table"
-                      ? TableIcon
-                      : nodeType === "folder"
-                        ? FolderIcon
-                        : DocumentIcon;
-
-                  visual = (
-                    <>
-                      <Icon visual={nodeIcon} className="h-5 w-5" />
-                      <Icon visual={logo} size="sm" />
-                    </>
-                  );
-                }
-              } else {
-                // For file attachments
-                const isImageType =
-                  contentFragment.contentType.startsWith("image/");
-                visual = (
-                  <Icon visual={isImageType ? ImageIcon : DocumentIcon} />
-                );
-
-                if (
-                  [
-                    "dust-application/slack",
-                    "text/vnd.dust.attachment.slack.thread",
-                  ].includes(contentFragment.contentType)
-                ) {
-                  visual = <Icon visual={SlackLogo} />;
-                }
-              }
-
-              const tooltipContent = contentFragment.contentNodeData ? (
-                <div className="flex flex-col gap-1">
-                  <div className="font-bold">{contentFragment.title}</div>
-                  <div className="flex gap-1 pt-1 text-sm">
-                    <Icon visual={FolderIcon} />
-                    <p>{contentFragment.contentNodeData.spaceName}</p>
-                  </div>
-                  <div className="text-element-600 text-sm">
-                    {contentFragment.sourceUrl || ""}
-                  </div>
-                </div>
-              ) : (
-                contentFragment.title
-              );
+              const attachmentCitation =
+                contentFragmentToAttachmentCitation(contentFragment);
 
               return (
-                <Tooltip
-                  key={contentFragment.sId}
-                  tooltipTriggerAsChild
-                  trigger={
-                    <Citation
-                      className="w-40"
-                      href={contentFragment.sourceUrl ?? undefined}
-                    >
-                      {contentFragment.sourceUrl &&
-                        !contentFragment.contentNodeData && (
-                          <CitationImage imgSrc={contentFragment.sourceUrl} />
-                        )}
-
-                      <CitationIcons>{visual}</CitationIcons>
-
-                      <CitationTitle className="truncate text-ellipsis">
-                        {contentFragment.title}
-                      </CitationTitle>
-
-                      {contentFragment.contentNodeData && (
-                        <CitationDescription className="truncate text-ellipsis">
-                          <div className="flex items-center gap-1">
-                            <span>
-                              {contentFragment.contentNodeData.spaceName}
-                            </span>
-                          </div>
-                        </CitationDescription>
-                      )}
-                    </Citation>
-                  }
-                  label={tooltipContent}
+                <AttachmentCitation
+                  key={attachmentCitation.id}
+                  attachmentCitation={attachmentCitation}
                 />
               );
             })

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -74,10 +74,10 @@ export function InputBarAttachments({
           <Icon visual={logo} size="sm" />
         ) : (
           <>
+            <Icon visual={logo} size="sm" />
             {getVisualForDataSourceViewContentNode(node)({
               className: "h-5 w-5",
             })}
-            <Icon visual={logo} size="sm" />
           </>
         );
 


### PR DESCRIPTION
## Description

This PR centralizes logic for rendering attachments in the assistant interface by introducing a common AttachmentCitation component. It consolidates the previously separate file and node attachment rendering into a single component that handles both types uniformly. This refactoring improves code maintainability and ensures consistent visual representation of attachments across the application

## Risk

Low - This is primarily a front-end refactoring that consolidates existing functionality without changing core behavior. The changes are focused on visual representation and code organization.

## Deploy Plan

- Deploy front-edge
- Deploy front
