### PR TITLE
Slack: increase startToCloseTimeout syncNonThreaded

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -27,10 +27,12 @@ const {
   startToCloseTimeout: "10 minutes",
 });
 
-const { deleteChannel, syncThread, syncNonThreaded } = proxyActivities<
-  typeof activities
->({
+const { deleteChannel, syncThread } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
+});
+
+const { syncNonThreaded } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "50 minutes",
 });
 
 /**


### PR DESCRIPTION
## Description

We have a lot of `startToCloseTimeout` on `syncNonThreaded` due to hitting Slack rate limit: [Logs](https://app.datadoghq.eu/logs?query=%40activityName%3AsyncNonThreaded&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1743630794856&to_ts=1743803594856&live=true). 

Trying to increase the limit, but we might want a better fix in the future. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

/ 

## Deploy Plan

Deploy connectors. 
