### PR TITLE
Optimize slow query on data source views (take 2)

### DIFF
--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -16,10 +16,13 @@ import { useEffect, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 
 import type { DatasetDataType } from "@app/lib/datasets";
-import { checkDatasetData, DATASET_DATA_TYPES } from "@app/lib/datasets";
-import { getDatasetTypes, getValueType } from "@app/lib/datasets";
-import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
-import { classNames } from "@app/lib/utils";
+import {
+  checkDatasetData,
+  DATASET_DATA_TYPES,
+  getDatasetTypes,
+  getValueType,
+} from "@app/lib/datasets";
+import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 import type {
   DatasetEntry,
   DatasetSchema,
@@ -578,7 +581,11 @@ export default function DatasetView({
                   Set the properties and types to ensure your dataset is valid
                   when you update it. The properties descriptions are used to
                   generate the inputs to your app when run from an Agent.
-                  <span className="text-warning-500 font-medium"> (JSON inputs are only supported when using Dust Apps through the API and not through agent actions)</span>
+                  <span className="font-medium text-warning-500">
+                    {" "}
+                    (JSON inputs are only supported when using Dust Apps through
+                    the API and not through agent actions)
+                  </span>
                 </p>
               ) : null}
             </div>

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -310,6 +310,19 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     });
   }
 
+  static async fetchAssistantDefaultSelectedByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    options?: FetchDataSourceOptions
+  ) {
+    return this.baseFetch(auth, options, {
+      where: {
+        id: ids,
+        assistantDefaultSelected: true,
+      },
+    });
+  }
+
   static async fetchByIds(
     auth: Authenticator,
     ids: string[],

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -304,11 +304,15 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     ids: ModelId[],
     options?: FetchDataSourceOptions
   ) {
+    const where: WhereOptions<DataSourceModel> = {
+      id: ids,
+    };
+    if (options?.assistantDefaultSelected) {
+      where["assistantDefaultSelected"] = options?.assistantDefaultSelected;
+    }
+
     return this.baseFetch(auth, options, {
-      where: {
-        id: ids,
-        assistantDefaultSelected: options?.assistantDefaultSelected,
-      },
+      where,
     });
   }
 

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -55,7 +55,6 @@ export type FetchDataSourceOptions = {
   limit?: number;
   order?: [string, "ASC" | "DESC"][];
   origin?: FetchDataSourceOrigin;
-  assistantDefaultSelected?: boolean;
 };
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -304,15 +304,10 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     ids: ModelId[],
     options?: FetchDataSourceOptions
   ) {
-    const where: WhereOptions<DataSourceModel> = {
-      id: ids,
-    };
-    if (options?.assistantDefaultSelected) {
-      where["assistantDefaultSelected"] = options?.assistantDefaultSelected;
-    }
-
     return this.baseFetch(auth, options, {
-      where,
+      where: {
+        id: ids,
+      },
     });
   }
 

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -55,6 +55,7 @@ export type FetchDataSourceOptions = {
   limit?: number;
   order?: [string, "ASC" | "DESC"][];
   origin?: FetchDataSourceOrigin;
+  assistantDefaultSelected?: boolean;
 };
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -306,19 +307,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     return this.baseFetch(auth, options, {
       where: {
         id: ids,
-      },
-    });
-  }
-
-  static async fetchAssistantDefaultSelectedByModelIds(
-    auth: Authenticator,
-    ids: ModelId[],
-    options?: FetchDataSourceOptions
-  ) {
-    return this.baseFetch(auth, options, {
-      where: {
-        id: ids,
-        assistantDefaultSelected: true,
+        assistantDefaultSelected: options?.assistantDefaultSelected,
       },
     });
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -234,11 +234,13 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       dataSourceViews.map((ds) => ds.dataSourceId)
     );
 
-    const includeEditedBy = fetchDataSourceViewOptions?.includeEditedBy;
     const dataSources = await DataSourceResource.fetchByModelIds(
       auth,
       dataSourceIds,
-      { includeEditedBy, assistantDefaultSelected }
+      {
+        includeEditedBy: fetchDataSourceViewOptions?.includeEditedBy,
+        assistantDefaultSelected,
+      }
     );
 
     for (const dsv of dataSourceViews) {
@@ -315,7 +317,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       return [];
     }
 
