### PR TITLE
Fix: build internal id correctly for db when setting permissions

### DIFF
--- a/connectors/src/connectors/bigquery/lib/permissions.ts
+++ b/connectors/src/connectors/bigquery/lib/permissions.ts
@@ -53,7 +53,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
 
     return new Ok(
       allDatabases.map((row) => {
-        const internalId = `${row.name}`;
+        const internalId = buildInternalId({ databaseName: row.name });
         const permission = syncedDatabasesInternalIds.includes(internalId)
           ? "read"
           : "none";


### PR DESCRIPTION
## Description

Missed one place (but the most important one) where we needed to build the internal id (as it can contains dots).

## Tests

Did some logged directly in a connector pod.

## Risk

Low

## Deploy Plan

Deploy connectors and wait for a resync.