### PR TITLE
[front] - fix: prevent buttons display when agent is "thinking"

### DIFF
--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -522,7 +522,7 @@ export function AgentMessage({
   );
 
   const buttons =
-    message.status === "failed"
+    message.status === "failed" || lastAgentStateClassification === "thinking"
       ? []
       : [
           <Button

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -436,7 +436,7 @@ export function AgentMessage({
   );
 
   const buttons =
-    message.status === "failed"
+    message.status === "failed" || lastAgentStateClassification === "thinking"
       ? []
       : [
           <Button


### PR DESCRIPTION
## Description

This PR hides action buttons for messages while the agent state is classified as "thinking"

**References:**
- https://github.com/dust-tt/tasks/issues/2545

## Risk

Low

## Deploy Plan

Deploy front