-    logger.info({ dataSourceViews }, "listAssistantDefaultSelected");
     return dataSourceViews.filter(
       (dsv) => dsv.dataSource.assistantDefaultSelected
     );

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -22,9 +22,8 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import type { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
@@ -300,22 +299,31 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
     const spaces = await SpaceResource.listForGroups(auth, [globalGroup.value]);
 
-    return this.baseFetch(auth, undefined, {
-      includes: [
-        {
-          model: DataSourceModel,
-          as: "dataSourceForView",
-          required: true,
-          where: {
-            assistantDefaultSelected: true,
-          },
-        },
-      ],
+    const dataSourceViews = await this.baseFetch(auth, undefined, {
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         vaultId: spaces.map((s) => s.id),
       },
     });
+
+    if (dataSourceViews.length === 0) {
+      return [];
+    }
+
+    const selectedDataSources =
+      await DataSourceResource.fetchAssistantDefaultSelectedByModelIds(
+        auth,
+        dataSourceViews.map((dsv) => dsv.dataSourceId)
+      );
+
+    const dataSourceMap = new Map(selectedDataSources.map((ds) => [ds.id, ds]));
+
+    return dataSourceViews
+      .filter((dsv) => dataSourceMap.has(dsv.dataSourceId))
+      .map((dsv) => {
+        dsv.ds = dataSourceMap.get(dsv.dataSourceId);
+        return dsv;
+      });
   }
 
   static async listForDataSourcesInSpace(
@@ -480,12 +488,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       {
         where: whereClause,
         order: [["updatedAt", "DESC"]],
-        includes: [
-          {
-            model: SpaceModel,
-            as: "space",
-          },
-        ],
       }
     );
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -318,7 +318,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     }
 
     return dataSourceViews.filter(
-      (dsv) => dsv.dataSource.assistantDefaultSelected
+      (dsv) => dsv.dataSource && dsv.dataSource.assistantDefaultSelected
     );
   }
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -22,7 +22,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import type { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -299,16 +299,22 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
     const spaces = await SpaceResource.listForGroups(auth, [globalGroup.value]);
 
-    const dataSourceViews = await this.baseFetch(auth, undefined, {
+    return this.baseFetch(auth, undefined, {
+      includes: [
+        {
+          model: DataSourceModel,
+          as: "dataSourceForView",
+          required: true,
+          where: {
+            assistantDefaultSelected: true,
+          },
+        },
+      ],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         vaultId: spaces.map((s) => s.id),
       },
     });
-
-    return dataSourceViews.filter(
-      (dsv) => dsv.dataSource.assistantDefaultSelected
-    );
   }
 
   static async listForDataSourcesInSpace(

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -301,7 +301,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
     const spaces = await SpaceResource.listForGroups(auth, [globalGroup.value]);
 
-    const dataSourceViews = await this.baseFetch(
+    return this.baseFetch(
       auth,
       undefined,
       {
@@ -311,14 +311,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         },
       },
       { assistantDefaultSelected: true }
-    );
-
-    if (dataSourceViews.length === 0) {
-      return [];
-    }
-
-    return dataSourceViews.filter(
-      (dsv) => dsv.dataSource && dsv.dataSource.assistantDefaultSelected
     );
   }
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -219,8 +219,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   private static async baseFetch(
     auth: Authenticator,
     fetchDataSourceViewOptions?: FetchDataSourceViewOptions,
-    options?: ResourceFindOptions<DataSourceViewModel>,
-    { assistantDefaultSelected }: { assistantDefaultSelected?: boolean } = {}
+    options?: ResourceFindOptions<DataSourceViewModel>
   ) {
     const { includeDeleted } = fetchDataSourceViewOptions ?? {};
 
@@ -239,7 +238,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       dataSourceIds,
       {
         includeEditedBy: fetchDataSourceViewOptions?.includeEditedBy,
-        assistantDefaultSelected,
       }
     );
 
@@ -301,16 +299,15 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
     const spaces = await SpaceResource.listForGroups(auth, [globalGroup.value]);
 
-    return this.baseFetch(
-      auth,
-      undefined,
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          vaultId: spaces.map((s) => s.id),
-        },
+    const dataSourceViews = await this.baseFetch(auth, undefined, {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        vaultId: spaces.map((s) => s.id),
       },
-      { assistantDefaultSelected: true }
+    });
+
+    return dataSourceViews.filter(
+      (dsv) => dsv.dataSource.assistantDefaultSelected
     );
   }
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -220,9 +220,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     auth: Authenticator,
     fetchDataSourceViewOptions?: FetchDataSourceViewOptions,
     options?: ResourceFindOptions<DataSourceViewModel>,
