### PR TITLE
[front] feat(top-nav): Use href instead of router to navigate

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -86,11 +86,7 @@ export const NavigationSidebar = React.forwardRef<
                     label={tab.hideLabel ? undefined : tab.label}
                     tooltip={tab.hideLabel ? tab.label : undefined}
                     icon={tab.icon}
-                    onClick={() => {
-                      if (tab.href) {
-                        void router.push(tab.href);
-                      }
-                    }}
+                    href={tab.href}
                   />
                 ))}
               </TabsList>


### PR DESCRIPTION
## Description
Using onClick for that use cases is not great accessbility wise, also it's not using Link, which robs us of prefetch which can make navigation a bit faster (when possible on the main pages)

## Tests
Locally & front-edge navigate to pages

## Risk
Almost none, but worst case links in the top nav bar would just stop working.

## Deploy Plan
Deploy on front
