### PR TITLE
[Attach] Fix: sometimes irrelevant match from pasting URL in inputbar

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -25,7 +25,7 @@ import { InputBarAttachmentsPicker } from "@app/components/assistant/conversatio
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
-import { isNodeCandidate } from "@app/lib/connectors";
+import { isNodeCandidate, isUrlCandidate } from "@app/lib/connectors";
 import { getSpaceAccessPriority } from "@app/lib/spaces";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { classNames } from "@app/lib/utils";
@@ -149,8 +149,14 @@ const InputBarContainer = ({
         }));
       });
 
-      if (nodesWithViews.length > 0) {
-        const sortedNodes = nodesWithViews.sort(
+      const nodes = nodesWithViews.filter(
+        (node) =>
+          isNodeCandidate(nodeOrUrlCandidate) ||
+          node.sourceUrl === nodeOrUrlCandidate?.url
+      );
+
+      if (nodes.length > 0) {
+        const sortedNodes = nodes.sort(
           (a, b) => b.spacePriority - a.spacePriority
         );
         const node = sortedNodes[0];
@@ -161,14 +167,15 @@ const InputBarContainer = ({
       // Reset node candidate after processing.
       // FIXME: This causes reset to early and it requires pasting the url twice.
       setNodeOrUrlCandidate(null);
-    } else {
-      sendNotification({
-        title: "No match for URL",
-        description: `Pasted URL does not match any content in knowledge. ${nodeOrUrlCandidate?.provider === "microsoft" ? "(Microsoft URLs are not supported)" : ""}`,
-        type: "info",
-      });
-      setNodeOrUrlCandidate(null);
+      return;
     }
+
+    sendNotification({
+      title: "No match for URL",
+      description: `Pasted URL does not match any content in knowledge. ${nodeOrUrlCandidate?.provider === "microsoft" ? "(Microsoft URLs are not supported)" : ""}`,
+      type: "info",
+    });
+    setNodeOrUrlCandidate(null);
   }, [
     searchResultNodes,
     onNodeSelect,

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -25,7 +25,7 @@ import { InputBarAttachmentsPicker } from "@app/components/assistant/conversatio
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
-import { isNodeCandidate, isUrlCandidate } from "@app/lib/connectors";
+import { isNodeCandidate } from "@app/lib/connectors";
 import { getSpaceAccessPriority } from "@app/lib/spaces";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { classNames } from "@app/lib/utils";
@@ -152,6 +152,8 @@ const InputBarContainer = ({
       const nodes = nodesWithViews.filter(
         (node) =>
           isNodeCandidate(nodeOrUrlCandidate) ||
+          // For nodes whose lookup is done on URL, since search was done also
+          // on title, we ensure the match was on the URL.
           node.sourceUrl === nodeOrUrlCandidate?.url
       );
 


### PR DESCRIPTION
Description
---
On pasting URLs in inputbar, we either find a node id and get that directly, or search by URL.

When searching by URL, we use the regular search endpoint so titles are also searched and matched with a particular search logic.

It may happen that a node is matched by title when pasting a URL this way. The PR ensures that for URL pastes using search by URL, we check that the match was on the URL

Risks
---
standard

Deploy
---
front
