### PR TITLE
fix(conversations): Fix getting conversation to be purge

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -34,10 +34,6 @@ import type { ResourceFindOptions } from "./types";
 export type FetchConversationOptions = {
   includeDeleted?: boolean;
   includeTest?: boolean;
-  /**
-   * before updatedAt. Less Than
-   */
-  updatedBefore?: Date;
 };
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -190,6 +186,18 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     return mentions;
+  }
+
+  static async listAllBeforeDate(date: Date): Promise<ConversationResource[]> {
+    const conversations = await this.model.findAll({
+      where: {
+        updatedAt: {
+          [Op.lt]: date,
+        },
+      },
+    });
+
+    return conversations.map((c) => new this(this.model, c.get()));
   }
 
   static canAccessConversation(

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -62,9 +62,8 @@ export async function purgeConversationsBatchActivity({
 
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const conversations = await ConversationResource.listAll(auth, {
-      updatedBefore: cutoffDate,
-    });
+    const conversations =
+      await ConversationResource.listAllBeforeDate(cutoffDate);
 
     logger.info(
       {


### PR DESCRIPTION
## Description
- Fix getting conversation after a given cutoffdate

## Tests
Tested locally by setting the data retention days to 1 day, then creating 2 conversations, and manually updating one of them to 4 days in the past, then running (in front) `sh temporal/data_retention/admin/cli.sh` to trigger the `data-retention-workflow`. It would remove the conversation before the cutoff date and keep today's one.

## Risk
- Giving the wrong date would return more conversations to be deleted.

## Deploy Plan
Deploy front
