### PR TITLE
[sparkle] - enh(DataTable,Breadcrumbs): various tweaks

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.487",
+  "version": "0.2.488",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.487",
+      "version": "0.2.488",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.487",
+  "version": "0.2.488",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -39,7 +39,7 @@ type LabelBreadcrumbItem = BaseBreadcrumbItem & {
   onClick?: never;
 };
 
-type BreadcrumbItem =
+export type BreadcrumbItem =
   | LinkBreadcrumbItem
   | ButtonBreadcrumbItem
   | LabelBreadcrumbItem;

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -11,7 +11,6 @@ import {
 } from "@sparkle/components/Dropdown";
 import { Icon } from "@sparkle/components/Icon";
 import { Tooltip } from "@sparkle/components/Tooltip";
-import { SparkleContext, SparkleContextLinkType } from "@sparkle/context";
 import { ChevronRightIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib";
 
@@ -65,10 +64,6 @@ const isButtonItem = (
   "onClick" in item && typeof item.onClick === "function";
 
 export function Breadcrumbs({ items, className }: BreadcrumbProps) {
-  const { components } = React.useContext(SparkleContext);
-
-  const Link: SparkleContextLinkType = components.link;
-
   const { itemsShown, itemsHidden } = items.reduce(
     (acc: BreadcrumbsAccumulator, item, index) => {
       if (items.length <= 5 || index < 2 || index >= items.length - 2) {
@@ -92,14 +87,14 @@ export function Breadcrumbs({ items, className }: BreadcrumbProps) {
             key={`breadcrumbs-${index}`}
             className="s-flex s-flex-row s-items-center s-gap-1"
           >
-            <Icon
-              visual={item.icon}
-              className="s-text-muted-foreground dark:s-text-muted-foreground-night"
-            />
             {item.label === ELLIPSIS_STRING ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" label={ELLIPSIS_STRING} />
+                  <Button
+                    variant="ghost"
+                    label={ELLIPSIS_STRING}
+                    icon={item.icon}
+                  />
                 </DropdownMenuTrigger>
 
                 <DropdownMenuContent align="start">
@@ -117,25 +112,33 @@ export function Breadcrumbs({ items, className }: BreadcrumbProps) {
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : isLinkItem(item) ? (
-              <Link
+              <Button
                 href={item.href}
+                icon={item.icon}
                 className={
                   index === itemsShown.length - 1
                     ? "s-font-medium s-text-foreground dark:s-text-foreground-night"
                     : "s-text-muted-foreground dark:s-text-muted-foreground-night"
                 }
-              >
-                {index === itemsShown.length - 1
-                  ? truncateWithTooltip(item.label, LABEL_TRUNCATE_LENGTH_END)
-                  : truncateWithTooltip(
-                      item.label,
-                      LABEL_TRUNCATE_LENGTH_MIDDLE
-                    )}
-              </Link>
+                variant="ghost"
+                label={
+                  index === itemsShown.length - 1
+                    ? truncateTextToLength(
+                        item.label,
+                        LABEL_TRUNCATE_LENGTH_END
+                      )
+                    : truncateTextToLength(
+                        item.label,
+                        LABEL_TRUNCATE_LENGTH_MIDDLE
+                      )
+                }
+                tooltip={item.label}
+              />
             ) : isButtonItem(item) ? (
               <Button
                 variant="ghost"
                 onClick={item.onClick}
+                icon={item.icon}
                 className={
                   index === itemsShown.length - 1
                     ? "s-font-medium s-text-foreground dark:s-text-foreground-night"
@@ -171,7 +174,7 @@ export function Breadcrumbs({ items, className }: BreadcrumbProps) {
               </div>
             )}
             {index === itemsShown.length - 1 ? null : (
-              <ChevronRightIcon className="s-text-primary-300 dark:s-text-primary-700" />
+              <Icon visual={ChevronRightIcon} />
             )}
           </div>
         );

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -98,6 +98,12 @@ interface DataTableProps<TData extends TBaseData> {
   setSorting?: (sorting: SortingState) => void;
   isServerSideSorting?: boolean;
   disablePaginationNumbers?: boolean;
+  getRowId?: (
+    originalRow: TData,
+    index: number,
+    parent?: Row<TData> | undefined
+  ) => string;
+  // row selection props
   rowSelection?: RowSelectionState;
   setRowSelection?: (rowSelection: RowSelectionState) => void;
   enableRowSelection?: boolean | ((row: Row<TData>) => boolean);
@@ -122,6 +128,7 @@ export function DataTable<TData extends TBaseData>({
   rowSelection,
   setRowSelection,
   enableRowSelection = false,
+  getRowId,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -191,6 +198,7 @@ export function DataTable<TData extends TBaseData>({
     },
     onPaginationChange,
     enableRowSelection,
+    getRowId,
   });
 
   useEffect(() => {
@@ -320,6 +328,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
   rowSelection,
   setRowSelection,
   enableRowSelection,
+  getRowId,
 }: ScrollableDataTableProps<TData>) {
   const windowSize = useWindowSize();
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -368,6 +377,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
       ...(enableRowSelection && { rowSelection }),
     },
     enableRowSelection,
+    getRowId,
   });
 
   useEffect(() => {

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -8,6 +8,7 @@ export {
 export { AttachmentChip } from "./AttachmentChip";
 export { Avatar } from "./Avatar";
 export { BarHeader } from "./BarHeader";
+export type { BreadcrumbItem } from "./Breadcrumbs";
 export { Breadcrumbs } from "./Breadcrumbs";
 export type {
   ButtonProps,

--- a/sparkle/src/stories/Breadcrumbs.stories.tsx
+++ b/sparkle/src/stories/Breadcrumbs.stories.tsx
@@ -18,7 +18,7 @@ export default meta;
 export const BreadcrumbsExample = () => {
   const items1 = [
     { label: "Home", href: "#", icon: HomeIcon },
-    { label: "Spaces", href: ".." },
+    { label: "Spaces", onClick: () => alert("Spaces clicked!") },
     { label: "My Space" },
   ];
   const items2 = [

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -633,6 +633,7 @@ export const DataTableWithRowSelectionExample = () => {
           rowSelection={rowSelection}
           setRowSelection={setRowSelection}
           enableRowSelection={true}
+          getRowId={(row) => row.name}
         />
 
         <div className="s-rounded-md s-border s-bg-muted/50 s-p-2">


### PR DESCRIPTION
## Description

This PR introduces two enhancements to `sparkle` components:
- Adds support for custom row identifiers in `DataTable` components through a new getRowId prop, enabling more flexible row management and selection features 
- Extends the `Breadcrumbs` component to support button-type items alongside existing link and label types, allowing non-navigation actions within breadcrumb trails. The implementation also includes UI improvements with simplified separator icons and better type-checking

## Risk

Low

## Deploy Plan

Publish sparkle