### PR TITLE
[sparkle] - enh(AttachmentChip): add Link props

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.452",
+  "version": "0.2.453",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.452",
+      "version": "0.2.453",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.452",
+  "version": "0.2.453",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/AttachmentChip.tsx
+++ b/sparkle/src/components/AttachmentChip.tsx
@@ -1,33 +1,54 @@
+import { cva } from "class-variance-authority";
 import React from "react";
 
 import { cn } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
+import { LinkWrapper, LinkWrapperProps } from "./LinkWrapper";
 
-interface AttachmentChipProps {
+const attachmentChipVariants = cva(
+  cn(
+    "s-box-border s-inline-flex s-items-center s-gap-1.5 s-rounded-lg s-px-2 s-py-1 s-text-sm s-font-semibold",
+    "s-border-border s-bg-background",
+    "dark:s-border-border-night dark:s-bg-background-night",
+    "s-text-foreground dark:s-text-foreground-night",
+    "s-max-w-44"
+  )
+);
+
+interface AttachmentChipBaseProps {
   label: string;
   icon?: React.ComponentType;
   className?: string;
 }
 
+type AttachmentChipButtonProps = AttachmentChipBaseProps & {
+  href?: never;
+} & {
+  [K in keyof Omit<LinkWrapperProps, "children">]?: never;
+};
+
+type AttachmentChipLinkProps = AttachmentChipBaseProps &
+  Omit<LinkWrapperProps, "children">;
+
+type AttachmentChipProps = AttachmentChipButtonProps | AttachmentChipLinkProps;
+
 export function AttachmentChip({
   label,
   icon,
   className,
+  ...props
 }: AttachmentChipProps) {
-  return (
-    <div
-      className={cn(
-        "s-box-border s-inline-flex s-items-center s-gap-1.5 s-rounded-lg s-px-2 s-py-1 s-text-sm s-font-semibold",
-        "s-border-border s-bg-background",
-        "dark:s-border-border-night dark:s-bg-background-night",
-        "s-text-foreground dark:s-text-foreground-night",
-        "s-max-w-44",
-        className
-      )}
-    >
+  const chipContent = (
+    <div className={cn(attachmentChipVariants({}), className)}>
       <Icon visual={icon} size="xs" className="s-shrink-0" />
       <span className="s-pointer s-grow s-truncate">{label}</span>
     </div>
+  );
+
+  return "href" in props && props.href ? (
+    <LinkWrapper {...props}>{chipContent}</LinkWrapper>
+  ) : (
+    chipContent
   );
 }


### PR DESCRIPTION
## Description

Enhances the `AttachmentChip` component by adding link capabilities through the `LinkWrapper` component. The component now supports link behavior while maintaining its visual appearance. 

## Risk

Low

## Deploy Plan

Publish sparkle