### PR TITLE
[public] add font preload

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -242,7 +242,27 @@ const Header = () => {
     <Head>
       <title>Accelerate your entire organization with custom AI agents</title>
       <link rel="shortcut icon" href="/static/favicon.png" />
-
+      <link
+        rel="preload"
+        href="/static/fonts/Geist-Regular.woff2"
+        as="font"
+        type="font/woff2"
+        crossOrigin="anonymous"
+      />
+      <link
+        rel="preload"
+        href="/static/fonts/Geist-Medium.woff2"
+        as="font"
+        type="font/woff2"
+        crossOrigin="anonymous"
+      />
+      <link
+        rel="preload"
+        href="/static/fonts/Geist-Bold.woff2"
+        as="font"
+        type="font/woff2"
+        crossOrigin="anonymous"
+      />
       <meta name="apple-mobile-web-app-title" content="Dust" />
       <link rel="apple-touch-icon" href="/static/AppIcon.png" />
       <link


### PR DESCRIPTION
## Description
This PR adds font preloading for our Geist font files used in the landing page. By preloading the Regular, Medium and Bold variants of Geist, we ensure critical fonts are downloaded earlier in the page lifecycle , improving initial page render performance and reducing content layout shifts.

⚠️ Ideally I would like to use [Next font loading feature](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) but it will take a bit more time to fully implement and test it everywhere. As a temp solution, I would like to add preload instruction at least for public page to avoid layout shift, since this is more noticeable in the new design.  

If you see a Network tab, you will see some Geist fonts are loaded earlier than other fonts and resources. 

before:

https://github.com/user-attachments/assets/e0f2c92b-eb79-49e9-9505-7ce3b5368962

after:

https://github.com/user-attachments/assets/63515f91-656f-43d4-8188-03e2c0218c3a




<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low risk change - only adds preload directives for existing font files that are already being loaded via CSS 

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
