### PR TITLE
feat(mcp_server_view): Add EditedByUser to response

### DIFF
--- a/front/components/actions/mcp/ActionsList.tsx
+++ b/front/components/actions/mcp/ActionsList.tsx
@@ -26,8 +26,10 @@ import {
   DEFAULT_MCP_SERVER_ICON,
   MCP_SERVER_ICONS,
 } from "@app/lib/actions/mcp_icons";
-import type { MCPServerType } from "@app/lib/actions/mcp_metadata";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
+import type {
+  MCPServerType,
+  MCPServerViewType,
+} from "@app/lib/actions/mcp_metadata";
 import {
   useAvailableMCPServers,
   useCreateInternalMCPServer,

--- a/front/components/actions/mcp/MCPServerDetailsSharing.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsSharing.tsx
@@ -9,8 +9,10 @@ import {
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
 
-import type { MCPServerType } from "@app/lib/actions/mcp_metadata";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
+import type {
+  MCPServerType,
+  MCPServerViewType,
+} from "@app/lib/actions/mcp_metadata";
 import {
   useAddMCPServerToSpace,
   useRemoveMCPServerViewFromSpace,

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -87,8 +87,8 @@ import {
   isDefaultActionName,
 } from "@app/components/assistant_builder/types";
 import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   ModelConfigurationType,

--- a/front/components/assistant_builder/AssistantBuilderContext.tsx
+++ b/front/components/assistant_builder/AssistantBuilderContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
 import type { AppType, DataSourceViewType, SpaceType } from "@app/types";
 
 type AssistantBuilderContextType = {

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -29,7 +29,7 @@ import type {
 } from "@app/components/assistant_builder/types";
 import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
 import { serverRequiresInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type {
   DataSourceViewSelectionConfigurations,

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -15,10 +15,10 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
 import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceSectionGroupType } from "@app/lib/spaces";
 import {
   CATEGORY_DETAILS,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -21,10 +21,9 @@ import { RedisMCPTransport } from "@app/lib/api/actions/mcp_local";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import logger from "@app/logger/logger";
-import type { OAuthProvider, OAuthUseCase } from "@app/types";
+import type { EditedByUser, OAuthProvider, OAuthUseCase } from "@app/types";
 import { assertNever, getOAuthConnectionAccessToken } from "@app/types";
 
 export type MCPToolType = {
@@ -52,7 +51,16 @@ export type RemoteMCPServerType = MCPServerType & {
   lastSyncAt?: Date | null;
 };
 
-type MCPServerDefinitionType = Omit<
+export interface MCPServerViewType {
+  id: string;
+  createdAt: number;
+  updatedAt: number;
+  spaceId: string;
+  server: MCPServerType;
+  editedByUser: EditedByUser | null;
+}
+
+export type MCPServerDefinitionType = Omit<
   MCPServerType,
   "tools" | "id" | "isDefault"
 >;

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -2,8 +2,10 @@ import { useSendNotification } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import type { MCPServerType } from "@app/lib/actions/mcp_metadata";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
+import type {
+  MCPServerType,
+  MCPServerViewType,
+} from "@app/lib/actions/mcp_metadata";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { DeleteMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]";

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -71,13 +71,7 @@ async function handler(
             const server = r.toJSON();
             const views = (
               await MCPServerViewResource.listByMCPServer(auth, server.id)
-            ).map((v) => ({
-              id: v.sId,
-              createdAt: v.createdAt.getTime(),
-              updatedAt: v.updatedAt.getTime(),
-              spaceId: v.space.sId,
-              server,
-            }));
+            ).map((v) => v.toJSON());
             return { ...server, views };
           },
           {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -2,10 +2,10 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -11,11 +11,11 @@ import type {
   BuilderFlow,
 } from "@app/components/assistant_builder/types";
 import { BUILDER_FLOWS } from "@app/components/assistant_builder/types";
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
 import { throwIfInvalidAgentConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -12,12 +12,12 @@ import type {
   BuilderFlow,
 } from "@app/components/assistant_builder/types";
 import { BUILDER_FLOWS } from "@app/components/assistant_builder/types";
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
 import { throwIfInvalidAgentConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { generateMockAgentConfigurationFromTemplate } from "@app/lib/api/assistant/templates";
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import type { MCPServerViewType } from "@app/lib/resources/mcp_server_view_resource";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
 import type {
   AgentConfigurationType,

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -3,6 +3,7 @@ import type { DataSourceViewType } from "./data_source_view";
 import type { ModelId } from "./shared/model_id";
 import type { Result } from "./shared/result";
 import { Err, Ok } from "./shared/result";
+import type { EditedByUser } from "./user";
 
 export const CONNECTOR_PROVIDERS = [
   "bigquery",
@@ -25,14 +26,6 @@ export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
 export function isConnectorProvider(val: string): val is ConnectorProvider {
   return (CONNECTOR_PROVIDERS as unknown as string[]).includes(val);
 }
-
-export type EditedByUser = {
-  editedAt: number | null;
-  fullName: string | null;
-  imageUrl: string | null;
-  email: string | null;
-  userId: string | null;
-};
 
 export type DataSourceType = {
   id: ModelId;

--- a/front/types/data_source_view.ts
+++ b/front/types/data_source_view.ts
@@ -4,9 +4,9 @@ import type {
   ConnectorStatusDetails,
   DataSourceType,
   DataSourceWithAgentsUsageType,
-  EditedByUser,
 } from "./data_source";
 import type { ModelId } from "./shared/model_id";
+import type { EditedByUser } from "./user";
 
 export interface DataSourceViewType {
   category: DataSourceViewCategory;

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -86,6 +86,14 @@ export type UserMetadataType = {
   value: string;
 };
 
+export type EditedByUser = {
+  editedAt: number | null;
+  fullName: string | null;
+  imageUrl: string | null;
+  email: string | null;
+  userId: string | null;
+};
+
 export function formatUserFullName(user?: {
   firstName?: string;
   lastName?: string | null;


### PR DESCRIPTION
## Description
In preparing task https://github.com/dust-tt/tasks/issues/2564 , adding a nullable `editedByUser` attributes to `MCPServerViewType`.
- Share EditedByUser of DataSource to MCPServerViewResource. Difference is for `MCPServerViewType` we're avoiding the undefined, null or a value.
- Move type `MCPServerViewType` to `mcp_metadata` to keep types related in
one place (avoid a solo type in the resource)

## Tests
- Locally fetching `GET /api/w/[wId]/mcp` and having `editedByUser` filled.

## Risk
- small, only adding new data to be fetched, and that feature is behind a feature flag.

## Deploy Plan
deploy front
