### PR TITLE
[front] fix(spaces): use ff in spaces categories list

### DIFF
--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -26,13 +26,13 @@ import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   DataSourceWithAgentsUsageType,
   SpaceType,
   WorkspaceType,
 } from "@app/types";
 import { DATA_SOURCE_VIEW_CATEGORIES, removeNulls } from "@app/types";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 type RowData = {
   category: string;

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -32,6 +32,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { DATA_SOURCE_VIEW_CATEGORIES, removeNulls } from "@app/types";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 type RowData = {
   category: string;
@@ -108,12 +109,16 @@ export const SpaceCategoriesList = ({
     spaceId: space.sId,
   });
 
+  const { hasFeature } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
   const { setIsSearchDisabled } = React.useContext(SpaceSearchContext);
 
   const rows: RowData[] = spaceInfo
     ? removeNulls(
         DATA_SOURCE_VIEW_CATEGORIES.map((category) =>
-          spaceInfo.categories[category]
+          spaceInfo.categories[category] &&
+          hasFeature(CATEGORY_DETAILS[category].flag)
             ? {
                 category,
                 ...spaceInfo.categories[category],


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

We currently show all of the categories in the list in each spaces, we don't leverage the `flag` string in the `CATEGORY_DETAILS`. 

This is leading to currently showing the "Actions" entry in the list to the spaces that don't have the MCP flag. (Not harmful, just bad UX as they are then hitting a 404 when clicking on the line, and clicking on "Add Action").

Example below (with Dust EU workspace) :
<img width="1512" alt="Capture d’écran 2025-04-07 à 16 01 15" src="https://github.com/user-attachments/assets/c3d8b595-804d-40a0-a4a7-d66296453cb1" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested manually, enabled and disabled ff. Behaves as expected.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Should be good. Safe to rollback. Only hides the Actions line in the list.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.