### PR TITLE
[Slack URL pasting] Prioritize thread URL matching

### DIFF
--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -210,8 +210,8 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
     extractor: (url: URL): NodeCandidate => {
       // Try each type of extraction in order
       const node =
-        extractMessageNodeId(url) ||
         extractThreadNodeId(url) ||
+        extractMessageNodeId(url) ||
         extractChannelNodeId(url);
       return node
         ? { node, provider: "slack" }


### PR DESCRIPTION
Description
---
This PR changes the order of URL extraction for Slack URLs to prioritize thread identification over message identification.

**Why this change is needed**
Thread URLs are more specific than message URLs as they contain a thread_ts parameter that explicitly identifies them as threads. Currently, a URL like
https://example.slack.com/archives/CHANNEL/p123?thread_ts=456 is identified as a message instead of a thread because the message extraction happens first.

Thread identification is more selective (requires the thread_ts parameter) than message identification (which only requires a path component starting with 'p'). By checking for threads first, we ensure that the more specific identifier is given priority, leading to more accurate classification of Slack URLs.

**Changes made:**
- Reordered the extraction functions in the slack provider's extractor to check for threads before messages
- No functional changes to the extraction logic itself

Risks
---
low

Deploy
---
front
