### PR TITLE
feat(MCP): add TableQuery configuration to MCP server actions

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -154,6 +154,7 @@ async function main() {
   await MCPServerView.sync({ alter: true });
   await MCPServerConnection.sync({ alter: true });
 
+  await AgentMCPServerConfiguration.sync({ alter: true });
   await AgentRetrievalConfiguration.sync({ alter: true });
   await AgentDustAppRunConfiguration.sync({ alter: true });
   await AgentTablesQueryConfiguration.sync({ alter: true });
@@ -162,7 +163,6 @@ async function main() {
   await AgentWebsearchConfiguration.sync({ alter: true });
   await AgentBrowseConfiguration.sync({ alter: true });
   await AgentReasoningConfiguration.sync({ alter: true });
-  await AgentMCPServerConfiguration.sync({ alter: true });
 
   await AgentDataSourceConfiguration.sync({ alter: true });
 

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -195,6 +195,21 @@ export async function submitAssistantBuilderForm({
                     a.configuration.dataSourceConfigurations,
                 })
               : null,
+            // TODO(2025-04-04 aubin): extract a function here.
+            tables: a.configuration.tablesConfigurations
+              ? Object.values(a.configuration.tablesConfigurations).flatMap(
+                  ({ dataSourceView, selectedResources }) => {
+                    return selectedResources.map((resource) => ({
+                      dataSourceViewId: dataSourceView.sId,
+                      workspaceId: owner.sId,
+                      tableId: getTableIdForContentNode(
+                        dataSourceView.dataSource,
+                        resource
+                      ),
+                    }));
+                  }
+                )
+              : null,
           },
         ];
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -128,6 +128,7 @@ export type AssistantBuilderReasoningConfiguration = {
 export type AssistantBuilderMCPServerConfiguration = {
   mcpServerViewId: string;
   dataSourceConfigurations: DataSourceViewSelectionConfigurations | null;
+  tablesConfigurations: DataSourceViewSelectionConfigurations | null;
 };
 
 // Builder State
@@ -365,6 +366,7 @@ export function getDefaultMCPServerActionConfiguration(): AssistantBuilderAction
     configuration: {
       mcpServerViewId: "not-a-valid-sId",
       dataSourceConfigurations: null,
+      tablesConfigurations: null,
     },
     name: DEFAULT_MCP_ACTION_NAME,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -19,31 +19,35 @@ async function getMCPServerMetadata(
   auth: Authenticator,
   { mcpServerView }: { mcpServerView: MCPServerViewResource }
 ): Promise<MCPServerType> {
-  if (mcpServerView.serverType === "remote") {
-    const remoteMCPServer = mcpServerView.getRemoteMCPServer();
+  switch (mcpServerView.serverType) {
+    case "remote": {
+      const remoteMCPServer = mcpServerView.getRemoteMCPServer();
 
-    // Note: this won't attempt to connect to remote servers and will use the cached metadata.
-    return remoteMCPServer.toJSON();
-  } else if (mcpServerView.serverType === "internal") {
-    if (!mcpServerView.internalMCPServerId) {
-      throw new Error(
-        `Internal MCP server ID is required for internal server type.`
-      );
+      // Note: this won't attempt to connect to remote servers and will use the cached metadata.
+      return remoteMCPServer.toJSON();
     }
+    case "internal": {
+      if (!mcpServerView.internalMCPServerId) {
+        throw new Error(
+          `Internal MCP server ID is required for internal server type.`
+        );
+      }
 
-    const internalMCPServer = await InternalMCPServerInMemoryResource.fetchById(
-      auth,
-      mcpServerView.internalMCPServerId
-    );
-    if (!internalMCPServer) {
-      throw new Error(
-        `Internal MCP server with ID ${mcpServerView.internalMCPServerId} not found.`
-      );
+      const internalMCPServer =
+        await InternalMCPServerInMemoryResource.fetchById(
+          auth,
+          mcpServerView.internalMCPServerId
+        );
+      if (!internalMCPServer) {
+        throw new Error(
+          `Internal MCP server with ID ${mcpServerView.internalMCPServerId} not found.`
+        );
+      }
+      return internalMCPServer.toJSON();
     }
-
-    return internalMCPServer.toJSON();
-  } else {
-    assertNever(mcpServerView.serverType);
+    default: {
+      assertNever(mcpServerView.serverType);
+    }
   }
 }
 
@@ -141,7 +145,9 @@ export async function fetchMCPServerActionConfigurations(
       );
     }
 
-    const metadata = await getMCPServerMetadata(auth, { mcpServerView });
+    const { name, description } = await getMCPServerMetadata(auth, {
+      mcpServerView,
+    });
 
     if (!actionsByConfigurationId.has(agentConfigurationId)) {
       actionsByConfigurationId.set(agentConfigurationId, []);
@@ -153,8 +159,8 @@ export async function fetchMCPServerActionConfigurations(
         id,
         sId,
         type: "mcp_server_configuration",
-        name: metadata.name,
-        description: metadata.description,
+        name,
+        description,
         mcpServerViewId: mcpServerView.sId,
         dataSources: dataSourceConfigurations.map(getDataSource),
         tables: tablesConfigurations.map(getTableConfiguration),

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -125,6 +125,7 @@ export async function fetchMCPServerActionConfigurations(
         description: metadata.description,
         mcpServerViewId: mcpServerView.sId,
         dataSources: dataSourceConfigurations.map(getDataSource),
+        tables: null,
       });
     }
   }

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -86,15 +86,13 @@ export async function fetchMCPServerActionConfigurations(
   for (const config of mcpServerConfigurations) {
     const { agentConfigurationId, sId, id, mcpServerViewId } = config;
 
-    const dataSourceConfigurations =
-      allDataSourceConfigurations.filter(
-        (ds) => ds.mcpServerConfigurationId === config.id
-      ) ?? [];
+    const dataSourceConfigurations = allDataSourceConfigurations.filter(
+      (ds) => ds.mcpServerConfigurationId === config.id
+    );
 
-    const tablesConfigurations =
-      allTablesConfigurations.filter(
-        (tc) => tc.mcpServerConfigurationId === config.id
-      ) ?? [];
+    const tablesConfigurations = allTablesConfigurations.filter(
+      (tc) => tc.mcpServerConfigurationId === config.id
+    );
 
     const mcpServerView = await MCPServerViewResource.fetchByModelPk(
       auth,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -8,6 +8,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getMCPEvents } from "@app/lib/actions/pubsub";
 import type { DataSourceConfiguration } from "@app/lib/actions/retrieval";
+import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
 import type {
   BaseActionRunParams,
   ExtractActionBlob,
@@ -43,7 +44,8 @@ export type MCPServerConfigurationType = {
   description: string | null;
 
   dataSources: DataSourceConfiguration[] | null;
-  // TODO(mcp): add other kind of configurations here such as table query.
+  tables: TableDataSourceConfiguration[] | null;
+  // TODO(mcp): add other kinds of configurations here.
 };
 
 export type MCPToolConfigurationType = Omit<

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -75,6 +75,7 @@ function makeMCPConfigurations({
       description: tool.description ?? null,
       inputSchema: tool.inputSchema || { type: "object", properties: {} },
       dataSources: config.dataSources,
+      tables: config.tables,
     };
   });
 }

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1061,12 +1061,11 @@ export async function createAgentActionConfiguration(
           { transaction: t }
         );
 
-        await createTableDataSourceConfiguration(
-          auth,
-          action.tables,
+        await createTableDataSourceConfiguration(auth, t, {
+          tableConfigurations: action.tables,
           tablesQueryConfig,
-          t
-        );
+          mcpConfig: null,
+        });
 
         return new Ok({
           id: tablesQueryConfig.id,
@@ -1198,12 +1197,21 @@ export async function createAgentActionConfiguration(
           { transaction: t }
         );
 
+        // Creating the AgentDataSourceConfiguration if configured
         if (action.dataSources) {
           await _createAgentDataSourcesConfigData(auth, t, {
             dataSourceConfigurations: action.dataSources,
             retrievalConfigurationId: null,
             processConfigurationId: null,
             mcpConfigurationId: mcpConfig.id,
+          });
+        }
+        // Creating the AgentTablesQueryConfigurationTable if configured
+        if (action.tables) {
+          await createTableDataSourceConfiguration(auth, t, {
+            tableConfigurations: action.tables,
+            tablesQueryConfig: null,
+            mcpConfig,
           });
         }
 
@@ -1215,6 +1223,7 @@ export async function createAgentActionConfiguration(
           description: action.description,
           mcpServerViewId: action.mcpServerViewId,
           dataSources: action.dataSources,
+          tables: action.tables,
         });
       });
     }

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -1,6 +1,7 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -80,7 +81,10 @@ export class AgentTablesQueryConfigurationTable extends WorkspaceAwareModel<Agen
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
   declare tablesQueryConfigurationId: ForeignKey<
     AgentTablesQueryConfiguration["id"]
-  >;
+  > | null;
+  declare mcpServerConfigurationId: ForeignKey<
+    AgentMCPServerConfiguration["id"]
+  > | null;
 
   declare dataSource: NonAttribute<DataSourceModel>;
   declare dataSourceView: NonAttribute<DataSourceViewModel>;
@@ -118,12 +122,23 @@ AgentTablesQueryConfigurationTable.init(
   }
 );
 
