### PR TITLE
Re-enable default actions creation

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -18,12 +18,12 @@ export const INTERNAL_MCP_SERVERS: Record<
   helloworld: {
     id: 1,
     isDefault: true,
-    flag: null,
+    flag: "mcp_actions",
   },
   "data-source-utils": {
     id: 2,
     isDefault: false,
-    flag: null,
+    flag: "mcp_actions",
   },
 };
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -401,6 +401,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerView> {
       }
     }
 
+    if (defaultInternalMCPServerIds.length === 0) {
+      return;
+    }
+
+    // TODO(mcp): Think this through and determine how / when we create the default internal mcp server views
+    // For now, only admins can create the default internal mcp server views otherwise, we would have an assert error
+    if (!auth.isAdmin()) {
+      return;
+    }
+
     // Get system and global spaces
     const spaces = await SpaceResource.listWorkspaceDefaultSpaces(auth);
 

--- a/front/pages/w/[wId]/actions.tsx
+++ b/front/pages/w/[wId]/actions.tsx
@@ -9,6 +9,7 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import type { MCPServerType } from "@app/lib/actions/mcp_metadata";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
@@ -29,6 +30,8 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
       notFound: true,
     };
   }
+
+  await MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth);
 
   return {
     props: {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -16,6 +16,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
   AppType,
@@ -58,6 +59,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     await Promise.all([
       getAccessibleSourcesAndApps(auth),
       getAgentConfiguration(auth, context.params?.aId as string, "full"),
+      MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth),
     ]);
 
   if (configuration?.scope === "workspace" && !auth.isBuilder()) {

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -24,6 +24,7 @@ import { AssistantSidebarMenu } from "@app/components/assistant/conversation/Sid
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { subFilter } from "@app/lib/utils";
 import type {
@@ -46,6 +47,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       notFound: true,
     };
   }
+
+  await MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth);
 
   const tabScope = ASSISTANT_MANAGER_TABS.map((tab) => tab.id).includes(
     context.query.tabScope as AssistantManagerTabsType


### PR DESCRIPTION
## Description

Re-enable default actions creation but avoid the assertion error by:
- putting all actions behind FF (so nothing to create)
- and only allowing admins to do it

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`