### PR TITLE
[Microsoft] Allow garbage coll. to delete root nodes in legit cases

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1103,6 +1103,7 @@ export async function microsoftGarbageCollectionActivity({
                 connectorId,
                 dataSourceConfig,
                 internalId: node.internalId,
+                deleteRootNode: true,
               });
             }
             break;

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -435,10 +435,12 @@ export async function deleteFolder({
   connectorId,
   dataSourceConfig,
   internalId,
+  deleteRootNode,
 }: {
   connectorId: number;
   dataSourceConfig: DataSourceConfig;
   internalId: string;
+  deleteRootNode?: boolean;
 }) {
   const folder = await MicrosoftNodeResource.fetchByInternalId(
     connectorId,
@@ -462,7 +464,11 @@ export async function deleteFolder({
     // Roots represent the user selection for synchronization As such, they
     // should be deleted first, explicitly by users, before deleting the
     // underlying folder
-    throw new Error("Unexpected: attempt to delete folder with root node");
+    if (deleteRootNode) {
+      await root.delete();
+    } else {
+      throw new Error("Unexpected: attempt to delete folder with root node");
+    }
   }
 
   await deleteDataSourceFolder({ dataSourceConfig, folderId: internalId });


### PR DESCRIPTION
Description
---
Fixes [this kind of
monitor](https://app.datadoghq.eu/logs?query=%22Unhandled%22%20%40attempt%3A%3E19%20service%3Aconnectors-worker%20-%40activityName%3A%28cacheBlockChildren%20OR%20getPagesAndDatabasesToSync%29&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZXl6UdwZefzwgAAABhBWlhsNlZBMUFBQ0dHVVhGVW5Zem5RQUoAAAAkMDE5NWU1ZWQtZjc1ZC00NGE2LTlmNjItODk2Y2JhNGQ0ZDZhAAA-FQ&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1743318000000&to_ts=1743319800000&live=false)

We prevented garbage collector to delete nodes who were roots. But in some cases, if the user deletes the folder on microsoft's side or if we can't access it anymore, it's reasonable to delete it on our end.

Risks
---
standard - cases in which we shouldn't have deleted but seems unlikely

Deploy
---
connectors
