### PR TITLE
enh(MCP): add more explicit error messages on invalid `sIds`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -52,7 +52,11 @@ export const getInternalMCPServerNameAndWorkspaceId = (
   }
 
   if (sIdParts.resourceName !== "internal_mcp_server") {
-    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
+    return new Err(
+      new Error(
+        `Invalid internal MCPServer sId: ${sId}, does not refer to an internal MCP server.`
+      )
+    );
   }
 
   // Swap keys and values.
@@ -61,14 +65,20 @@ export const getInternalMCPServerNameAndWorkspaceId = (
   );
 
   if (!details) {
-    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
+    return new Err(
+      new Error(
+        `Invalid internal MCPServer sId: ${sId}, ID does not match any known internal MCPServer.`
+      )
+    );
   }
 
   if (!isInternalMCPServerName(details[0])) {
-    return new Err(new Error(`Invalid internal MCPServer sId: ${sId}`));
+    return new Err(
+      new Error(`Invalid internal MCPServer name: ${details[0]}, sId: ${sId}`)
+    );
   }
 
-  const name: InternalMCPServerNameType = details[0];
+  const name = details[0];
 
   return new Ok({
     name,


### PR DESCRIPTION
## Description

- Had an error locally due to having an internal MCP server in db that did not exist yet and realized the error message was not super detailed.
- This PR adds more detailed error messages on invalid internal MCP server `sId`.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.