### PR TITLE
Add `connectors/admin/test.sh` script to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.sqlite
 .DS_Store
 .idea
-test.sh
 test.ts
 .env.local
 qdrant_storage

--- a/connectors/admin/test.sh
+++ b/connectors/admin/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check that we have TEST_CONNECTORS_DATABASE_URI set
+if [ -z "$TEST_CONNECTORS_DATABASE_URI" ]; then
+    echo "Error: TEST_CONNECTORS_DATABASE_URI is not set"
+    exit 1
+fi
+
+# Init the test db
+echo "Syncing test db schemas..."
+NODE_ENV=test CONNECTORS_DATABASE_URI=$TEST_CONNECTORS_DATABASE_URI npx tsx "$SCRIPT_DIR/db.ts"
+
+# Start the tests
+NODE_ENV=test CONNECTORS_DATABASE_URI=$TEST_CONNECTORS_DATABASE_URI npm run test


### PR DESCRIPTION
## Description

- This PR adds an admin script to run tests in connectors.
- This PR also removes test.sh from the root `gitignore`.

## Tests

## Risk

## Deploy Plan

- No deploy.