### PR TITLE
Fix for convo data retention: we pass auth to make sure we filter on workspace id

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -87,8 +87,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const conversations = await this.model.findAll({
       where: {
-        ...options.where,
         ...where,
+        ...options.where,
         workspaceId: workspace.id,
       },
       limit: options.limit,
@@ -188,16 +188,22 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return mentions;
   }
 
-  static async listAllBeforeDate(date: Date): Promise<ConversationResource[]> {
-    const conversations = await this.model.findAll({
-      where: {
-        updatedAt: {
-          [Op.lt]: date,
+  static async listAllBeforeDate(
+    auth: Authenticator,
+    date: Date
+  ): Promise<ConversationResource[]> {
+    const conversations = await this.baseFetch(
+      auth,
+      { includeDeleted: true, includeTest: true },
+      {
+        where: {
+          updatedAt: {
+            [Op.lt]: date,
+          },
         },
-      },
-    });
-
-    return conversations.map((c) => new this(this.model, c.get()));
+      }
+    );
+    return conversations;
   }
 
   static canAccessConversation(

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -62,8 +62,10 @@ export async function purgeConversationsBatchActivity({
 
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const conversations =
-      await ConversationResource.listAllBeforeDate(cutoffDate);
+    const conversations = await ConversationResource.listAllBeforeDate(
+      auth,
+      cutoffDate
+    );
 
     logger.info(
       {


### PR DESCRIPTION
## Description

The refactor from yesterday was actually not okay since if we had activated again the workflow for data retention we would have matched the old conversations for all workspaces. 

Fix is passing the auth to listAllBeforeDate and calling baseFetch. 

I also changed the order of the options/where in baseFetch. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
