### PR TITLE
Publish the exploratory features page + remove labs_github_actions FF

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -1,8 +1,6 @@
 import {
   Avatar,
-  BookOpenIcon,
   ChevronDownIcon,
-  CloudArrowLeftRightIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -13,7 +11,6 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-  EyeIcon,
   Icon,
   LightbulbIcon,
   LightModeIcon,

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -38,9 +38,6 @@ export function UserMenu({
   const router = useRouter();
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
-  const hasBetaAccess = featureFlags.some((flag: string) =>
-    flag.startsWith("labs_")
-  );
   const sendNotification = useSendNotification();
 
   const forceRoleUpdate = useMemo(
@@ -89,16 +86,12 @@ export function UserMenu({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent>
-        {hasBetaAccess && (
-          <>
-            <DropdownMenuLabel label="Beta" />
-            <DropdownMenuItem
-              label="Exploratory features"
-              icon={TestTubeIcon}
-              href={`/w/${owner.sId}/labs`}
-            />
-          </>
-        )}
+        <DropdownMenuLabel label="Beta" />
+        <DropdownMenuItem
+          label="Exploratory features"
+          icon={TestTubeIcon}
+          href={`/w/${owner.sId}/labs`}
+        />
 
         {showDebugTools(featureFlags) && (
           <>

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -95,34 +95,11 @@ export function UserMenu({
         {hasBetaAccess && (
           <>
             <DropdownMenuLabel label="Beta" />
-            {featureFlags.includes("labs_features") && (
-              <DropdownMenuItem
-                label="Beta features"
-                icon={TestTubeIcon}
-                href={`/w/${owner.sId}/labs`}
-              />
-            )}
-            {featureFlags.includes("labs_transcripts") && (
-              <DropdownMenuItem
-                label="Meeting transcripts"
-                icon={BookOpenIcon}
-                href={`/w/${owner.sId}/labs/transcripts`}
-              />
-            )}
-            {featureFlags.includes("labs_trackers") && (
-              <DropdownMenuItem
-                label="Trackers"
-                icon={EyeIcon}
-                href={`/w/${owner.sId}/labs/trackers`}
-              />
-            )}
-            {featureFlags.includes("labs_github_actions") && (
-              <DropdownMenuItem
-                label="Platform Actions"
-                icon={CloudArrowLeftRightIcon}
-                href={`/w/${owner.sId}/labs/platform_actions`}
-              />
-            )}
+            <DropdownMenuItem
+              label="Exploratory features"
+              icon={TestTubeIcon}
+              href={`/w/${owner.sId}/labs`}
+            />
           </>
         )}
 

--- a/front/components/labs/FeatureAccessButton.tsx
+++ b/front/components/labs/FeatureAccessButton.tsx
@@ -7,6 +7,7 @@ interface FeatureAccessButtonProps {
   featureName: string;
   managePath: string;
   owner: LightWorkspaceType;
+  canRequestAccess: boolean;
 }
 
 export function FeatureAccessButton({
@@ -14,6 +15,7 @@ export function FeatureAccessButton({
   featureName,
   managePath,
   owner,
+  canRequestAccess,
 }: FeatureAccessButtonProps) {
   return (
     <>
@@ -26,7 +28,11 @@ export function FeatureAccessButton({
           href={managePath}
         />
       ) : (
-        <RequestFeatureAccessModal owner={owner} featureName={featureName} />
+        <RequestFeatureAccessModal
+          owner={owner}
+          featureName={featureName}
+          canRequestAccess={canRequestAccess}
+        />
       )}
     </>
   );

--- a/front/components/labs/RequestFeatureAccessModal.tsx
+++ b/front/components/labs/RequestFeatureAccessModal.tsx
@@ -71,18 +71,20 @@ export function RequestFeatureAccessModal({
         <SheetContainer>
           <div className="flex flex-col gap-4 p-4">
             <div className="flex flex-col gap-2">
-              <div className="flex flex-col gap-2">
-                <p className="text-element-700 mb-2 text-sm">
-                  {`This feature is currently in beta. If you'd like to request access, please fill out the form below.`}
-                </p>
-              </div>
               {canRequestAccess ? (
-                <TextArea
-                  placeholder={`Please tell us why you'd like to access ${featureName}`}
-                  value={message}
-                  onChange={(e) => setMessage(e.target.value)}
-                  className="mb-2"
-                />
+                <>
+                  <div className="flex flex-col gap-2">
+                    <p className="text-element-700 mb-2 text-sm">
+                      {`This feature is currently in beta. If you'd like to request access, please fill out the form below.`}
+                    </p>
+                  </div>
+                  <TextArea
+                    placeholder={`Please tell us why you'd like to access ${featureName}`}
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    className="mb-2"
+                  />
+                </>
               ) : (
                 <p className="text-element-700 mb-2 text-sm">
                   {`You don't have permission to request access to this feature. Please ask a Dust administrator to make the request.`}

--- a/front/components/labs/RequestFeatureAccessModal.tsx
+++ b/front/components/labs/RequestFeatureAccessModal.tsx
@@ -19,11 +19,13 @@ import type { LightWorkspaceType } from "@app/types";
 interface RequestFeatureAccessModal {
   owner: LightWorkspaceType;
   featureName: string;
+  canRequestAccess: boolean;
 }
 
 export function RequestFeatureAccessModal({
   owner,
   featureName,
+  canRequestAccess,
 }: RequestFeatureAccessModal) {
   const [message, setMessage] = useState("");
   const sendNotification = useSendNotification();
@@ -33,6 +35,9 @@ export function RequestFeatureAccessModal({
   };
 
   const onSave = async () => {
+    if (!canRequestAccess) {
+      return;
+    }
     try {
       await sendRequestFeatureAccessEmail({
         emailMessage: message,
@@ -71,12 +76,18 @@ export function RequestFeatureAccessModal({
                   {`This feature is currently in beta. If you'd like to request access, please fill out the form below.`}
                 </p>
               </div>
-              <TextArea
-                placeholder={`Please tell us why you'd like to access ${featureName}`}
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
-                className="mb-2"
-              />
+              {canRequestAccess ? (
+                <TextArea
+                  placeholder={`Please tell us why you'd like to access ${featureName}`}
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  className="mb-2"
+                />
+              ) : (
+                <p className="text-element-700 mb-2 text-sm">
+                  {`You don't have permission to request access to this feature. Please ask a Dust administrator to make the request.`}
+                </p>
+              )}
             </div>
           </div>
         </SheetContainer>
@@ -89,7 +100,7 @@ export function RequestFeatureAccessModal({
           rightButtonProps={{
             label: "Send",
             onClick: onSave,
-            disabled: message.length === 0,
+            disabled: message.length === 0 || !canRequestAccess,
           }}
         />
       </SheetContent>

--- a/front/pages/w/[wId]/labs/index.tsx
+++ b/front/pages/w/[wId]/labs/index.tsx
@@ -135,6 +135,7 @@ export default function LabsTranscriptsIndex({
                       featureName={item.label}
                       managePath={`/w/${owner.sId}/labs/${item.id}`}
                       owner={owner}
+                      canRequestAccess={isAdmin}
                     />
                   }
                   visual={<Icon visual={item.icon} />}
@@ -160,6 +161,7 @@ export default function LabsTranscriptsIndex({
                           featureName={`${item.label} connection`}
                           managePath={`/w/${owner.sId}/labs/connections/${item.id}`}
                           owner={owner}
+                          canRequestAccess={isAdmin}
                         />
                       }
                       visual={<ContextItem.Visual visual={item.logo} />}

--- a/front/pages/w/[wId]/labs/index.tsx
+++ b/front/pages/w/[wId]/labs/index.tsx
@@ -37,19 +37,18 @@ const LABS_FEATURES: LabsFeatureItemType[] = [
     id: "trackers",
     label: "Document Tracker",
     featureFlag: "labs_trackers",
-    visibleWithoutAccess: false,
+    visibleWithoutAccess: true,
     icon: BookOpenIcon,
     description:
       "Document monitoring made simple - receive alerts when documents are out of date.",
   },
 ];
-
 const LABS_CONNECTIONS: LabsConnectionItemType[] = [
   {
     id: "hubspot",
     label: "Hubspot",
     featureFlag: "labs_connection_hubspot",
-    visibleWithoutAccess: true,
+    visibleWithoutAccess: false,
     logo: HubspotLogo,
     description: "Import your Hubspot data into Dust.",
   },
@@ -103,6 +102,8 @@ export default function LabsTranscriptsIndex({
   featureFlags,
   isAdmin,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const visibleConnections = getVisibleConnections(featureFlags);
+  const visibleFeatures = getVisibleFeatures(featureFlags);
   return (
     <ConversationsNavigationProvider>
       <AppLayout
@@ -113,7 +114,7 @@ export default function LabsTranscriptsIndex({
       >
         <Page>
           <Page.Header
-            title="Beta features"
+            title="Exploratory features"
             icon={TestTubeIcon}
             description="Expect some bumps and changes. Feedback welcome, tell us what you think!"
           />
@@ -124,7 +125,7 @@ export default function LabsTranscriptsIndex({
                 description="All features presented here are in beta and may change or be removed."
               />
 
-              {getVisibleFeatures(featureFlags).map((item) => (
+              {visibleFeatures.map((item) => (
                 <ContextItem
                   key={item.id}
                   title={item.label}
@@ -142,14 +143,14 @@ export default function LabsTranscriptsIndex({
                 </ContextItem>
               ))}
 
-              {isAdmin && (
+              {isAdmin && visibleConnections.length > 0 && (
                 <>
                   <ContextItem.SectionHeader
                     title="Connections"
                     description="These connections are being tested and may require some manual steps."
                   />
 
-                  {getVisibleConnections(featureFlags).map((item) => (
+                  {visibleConnections.map((item) => (
                     <ContextItem
                       key={item.id}
                       title={item.label}

--- a/front/pages/w/[wId]/labs/trackers/index.tsx
+++ b/front/pages/w/[wId]/labs/trackers/index.tsx
@@ -166,7 +166,7 @@ export default function TrackerConfigurations({
 
   const items = [
     {
-      label: "Beta features",
+      label: "Exploratory features",
       href: `/w/${owner.sId}/labs`,
     },
     {

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -145,7 +145,7 @@ export default function LabsTranscriptsIndex({
   const agents = agentConfigurations.filter((a) => a.status === "active");
   const items = [
     {
-      label: "Beta features",
+      label: "Exploratory features",
       href: `/w/${owner.sId}/labs`,
     },
     {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -4,7 +4,6 @@ export const WHITELISTABLE_FEATURES = [
   "labs_features",
   "labs_transcripts",
   "labs_connection_hubspot",
-  "labs_github_actions",
   "labs_trackers",
   "openai_o1_feature",
   "openai_o1_mini_feature",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -794,7 +794,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_transcripts"
   | "labs_connection_hubspot"
   | "labs_trackers"
-  | "labs_github_actions"
   | "document_tracker"
   | "openai_o1_feature"
   | "openai_o1_mini_feature"


### PR DESCRIPTION
## Description

- Publish the exploratory features page to all workspaces
- Remove labs_github_actions FF
- Goal is to see user discovery and appetite (transcripts and doc tracker are visible and users can request access)


<img width="210" alt="Screenshot 2025-04-03 at 17 04 31" src="https://github.com/user-attachments/assets/2da3468d-7c9c-4428-9367-06cd025dac7d" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
