### PR TITLE
[Relocation] Delete empty workspaces during user migration

### DIFF
--- a/front/admin/relocate_users.ts
+++ b/front/admin/relocate_users.ts
@@ -3,13 +3,23 @@ import type { ApiResponse } from "auth0";
 import { getAuth0ManagemementClient } from "@app/lib/api/auth0";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
+import { deleteWorkspace } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { Workspace } from "@app/lib/models/workspace";
+import {
+  FREE_NO_PLAN_CODE,
+  FREE_TEST_PLAN_CODE,
+} from "@app/lib/plans/plan_codes";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { Result } from "@app/types";
 import { Err, Ok, removeNulls } from "@app/types";
+import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
 
 let remaining = 10;
 let resetTime = Date.now();
@@ -40,6 +50,37 @@ function makeAuth0Throttler<T>(
 
     return res.data;
   };
+}
+
+async function isWorkspaceEmpty(auth: Authenticator) {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.getNonNullableSubscription();
+
+  // Check if workspace is on a free plan
+  if (
+    ![FREE_NO_PLAN_CODE, FREE_TEST_PLAN_CODE].includes(subscription.plan.code)
+  ) {
+    return false;
+  }
+
+  // Check for data sources
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+  if (dataSources.length > 0) {
+    return false;
+  }
+
+  // Check for agents
+  const agents = await AgentConfiguration.findAll({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+
+  if (agents.length > 0) {
+    return false;
+  }
+
+  return true;
 }
 
 async function changeUserRegion(
@@ -114,20 +155,58 @@ export async function updateAllWorkspaceUsersRegionMetadata(
   const externalMemberships = allMemberships.filter(
     (m) => m.workspaceId !== workspace.id
   );
-  if (externalMemberships.length > 0) {
-    logger.error(
-      {
-        existingMemberships: externalMemberships.map((m) => ({
-          userId: m.userId,
-          workspaceId: m.workspaceId,
-        })),
-      },
-      "Some users have multiple memberships. Can be ignored by setting the " +
-        "forceUsersWithMultipleMemberships flag."
-    );
 
-    if (!forceUsersWithMultipleMemberships) {
-      return new Err(new Error("Some users have mutiple memberships"));
+  if (externalMemberships.length > 0) {
+    // Group memberships by workspace to check each one
+    const workspaceIds = [
+      ...new Set(externalMemberships.map((m) => m.workspaceId)),
+    ];
+    const workspaces = await Workspace.findAll({
+      where: {
+        id: workspaceIds,
+      },
+    });
+
+    const nonEmptyWorkspaces = [];
+    for (const w of workspaces) {
+      const workspaceAuth = await Authenticator.internalAdminForWorkspace(
+        w.sId
+      );
+      const isEmpty = await isWorkspaceEmpty(workspaceAuth);
+
+      if (isEmpty && execute) {
+        // Delete empty workspace
+        logger.info({ workspaceId: w.sId }, "Found empty workspace, deleting");
+        const deleteRes = await launchDeleteWorkspaceWorkflow({
+          workspaceId: w.sId,
+        });
+        if (deleteRes.isErr()) {
+          logger.error(
+            { workspaceId: w.sId, error: deleteRes.error.message },
+            "Failed to delete workspace"
+          );
+        }
+      } else if (!isEmpty) {
+        nonEmptyWorkspaces.push(w);
+      }
+    }
+
+    if (nonEmptyWorkspaces.length > 0) {
+      logger.error(
+        {
+          nonEmptyWorkspaces: nonEmptyWorkspaces.map((w) => ({
+            workspaceId: w.sId,
+          })),
+        },
+        "Some users have memberships in non-empty workspaces. Can be ignored by setting the " +
+          "forceUsersWithMultipleMemberships flag."
+      );
+
+      if (!forceUsersWithMultipleMemberships) {
+        return new Err(
+          new Error("Some users have memberships in non-empty workspaces")
+        );
+      }
     }
   }
 

--- a/front/admin/relocate_users.ts
+++ b/front/admin/relocate_users.ts
@@ -16,10 +16,10 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
+import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
 import { makeScript } from "@app/scripts/helpers";
 import type { Result } from "@app/types";
 import { Err, Ok, removeNulls } from "@app/types";
-import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
 
 let remaining = 10;
 let resetTime = Date.now();


### PR DESCRIPTION
Description
---
During workspace relocation, when checking for users with multiple memberships, we now:
- Check if the user's other workspaces are empty (free plan, no data sources, no agents)
- Delete empty workspaces automatically during the migration process \
- Only block migration if users have memberships in non-empty workspaces.

This change helps clean up unused workspaces during relocation while still maintaining the safety check for users with active workspaces in different regions.

Changes:
- Added isWorkspaceEmpty() function to check workspace status
- Modified updateAllWorkspaceUsersRegionMetadata to handle empty workspace deletion
- Updated error messages to be more specific about non-empty workspaces - Added necessary imports for workspace and subscription handling

Risks
---
standard

Deploy
---
front
