### PR TITLE
chore(conversation): remove groupIds

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -579,8 +579,6 @@ async function fetchWorkspaceAgentConfigurationsForView(
           GroupResource.modelIdToSId({ id, workspaceId: owner.id })
         )
       ),
-      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-      groupIds: [],
     };
 
     agentConfigurationTypes.push(agentConfigurationType);

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -146,8 +146,6 @@ export async function createConversation(
     content: [],
     requestedGroupIds:
       conversation.getConversationRequestedGroupIdsFromModel(auth),
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
   };
 }
 
@@ -300,8 +298,6 @@ export async function getConversation(
     content,
     requestedGroupIds:
       conversation.getConversationRequestedGroupIdsFromModel(auth),
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
   });
 }
 

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -214,8 +214,6 @@ function _getHelperGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -252,8 +250,6 @@ function _getGPT35TurboGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -299,8 +295,6 @@ function _getGPT4GlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -342,7 +336,6 @@ function _getO3MiniGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -380,8 +373,6 @@ function _getO1GlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: false,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -419,8 +410,6 @@ function _getO1MiniGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: false,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -460,8 +449,6 @@ function _getO1HighReasoningGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: false,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -494,8 +481,6 @@ function _getClaudeInstantGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -535,8 +520,6 @@ function _getClaude2GlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -570,8 +553,6 @@ function _getClaude3HaikuGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -610,8 +591,6 @@ function _getClaude3OpusGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -653,8 +632,6 @@ function _getClaude3GlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -696,8 +673,6 @@ function _getClaude3_7GlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -740,8 +715,6 @@ function _getMistralLargeGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -784,8 +757,6 @@ function _getMistralMediumGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -822,8 +793,6 @@ function _getMistralSmallGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -865,8 +834,6 @@ function _getGeminiProGlobalAgent({
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -906,8 +873,6 @@ function _getDeepSeekR1GlobalAgent({
     maxStepsPerRun: 1,
     visualizationEnabled: false,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -975,8 +940,6 @@ function _getManagedDataSourceAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: false,
       templateId: null,
-      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-      groupIds: [],
       requestedGroupIds: [],
     };
   }
@@ -1004,8 +967,6 @@ function _getManagedDataSourceAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: false,
       templateId: null,
-      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-      groupIds: [],
       requestedGroupIds: [],
     };
   }
@@ -1045,8 +1006,6 @@ function _getManagedDataSourceAgent(
     maxStepsPerRun: 1,
     visualizationEnabled: false,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }
@@ -1225,8 +1184,6 @@ function _getDustGlobalAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: true,
       templateId: null,
-      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-      groupIds: [],
       requestedGroupIds: [],
     };
   }
@@ -1254,8 +1211,6 @@ function _getDustGlobalAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: true,
       templateId: null,
-      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-      groupIds: [],
       requestedGroupIds: [],
     };
   }
@@ -1361,8 +1316,6 @@ function _getDustGlobalAgent(
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
     templateId: null,
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: [],
     requestedGroupIds: [],
   };
 }

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -48,9 +48,6 @@ export class AgentConfiguration extends WorkspaceAwareModel<AgentConfiguration> 
 
   declare requestedGroupIds: number[][];
 
-  // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-  declare groupIds?: number[];
-
   declare author: NonAttribute<UserModel>;
 }
 
@@ -148,13 +145,6 @@ AgentConfiguration.init(
     },
     requestedGroupIds: {
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT)),
-      allowNull: false,
-      defaultValue: [],
-    },
-
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: {
-      type: DataTypes.ARRAY(DataTypes.INTEGER),
       allowNull: false,
       defaultValue: [],
     },

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -24,9 +24,6 @@ export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare visibility: CreationOptional<ConversationVisibility>;
 
   declare requestedGroupIds: number[][];
-
-  // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-  declare groupIds?: number[];
 }
 
 ConversationModel.init(
@@ -56,13 +53,6 @@ ConversationModel.init(
     },
     requestedGroupIds: {
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT)),
-      allowNull: false,
-      defaultValue: [],
-    },
-
-    // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-    groupIds: {
-      type: DataTypes.ARRAY(DataTypes.INTEGER),
       allowNull: false,
       defaultValue: [],
     },

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -238,8 +238,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       visibility: conversation.visibility,
       requestedGroupIds:
         conversation.getConversationRequestedGroupIdsFromModel(auth),
-      // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-      groupIds: [],
     });
   }
 
@@ -324,8 +322,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
             visibility: c.visibility,
             requestedGroupIds:
               c.getConversationRequestedGroupIdsFromModel(auth),
-            // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-            groupIds: [],
           }) satisfies ConversationWithoutContentType
       );
 

--- a/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
+++ b/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
@@ -69,10 +69,12 @@ makeScript({}, async ({ execute }, logger) => {
 
       if (execute) {
         logger.info(
+          // @ts-expect-error `groupIds` was removed
           { agentId: agent.sId, newGroupIds, prevGroupIds: agent.groupIds },
           `Backfilling agent group IDs`
         );
         await agent.update({
+          // @ts-expect-error `groupIds` was removed
           groupIds,
         });
       }

--- a/front/migrations/20240927_backfill_conversations_groupIds.ts
+++ b/front/migrations/20240927_backfill_conversations_groupIds.ts
@@ -117,6 +117,7 @@ async function updateConversation(
         where: { sId: agentConfigurationIds },
       })
     )
+      // @ts-expect-error `groupIds` was removed
       .map((agent) => agent.groupIds)
       .flat()
   );

--- a/front/migrations/db/migration_198.sql
+++ b/front/migrations/db/migration_198.sql
@@ -1,0 +1,3 @@
+-- Migration created on Apr 03, 2025
+ALTER TABLE "public"."conversations" DROP COLUMN "groupIds";
+ALTER TABLE "public"."agent_configurations" DROP COLUMN "groupIds";

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -136,9 +136,6 @@ export type LightAgentConfigurationType = {
   // Example: [[1,2], [3,4]] means (1 OR 2) AND (3 OR 4)
   requestedGroupIds: string[][];
 
-  // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-  groupIds?: string[];
-
   reasoningEffort?: AgentReasoningEffort;
 };
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -213,9 +213,6 @@ export type ConversationWithoutContentType = {
   title: string | null;
   visibility: ConversationVisibility;
   requestedGroupIds: string[][];
-
-  // TODO(2025-01-15) `groupId` clean-up. Remove once Chrome extension uses optional.
-  groupIds?: string[];
 };
 
 /**


### PR DESCRIPTION
## Description
- Remove `groupIds` from `ConversationModel` and `AgentConfiguration`
- Add `// @ts-expect-error` to backfill where `groupIds` is called
- Run `npm run create-db-migration` to create migration

## Tests
- Manually chatted with bots, from the homepage and also continuing previous discussions.

## Risk
We're removing an already unused attribute, risk are minimal.

## Deploy Plan
Because we're dropping a attribute, we will deploy but not run the migration right now. We'll do that in 3 or 4 days.