+// Table query config <> Table config
 AgentTablesQueryConfiguration.hasMany(AgentTablesQueryConfigurationTable, {
-  foreignKey: { name: "tablesQueryConfigurationId", allowNull: false },
+  foreignKey: { name: "tablesQueryConfigurationId", allowNull: true },
   onDelete: "RESTRICT",
 });
 AgentTablesQueryConfigurationTable.belongsTo(AgentTablesQueryConfiguration, {
-  foreignKey: { name: "tablesQueryConfigurationId", allowNull: false },
+  foreignKey: { name: "tablesQueryConfigurationId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+
+// MCP server config <> Table config
+AgentMCPServerConfiguration.hasMany(AgentTablesQueryConfigurationTable, {
+  foreignKey: { name: "mcpServerConfigurationId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+AgentTablesQueryConfigurationTable.belongsTo(AgentMCPServerConfiguration, {
+  foreignKey: { name: "mcpServerConfigurationId", allowNull: true },
   onDelete: "RESTRICT",
 });
 

--- a/front/migrations/db/migration_201.sql
+++ b/front/migrations/db/migration_201.sql
@@ -1,3 +1,5 @@
 -- Migration created on Apr 04, 2025
-ALTER TABLE "public"."agent_tables_query_configuration_tables" ADD COLUMN "mcpServerConfigurationId" BIGINT REFERENCES "agent_mcp_server_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "agent_tables_query_configuration_tables"  ALTER COLUMN "tablesQueryConfigurationId" DROP NOT NULL;
+ALTER TABLE "public"."agent_tables_query_configuration_tables"
+  ADD COLUMN "mcpServerConfigurationId" BIGINT REFERENCES "agent_mcp_server_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "agent_tables_query_configuration_tables"
+  ALTER COLUMN "tablesQueryConfigurationId" DROP NOT NULL;

--- a/front/migrations/db/migration_201.sql
+++ b/front/migrations/db/migration_201.sql
@@ -1,0 +1,3 @@
+-- Migration created on Apr 04, 2025
+ALTER TABLE "public"."agent_tables_query_configuration_tables" ADD COLUMN "mcpServerConfigurationId" BIGINT REFERENCES "agent_mcp_server_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "agent_tables_query_configuration_tables"  ALTER COLUMN "tablesQueryConfigurationId" DROP NOT NULL;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -489,6 +489,7 @@ export async function createOrUpgradeAgentConfiguration({
           name: action.name,
           description: action.description ?? DEFAULT_MCP_ACTION_DESCRIPTION,
           dataSources: action.dataSources,
+          tables: action.tables,
         },
         agentConfigurationRes.value
       );

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -144,6 +144,16 @@ const MCPServerActionConfigurationSchema = t.type({
       })
     ),
   ]),
