### PR TITLE
Fix agent preview missing ConversationsNavigationProvider

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -20,6 +20,7 @@ import {
 import { Separator } from "@radix-ui/react-select";
 import { useContext, useEffect } from "react";
 
+import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
@@ -157,33 +158,35 @@ export default function AssistantBuilderRightPanel({
           user && (
             <div className="flex h-full w-full flex-1 flex-col justify-between overflow-x-hidden">
               {draftAssistant ? (
-                <GenerationContextProvider>
-                  <div className="flex-grow overflow-y-auto">
-                    {conversation && (
-                      <ConversationViewer
+                <ConversationsNavigationProvider>
+                  <GenerationContextProvider>
+                    <div className="flex-grow overflow-y-auto">
+                      {conversation && (
+                        <ConversationViewer
+                          owner={owner}
+                          user={user}
+                          conversationId={conversation.sId}
+                          onStickyMentionsChange={setStickyMentions}
+                          isInModal
+                          isFading={isFading}
+                          key={conversation.sId}
+                        />
+                      )}
+                    </div>
+                    <div className="shrink-0">
+                      <AssistantInputBar
                         owner={owner}
-                        user={user}
-                        conversationId={conversation.sId}
-                        onStickyMentionsChange={setStickyMentions}
-                        isInModal
-                        isFading={isFading}
-                        key={conversation.sId}
+                        onSubmit={handleSubmit}
+                        stickyMentions={stickyMentions}
+                        conversationId={conversation?.sId || null}
+                        additionalAgentConfiguration={draftAssistant}
+                        actions={["attachment"]}
+                        disableAutoFocus
+                        isFloating={false}
                       />
-                    )}
-                  </div>
-                  <div className="shrink-0">
-                    <AssistantInputBar
-                      owner={owner}
-                      onSubmit={handleSubmit}
-                      stickyMentions={stickyMentions}
-                      conversationId={conversation?.sId || null}
-                      additionalAgentConfiguration={draftAssistant}
-                      actions={["attachment"]}
-                      disableAutoFocus
-                      isFloating={false}
-                    />
-                  </div>
-                </GenerationContextProvider>
+                    </div>
+                  </GenerationContextProvider>
+                </ConversationsNavigationProvider>
               ) : (
                 <div className="flex h-full w-full items-center justify-center">
                   <Spinner />


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/2595

The introduction of the image generation action and its modal relied on ConversationsNavigationProvider in AgentMessage (all conversations) which was not available in agent preview. Adding the context there.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`