### PR TITLE
fix: move theme provider to RootLayout

### DIFF
--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -9,6 +9,7 @@ import type { UrlObject } from "url";
 
 import { ConfirmPopupArea } from "@app/components/Confirm";
 import { SidebarProvider } from "@app/components/sparkle/SidebarContext";
+import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
 import { isAPIErrorResponse } from "@app/types";
 
 function NextLinkWrapper({
@@ -74,27 +75,29 @@ export default function RootLayout({
 
   return (
     <SparkleContext.Provider value={{ components: { link: NextLinkWrapper } }}>
-      <SWRConfig
-        value={{
-          onError: async (error) => {
-            if (
-              isAPIErrorResponse(error) &&
-              error.error.type === "not_authenticated"
-            ) {
-              // Redirect to login page.
-              await router.push("/api/auth/login");
-            }
-          },
-        }}
-      >
-        <UserProvider>
-          <SidebarProvider>
-            <ConfirmPopupArea>
-              <Notification.Area>{children}</Notification.Area>
-            </ConfirmPopupArea>
-          </SidebarProvider>
-        </UserProvider>
-      </SWRConfig>
+      <ThemeProvider>
+        <SWRConfig
+          value={{
+            onError: async (error) => {
+              if (
+                isAPIErrorResponse(error) &&
+                error.error.type === "not_authenticated"
+              ) {
+                // Redirect to login page.
+                await router.push("/api/auth/login");
+              }
+            },
+          }}
+        >
+          <UserProvider>
+            <SidebarProvider>
+              <ConfirmPopupArea>
+                <Notification.Area>{children}</Notification.Area>
+              </ConfirmPopupArea>
+            </SidebarProvider>
+          </UserProvider>
+        </SWRConfig>
+      </ThemeProvider>
     </SparkleContext.Provider>
   );
 }

--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -2,7 +2,6 @@ import Head from "next/head";
 import React from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
-import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { usePokeRegion } from "@app/lib/swr/poke";
 
@@ -18,12 +17,12 @@ export default function PokeLayout({
   title: string;
 }) {
   return (
-    <ThemeProvider>
+    <>
       <Head>
         <title>{"Poke - " + title}</title>
       </Head>
       <PokeLayoutContent>{children}</PokeLayoutContent>
-    </ThemeProvider>
+    </>
   );
 }
 

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -82,7 +82,7 @@ export default function AppLayout({
   }, [user?.email, user?.fullName, user?.sId]);
 
   return (
-    <ThemeProvider>
+    <>
       <Head>
         <title>{pageTitle ? pageTitle : `Dust - ${owner.name}`}</title>
         <link rel="shortcut icon" href="/static/favicon.png" />
@@ -196,6 +196,6 @@ export default function AppLayout({
               })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
             `}
       </Script>
-    </ThemeProvider>
+    </>
   );
 }

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -8,7 +8,6 @@ import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/con
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import { Navigation } from "@app/components/navigation/Navigation";
 import { QuickStartGuide } from "@app/components/QuickStartGuide";
-import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
 import { useUser } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is to prevent re-initializing theme provider on every page navigation (you can see [the video](https://dust.tt/w/0ec9852c2f/assistant/iOlVN5dNS2) reported by Edo). Right now we remount AppLayout on every page navigation (which is another problem), thus remounting Theme provider, we always see the flickering if you have dark theme. 

⚠️ This won't fix the flickering on the initial page load when you use dark theme. If I understand it correctly we need to inject script and apply class (like Seb checked https://dust.tt/w/0ec9852c2f/assistant/iOlVN5dNS2) I will do it another PR. 


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
- Checked nothing broken and worked in App and Poke, and nothing breaks in Landing (is there anything else I should check?)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Feels low, the worst case you will only have light theme

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
