### PR TITLE
[front] fix(mcp/request): Filter out actions that are in company data

### DIFF
--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -31,18 +31,25 @@ async function handler(
     case "GET": {
       const workspaceServerViews =
         await MCPServerViewResource.listByWorkspace(auth);
+
       const spaceServerViews = await MCPServerViewResource.listBySpace(
         auth,
         space
       );
 
       const serverViews = _.uniqBy(
-        _.differenceWith(workspaceServerViews, spaceServerViews, (a, b) => {
-          return (
-            (a.internalMCPServerId ?? a.remoteMCPServerId) ===
-            (b.internalMCPServerId ?? b.remoteMCPServerId)
-          );
-        }),
+        _.differenceWith(
+          workspaceServerViews.filter(
+            (s) => s.space.kind !== "global" && s.space.kind !== "system"
+          ),
+          spaceServerViews,
+          (a, b) => {
+            return (
+              (a.internalMCPServerId ?? a.remoteMCPServerId) ===
+              (b.internalMCPServerId ?? b.remoteMCPServerId)
+            );
+          }
+        ),
         (s) => s.internalMCPServerId ?? s.remoteMCPServerId
       );
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -37,19 +37,25 @@ async function handler(
         space
       );
 
+      const nonCompanyDataServerViews = workspaceServerViews.filter(
+        (s) => s.space.kind !== "global" && s.space.kind !== "system"
+      );
+
+      // We get the actions that aren't activated in Company Data and not in the space making the request
+      const serverViewsNotActivated = _.differenceWith(
+        nonCompanyDataServerViews,
+        spaceServerViews,
+        (a, b) => {
+          return (
+            (a.internalMCPServerId ?? a.remoteMCPServerId) ===
+            (b.internalMCPServerId ?? b.remoteMCPServerId)
+          );
+        }
+      );
+
+      // We can have duplicate because some actions can be activated in many spaces
       const serverViews = _.uniqBy(
-        _.differenceWith(
-          workspaceServerViews.filter(
-            (s) => s.space.kind !== "global" && s.space.kind !== "system"
-          ),
-          spaceServerViews,
-          (a, b) => {
-            return (
-              (a.internalMCPServerId ?? a.remoteMCPServerId) ===
-              (b.internalMCPServerId ?? b.remoteMCPServerId)
-            );
-          }
-        ),
+        serverViewsNotActivated,
         (s) => s.internalMCPServerId ?? s.remoteMCPServerId
       );
 


### PR DESCRIPTION
## Description
- Fix https://github.com/dust-tt/tasks/issues/2602
- we were showing all the actions not activated for the given space, and we're supposed to only show actions not activated for the space that also are not in Company Data (as they cannot be added in Company Data AND in the specific space)

## Tests
- Locally test that my non admin user can request actions that is activated only for a specific spaces (all actions activated in Company Data are not in the options)

## Risk
Showing less actions that they be getting.

## Deploy Plan
Deploy on front.
