### PR TITLE
[JIT] Fix: don't silently ignore attachment not uploaded

### DIFF
--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -51,7 +51,9 @@ export async function generateSnippet(
     });
 
     if (schemaRes.isErr()) {
-      return new Err(new Error("Invalid CSV content"));
+      return new Err(
+        new Error(`Invalid CSV content: ${schemaRes.error.message}`)
+      );
     }
 
     let snippet = `${file.contentType} file with headers: ${schemaRes.value.schema.map((c) => c.name).join(",")}`;

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -148,19 +148,23 @@ async function handler(
             jitDataSource.value,
             { file }
           );
-          // For now, silently log the error
           if (rUpsert.isErr()) {
-            {
-              logger.warn({
-                fileModelId: file.id,
-                workspaceId: auth.workspace()?.sId,
-                contentType: file.contentType,
-                useCase: file.useCase,
-                useCaseMetadata: file.useCaseMetadata,
+            logger.error({
+              fileModelId: file.id,
+              workspaceId: auth.workspace()?.sId,
+              contentType: file.contentType,
+              useCase: file.useCase,
+              useCaseMetadata: file.useCaseMetadata,
+              message: "Failed to upsert the file.",
+              error: rUpsert.error,
+            });
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
                 message: "Failed to upsert the file.",
-                error: rUpsert.error,
-              });
-            }
+              },
+            });
           }
         }
       }

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -160,19 +160,23 @@ async function handler(
             { file }
           );
 
-          // For now, silently log the error
           if (rUpsert.isErr()) {
-            {
-              logger.warn({
-                fileModelId: file.id,
-                workspaceId: auth.workspace()?.sId,
-                contentType: file.contentType,
-                useCase: file.useCase,
-                useCaseMetadata: file.useCaseMetadata,
+            logger.error({
+              fileModelId: file.id,
+              workspaceId: auth.workspace()?.sId,
+              contentType: file.contentType,
+              useCase: file.useCase,
+              useCaseMetadata: file.useCaseMetadata,
+              message: "Failed to upsert the file.",
+              error: rUpsert.error,
+            });
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
                 message: "Failed to upsert the file.",
-                error: rUpsert.error,
-              });
-            }
+              },
+            });
           }
         }
       }


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/2524

Failures to process attachments were previoulsy just logged as warning, not acted upon.

This caused errors down the line as they were still present as content fragment but could not be acted upon (see issue).

This PR fixes by returning errors instead of silent warning logs.

**Additional note**

An underlying topic, discovered while fixing but not adressed by the PR, is that apparently snippet generation failure makes the whole upsertion fail, which may be an issue (although unsure about that). But snippet generation failures seem [rare AFAICT](https://app.datadoghq.eu/logs?query=%28%22Failed%20to%20upsert%20the%20file%22%29%20%22generate%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1742746677917&to_ts=1744042677917&live=true)

@Fraggle @spolu as the JIT guys, leaving you to decide if/when/how this second part is worth adressing.

Risks
---
standard. people should now see errors more directly (right at upsert time).

Deploy
---
front
