### PR TITLE
[front] - fix(workspace): make settings responsive

### DIFF
--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -204,16 +204,14 @@ export default function WorkspaceAdmin({
           />
           <Page.Vertical align="stretch" gap="md">
             <Page.H variant="h4">Analytics</Page.H>
-            <Page.Horizontal gap="lg">
-              <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
-                <QuickInsights owner={owner} />
-                <ActivityReport
-                  isDownloading={isDownloadingData}
-                  monthOptions={monthOptions}
-                  handleDownload={handleDownload}
-                />
-              </div>
-            </Page.Horizontal>
+            <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
+              <QuickInsights owner={owner} />
+              <ActivityReport
+                isDownloading={isDownloadingData}
+                monthOptions={monthOptions}
+                handleDownload={handleDownload}
+              />
+            </div>
           </Page.Vertical>
           <Page.Vertical align="stretch" gap="md">
             <Page.H variant="h4">Settings</Page.H>

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -205,7 +205,7 @@ export default function WorkspaceAdmin({
           <Page.Vertical align="stretch" gap="md">
             <Page.H variant="h4">Analytics</Page.H>
             <Page.Horizontal gap="lg">
-              <div className="grid w-full grid-cols-2 gap-4">
+              <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
                 <QuickInsights owner={owner} />
                 <ActivityReport
                   isDownloading={isDownloadingData}


### PR DESCRIPTION
## Description

This PR adds the following changes:
 - Changed the grid column layout from 2 columns to 1 for better responsiveness on mobile devices
 - Maintained 2 columns layout for medium and larger screen sizes using responsive design classes

**References:**
- https://github.com/dust-tt/dust/pull/11791

## Risk

Low

## Deploy Plan

Deploy front