### PR TITLE
fix(Confluence): prevent `nearRateLimit` errors from popping up as "Unhandled Activity Errors"

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -449,7 +449,7 @@ export class ConfluenceClient {
         `Near rate limit: ${this.apiUrl}${endpoint}`,
         {
           type: "http_response_error",
-          status: response.status,
+          status: 429, // We fake a 429 here to make sure the error is caught in the cast_known_errors.
           data: { url: `${this.apiUrl}${endpoint}`, response },
         }
       );


### PR DESCRIPTION
## Description

- A previous PR introduced a detection on API calls that are near the rate limits for Confluence.
- The behavior introduced consisted in throwing an error, in a similar fashion to 429 responses.
- This caused the Unhandled Activity Error monitor to trigger because the error was not caught in `cast_known_errors`.
- This PR fixes that.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.