### PR TITLE
feat(MCP) - Add a tool to print the data source name

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -29,7 +29,7 @@ import type {
   ModelId,
   Result,
 } from "@app/types";
-import { Ok } from "@app/types";
+import { normalizeError, Ok } from "@app/types";
 
 export type MCPServerConfigurationType = {
   id: ModelId;
@@ -463,7 +463,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         messageId: agentMessage.sId,
         error: {
           code: "tool_error",
-          message: `Error calling tool ${actionConfiguration.name}: ${JSON.stringify(rawInputs)} => ${JSON.stringify(r.error.message)}`,
+          message: `Error calling tool ${actionConfiguration.name}: ${JSON.stringify(rawInputs)} => ${JSON.stringify(normalizeError(r.error.message))}`,
         },
       };
       return;

--- a/front/lib/actions/mcp_internal_actions/data_source_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/data_source_utils.ts
@@ -33,7 +33,7 @@ async function fetchAgentDataSourceConfiguration(
     );
   }
 
-  const [, workspaceId, dataSourceConfigId] = match;
+  const [, , dataSourceConfigId] = match;
   const sIdParts = getResourceNameAndIdFromSId(dataSourceConfigId);
   if (!sIdParts) {
     return new Err(
@@ -53,16 +53,18 @@ async function fetchAgentDataSourceConfiguration(
       nest: true,
       include: [{ model: DataSourceModel, as: "dataSource", required: true }],
     });
+
   if (
     agentDataSourceConfiguration &&
-    agentDataSourceConfiguration.workspaceId !== parseInt(workspaceId, 10)
+    agentDataSourceConfiguration.workspaceId !== sIdParts.workspaceId
   ) {
     return new Err(
       new Error(
-        `Data source configuration ${dataSourceConfigId} does not belong to workspace ${workspaceId}`
+        `Data source configuration ${dataSourceConfigId} does not belong to workspace ${sIdParts.workspaceId}`
       )
     );
   }
+
   return new Ok(agentDataSourceConfiguration);
 }
 
@@ -92,7 +94,7 @@ function createServer(): McpServer {
             .filter((res) => res.isErr())
             .map((res) => ({
               type: "text",
-              text: res.isErr() ? res.error.message : "",
+              text: res.isErr() ? res.error.message : "unknown error",
             })),
         };
       }

--- a/front/lib/actions/mcp_internal_actions/data_source_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/data_source_utils.ts
@@ -54,17 +54,6 @@ async function fetchAgentDataSourceConfiguration(
       include: [{ model: DataSourceModel, as: "dataSource", required: true }],
     });
 
-  if (
-    agentDataSourceConfiguration &&
-    agentDataSourceConfiguration.workspaceId !== sIdParts.workspaceId
-  ) {
-    return new Err(
-      new Error(
-        `Data source configuration ${dataSourceConfigId} does not belong to workspace ${sIdParts.workspaceId}`
-      )
-    );
-  }
-
   return new Ok(agentDataSourceConfiguration);
 }
 

--- a/front/lib/actions/mcp_internal_actions/data_source_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/data_source_utils.ts
@@ -66,7 +66,7 @@ async function fetchAgentDataSourceConfiguration(
   return new Ok(agentDataSourceConfiguration);
 }
 
