### PR TITLE
enh(Confluence): Lower the pressure on rate limits

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -307,7 +307,10 @@ export class ConfluenceClient {
   private async request<T>(
     endpoint: string,
     codec: t.Type<T>,
-    retryCount: number = 0
+    {
+      retryCount = 0,
+      bypassThrottle = false,
+    }: { retryCount?: number; bypassThrottle?: boolean } = {}
   ): Promise<T> {
     const response = await (async () => {
       try {
@@ -401,7 +404,10 @@ export class ConfluenceClient {
             delayMs < MAX_RETRY_AFTER_DELAY
           ) {
             await setTimeoutAsync(delayMs);
-            return this.request(endpoint, codec, retryCount + 1);
+            return this.request(endpoint, codec, {
+              retryCount: retryCount + 1,
+              bypassThrottle: bypassThrottle,
+            });
           }
         }
 
@@ -633,7 +639,8 @@ export class ConfluenceClient {
 
     const spaces = await this.request(
       `${this.restApiBaseUrl}/spaces?${params.toString()}`,
-      ConfluencePaginatedResults(ConfluenceSpaceCodec)
+      ConfluencePaginatedResults(ConfluenceSpaceCodec),
+      { bypassThrottle: true }
     );
 
     const nextPageCursor = extractCursorFromLinks(spaces._links);

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -190,6 +190,16 @@ const ConfluenceReadOperationRestrictionsCodec = t.type({
   restrictions: RestrictionsCodec,
 });
 
+// Headers provided by Confluence API to provide information on the rate limiting.
+// https://developer.atlassian.com/cloud/confluence/rate-limiting/
+// The exact rate limit model is not detailed, but can be assumed to be a combination of multiple different systems.
+const RATE_LIMIT_HEADERS = {
+  // As per the doc: "maximum number of requests that a user can make within a specific (unspecified) time window".
+  limit: "x-ratelimit-limit",
+  // As per the doc: "number of requests remaining in the current rate limit window before the limit is reached".
+  remaining: "x-ratelimit-remaining",
+} as const;
+
 // If Confluence does not provide a retry-after header, we use this constant to signal no delay.
 const NO_RETRY_AFTER_DELAY = -1;
 // Number of times we retry when rate limited and Confluence does provide a retry-after header.

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -363,7 +363,10 @@ export class ConfluenceClient {
           "provider:confluence",
           "status:rate_limited",
         ]);
-        logRateLimitHeaders(response, { endpoint });
+        logRateLimitHeaders(response, {
+          endpoint,
+          statusCode: response.status,
+        });
 
         if (retryCount < MAX_RATE_LIMIT_RETRY_COUNT) {
           const delayMs = getRetryAfterDuration(response);

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -440,6 +440,7 @@ export class ConfluenceClient {
         endpoint,
         statusCode: response.status,
       });
+
       throw new ConfluenceClientError(
         `Near rate limit: ${this.apiUrl}${endpoint}`,
         {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -240,7 +240,7 @@ export class ConfluenceClient {
   private readonly apiUrl = "https://api.atlassian.com";
   private readonly restApiBaseUrl: string;
   private readonly legacyRestApiBaseUrl: string;
-  private readonly proxyAgent: ProxyAgent | undefined;
+  private readonly proxyAgent?: ProxyAgent;
 
   constructor(
     private readonly authToken: string,
@@ -254,17 +254,17 @@ export class ConfluenceClient {
   ) {
     this.restApiBaseUrl = `/ex/confluence/${cloudId}/wiki/api/v2`;
     this.legacyRestApiBaseUrl = `/ex/confluence/${cloudId}/wiki/rest/api`;
-    this.proxyAgent = useProxy
-      ? new ProxyAgent(
-          `http://${EnvironmentConfig.getEnvVariable(
-            "PROXY_USER_NAME"
-          )}:${EnvironmentConfig.getEnvVariable(
-            "PROXY_USER_PASSWORD"
-          )}@${EnvironmentConfig.getEnvVariable(
-            "PROXY_HOST"
-          )}:${EnvironmentConfig.getEnvVariable("PROXY_PORT")}`
-        )
-      : undefined;
+    if (useProxy) {
+      this.proxyAgent = new ProxyAgent(
+        `http://${EnvironmentConfig.getEnvVariable(
+          "PROXY_USER_NAME"
+        )}:${EnvironmentConfig.getEnvVariable(
+          "PROXY_USER_PASSWORD"
+        )}@${EnvironmentConfig.getEnvVariable(
+          "PROXY_HOST"
+        )}:${EnvironmentConfig.getEnvVariable("PROXY_PORT")}`
+      );
+    }
   }
 
   private async request<T>(

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -236,6 +236,23 @@ function getRetryAfterDuration(response: Response): number {
   return NO_RETRY_AFTER_DELAY;
 }
 
+function logRateLimitHeaders(response: Response, endpoint: string) {
+  const rateLimitHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase().startsWith("x-ratelimit")) {
+      rateLimitHeaders[key] = value;
+    }
+  });
+
+  logger.info(
+    {
+      rateLimitHeaders,
+      endpoint,
+    },
+    "[Confluence] Headers relative to the rate limit"
+  );
+}
+
 export class ConfluenceClient {
   private readonly apiUrl = "https://api.atlassian.com";
   private readonly restApiBaseUrl: string;
@@ -343,20 +360,7 @@ export class ConfluenceClient {
           "provider:confluence",
           "status:rate_limited",
         ]);
-        const rateLimitHeaders: Record<string, string> = {};
-        response.headers.forEach((value, key) => {
-          if (key.toLowerCase().startsWith("x-ratelimit")) {
-            rateLimitHeaders[key] = value;
-          }
-        });
-
-        logger.info(
-          {
-            rateLimitHeaders,
-            endpoint,
-          },
-          "[Confluence] Headers relative to the rate limit"
-        );
+        logRateLimitHeaders(response, endpoint);
 
         if (retryCount < MAX_RATE_LIMIT_RETRY_COUNT) {
           const delayMs = getRetryAfterDuration(response);

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -236,7 +236,10 @@ function getRetryAfterDuration(response: Response): number {
   return NO_RETRY_AFTER_DELAY;
 }
 
-function logRateLimitHeaders(response: Response, endpoint: string) {
+function logRateLimitHeaders(
+  response: Response,
+  loggerArgs: Record<string, string | number | null>
+) {
   const rateLimitHeaders: Record<string, string> = {};
   response.headers.forEach((value, key) => {
     if (key.toLowerCase().startsWith("x-ratelimit")) {
@@ -247,7 +250,7 @@ function logRateLimitHeaders(response: Response, endpoint: string) {
   logger.info(
     {
       rateLimitHeaders,
-      endpoint,
+      ...loggerArgs,
     },
     "[Confluence] Headers relative to the rate limit"
   );
@@ -360,7 +363,7 @@ export class ConfluenceClient {
           "provider:confluence",
           "status:rate_limited",
         ]);
-        logRateLimitHeaders(response, endpoint);
+        logRateLimitHeaders(response, { endpoint });
 
         if (retryCount < MAX_RATE_LIMIT_RETRY_COUNT) {
           const delayMs = getRetryAfterDuration(response);

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -434,6 +434,11 @@ export class ConfluenceClient {
       );
     }
 
+    logRateLimitHeaders(response, {
+      endpoint,
+      statusCode: response.status,
+    });
+
     // When approaching the rate limit, we defer the handling of the backoff to Temporal.
     // We have no accurate estimation of the time we should wait here, the goal here is more to warm up the exponential
     // backoff to slow down the queries as soon as they approach the rate limit.
@@ -442,10 +447,6 @@ export class ConfluenceClient {
         "provider:confluence",
         "status:near_rate_limit",
       ]);
-      logRateLimitHeaders(response, {
-        endpoint,
-        statusCode: response.status,
-      });
 
       throw new ConfluenceClientError(
         `Near rate limit: ${this.apiUrl}${endpoint}`,


### PR DESCRIPTION
## Description

This PR has two main goals:
- Allow collecting more data points on the behavior of Confluence's rate limits.
- Implement a strategy to slow down the query whenever close to reaching the rate limit.

The latter relies on the headers provided by the API:
- `X-RateLimit-Limit`: maximum number of requests that a user can make within a specific time window.
- `X-RateLimit-Remaining`: number of requests remaining in the current rate limit window before the limit is reached.
- `X-RateLimit-NearLimit`: indicates that less than 20% of any budget remains.

Given that the exact rate limit model is unknown (in particular the time window mentioned above), this strategy is a best effort to reduce the load when approaching the rate limit by warming up the exponential backoff when approaching a rate limit.

Depending on the metrics collected, we may improve this strategy by waiting for small amounts of time (determined by the analysis of the distribution of remaining/limit) when near a rate limit.

Side note: this is gonna be costly (more activities, more cardinality on the dd metric).

The endpoint to list spaces bypasses this mechanism to allow end users to fully take advantage of the remaining 30%.

## Tests

## Risk

## Deploy Plan

- Deploy connectors.
