### PR TITLE
[front] mcp(remote): allow icon update for remote servers

### DIFF
--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -15,7 +15,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -19,7 +19,7 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import { ALLOWED_ICONS, MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
 import type { RemoteMCPServerType } from "@app/lib/actions/mcp_metadata";
 import {
   useMCPServers,
@@ -36,7 +36,7 @@ interface RemoteMCPFormProps {
 const MCPFormSchema = z.object({
   name: z.string().min(1, "Name is required."),
   description: z.string().min(1, "Description is required."),
-  icon: z.enum(["rocket", "command"], { required_error: "Icon is required." }),
+  icon: z.enum(ALLOWED_ICONS, { required_error: "Icon is required." }),
 });
 
 export type MCPFormType = z.infer<typeof MCPFormSchema>;
@@ -72,10 +72,8 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
     try {
       const result = await updateServer({
         name: values.name,
-        url: mcpServer.url || "",
         description: values.description,
         icon: values.icon,
-        tools: mcpServer.tools,
       });
       if (result.success) {
         void mutateMCPServers();

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -1,5 +1,9 @@
 import {
   Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   EyeIcon,
   EyeSlashIcon,
   Input,
@@ -11,10 +15,11 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import React, { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
 import type { RemoteMCPServerType } from "@app/lib/actions/mcp_metadata";
 import {
   useMCPServers,
@@ -31,6 +36,7 @@ interface RemoteMCPFormProps {
 const MCPFormSchema = z.object({
   name: z.string().min(1, "Name is required."),
   description: z.string().min(1, "Description is required."),
+  icon: z.enum(["rocket", "command"], { required_error: "Icon is required." }),
 });
 
 export type MCPFormType = z.infer<typeof MCPFormSchema>;
@@ -47,6 +53,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
     defaultValues: {
       name: mcpServer.name,
       description: mcpServer.description,
+      icon: mcpServer.icon,
     },
   });
 
@@ -67,6 +74,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
         name: values.name,
         url: mcpServer.url || "",
         description: values.description,
+        icon: values.icon,
         tools: mcpServer.tools,
       });
       if (result.success) {
@@ -178,19 +186,58 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
       <Separator className="my-4" />
 
       <Page.SectionHeader title="Settings" />
-      <div>
-        <Label htmlFor="name">Name</Label>
-        <Controller
-          control={form.control}
-          name="name"
-          render={({ field }) => (
-            <Input
-              {...field}
-              isError={!!form.formState.errors.name}
-              message={form.formState.errors.name?.message}
-            />
-          )}
-        />
+      <div className="flex space-x-2">
+        <div className="flex-grow">
+          <Label htmlFor="name">Name</Label>
+          <Controller
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <Input
+                {...field}
+                isError={!!form.formState.errors.name}
+                message={form.formState.errors.name?.message}
+              />
+            )}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="icon">Icon</Label>
+          <br />
+          <Controller
+            control={form.control}
+            name="icon"
+            render={({ field }) => {
+              const currentIcon = field.value;
+              const Icon = MCP_SERVER_ICONS[currentIcon];
+              return (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      className="capitalize"
+                      variant="outline"
+                      label={currentIcon}
+                      icon={Icon}
+                      isSelect
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    {Object.entries(MCP_SERVER_ICONS).map(([value, Icon]) => (
+                      <DropdownMenuItem
+                        key={value}
+                        className="capitalize"
+                        label={value}
+                        icon={Icon}
+                        onClick={() => field.onChange(value)}
+                      />
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              );
+            }}
+          />
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -7,7 +7,7 @@ export const MCP_SERVER_ICONS: Record<AllowedIconType, React.ComponentType> = {
 
 export const DEFAULT_MCP_SERVER_ICON = "rocket" as const;
 
-const ALLOWED_ICONS = ["command", "rocket"] as const;
+export const ALLOWED_ICONS = ["command", "rocket"] as const;
 export type AllowedIconType = (typeof ALLOWED_ICONS)[number];
 
 export const isAllowedIconType = (icon: string): icon is AllowedIconType =>

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -8,6 +8,7 @@ import type {
 } from "sequelize";
 
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import type { AllowedIconType } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType, MCPToolType } from "@app/lib/actions/mcp_metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerView } from "@app/lib/models/assistant/actions/mcp_server_view";
@@ -202,6 +203,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServer> {
       name,
       description,
       url,
+      icon,
       sharedSecret,
       cachedTools,
       lastSyncAt,
@@ -209,6 +211,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServer> {
       name?: string;
       description?: string;
       url?: string;
+      icon?: AllowedIconType;
       sharedSecret?: string;
       cachedTools: MCPToolType[];
       lastSyncAt: Date;
@@ -218,6 +221,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServer> {
       name,
       description,
       url,
+      icon,
       sharedSecret,
       cachedTools,
       lastSyncAt,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -202,7 +202,6 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServer> {
     {
       name,
       description,
-      url,
       icon,
       sharedSecret,
       cachedTools,
@@ -210,17 +209,15 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServer> {
     }: {
       name?: string;
       description?: string;
-      url?: string;
       icon?: AllowedIconType;
       sharedSecret?: string;
-      cachedTools: MCPToolType[];
+      cachedTools?: MCPToolType[];
       lastSyncAt: Date;
     }
   ) {
     await this.update({
       name,
       description,
-      url,
       icon,
       sharedSecret,
       cachedTools,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -280,10 +280,8 @@ export function useUpdateRemoteMCPServer(
 
   const updateServer = async (data: {
     name: string;
-    url: string;
     icon: string;
     description: string;
-    tools: { name: string; description: string }[];
   }): Promise<PatchMCPServerResponseBody> => {
     const response = await fetch(`/api/w/${owner.sId}/mcp/${serverId}`, {
       method: "PATCH",

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -281,6 +281,7 @@ export function useUpdateRemoteMCPServer(
   const updateServer = async (data: {
     name: string;
     url: string;
+    icon: string;
     description: string;
     tools: { name: string; description: string }[];
   }): Promise<PatchMCPServerResponseBody> => {

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -124,9 +124,9 @@ async function handler(
         });
       }
 
-      const { name, url, description, tools } = req.body;
+      const { name, url, icon, description, tools } = req.body;
 
-      if (!name && !url && !description && !tools) {
+      if (!name && !url && !icon && !description && !tools) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -139,6 +139,7 @@ async function handler(
       await server.updateMetadata(auth, {
         name,
         url,
+        icon,
         description,
         cachedTools: tools,
         lastSyncAt: new Date(),

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -124,9 +124,9 @@ async function handler(
         });
       }
 
-      const { name, url, icon, description, tools } = req.body;
+      const { name, icon, description } = req.body;
 
-      if (!name && !url && !icon && !description && !tools) {
+      if (!name && !icon && !description) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -138,10 +138,8 @@ async function handler(
 
       await server.updateMetadata(auth, {
         name,
-        url,
         icon,
         description,
-        cachedTools: tools,
         lastSyncAt: new Date(),
       });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds the opportunity to update the icon of a remote MCP Server. See UI on the screen below.

![image](https://github.com/user-attachments/assets/854d52fb-a355-4cf5-a6c0-59b249e3ac96)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, changes icon nicely.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Behind ff, safed to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.