### PR TITLE
[front,sparkle] - chore(AttachmentPicker): polish

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -24,7 +24,10 @@ import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
-import { useSpaces, useSpacesSearchWithInfiniteScroll } from "@app/lib/swr/spaces";
+import {
+  useSpaces,
+  useSpacesSearchWithInfiniteScroll,
+} from "@app/lib/swr/spaces";
 import type { DataSourceViewContentNode, LightWorkspaceType } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
@@ -180,10 +183,15 @@ export const InputBarAttachmentsPicker = ({
                         className: "min-w-4",
                       })
                     }
-                    extraIcon={isWebsite(item.dataSourceView.dataSource) || isFolder(item.dataSourceView.dataSource) ? undefined: getConnectorProviderLogoWithFallback({
-                      provider:
-                        item.dataSourceView.dataSource.connectorProvider,
-                    })}
+                    extraIcon={
+                      isWebsite(item.dataSourceView.dataSource) ||
+                      isFolder(item.dataSourceView.dataSource)
+                        ? undefined
+                        : getConnectorProviderLogoWithFallback({
+                            provider:
+                              item.dataSourceView.dataSource.connectorProvider,
+                          })
+                    }
                     disabled={attachedNodes.some(
                       (attachedNode) =>
                         attachedNode.internalId === item.internalId &&

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -24,12 +24,10 @@ import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
-import {
-  useSpaces,
-  useSpacesSearchWithInfiniteScroll,
-} from "@app/lib/swr/spaces";
+import { useSpaces, useSpacesSearchWithInfiniteScroll } from "@app/lib/swr/spaces";
 import type { DataSourceViewContentNode, LightWorkspaceType } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
+import { isFolder, isWebsite } from "@app/lib/data_sources";
 
 interface InputBarAttachmentsPickerProps {
   owner: LightWorkspaceType;
@@ -182,7 +180,7 @@ export const InputBarAttachmentsPicker = ({
                         className: "min-w-4",
                       })
                     }
-                    extraIcon={getConnectorProviderLogoWithFallback({
+                    extraIcon={isWebsite(item.dataSourceView.dataSource) || isFolder(item.dataSourceView.dataSource) ? undefined: getConnectorProviderLogoWithFallback({
                       provider:
                         item.dataSourceView.dataSource.connectorProvider,
                     })}

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -24,13 +24,13 @@ import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
+import { isFolder, isWebsite } from "@app/lib/data_sources";
 import {
   useSpaces,
   useSpacesSearchWithInfiniteScroll,
 } from "@app/lib/swr/spaces";
 import type { DataSourceViewContentNode, LightWorkspaceType } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
-import { isFolder, isWebsite } from "@app/lib/data_sources";
 
 interface InputBarAttachmentsPickerProps {
   owner: LightWorkspaceType;

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.459",
+  "version": "0.2.460",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.459",
+      "version": "0.2.460",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.459",
+  "version": "0.2.460",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -102,6 +102,7 @@ interface ItemWithLabelIconAndDescriptionProps {
   extraIcon?: React.ComponentType;
   description?: string;
   children?: React.ReactNode;
+  truncate?: boolean;
 }
 
 const ItemWithLabelIconAndDescription = <
@@ -111,12 +112,13 @@ const ItemWithLabelIconAndDescription = <
   icon,
   extraIcon,
   description,
+  truncate,
   children,
 }: T) => {
   return (
     <>
       {label && (
-        <div className="s-grid s-grid-cols-[auto,1fr,auto] s-items-center s-gap-x-1.5">
+        <div className="s-grid s-grid-cols-[auto,1fr,auto] s-items-center s-gap-x-2.5">
           {(icon || extraIcon) && (
             <div
               className={cn(
@@ -137,16 +139,21 @@ const ItemWithLabelIconAndDescription = <
                   position="bottom-right"
                 />
               ) : icon ? (
-                <Icon size={description ? "sm" : "xs"} visual={icon} />
-              ) : extraIcon ? (
-                <Icon size="xs" visual={extraIcon} />
+                <Icon size="sm" visual={icon} />
               ) : null}
             </div>
           )}
           <div className="s-flex s-flex-col">
-            <span>{label}</span>
+            <span className={truncate ? "s-line-clamp-1" : undefined}>
+              {label}
+            </span>
             {description && (
-              <span className={menuStyleClasses.description}>
+              <span
+                className={cn(
+                  menuStyleClasses.description,
+                  truncate && "s-line-clamp-1"
+                )}
+              >
                 {description}
               </span>
             )}
@@ -237,6 +244,7 @@ export type DropdownMenuItemProps = MutuallyExclusiveProps<
   LabelAndIconProps & {
     description?: string;
     extraIcon?: React.ComponentType;
+    truncateText?: boolean;
   }
 >;
 
@@ -253,6 +261,7 @@ const DropdownMenuItem = React.forwardRef<
       inset,
       icon,
       extraIcon,
+      truncateText,
       label,
       href,
       target,
@@ -289,6 +298,7 @@ const DropdownMenuItem = React.forwardRef<
             icon={icon}
             extraIcon={extraIcon}
             description={description}
+            truncate={truncateText}
           >
             {children}
           </ItemWithLabelIconAndDescription>

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -314,7 +314,7 @@ function DropdownMenuSearchbarDemo() {
   const [selectedItem, setSelectedItem] = React.useState<string | null>(null);
 
   const items = [
-    "Automated Data Processing",
+    "Automated Data Processing Automated Data Processing Automated Data Processing Automated Data Processing",
     "Business Intelligence Dashboard",
     "Cloud Infrastructure Setup",
     "Data Migration Service",
@@ -379,6 +379,7 @@ function DropdownMenuSearchbarDemo() {
                   setSelectedItem(item);
                   setSearchText("");
                 }}
+                truncateText
               />
             );
           })}


### PR DESCRIPTION
## Description

This PR aims at polishing the `InputBarAttachmentsPicker` to fit label and description in one line and tweak the size of the double icons.

Note: sparkle changes will be shipped with a follow up front PR

## Risk

Low

## Deploy Plan

- Publish sparkle