### PR TITLE
fix: update broken google ai studio api check

### DIFF
--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -222,7 +222,7 @@ async function handler(
 
         case "google_ai_studio":
           const { api_key } = config;
-          const testUrlGoogleAIStudio = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${api_key}`;
+          const testUrlGoogleAIStudio = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${api_key}`;
           const testRequestBodyGoogleAIStudio = {
             contents: {
               role: "user",


### PR DESCRIPTION
Uses a valid model to check Google AI Studio API.

## Description

Fixes #11678 by changing the url for the Google AI Studio API check from '/v1beta/models/gemini-pro' to '/v1beta/models/gemini-2.0-flash'

No other changes were made.

"gemini-pro" is no longer on the list of supported models, so adding an API key for Google AI Studio always fails with the message "Error: "models/gemini-pro is not found for API version v1beta, or is not supported for generateContent.". This commit fixes this by changing the request to a newer model version.

## Tests

Tested the new API endpoint.

## Risk

Minimal – the functionality is currently broken, changing part of the URL fixes that.

## Deploy Plan

n/a
