### PR TITLE
Fix initial builder state when editing an agent with MCP actions

### DIFF
--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -21,7 +21,10 @@ import type {
   DataSourceConfiguration,
   RetrievalConfigurationType,
 } from "@app/lib/actions/retrieval";
-import type { TablesQueryConfigurationType } from "@app/lib/actions/tables_query";
+import {
+  TableDataSourceConfiguration,
+  TablesQueryConfigurationType,
+} from "@app/lib/actions/tables_query";
 import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import {
   isBrowseConfiguration,
@@ -249,10 +252,19 @@ async function getMCPServerActionConfiguration(
 
   builderAction.configuration.dataSourceConfigurations = action.dataSources
     ? await renderDataSourcesConfigurations(
-        { ...action, dataSources: action.dataSources }, // overriding to satisfy the typing
+        { ...action, dataSources: action.dataSources }, // repeating action.dataSources to satisfy the typing
         dataSourceViews
       )
     : null;
+
+  builderAction.configuration.tablesConfigurations = action.tables
+    ? await renderTableDataSourcesConfigurations(
+        { ...action, tables: action.tables },
+        dataSourceViews
+      )
+    : null;
+
+  builderAction.configuration.childAgentId = action.childAgentId;
 
   return builderAction;
 }
@@ -345,7 +357,9 @@ async function renderDataSourcesConfigurations(
 }
 
 async function renderTableDataSourcesConfigurations(
-  action: TablesQueryConfigurationType,
+  action:
+    | TablesQueryConfigurationType
+    | (MCPServerConfigurationType & { tables: TableDataSourceConfiguration[] }),
   dataSourceViews: DataSourceViewResource[]
 ): Promise<DataSourceViewSelectionConfigurations> {
   const selectedResources = action.tables.map((table) => ({

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -21,7 +21,7 @@ import type {
   DataSourceConfiguration,
   RetrievalConfigurationType,
 } from "@app/lib/actions/retrieval";
-import {
+import type {
   TableDataSourceConfiguration,
   TablesQueryConfigurationType,
 } from "@app/lib/actions/tables_query";


### PR DESCRIPTION
## Description

- The initial state of the `AssistantBuilder` currently did not load the existing table and child Agent configuration.
- This PR fixes the initial builder state when editing an agent with MCP actions.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.