### PR TITLE
fix(MCP) - fix input injection for nested schemas

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -42,6 +42,10 @@ export type ConfigurableToolInputType = z.infer<
   (typeof ConfigurableToolInputSchemas)[InternalConfigurationMimeType]
 >;
 
+/**
+ * Mapping between the mime types we used to identify a configurable resource
+ * and the JSON schema resulting from the Zod schema defined above.
+ */
 const ConfigurableToolInputJSONSchemas = Object.fromEntries(
   Object.entries(ConfigurableToolInputSchemas).map(([key, schema]) => [
     key,
@@ -49,6 +53,10 @@ const ConfigurableToolInputJSONSchemas = Object.fromEntries(
   ])
 ) as Record<InternalConfigurationMimeType, JSONSchema>;
 
+/**
+ * Defines how we fill the actual inputs of the tool for each mime type.
+ * TODO(mcp): typing too weak here, testing the inference is hard before we have more INTERNAL_MIME_TYPES.CONFIGURATION.
+ */
 function generateConfiguredInput({
   actionConfiguration,
   owner,

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -4,6 +4,8 @@ import type {
 } from "json-schema";
 import { isEqual } from "lodash";
 
+import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+
 /**
  * Type guard to check if a value is a JSONSchema object
  */
@@ -140,10 +142,10 @@ export function findSchemaAtPath(
  * Sets a value at a specific path in a nested object structure.
  * Assumes that intermediate objects already exist.
  */
-export function setValueAtPath<T>(
+export function setValueAtPath(
   obj: Record<string, unknown>,
   path: string[],
-  value: T
+  value: ConfigurableToolInputType
 ): void {
   if (path.length === 0) {
     return;

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -2,6 +2,7 @@ import type {
   JSONSchema7 as JSONSchema,
   JSONSchema7Definition as JSONSchemaDefinition,
 } from "json-schema";
+import { isEqual } from "lodash";
 
 /**
  * Type guard to check if a value is a JSONSchema object
@@ -12,17 +13,26 @@ export function isJSONSchemaObject(
   return value !== null && typeof value === "object";
 }
 
+/**
+ * Compares two JSON schemas for equality, only checking the properties, items and required fields.
+ * In particular, it ignores the $schema field.
+ */
 export function schemasAreEqual(
   schemaA: JSONSchema,
   schemaB: JSONSchema
 ): boolean {
-  return (
-    schemaA.type === schemaB.type &&
-    schemaA.items === schemaB.items &&
-    schemaA.properties === schemaB.properties &&
-    schemaA.required === schemaB.required
-  );
+  if (schemaA.type !== schemaB.type) {
+    return false;
+  }
+  if (!isEqual(schemaA.required, schemaB.required)) {
+    return false;
+  }
+  if (!isEqual(schemaA.items, schemaB.items)) {
+    return false;
+  }
+  return isEqual(schemaA.properties, schemaB.properties);
 }
+
 /**
  * Recursively checks if a schema contains a specific sub-schema anywhere in its structure.
  * This function handles nested objects and arrays.


### PR DESCRIPTION
## Description

Direct follow up on https://github.com/dust-tt/dust/pull/11710.
This PR fixes the input reinjection mechanism for nested input schemas. For instance if your input schema is the following:
```typescript
{
  query: z.string(),
  dataSources: z.object({
    fieldA: z.string(),
    fieldB:
      ConfigurableToolInputSchemas[
        INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE
      ],
  }),
}
```

then the model will be presented with:

```typescript
{
  query: z.string(),
  dataSources: z.object({
    fieldA: z.string(),
  }),
}
```
and `fieldB` will be correctly reinjected before calling the tool.

The JSONSchema parsing and comparison is quite brittle, what protects us is the fact that the schemas we compare against are the ones we provide in `ConfigurableToolInputSchemas`, so we should keep these simple.

## Tests

- Tested with the example above.

## Risk

- N/A.

## Deploy Plan

- Deploy front.