### PR TITLE
[sparkle]  Add grow option in CellContent

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.453",
+  "version": "0.2.454",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.453",
+      "version": "0.2.454",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.453",
+  "version": "0.2.454",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -794,6 +794,7 @@ interface CellContentProps extends React.TdHTMLAttributes<HTMLDivElement> {
   roundedAvatar?: boolean;
   children?: ReactNode;
   description?: string;
+  grow?: boolean;
 }
 
 DataTable.CellContent = function CellContent({
@@ -805,10 +806,18 @@ DataTable.CellContent = function CellContent({
   icon,
   iconClassName,
   description,
+  grow = false,
   ...props
 }: CellContentProps) {
   return (
-    <div className={cn("s-flex s-items-center", className)} {...props}>
+    <div
+      className={cn(
+        "s-flex s-items-center",
+        grow ? "s-flex-grow" : "",
+        className
+      )}
+      {...props}
+    >
       {avatarUrl && avatarTooltipLabel && (
         <Tooltip
           trigger={
@@ -840,15 +849,18 @@ DataTable.CellContent = function CellContent({
           )}
         />
       )}
-      <div className="s-flex s-shrink s-truncate">
-        <span
+      <div
+        className={cn("s-flex s-shrink s-truncate", grow ? "s-flex-grow" : "")}
+      >
+        <div
           className={cn(
+            grow ? "s-flex-grow" : "",
             "s-truncate s-text-sm",
             "s-text-foreground dark:s-text-foreground-night"
           )}
         >
           {children}
-        </span>
+        </div>
         {description && (
           <span
             className={cn(


### PR DESCRIPTION
## Description

Adds a "grow" option in CellContent that will make the cell take all available width

## Tests


## Risk

none

## Deploy Plan

publish sparkle
