### PR TITLE
[sparkle] - feat(DoubleIcon): introduce DoubleIcon component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.456",
+  "version": "0.2.457",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.456",
+      "version": "0.2.457",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.456",
+  "version": "0.2.457",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DoubleIcon.tsx
+++ b/sparkle/src/components/DoubleIcon.tsx
@@ -1,6 +1,8 @@
-import React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import React from "react";
+
 import { cn } from "@sparkle/lib/utils";
+
 import { Icon, IconProps } from "./Icon";
 
 const positionVariants = cva("s-flex s-absolute", {

--- a/sparkle/src/components/DoubleIcon.tsx
+++ b/sparkle/src/components/DoubleIcon.tsx
@@ -1,0 +1,43 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import React from "react";
+
+import { cn } from "@sparkle/lib/utils";
+
+import { Icon, IconProps } from "./Icon";
+
+const positionVariants = cva("s-flex", {
+  variants: {
+    position: {
+      "bottom-right": "-s-ml-1.5 s-mt-1.5",
+      "top-right": "-s-ml-1.5 -s-mt-1.5",
+      "bottom-left": "s-ml-1.5 s-mt-1.5",
+      "top-left": "s-ml-1.5 -s-mt-1.5",
+    },
+  },
+  defaultVariants: {
+    position: "bottom-right",
+  },
+});
+
+export interface DoubleIconProps extends VariantProps<typeof positionVariants> {
+  mainIconProps: IconProps;
+  secondaryIconProps: IconProps;
+  position?: "bottom-right" | "top-right" | "bottom-left" | "top-left";
+  className?: string;
+}
+
+export const DoubleIcon = ({
+  mainIconProps,
+  secondaryIconProps,
+  position = "bottom-right",
+  className,
+}: DoubleIconProps) => {
+  return (
+    <div className={cn("s-relative s-inline-flex", className)}>
+      <Icon {...mainIconProps} />
+      <div className={positionVariants({ position })}>
+        <Icon {...secondaryIconProps} />
+      </div>
+    </div>
+  );
+};

--- a/sparkle/src/components/DoubleIcon.tsx
+++ b/sparkle/src/components/DoubleIcon.tsx
@@ -1,17 +1,15 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import React from "react";
-
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@sparkle/lib/utils";
-
 import { Icon, IconProps } from "./Icon";
 
-const positionVariants = cva("s-flex", {
+const positionVariants = cva("s-flex s-absolute", {
   variants: {
     position: {
-      "bottom-right": "-s-ml-1.5 s-mt-1.5",
-      "top-right": "-s-ml-1.5 -s-mt-1.5",
-      "bottom-left": "s-ml-1.5 s-mt-1.5",
-      "top-left": "s-ml-1.5 -s-mt-1.5",
+      "bottom-right": "s-bottom-[-0.375rem] s-right-[-0.375rem]",
+      "top-right": "s-top-[-0.375rem] s-right-[-0.375rem]",
+      "bottom-left": "s-bottom-[-0.375rem] s-left-[-0.375rem]",
+      "top-left": "s-top-[-0.375rem] s-left-[-0.375rem]",
     },
   },
   defaultVariants: {

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -7,6 +7,7 @@ import { LinkWrapper, LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import { SearchInput, SearchInputProps } from "@sparkle/components/SearchInput";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
+import { DoubleIcon } from "@sparkle/components/DoubleIcon";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 
@@ -123,12 +124,23 @@ const ItemWithLabelIconAndDescription = <
                 description ? "s-items-start s-pt-0.5" : "s-items-center"
               )}
             >
-              {icon && <Icon size={description ? "sm" : "xs"} visual={icon} />}
-              {extraIcon && (
-                <div className="-s-ml-1.5 s-mt-1.5">
-                  <Icon size="xs" visual={extraIcon} />
-                </div>
-              )}
+              {icon && extraIcon ? (
+                <DoubleIcon
+                  mainIconProps={{
+                    visual: icon,
+                    size: description ? "sm" : "xs",
+                  }}
+                  secondaryIconProps={{
+                    visual: extraIcon,
+                    size: "xs",
+                  }}
+                  position="bottom-right"
+                />
+              ) : icon ? (
+                <Icon size={description ? "sm" : "xs"} visual={icon} />
+              ) : extraIcon ? (
+                <Icon size="xs" visual={extraIcon} />
+              ) : null}
             </div>
           )}
           <div className="s-flex s-flex-col">

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -2,12 +2,12 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { cva } from "class-variance-authority";
 import * as React from "react";
 
+import { DoubleIcon } from "@sparkle/components/DoubleIcon";
 import { Icon } from "@sparkle/components/Icon";
 import { LinkWrapper, LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import { SearchInput, SearchInputProps } from "@sparkle/components/SearchInput";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
-import { DoubleIcon } from "@sparkle/components/DoubleIcon";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -46,6 +46,7 @@ export {
 export { Counter } from "./Counter";
 export type { DataTableMoreButtonProps, MenuItem } from "./DataTable";
 export { DataTable, ScrollableDataTable } from "./DataTable";
+export { DoubleIcon } from "./DoubleIcon";
 export {
   Dialog,
   DialogClose,

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -46,7 +46,6 @@ export {
 export { Counter } from "./Counter";
 export type { DataTableMoreButtonProps, MenuItem } from "./DataTable";
 export { DataTable, ScrollableDataTable } from "./DataTable";
-export { DoubleIcon } from "./DoubleIcon";
 export {
   Dialog,
   DialogClose,
@@ -60,6 +59,7 @@ export {
   DialogTitle,
   DialogTrigger,
 } from "./Dialog";
+export { DoubleIcon } from "./DoubleIcon";
 export type { DropdownMenuItemProps } from "./Dropdown";
 export {
   DropdownMenu,

--- a/sparkle/src/stories/DoubleIcon.stories.tsx
+++ b/sparkle/src/stories/DoubleIcon.stories.tsx
@@ -1,0 +1,163 @@
+import type { Meta } from "@storybook/react";
+import React from "react";
+
+import { DoubleIcon } from "@sparkle/components";
+import {
+  ChatBubbleBottomCenterTextIcon,
+  CheckCircleIcon,
+  DocumentIcon,
+  FolderIcon,
+  HeartIcon,
+  PlusIcon,
+  SparklesIcon,
+  StarIcon,
+  UserIcon,
+} from "@sparkle/icons";
+import { SlackLogo } from "@sparkle/logo";
+
+const meta = {
+  title: "Primitives/DoubleIcon",
+  component: DoubleIcon,
+} satisfies Meta<typeof DoubleIcon>;
+
+export default meta;
+
+export const IconPositions = () => (
+  <div className="s-flex s-flex-col s-gap-8">
+    <div className="s-flex s-items-center s-gap-16">
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <DoubleIcon
+          mainIconProps={{
+            visual: ChatBubbleBottomCenterTextIcon,
+            size: "md",
+            className: "s-text-primary-500",
+          }}
+          secondaryIconProps={{
+            visual: CheckCircleIcon,
+            size: "xs",
+            className: "s-text-success-500",
+          }}
+          position="bottom-right"
+        />
+        <span className="s-text-xs s-text-muted-foreground">bottom-right</span>
+      </div>
+
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <DoubleIcon
+          mainIconProps={{
+            visual: ChatBubbleBottomCenterTextIcon,
+            size: "md",
+            className: "s-text-primary-500",
+          }}
+          secondaryIconProps={{
+            visual: CheckCircleIcon,
+            size: "xs",
+            className: "s-text-success-500",
+          }}
+          position="top-right"
+        />
+        <span className="s-text-xs s-text-muted-foreground">top-right</span>
+      </div>
+
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <DoubleIcon
+          mainIconProps={{
+            visual: ChatBubbleBottomCenterTextIcon,
+            size: "md",
+            className: "s-text-primary-500",
+          }}
+          secondaryIconProps={{
+            visual: CheckCircleIcon,
+            size: "xs",
+            className: "s-text-success-500",
+          }}
+          position="bottom-left"
+        />
+        <span className="s-text-xs s-text-muted-foreground">bottom-left</span>
+      </div>
+
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <DoubleIcon
+          mainIconProps={{
+            visual: ChatBubbleBottomCenterTextIcon,
+            size: "md",
+            className: "s-text-primary-500",
+          }}
+          secondaryIconProps={{
+            visual: CheckCircleIcon,
+            size: "xs",
+            className: "s-text-success-500",
+          }}
+          position="top-left"
+        />
+        <span className="s-text-xs s-text-muted-foreground">top-left</span>
+      </div>
+    </div>
+
+    <div className="s-flex s-items-center s-gap-16">
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <DoubleIcon
+          mainIconProps={{
+            visual: DocumentIcon,
+            size: "md",
+            className: "s-text-blue-500",
+          }}
+          secondaryIconProps={{
+            visual: PlusIcon,
+            size: "xs",
+            className: "s-text-highlight-500",
+          }}
+          position="bottom-right"
+        />
+      </div>
+
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <DoubleIcon
+          mainIconProps={{
+            visual: UserIcon,
+            size: "md",
+            className: "s-text-purple-500",
+          }}
+          secondaryIconProps={{
+            visual: StarIcon,
+            size: "xs",
+            className: "s-text-golden-500",
+          }}
+          position="top-right"
+        />
+      </div>
+
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <DoubleIcon
+          mainIconProps={{
+            visual: SlackLogo,
+            size: "md",
+            className: "s-text-green-500",
+          }}
+          secondaryIconProps={{
+            visual: FolderIcon,
+            size: "sm",
+            className: "s-text-red-500",
+          }}
+          position="bottom-right"
+        />
+      </div>
+
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <DoubleIcon
+          mainIconProps={{
+            visual: HeartIcon,
+            size: "md",
+            className: "s-text-red-500",
+          }}
+          secondaryIconProps={{
+            visual: SparklesIcon,
+            size: "xs",
+            className: "s-text-golden-500",
+          }}
+          position="top-left"
+        />
+      </div>
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Description

Introduces a new DoubleIcon component in Sparkle to display stacked icons with configurable positioning. This component enables visual combinations of two icons, with the secondary icon positioned relative to the main one (bottom-right, top-right, bottom-left, or top-left). The component has been integrated into the Dropdown component to improve icon display in menu items.

Low

## Risk

Low

## Deploy Plan

- Publish sparkle
- Update front