### PR TITLE
[extension] - chore(Attachments): port front changes

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
-        "@dust-tt/client": "^1.0.36",
-        "@dust-tt/sparkle": "^0.2.453",
+        "@dust-tt/client": "^1.0.37",
+        "@dust-tt/sparkle": "^0.2.454",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@tailwindcss/forms": "^0.5.9",
         "@tiptap/extension-character-count": "^2.9.1",
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.36.tgz",
-      "integrity": "sha512-ywQWnLQ0QgM2M9LNr75nuPCEMXi1bmARwtaIl6/zMHXLQr0Zc+hKEWhOE8zGjb8CqweLst+7YaAjTZa+ZGef+A==",
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.37.tgz",
+      "integrity": "sha512-VstvCSW7USzKXOeeVqCBJhQlKcZvG5VWlXW7ygsM/IiZ0rkeYStmKJRta0XPuJ+GB8/XHVJqyJLWku/PFVKnrg==",
       "dependencies": {
         "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.453",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.453.tgz",
-      "integrity": "sha512-C6tvcA6qoWE5iiyBaNyoxQ3+N12mz+gTS3vTaA/Qx0Egjc9rZA0eihCNBixPzvkFcdCwLopZFQubOhzrDg4/Cw==",
+      "version": "0.2.454",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.454.tgz",
+      "integrity": "sha512-ANDToNoQT2Q+oQwqdnmUpPHY8BA2YRo4mSAg6t1InEDoMMgm8quWdf5acucPo9XP+1Mziz1h7iRtI0TsFCgu2Q==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -57,8 +57,8 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
-    "@dust-tt/client": "^1.0.36",
-    "@dust-tt/sparkle": "^0.2.453",
+    "@dust-tt/client": "^1.0.37",
+    "@dust-tt/sparkle": "^0.2.454",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@tailwindcss/forms": "^0.5.9",
     "@tiptap/extension-character-count": "^2.9.1",

--- a/extension/ui/components/conversation/AttachmentCitation.tsx
+++ b/extension/ui/components/conversation/AttachmentCitation.tsx
@@ -1,0 +1,205 @@
+import { getConnectorProviderLogoWithFallback } from "@app/shared/lib/connector_providers";
+import type { ContentFragmentType } from "@dust-tt/client";
+import {
+  Citation,
+  CitationClose,
+  CitationDescription,
+  CitationIcons,
+  CitationImage,
+  CitationTitle,
+  DocumentIcon,
+  FolderIcon,
+  Icon,
+  ImageIcon,
+  TableIcon,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+export type FileAttachment = {
+  type: "file";
+  id: string;
+  title: string;
+  preview?: string;
+  isUploading: boolean;
+  onRemove: () => void;
+};
+
+export type NodeAttachment = {
+  type: "node";
+  id: string;
+  title: string;
+  spaceName: string;
+  spaceIcon: React.ComponentType;
+  visual: React.ReactNode;
+  path: string;
+  onRemove: () => void;
+  url: string | null;
+};
+
+export type Attachment = FileAttachment | NodeAttachment;
+
+interface BaseAttachmentCitation {
+  id: string;
+  title: string;
+  sourceUrl?: string | null;
+  visual: React.ReactNode;
+}
+
+interface FileAttachmentCitation extends BaseAttachmentCitation {
+  type: "file";
+  preview?: string;
+  isUploading?: boolean;
+  spaceName?: never;
+  path?: never;
+  spaceIcon?: never;
+}
+
+interface NodeAttachmentCitation extends BaseAttachmentCitation {
+  type: "node";
+  spaceName: string;
+  path?: string;
+  spaceIcon?: React.ComponentType;
+  preview?: never;
+  isUploading?: never;
+}
+
+export type AttachmentCitation =
+  | FileAttachmentCitation
+  | NodeAttachmentCitation;
+
+type AttachmentCitationProps = {
+  attachmentCitation: AttachmentCitation;
+  onRemove?: () => void;
+};
+
+export function AttachmentCitation({
+  attachmentCitation,
+  onRemove,
+}: AttachmentCitationProps) {
+  const tooltipContent =
+    attachmentCitation.type === "file" ? (
+      attachmentCitation.title
+    ) : (
+      <div className="flex flex-col gap-1">
+        <div className="font-bold">{attachmentCitation.title}</div>
+        <div className="flex gap-1 pt-1 text-sm">
+          <Icon visual={attachmentCitation.spaceIcon} />
+          <p>{attachmentCitation.spaceName}</p>
+        </div>
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {attachmentCitation.path}
+        </div>
+      </div>
+    );
+
+  return (
+    <Tooltip
+      trigger={
+        <Citation
+          className="w-40"
+          href={attachmentCitation.sourceUrl ?? undefined}
+          isLoading={
+            attachmentCitation.type === "file" && attachmentCitation.isUploading
+          }
+          action={
+            onRemove && (
+              <CitationClose
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove();
+                }}
+              />
+            )
+          }
+        >
+          {attachmentCitation.type === "file" && attachmentCitation.preview && (
+            <CitationImage imgSrc={attachmentCitation.preview} />
+          )}
+          <CitationIcons>{attachmentCitation.visual}</CitationIcons>
+          <CitationTitle className="truncate text-ellipsis">
+            {attachmentCitation.title}
+          </CitationTitle>
+          {attachmentCitation.type === "node" && (
+            <CitationDescription className="truncate text-ellipsis">
+              <span>{attachmentCitation.spaceName}</span>
+            </CitationDescription>
+          )}
+        </Citation>
+      }
+      label={tooltipContent}
+    />
+  );
+}
+
+export function contentFragmentToAttachmentCitation(
+  contentFragment: ContentFragmentType
+): AttachmentCitation {
+  if (contentFragment.contentNodeData) {
+    const { provider, nodeType } = contentFragment.contentNodeData;
+    const logo = getConnectorProviderLogoWithFallback({ provider });
+
+    const visual =
+      provider && ["webcrawler", "folder"].includes(provider) ? (
+        <Icon visual={logo} />
+      ) : (
+        <>
+          <Icon visual={logo} />
+          <Icon
+            visual={
+              nodeType === "table"
+                ? TableIcon
+                : nodeType === "folder"
+                  ? FolderIcon
+                  : DocumentIcon
+            }
+          />
+        </>
+      );
+
+    return {
+      type: "node",
+      id: contentFragment.sId,
+      title: contentFragment.title,
+      sourceUrl: contentFragment.sourceUrl,
+      visual,
+      spaceName: contentFragment.contentNodeData.spaceName,
+    };
+  }
+
+  const isImageType = contentFragment.contentType.startsWith("image/");
+  return {
+    type: "file",
+    id: contentFragment.sId,
+    title: contentFragment.title,
+    sourceUrl: contentFragment.sourceUrl,
+    visual: <Icon visual={isImageType ? ImageIcon : DocumentIcon} />,
+  };
+}
+
+export function attachmentToAttachmentCitation(
+  attachment: Attachment
+): AttachmentCitation {
+  if (attachment.type === "file") {
+    return {
+      type: "file",
+      id: attachment.id,
+      title: attachment.title,
+      preview: attachment.preview,
+      isUploading: attachment.isUploading,
+      visual: <Icon visual={attachment.preview ? ImageIcon : DocumentIcon} />,
+      sourceUrl: null,
+    };
+  } else {
+    return {
+      type: "node",
+      id: attachment.id,
+      title: attachment.title,
+      spaceName: attachment.spaceName,
+      spaceIcon: attachment.spaceIcon,
+      path: attachment.path,
+      visual: attachment.visual,
+      sourceUrl: attachment.url,
+    };
+  }
+}

