### PR TITLE
Add support for default and ff on actions

### DIFF
--- a/front/components/actions/mcp/ActionsList.tsx
+++ b/front/components/actions/mcp/ActionsList.tsx
@@ -243,64 +243,67 @@ export const AdminActionsList = ({
       onClick: () => {
         setShowDetails(serverView.server);
       },
-      actions: [
-        {
-          disabled:
-            !groupedSpaces.available || groupedSpaces.available.length === 0,
-          kind: "submenu",
-          label: "Add to space",
-          items: (groupedSpaces.available || []).map((s) => ({
-            id: s.sId,
-            name: s.name,
-          })),
-          onSelect: async (spaceId) => {
-            const space = availableSpaces.find((s) => s.sId === spaceId);
-            if (!space) {
-              throw new Error("Space not found");
-            }
-            await addToSpace(serverView.server, space);
-            await mutateMCPServers();
-          },
-        },
-        {
-          disabled:
-            !groupedSpaces.included || groupedSpaces.included.length === 0,
-          kind: "submenu",
-          label: "Remove from space",
-          items: (groupedSpaces.included || []).map((s) => ({
-            id: s.sId,
-            name: s.name,
-          })),
-          onSelect: async (spaceId) => {
-            const space = availableSpaces.find((s) => s.sId === spaceId);
-            if (!space) {
-              throw new Error("Space not found");
-            }
+      actions: serverView.server.isDefault
+        ? []
+        : [
+            {
+              disabled:
+                !groupedSpaces.available ||
+                groupedSpaces.available.length === 0,
+              kind: "submenu",
+              label: "Add to space",
+              items: (groupedSpaces.available || []).map((s) => ({
+                id: s.sId,
+                name: s.name,
+              })),
+              onSelect: async (spaceId) => {
+                const space = availableSpaces.find((s) => s.sId === spaceId);
+                if (!space) {
+                  throw new Error("Space not found");
+                }
+                await addToSpace(serverView.server, space);
+                await mutateMCPServers();
+              },
+            },
+            {
+              disabled:
+                !groupedSpaces.included || groupedSpaces.included.length === 0,
+              kind: "submenu",
+              label: "Remove from space",
+              items: (groupedSpaces.included || []).map((s) => ({
+                id: s.sId,
+                name: s.name,
+              })),
+              onSelect: async (spaceId) => {
+                const space = availableSpaces.find((s) => s.sId === spaceId);
+                if (!space) {
+                  throw new Error("Space not found");
+                }
 
-            const viewToDelete = linkedServerViews?.find(
-              (v) => v.spaceId === spaceId
-            );
-            if (viewToDelete) {
-              await removeFromSpace(viewToDelete, space);
-              await mutateMCPServers();
-            }
-          },
-        },
-        {
-          kind: "item",
-          label: "Edit",
-          onSelect: () => {
-            setShowDetails(serverView.server);
-          },
-        },
-        {
-          kind: "item",
-          label: serverType === "internal" ? "Disable" : "Delete",
-          onSelect: async () => {
-            await deleteServer(serverView.server.id);
-          },
-        },
-      ],
+                const viewToDelete = linkedServerViews?.find(
+                  (v) => v.spaceId === spaceId
+                );
+                if (viewToDelete) {
+                  await removeFromSpace(viewToDelete, space);
+                  await mutateMCPServers();
+                }
+              },
+            },
+            {
+              kind: "item",
+              label: "Edit",
+              onSelect: () => {
+                setShowDetails(serverView.server);
+              },
+            },
+            {
+              kind: "item",
+              label: serverType === "internal" ? "Disable" : "Delete",
+              onSelect: async () => {
+                await deleteServer(serverView.server.id);
+              },
+            },
+          ],
     };
   });
   const columns = getTableColumns();

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -175,14 +175,17 @@ export function ActionValidationProvider({
                 <span className="font-medium">Action:</span>{" "}
                 {currentValidation?.action.functionCallName}
               </div>
-              <div>
-                <span className="font-medium">Inputs:</span>
-                <pre className="mt-2 whitespace-pre-wrap rounded bg-primary-50 p-2 text-sm dark:bg-primary-50-night">
-                  {sanitizeHtml(
-                    JSON.stringify(currentValidation?.inputs, null, 2)
-                  )}
-                </pre>
-              </div>
+              {currentValidation?.inputs &&
+                Object.keys(currentValidation.inputs).length > 0 && (
+                  <div>
+                    <span className="font-medium">Inputs:</span>
+                    <pre className="mt-2 whitespace-pre-wrap rounded bg-primary-50 p-2 text-sm dark:bg-primary-50-night">
+                      {sanitizeHtml(
+                        JSON.stringify(currentValidation?.inputs, null, 2)
+                      )}
+                    </pre>
+                  </div>
+                )}
               <div>Do you want to allow this action to proceed?</div>
 
               {validationQueue.length > 0 && (

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -1,4 +1,10 @@
-import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  getResourceNameAndIdFromSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
+import type { ModelId } from "@app/types";
 
 export const getServerTypeAndIdFromSId = (
   mcpServerId: string
@@ -23,4 +29,30 @@ export const getServerTypeAndIdFromSId = (
         `Invalid MCP server ID: ${mcpServerId} resourceName: ${resourceName}`
       );
   }
+};
+
+export const internalMCPServerNameToSId = ({
+  name,
+  workspaceId,
+}: {
+  name: InternalMCPServerNameType;
+  workspaceId: ModelId;
+}): string => {
+  return makeSId("internal_mcp_server", {
+    id: INTERNAL_MCP_SERVERS[name].id,
+    workspaceId,
+  });
+};
+
+export const remoteMCPServerNameToSId = ({
+  remoteMCPServerId,
+  workspaceId,
+}: {
+  remoteMCPServerId: ModelId;
+  workspaceId: ModelId;
+}): string => {
+  return makeSId("remote_mcp_server", {
+    id: remoteMCPServerId,
+    workspaceId,
+  });
 };

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,4 +1,96 @@
+import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
+import type { ModelId, Result, WhitelistableFeature } from "@app/types";
+import { Err, Ok } from "@app/types";
+
 export const AVAILABLE_INTERNAL_MCPSERVER_NAMES = [
   "helloworld",
   "data-source-utils",
 ] as const;
+
+export const INTERNAL_MCP_SERVERS: Record<
+  InternalMCPServerNameType,
+  {
+    id: number;
+    isDefault: boolean;
+    flag: WhitelistableFeature | null;
+  }
+> = {
+  helloworld: {
+    id: 1,
+    isDefault: true,
+    flag: null,
+  },
+  "data-source-utils": {
+    id: 2,
+    isDefault: false,
+    flag: null,
+  },
+};
+
+export type InternalMCPServerNameType =
+  (typeof AVAILABLE_INTERNAL_MCPSERVER_NAMES)[number];
+
+export const isDefaultInternalMCPServer = (
+  name: InternalMCPServerNameType
+): boolean => {
+  return INTERNAL_MCP_SERVERS[name].isDefault;
+};
+
+export const getInternalMCPServerNameAndWorkspaceId = (
+  sId: string
+): Result<
+  {
+    name: InternalMCPServerNameType;
+    workspaceId: ModelId;
+  },
+  Error
+> => {
+  const sIdParts = getResourceNameAndIdFromSId(sId);
+
+  if (!sIdParts) {
+    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
+  }
+
+  if (sIdParts.resourceName !== "internal_mcp_server") {
+    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
+  }
+
+  // Swap keys and values.
+  const details = Object.entries(INTERNAL_MCP_SERVERS).find(
+    ([, internalMCPServer]) => internalMCPServer.id === sIdParts.resourceId
+  );
+
+  if (!details) {
+    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
+  }
+
+  if (!isInternalMCPServerName(details[0])) {
+    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
+  }
+
+  const name: InternalMCPServerNameType = details[0];
+
+  return new Ok({
+    name,
+    workspaceId: sIdParts.workspaceId,
+  });
+};
+
+export const isInternalMCPServerName = (
+  name: string
+): name is InternalMCPServerNameType =>
+  AVAILABLE_INTERNAL_MCPSERVER_NAMES.includes(
+    name as InternalMCPServerNameType
+  );
+
+export const isValidInternalMCPServerId = (
+  workspaceId: ModelId,
+  sId: string
+): boolean => {
+  const r = getInternalMCPServerNameAndWorkspaceId(sId);
+  if (r.isOk()) {
+    return r.value.workspaceId === workspaceId;
+  }
+
+  return false;
+};

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -2,91 +2,29 @@ import type { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
-import { AVAILABLE_INTERNAL_MCPSERVER_NAMES } from "@app/lib/actions/mcp_internal_actions/constants";
-import dataSourceUtilsServer from "@app/lib/actions/mcp_internal_actions/data_source_utils";
-import helloWorldServer from "@app/lib/actions/mcp_internal_actions/helloworld";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  getInternalMCPServerNameAndWorkspaceId,
+  INTERNAL_MCP_SERVERS,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import { default as dataSourceUtilsServer } from "@app/lib/actions/mcp_internal_actions/data_source_utils";
+import { default as helloWorldServer } from "@app/lib/actions/mcp_internal_actions/helloworld";
 import type { Authenticator } from "@app/lib/auth";
-import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
-import type { ModelId, Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { getFeatureFlags } from "@app/lib/auth";
+import { assertNever } from "@app/types";
 
-export const INTERNAL_MCP_SERVERS: Record<
-  InternalMCPServerNameType,
-  {
-    id: number;
-    createServer: (auth: Authenticator, mcpServerId: string) => McpServer;
-  }
-> = {
-  helloworld: {
-    id: 1,
-    createServer: helloWorldServer,
-  },
-  "data-source-utils": {
-    id: 2,
-    createServer: dataSourceUtilsServer,
-  },
-};
-
-export type InternalMCPServerNameType =
-  (typeof AVAILABLE_INTERNAL_MCPSERVER_NAMES)[number];
-
-const getInternalMCPServerNameAndWorkspaceId = (
-  sId: string
-): Result<
-  {
-    name: InternalMCPServerNameType;
-    workspaceId: ModelId;
-  },
-  Error
-> => {
-  const sIdParts = getResourceNameAndIdFromSId(sId);
-
-  if (!sIdParts) {
-    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
-  }
-
-  if (sIdParts.resourceName !== "internal_mcp_server") {
-    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
-  }
-
-  // Swap keys and values.
-  const details = Object.entries(INTERNAL_MCP_SERVERS).find(
-    ([, internalMCPServer]) => internalMCPServer.id === sIdParts.resourceId
-  );
-
-  if (!details) {
-    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
-  }
-
-  if (!isInternalMCPServerName(details[0])) {
-    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
-  }
-
-  const name: InternalMCPServerNameType = details[0];
-
-  return new Ok({
-    name,
-    workspaceId: sIdParts.workspaceId,
-  });
-};
-
-export const isInternalMCPServerName = (
-  name: string
-): name is InternalMCPServerNameType =>
-  AVAILABLE_INTERNAL_MCPSERVER_NAMES.includes(
-    name as InternalMCPServerNameType
-  );
-
-export const isValidInternalMCPServerId = (
+export const isEnabledForWorkspace = async (
   auth: Authenticator,
-  sId: string
-): boolean => {
-  const r = getInternalMCPServerNameAndWorkspaceId(sId);
-  if (r.isOk()) {
-    return r.value.workspaceId === auth.getNonNullableWorkspace().id;
+  name: InternalMCPServerNameType
+): Promise<boolean> => {
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+
+  const flag = INTERNAL_MCP_SERVERS[name].flag;
+  if (!flag) {
+    return true;
   }
 
-  return false;
+  return featureFlags.includes(flag);
 };
 
 export const connectToInternalMCPServer = async (
@@ -105,8 +43,18 @@ export const connectToInternalMCPServer = async (
     );
   }
 
-  const { createServer } = INTERNAL_MCP_SERVERS[internalMCPServerName];
-  const server = createServer(auth, mcpServerId);
+  let server: McpServer;
+
+  switch (internalMCPServerName) {
+    case "helloworld":
+      server = helloWorldServer(auth, mcpServerId);
+      break;
+    case "data-source-utils":
+      server = dataSourceUtilsServer();
+      break;
+    default:
+      assertNever(internalMCPServerName);
+  }
 
   await server.connect(transport);
 

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -38,9 +38,13 @@ export type MCPServerType = {
   icon: AllowedIconType;
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
+  isDefault: boolean;
 };
 
-export type MCPServerDefinitionType = Omit<MCPServerType, "tools" | "id">;
+export type MCPServerDefinitionType = Omit<
+  MCPServerType,
+  "tools" | "id" | "isDefault"
+>;
 
 export type AuthorizationInfo = {
   provider: OAuthProvider;
@@ -219,6 +223,7 @@ export async function fetchRemoteServerMetaDataByURL(
     return {
       ...metadata,
       tools: serverTools,
+      isDefault: false,
     };
   } finally {
     await mcpClient.close();

--- a/front/lib/models/assistant/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view_helper.ts
@@ -1,0 +1,49 @@
+import type { Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import type { ModelId } from "@app/types";
+
+export const destroyMCPServerViewDependencies = async (
+  auth: Authenticator,
+  {
+    mcpServerViewId,
+    transaction,
+  }: {
+    mcpServerViewId: ModelId;
+    transaction?: Transaction;
+  }
+) => {
+  // Delete all dependencies.
+  // TODO(mcp) add table datasources etc when they are implemented in AB
+  const agentConfigurationIds = (
+    await AgentMCPServerConfiguration.findAll({
+      attributes: ["id"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        mcpServerViewId: mcpServerViewId,
+      },
+      transaction,
+    })
+  ).map((view: AgentMCPServerConfiguration) => view.id);
+
+  await AgentDataSourceConfiguration.destroy({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      mcpServerConfigurationId: {
+        [Op.in]: agentConfigurationIds,
+      },
+    },
+    transaction,
+  });
+
+  await AgentMCPServerConfiguration.destroy({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      mcpServerViewId: mcpServerViewId,
+    },
+    transaction,
+  });
+};

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -105,12 +105,14 @@ export class InternalMCPServerInMemoryResource {
       },
     });
 
-    await Promise.all(
-      mcpServerViews.map(async (mcpServerView) => {
+    await concurrentExecutor(
+      mcpServerViews,
+      async (mcpServerView) => {
         await destroyMCPServerViewDependencies(auth, {
           mcpServerViewId: mcpServerView.id,
         });
-      })
+      },
+      { concurrency: 10 }
     );
 
     await MCPServerView.destroy({

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -8,12 +8,14 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
-import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import {
+  getServerTypeAndIdFromSId,
+  remoteMCPServerNameToSId,
+} from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerConnection } from "@app/lib/models/assistant/actions/mcp_server_connection";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -222,8 +224,8 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       },
       remoteMCPServerId:
         this.remoteMCPServerId &&
-        RemoteMCPServerResource.modelIdToSId({
-          id: this.remoteMCPServerId,
+        remoteMCPServerNameToSId({
+          remoteMCPServerId: this.remoteMCPServerId,
           workspaceId: this.workspaceId,
         }),
     };

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -2,7 +2,8 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions";
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPServerType } from "@app/lib/actions/mcp_metadata";
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -190,12 +191,10 @@ async function handler(
           });
         }
 
-        const internalMCPServerId = InternalMCPServerInMemoryResource.nameToSId(
-          {
-            name,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          }
-        );
+        const internalMCPServerId = internalMCPServerNameToSId({
+          name,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        });
 
         const existingServer =
           await InternalMCPServerInMemoryResource.fetchById(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -1,8 +1,8 @@
 import type { RequestMethod } from "node-mocks-http";
 import { describe, expect } from "vitest";
 
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { Authenticator } from "@app/lib/auth";
-import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -38,7 +38,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
     const regularSpace = await SpaceFactory.regular(workspace, t);
 
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    const mcpServerId = InternalMCPServerInMemoryResource.nameToSId({
+    const mcpServerId = internalMCPServerNameToSId({
       name: "helloworld",
       workspaceId: workspace.id,
     });
@@ -90,7 +90,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
 describe("Method Support /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
   itInTransaction("only supports DELETE method", async (t) => {
     const { req, res, workspace, space } = await setupTest(t, "admin", "GET");
-    const mcpServerId = InternalMCPServerInMemoryResource.nameToSId({
+    const mcpServerId = internalMCPServerNameToSId({
       name: "helloworld",
       workspaceId: workspace.id,
     });

--- a/front/pages/w/[wId]/actions.tsx
+++ b/front/pages/w/[wId]/actions.tsx
@@ -11,6 +11,7 @@ import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/actions/mcp_metadata";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 
@@ -32,6 +33,8 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
       notFound: true,
     };
   }
+
+  await MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth);
 
   return {
     props: {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -16,6 +16,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
   AppType,
@@ -58,6 +59,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     await Promise.all([
       getAccessibleSourcesAndApps(auth),
       getAgentConfiguration(auth, context.params?.aId as string, "full"),
+      MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth),
     ]);
 
   if (configuration?.scope === "workspace" && !auth.isBuilder()) {

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -24,6 +24,7 @@ import { AssistantSidebarMenu } from "@app/components/assistant/conversation/Sid
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { subFilter } from "@app/lib/utils";
 import type {
@@ -46,6 +47,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       notFound: true,
     };
   }
+
+  await MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth);
 
   const tabScope = ASSISTANT_MANAGER_TABS.map((tab) => tab.id).includes(
     context.query.tabScope as AssistantManagerTabsType


### PR DESCRIPTION
## Description

- Add support for feature flag and default status on internal actions.
- Exclude by feature flag when listing available internal actions.
- Fix deletions of actions
- Remove "..." menu for default actions
- Automatically create missing default internal actions at strategic moments: create / edit assistants, list actions (not a fan of the solution, might revisit later)

## Tests

Local but will add some.

## Risk

Low, behind FF.

## Deploy Plan

Deploy `front` and check
