### PR TITLE
Add image generation tool.

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -91,7 +91,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.32",
+      "version": "1.0.37",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/front/components/actions/mcp/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/MCPActionDetails.tsx
@@ -1,11 +1,13 @@
-import { ServerIcon } from "@dust-tt/sparkle";
-import { Markdown } from "@dust-tt/sparkle";
+import { cn, CodeBlock, CollapsibleComponent } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
 import type { MCPActionType } from "@app/lib/actions/mcp";
+import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
+import { isSupportedImageContentType } from "@app/types";
 
 export function MCPActionDetails({
+  owner,
   action,
   defaultOpen,
 }: ActionDetailsComponentBaseProps<MCPActionType>) {
@@ -14,34 +16,84 @@ export function MCPActionDetails({
     <ActionDetailsWrapper
       actionName={action.functionCallName ?? "Calling MCP Server"}
       defaultOpen={defaultOpen}
-      visual={ServerIcon}
+      visual={ACTION_SPECIFICATIONS["MCP"].cardIcon}
     >
       <div className="flex flex-col gap-1 gap-4 py-4 pl-6">
-        <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-          <Markdown
-            content={`\`\`\`json\n${JSON.stringify(action.params).replace("\n", "aa") ?? ""}`}
-            textColor="text-muted-foreground"
-            isStreaming={false}
-            forcedTextSize="md"
-            isLastMessage={false}
-          />
-        </div>
+        <CollapsibleComponent
+          rootProps={{ defaultOpen: !action.generatedFiles.length }}
+          triggerChildren={
+            <div
+              className={cn(
+                "text-foreground dark:text-foreground-night",
+                "flex flex-row items-center gap-x-2"
+              )}
+            >
+              <span className="heading-base">Inputs</span>
+            </div>
+          }
+          contentChildren={
+            <CodeBlock wrapLongLines className="language-json">
+              {JSON.stringify(action.params, undefined, 2) ?? ""}
+            </CodeBlock>
+          }
+        />
 
         {action.output && (
-          <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-            <Markdown
-              content={`\`\`\`json\n${action.output
-                // @ts-expect-error TODO(mcp): fixing typing resulting to unknown type
-                .filter((o) => o.text || o.resource.text)
-                // @ts-expect-error TODO(mcp): fixing typing resulting to unknown type
-                .map((o) => o.text || o.resource.text)
-                .join("\n")}`}
-              textColor="text-muted-foreground"
-              isStreaming={false}
-              forcedTextSize="md"
-              isLastMessage={false}
-            />
-          </div>
+          <CollapsibleComponent
+            rootProps={{ defaultOpen: !action.generatedFiles.length }}
+            triggerChildren={
+              <div
+                className={cn(
+                  "text-foreground dark:text-foreground-night",
+                  "flex flex-row items-center gap-x-2"
+                )}
+              >
+                <span className="heading-base">Output</span>
+              </div>
+            }
+            contentChildren={
+              <CodeBlock wrapLongLines>
+                {action.output
+                  // @ts-expect-error TODO(mcp): fixing typing resulting to unknown type
+                  .filter((o) => o.text || o.resource.text)
+                  // @ts-expect-error TODO(mcp): fixing typing resulting to unknown type
+                  .map((o) => o.text || o.resource.text)
+                  .join("\n")}
+              </CodeBlock>
+            }
+          />
+        )}
+
+        {action.generatedFiles.length > 0 && (
+          <>
+            <span className="heading-base">Generated Files</span>
+            <div className="flex flex-col gap-1">
+              {action.generatedFiles.map((file) => {
+                if (isSupportedImageContentType(file.contentType)) {
+                  return (
+                    <div key={file.fileId} className="mr-5">
+                      <img
+                        className="rounded-xl"
+                        src={`/api/w/${owner.sId}/files/${file.fileId}`}
+                        alt={`${file.title}`}
+                      />
+                    </div>
+                  );
+                }
+                return (
+                  <div key={file.fileId}>
+                    <a
+                      href={file.fileId}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {file.title}
+                    </a>
+                  </div>
+                );
+              })}
+            </div>
+          </>
         )}
       </div>
     </ActionDetailsWrapper>

--- a/front/components/assistant/conversation/ConversationsNavigationProvider.tsx
+++ b/front/components/assistant/conversation/ConversationsNavigationProvider.tsx
@@ -1,11 +1,20 @@
+import { Dialog, DialogContainer, DialogContent } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { RefObject } from "react";
-import { createContext, useCallback, useContext, useMemo, useRef } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 interface ConversationsNavigationContextType {
   conversationsNavigationRef: RefObject<HTMLDivElement>;
   scrollConversationsToTop: () => void;
   activeConversationId: string | null;
+  setIsImageUrl: (imageUrl: string | null) => void;
 }
 
 const ConversationsNavigationContext =
@@ -20,6 +29,7 @@ export function ConversationsNavigationProvider({
 }) {
   const router = useRouter();
   const conversationsNavigationRef = useRef<HTMLDivElement>(null);
+  const [isImageUrl, setIsImageUrl] = useState<string | null>(null);
 
   const scrollConversationsToTop = useCallback(() => {
     if (conversationsNavigationRef.current) {
@@ -52,10 +62,44 @@ export function ConversationsNavigationProvider({
         conversationsNavigationRef,
         scrollConversationsToTop,
         activeConversationId,
+        setIsImageUrl,
       }}
     >
+      <ImageModal imageUrl={isImageUrl} onClose={() => setIsImageUrl(null)} />
       {children}
     </ConversationsNavigationContext.Provider>
+  );
+}
+
+interface ImageModalProps {
+  imageUrl: string | null;
+  onClose: () => void;
+}
+
+export function ImageModal({ imageUrl, onClose }: ImageModalProps) {
+  return (
+    <Dialog
+      open={!!imageUrl}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="xl">
+        <DialogContainer>
+          <div className="flex items-center justify-center">
+            {imageUrl && (
+              <img
+                src={imageUrl}
+                alt="Full size view"
+                className="max-h-[80vh] w-auto object-contain"
+              />
+            )}
+          </div>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -3,10 +3,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { MCPToolResultContent } from "@app/lib/actions/mcp_actions";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
 import {
-  isDefaultInternalMCPServer,
-  isInternalMCPServerName,
-} from "@app/lib/actions/mcp_internal_actions/constants";
-import {
   augmentInputsWithConfiguration,
   hideInternalConfiguration,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
@@ -14,6 +10,7 @@ import { getMCPEvents } from "@app/lib/actions/pubsub";
 import type { DataSourceConfiguration } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
 import type {
+  ActionGeneratedFileType,
   BaseActionRunParams,
   ExtractActionBlob,
 } from "@app/lib/actions/types";
@@ -22,11 +19,15 @@ import {
   BaseActionConfigurationServerRunner,
 } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { isPlatformMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPAction,
   AgentMCPActionOutputItem,
 } from "@app/lib/models/assistant/actions/mcp";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import logger from "@app/logger/logger";
 import type {
   FunctionCallType,
@@ -34,7 +35,7 @@ import type {
   ModelId,
   Result,
 } from "@app/types";
-import { Ok } from "@app/types";
+import { isSupportedFileContentType, Ok, removeNulls } from "@app/types";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;
@@ -69,6 +70,7 @@ export type PlatformMCPToolConfigurationType = Omit<
 > & {
   type: "mcp_configuration";
   inputSchema: JSONSchema;
+  isDefault: boolean;
 };
 
 export type LocalMCPToolConfigurationType = Omit<
@@ -142,7 +144,7 @@ export class MCPActionType extends BaseAction {
   readonly type = "tool_action" as const;
 
   constructor(blob: MCPActionBlob) {
-    super(blob.id, blob.type);
+    super(blob.id, blob.type, blob.generatedFiles);
 
     this.agentMessageId = blob.agentMessageId;
     this.mcpServerConfigurationId = blob.mcpServerConfigurationId;
@@ -285,8 +287,8 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       | "pending"
       | "denied" = "pending";
     if (
-      isInternalMCPServerName(actionConfiguration.name) &&
-      isDefaultInternalMCPServer(actionConfiguration.name)
+      isPlatformMCPToolConfiguration(actionConfiguration) &&
+      actionConfiguration.isDefault
     ) {
       status = "allowed_implicitly";
     } else {
@@ -304,7 +306,12 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
           actionId: mcpAction.id,
         });
 
-        localLogger.info("Waiting for action validation");
+        localLogger.info(
+          {
+            actionName: actionConfiguration.name,
+          },
+          "Waiting for action validation"
+        );
 
         // Start listening for action events
         for await (const event of actionEventGenerator) {
@@ -439,14 +446,40 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
     }
 
     const content = r.value;
+    const generatedFiles: ActionGeneratedFileType[] = [];
+    for (const c of content) {
+      let file: FileResource | null = null;
+      if (
+        c.type === "resource" &&
+        c.resource.mimeType &&
+        isSupportedFileContentType(c.resource.mimeType)
+      ) {
+        const r = await processAndStoreFromUrl(auth, {
+          url: c.resource.uri,
+          useCase: "conversation",
+          fileName: "generated-image.png",
+          contentType: c.resource.mimeType,
+        });
+        if (r.isErr()) {
+          localLogger.error({ error: r.error }, "Error upserting file");
+          continue;
+        }
+        file = r.value;
+        generatedFiles.push({
+          fileId: file.sId,
+          contentType: c.resource.mimeType,
+          title: file.fileName,
+          snippet: null,
+        });
+      }
 
-    await AgentMCPActionOutputItem.bulkCreate(
-      content.map((c) => ({
+      await AgentMCPActionOutputItem.create({
         workspaceId: owner.id,
         agentMCPActionId: action.id,
         content: c,
-      }))
-    );
+        fileId: file?.id,
+      });
+    }
 
     yield {
       type: "tool_success",
@@ -455,6 +488,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       messageId: agentMessage.sId,
       action: new MCPActionType({
         ...actionBaseParams,
+        generatedFiles,
         executionState: status,
         id: action.id,
         isError: false,
@@ -485,6 +519,13 @@ export async function mcpActionTypesFromAgentMessageIds(
         model: AgentMCPActionOutputItem,
         as: "outputItems",
         required: false,
+        include: [
+          {
+            model: FileModel,
+            as: "file",
+            required: false,
+          },
+        ],
       },
     ],
   });
@@ -493,7 +534,7 @@ export async function mcpActionTypesFromAgentMessageIds(
     return new MCPActionType({
       id: action.id,
       params: action.params,
-      output: action.outputItems.map((i) => i.content),
+      output: action.outputItems.map((o) => o.content),
       functionCallId: action.functionCallId,
       functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,
@@ -502,7 +543,26 @@ export async function mcpActionTypesFromAgentMessageIds(
       executionState: action.executionState,
       isError: action.isError,
       type: "tool_action",
-      generatedFiles: [],
+      generatedFiles: removeNulls(
+        action.outputItems.map((o) => {
+          if (!o.file) {
+            return null;
+          }
+
+          const file = o.file;
+          const fileSid = FileResource.modelIdToSId({
+            id: file.id,
+            workspaceId: action.workspaceId,
+          });
+
+          return {
+            fileId: fileSid,
+            contentType: file.contentType,
+            title: file.fileName,
+            snippet: file.snippet,
+          };
+        })
+      ),
     });
   });
 }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -9,9 +9,11 @@ import type {
   PlatformMCPServerConfigurationType,
   PlatformMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
+import { isDefaultInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   MCPConnectionParams,
   MCPToolType,
+  MCPToolWithIsDefaultType,
 } from "@app/lib/actions/mcp_metadata";
 import {
   connectToMCPServer,
@@ -74,10 +76,10 @@ const Schema = z.union([
 
 export type MCPToolResultContent = z.infer<typeof Schema>;
 
-function makePlatformMCPConfigurations(
+function makePlatformMCPToolConfigurations(
   config: PlatformMCPServerConfigurationType,
-  tools: MCPToolType[]
-) {
+  tools: (MCPToolType & { isDefault: boolean })[]
+): PlatformMCPToolConfigurationType[] {
   return tools.map((tool) => ({
     sId: generateRandomModelSId(),
     type: "mcp_configuration",
@@ -88,10 +90,11 @@ function makePlatformMCPConfigurations(
     mcpServerViewId: config.mcpServerViewId,
     dataSources: config.dataSources || [], // Ensure dataSources is always an array
     tables: config.tables,
+    isDefault: tool.isDefault,
   }));
 }
 
-function makeLocalMCPConfigurations(
+function makeLocalMCPToolConfigurations(
   config: LocalMCPServerConfigurationType,
   tools: MCPToolType[]
 ): LocalMCPToolConfigurationType[] {
@@ -103,28 +106,33 @@ function makeLocalMCPConfigurations(
     inputSchema: tool.inputSchema || EMPTY_INPUT_SCHEMA,
     id: config.id,
     localMcpServerId: config.localMcpServerId,
+    isDefault: false, // can't be default for local MCP servers.
   }));
 }
 
-type MCPConfigurationResult<T> = T extends PlatformMCPServerConfigurationType
-  ? PlatformMCPToolConfigurationType[]
-  : LocalMCPToolConfigurationType[];
+type MCPToolConfigurationResult<T> =
+  T extends PlatformMCPServerConfigurationType
+    ? PlatformMCPToolConfigurationType[]
+    : LocalMCPToolConfigurationType[];
 
-function makeMCPConfigurations<T extends MCPServerConfigurationType>({
+function makeMCPToolConfigurations<T extends MCPServerConfigurationType>({
   config,
   tools,
 }: {
   config: T;
-  tools: MCPToolType[];
-}): MCPConfigurationResult<T> {
+  tools: MCPToolWithIsDefaultType[];
+}): MCPToolConfigurationResult<T> {
   if (isPlatformMCPServerConfiguration(config)) {
-    return makePlatformMCPConfigurations(
+    return makePlatformMCPToolConfigurations(
       config,
       tools
-    ) as MCPConfigurationResult<T>;
+    ) as MCPToolConfigurationResult<T>;
   }
 
-  return makeLocalMCPConfigurations(config, tools) as MCPConfigurationResult<T>;
+  return makeLocalMCPToolConfigurations(
+    config,
+    tools
+  ) as MCPToolConfigurationResult<T>;
 }
 
 /**
@@ -257,7 +265,7 @@ export async function tryListMCPTools(
         messageId,
       });
 
-      return makeMCPConfigurations({
+      return makeMCPToolConfigurations({
         config: action,
         tools,
       });
@@ -277,7 +285,7 @@ async function listMCPServerTools(
     conversationId: string;
     messageId: string;
   }
-): Promise<MCPToolType[]> {
+): Promise<MCPToolWithIsDefaultType[]> {
   const owner = auth.getNonNullableWorkspace();
   let mcpClient;
 
@@ -292,16 +300,27 @@ async function listMCPServerTools(
 
   try {
     // Connect to the MCP server.
-    mcpClient = await connectToMCPServer(auth, connectionParamsRes.value);
+    const config = connectionParamsRes.value;
+    mcpClient = await connectToMCPServer(auth, config);
+    const isDefault =
+      "mcpServerId" in config
+        ? isDefaultInternalMCPServer(config.mcpServerId)
+        : false;
 
-    let allTools: MCPToolType[] = [];
+    let allTools: MCPToolWithIsDefaultType[] = [];
     let nextPageCursor;
 
     // Fetch all tools, handling pagination if supported by the MCP server.
     do {
       const { tools, nextCursor } = await mcpClient.listTools();
       nextPageCursor = nextCursor;
-      allTools = [...allTools, ...extractMetadataFromTools(tools)];
+      allTools = [
+        ...allTools,
+        ...extractMetadataFromTools(tools).map((tool) => ({
+          ...tool,
+          isDefault,
+        })),
+      ];
     } while (nextPageCursor);
 
     logger.debug(

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -2,6 +2,7 @@ import {
   CommandIcon,
   FolderTableIcon,
   GithubIcon,
+  ImageIcon,
   RocketIcon,
 } from "@dust-tt/sparkle";
 
@@ -10,11 +11,18 @@ export const MCP_SERVER_ICONS: Record<AllowedIconType, React.ComponentType> = {
   rocket: RocketIcon,
   table: FolderTableIcon,
   github: GithubIcon,
+  image: ImageIcon,
 } as const;
 
 export const DEFAULT_MCP_SERVER_ICON = "rocket" as const;
 
-export const ALLOWED_ICONS = ["command", "rocket", "table", "github"] as const;
+export const ALLOWED_ICONS = [
+  "command",
+  "rocket",
+  "table",
+  "github",
+  "image",
+] as const;
 export type AllowedIconType = (typeof ALLOWED_ICONS)[number];
 
 export const isAllowedIconType = (icon: string): icon is AllowedIconType =>

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -7,6 +7,7 @@ export const AVAILABLE_INTERNAL_MCPSERVER_NAMES = [
   "helloworld",
   "table-utils",
   "github",
+  "image-generation-dalle",
 ] as const;
 
 export const INTERNAL_MCP_SERVERS: Record<
@@ -19,7 +20,7 @@ export const INTERNAL_MCP_SERVERS: Record<
 > = {
   helloworld: {
     id: 1,
-    isDefault: true,
+    isDefault: false,
     flag: "mcp_actions",
   },
   "data-source-utils": {
@@ -37,15 +38,28 @@ export const INTERNAL_MCP_SERVERS: Record<
     isDefault: false,
     flag: "mcp_actions",
   },
+  "image-generation-dalle": {
+    id: 5,
+    isDefault: true,
+    flag: "mcp_actions",
+  },
 };
 
 export type InternalMCPServerNameType =
   (typeof AVAILABLE_INTERNAL_MCPSERVER_NAMES)[number];
 
-export const isDefaultInternalMCPServer = (
+export const isDefaultInternalMCPServerByName = (
   name: InternalMCPServerNameType
 ): boolean => {
   return INTERNAL_MCP_SERVERS[name].isDefault;
+};
+
+export const isDefaultInternalMCPServer = (sId: string): boolean => {
+  const r = getInternalMCPServerNameAndWorkspaceId(sId);
+  if (r.isErr()) {
+    return false;
+  }
+  return isDefaultInternalMCPServerByName(r.value.name);
 };
 
 export const getInternalMCPServerNameAndWorkspaceId = (

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation_dalle.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation_dalle.ts
@@ -1,0 +1,87 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import OpenAI from "openai";
+import { z } from "zod";
+
+import type { InternalMCPServerDefinitionType } from "@app/lib/actions/mcp_metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { dustManagedCredentials } from "@app/types";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "image-generation-dalle",
+  version: "1.0.0",
+  description: "Generate images with the Dall-E v3 model from OpenAI.",
+  icon: "image",
+  authorization: null,
+};
+
+const createServer = (auth: Authenticator): McpServer => {
+  const server = new McpServer(serverInfo);
+
+  server.tool(
+    "generate_image",
+    "Generate an image from a text prompt",
+    {
+      prompt: z
+        .string()
+        .max(4000)
+        .describe(
+          "A text description of the desired image(s). The maximum length is 4000 characters."
+        ),
+      quality: z
+        .enum(["standard", "hd"])
+        .optional()
+        .default("standard")
+        .describe(
+          "The quality of the generated images. Must be one of standard or hd"
+        ),
+      style: z
+        .enum(["vivid", "natural"])
+        .optional()
+        .default("vivid")
+        .describe(
+          "The style of the generated images. Must be one of vivid or natural"
+        ),
+      size: z
+        .enum(["1024x1024", "1792x1024", "1024x1792"])
+        .optional()
+        .default("1024x1024")
+        .describe(
+          "The size of the generated images. Must be one of 1024x1024, 1792x1024, or 1024x1792"
+        ),
+    },
+    async ({ prompt, quality, style, size }) => {
+      const credentials = dustManagedCredentials();
+      const openai = new OpenAI({
+        apiKey: credentials.OPENAI_API_KEY,
+      });
+
+      const images = await openai.images.generate({
+        model: "dall-e-3",
+        prompt,
+        size,
+        quality,
+        style,
+        response_format: "url",
+        user: `workspace-${auth.getNonNullableWorkspace().sId}`,
+      });
+
+      const content = images.data.map((image) => ({
+        type: "resource" as const,
+        resource: {
+          mimeType: "image/png",
+          uri: image.url!,
+          text: `Here is the image's url: ${image.url}`,
+        },
+      }));
+
+      return {
+        isError: false,
+        content,
+      };
+    }
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -4,6 +4,7 @@ import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_ac
 import { default as dataSourceUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/data_source_utils";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
 import { default as helloWorldServer } from "@app/lib/actions/mcp_internal_actions/servers/helloworld";
+import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation_dalle";
 import { default as tableUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/table_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types";
@@ -27,6 +28,8 @@ export function getInternalMCPServer(
       return tableUtilsServer();
     case "github":
       return githubServer(auth, mcpServerId);
+    case "image-generation-dalle":
+      return imageGenerationDallEServer(auth);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -33,6 +33,10 @@ export type MCPToolType = {
   inputSchema: JSONSchema | undefined;
 };
 
+export type MCPToolWithIsDefaultType = MCPToolType & {
+  isDefault: boolean;
+};
+
 export type MCPServerType = {
   id: string;
   name: string;

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -175,6 +175,8 @@ export class AgentMCPActionOutputItem extends WorkspaceAwareModel<AgentMCPAction
   declare agentMCPActionId: ForeignKey<AgentMCPAction["id"]>;
   declare content: MCPToolResultContent;
   declare fileId: ForeignKey<FileModel["id"]> | null;
+
+  declare file: NonAttribute<FileModel>;
 }
 
 AgentMCPActionOutputItem.init(
@@ -198,7 +200,7 @@ AgentMCPActionOutputItem.init(
             throw new Error("Content must be an object");
           }
           const content = value as { type: string };
-          if (!["text", "image", "embedded_resource"].includes(content.type)) {
+          if (!["text", "image", "resource"].includes(content.type)) {
             throw new Error("Invalid content type");
           }
         },

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -431,6 +431,14 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerView> {
     }
   }
 
+  get isDefault(): boolean {
+    if (this.serverType !== "internal" || !this.internalMCPServerId) {
+      return false;
+    }
+
+    return isDefaultInternalMCPServer(this.internalMCPServerId);
+  }
+
   static async ensureAllDefaultActionsAreCreated(auth: Authenticator) {
     const names = AVAILABLE_INTERNAL_MCPSERVER_NAMES;
 


### PR DESCRIPTION
## Description

- Add tool to generate image
- Add handling mcp server that generate "resource" of mime type compatible with images
- Add ability to display them in the conversation (as they are generated)
- Add ability to zoom on them
- Improved the display of tools details from an MCP action execution
- Fixed the handling of default internal server (they should not be requiring approval - it wasn't working)

<img width="875" alt="image" src="https://github.com/user-attachments/assets/bc304be9-c677-4d6e-84d1-48ed988ef48b" />
<img width="1833" alt="image" src="https://github.com/user-attachments/assets/5daa92ac-1891-4073-adcd-54f6fbf6dcf1" />
<img width="1850" alt="image" src="https://github.com/user-attachments/assets/bde61561-f7dd-46b7-a157-dc310aba5479" />



## Tests

Local

## Risk

Low, behind FF

## Deploy Plan

Deploy `front` and enjoy !