### PR TITLE
[front] - feat(search): support filtering content nodes by parent ID

### DIFF
--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -256,12 +256,14 @@ export async function searchContenNodesInSpace(
     options,
     query,
     viewType,
+    parentId,
   }: {
     excludedNodeMimeTypes: readonly string[];
     includeDataSources: boolean;
     options: CoreAPISearchOptions;
     query: string;
     viewType: ContentNodesViewType;
+    parentId?: string;
   }
 ): Promise<
   Result<
@@ -287,6 +289,7 @@ export async function searchContenNodesInSpace(
       excludedNodeMimeTypes,
       includeDataSources,
       viewType,
+      parentId,
     }
   );
 

--- a/front/lib/search.ts
+++ b/front/lib/search.ts
@@ -55,11 +55,13 @@ export function getSearchFilterFromDataSourceViews(
     includeDataSources,
     viewType,
     nodeIds,
+    parentId,
   }: {
     excludedNodeMimeTypes: readonly string[];
     includeDataSources: boolean;
     viewType: ContentNodesViewType;
     nodeIds?: string[];
+    parentId?: string;
   }
 ) {
   const groupedPerDataSource = dataSourceViews.reduce(
@@ -113,5 +115,6 @@ export function getSearchFilterFromDataSourceViews(
     excluded_node_mime_types: excludedNodeMimeTypes,
     node_types: getCoreViewTypeFilter(viewType),
     node_ids: nodeIds,
+    ...(parentId && { parent_id: parentId }),
   };
 }

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -615,6 +615,7 @@ export function useSpaceSearch({
   space,
   viewType,
   pagination,
+  parentId,
 }: {
   dataSourceViews: DataSourceViewType[];
   disabled?: boolean;
@@ -625,6 +626,7 @@ export function useSpaceSearch({
   viewType: ContentNodesViewType;
   warningCode?: SearchWarningCode;
   pagination?: CursorPaginationParams;
+  parentId?: string;
 }): {
   isSearchLoading: boolean;
   isSearchError: boolean;
@@ -649,11 +651,12 @@ export function useSpaceSearch({
     limit: pagination?.limit ?? DEFAULT_SEARCH_LIMIT,
     query: search,
     viewType,
+    parentId,
   };
 
   // Only perform a query if we have a valid search.
   const url =
-    search.length >= MIN_SEARCH_QUERY_SIZE
+    search.length >= MIN_SEARCH_QUERY_SIZE || parentId
       ? `/api/w/${owner.sId}/spaces/${space.sId}/search?${params}`
       : null;
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -33,6 +33,7 @@ const SearchRequestBody = t.type({
   ]),
   includeDataSources: t.boolean,
   limit: t.number,
+  parentId: t.union([t.undefined, t.string]),
 });
 export type PostSpaceSearchRequestBody = t.TypeOf<typeof SearchRequestBody>;
 
@@ -82,7 +83,7 @@ async function handler(
     });
   }
 
-  const { dataSourceViewIds, includeDataSources, query, viewType } =
+  const { dataSourceViewIds, includeDataSources, query, viewType, parentId } =
     bodyValidation.right;
 
   // If no data source views are provided, use all data source views in the space.
@@ -91,7 +92,7 @@ async function handler(
       ? await DataSourceViewResource.listBySpace(auth, space)
       : await DataSourceViewResource.fetchByIds(auth, dataSourceViewIds);
 
-  if (query.length < MIN_SEARCH_QUERY_SIZE) {
+  if (query.length < MIN_SEARCH_QUERY_SIZE && !parentId) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -134,6 +135,7 @@ async function handler(
       },
       query,
       viewType,
+      parentId,
     }
   );
 


### PR DESCRIPTION
## Description

This PR update the `/w/[wId]/spaces/[spaceId]/search` endpoint to support filter nodes by `parent_id`.

This is required to build a new data source selection experience within the assistant builder. One will be able to search, traverse (and search within nodes). This aims at replicating the current "Knowledge" experience.

## Tests

Tested locally 

## Risk

It adds an optional parameter, so shouldn't break anything as this is not being used anywhere yet.

## Deploy Plan

- Deploy front
