### PR TITLE
Slack cli: channel add/remove to/from sync

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -1,4 +1,7 @@
-import { updateSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
+import {
+  joinChannel,
+  updateSlackChannelInConnectorsDb,
+} from "@connectors/connectors/slack/lib/channels";
 import {
   getSlackChannelSourceUrl,
   slackChannelInternalIdFromSlackChannelId,
@@ -283,6 +286,66 @@ export const slack = async ({
         sourceUrl: getSlackChannelSourceUrl(args.channelId, slackConfiguration),
         providerVisibility: channel.private ? "private" : "public",
       });
+      return { success: true };
+    }
+
+    case "add-channel-to-sync": {
+      if (!args.wId) {
+        throw new Error("Missing --wId argument");
+      }
+      if (!args.channelId) {
+        throw new Error("Missing --channelId argument");
+      }
+      const connector = await ConnectorModel.findOne({
+        where: { workspaceId: `${args.wId}`, type: "slack" },
+      });
+      if (!connector) {
+        throw new Error(`Could not find connector for workspace ${args.wId}`);
+      }
+
+      const remoteChannel = await getChannel(connector.id, args.channelId);
+      if (!remoteChannel.name) {
+        throw new Error(
+          `Could not find channel name for channel ${args.channelId}`
+        );
+      }
+
+      const joinRes = await joinChannel(connector.id, args.channelId);
+      if (joinRes.isErr()) {
+        throw new Error(
+          `Could not join channel ${args.channelId}: ${joinRes.error}`
+        );
+      }
+
+      // const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+      const slackConfiguration =
+        await SlackConfigurationResource.fetchByConnectorId(connector.id);
+      if (!slackConfiguration) {
+        throw new Error(
+          `Could not find Slack configuration for connector ${connector.id}`
+        );
+      }
+
+      const channel = await updateSlackChannelInConnectorsDb({
+        slackChannelId: args.channelId,
+        slackChannelName: remoteChannel.name,
+        connectorId: connector.id,
+        createIfNotExistsWithParams: {
+          permission: "read_write",
+          private: !!remoteChannel.is_private,
+        },
+      });
+
+      const workflowRes = await launchSlackSyncWorkflow(connector.id, null, [
+        channel.slackId,
+      ]);
+      if (workflowRes.isErr()) {
+        throw new Error(
+          `Could not launch workflow for channel ${args.channelId}: ${workflowRes.error}`
+        );
+      }
+
       return { success: true };
     }
 

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -143,6 +143,8 @@ export const SlackCommandSchema = t.type({
     t.literal("whitelist-domains"),
     t.literal("whitelist-bot"),
     t.literal("sync-channel-metadata"),
+    t.literal("add-channel-to-sync"),
+    t.literal("remove-channel-from-sync"),
   ]),
   args: t.record(
     t.string,


### PR DESCRIPTION
## Description

Add ability in the Slack cli to add/remove channel from sync. Useful when a channel is a high volume high noise channel and breaks our webhook handling to remove the channel from the sync + garbage collect its content.

for: https://github.com/dust-tt/tasks/issues/2516

## Tests

N/A

## Risk

Low - internal cli

## Deploy Plan

- deploy connectors