-    {
-      filterAssistantDefaultSelected = false,
-    }: { filterAssistantDefaultSelected?: boolean } = {}
+    { assistantDefaultSelected }: { assistantDefaultSelected?: boolean } = {}
   ) {
     const { includeDeleted } = fetchDataSourceViewOptions ?? {};
 
@@ -237,21 +235,11 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     );
 
     const includeEditedBy = fetchDataSourceViewOptions?.includeEditedBy;
-    let dataSources;
-    if (filterAssistantDefaultSelected) {
-      dataSources =
-        await DataSourceResource.fetchAssistantDefaultSelectedByModelIds(
-          auth,
-          dataSourceIds,
-          { includeEditedBy }
-        );
-    } else {
-      dataSources = await DataSourceResource.fetchByModelIds(
-        auth,
-        dataSourceIds,
-        { includeEditedBy }
-      );
-    }
+    const dataSources = await DataSourceResource.fetchByModelIds(
+      auth,
+      dataSourceIds,
+      { includeEditedBy, assistantDefaultSelected }
+    );
 
     for (const dsv of dataSourceViews) {
       dsv.ds = dataSources.find((ds) => ds.id === dsv.dataSourceId);
@@ -320,13 +308,14 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
           vaultId: spaces.map((s) => s.id),
         },
       },
-      { filterAssistantDefaultSelected: true }
+      { assistantDefaultSelected: true }
     );
 
     if (dataSourceViews.length === 0) {
       return [];
     }
 
+    logger.info({ dataSourceViews }, "listAssistantDefaultSelected");
     return dataSourceViews.filter(
       (dsv) => dsv.dataSource.assistantDefaultSelected
     );

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -82,7 +82,7 @@ export abstract class ResourceWithSpace<
     }
 
     const spaceIds = blobs.map((b) => b.vaultId);
-    const spaces = await SpaceResource.fetchByModelIds(auth, spaceIds, {
+    const spaces = await SpaceResource.fetchByModelIdsUnsafe(spaceIds, {
       includeDeleted,
     });
 

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -119,8 +119,8 @@ export abstract class ResourceWithSpace<
 
           return new this(this.model, b.get(), space, includedResults);
         })
-        // Filter out null entries (where space was not found) and resources that the user cannot fetch.
-        .filter((cls): cls is T => cls !== null && cls.canFetch(auth))
+        // Filter out resources that the user cannot fetch.
+        .filter((cls) => cls.canFetch(auth))
     );
   }
 

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -93,7 +93,7 @@ export abstract class ResourceWithSpace<
           // Skip entries where space is not found, which can happen when using the @help agent.
           // @help can use retrieval, which relies on a data source view that is on another workspace.
           if (!space) {
-            return null;
+            throw new Error("Unreachable: space not found.");
           }
 
           const includedResults = (includes || []).reduce<IncludeType>(

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -90,8 +90,10 @@ export abstract class ResourceWithSpace<
       blobs
         .map((b) => {
           const space = spaces.find((space) => space.id === b.vaultId);
+          // Skip entries where space is not found, which can happen when using the @help agent.
+          // @help can use retrieval, which relies on a data source view that is on another workspace.
           if (!space) {
-            throw new Error("Unreachable: space not found");
+            return null;
           }
 
           const includedResults = (includes || []).reduce<IncludeType>(
@@ -117,8 +119,8 @@ export abstract class ResourceWithSpace<
 
           return new this(this.model, b.get(), space, includedResults);
         })
-        // Filter out resources that the user cannot fetch.
-        .filter((cls) => cls.canFetch(auth))
+        // Filter out null entries (where space was not found) and resources that the user cannot fetch.
+        .filter((cls): cls is T => cls !== null && cls.canFetch(auth))
     );
   }
 

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -22,7 +22,6 @@ import type {
   ResourceFindOptions,
 } from "@app/lib/resources/types";
 import type { Result } from "@app/types";