-const createServer = (): McpServer => {
+function createServer(): McpServer {
   const server = new McpServer(serverInfo);
 
   server.tool(
@@ -107,6 +107,6 @@ const createServer = (): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/data_source_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/data_source_utils.ts
@@ -2,8 +2,17 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import {
+  ConfigurableToolInputSchemas,
+  DATA_SOURCE_CONFIGURATION_URI_PATTERN,
+} from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerDefinitionType } from "@app/lib/actions/mcp_metadata";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 const serverInfo: MCPServerDefinitionType = {
   name: "data-source-utils",
@@ -14,12 +23,55 @@ const serverInfo: MCPServerDefinitionType = {
   authorization: null,
 };
 
+async function fetchAgentDataSourceConfiguration(
+  uri: string
+): Promise<Result<AgentDataSourceConfiguration | null, Error>> {
+  const match = uri.match(DATA_SOURCE_CONFIGURATION_URI_PATTERN);
+  if (!match) {
+    return new Err(
+      new Error(`Invalid URI for a data source configuration: ${uri}`)
+    );
+  }
+
+  const [, workspaceId, dataSourceConfigId] = match;
+  const sIdParts = getResourceNameAndIdFromSId(dataSourceConfigId);
+  if (!sIdParts) {
+    return new Err(
+      new Error(`Invalid data source configuration ID: ${dataSourceConfigId}`)
+    );
+  }
+  if (sIdParts.resourceName !== "data_source_configuration") {
+    return new Err(
+      new Error(
+        `ID is not a data source configuration ID: ${dataSourceConfigId}`
+      )
+    );
+  }
+
+  const agentDataSourceConfiguration =
+    await AgentDataSourceConfiguration.findByPk(sIdParts.resourceId, {
+      nest: true,
+      include: [{ model: DataSourceModel, as: "dataSource", required: true }],
+    });
+  if (
+    agentDataSourceConfiguration &&
+    agentDataSourceConfiguration.workspaceId !== parseInt(workspaceId, 10)
+  ) {
+    return new Err(
+      new Error(
+        `Data source configuration ${dataSourceConfigId} does not belong to workspace ${workspaceId}`
+      )
+    );
+  }
+  return new Ok(agentDataSourceConfiguration);
+}
+
 const createServer = (): McpServer => {
   const server = new McpServer(serverInfo);
 
   server.tool(
-    "pass-through",
-    "Super useful tool that should be used at all time.",
+    "show-data-source-names",
+    "Shows the names of the data sources available.",
     {
       query: z.string(),
       dataSources:
@@ -27,15 +79,29 @@ const createServer = (): McpServer => {
           INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE
         ],
     },
-    ({ dataSources: [{ uri, mimeType }] }) => {
+    async ({ dataSources }) => {
+      const agentDataSourceConfigurations = await concurrentExecutor(
+        dataSources,
+        async ({ uri }) => fetchAgentDataSourceConfiguration(uri),
+        { concurrency: 10 }
+      );
+      if (agentDataSourceConfigurations.some((res) => res.isErr())) {
+        return {
+          isError: true,
+          content: agentDataSourceConfigurations
+            .filter((res) => res.isErr())
+            .map((res) => ({
+              type: "text",
+              text: res.isErr() ? res.error.message : "",
+            })),
+        };
+      }
       return {
         isError: false,
-        content: [
-          {
-            type: "text",
-            text: `Got the URI: ${uri} and the mimeType ${mimeType}`,
-          },
-        ],
+        content: agentDataSourceConfigurations.map((res) => ({
+          type: "text",
+          text: (res.isOk() && res.value?.dataSource?.name) || "unknown",
+        })),
       };
     }
   );

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -22,10 +22,7 @@ import type { WorkspaceType } from "@app/types";
 /**
  * Mapping between the mime types we used to identify a configurable resource and the Zod schema used to validate it.
  */
-export const ConfigurableToolInputSchemas: Record<
-  InternalConfigurationMimeType,
-  z.ZodSchema
-> = {
+export const ConfigurableToolInputSchemas = {
   [INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE]: z.array(
     z.object({
       uri: z
@@ -36,7 +33,9 @@ export const ConfigurableToolInputSchemas: Record<
       mimeType: z.literal(INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE),
     })
   ),
-} as const;
+  // We use a satisfies here to ensure that all the InternalConfigurationMimeType are covered whilst preserving the type
+  // inference in tools definitions (server.tool is templated).
+} as const satisfies Record<InternalConfigurationMimeType, z.ZodSchema>;
 
 export type ConfigurableToolInputType = z.infer<
   (typeof ConfigurableToolInputSchemas)[InternalConfigurationMimeType]

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -19,17 +19,16 @@ import {
 } from "@app/lib/utils/json_schemas";
 import type { WorkspaceType } from "@app/types";
 
+export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
+  /^data_source_configuration:\/\/dust\/w\/(\w+)\/data_source_configurations\/(\w+)$/;
+
 /**
  * Mapping between the mime types we used to identify a configurable resource and the Zod schema used to validate it.
  */
 export const ConfigurableToolInputSchemas = {
   [INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE]: z.array(
     z.object({
-      uri: z
-        .string()
-        .regex(
-          /^data_source_configuration:\/\/dust\/w\/(\w+)\/data_source_configurations\/(\w+)$/
-        ),
+      uri: z.string().regex(DATA_SOURCE_CONFIGURATION_URI_PATTERN),
       mimeType: z.literal(INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE),
     })
   ),


### PR DESCRIPTION
## Description

- This PR extends the `data-source-utils` server to add a tool that prints the name of the data sources linked to the action.
- This tool can be used for testing purposes and the logic will be reused when migrating current actions to an MCP tool.
- This PR also slightly improves error displays.

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy front.