### PR TITLE
Optimize slow query on data source views

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -310,6 +310,19 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     });
   }
 
+  static async fetchAssistantDefaultSelectedByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    options?: FetchDataSourceOptions
+  ) {
+    return this.baseFetch(auth, options, {
+      where: {
+        id: ids,
+        assistantDefaultSelected: true,
+      },
+    });
+  }
+
   static async fetchByIds(
     auth: Authenticator,
     ids: string[],

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -316,14 +316,12 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         dataSourceViews.map((dsv) => dsv.dataSourceId)
       );
 
-    const selectedDataSourceIds = new Set(
-      selectedDataSources.map((ds) => ds.id)
-    );
+    const dataSourceMap = new Map(selectedDataSources.map((ds) => [ds.id, ds]));
 
     return dataSourceViews
-      .filter((dsv) => selectedDataSourceIds.has(dsv.dataSourceId))
+      .filter((dsv) => dataSourceMap.has(dsv.dataSourceId))
       .map((dsv) => {
-        dsv.ds = selectedDataSources.find((ds) => ds.id === dsv.dataSourceId);
+        dsv.ds = dataSourceMap.get(dsv.dataSourceId);
         return dsv;
       });
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -24,7 +24,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
@@ -480,12 +479,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       {
         where: whereClause,
         order: [["updatedAt", "DESC"]],
-        includes: [
-          {
-            model: SpaceModel,
-            as: "space",
-          },
-        ],
       }
     );
   }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -30,8 +30,7 @@ import type {
   SpaceKind,
   SpaceType,
 } from "@app/types";
-import { Err } from "@app/types";
-import { Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -324,6 +323,19 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
 
     return space;
+  }
+
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    { includeDeleted }: { includeDeleted?: boolean } = {}
+  ): Promise<SpaceResource[]> {
+    return (
+      this.baseFetch(auth, {
+        where: { id: ids },
+        includeDeleted,
+      }) ?? []
+    );
   }
 
   static async isNameAvailable(


### PR DESCRIPTION
## Description

- We observed a [slow query](https://console.cloud.google.com/sql/instances/cell-00001-front-db/insights;database=front;start=2025-04-07T14:09:47.653Z;end=2025-04-07T14:53:28.467Z;trace=d1f990ac007b3c8c0df91ef59c5d844c;span=e41f13d0e2cb486d;query_hash=14032010861328640332;sort_by=TOTAL_EXEC_TIME/executed?invt=AbuIKA&project=prj-dust-europe-west1) in production.
- Looking at the query plan, we see a nested loop and a bitmap heap scan that contribute a lot to the latency and to the overall cost of the query.
- The query is truncated but we can safely assume that the nested includes on `data_source_views->space->groups->group_vaults` are translated into a highly complex SQL query by Sequelize, whereas what we are aiming to do is fairly simple.
- This PR suggests replacing some of the includes with subsequent queries: we fetch one resource, then fetch the other.

## Tests

- Tested locally.

## Risk

- Quite high.

## Deploy Plan

- Deploy front.