+  tables: t.union([
+    t.null,
+    t.array(
+      t.type({
+        dataSourceViewId: t.string,
+        tableId: t.string,
+        workspaceId: t.string,
+      })
+    ),
+  ]),
 });
 
 const ProcessActionConfigurationSchema = t.type({


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/2364.
This PR adds the possibility to configure Tables when adding an MCP server.
- First part is to add the corresponding relationships in types and in data model (FK from `AgentTablesQueryConfigurationTable` to `AgentMCPServerConfiguration`, state in assistant build, in config + plumbing).
- Second part is to update the fetch in `fetchMCPServerActionConfigurations` (in `fetchWorkspaceAgentConfigurationsForView`).

Three follow up PRs are planned:
- Trigger the correct flow in Assistant Builder to populate the `tables` configuration (currently kept from `getDefaultMCPServerActionConfiguration` so stays null).
- Refactor to group the parts that deal with the configuration (e.g translation `AgentTablesQueryConfigurationTable => TableDataSourceConfiguration`), currently the Table Query table configuration is very tied to the Table Query action (which makes sense since it was the only tool that used it).
- Implement the zod schema for the new configuration, add the mime type and implement the URI generation.

## Tests

- TBC

## Risk

- N/A.

## Deploy Plan

- Run migration.
- Deploy front.