### PR TITLE
Flav/fix more file upsert errors

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1606,10 +1606,14 @@ export async function postNewContentFragment(
     return new Err(new ConversationError("conversation_access_restricted"));
   }
 
-  await maybeUpsertFileAttachment(auth, {
+  const upsertAttachmentRes = await maybeUpsertFileAttachment(auth, {
     contentFragments: [cf],
     conversation,
   });
+
+  if (upsertAttachmentRes.isErr()) {
+    return upsertAttachmentRes;
+  }
 
   const messageId = generateRandomModelSId();
 

--- a/front/lib/api/files/attachments.ts
+++ b/front/lib/api/files/attachments.ts
@@ -7,7 +7,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType, Result } from "@app/types";
-import { Err, Ok, removeNulls } from "@app/types";
+import { Ok, removeNulls } from "@app/types";
 
 // When we send the attachments at the conversation creation, we are missing the useCaseMetadata
 // Therefore, we couldn't upsert them to the conversation datasource.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/11829.

It fixes file upsert issue when a conversation is created with both upsertable/not upsertable files. It was not crashing since the return type of the function is ignored. Improve error hygiene, for some unknown reasons we proxy errors and end up loosing the appropriate stack trace, logging errors as object over proper Error.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
