### PR TITLE
Feat/request actions

### DIFF
--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -114,7 +114,7 @@ export function RequestDataSourceModal({
                   </p>
                 </label>
               )}
-              {dataSources.length > 1 && (
+              {dataSources.length >= 1 && (
                 <>
                   <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                     <p>Where are the requested Data hosted?</p>

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -17,6 +17,8 @@ import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
 import { useMCPServerViews } from "@app/lib/swr/mcp_server_views";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
+import { RequestActionsModal } from "./mcp/RequestActionsModal";
+
 type RowData = {
   name: string;
   description: string;
@@ -115,7 +117,7 @@ export const SpaceActionsList = ({
           }}
         />
       ) : (
-        <Button label="Request Action" variant="primary" icon={PlusIcon} />
+        <RequestActionsModal owner={owner} space={space} />
       )}
     </>
   );

--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -1,0 +1,191 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  PlusIcon,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  Spinner,
+  TextArea,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import _ from "lodash";
+import { useState } from "react";
+
+import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
+import { sendRequestActionsAccessEmail } from "@app/lib/email";
+import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_server_views";
+import logger from "@app/logger/logger";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
+
+interface RequestActionsModal {
+  owner: LightWorkspaceType;
+  space: SpaceType;
+}
+
+export function RequestActionsModal({ owner, space }: RequestActionsModal) {
+  const { serverViews, isMCPServerViewsLoading: isLoading } =
+    useMCPServerViewsNotActivated({ owner, space });
+  const [selectedMcpServer, setSelectedMcpServer] =
+    useState<MCPServerViewType | null>(null);
+
+  const [message, setMessage] = useState("");
+  const sendNotification = useSendNotification();
+
+  const onClose = () => {
+    setMessage("");
+  };
+
+  const onSave = async () => {
+    const userToId = selectedMcpServer?.editedByUser?.userId;
+    if (!userToId || !selectedMcpServer) {
+      sendNotification({
+        type: "error",
+        title: "Error sending email",
+        description: "An unexpected error occurred while sending email.",
+      });
+    } else {
+      try {
+        await sendRequestActionsAccessEmail({
+          userTo: userToId,
+          emailMessage: message,
+          serverName: selectedMcpServer.server.name,
+          owner,
+        });
+        sendNotification({
+          type: "success",
+          title: "Email sent!",
+          description: `Your request was sent to ${selectedMcpServer.editedByUser?.fullName}`,
+        });
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Error sending email",
+          description:
+            "An unexpected error occurred while sending the request.",
+        });
+        logger.error(
+          {
+            userToId,
+            mcpServerId: selectedMcpServer.id,
+            error: e,
+          },
+          "Error sending email"
+        );
+      }
+      onClose();
+    }
+  };
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button label="Request Action" icon={PlusIcon} />
+      </SheetTrigger>
+      <SheetContent size="lg">
+        <SheetHeader>
+          <SheetTitle>
+            Requesting Access to {selectedMcpServer?.server.name}
+          </SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <div className="flex flex-col gap-4 p-4">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                {isLoading && <Spinner size="lg" />}
+
+                {!isLoading && serverViews.length === 0 && (
+                  <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                    <p>
+                      You have no connection set up. Ask an admin to set one up.
+                    </p>
+                  </label>
+                )}
+
+                {serverViews.length >= 1 && (
+                  <>
+                    <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                      <p>Which server you want to get access to?</p>
+                    </label>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        {selectedMcpServer ? (
+                          <Button
+                            variant="outline"
+                            label={selectedMcpServer.server.name}
+                            icon={
+                              MCP_SERVER_ICONS[selectedMcpServer.server.icon]
+                            }
+                          />
+                        ) : (
+                          <Button
+                            label="Pick your MCP Server"
+                            variant="outline"
+                            size="sm"
+                            isSelect
+                          />
+                        )}
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        {serverViews.map((v) => (
+                          <DropdownMenuItem
+                            key={v.id}
+                            label={v.server.name}
+                            icon={MCP_SERVER_ICONS[v.server.icon]}
+                            onClick={() => setSelectedMcpServer(v)}
+                          />
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </>
+                )}
+              </div>
+
+              {selectedMcpServer && (
+                <div className="flex flex-col gap-2">
+                  <p className="mb-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    {_.capitalize(
+                      selectedMcpServer.editedByUser?.fullName ?? ""
+                    )}{" "}
+                    is the administrator for the {selectedMcpServer.server.name}{" "}
+                    server within Dust. Send an email to{" "}
+                    {_.capitalize(
+                      selectedMcpServer.editedByUser?.fullName ?? ""
+                    )}
+                    , explaining your request.
+                  </p>
+                  <TextArea
+                    placeholder={`Hello`}
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    className="mb-2"
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Send",
+            onClick: onSave,
+            disabled: message.length === 0,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -105,7 +105,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                 {!isLoading && serverViews.length === 0 && (
                   <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                     <p>
-                      You have no connection set up. Ask an admin to set one up.
+                      You have no actions set up. Ask an admin to set one up.
                     </p>
                   </label>
                 )}
@@ -113,7 +113,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                 {serverViews.length >= 1 && (
                   <>
                     <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
-                      <p>Which server you want to get access to?</p>
+                      <p>Which actions you want to get access to?</p>
                     </label>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
@@ -156,7 +156,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                       selectedMcpServer.editedByUser?.fullName ?? ""
                     )}{" "}
                     is the administrator for the {selectedMcpServer.server.name}{" "}
-                    server within Dust. Send an email to{" "}
+                    action within Dust. Send an email to{" "}
                     {_.capitalize(
                       selectedMcpServer.editedByUser?.fullName ?? ""
                     )}

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -69,14 +69,17 @@ export async function sendRequestFeatureAccessEmail({
 export async function sendRequestActionsAccessEmail({
   userTo,
   emailMessage,
+  serverName,
   owner,
 }: {
   userTo: string;
   emailMessage: string;
+  serverName: string;
   owner: LightWorkspaceType;
 }) {
   const emailBlob: PostRequestActionsAccessBody = {
     emailMessage,
+    serverName,
     userTo,
   };
 

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -1,5 +1,6 @@
 import type { PostRequestAccessBody } from "@app/pages/api/w/[wId]/data_sources/request_access";
 import type { PostRequestFeatureAccessBody } from "@app/pages/api/w/[wId]/labs/request_access";
+import type { PostRequestActionsAccessBody } from "@app/pages/api/w/[wId]/mcp/request_access";
 import type { LightWorkspaceType } from "@app/types";
 
 export async function sendRequestDataSourceEmail({
@@ -50,6 +51,36 @@ export async function sendRequestFeatureAccessEmail({
   };
 
   const res = await fetch(`/api/w/${owner.sId}/labs/request_access`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(emailBlob),
+  });
+
+  if (!res.ok) {
+    const errorData = await res.json();
+    throw new Error(errorData.error?.message || "Failed to send email");
+  }
+
+  return res.json();
+}
+
+export async function sendRequestActionsAccessEmail({
+  userTo,
+  emailMessage,
+  owner,
+}: {
+  userTo: string;
+  emailMessage: string;
+  owner: LightWorkspaceType;
+}) {
+  const emailBlob: PostRequestActionsAccessBody = {
+    emailMessage,
+    userTo,
+  };
+
+  const res = await fetch(`/api/w/${owner.sId}/mcp/request_access`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -13,10 +13,20 @@ import type {
   GetMCPServerViewsResponseBody,
   PostMCPServerViewResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/mcp_views";
+import type { GetMCPServerViewsNotActivatedResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 function getMCPServerViewsKey(owner: LightWorkspaceType, space?: SpaceType) {
   return space ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views` : null;
+}
+
+function getMCPServerViewsNotActivatedKey(
+  owner: LightWorkspaceType,
+  space?: SpaceType
+) {
+  return space
+    ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views/not_activated`
+    : null;
 }
 
 export function useMCPServerViews({
@@ -30,6 +40,30 @@ export function useMCPServerViews({
 }) {
   const configFetcher: Fetcher<GetMCPServerViewsResponseBody> = fetcher;
   const url = getMCPServerViewsKey(owner, space);
+  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    disabled,
+  });
+  const serverViews = useMemo(() => (data ? data.serverViews : []), [data]);
+  return {
+    serverViews,
+    isMCPServerViewsLoading: !error && !data && !disabled,
+    isMCPServerViewsError: error,
+    mutateMCPServerViews: mutate,
+  };
+}
+
+export function useMCPServerViewsNotActivated({
+  owner,
+  space,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  space?: SpaceType;
+  disabled?: boolean;
+}) {
+  const configFetcher: Fetcher<GetMCPServerViewsNotActivatedResponseBody> =
+    fetcher;
+  const url = getMCPServerViewsNotActivatedKey(owner, space);
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
     disabled,
   });

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -20,15 +20,6 @@ function getMCPServerViewsKey(owner: LightWorkspaceType, space?: SpaceType) {
   return space ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views` : null;
 }
 
-function getMCPServerViewsNotActivatedKey(
-  owner: LightWorkspaceType,
-  space?: SpaceType
-) {
-  return space
-    ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views/not_activated`
-    : null;
-}
-
 export function useMCPServerViews({
   owner,
   space,
@@ -58,15 +49,18 @@ export function useMCPServerViewsNotActivated({
   disabled,
 }: {
   owner: LightWorkspaceType;
-  space?: SpaceType;
+  space: SpaceType;
   disabled?: boolean;
 }) {
   const configFetcher: Fetcher<GetMCPServerViewsNotActivatedResponseBody> =
     fetcher;
-  const url = getMCPServerViewsNotActivatedKey(owner, space);
-  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
-    disabled,
-  });
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views/not_activated`,
+    configFetcher,
+    {
+      disabled,
+    }
+  );
   const serverViews = useMemo(() => (data ? data.serverViews : []), [data]);
   return {
     serverViews,

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -35,7 +35,7 @@ async function handler(
       status_code: 401,
       api_error: {
         type: "mcp_auth_error",
-        message: "You are not authorized to submit connections requests.",
+        message: "You are not authorized to submit actions requests.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -14,6 +14,7 @@ import { apiError } from "@app/logger/withlogging";
 export const PostRequestActionsAccessBodySchema = t.type({
   emailMessage: t.string,
   userTo: t.string,
+  serverName: t.string,
 });
 
 export type PostRequestActionsAccessBody = t.TypeOf<
@@ -38,7 +39,6 @@ async function handler(
       },
     });
   }
-
   const { method } = req;
 
   if (method !== "POST") {
@@ -102,7 +102,7 @@ async function handler(
   const result = await sendEmailWithTemplate({
     to: userRecipient.email,
     from: { name: "Dust team", email: "support@dust.help" },
-    subject: `[Dust] Request Data source from ${emailRequester}`,
+    subject: `[Dust] Request Action from ${emailRequester}`,
     body,
   });
 

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -1,0 +1,121 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { sendEmailWithTemplate } from "@app/lib/api/email";
+import type { Authenticator } from "@app/lib/auth";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+export const PostRequestActionsAccessBodySchema = t.type({
+  emailMessage: t.string,
+  userTo: t.string,
+});
+
+export type PostRequestActionsAccessBody = t.TypeOf<
+  typeof PostRequestActionsAccessBodySchema
+>;
+
+const MAX_ACCESS_REQUESTS_PER_DAY = 30;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  auth: Authenticator
+) {
+  const user = auth.getNonNullableUser();
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "mcp_auth_error",
+        message: "You are not authorized to submit connections requests.",
+      },
+    });
+  }
+
+  const { method } = req;
+
+  if (method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected",
+      },
+    });
+  }
+
+  const bodyValidation = PostRequestActionsAccessBodySchema.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const emailRequester = user.email;
+  const { emailMessage, userTo } = bodyValidation.right;
+
+  const userRecipient = await UserResource.fetchById(userTo);
+
+  if (!userRecipient) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "The user was not found",
+      },
+    });
+  }
+
+  const rateLimitKey = `access_requests:${user.sId}`;
+  const remaining = await rateLimiter({
+    key: rateLimitKey,
+    maxPerTimeframe: MAX_ACCESS_REQUESTS_PER_DAY,
+    timeframeSeconds: 24 * 60 * 60, // 1 day
+    logger,
+  });
+
+  if (remaining === 0) {
+    return apiError(req, res, {
+      status_code: 429,
+      api_error: {
+        type: "rate_limit_error",
+        message: `You have reached the limit of ${MAX_ACCESS_REQUESTS_PER_DAY} access requests per day. Please try again tomorrow.`,
+      },
+    });
+  }
+
+  const body = `${emailRequester} has sent you a request regarding access to actions: ${emailMessage}`;
+
+  const result = await sendEmailWithTemplate({
+    to: userRecipient.email,
+    from: { name: "Dust team", email: "support@dust.help" },
+    subject: `[Dust] Request Data source from ${emailRequester}`,
+    body,
+  });
+
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to send email",
+      },
+    });
+  }
+  return res.status(200).json({ success: true, emailTo: userRecipient.email });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect } from "vitest";
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./index";
+
+describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated", () => {
+  itInTransaction("returns MCP servers views", async (t) => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    // Create a system space
+    const systemSpace = await SpaceFactory.system(workspace, t);
+    req.query.spaceId = systemSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      success: true,
+      serverViews: expect.any(Array),
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -1,0 +1,60 @@
+import _ from "lodash";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { MCPServerViewType } from "@app/lib/actions/mcp_metadata";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type GetMCPServerViewsNotActivatedResponseBody = {
+  success: boolean;
+  serverViews: MCPServerViewType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetMCPServerViewsNotActivatedResponseBody>
+  >,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  const { method } = req;
+
+  if (method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected",
+      },
+    });
+  }
+
+  const workspaceServerViews =
+    await MCPServerViewResource.listByWorkspace(auth);
+  const spaceServerViews = await MCPServerViewResource.listBySpace(auth, space);
+
+  const serverViews = _.uniqBy(
+    _.differenceWith(workspaceServerViews, spaceServerViews, (a, b) => {
+      return (
+        (a.internalMCPServerId ?? a.remoteMCPServerId) ===
+        (b.internalMCPServerId ?? b.remoteMCPServerId)
+      );
+    }),
+    (s) => s.internalMCPServerId ?? s.remoteMCPServerId
+  );
+
+  return res.status(200).json({
+    success: true,
+    serverViews: serverViews.map((s) => s.toJSON()),
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, { space: { requireCanRead: true } })
+);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -1,3 +1,4 @@
+import { removeNulls } from "@dust-tt/client";
 import _ from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -51,7 +52,16 @@ async function handler(
 
   return res.status(200).json({
     success: true,
-    serverViews: serverViews.map((s) => s.toJSON()),
+    serverViews: removeNulls(
+      serverViews.map((s) => {
+        // TODO: update
+        try {
+          return s.toJSON();
+        } catch (err) {
+          return null;
+        }
+      })
+    ),
   });
 }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -8,6 +8,7 @@ import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -54,10 +55,20 @@ async function handler(
     success: true,
     serverViews: removeNulls(
       serverViews.map((s) => {
-        // TODO: update
+        // WARN: Probably due to Intenal MCP Server view pointing to `internalMCPServerId` that doesn't exists anymore.
+        // Need to think about migration of mcp_server_view when we're updating internal mcp servers.
         try {
           return s.toJSON();
         } catch (err) {
+          logger.error(
+            {
+              serverViewId: s.sId,
+              workspaceId: s.workspaceId,
+              spaceId: space.sId,
+              userId: auth.getNonNullableUser().id,
+            },
+            "couldn't toJSON() a mcp_server_view"
+          );
           return null;
         }
       })


### PR DESCRIPTION
## Description
- Add modal to request actions to be added by an admin in a space (https://github.com/dust-tt/tasks/issues/2564)
- Add the backend route to send said email
- Add a backend route to get the actions installed in the workspace by not in the space

## Tests
- Tested locally with a user that is not the admin, with 2 spaces, one with 2/3 actions installed, and a second one with nothing installed. The modal shows properly the actions installed in the workspace but not in the space (actions missing for the first space, and all for the second).

## Risk
Small, not showing the proper actions available to be requested, and sending the email to the wrong admin.

## Deploy Plan
Deploy front.
