### PR TITLE
feat(MCP): add additionalConfiguration column to MCP server configuration

### DIFF
--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -266,6 +266,9 @@ async function getMCPServerActionConfiguration(
 
   builderAction.configuration.childAgentId = action.childAgentId;
 
+  builderAction.configuration.additionalConfiguration =
+    action.additionalConfiguration;
+
   return builderAction;
 }
 

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -201,6 +201,7 @@ export async function submitAssistantBuilderForm({
             tablesConfigurations,
             dataSourceConfigurations,
             childAgentId,
+            additionalConfiguration,
           },
         } = a;
         return [
@@ -216,6 +217,7 @@ export async function submitAssistantBuilderForm({
               ? processTableSelection({ owner, tablesConfigurations })
               : null,
             childAgentId,
+            additionalConfiguration,
           },
         ];
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -1,6 +1,7 @@
 import { CircleIcon, SquareIcon, TriangleIcon } from "@dust-tt/sparkle";
 import { uniqueId } from "lodash";
-import type React, { SVGProps } from "react";
+import type { SVGProps } from "react";
+import type React from "react";
 
 import {
   DEFAULT_MCP_ACTION_DESCRIPTION,
@@ -129,7 +130,7 @@ export type AssistantBuilderMCPServerConfiguration = {
   dataSourceConfigurations: DataSourceViewSelectionConfigurations | null;
   tablesConfigurations: DataSourceViewSelectionConfigurations | null;
   childAgentId: string | null;
-  additionalConfiguration: Record<string, boolean | string | null>;
+  additionalConfiguration: Record<string, boolean>;
 };
 
 // Builder State

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -130,7 +130,7 @@ export type AssistantBuilderMCPServerConfiguration = {
   dataSourceConfigurations: DataSourceViewSelectionConfigurations | null;
   tablesConfigurations: DataSourceViewSelectionConfigurations | null;
   childAgentId: string | null;
-  additionalConfiguration: Record<string, boolean>;
+  additionalConfiguration: Record<string, boolean | number | string | null>;
 };
 
 // Builder State

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -130,6 +130,7 @@ export type AssistantBuilderMCPServerConfiguration = {
   dataSourceConfigurations: DataSourceViewSelectionConfigurations | null;
   tablesConfigurations: DataSourceViewSelectionConfigurations | null;
   childAgentId: string | null;
+  additionalConfiguration: Record<string, boolean>;
 };
 
 // Builder State
@@ -369,6 +370,7 @@ export function getDefaultMCPServerActionConfiguration(): AssistantBuilderAction
       dataSourceConfigurations: null,
       tablesConfigurations: null,
       childAgentId: null,
+      additionalConfiguration: {},
     },
     name: DEFAULT_MCP_ACTION_NAME,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -1,7 +1,6 @@
 import { CircleIcon, SquareIcon, TriangleIcon } from "@dust-tt/sparkle";
 import { uniqueId } from "lodash";
-import type { SVGProps } from "react";
-import type React from "react";
+import type React, { SVGProps } from "react";
 
 import {
   DEFAULT_MCP_ACTION_DESCRIPTION,
@@ -130,7 +129,7 @@ export type AssistantBuilderMCPServerConfiguration = {
   dataSourceConfigurations: DataSourceViewSelectionConfigurations | null;
   tablesConfigurations: DataSourceViewSelectionConfigurations | null;
   childAgentId: string | null;
-  additionalConfiguration: Record<string, boolean>;
+  additionalConfiguration: Record<string, boolean | string | null>;
 };
 
 // Builder State

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -99,7 +99,7 @@ export async function fetchMCPServerActionConfigurations(
   >();
 
   for (const config of mcpServerConfigurations) {
-    const { agentConfigurationId, sId, id, mcpServerViewId } = config;
+    const { agentConfigurationId, mcpServerViewId } = config;
 
     const dataSourceConfigurations = allDataSourceConfigurations.filter(
       (ds) => ds.mcpServerConfigurationId === config.id
@@ -131,8 +131,8 @@ export async function fetchMCPServerActionConfigurations(
     const actions = actionsByConfigurationId.get(agentConfigurationId);
     if (actions) {
       actions.push({
-        id,
-        sId,
+        id: config.id,
+        sId: config.sId,
         type: "mcp_server_configuration",
         name,
         description,
@@ -145,6 +145,7 @@ export async function fetchMCPServerActionConfigurations(
           childAgentConfigurations.length > 0
             ? childAgentConfigurations[0].agentConfigurationId
             : null,
+        additionalConfiguration: config.additionalConfiguration,
       });
     }
   }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -54,7 +54,7 @@ export type PlatformMCPServerConfigurationType =
     dataSources: DataSourceConfiguration[] | null;
     tables: TableDataSourceConfiguration[] | null;
     childAgentId: string | null;
-    additionalConfiguration: Record<string, boolean>;
+    additionalConfiguration: Record<string, boolean | number | string | null>;
     mcpServerViewId: string; // Hold the sId of the MCP server view.
   };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -54,7 +54,7 @@ export type PlatformMCPServerConfigurationType =
     dataSources: DataSourceConfiguration[] | null;
     tables: TableDataSourceConfiguration[] | null;
     childAgentId: string | null;
-    additionalConfiguration: Record<string, boolean | string | null>;
+    additionalConfiguration: Record<string, boolean>;
     mcpServerViewId: string; // Hold the sId of the MCP server view.
   };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -54,6 +54,7 @@ export type PlatformMCPServerConfigurationType =
     dataSources: DataSourceConfiguration[] | null;
     tables: TableDataSourceConfiguration[] | null;
     childAgentId: string | null;
+    additionalConfiguration: Record<string, boolean>;
     mcpServerViewId: string; // Hold the sId of the MCP server view.
   };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -54,7 +54,7 @@ export type PlatformMCPServerConfigurationType =
     dataSources: DataSourceConfiguration[] | null;
     tables: TableDataSourceConfiguration[] | null;
     childAgentId: string | null;
-    additionalConfiguration: Record<string, boolean>;
+    additionalConfiguration: Record<string, boolean | string | null>;
     mcpServerViewId: string; // Hold the sId of the MCP server view.
   };
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -90,6 +90,7 @@ function makePlatformMCPToolConfigurations(
     tables: config.tables,
     isDefault: tool.isDefault,
     childAgentId: config.childAgentId,
+    additionalConfiguration: config.additionalConfiguration,
   }));
 }
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1199,6 +1199,7 @@ export async function createAgentActionConfiguration(
             agentConfigurationId: agentConfiguration.id,
             workspaceId: owner.id,
             mcpServerViewId: mcpServerView.value.id,
+            additionalConfiguration: action.additionalConfiguration,
           },
           { transaction: t }
         );
