### PR TITLE
fix(remote tables): revert to using internal ID as table name

### DIFF
--- a/connectors/src/lib/remote_databases/activities.test.ts
+++ b/connectors/src/lib/remote_databases/activities.test.ts
@@ -487,7 +487,8 @@ describe("sync remote databases", async () => {
         dataSourceConfig: dataSourceConfig,
         tableId:
           "test__DUST_DOT__db.test__DUST_DOT__schema.test__DUST_DOT__table",
-        tableName: "test__DUST_DOT__db.test__DUST_DOT__schema.test__DUST_DOT__table",
+        tableName:
+          "test__DUST_DOT__db.test__DUST_DOT__schema.test__DUST_DOT__table",
         remoteDatabaseTableId:
           "test__DUST_DOT__db.test__DUST_DOT__schema.test__DUST_DOT__table",
         remoteDatabaseSecretId: connector.connectionId,

--- a/connectors/src/lib/remote_databases/activities.test.ts
+++ b/connectors/src/lib/remote_databases/activities.test.ts
@@ -265,7 +265,7 @@ describe("sync remote databases", async () => {
       expect(upsertDataSourceRemoteTable).toHaveBeenCalledWith({
         dataSourceConfig: dataSourceConfig,
         tableId: "test-db.test-schema.test-table",
-        tableName: "test-table",
+        tableName: "test-db.test-schema.test-table",
         remoteDatabaseTableId: "custom-remote-table-id",
         remoteDatabaseSecretId: connector.connectionId,
         tableDescription: "",
@@ -487,7 +487,7 @@ describe("sync remote databases", async () => {
         dataSourceConfig: dataSourceConfig,
         tableId:
           "test__DUST_DOT__db.test__DUST_DOT__schema.test__DUST_DOT__table",
-        tableName: "test.table",
+        tableName: "test__DUST_DOT__db.test__DUST_DOT__schema.test__DUST_DOT__table",
         remoteDatabaseTableId:
           "test__DUST_DOT__db.test__DUST_DOT__schema.test__DUST_DOT__table",
         remoteDatabaseSecretId: connector.connectionId,
@@ -572,7 +572,7 @@ describe("sync remote databases", async () => {
       expect(upsertDataSourceRemoteTable).toHaveBeenCalledWith({
         dataSourceConfig: dataSourceConfig,
         tableId: "test-db.test-schema.test-table",
-        tableName: "test-table",
+        tableName: "test-db.test-schema.test-table",
         remoteDatabaseTableId: "custom-remote-table-id",
         remoteDatabaseSecretId: connector.connectionId,
         tableDescription: "",

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -328,7 +328,7 @@ const createTableAndHierarchy = async ({
     await upsertDataSourceRemoteTable({
       dataSourceConfig,
       tableId: tableInternalId,
-      tableName: table.name,
+      tableName: tableInternalId,
       remoteDatabaseTableId: internalTableIdToRemoteTableId(tableInternalId),
       remoteDatabaseSecretId: connector.connectionId,
       tableDescription: "",


### PR DESCRIPTION
## Description

This was incorrectly changed to `table.name` instead of internal ID in https://github.com/dust-tt/dust/pull/11575. This cannot work, as we require uniqueness of table names within a datasource.

## Tests

NA

## Risk


## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
