### PR TITLE
[URL Pasting] Fix pasting issue erasing message content

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension.ts
@@ -52,7 +52,8 @@ export const URLDetectionExtension = Extension.create<URLFormatOptions>({
                   if (!urlPositions) {
                     throw new Error("Unreachable: urlPositions is not defined");
                   }
-                  const from = urlPositions[index] + 1;
+                  const { from: selectionFrom } = view.state.selection;
+                  const from = selectionFrom + urlPositions[index];
                   const nodeId = isUrlNodeCandidate
                     ? nodeCandidate.url
                     : nodeCandidate.node;


### PR DESCRIPTION
Description
---
As detected by @Jules
When pasting URL, recent change was incorrect, used start of clipboard selection instead of start of message content as offset.

Risk
---
low

Deploy
---
front

