### PR TITLE
[sparkle] - fix(ScrollableDataTable): row selection

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.458",
+  "version": "0.2.459",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.458",
+      "version": "0.2.459",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.458",
+  "version": "0.2.459",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -361,10 +361,13 @@ export function ScrollableDataTable<TData extends TBaseData>({
     getCoreRowModel: getCoreRowModel(),
     enableColumnResizing: true,
     onRowSelectionChange,
-    enableRowSelection,
+    ...(enableRowSelection && {
+      onRowSelectionChange,
+    }),
     state: {
-      rowSelection,
+      ...(enableRowSelection && { rowSelection }),
     },
+    enableRowSelection,
   });
 
   useEffect(() => {
@@ -509,7 +512,9 @@ export function ScrollableDataTable<TData extends TBaseData>({
                     widthClassName={widthClassName}
                     onClick={row.original.onClick}
                     className="s-absolute s-w-full"
-                    data-selected={row.getIsSelected()}
+                    {...(enableRowSelection && {
+                      "data-selected": row.getIsSelected(),
+                    })}
                     style={{
                       transform: `translateY(${virtualRow.start}px)`,
                     }}


### PR DESCRIPTION
## Description

This PR aims at fixing a bug when the row selection was not enabled for a ScrollableDataTable, following up this PR https://github.com/dust-tt/dust/pull/11803

Trace: 
```
index.mjs:2162 Uncaught TypeError: Cannot read properties of undefined (reading '0')
    at isRowSelected (index.mjs:2162:40)
    at row.getIsSelected (index.mjs:2058:14)
    at eval (DataTable.js:92:321)
    at Array.map (<anonymous>)
    at DataTable (DataTable.js:92:119)
    at renderWithHooks (react-dom.development.js:15486:18)
    at mountIndeterminateComponent (react-dom.development.js:20098:13)
    at beginWork (react-dom.development.js:21621:16)
    at HTMLUnknownElement.callCallback (react-dom.development.js:4164:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:16)
    at invokeGuardedCallback (react-dom.development.js:4277:31)
    at beginWork$1 (react-dom.development.js:27485:7)
    at performUnitOfWork (react-dom.development.js:26591:12)
    at workLoopSync (react-dom.development.js:26500:5)
    at renderRootSync (react-dom.development.js:26468:7)
    at recoverFromConcurrentError (react-dom.development.js:25884:20)
    at performSyncWorkOnRoot (react-dom.development.js:26130:20)
    at flushSyncCallbacks (react-dom.development.js:12042:22)
    at eval (react-dom.development.js:25685:13)
```

## Risk

Low

## Deploy Plan

Publish sparkle