### PR TITLE
[front] - fix(search): display folder's name in search

### DIFF
--- a/front/components/spaces/search/columns.tsx
+++ b/front/components/spaces/search/columns.tsx
@@ -36,7 +36,15 @@ export function makeColumnsForSearchResults(): ColumnDef<RowData, any>[] {
       id: "location",
       enableSorting: false,
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.BasicCellContent label={info.getValue()} className="pr-2" />
+        <DataTable.BasicCellContent
+          label={
+            // Displaying data source name for folders
+            info.row.original.dataSourceView.category === "folder"
+              ? info.row.original.dataSourceView.dataSource.name
+              : info.getValue()
+          }
+          className="pr-2"
+        />
       ),
       meta: {
         sizeRatio: 25,


### PR DESCRIPTION
## Description

This PR updates the location cell to show the data source name instead of the folder name for "folders" items in search results.

## Risk

Low

## Deploy Plan

Deploy front