### PR TITLE
[poke] fix(conversation): Fix getting conversation from poke

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -68,13 +68,17 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   private static getOptions(
     options?: FetchConversationOptions
   ): ResourceFindOptions<ConversationModel> {
-    const result: ResourceFindOptions<ConversationModel> = {
-      where: {
-        visibility: options?.includeDeleted ? {} : { [Op.ne]: "deleted" },
-      },
-    };
+    const where: ResourceFindOptions<ConversationModel>["where"] = {};
 
-    return result;
+    if (!options?.includeDeleted) {
+      where.visibility = {
+        [Op.ne]: "deleted",
+      };
+    }
+
+    return {
+      where,
+    };
   }
 
   private static async baseFetch(


### PR DESCRIPTION
## Description
- Fix getting a conversation from poke. The query wanted to include deleted ones and that broke the sequalize query.
- tl;dr: `visibility: {}` is not a valid query

## Tests
- Accessed conversations from local dust and local poke

## Risk
none

## Deploy Plan
quick fix, just have to deploy
