### PR TITLE
Add production check for paused connectors

### DIFF
--- a/front/lib/production_checks/checks/check_paused_connectors.ts
+++ b/front/lib/production_checks/checks/check_paused_connectors.ts
@@ -1,0 +1,84 @@
+import { QueryTypes } from "sequelize";
+
+import type { CheckFunction } from "@app/lib/production_checks/types";
+import {
+  getConnectorsPrimaryDbConnection,
+  getFrontPrimaryDbConnection,
+} from "@app/lib/production_checks/utils";
+
+interface PausedConnector {
+  id: number;
+  workspaceId: string;
+  pausedAt: Date | null;
+}
+
+interface WorkspaceSubscription {
+  workspaceId: string;
+  planCode: string;
+}
+
+export const checkPausedConnectors: CheckFunction = async (
+  _checkName,
+  logger,
+  reportSuccess,
+  reportFailure
+) => {
+  const connectorsDb = getConnectorsPrimaryDbConnection();
+  const frontDb = getFrontPrimaryDbConnection();
+  const connectorsToReport: PausedConnector[] = [];
+
+  // Get all paused connectors that have been paused for more than 15 days.
+  const pausedConnectors: PausedConnector[] = await connectorsDb.query(
+    `SELECT id, "workspaceId", "pausedAt" FROM connectors WHERE "pausedAt" IS NOT NULL AND "pausedAt" < NOW() - INTERVAL '15 day' and "errorType" IS NULL`,
+    {
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  // Get all workspace subscriptions for the paused connectors workspaces.
+  const workspaceSubscriptions: WorkspaceSubscription[] = await frontDb.query(
+    `SELECT "workspaces"."sId" AS "workspaceId", "plans"."code" AS "planCode"
+      FROM "workspaces"
+      LEFT JOIN "subscriptions" ON "workspaces"."id" = "subscriptions"."workspaceId"
+      LEFT JOIN "plans" ON "subscriptions"."planId" = "plans"."id"
+      WHERE "workspaces"."sId" IN (:workspaceIds)
+      AND "subscriptions"."status" = 'active'; `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: {
+        workspaceIds: pausedConnectors.map((c) => c.workspaceId),
+      },
+    }
+  );
+
+  // If the connector is paused and the workspace has a valid subscription, add it to the report.
+  for (const connector of pausedConnectors) {
+    logger.info(
+      { connector },
+      "Connector is paused. Checking if worskpace has a valid subscription."
+    );
+
+    const workspaceSubscription = workspaceSubscriptions.find(
+      (s) => s.workspaceId === connector.workspaceId
+    );
+
+    if (workspaceSubscription && workspaceSubscription.planCode.length) {
+      connectorsToReport.push(connector);
+    } else {
+      logger.info(
+        { connector },
+        "Connector is paused but workspace has no valid subscription. Skipping."
+      );
+    }
+  }
+
+  // If there are any connectors to report, report a failure.
+  if (connectorsToReport.length > 0) {
+    reportFailure(
+      { connectorsToReport },
+      "Paused connectors for a workspace with a subscription for more than 15 days."
+    );
+  } else {
+    reportSuccess({});
+  }
+};

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -7,6 +7,7 @@ import { checkConnectorsLastSyncSuccess } from "@app/lib/production_checks/check
 import { checkDataSourcesConsistency } from "@app/lib/production_checks/checks/check_data_sources_consistency";
 import { checkExtraneousWorkflows } from "@app/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors";
 import { checkNotionActiveWorkflows } from "@app/lib/production_checks/checks/check_notion_active_workflows";
+import { checkPausedConnectors } from "@app/lib/production_checks/checks/check_paused_connectors";
 import { checkWebcrawlerSchedulerActiveWorkflow } from "@app/lib/production_checks/checks/check_webcrawler_scheduler_active_workflow";
 import { managedDataSourceGCGdriveCheck } from "@app/lib/production_checks/checks/managed_data_source_gdrive_gc";
 import type { Check } from "@app/lib/production_checks/types";
@@ -51,6 +52,11 @@ export const REGISTERED_CHECKS: Check[] = [
   {
     name: "check_webcrawler_scheduler_active_workflow",
     check: checkWebcrawlerSchedulerActiveWorkflow,
+    everyHour: 8,
+  },
+  {
+    name: "checked_paused_connectors",
+    check: checkPausedConnectors,
     everyHour: 8,
   },
 ];


### PR DESCRIPTION
## Description

Adding a production check to make sure we do not forget to unpause connectors. 
If a connector is meant to be paused for more than 2 weeks, we should simply error it. 

I am filtering out paused connectors for workspaces without a plan since when we downgrade a workspace we first pause all connectors to then remove the workspace 15 days later. 

## Tests

I only tested the queries. 

## Risk

Can be rolled back if there's an issue, only affects production checks.

## Deploy Plan

Deploy front. 