-import logger from "@app/logger/logger";
 
 // Interface to enforce workspaceId and vaultId.
 interface ModelWithSpace extends ResourceWithId {
@@ -86,7 +85,6 @@ export abstract class ResourceWithSpace<
     const spaces = await SpaceResource.fetchByModelIds(auth, spaceIds, {
       includeDeleted,
     });
-    logger.info({ spaces }, "SPACES in baseFetchWithAuthorization");
 
     return (
       blobs

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -90,8 +90,6 @@ export abstract class ResourceWithSpace<
       blobs
         .map((b) => {
           const space = spaces.find((space) => space.id === b.vaultId);
-          // Skip entries where space is not found, which can happen when using the @help agent.
-          // @help can use retrieval, which relies on a data source view that is on another workspace.
           if (!space) {
             throw new Error("Unreachable: space not found.");
           }

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -22,6 +22,7 @@ import type {
   ResourceFindOptions,
 } from "@app/lib/resources/types";
 import type { Result } from "@app/types";
+import logger from "@app/logger/logger";
 
 // Interface to enforce workspaceId and vaultId.
 interface ModelWithSpace extends ResourceWithId {
@@ -82,7 +83,10 @@ export abstract class ResourceWithSpace<
     }
 
     const spaceIds = blobs.map((b) => b.vaultId);
-    const spaces = await SpaceResource.fetchByModelIds(auth, spaceIds);
+    const spaces = await SpaceResource.fetchByModelIds(auth, spaceIds, {
+      includeDeleted,
+    });
+    logger.info({ spaces }, "SPACES in baseFetchWithAuthorization");
 
     return (
       blobs

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -30,8 +30,7 @@ import type {
   SpaceKind,
   SpaceType,
 } from "@app/types";
-import { Err } from "@app/types";
-import { Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -324,6 +323,19 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
 
     return space;
+  }
+
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    { includeDeleted }: { includeDeleted?: boolean } = {}
+  ): Promise<SpaceResource[]> {
+    return (
+      this.baseFetch(auth, {
+        where: { id: ids },
+        includeDeleted,
+      }) ?? []
+    );
   }
 
   static async isNameAvailable(

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -325,16 +325,26 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return space;
   }
 
-  static async fetchByModelIds(
-    auth: Authenticator,
+  // Runs a findAll directly on the provided IDs, without any check on auth.
+  static async fetchByModelIdsUnsafe(
     ids: ModelId[],
     { includeDeleted }: { includeDeleted?: boolean } = {}
   ): Promise<SpaceResource[]> {
-    const spaces = await this.baseFetch(auth, {
-      where: { id: ids },
+    const includeClauses: Includeable[] = [
+      {
+        model: GroupResource.model,
+      },
+    ];
+
+    const spacesModels = await this.model.findAll({
+      where: {
+        id: ids,
+      },
+      include: includeClauses,
       includeDeleted,
     });
-    return spaces ?? [];
+
+    return spacesModels.map(this.fromModel);
   }
 
   static async isNameAvailable(

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -325,28 +325,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return space;
   }
 
-  // Runs a findAll directly on the provided IDs, without any check on auth.
-  static async fetchByModelIdsUnsafe(
-    ids: ModelId[],
-    { includeDeleted }: { includeDeleted?: boolean } = {}
-  ): Promise<SpaceResource[]> {
-    const includeClauses: Includeable[] = [
-      {
-        model: GroupResource.model,
-      },
-    ];
-
-    const spacesModels = await this.model.findAll({
-      where: {
-        id: ids,
-      },
-      include: includeClauses,
-      includeDeleted,
-    });
-
-    return spacesModels.map(this.fromModel);
-  }
-
   static async isNameAvailable(
     auth: Authenticator,
     name: string

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -330,12 +330,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     ids: ModelId[],
     { includeDeleted }: { includeDeleted?: boolean } = {}
   ): Promise<SpaceResource[]> {
-    return (
-      this.baseFetch(auth, {
-        where: { id: ids },
-        includeDeleted,
-      }) ?? []
-    );
+    const spaces = await this.baseFetch(auth, {
+      where: { id: ids },
+      includeDeleted,
+    });
+    return spaces ?? [];
   }
 
   static async isNameAvailable(


### PR DESCRIPTION
## Description

- Fixed version of https://github.com/dust-tt/dust/pull/11808.
- The original version caused crashes (resulting on an unending loading spinner) when rendering agent messages for conversations that involved the `@help` agent + retrieval. The retrieval document are indeed on a `dataSourceView` that is on another workspace (dust-apps) so the space cannot be fetched.

## Tests

- Tested on locally + on front-edge.

## Risk

- Quite high, lower than before.

## Deploy Plan

- Deploy front.