--- a/extension/ui/components/conversation/MessageItem.tsx
+++ b/extension/ui/components/conversation/MessageItem.tsx
@@ -10,18 +10,12 @@ import type {
   ConversationMessageReactionsType,
   LightWorkspaceType,
 } from "@dust-tt/client";
-import {
-  Avatar,
-  Citation,
-  CitationIcons,
-  CitationImage,
-  CitationTitle,
-  DocumentTextIcon,
-  Icon,
-  SlackLogo,
-} from "@dust-tt/sparkle";
 import React from "react";
 import { useSWRConfig } from "swr";
+import {
+  AttachmentCitation,
+  contentFragmentToAttachmentCitation,
+} from "@app/ui/components/conversation/AttachmentCitation";
 
 interface MessageItemProps {
   conversationId: string;
@@ -100,50 +94,24 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       case "user_message":
         const citations = message.contenFragments
           ? message.contenFragments.map((contentFragment) => {
-              const citationType = ["dust-application/slack"].includes(
-                contentFragment.contentType
-              )
-                ? "slack"
-                : "document";
-
-              const icon =
-                citationType === "slack" ? SlackLogo : DocumentTextIcon;
+              const attachmentCitation =
+                contentFragmentToAttachmentCitation(contentFragment);
 
               return (
-                <Citation
-                  key={contentFragment.sId}
-                  href={contentFragment.sourceUrl ?? undefined}
-                >
-                  <div className="flex gap-2">
-                    {contentFragment.context.profilePictureUrl && (
-                      <CitationIcons>
-                        <Avatar
-                          visual={contentFragment.context.profilePictureUrl}
-                          size="xs"
-                        />
-                      </CitationIcons>
-                    )}
-                    {contentFragment.sourceUrl ? (
-                      <>
-                        <CitationImage imgSrc={contentFragment.sourceUrl} />
-                        <CitationIcons>
-                          <Icon visual={icon} />
-                        </CitationIcons>
-                      </>
-                    ) : (
-                      <CitationIcons>
-                        <Icon visual={icon} />
-                      </CitationIcons>
-                    )}
-                  </div>
-                  <CitationTitle>{contentFragment.title}</CitationTitle>
-                </Citation>
+                <AttachmentCitation
+                  key={attachmentCitation.id}
+                  attachmentCitation={attachmentCitation}
+                />
               );
             })
           : undefined;
 
         return (
-          <div key={`message-id-${sId}`} ref={ref}>
+          <div
+            key={`message-id-${sId}`}
+            ref={ref}
+            className="w-fit min-w-60 max-w-full"
+          >
             <UserMessage
               citations={citations}
               conversationId={conversationId}

--- a/extension/ui/components/conversation/MessageItem.tsx
+++ b/extension/ui/components/conversation/MessageItem.tsx
@@ -107,11 +107,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           : undefined;
 
         return (
-          <div
-            key={`message-id-${sId}`}
-            ref={ref}
-            className="w-fit min-w-60 max-w-full"
-          >
+          <div key={`message-id-${sId}`} ref={ref} className="w-full">
             <UserMessage
               citations={citations}
               conversationId={conversationId}

--- a/extension/ui/components/conversation/MessageItem.tsx
+++ b/extension/ui/components/conversation/MessageItem.tsx
@@ -3,6 +3,10 @@ import { useDustAPI } from "@app/shared/lib/dust_api";
 import type { AgentMessageFeedbackType } from "@app/shared/lib/feedbacks";
 import type { StoredUser } from "@app/shared/services/auth";
 import { AgentMessage } from "@app/ui/components/conversation/AgentMessage";
+import {
+  AttachmentCitation,
+  contentFragmentToAttachmentCitation,
+} from "@app/ui/components/conversation/AttachmentCitation";
 import type { FeedbackSelectorProps } from "@app/ui/components/conversation/FeedbackSelector";
 import { UserMessage } from "@app/ui/components/conversation/UserMessage";
 import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
@@ -12,10 +16,6 @@ import type {
 } from "@dust-tt/client";
 import React from "react";
 import { useSWRConfig } from "swr";
-import {
-  AttachmentCitation,
-  contentFragmentToAttachmentCitation,
-} from "@app/ui/components/conversation/AttachmentCitation";
 
 interface MessageItemProps {
   conversationId: string;

--- a/extension/ui/components/input_bar/InputBarAttachment.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachment.tsx
@@ -3,18 +3,20 @@ import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/shared/lib/content_nodes";
+import type {
+  Attachment,
+  FileAttachment,
+  NodeAttachment,
+} from "@app/ui/components/conversation/AttachmentCitation";
+import {
+  AttachmentCitation,
+  attachmentToAttachmentCitation,
+} from "@app/ui/components/conversation/AttachmentCitation";
 import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
 import type { DataSourceViewContentNodeType } from "@dust-tt/client";
 import { isFolder, isWebsite } from "@dust-tt/client";
 import { Icon } from "@dust-tt/sparkle";
 import { useMemo } from "react";
-import {
-  Attachment,
-  AttachmentCitation,
-  attachmentToAttachmentCitation,
-  FileAttachment,
-  NodeAttachment,
-} from "@app/ui/components/conversation/AttachmentCitation";
 
 interface FileAttachmentsProps {
   service: FileUploaderService;

--- a/extension/ui/components/input_bar/InputBarAttachment.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachment.tsx
@@ -6,41 +6,15 @@ import {
 import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
 import type { DataSourceViewContentNodeType } from "@dust-tt/client";
 import { isFolder, isWebsite } from "@dust-tt/client";
-import {
-  Citation,
-  CitationClose,
-  CitationDescription,
-  CitationIcons,
-  CitationImage,
-  CitationTitle,
-  DocumentIcon,
-  Icon,
-  ImageIcon,
-  Tooltip,
-} from "@dust-tt/sparkle";
+import { Icon } from "@dust-tt/sparkle";
 import { useMemo } from "react";
-
-type FileAttachment = {
-  type: "file";
-  id: string;
-  title: string;
-  preview?: string;
-  isUploading: boolean;
-  onRemove: () => void;
-};
-
-type NodeAttachment = {
-  type: "node";
-  id: string;
-  title: string;
-  spaceName: string;
-  spaceIcon: React.ComponentType;
-  visual: React.ReactNode;
-  path: string;
-  onRemove: () => void;
-};
-
-type Attachment = FileAttachment | NodeAttachment;
+import {
+  Attachment,
+  AttachmentCitation,
+  attachmentToAttachmentCitation,
+  FileAttachment,
+  NodeAttachment,
+} from "@app/ui/components/conversation/AttachmentCitation";
 
 interface FileAttachmentsProps {
   service: FileUploaderService;
@@ -85,28 +59,31 @@ export function InputBarAttachments({
           provider: node.dataSourceView.dataSource.connectorProvider,
         });
 
-        const nodeId = node.internalId ?? `node-${node.internalId}`;
         const spaceName =
           nodes.spacesMap[node.dataSourceView.spaceId].name ?? "Unknown Space";
         const { dataSource } = node.dataSourceView;
+
+        const isWebsiteOrFolder = isWebsite(dataSource) || isFolder(dataSource);
+        const visual = isWebsiteOrFolder ? (
+          <Icon visual={logo} size="sm" />
+        ) : (
+          <>
+            <Icon visual={logo} size="sm" />
+            {getVisualForDataSourceViewContentNode(node)({
+              className: "h-5 w-5",
+            })}
+          </>
+        );
+
         return {
           type: "node",
-          id: nodeId,
+          id: `${node.dataSourceView.dataSource.sId}-${node.internalId}`,
           title: node.title,
+          url: node.sourceUrl ?? null,
           spaceName,
           spaceIcon: nodes.spacesMap[node.dataSourceView.spaceId].icon,
           path: getLocationForDataSourceViewContentNode(node),
-          visual:
-            isWebsite(dataSource) || isFolder(dataSource) ? (
-              <Icon visual={logo} size="sm" />
-            ) : (
-              <>
-                {getVisualForDataSourceViewContentNode(node)({
-                  className: "h-5 w-5",
-                })}
-                <Icon visual={logo} size="sm" />
-              </>
-            ),
+          visual,
           onRemove: () => nodes.onRemove(node),
         };
       }) || []
@@ -120,70 +97,14 @@ export function InputBarAttachments({
   }
 
   return (
-    <div className="mr-3 flex gap-2 overflow-auto border-b border-separator pb-3">
+    <div className="mr-3 flex gap-2 overflow-auto border-b border-separator pb-3 pt-3">
       {allAttachments.map((attachment) => {
-        const isFile = attachment.type === "file";
-
+        const attachmentCitation = attachmentToAttachmentCitation(attachment);
         return (
-          <Tooltip
-            key={`${attachment.type}-${attachment.id}`}
-            tooltipTriggerAsChild
-            trigger={
-              <Citation
-                className="w-40"
-                isLoading={attachment.type === "file" && attachment.isUploading}
-                action={
-                  <CitationClose
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      attachment.onRemove();
-                    }}
-                  />
-                }
-              >
-                {isFile && attachment.preview && (
-                  <CitationImage imgSrc={attachment.preview} />
-                )}
-
-                <CitationIcons>
-                  {isFile ? (
-                    <Icon
-                      visual={attachment.preview ? ImageIcon : DocumentIcon}
-                    />
-                  ) : (
-                    attachment.visual
-                  )}
-                </CitationIcons>
-
-                <CitationTitle className="truncate text-ellipsis">
-                  {attachment.title}
-                </CitationTitle>
-
-                {!isFile && (
-                  <CitationDescription className="truncate text-ellipsis">
-                    <div className="flex items-center gap-1">
-                      <span>{attachment.spaceName}</span>
-                    </div>
-                  </CitationDescription>
-                )}
-              </Citation>
-            }
-            label={
-              attachment.type === "file" ? (
-                attachment.title
-              ) : (
-                <div className="flex flex-col gap-1">
-                  <div className="font-bold">{attachment.title}</div>
-                  <div className="flex gap-1 pt-1 text-sm">
-                    <Icon visual={attachment.spaceIcon} />
-                    <p>{attachment.spaceName}</p>
-                  </div>
-                  <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    {attachment.path}
-                  </div>
-                </div>
-              )
-            }
+          <AttachmentCitation
+            key={attachmentCitation.id}
+            attachmentCitation={attachmentCitation}
+            onRemove={attachment.onRemove}
           />
         );
       })}

--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -36,14 +36,12 @@ interface InputBarAttachmentsPickerProps {
   onNodeSelect: (node: DataSourceViewContentNodeType) => void;
   isLoading?: boolean;
   attachedNodes: DataSourceViewContentNodeType[];
-  isAttachedFromDataSourceActivated: boolean;
 }
 
 export const InputBarAttachmentsPicker = ({
   fileUploaderService,
   onNodeSelect,
   attachedNodes,
-  isAttachedFromDataSourceActivated,
   isLoading = false,
 }: InputBarAttachmentsPickerProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -98,7 +96,7 @@ export const InputBarAttachmentsPicker = ({
     }
   };
 
-  return isAttachedFromDataSourceActivated ? (
+  return (
     <DropdownMenu
       open={isOpen}
       onOpenChange={(open) => {
@@ -202,28 +200,5 @@ export const InputBarAttachmentsPicker = ({
         )}
       </DropdownMenuContent>
     </DropdownMenu>
-  ) : (
-    <>
-      <Input
-        type="file"
-        ref={fileInputRef}
-        style={{ display: "none" }}
-        onChange={async (e) => {
-          setIsOpen(false);
-          await fileUploaderService.handleFileChange(e);
-          if (fileInputRef.current) {
-            fileInputRef.current.value = "";
-          }
-        }}
-        multiple={true}
-      />
-      <Button
-        size="xs"
-        variant="ghost-secondary"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={isLoading}
-        icon={AttachmentIcon}
-      />
-    </>
   );
 };

--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -73,17 +73,11 @@ export const InputBarContainer = ({
     []
   );
 
-  const isAttachedFromDataSourceActivated: boolean = false;
-
   const { editor, editorService } = useCustomEditor({
     suggestions,
     onEnterKeyDown,
     disableAutoFocus,
-    ...(isAttachedFromDataSourceActivated
-      ? {
-          onUrlDetected: handleUrlDetected,
-        }
-      : {}),
+    onUrlDetected: handleUrlDetected,
   });
 
   const sendNotification = useSendNotification();
@@ -112,10 +106,7 @@ export const InputBarContainer = ({
           searchSourceUrls: true,
           includeDataSources: true,
           viewType: "all",
-          disabled:
-            isSpacesLoading ||
-            !nodeOrUrlCandidate ||
-            !isAttachedFromDataSourceActivated,
+          disabled: isSpacesLoading || !nodeOrUrlCandidate,
           spaceIds: spaces.map((s) => s.sId),
         }
   );
@@ -234,9 +225,6 @@ export const InputBarContainer = ({
               onNodeSelect || ((node) => console.log(`Selected ${node.title}`))
             }
             attachedNodes={attachedNodes}
-            isAttachedFromDataSourceActivated={
-              isAttachedFromDataSourceActivated
-            }
           />
           <AssistantPicker
             owner={owner}

--- a/extension/ui/components/markdown/ContentNodeMentionBlock.tsx
+++ b/extension/ui/components/markdown/ContentNodeMentionBlock.tsx
@@ -1,4 +1,5 @@
-import { Chip } from "@dust-tt/sparkle";
+import { AttachmentChip } from "@dust-tt/sparkle";
+import React from "react";
 import { visit } from "unist-util-visit";
 
 export function ContentNodeMentionBlock({
@@ -8,9 +9,7 @@ export function ContentNodeMentionBlock({
   title: string;
   url: string;
 }) {
-  return (
-    <Chip label={title} size="xs" color="sky" href={url} target="_blank" />
-  );
+  return <AttachmentChip label={title} href={url} target="_blank" />;
 }
 
 export function contentNodeMentionDirective() {


### PR DESCRIPTION
## Description

This PR ports the front-end changes for attachments in conversations to the extension. It includes the centralization of attachment handling through a unified `AttachmentCitation` component that handles both file and node attachments consistently. The changes streamline the visual representation of attachments and improve code maintainability.

**References:**
 - https://github.com/dust-tt/dust/pull/11724

## Risk

Low

## Deploy Plan

N/A