### PR TITLE
[front] mcp(validation): don't ask again

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -11,8 +11,8 @@ import {
 } from "@dust-tt/sparkle";
 import { createContext, useCallback, useEffect, useState } from "react";
 
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPActionType } from "@app/lib/actions/mcp";
-import { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { useUpdateUserMetadata } from "@app/lib/swr/user";
 
 type ActionValidationContextType = {
@@ -155,7 +155,7 @@ export function ActionValidationProvider({
       `server.${currentValidation.serverId}`,
       currentValidation.action.functionCallName
     );
-  }, [currentValidation]);
+  }, [currentValidation, updateUserMetadata]);
 
   useEffect(() => {
     if (currentValidation) {

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -95,7 +95,9 @@ export function ActionValidationProvider({
   const [isProcessing, setIsProcessing] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const { updateUserMetadata } = useUpdateUserMetadata();
+  const { updateUserMetadata } = useUpdateUserMetadata(
+    "mcpServerToolValidation"
+  );
 
   const sendCurrentValidation = useCallback(
     async (approved: boolean) => {
@@ -152,8 +154,7 @@ export function ActionValidationProvider({
     }
 
     void updateUserMetadata(
-      `server.${currentValidation.serverId}`,
-      currentValidation.action.functionCallName
+      `${currentValidation.serverId}:${currentValidation.action.functionCallName}`
     );
   }, [currentValidation, updateUserMetadata]);
 
@@ -225,7 +226,7 @@ export function ActionValidationProvider({
               )}
             </div>
           </DialogContainer>
-          <DialogFooterg>
+          <DialogFooter>
             <Button
               label="Decline"
               variant="outline"

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -119,7 +119,7 @@ export function ActionValidationProvider({
       );
 
       if (!response.ok) {
-        setErrorMessage(`Failed to assess action approval. Please try again.`);
+        setErrorMessage("Failed to assess action approval. Please try again.");
         return;
       }
     },
@@ -165,12 +165,12 @@ export function ActionValidationProvider({
         onOpenChange={(open) => {
           if (open === false && !isProcessing) {
             if (currentValidation) {
-              void handleSubmit("action_rejected");
+              void handleSubmit("rejected");
             }
           }
         }}
       >
-        <DialogContent>
+        <DialogContent isAlertDialog>
           <DialogHeader>
             <DialogTitle>Action Validation Required</DialogTitle>
           </DialogHeader>
@@ -209,7 +209,7 @@ export function ActionValidationProvider({
             <Button
               label="Decline"
               variant="outline"
-              onClick={() => handleSubmit("action_rejected")}
+              onClick={() => handleSubmit("rejected")}
               disabled={isProcessing}
             >
               {isProcessing && (
@@ -224,7 +224,7 @@ export function ActionValidationProvider({
                 label="Approve and never ask again"
                 variant="ghost"
                 onClick={() => {
-                  handleSubmit("action_always_approved");
+                  handleSubmit("always_approved");
                 }}
                 disabled={isProcessing}
               >
@@ -239,7 +239,7 @@ export function ActionValidationProvider({
             <Button
               label="Approve"
               variant="primary"
-              onClick={() => handleSubmit("action_approved")}
+              onClick={() => handleSubmit("approved")}
               disabled={isProcessing}
             >
               {isProcessing && (

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -225,7 +225,7 @@ export function ActionValidationProvider({
               )}
             </div>
           </DialogContainer>
-          <DialogFooter className="flex justify-between">
+          <DialogFooterg>
             <Button
               label="Decline"
               variant="outline"
@@ -239,39 +239,37 @@ export function ActionValidationProvider({
                 </div>
               )}
             </Button>
-            <div className="flex gap-2">
-              {currentValidation?.stake === "low" && (
-                <Button
-                  label="Approve and never ask again"
-                  variant="ghost"
-                  onClick={() => {
-                    handleNeverAskAgain();
-                    handleSubmit(true);
-                  }}
-                  disabled={isProcessing}
-                >
-                  {isProcessing && (
-                    <div className="flex items-center">
-                      <span className="mr-2">Approving</span>
-                      <Spinner size="xs" variant="dark" />
-                    </div>
-                  )}
-                </Button>
-              )}
+            {currentValidation?.stake === "low" && (
               <Button
-                label="Approve"
-                variant="primary"
-                onClick={() => handleSubmit(true)}
+                label="Approve and never ask again"
+                variant="ghost"
+                onClick={() => {
+                  handleNeverAskAgain();
+                  handleSubmit(true);
+                }}
                 disabled={isProcessing}
               >
                 {isProcessing && (
                   <div className="flex items-center">
                     <span className="mr-2">Approving</span>
-                    <Spinner size="xs" variant="light" />
+                    <Spinner size="xs" variant="dark" />
                   </div>
                 )}
               </Button>
-            </div>
+            )}
+            <Button
+              label="Approve"
+              variant="primary"
+              onClick={() => handleSubmit(true)}
+              disabled={isProcessing}
+            >
+              {isProcessing && (
+                <div className="flex items-center">
+                  <span className="mr-2">Approving</span>
+                  <Spinner size="xs" variant="light" />
+                </div>
+              )}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -266,7 +266,6 @@ export function AgentMessage({
             action: event.action,
             inputs: event.inputs,
             stake: event.stake,
-            serverId: event.serverId,
           });
           break;
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -265,6 +265,8 @@ export function AgentMessage({
             conversationId: conversationId,
             action: event.action,
             inputs: event.inputs,
+            stake: event.stake,
+            serverId: event.serverId,
           });
           break;
 

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -55,8 +55,8 @@ export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVELS)[number];
 export const DEFAULT_MCP_TOOL_STAKE_LEVEL: MCPToolStakeLevelType = "high";
 
 export const MCP_VALIDATION_OUTPUTS = [
-  "action_approved",
-  "action_rejected",
-  "action_always_approved",
+  "approved",
+  "rejected",
+  "always_approved",
 ] as const;
 export type MCPValidationOutputType = (typeof MCP_VALIDATION_OUTPUTS)[number];

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -53,3 +53,10 @@ export const DEFAULT_MCP_ACTION_ICON = "command";
 export const MCP_TOOL_STAKE_LEVELS = ["high", "low"] as const;
 export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVELS)[number];
 export const DEFAULT_MCP_TOOL_STAKE_LEVEL: MCPToolStakeLevelType = "high";
+
+export const MCP_VALIDATION_OUTPUTS = [
+  "action_approved",
+  "action_rejected",
+  "action_always_approved",
+] as const;
+export type MCPValidationOutputType = (typeof MCP_VALIDATION_OUTPUTS)[number];

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -615,16 +615,22 @@ async function computeStatusFromConfig(
     return { status: "pending" };
   }
 
-  const neverAskSetting = await user.getMetadata(`server.${mcpServer.id}`);
+  if (!serverMetadata || serverMetadata?.permission === "high") {
+    return { status: "pending" };
+  }
+
+  const neverAskSetting = await user.getMetadata(`mcpServerToolValidation`);
   if (
     neverAskSetting &&
-    neverAskSetting.value.includes(actionConfiguration.name)
+    neverAskSetting.value.includes(
+      `${mcpServer.id}:${actionConfiguration.name}`
+    )
   ) {
     return { status: "allowed_implicitly" };
   }
 
   return {
-    stake: serverMetadata?.permission,
+    stake: "low",
     status: "pending",
     serverId: mcpServer.id,
   };

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -610,12 +610,12 @@ async function computeStatusFromConfig(
       toolName: actionConfiguration.name,
     });
 
-  const user = await UserResource.fetchById(auth.getNonNullableUser().sId);
-  if (!user) {
+  if (!serverMetadata || serverMetadata?.permission === "high") {
     return { status: "pending" };
   }
 
-  if (!serverMetadata || serverMetadata?.permission === "high") {
+  const user = await UserResource.fetchById(auth.getNonNullableUser().sId);
+  if (!user) {
     return { status: "pending" };
   }
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1,10 +1,8 @@
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
-import type {MCPToolStakeLevelType} from "@app/lib/actions/constants";
-import {
-  DEFAULT_MCP_TOOL_STAKE_LEVEL
-} from "@app/lib/actions/constants";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import { DEFAULT_MCP_TOOL_STAKE_LEVEL } from "@app/lib/actions/constants";
 import type { MCPToolResultContent } from "@app/lib/actions/mcp_actions";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
 import {
@@ -331,26 +329,25 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
           const { data } = event;
 
           if (
-            data.type === "action_always_approved" &&
+            data.type === "always_approved" &&
             data.actionId === mcpAction.id
           ) {
             assert(isPlatformMCPToolConfiguration(actionConfiguration));
             const user = auth.getNonNullableUser();
             await user.appendToMetadata(
-              `mcpServersToolsValidations`,
-              `${actionConfiguration.toolServerId}:${actionConfiguration.name}`
+              `toolsValidations:${actionConfiguration.toolServerId}`,
+              `${actionConfiguration.name}`
             );
           }
 
           if (
-            (data.type === "action_approved" ||
-              data.type === "action_always_approved") &&
+            (data.type === "approved" || data.type === "always_approved") &&
             data.actionId === mcpAction.id
           ) {
             status = "allowed_explicitly";
             break;
           } else if (
-            data.type === "action_rejected" &&
+            data.type === "rejected" &&
             data.actionId === mcpAction.id
           ) {
             status = "denied";
@@ -613,11 +610,13 @@ async function getExecutionStatusFromConfig(
   }
 
   const user = auth.getNonNullableUser();
-  const neverAskSetting = await user.getMetadata(`mcpServersToolsValidations`);
+  const neverAskSetting = await user.getMetadata(
+    `toolsValidations:${actionConfiguration.toolServerId}`
+  );
   if (
     neverAskSetting &&
     neverAskSetting.value.includes(
-      `${actionConfiguration.toolServerId}:${actionConfiguration.name}`
+      `${actionConfiguration.name}`
     )
   ) {
     return { status: "allowed_implicitly" };

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1,7 +1,9 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolResultContent } from "@app/lib/actions/mcp_actions";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
+import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
   augmentInputsWithConfiguration,
   hideInternalConfiguration,
@@ -27,7 +29,10 @@ import {
   AgentMCPActionOutputItem,
 } from "@app/lib/models/assistant/actions/mcp";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
+import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type {
   FunctionCallType,
@@ -36,11 +41,6 @@ import type {
   Result,
 } from "@app/types";
 import { isSupportedFileContentType, Ok, removeNulls } from "@app/types";
-import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
-import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import { UserResource } from "@app/lib/resources/user_resource";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -23,6 +23,7 @@ import {
 } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { isPlatformMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -584,45 +585,4 @@ export async function mcpActionTypesFromAgentMessageIds(
       ),
     });
   });
-}
-
-async function getExecutionStatusFromConfig(
-  auth: Authenticator,
-  actionConfiguration: MCPToolConfigurationType
-): Promise<{
-  stake?: MCPToolStakeLevelType;
-  status: "allowed_implicitly" | "pending";
-  serverId?: string;
-}> {
-  if (!isPlatformMCPToolConfiguration(actionConfiguration)) {
-    return { status: "pending" };
-  }
-
-  if (actionConfiguration.isDefault) {
-    return { status: "allowed_implicitly" };
-  }
-
-  if (
-    !actionConfiguration.permission ||
-    actionConfiguration.permission === "high"
-  ) {
-    return { status: "pending" };
-  }
-
-  const user = auth.getNonNullableUser();
-  const neverAskSetting = await user.getMetadata(
-    `toolsValidations:${actionConfiguration.toolServerId}`
-  );
-  if (
-    neverAskSetting &&
-    neverAskSetting.value.includes(
-      `${actionConfiguration.name}`
-    )
-  ) {
-    return { status: "allowed_implicitly" };
-  }
-
-  return {
-    status: "pending",
-  };
 }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -290,18 +290,16 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       action: mcpAction,
     };
 
-    let status:
-      | "allowed_implicitly"
-      | "allowed_explicitly"
-      | "pending"
-      | "denied" = "pending";
-
     const {
       status: s,
       stake,
       serverId,
     } = await computeStatusFromConfig(auth, actionConfiguration);
-    status = s;
+    let status:
+      | "allowed_implicitly"
+      | "allowed_explicitly"
+      | "pending"
+      | "denied" = s;
 
     if (status === "pending") {
       yield {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -25,10 +25,7 @@ import {
   isPlatformMCPServerConfiguration,
   isPlatformMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
-import type {
-  MCPToolType,
-  MCPToolWithStakeLevelType,
-} from "@app/lib/api/mcp";
+import type { MCPToolType, MCPToolWithStakeLevelType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";

--- a/front/lib/actions/pubsub.ts
+++ b/front/lib/actions/pubsub.ts
@@ -1,3 +1,4 @@
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { createCallbackPromise } from "@app/lib/utils";
@@ -14,7 +15,7 @@ export async function* getMCPEvents({
   {
     eventId: string;
     data: {
-      type: "action_approved" | "action_rejected";
+      type: MCPValidationOutputType;
       created: number;
       actionId: number;
       messageId?: string;

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -1,3 +1,4 @@
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import { publishEvent } from "@app/lib/api/assistant/pubsub";
 import logger from "@app/logger/logger";
 
@@ -16,10 +17,9 @@ export async function validateAction({
   conversationId: string;
   messageId: string;
   actionId: number;
-  approved: boolean;
+  approved: MCPValidationOutputType;
 }): Promise<{ success: boolean }> {
   const actionChannel = getActionChannel(actionId);
-  const eventType = approved ? "action_approved" : "action_rejected";
 
   logger.info(
     {
@@ -37,7 +37,7 @@ export async function validateAction({
     origin: "action_validation",
     channel: actionChannel,
     event: JSON.stringify({
-      type: eventType,
+      type: approved,
       created: Date.now(),
       actionId: actionId,
       messageId: messageId,

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -18,7 +18,7 @@ export type MCPToolWithIsDefaultType = MCPToolType & {
 
 export type MCPToolWithStakeLevelType = MCPToolWithIsDefaultType & {
   stakeLevel?: MCPToolStakeLevelType;
-  toolServerSId?: string;
+  toolServerId?: string;
 };
 
 export type MCPServerType = {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { AllowedIconType } from "@app/lib/actions/mcp_icons";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
@@ -13,6 +14,11 @@ export type MCPToolType = {
 
 export type MCPToolWithIsDefaultType = MCPToolType & {
   isDefault: boolean;
+};
+
+export type MCPToolWithStakeLevelType = MCPToolWithIsDefaultType & {
+  stakeLevel?: MCPToolStakeLevelType;
+  toolServerSId?: string;
 };
 
 export type MCPServerType = {

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -260,6 +260,25 @@ export class UserResource extends BaseResource<UserModel> {
     await metadata.update({ value });
   }
 
+  async appendToMetadata(key: string, value: string) {
+    const metadata = await UserMetadataModel.findOne({
+      where: {
+        userId: this.id,
+        key,
+      },
+    });
+    if (!metadata) {
+      await UserMetadataModel.create({
+        userId: this.id,
+        key,
+        value,
+      });
+      return;
+    }
+    const newValue = `${metadata.value}, ${value}`;
+    await metadata.update({ value: newValue });
+  }
+
   async deleteAllMetadata() {
     return UserMetadataModel.destroy({
       where: {

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -26,6 +26,8 @@ export interface SearchMembersPaginationParams {
   limit: number;
 }
 
+const USER_METADATA_COMMA_SEPARATOR = ",";
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
 export interface UserResource extends ReadonlyAttributesType<UserModel> {}
@@ -275,7 +277,7 @@ export class UserResource extends BaseResource<UserModel> {
       });
       return;
     }
-    const newValue = `${metadata.value}, ${value}`;
+    const newValue = `${metadata.value}${USER_METADATA_COMMA_SEPARATOR}${value}`;
     await metadata.update({ value: newValue });
   }
 

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -30,17 +30,3 @@ export function useUserMetadata(key: string) {
     mutateMetadata: mutate,
   };
 }
-
-export function useUpdateUserMetadata(key: string) {
-  const updateUserMetadata = async (value: string) => {
-    await fetch(`/api/user/metadata/${encodeURIComponent(key)}`, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ value }),
-    });
-  };
-
-  return { updateUserMetadata };
-}

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -31,8 +31,8 @@ export function useUserMetadata(key: string) {
   };
 }
 
-export function useUpdateUserMetadata() {
-  const updateUserMetadata = async (key: string, value: string) => {
+export function useUpdateUserMetadata(key: string) {
+  const updateUserMetadata = async (value: string) => {
     await fetch(`/api/user/metadata/${encodeURIComponent(key)}`, {
       method: "PATCH",
       headers: {

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -30,3 +30,17 @@ export function useUserMetadata(key: string) {
     mutateMetadata: mutate,
   };
 }
+
+export function useUpdateUserMetadata() {
+  const updateUserMetadata = async (key: string, value: string) => {
+    await fetch(`/api/user/metadata/${encodeURIComponent(key)}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ value }),
+    });
+  };
+
+  return { updateUserMetadata };
+}

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -6,7 +7,6 @@ import { getUserFromSession } from "@app/lib/iam/session";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { UserMetadataType, WithAPIErrorResponse } from "@app/types";
-import { z } from "zod";
 
 export type PostUserMetadataResponseBody = {
   metadata: UserMetadataType;

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -14,10 +13,6 @@ export type PostUserMetadataResponseBody = {
 export type GetUserMetadataResponseBody = {
   metadata: UserMetadataType | null;
 };
-
-const PatchUserMetadataRequestBodySchema = z.object({
-  value: z.string(),
-});
 
 async function handler(
   req: NextApiRequest,
@@ -97,34 +92,13 @@ async function handler(
       });
       return;
 
-    // PATCH is used to append a value to the existing metadata
-    case "PATCH":
-      const body = PatchUserMetadataRequestBodySchema.safeParse(req.body);
-      if (!body.success || !body.data.value) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "The request body is invalid, expects { value: string }.",
-          },
-        });
-      }
-
-      await u.appendToMetadata(key, body.data.value);
-      return res.status(200).json({
-        metadata: {
-          key,
-          value: body.data.value,
-        },
-      });
-
     default:
       return apiError(req, res, {
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
           message:
-            "The method passed is not supported, GET, PATCH, or POST is expected.",
+            "The method passed is not supported, GET, or POST is expected.",
         },
       });
   }

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -124,7 +124,7 @@ async function handler(
         api_error: {
           type: "method_not_supported_error",
           message:
-            "The method passed is not supported, GET, PATCH, POST or DELETE is expected.",
+            "The method passed is not supported, GET, PATCH, or POST is expected.",
         },
       });
   }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -12,11 +12,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 export const ValidateActionSchema = z.object({
   actionId: z.number(),
-  approved: z.enum([
-    "action_approved",
-    "action_rejected",
-    "action_always_approved",
-  ]),
+  approved: z.enum(["approved", "rejected", "always_approved"]),
 });
 
 export type ValidateActionResponse = {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -12,7 +12,11 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 export const ValidateActionSchema = z.object({
   actionId: z.number(),
-  approved: z.boolean(),
+  approved: z.enum([
+    "action_approved",
+    "action_rejected",
+    "action_always_approved",
+  ]),
 });
 
 export type ValidateActionResponse = {

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.38",
+      "version": "1.0.39",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2811,7 +2811,7 @@ export type ValidateActionResponseType = z.infer<
 
 export const ValidateActionRequestBodySchema = z.object({
   actionId: z.number(),
-  approved: z.enum(["action_approved", "action_rejected", "action_always_approved"]),
+  approved: z.enum(["approved", "rejected", "always_approved"]),
 });
 
 export type ValidateActionRequestBodyType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1317,7 +1317,6 @@ const MCPApproveExecutionEventSchema = z.object({
   action: MCPActionTypeSchema,
   inputs: z.record(z.any()),
   stake: z.optional(z.enum(["low", "high"])),
-  serverId: z.optional(z.string()),
 });
 
 const AgentErrorEventSchema = z.object({

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1316,6 +1316,8 @@ const MCPApproveExecutionEventSchema = z.object({
   messageId: z.string(),
   action: MCPActionTypeSchema,
   inputs: z.record(z.any()),
+  stake: z.optional(z.enum(["low", "high"])),
+  serverId: z.optional(z.string()),
 });
 
 const AgentErrorEventSchema = z.object({

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2811,7 +2811,7 @@ export type ValidateActionResponseType = z.infer<
 
 export const ValidateActionRequestBodySchema = z.object({
   actionId: z.number(),
-  approved: z.boolean(),
+  approved: z.enum(["action_approved", "action_rejected", "action_always_approved"]),
 });
 
 export type ValidateActionRequestBodyType = z.infer<


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

For full context see https://dust4ai.slack.com/archives/C050SM8NSPK/p1744121273716959?thread_ts=1744038871.356409&cid=C050SM8NSPK TLDR :

An Admin sets "high stake" or "low stake" for each tool of each action. All actions will default to high stake for security reason.
If stake is high :
- user can choose between approve or reject execution

If stake is low :
- user can choose between approve / approve and don't ask again / reject
- user can click on a button in the profile submenu (in the bottom left), like "reset action approvals" to delete the approval metadata

_This PR aims at implementing the Don't ask again button_

The click on don't ask again leads to storing in the user metadata, under the `mcpServerToolValidation` key, the list of `serverId:toolName` that doesn't need validation.

Still left to do on that topic : 
- [x] Button to reset your approvals
- [ ] Allow those for internal actions

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.
- Tested setting high/low permission.
- Tested sending message => works, and stores the right key/values.
- Tested changing the permission from low to high after some uses => high takes priority over low&never-ask-again as intended.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Behind ff, safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Deploy front.
