### PR TITLE
allow readme.io to call the api

### DIFF
--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -4,8 +4,8 @@ const STATIC_ALLOWED_ORIGINS = [
   // Chrome extension.
   "chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg",
   "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn",
-  // readme.io documentation
-  "https://try.readme.io",
+  // Documentation website.
+  "https://docs.dust.tt",
 ] as const;
 
 const ALLOWED_ORIGIN_PATTERNS = [

--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -4,6 +4,8 @@ const STATIC_ALLOWED_ORIGINS = [
   // Chrome extension.
   "chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg",
   "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn",
+  // readme.io documentation
+  "https://try.readme.io",
 ] as const;
 
 const ALLOWED_ORIGIN_PATTERNS = [


### PR DESCRIPTION
## Description
All calls from the [readme playground](https://docs.dust.tt/reference/get_api-v1-w-wid-assistant-agent-configurations) docs seem to be blocked (any api key)

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/7ad373cb-9a6d-4807-9dc5-dd5882f0a6e1" />


from [the dashboard](https://dash.readme.com/project/dust-tt/v1.1/overview)
<img width="883" alt="image" src="https://github.com/user-attachments/assets/fddb52e5-6662-4f3b-b063-bfcc6ae65602" />

[spotted here](https://app.frontapp.com/open/cnv_1a5w30wm?key=SSKqz5xK5q5IaR6hFONI3mJC8SnEhwVh)

## Tests

can't test until deployed :/

