### PR TITLE
enh(Confluence): add back the near rate limit throttling strategy

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -190,6 +190,20 @@ const ConfluenceReadOperationRestrictionsCodec = t.type({
   restrictions: RestrictionsCodec,
 });
 
+// Headers provided by Confluence API to provide information on the rate limiting.
+// https://developer.atlassian.com/cloud/confluence/rate-limiting/
+// The exact rate limit model is not detailed, but can be assumed to be a combination of multiple different systems.
+const RATE_LIMIT_HEADERS = {
+  // As per the doc: "maximum number of requests that a user can make within a specific (unspecified) time window".
+  limit: "x-ratelimit-limit",
+  // As per the doc: "number of requests remaining in the current rate limit window before the limit is reached".
+  remaining: "x-ratelimit-remaining",
+  // As per the doc: "When true, indicates that less than 20% of any budget remains."
+  nearLimit: "x-ratelimit-nearlimit",
+} as const;
+
+// Ratio remaining / limit at which we start to slow down the requests.
+const THROTTLE_TRIGGER_RATIO = 0.3;
 // If Confluence does not provide a retry-after header, we use this constant to signal no delay.
 const NO_RETRY_AFTER_DELAY = -1;
 // Number of times we retry when rate limited and Confluence does provide a retry-after header.
@@ -224,6 +238,19 @@ function getRetryAfterDuration(response: Response): number {
   }
 
   return NO_RETRY_AFTER_DELAY;
+}
+
+function checkNearRateLimit(response: Response): boolean {
+  const nearLimit = response.headers.get(RATE_LIMIT_HEADERS.nearLimit);
+  const remaining = response.headers.get(RATE_LIMIT_HEADERS.remaining);
+  const limit = response.headers.get(RATE_LIMIT_HEADERS.limit);
+
+  return (
+    nearLimit?.toLowerCase() === "true" ||
+    (!!remaining &&
+      !!limit &&
+      parseInt(remaining, 10) / parseInt(limit, 10) < THROTTLE_TRIGGER_RATIO)
+  );
 }
 
 function logRateLimitHeaders(
@@ -395,6 +422,25 @@ export class ConfluenceClient {
 
       throw new ConfluenceClientError(
         `Confluence API responded with status: ${response.status}: ${this.apiUrl}${endpoint}`,
+        {
+          type: "http_response_error",
+          status: response.status,
+          data: { url: `${this.apiUrl}${endpoint}`, response },
+        }
+      );
+    }
+
+    // When approaching the rate limit, we defer the handling of the backoff to Temporal.
+    // We have no accurate estimation of the time we should wait here, the goal here is more to warm up the exponential
+    // backoff to slow down the queries as soon as they approach the rate limit.
+    if (checkNearRateLimit(response)) {
+      statsDClient.increment("external.api.calls", 1, [
+        "provider:confluence",
+        "status:near_rate_limit",
+      ]);
+
+      throw new ConfluenceClientError(
+        `Near rate limit: ${this.apiUrl}${endpoint}`,
         {
           type: "http_response_error",
           status: response.status,

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -311,7 +311,10 @@ export class ConfluenceClient {
   private async request<T>(
     endpoint: string,
     codec: t.Type<T>,
-    retryCount: number = 0
+    {
+      retryCount = 0,
+      bypassThrottle = false,
+    }: { retryCount?: number; bypassThrottle?: boolean } = {}
   ): Promise<T> {
     const response = await (async () => {
       try {
@@ -403,7 +406,10 @@ export class ConfluenceClient {
             delayMs < MAX_RETRY_AFTER_DELAY
           ) {
             await setTimeoutAsync(delayMs);
-            return this.request(endpoint, codec, retryCount + 1);
+            return this.request(endpoint, codec, {
+              retryCount: retryCount + 1,
+              bypassThrottle: bypassThrottle,
+            });
           }
         }
 
@@ -636,7 +642,8 @@ export class ConfluenceClient {
 
     const spaces = await this.request(
       `${this.restApiBaseUrl}/spaces?${params.toString()}`,
-      ConfluencePaginatedResults(ConfluenceSpaceCodec)
+      ConfluencePaginatedResults(ConfluenceSpaceCodec),
+      { bypassThrottle: true }
     );
 
     const nextPageCursor = extractCursorFromLinks(spaces._links);


### PR DESCRIPTION
## Description

Rollback of https://github.com/dust-tt/dust/pull/11765.
This PR adds back the throttling strategy when we approach the rate limit.
I had actually squeezed the metric increment on success in https://github.com/dust-tt/dust/pull/11759.
Therefore, it may have been working all this time.

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.