### PR TITLE
enh(MCP): correct typo on `executionState` enum

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -131,8 +131,8 @@ export class MCPActionType extends BaseAction {
   readonly agentMessageId: ModelId;
   readonly executionState:
     | "pending"
-    | "allowed_explicitely"
-    | "allowed_implicitely"
+    | "allowed_explicitly"
+    | "allowed_implicitly"
     | "denied" = "pending";
 
   readonly mcpServerConfigurationId: string;
@@ -442,7 +442,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       messageId: agentMessage.sId,
       action: new MCPActionType({
         ...actionBaseParams,
-        executionState: "allowed_explicitely",
+        executionState: "allowed_explicitly",
         id: action.id,
         isError: false,
         output: content,

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -94,8 +94,8 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
   declare isError: boolean;
   declare executionState:
     | "pending"
-    | "allowed_explicitely"
-    | "allowed_implicitely"
+    | "allowed_explicitly"
+    | "allowed_implicitly"
     | "denied";
 
   declare outputItems: NonAttribute<AgentMCPActionOutputItem[]>;
@@ -138,7 +138,7 @@ AgentMCPAction.init(
       allowNull: false,
       validate: {
         isIn: [
-          ["pending", "allowed_explicitely", "allowed_implicitely", "denied"],
+          ["pending", "allowed_explicitly", "allowed_implicitly", "denied"],
         ],
       },
     },


### PR DESCRIPTION
## Description

This PR fixes a typo in the words used to describe the execution state of MCP actions.
No migration required, we have some Sequelize validation but no SQL constraint.
No backfill required, the only 2 rows in `agent_mcp_actions` do not have any of the misspelled value in the column `executionState` (they are 'pending').

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy front.