### PR TITLE
Increase timeout, remove retries

### DIFF
--- a/front/types/shared/text_extraction/index.ts
+++ b/front/types/shared/text_extraction/index.ts
@@ -93,7 +93,7 @@ export function isTextExtractionSupportedContentType(
 }
 
 const DEFAULT_HANDLER = "text";
-const DEFAULT_TIMEOUT_IN_MS = 60000;
+const DEFAULT_TIMEOUT_IN_MS = 300000;
 
 export class TextExtraction {
   constructor(
@@ -129,38 +129,15 @@ export class TextExtraction {
     fileStream: Readable,
     contentType: SupportedContentTypes
   ): Promise<Readable> {
-    const response = await withRetries(
-      this.options.logger,
-      ({
-        url,
-        additionalHeaders,
-        contentType,
-        fileStream,
-      }: {
-        url: string;
-        additionalHeaders: HeadersInit;
-        contentType: SupportedContentTypes;
-        fileStream: Readable;
-      }) =>
-        fetch(`${url}/tika/`, {
-          method: "PUT",
-          headers: {
-            "Content-Type": contentType,
-            ...additionalHeaders,
-          },
-          body: Readable.toWeb(fileStream),
-          duplex: "half",
-        } as RequestInitWithDuplex),
-      {
-        retries: 3,
-        delayBetweenRetriesMs: 1000,
-      }
-    )({
-      url: this.url,
-      additionalHeaders: this.getAdditionalHeaders(),
-      contentType,
-      fileStream,
-    });
+    const response = await fetch(`${this.url}/tika/`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": contentType,
+        ...this.getAdditionalHeaders(),
+      },
+      body: Readable.toWeb(fileStream),
+      duplex: "half",
+    } as RequestInitWithDuplex);
 
     if (!response.body) {
       throw new Error("Response body is null");


### PR DESCRIPTION
## Description

- Increase timeout as OCR can take more than a min - 5 min looks reasonable
- Remved withRetries - it does not seem possible when used with a fromStream and generates a lot of errors, and also multiply the load (it retries after every timeout)
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

ocr  only

## Deploy Plan

deploy front