### PR TITLE
[front] mcp(remote): better defaults & implementation

### DIFF
--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -18,6 +18,7 @@ import { useCallback, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import { ALLOWED_ICONS, MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
 import type { RemoteMCPServerType } from "@app/lib/actions/mcp_metadata";
 import {
@@ -26,7 +27,6 @@ import {
   useUpdateRemoteMCPServer,
 } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types";
-import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 
 interface RemoteMCPFormProps {
   owner: LightWorkspaceType;
@@ -73,34 +73,37 @@ export function RemoteMCPForm({
   const { updateServer } = useUpdateRemoteMCPServer(owner, mcpServer.id);
   const { syncServer } = useSyncRemoteMCPServer(owner, mcpServer.id);
 
-  const onSubmit = useCallback(async (values: MCPFormType) => {
-    try {
-      const result = await updateServer({
-        name: values.name,
-        description: values.description,
-        icon: values.icon,
-      });
-      if (result.success) {
-        void mutateMCPServers();
-
-        sendNotification({
-          title: "MCP server updated",
-          type: "success",
-          description: "The MCP server has been successfully updated.",
+  const onSubmit = useCallback(
+    async (values: MCPFormType) => {
+      try {
+        const result = await updateServer({
+          name: values.name,
+          description: values.description,
+          icon: values.icon,
         });
+        if (result.success) {
+          void mutateMCPServers();
 
-        form.reset(values);
-      } else {
-        throw new Error("Failed to update MCP server");
+          sendNotification({
+            title: "MCP server updated",
+            type: "success",
+            description: "The MCP server has been successfully updated.",
+          });
+
+          form.reset(values);
+        } else {
+          throw new Error("Failed to update MCP server");
+        }
+      } catch (err) {
+        sendNotification({
+          title: "Error updating MCP server",
+          type: "error",
+          description: err instanceof Error ? err.message : "An error occurred",
+        });
       }
-    } catch (err) {
-      sendNotification({
-        title: "Error updating MCP server",
-        type: "error",
-        description: err instanceof Error ? err.message : "An error occurred",
-      });
-    }
-  }, [updateServer, mutateMCPServers, sendNotification, form]);
+    },
+    [updateServer, mutateMCPServers, sendNotification, form]
+  );
 
   const handleSynchronize = useCallback(async () => {
     if (!url) {
@@ -255,7 +258,9 @@ export function RemoteMCPForm({
                 {...field}
                 isError={!!form.formState.errors.description?.message}
                 message={form.formState.errors.description?.message}
-                placeholder={mcpServer.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION}
+                placeholder={
+                  mcpServer.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION
+                }
               />
               <p className="text-xs text-gray-500">
                 This is only for internal reference and is not shown to the
@@ -273,7 +278,9 @@ export function RemoteMCPForm({
           onClick={async (event: Event) => {
             event.preventDefault();
             void form.handleSubmit(onSubmit)();
-            onSave();
+            if (form.formState.isValid) {
+              onSave();
+            }
           }}
         />
       </div>

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -14,7 +14,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -26,6 +26,7 @@ import {
   useUpdateRemoteMCPServer,
 } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types";
+import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 
 interface RemoteMCPFormProps {
   owner: LightWorkspaceType;
@@ -72,7 +73,7 @@ export function RemoteMCPForm({
   const { updateServer } = useUpdateRemoteMCPServer(owner, mcpServer.id);
   const { syncServer } = useSyncRemoteMCPServer(owner, mcpServer.id);
 
-  const onSubmit = async (values: MCPFormType) => {
+  const onSubmit = useCallback(async (values: MCPFormType) => {
     try {
       const result = await updateServer({
         name: values.name,
@@ -99,9 +100,9 @@ export function RemoteMCPForm({
         description: err instanceof Error ? err.message : "An error occurred",
       });
     }
-  };
+  }, [updateServer, mutateMCPServers, sendNotification, form]);
 
-  const handleSynchronize = async () => {
+  const handleSynchronize = useCallback(async () => {
     if (!url) {
       setSyncError("Please enter a valid URL before synchronizing.");
       return;
@@ -140,7 +141,7 @@ export function RemoteMCPForm({
     } finally {
       setIsSynchronizing(false);
     }
-  };
+  }, [url, syncServer, mutateMCPServers, sendNotification]);
 
   const toggleSecretVisibility = () => {
     setIsSecretVisible(!isSecretVisible);
@@ -254,7 +255,7 @@ export function RemoteMCPForm({
                 {...field}
                 isError={!!form.formState.errors.description?.message}
                 message={form.formState.errors.description?.message}
-                placeholder={mcpServer.cachedDescription}
+                placeholder={mcpServer.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION}
               />
               <p className="text-xs text-gray-500">
                 This is only for internal reference and is not shown to the

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -47,7 +47,7 @@ export type MCPServerType = {
 export type RemoteMCPServerType = MCPServerType & {
   url?: string;
   cachedName?: string;
-  cachedDescription?: string;
+  cachedDescription?: string | null;
   sharedSecret?: string;
   lastSyncAt?: Date | null;
 };

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -29,7 +29,7 @@ export class RemoteMCPServer extends WorkspaceAwareModel<RemoteMCPServer> {
   declare version: string;
 
   declare cachedName: string;
-  declare cachedDescription: string;
+  declare cachedDescription: string | null;
   declare cachedTools: MCPToolType[];
 
   declare lastSyncAt: Date | null;
@@ -52,7 +52,6 @@ RemoteMCPServer.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: DEFAULT_MCP_ACTION_NAME,
     },
     url: {
       type: DataTypes.STRING,
@@ -61,12 +60,10 @@ RemoteMCPServer.init(
     description: {
       type: DataTypes.TEXT,
       allowNull: false,
-      defaultValue: DEFAULT_MCP_ACTION_DESCRIPTION,
     },
     icon: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: DEFAULT_MCP_SERVER_ICON,
     },
     version: {
       type: DataTypes.STRING,
@@ -76,12 +73,10 @@ RemoteMCPServer.init(
     cachedName: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: DEFAULT_MCP_ACTION_NAME,
     },
     cachedDescription: {
       type: DataTypes.TEXT,
-      allowNull: false,
-      defaultValue: DEFAULT_MCP_ACTION_DESCRIPTION,
+      allowNull: true,
     },
     cachedTools: {
       type: DataTypes.JSONB,

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -1,16 +1,9 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import {
-  DEFAULT_MCP_ACTION_DESCRIPTION,
-  DEFAULT_MCP_ACTION_NAME,
-  DEFAULT_MCP_ACTION_VERSION,
-} from "@app/lib/actions/constants";
+import { DEFAULT_MCP_ACTION_VERSION } from "@app/lib/actions/constants";
 import type { AllowedIconType } from "@app/lib/actions/mcp_icons";
-import {
-  DEFAULT_MCP_SERVER_ICON,
-  isAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
+import { isAllowedIconType } from "@app/lib/actions/mcp_icons";
 import type {
   AuthorizationInfo,
   MCPToolType,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -269,7 +269,8 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServer> {
       tools: this.cachedTools,
 
       cachedName: this.cachedName,
-      cachedDescription: this.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION,
+      cachedDescription:
+        this.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION,
       authorization: this.authorization,
       isDefault: false, // So far we don't have defaults remote MCP servers.
 

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -254,7 +254,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServer> {
   toJSON(): MCPServerType & {
     // Remote MCP Server specifics
     cachedName: string;
-    cachedDescription: string;
+    cachedDescription: string | null;
     url: string;
     lastSyncAt: number | null;
     sharedSecret: string;
@@ -269,7 +269,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServer> {
       tools: this.cachedTools,
 
       cachedName: this.cachedName,
-      cachedDescription: this.cachedDescription,
+      cachedDescription: this.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION,
       authorization: this.authorization,
       isDefault: false, // So far we don't have defaults remote MCP servers.
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -10,7 +10,6 @@ import type {
 import type {
   DeleteMCPServerResponseBody,
   GetMCPServerResponseBody,
-  GetRemoteMCPServerResponseBody,
   PatchMCPServerResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/[serverId]";
 import type { SyncMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/sync";
@@ -49,10 +48,8 @@ export function useMCPServer({
     };
   }
 
-  const server = useMemo(() => (data ? data.server : null), [data]);
-
   return {
-    server,
+    server: data?.server || null,
     isMCPServerLoading: !error && !data && !disabled,
     isMCPServerError: !!error,
     mutateMCPServer: mutate,
@@ -76,40 +73,6 @@ export function useAvailableMCPServers({
     availableMCPServers,
     isAvailableMCPServersLoading: !error && !data,
     isAvailableMCPServersError: error,
-  };
-}
-
-export function useRemoteMCPServer({
-  disabled,
-  owner,
-  serverId,
-}: {
-  disabled?: boolean;
-  owner: LightWorkspaceType;
-  serverId: string;
-}) {
-  const serverFetcher: Fetcher<GetRemoteMCPServerResponseBody> = fetcher;
-
-  const url = serverId ? `/api/w/${owner.sId}/mcp/${serverId}` : null;
-
-  const { data, error, mutate } = useSWRWithDefaults(url, serverFetcher, {
-    disabled,
-  });
-
-  if (!serverId) {
-    return {
-      server: null,
-      isServerLoading: false,
-      isServerError: true,
-      mutateMCPServer: () => {},
-    };
-  }
-
-  return {
-    server: data?.server || null,
-    isServerLoading: !error && !data,
-    isServerError: !!error,
-    mutateMCPServer: mutate,
   };
 }
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -49,8 +49,10 @@ export function useMCPServer({
     };
   }
 
+  const server = useMemo(() => (data ? data.server : null), [data]);
+
   return {
-    server: data?.server || null,
+    server,
     isMCPServerLoading: !error && !data && !disabled,
     isMCPServerError: !!error,
     mutateMCPServer: mutate,

--- a/front/migrations/db/migration_204.sql
+++ b/front/migrations/db/migration_204.sql
@@ -1,0 +1,8 @@
+-- Migration created on Apr 08, 2025
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedDescription" DROP NOT NULL;
+
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "name" DROP DEFAULT;
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "description" DROP DEFAULT;
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "icon" DROP DEFAULT;
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedName" DROP DEFAULT;
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "cachedDescription" DROP DEFAULT;

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -14,14 +14,6 @@ export type GetMCPServerResponseBody = {
   server: MCPServerType;
 };
 
-export type GetRemoteMCPServerResponseBody = {
-  server: MCPServerType & {
-    url: string;
-    lastSyncAt: Date | null;
-    sharedSecret: string;
-  };
-};
-
 export type PatchMCPServerResponseBody = {
   success: boolean;
   server: MCPServerType;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR cleans the remote mcp server code, and fixes some of the still valid feedbacks from https://github.com/dust-tt/dust/pull/11721
Also removing the magic default strings for the remote_mcp_servers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Behind ff, safe to rollback

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front,
Migrate 204.