### PR TITLE
[sparkle] - feat(DataTable): selectable rows

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.454",
+  "version": "0.2.455",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.454",
+      "version": "0.2.455",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.454",
+  "version": "0.2.455",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -313,6 +313,9 @@ export function ScrollableDataTable<TData extends TBaseData>({
   maxHeight = "s-h-100",
   onLoadMore,
   isLoading = false,
+  rowSelection,
+  setRowSelection,
+  enableRowSelection,
 }: ScrollableDataTableProps<TData>) {
   const windowSize = useWindowSize();
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -338,12 +341,25 @@ export function ScrollableDataTable<TData extends TBaseData>({
     };
   }, []);
 
+  const onRowSelectionChange =
+    rowSelection && setRowSelection
+      ? (updater: Updater<RowSelectionState>) => {
+          const newValue =
+            typeof updater === "function" ? updater(rowSelection) : updater;
+          setRowSelection(newValue);
+        }
+      : undefined;
+
   const table = useReactTable({
     data,
     columns,
     rowCount: totalRowCount,
     getCoreRowModel: getCoreRowModel(),
     enableColumnResizing: true,
+    onRowSelectionChange,
+    state: {
+      rowSelection,
+    },
   });
 
   useEffect(() => {
@@ -488,6 +504,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
                     widthClassName={widthClassName}
                     onClick={row.original.onClick}
                     className="s-absolute s-w-full"
+                    data-selected={row.getIsSelected()}
                     style={{
                       transform: `translateY(${virtualRow.start}px)`,
                     }}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -8,6 +8,7 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   PaginationState,
+  Row,
   RowSelectionState,
   type SortingState,
   Updater,
@@ -39,7 +40,13 @@ import {
   Tooltip,
 } from "@sparkle/components";
 import { useCopyToClipboard } from "@sparkle/hooks";
-import { ArrowDownIcon, ArrowUpIcon, ClipboardCheckIcon, ClipboardIcon, MoreIcon } from "@sparkle/icons";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  MoreIcon,
+} from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
 import { breakpoints, useWindowSize } from "./WindowUtility";
@@ -93,7 +100,7 @@ interface DataTableProps<TData extends TBaseData> {
   disablePaginationNumbers?: boolean;
   rowSelection?: RowSelectionState;
   setRowSelection?: (rowSelection: RowSelectionState) => void;
-  enableRowSelection?: boolean | ((row: TData) => boolean);
+  enableRowSelection?: boolean | ((row: Row<TData>) => boolean);
 }
 
 export function DataTable<TData extends TBaseData>({
@@ -1028,13 +1035,14 @@ DataTable.Caption = function Caption({
   );
 };
 
-export function createSelectionColumn<TData>(): ColumnDef<TData, unknown> {
+export function createSelectionColumn<TData>(): ColumnDef<TData> {
   return {
     id: "select",
     enableSorting: false,
     enableHiding: false,
     header: ({ table }) => (
       <Checkbox
+        size="xs"
         checked={
           table.getIsAllRowsSelected()
             ? true
@@ -1042,21 +1050,29 @@ export function createSelectionColumn<TData>(): ColumnDef<TData, unknown> {
               ? "partial"
               : false
         }
-        onCheckedChange={table.getToggleAllRowsSelectedHandler()}
-        size="xs"
+        onCheckedChange={(state) => {
+          if (state === "indeterminate") {
+            return;
+          }
+          table.toggleAllRowsSelected(state);
+        }}
       />
     ),
     cell: ({ row }) => (
       <Checkbox
+        size="xs"
         checked={row.getIsSelected()}
         disabled={!row.getCanSelect()}
-        onCheckedChange={row.getToggleSelectedHandler()}
-        size="xs"
+        onCheckedChange={(state) => {
+          if (state === "indeterminate") {
+            return;
+          }
+          row.toggleSelected(state);
+        }}
       />
     ),
     meta: {
       className: "s-w-10 s-text-start",
-      sizeRatio: 5,
     },
   };
 }

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -256,6 +256,7 @@ export function DataTable<TData extends TBaseData>({
               widthClassName={widthClassName}
               key={row.id}
               onClick={row.original.onClick}
+              data-selected={row.getIsSelected()}
             >
               {row.getVisibleCells().map((cell) => {
                 const breakpoint = columnsBreakpoints[cell.column.id];
@@ -637,6 +638,7 @@ interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
   onClick?: () => void;
   widthClassName: string;
+  "data-selected"?: boolean;
 }
 
 DataTable.Row = function Row({
@@ -654,6 +656,8 @@ DataTable.Row = function Row({
         onClick
           ? "s-cursor-pointer hover:s-bg-muted dark:hover:s-bg-muted-night"
           : "",
+        props["data-selected"] &&
+          "s-bg-highlight-50 dark:s-bg-highlight-900/10",
         widthClassName,
         className
       )}
@@ -1059,20 +1063,22 @@ export function createSelectionColumn<TData>(): ColumnDef<TData> {
       />
     ),
     cell: ({ row }) => (
-      <Checkbox
-        size="xs"
-        checked={row.getIsSelected()}
-        disabled={!row.getCanSelect()}
-        onCheckedChange={(state) => {
-          if (state === "indeterminate") {
-            return;
-          }
-          row.toggleSelected(state);
-        }}
-      />
+      <div className="s-flex s-h-full s-w-full s-items-center">
+        <Checkbox
+          size="xs"
+          checked={row.getIsSelected()}
+          disabled={!row.getCanSelect()}
+          onCheckedChange={(state) => {
+            if (state === "indeterminate") {
+              return;
+            }
+            row.toggleSelected(state);
+          }}
+        />
+      </div>
     ),
     meta: {
-      className: "s-w-10 s-text-start",
+      className: "s-w-10",
     },
   };
 }

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -357,6 +357,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
     getCoreRowModel: getCoreRowModel(),
     enableColumnResizing: true,
     onRowSelectionChange,
+    enableRowSelection,
     state: {
       rowSelection,
     },

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -1,9 +1,5 @@
 import type { Meta } from "@storybook/react";
-import {
-  ColumnDef,
-  PaginationState,
-  SortingState,
-} from "@tanstack/react-table";
+import { ColumnDef, PaginationState, RowSelectionState, SortingState } from "@tanstack/react-table";
 import React, { useCallback, useMemo, useState } from "react";
 
 import {
@@ -19,7 +15,7 @@ import {
   Input,
   ScrollableDataTable,
 } from "@sparkle/components/";
-import { MenuItem } from "@sparkle/components/DataTable";
+import { createSelectionColumn, MenuItem } from "@sparkle/components/DataTable";
 import { FolderIcon } from "@sparkle/icons";
 
 const meta = {
@@ -45,6 +41,7 @@ type Data = {
     React.ComponentPropsWithoutRef<typeof DropdownMenu>,
     "modal"
   >;
+  id?: number;
   roundedAvatar?: boolean;
 };
 
@@ -529,6 +526,7 @@ const createData = (start: number, count: number) => {
   return Array(count)
     .fill(0)
     .map((_, i) => ({
+      id: i,
       name: `Item ${start + i + 1}`,
       usedBy: Math.floor(Math.random() * 100),
       addedBy: `UserUserUserUserUserUserUserUserUserUserUser ${Math.floor(Math.random() * 10) + 1}`,
@@ -585,6 +583,55 @@ export const ScrollableDataTableExample = () => {
 
         <div className="s-text-sm s-text-muted-foreground">
           Loaded {data.length} rows. Scroll to the bottom to load more.
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const DataTableWithRowSelectionExample = () => {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [data] = useState<Data[]>(() => createData(0, 10));
+  const [filter, setFilter] = useState("");
+
+  const columnsWithSelection: ColumnDef<Data>[] = useMemo(
+    () => [
+      createSelectionColumn<Data>(),
+      ...columns,
+    ],
+    []
+  );
+
+  return (
+    <div className="s-flex s-w-full s-max-w-4xl s-flex-col s-gap-6">
+      <h3 className="s-text-lg s-font-medium">DataTable with Row Selection</h3>
+
+      <div className="s-flex s-flex-col s-gap-4">
+        <Input
+          name="filter"
+          placeholder="Filter"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+
+        <DataTable
+          data={data}
+          filter={filter}
+          filterColumn="name"
+          columns={columnsWithSelection}
+          rowSelection={rowSelection}
+          setRowSelection={setRowSelection}
+          enableRowSelection={(row) => (row.id ? row.id % 2 === 0 : false)}
+        />
+
+        <div className="s-rounded-md s-border s-bg-muted/50 s-p-2">
+          <h4 className="s-mb-2 s-font-medium">Selection State:</h4>
+          <pre className="s-overflow-auto s-text-xs">
+            {JSON.stringify(rowSelection, null, 2)}
+          </pre>
+          <p className="s-mt-2 s-text-sm">
+            Selected {Object.keys(rowSelection).length} of {data.length} rows
+          </p>
         </div>
       </div>
     </div>

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -545,6 +545,7 @@ const createData = (start: number, count: number) => {
 
 export const ScrollableDataTableExample = () => {
   const [filter, setFilter] = useState("");
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [data, setData] = useState(() => createData(0, 50));
   const [isLoading, setIsLoading] = useState(false);
 
@@ -562,6 +563,11 @@ export const ScrollableDataTableExample = () => {
   const columnsWithSize = columns.map((column, index) => {
     return { ...column, meta: { sizeRatio: index % 2 === 0 ? 15 : 10 } };
   });
+
+  const columnsWithSelection: ColumnDef<Data>[] = useMemo(
+    () => [createSelectionColumn<Data>(), ...columnsWithSize],
+    []
+  );
   return (
     <div className="s-flex s-w-full s-max-w-4xl s-flex-col s-gap-6">
       <h3 className="s-text-lg s-font-medium">
@@ -580,10 +586,13 @@ export const ScrollableDataTableExample = () => {
           data={data}
           filter={filter}
           filterColumn="name"
-          columns={columnsWithSize}
+          columns={columnsWithSelection}
           onLoadMore={loadMore}
           isLoading={isLoading}
           maxHeight="s-max-h-[500px]"
+          rowSelection={rowSelection}
+          setRowSelection={setRowSelection}
+          enableRowSelection={true}
         />
 
         <div className="s-text-sm s-text-muted-foreground">

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta } from "@storybook/react";
-import { ColumnDef, PaginationState, RowSelectionState, SortingState } from "@tanstack/react-table";
+import {
+  ColumnDef,
+  PaginationState,
+  RowSelectionState,
+  SortingState,
+} from "@tanstack/react-table";
 import React, { useCallback, useMemo, useState } from "react";
 
 import {
@@ -595,10 +600,7 @@ export const DataTableWithRowSelectionExample = () => {
   const [filter, setFilter] = useState("");
 
   const columnsWithSelection: ColumnDef<Data>[] = useMemo(
-    () => [
-      createSelectionColumn<Data>(),
-      ...columns,
-    ],
+    () => [createSelectionColumn<Data>(), ...columns],
     []
   );
 
@@ -621,7 +623,7 @@ export const DataTableWithRowSelectionExample = () => {
           columns={columnsWithSelection}
           rowSelection={rowSelection}
           setRowSelection={setRowSelection}
-          enableRowSelection={(row) => (row.id ? row.id % 2 === 0 : false)}
+          enableRowSelection={true}
         />
 
         <div className="s-rounded-md s-border s-bg-muted/50 s-p-2">


### PR DESCRIPTION
## Description

This PR adds row selection functionality to the `DataTable` component in sparkle. Users can now select individual rows or all rows at once using checkboxes.

![Screenshot 2025-04-07 at 17 20 31](https://github.com/user-attachments/assets/4409be22-65ae-418b-af04-0197d85aebd6)

## Risk

Low

## Deploy Plan

Publish sparkle