@@ -1238,6 +1239,7 @@ export async function createAgentActionConfiguration(
           dataSources: action.dataSources,
           tables: action.tables,
           childAgentId: action.childAgentId,
+          additionalConfiguration: action.additionalConfiguration,
         });
       });
     }

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -42,9 +42,17 @@ AgentMCPServerConfiguration.init(
       type: DataTypes.JSONB,
       allowNull: false,
       validate: {
-        isValidContent(value: unknown) {
-          if (!value || typeof value !== "object") {
-            throw new Error("Content must be an object");
+        isValidJSON(value: string) {
+          if (value) {
+            let parsed;
+            try {
+              parsed = JSON.parse(value);
+            } catch (e) {
+              throw new Error("Response format is invalid JSON");
+            }
+            if (parsed && typeof parsed !== "object") {
+              throw new Error("Response format is invalid JSON");
+            }
           }
         },
       },

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -17,6 +17,8 @@ export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPSer
 
   declare sId: string;
 
+  declare additionalConfiguration: Record<string, boolean>;
+
   declare mcpServerViewId: ForeignKey<MCPServerViewModel["id"]>;
 }
 
@@ -35,6 +37,17 @@ AgentMCPServerConfiguration.init(
     sId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    additionalConfiguration: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      validate: {
+        isValidContent(value: unknown) {
+          if (!value || typeof value !== "object") {
+            throw new Error("Content must be an object");
+          }
+        },
+      },
     },
     mcpServerViewId: {
       type: DataTypes.BIGINT,

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -17,7 +17,7 @@ export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPSer
 
   declare sId: string;
 
-  declare additionalConfiguration: Record<string, boolean>;
+  declare additionalConfiguration: Record<string, boolean | string | null>;
 
   declare mcpServerViewId: ForeignKey<MCPServerViewModel["id"]>;
 }

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -17,7 +17,10 @@ export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPSer
 
   declare sId: string;
 
-  declare additionalConfiguration: Record<string, boolean>;
+  declare additionalConfiguration: Record<
+    string,
+    boolean | number | string | null
+  >;
 
   declare mcpServerViewId: ForeignKey<MCPServerViewModel["id"]>;
 }

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -17,7 +17,7 @@ export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPSer
 
   declare sId: string;
 
-  declare additionalConfiguration: Record<string, boolean | string | null>;
+  declare additionalConfiguration: Record<string, boolean>;
 
   declare mcpServerViewId: ForeignKey<MCPServerViewModel["id"]>;
 }

--- a/front/migrations/db/migration_207.sql
+++ b/front/migrations/db/migration_207.sql
@@ -1,0 +1,9 @@
+-- Migration created on Apr 09, 2025
+ALTER TABLE "public"."agent_mcp_server_configurations"
+  ADD COLUMN "additionalConfiguration" JSONB;
+
+UPDATE "public"."agent_mcp_server_configurations"
+SET "additionalConfiguration" = '{}';
+
+ALTER TABLE "public"."agent_mcp_server_configurations"
+  ALTER COLUMN "additionalConfiguration" SET NOT NULL;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -492,6 +492,7 @@ export async function createOrUpgradeAgentConfiguration({
           dataSources: action.dataSources || null,
           tables: action.tables,
           childAgentId: action.childAgentId,
+          additionalConfiguration: action.additionalConfiguration,
         } as PlatformMCPServerConfigurationType,
         agentConfigurationRes.value
       );

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -147,6 +147,7 @@ const MCPServerActionConfigurationSchema = t.type({
   dataSources: t.union([t.null, DataSourcesConfigurationsCodec]),
   tables: t.union([t.null, TablesConfigurationsCodec]),
   childAgentId: t.union([t.null, t.string]),
+  additionalConfiguration: t.record(t.string, t.boolean),
 });
 
 const ProcessActionConfigurationSchema = t.type({

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -147,7 +147,10 @@ const MCPServerActionConfigurationSchema = t.type({
   dataSources: t.union([t.null, DataSourcesConfigurationsCodec]),
   tables: t.union([t.null, TablesConfigurationsCodec]),
   childAgentId: t.union([t.null, t.string]),
-  additionalConfiguration: t.record(t.string, t.boolean),
+  additionalConfiguration: t.record(
+    t.string,
+    t.union([t.boolean, t.number, t.string, t.null])
+  ),
 });
 
 const ProcessActionConfigurationSchema = t.type({


### PR DESCRIPTION
## Description

- This PR adds a field additionalConfiguration to `MCPServerConfiguration`, saves it, loads it, passes it around accordingly.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Run `migration_207.sql`.
- Deploy front.
