### PR TITLE
[front] mcp(validation): tool permission setup UI

### DIFF
--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -28,7 +28,12 @@ export function MCPServerDetailsInfo({
           onSave={onFormSave}
         />
       )}
-      <ToolsList tools={mcpServer.tools} />
+      <ToolsList
+        owner={owner}
+        tools={mcpServer.tools}
+        serverType={serverType}
+        serverId={mcpServer.id}
+      />
     </div>
   );
 }

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -1,29 +1,128 @@
-import { Page } from "@dust-tt/sparkle";
+import { DEFAULT_MCP_TOOL_STAKE_LEVEL, MCP_TOOL_STAKE_LEVEL_TYPE, MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import {
+  useMCPServerToolsPermissions,
+  useUpdateMCPServerToolsPermissions,
+} from "@app/lib/swr/mcp_servers";
+import { LightWorkspaceType } from "@app/types";
+import {
+  BookOpenIcon,
+  Button,
+  CheckCircleIcon,
+  ContentMessage,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  ExclamationCircleIcon,
+  Page,
+} from "@dust-tt/sparkle";
 
 export function ToolsList({
+  owner,
   tools,
+  serverType,
+  serverId,
 }: {
+  owner: LightWorkspaceType;
   tools: { name: string; description: string }[];
+  serverType: "remote" | "internal";
+  serverId: string;
 }) {
+  const { toolsPermissions } = useMCPServerToolsPermissions({
+    owner,
+    serverId,
+  });
+
+  const { updateToolPermission } = useUpdateMCPServerToolsPermissions({
+    owner,
+    serverId,
+  });
+
+  const handleClick = (
+    name: string,
+    permission: MCPToolStakeLevelType
+  ) => {
+    void updateToolPermission({
+      toolName: name,
+      permission,
+    });
+  };
+
   return (
     <div className="mb-2 flex w-full flex-col gap-y-2 pt-2">
       <Page.SectionHeader title="Available Tools" />
+      {serverType === "remote" && (
+        <ContentMessage icon={BookOpenIcon} title="Tools">
+          <p className="text-sm">
+            Please set the tool permissions for this action.
+          </p>
+          <p>
+            A Low stake operation will allow the model to use the tool directly,
+            while a High stake operation needs particular attention, and asks
+            the user for confirmation before letting the model use the tool.
+          </p>
+        </ContentMessage>
+      )}
       <div className="space-y-4 rounded-md border p-4">
         {tools && tools.length > 0 ? (
           tools.map(
-            (tool: { name: string; description: string }, index: number) => (
-              <div
-                key={index}
-                className="border-b pb-4 last:border-b-0 last:pb-0"
-              >
-                <h4 className="text-sm font-medium">{tool.name}</h4>
-                {tool.description && (
-                  <p className="mt-1 text-xs text-gray-500">
-                    {tool.description}
-                  </p>
-                )}
-              </div>
-            )
+            (tool: { name: string; description: string }, index: number) => {
+              const toolPermission = toolsPermissions[tool.name]
+                ? toolsPermissions[tool.name]
+                : DEFAULT_MCP_TOOL_STAKE_LEVEL;
+              return (
+                <div
+                  key={index}
+                  className="border-b pb-4 last:border-b-0 last:pb-0"
+                >
+                  <div className="flex items-center">
+                    <h4 className="flex-grow text-sm font-medium">
+                      {tool.name}
+                    </h4>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        disabled={serverType === "internal"}
+                        asChild
+                      >
+                        <Button
+                          className="capitalize"
+                          variant="outline"
+                          label={`${toolPermission} stake`}
+                          icon={
+                            toolPermission === DEFAULT_MCP_TOOL_STAKE_LEVEL
+                              ? ExclamationCircleIcon
+                              : CheckCircleIcon
+                      }
+                          isSelect
+                        />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        {MCP_TOOL_STAKE_LEVEL_TYPE.map((permission) => (
+                          <DropdownMenuItem
+                            key={permission}
+                            className="capitalize"
+                            label={`${permission} stake`}
+                            icon={
+                              permission === DEFAULT_MCP_TOOL_STAKE_LEVEL
+                                ? ExclamationCircleIcon
+                                : CheckCircleIcon
+                            }
+                            onClick={() => {
+                              handleClick(tool.name, permission);
+                            }}
+                          />
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                  {tool.description && (
+                    <p className="mt-1 text-xs text-gray-500">
+                      {tool.description}
+                    </p>
+                  )}
+                </div>
+              );
+            }
           )
         ) : (
           <p className="text-sm text-gray-500">No tools available</p>

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -1,9 +1,3 @@
-import { DEFAULT_MCP_TOOL_STAKE_LEVEL, MCP_TOOL_STAKE_LEVEL_TYPE, MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import {
-  useMCPServerToolsPermissions,
-  useUpdateMCPServerToolsPermissions,
-} from "@app/lib/swr/mcp_servers";
-import { LightWorkspaceType } from "@app/types";
 import {
   BookOpenIcon,
   Button,
@@ -16,6 +10,17 @@ import {
   ExclamationCircleIcon,
   Page,
 } from "@dust-tt/sparkle";
+
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import {
+  DEFAULT_MCP_TOOL_STAKE_LEVEL,
+  MCP_TOOL_STAKE_LEVEL_TYPE,
+} from "@app/lib/actions/constants";
+import {
+  useMCPServerToolsPermissions,
+  useUpdateMCPServerToolsPermissions,
+} from "@app/lib/swr/mcp_servers";
+import type { LightWorkspaceType } from "@app/types";
 
 export function ToolsList({
   owner,
@@ -38,10 +43,7 @@ export function ToolsList({
     serverId,
   });
 
-  const handleClick = (
-    name: string,
-    permission: MCPToolStakeLevelType
-  ) => {
+  const handleClick = (name: string, permission: MCPToolStakeLevelType) => {
     void updateToolPermission({
       toolName: name,
       permission,
@@ -92,7 +94,7 @@ export function ToolsList({
                             toolPermission === DEFAULT_MCP_TOOL_STAKE_LEVEL
                               ? ExclamationCircleIcon
                               : CheckCircleIcon
-                      }
+                          }
                           isSelect
                         />
                       </DropdownMenuTrigger>

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -14,7 +14,7 @@ import {
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   DEFAULT_MCP_TOOL_STAKE_LEVEL,
-  MCP_TOOL_STAKE_LEVEL_TYPE,
+  MCP_TOOL_STAKE_LEVELS,
 } from "@app/lib/actions/constants";
 import {
   useMCPServerToolsPermissions,
@@ -99,7 +99,7 @@ export function ToolsList({
                         />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent>
-                        {MCP_TOOL_STAKE_LEVEL_TYPE.map((permission) => (
+                        {MCP_TOOL_STAKE_LEVELS.map((permission) => (
                           <DropdownMenuItem
                             key={permission}
                             className="capitalize"

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -81,41 +81,40 @@ export function ToolsList({
                     <h4 className="flex-grow text-sm font-medium">
                       {tool.name}
                     </h4>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger
-                        disabled={serverType === "internal"}
-                        asChild
-                      >
-                        <Button
-                          className="capitalize"
-                          variant="outline"
-                          label={`${toolPermission} stake`}
-                          icon={
-                            toolPermission === DEFAULT_MCP_TOOL_STAKE_LEVEL
-                              ? ExclamationCircleIcon
-                              : CheckCircleIcon
-                          }
-                          isSelect
-                        />
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent>
-                        {MCP_TOOL_STAKE_LEVELS.map((permission) => (
-                          <DropdownMenuItem
-                            key={permission}
+                    {serverType === "remote" && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
                             className="capitalize"
-                            label={`${permission} stake`}
+                            variant="outline"
+                            label={`${toolPermission} stake`}
                             icon={
-                              permission === DEFAULT_MCP_TOOL_STAKE_LEVEL
+                              toolPermission === DEFAULT_MCP_TOOL_STAKE_LEVEL
                                 ? ExclamationCircleIcon
                                 : CheckCircleIcon
                             }
-                            onClick={() => {
-                              handleClick(tool.name, permission);
-                            }}
+                            isSelect
                           />
-                        ))}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent>
+                          {MCP_TOOL_STAKE_LEVELS.map((permission) => (
+                            <DropdownMenuItem
+                              key={permission}
+                              className="capitalize"
+                              label={`${permission} stake`}
+                              icon={
+                                permission === DEFAULT_MCP_TOOL_STAKE_LEVEL
+                                  ? ExclamationCircleIcon
+                                  : CheckCircleIcon
+                              }
+                              onClick={() => {
+                                handleClick(tool.name, permission);
+                              }}
+                            />
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
                   </div>
                   {tool.description && (
                     <p className="mt-1 text-xs text-gray-500">

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -51,5 +51,5 @@ export const DEFAULT_MCP_ACTION_DESCRIPTION =
 export const DEFAULT_MCP_ACTION_ICON = "command";
 
 export const MCP_TOOL_STAKE_LEVEL_TYPE = ["high", "low"] as const;
-export type MCPToolStakeLevelType = typeof MCP_TOOL_STAKE_LEVEL_TYPE[number];
+export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVEL_TYPE)[number];
 export const DEFAULT_MCP_TOOL_STAKE_LEVEL: MCPToolStakeLevelType = "high";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -50,6 +50,6 @@ export const DEFAULT_MCP_ACTION_DESCRIPTION =
   "Call a tool to answer a question.";
 export const DEFAULT_MCP_ACTION_ICON = "command";
 
-export const MCP_TOOL_STAKE_LEVEL_TYPE = ["high", "low"] as const;
-export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVEL_TYPE)[number];
+export const MCP_TOOL_STAKE_LEVELS = ["high", "low"] as const;
+export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVELS)[number];
 export const DEFAULT_MCP_TOOL_STAKE_LEVEL: MCPToolStakeLevelType = "high";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -49,3 +49,7 @@ export const DEFAULT_MCP_ACTION_VERSION = "1.0.0";
 export const DEFAULT_MCP_ACTION_DESCRIPTION =
   "Call a tool to answer a question.";
 export const DEFAULT_MCP_ACTION_ICON = "command";
+
+export const MCP_TOOL_STAKE_LEVEL_TYPE = ["high", "low"] as const;
+export type MCPToolStakeLevelType = typeof MCP_TOOL_STAKE_LEVEL_TYPE[number];
+export const DEFAULT_MCP_TOOL_STAKE_LEVEL: MCPToolStakeLevelType = "high";

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -34,8 +34,6 @@ export type AuthorizationInfo = {
   use_case: OAuthUseCase;
 };
 
-export type MCPToolPermissionLevelType = "high" | "low";
-
 async function getAccessTokenForRemoteMCPServer(
   auth: Authenticator,
   remoteMCPServer: RemoteMCPServerResource

--- a/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { MCPToolStakeLevelType } from "@app/lib/actions/mcp_metadata";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";

--- a/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { MCPToolPermissionLevelType } from "@app/lib/actions/mcp_metadata";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/mcp_metadata";
 import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -12,7 +12,7 @@ export class RemoteMCPServerToolMetadataModel extends WorkspaceAwareModel<Remote
 
   declare remoteMCPServerId: ForeignKey<RemoteMCPServerModel["id"]>;
   declare toolName: string;
-  declare permission: MCPToolPermissionLevelType;
+  declare permission: MCPToolStakeLevelType;
 }
 
 RemoteMCPServerToolMetadataModel.init(

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -141,14 +141,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     assert(
       systemSpace.canWrite(auth),
       "The user is not authorized to update a tool metadata"
-    );
-
-    console.log(
-      "Updating or creating tool metadata",
-      serverId,
-      toolName,
-      permission
-    );
+    );gs
 
     const toolMetadata = await this.fetchByServerIdAndToolName(auth, {
       serverId,

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -143,21 +143,14 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
       "The user is not authorized to update a tool metadata"
     );
 
-    const toolMetadata = await this.fetchByServerIdAndToolName(auth, {
-      serverId,
+    const [toolMetadata] = await this.model.upsert({
+      remoteMCPServerId: serverId,
       toolName,
+      permission,
+      workspaceId: auth.getNonNullableWorkspace().id,
     });
-    if (toolMetadata) {
-      await toolMetadata.update({
-        permission,
-      });
-    } else {
-      await this.makeNew(auth, {
-        remoteMCPServerId: serverId,
-        toolName,
-        permission,
-      });
-    }
+
+    return new this(this.model, toolMetadata.get());
   }
 
   // Delete

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -141,7 +141,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     assert(
       systemSpace.canWrite(auth),
       "The user is not authorized to update a tool metadata"
-    );gs
+    );
 
     const toolMetadata = await this.fetchByServerIdAndToolName(auth, {
       serverId,

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -6,7 +6,7 @@ import type {
   Transaction,
 } from "sequelize";
 
-import type { MCPToolPermissionLevelType } from "@app/lib/actions/mcp_metadata";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/assistant/actions/remote_mcp_server_tool_metadata";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -14,7 +14,14 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
+import { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
+export interface RemoteMCPServerToolMetadataResource
+  extends ReadonlyAttributesType<RemoteMCPServerToolMetadataModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPServerToolMetadataModel> {
   static model: ModelStatic<RemoteMCPServerToolMetadataModel> =
     RemoteMCPServerToolMetadataModel;
@@ -39,7 +46,13 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
       "The user is not authorized to create a tool metadata"
     );
 
-    const toolMetadata = await this.model.create(blob, { transaction });
+    const toolMetadata = await this.model.create(
+      {
+        ...blob,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      { transaction }
+    );
 
     return new this(RemoteMCPServerToolMetadataModel, toolMetadata.get());
   }
@@ -73,7 +86,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
 
   static async fetchByServerId(
     auth: Authenticator,
-    serverId: string,
+    serverId: number,
     options?: ResourceFindOptions<RemoteMCPServerToolMetadataModel>
   ): Promise<RemoteMCPServerToolMetadataResource[]> {
     return this.baseFetch(auth, {
@@ -90,7 +103,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
       serverId,
       toolName,
     }: {
-      serverId: string;
+      serverId: number;
       toolName: string;
     },
     options?: ResourceFindOptions<RemoteMCPServerToolMetadataModel>
@@ -112,9 +125,17 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
 
   // Update
 
-  async setPermission(
+  static async updateOrCreatePermission(
     auth: Authenticator,
-    permission: MCPToolPermissionLevelType
+    {
+      serverId,
+      toolName,
+      permission,
+    }: {
+      serverId: number;
+      toolName: string;
+      permission: MCPToolStakeLevelType;
+    }
   ) {
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
     assert(
@@ -122,9 +143,28 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
       "The user is not authorized to update a tool metadata"
     );
 
-    await this.update({
-      permission,
+    console.log(
+      "Updating or creating tool metadata",
+      serverId,
+      toolName,
+      permission
+    );
+
+    const toolMetadata = await this.fetchByServerIdAndToolName(auth, {
+      serverId,
+      toolName,
     });
+    if (toolMetadata) {
+      toolMetadata.update({
+        permission,
+      });
+    } else {
+      await this.makeNew(auth, {
+        remoteMCPServerId: serverId,
+        toolName,
+        permission,
+      });
+    }
   }
 
   // Delete
@@ -152,5 +192,19 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     }
 
     return new Ok(result);
+  }
+
+  // toJSON
+
+  toJSON(): {
+    remoteMCPServerId: number;
+    toolName: string;
+    permission: MCPToolStakeLevelType;
+  } {
+    return {
+      remoteMCPServerId: this.remoteMCPServerId,
+      toolName: this.toolName,
+      permission: this.permission,
+    };
   }
 }

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -11,10 +11,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/assistant/actions/remote_mcp_server_tool_metadata";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -155,7 +155,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
       toolName,
     });
     if (toolMetadata) {
-      toolMetadata.update({
+      await toolMetadata.update({
         permission,
       });
     } else {

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -13,13 +13,13 @@ import type {
   PatchMCPServerResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/[serverId]";
 import type { SyncMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/sync";
+import type { GetMCPServerToolsPermissionsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools";
+import type { PatchMCPServerToolsPermissionsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]";
 import type {
   GetConnectionsResponseBody,
   PostConnectionResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/connections";
 import type { LightWorkspaceType } from "@app/types";
-import { GetMCPServerToolsPermissionsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools";
-import { PatchMCPServerToolsPermissionsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]";
 
 /**
  * Hook to fetch a specific remote MCP server by ID

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -430,6 +430,8 @@ export function useUpdateMCPServerToolsPermissions({
     serverId,
   });
 
+  const sendNotification = useSendNotification();
+
   const updateToolPermission = async ({
     toolName,
     permission,
@@ -448,11 +450,16 @@ export function useUpdateMCPServerToolsPermissions({
 
     if (!response.ok) {
       const error = await response.json();
-      console.log(error);
       throw new Error(
         error.api_error?.message || "Failed to update permission"
       );
     }
+
+    sendNotification({
+      type: "success",
+      title: "Permission updated",
+      description: `The permission for ${toolName} has been updated.`,
+    });
 
     await mutateToolsPermissions();
     return response.json();

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -1,13 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { Authenticator } from "@app/lib/auth";
-import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/assistant/actions/remote_mcp_server_tool_metadata";
+import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { apiError } from "@app/logger/withlogging";
-import { WithAPIErrorResponse } from "@app/types";
-import { de } from "@faker-js/faker";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { WithAPIErrorResponse } from "@app/types";
+import { assertNever } from "@app/types";
 
 export type PatchMCPServerToolsPermissionsResponseBody = {
   success: boolean;
@@ -89,15 +89,18 @@ async function handler(
           return res.status(200).json({ success: true });
         }
         default:
-          return apiError(req, res, {
-            status_code: 405,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Method not allowed.",
-            },
-          });
+          assertNever(serverType);
       }
+      break;
     }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, PATCH expected.",
+        },
+      });
   }
 }
 

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -1,0 +1,104 @@
+import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/assistant/actions/remote_mcp_server_tool_metadata";
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { apiError } from "@app/logger/withlogging";
+import { WithAPIErrorResponse } from "@app/types";
+import { de } from "@faker-js/faker";
+import { NextApiRequest, NextApiResponse } from "next";
+
+export type PatchMCPServerToolsPermissionsResponseBody = {
+  success: boolean;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PatchMCPServerToolsPermissionsResponseBody>
+  >,
+  auth: Authenticator
+) {
+  const { serverId, toolName } = req.query;
+
+  if (typeof serverId !== "string" || typeof toolName !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "mcp_auth_error",
+        message:
+          "You are not authorized to make request to inspect an MCP server.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "PATCH": {
+      const { serverType, id } = getServerTypeAndIdFromSId(serverId);
+      if (!id) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid server ID.",
+          },
+        });
+      }
+
+      switch (serverType) {
+        case "internal":
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Internal MCP server does not support editing tool permissions.",
+            },
+          });
+        case "remote": {
+          const { permission } = req.body;
+          if (!permission) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Permission is required.",
+              },
+            });
+          }
+
+          await RemoteMCPServerToolMetadataResource.updateOrCreatePermission(
+            auth,
+            {
+              serverId: id,
+              toolName,
+              permission: permission as MCPToolStakeLevelType,
+            }
+          );
+          return res.status(200).json({ success: true });
+        }
+        default:
+          return apiError(req, res, {
+            status_code: 405,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Method not allowed.",
+            },
+          });
+      }
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/index.ts
@@ -1,12 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { apiError } from "@app/logger/withlogging";
-import { assertNever, WithAPIErrorResponse } from "@app/types";
-import { NextApiRequest, NextApiResponse } from "next";
-import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import type { WithAPIErrorResponse } from "@app/types";
+import { assertNever } from "@app/types";
 
 export type GetMCPServerToolsPermissionsResponseBody = {
   permissions: {
@@ -68,6 +69,7 @@ async function handler(
         default:
           assertNever(serverType);
       }
+      break;
     }
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/index.ts
@@ -1,0 +1,82 @@
+import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { apiError } from "@app/logger/withlogging";
+import { assertNever, WithAPIErrorResponse } from "@app/types";
+import { NextApiRequest, NextApiResponse } from "next";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+
+export type GetMCPServerToolsPermissionsResponseBody = {
+  permissions: {
+    [toolId: string]: MCPToolStakeLevelType;
+  };
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetMCPServerToolsPermissionsResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { serverId } = req.query;
+
+  if (typeof serverId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "mcp_auth_error",
+        message:
+          "You are not authorized to make request to inspect an MCP server.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { serverType, id } = getServerTypeAndIdFromSId(serverId);
+      switch (serverType) {
+        case "internal":
+          return res.status(200).json({ permissions: {} });
+        case "remote":
+          const resources =
+            await RemoteMCPServerToolMetadataResource.fetchByServerId(auth, id);
+
+          const permissions = resources.reduce(
+            (acc: { [key: string]: MCPToolStakeLevelType }, resource) => {
+              acc[resource.toolName] = resource.permission;
+              return acc;
+            },
+            {}
+          );
+
+          return res.status(200).json({
+            permissions,
+          });
+        default:
+          assertNever(serverType);
+      }
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET expected.",
+        },
+      });
+  }
+}
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

For full context see https://dust4ai.slack.com/archives/C050SM8NSPK/p1744121273716959?thread_ts=1744038871.356409&cid=C050SM8NSPK _TLDR :_

An Admin sets "high stake" or "low stake" for each tool of each action. All actions will default to high stake for security reason.
If stake is high :
- user can choose between approve or reject execution

If stake is low :
- user can choose between approve / approve and don't ask again / reject
- user can click on a button in the profile submenu (in the bottom left), like "reset action approvals" to delete the approval metadata

_This PR aims at creating the UI allowing the admin to set a tool as high or low stake_

- This only concerns remote servers for now.
- Internal servers will come later when I settle on an implementation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Not used, behind ff.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.