### PR TITLE
Reuse destroy conversation on scrub workspace and convo retention workflow

### DIFF
--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -1,10 +1,11 @@
 import { Op } from "sequelize";
 
+import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import logger from "@app/logger/logger";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 
 /**
  * Get workspace ids with conversations retention policy.
@@ -76,9 +77,13 @@ export async function purgeConversationsBatchActivity({
       "Purging conversations for workspace."
     );
 
-    await concurrentExecutor(conversations, async (c) => c.delete(auth), {
-      concurrency: 4,
-    });
+    await concurrentExecutor(
+      conversations,
+      async (c) => destroyConversation(auth, { conversationId: c.sId }),
+      {
+        concurrency: 4,
+      }
+    );
 
     res.push({
       workspaceModelId: workspace.id,

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -4,6 +4,7 @@ import {
   archiveAgentConfiguration,
   getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration";
+import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import { isGlobalAgentId } from "@app/lib/api/assistant/global_agents";
 import config from "@app/lib/api/config";
 import {
@@ -131,7 +132,7 @@ export async function deleteAllConversations(auth: Authenticator) {
   for (const conversationChunk of conversationChunks) {
     await Promise.all(
       conversationChunk.map(async (c) => {
-        await c.delete(auth);
+        await destroyConversation(auth, { conversationId: c.sId });
       })
     );
   }


### PR DESCRIPTION
## Description

PR 1: reintroduce destroyConversation that was not used for: https://github.com/dust-tt/dust/pull/11714/files

## Tests

/ 

## Risk

It was replaced by just a delete of the convo. 

## Deploy Plan

Deploy front. 
