### PR TITLE
Fix 500 errors when uploading images in conversations

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -1032,10 +1032,6 @@ async function getOrCreateConversationDataSource(
 function validateFileMetadataForConversation(
   file: FileResource
 ): Result<string, Error> {
-  if (!file.useCaseMetadata) {
-    return new Err(new Error("Field useCaseMetadata is missing from metadata"));
-  }
-
   const conversationId = file.useCaseMetadata?.conversationId;
   if (!conversationId) {
     return new Err(new Error("Field conversationId is missing from metadata"));

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -406,12 +406,13 @@ const getProcessingFunction = ({
   assertNever(contentType);
 };
 
-export const isUpsertSupported = (arg: {
+export const isFileTypeUpsertableForUseCase = (arg: {
   contentType: SupportedFileContentType;
   useCase: FileUseCase;
 }): boolean => {
-  const processing = getProcessingFunction(arg);
-  return !!processing;
+  const processingFunction = getProcessingFunction(arg);
+
+  return processingFunction !== undefined;
 };
 
 const maybeApplyProcessing: ProcessingFunction = async (
@@ -474,7 +475,7 @@ export async function processAndUpsertToDataSource(
     });
   }
 
-  if (!isUpsertSupported(file)) {
+  if (!isFileTypeUpsertableForUseCase(file)) {
     return new Err({
       name: "dust_error",
       code: "invalid_request_error",

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -4,7 +4,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/upload";
-import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
+import {
+  isFileTypeUpsertableForUseCase,
+  processAndUpsertToDataSource,
+} from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
@@ -132,8 +135,11 @@ async function handler(
         });
       }
 
-      // Only upsert immediately in case of conversation
-      if (file.useCase === "conversation") {
+      // For files with useCase "conversation" that support upsert, directly add them to the data source.
+      if (
+        file.useCase === "conversation" &&
+        isFileTypeUpsertableForUseCase(file)
+      ) {
         const jitDataSource = await getOrCreateConversationDataSourceFromFile(
           auth,
           file

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -4,7 +4,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/upload";
-import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
+import {
+  isFileTypeUpsertableForUseCase,
+  processAndUpsertToDataSource,
+} from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileVersion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -140,8 +143,11 @@ async function handler(
         });
       }
 
-      // Only upsert immediately in case of conversation
-      if (file.useCase === "conversation") {
+      // For files with useCase "conversation" that support upsert, directly add them to the data source.
+      if (
+        file.useCase === "conversation" &&
+        isFileTypeUpsertableForUseCase(file)
+      ) {
         const jitDataSource = await getOrCreateConversationDataSourceFromFile(
           auth,
           file


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See this error: [logs](https://app.datadoghq.eu/logs?query=%22Failed%20to%20upsert%20the%20file%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1744017771451&to_ts=1744104171451&live=true).

When users upload images in a conversation, while the upload itself succeeds, the API call returns a 500 error with the message "Failed to upsert the file". This happens because we incorrectly assumed all files could be upserted to the conversation data source.

This PR changes the behavior to only attempt data source creation and upsert for file types that actually support it. Images and other non-upsertable files are now gracefully handled without triggering errors.

Changes:
- Added explicit file type + use case validation via `isFileTypeUpsertableForUseCase`
- Skip data source operations for unsupported files instead of failing
- Improved code clarity around file type handling logic

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
I could reproduce locally, by attempting to upload an image on an existing conversation with some existing attachments.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
