### PR TITLE
[front] Add avatars for default actions

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -12,10 +12,7 @@ import {
 import { useState } from "react";
 import React from "react";
 
-import {
-  DEFAULT_MCP_SERVER_ICON,
-  MCP_SERVER_ICONS,
-} from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
@@ -73,16 +70,7 @@ export const AddActionMenu = ({
               <DropdownMenuItem
                 key={mcpServer.id}
                 label={mcpServer.name}
-                icon={() => (
-                  <Avatar
-                    visual={React.createElement(
-                      MCP_SERVER_ICONS[
-                        mcpServer.icon || DEFAULT_MCP_SERVER_ICON
-                      ]
-                    )}
-                    size="xs"
-                  />
-                )}
+                icon={() => <Avatar visual={getVisual(mcpServer)} size="xs" />}
                 description={mcpServer.description}
                 onClick={async () => {
                   createInternalMCPServer(mcpServer);

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -28,10 +28,7 @@ import { MCPServerDetailsInfo } from "@app/components/actions/mcp/MCPServerDetai
 import { MCPServerDetailsSharing } from "@app/components/actions/mcp/MCPServerDetailsSharing";
 import { useMCPConnectionManagement } from "@app/hooks/useMCPConnectionManagement";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import {
-  DEFAULT_MCP_SERVER_ICON,
-  MCP_SERVER_ICONS,
-} from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
   useDeleteMCPServer,
@@ -147,11 +144,9 @@ export function MCPServerDetails({
               <SheetTitle />
             </VisuallyHidden>
             <div className="flex flex-col items-center gap-3 sm:flex-row">
-              <Avatar
-                visual={React.createElement(
-                  MCP_SERVER_ICONS[mcpServer?.icon || DEFAULT_MCP_SERVER_ICON]
-                )}
-              />
+              {effectiveMCPServer && (
+                <Avatar visual={getVisual(effectiveMCPServer)} />
+              )}
               <div className="flex grow flex-col gap-1">
                 <div
                   className={classNames(

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -19,7 +19,11 @@ import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
-import { ALLOWED_ICONS, MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import {
+  ALLOWED_ICONS,
+  DEFAULT_MCP_SERVER_ICON,
+  MCP_SERVER_ICONS,
+} from "@app/lib/actions/mcp_icons";
 import type { RemoteMCPServerType } from "@app/lib/api/mcp";
 import {
   useMCPServers,
@@ -58,7 +62,7 @@ export function RemoteMCPForm({
     defaultValues: {
       name: mcpServer.name,
       description: mcpServer.description,
-      icon: mcpServer.icon,
+      icon: mcpServer.icon ?? DEFAULT_MCP_SERVER_ICON,
     },
   });
 

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -22,6 +22,7 @@ import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import {
   ALLOWED_ICONS,
   DEFAULT_MCP_SERVER_ICON,
+  isAllowedIconType,
   MCP_SERVER_ICONS,
 } from "@app/lib/actions/mcp_icons";
 import type { RemoteMCPServerType } from "@app/lib/api/mcp";
@@ -62,7 +63,9 @@ export function RemoteMCPForm({
     defaultValues: {
       name: mcpServer.name,
       description: mcpServer.description,
-      icon: mcpServer.icon ?? DEFAULT_MCP_SERVER_ICON,
+      icon: isAllowedIconType(mcpServer.visual)
+        ? mcpServer.visual
+        : DEFAULT_MCP_SERVER_ICON,
     },
   });
 

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   BookOpenIcon,
   Button,
   Card,
@@ -15,7 +16,6 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Icon,
   InformationCircleIcon,
   Input,
   MoreIcon,
@@ -86,7 +86,7 @@ import {
   getDefaultActionConfiguration,
   isDefaultActionName,
 } from "@app/components/assistant_builder/types";
-import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -158,15 +158,15 @@ function actionIcon(
   mcpServerViews: MCPServerViewType[]
 ) {
   if (action.type === "MCP") {
-    const serverIcon = mcpServerViews.find(
+    const server = mcpServerViews.find(
       (v) => v.id === action.configuration.mcpServerViewId
-    )?.server.icon;
+    )?.server;
 
-    if (serverIcon) {
-      return MCP_SERVER_ICONS[serverIcon];
+    if (server) {
+      return getVisual(server);
     }
   }
-  return ACTION_SPECIFICATIONS[action.type].cardIcon;
+  return React.createElement(ACTION_SPECIFICATIONS[action.type].cardIcon);
 }
 
 function actionDisplayName(action: AssistantBuilderActionConfiguration) {
@@ -792,12 +792,8 @@ function ActionCard({
       }
     >
       <div className="flex w-full flex-col gap-2 text-sm">
-        <div className="flex w-full gap-1 font-medium text-foreground dark:text-foreground-night">
-          <Icon
-            visual={actionIcon(action, mcpServerViews)}
-            size="sm"
-            className="text-foreground dark:text-foreground-night"
-          />
+        <div className="flex w-full items-center gap-1 font-medium text-foreground dark:text-foreground-night">
+          <Avatar visual={actionIcon(action, mcpServerViews)} />
           <div className="w-full truncate">{actionDisplayName(action)}</div>
         </div>
         {isLegacyConfig ? (

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -793,7 +793,7 @@ function ActionCard({
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-1 font-medium text-foreground dark:text-foreground-night">
-          <Avatar visual={actionIcon(action, mcpServerViews)} />
+          <Avatar size="xs" visual={actionIcon(action, mcpServerViews)} />
           <div className="w-full truncate">{actionDisplayName(action)}</div>
         </div>
         {isLegacyConfig ? (

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -792,7 +792,7 @@ function ActionCard({
       }
     >
       <div className="flex w-full flex-col gap-2 text-sm">
-        <div className="flex w-full items-center gap-1 font-medium text-foreground dark:text-foreground-night">
+        <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
           <Avatar size="xs" visual={actionIcon(action, mcpServerViews)} />
           <div className="w-full truncate">{actionDisplayName(action)}</div>
         </div>

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -2,7 +2,6 @@ import {
   Avatar,
   classNames,
   ContentMessage,
-  Icon,
   InformationCircleIcon,
   Label,
   RadioGroup,

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   classNames,
   ContentMessage,
   Icon,
@@ -28,7 +29,7 @@ import type {
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
 import { useMCPServerRequiredConfiguration } from "@app/hooks/useMCPServerRequiredConfiguration";
-import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type {
@@ -321,38 +322,37 @@ export function ActionMCP({
                                 id={mcpServerView.id}
                                 iconPosition="start"
                                 customItem={
-                                  <div className="flex items-center gap-1 pl-2">
-                                    <Icon
-                                      visual={
-                                        MCP_SERVER_ICONS[
-                                          mcpServerView.server.icon
-                                        ]
-                                      }
-                                      size="md"
-                                      className={classNames(
-                                        "inline-block flex-shrink-0 align-middle"
-                                      )}
-                                    />
-                                    <Label
-                                      className={classNames(
-                                        "font-bold",
-                                        "align-middle",
-                                        "text-foreground dark:text-foreground-night"
-                                      )}
-                                      htmlFor={mcpServerView.id}
-                                    >
-                                      {mcpServerView.server.name}
-                                    </Label>
+                                  <div className="flex flex-row items-center gap-2">
+                                    <div>
+                                      <Avatar
+                                        visual={getVisual(mcpServerView.server)}
+                                      />
+                                    </div>
+                                    <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
+                                      <div className="flex flex-col gap-1">
+                                        <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                                          <Label
+                                            className={classNames(
+                                              "font-bold",
+                                              "align-middle",
+                                              "text-foreground dark:text-foreground-night"
+                                            )}
+                                            htmlFor={mcpServerView.id}
+                                          >
+                                            {mcpServerView.server.name}
+                                          </Label>
+                                        </div>
+                                        <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                                          {mcpServerView.server.description}
+                                        </div>
+                                      </div>
+                                    </div>
                                   </div>
                                 }
                                 onClick={() => {
                                   handleServerSelection(mcpServerView);
                                 }}
-                              >
-                                <div className="text-element-700 dark:text-element-700-night ml-10 mt-1 text-sm">
-                                  {mcpServerView.server.description}
-                                </div>
-                              </RadioGroupCustomItem>
+                              ></RadioGroupCustomItem>
                               {idx !== arr.length - 1 && <Separator />}
                             </React.Fragment>
                           );

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Button,
   DataTable,
   PlusIcon,
@@ -13,7 +14,7 @@ import * as React from "react";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import { useMCPServerViews } from "@app/lib/swr/mcp_server_views";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
@@ -22,7 +23,7 @@ import { RequestActionsModal } from "./mcp/RequestActionsModal";
 type RowData = {
   name: string;
   description: string;
-  icon: React.ComponentType;
+  visual: string | React.ReactNode;
   onClick?: () => void;
 };
 
@@ -31,8 +32,13 @@ const getTableColumns = (): ColumnDef<RowData, string>[] => {
     {
       id: "name",
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent icon={info.row.original.icon}>
-          {info.getValue()}
+        <DataTable.CellContent>
+          <div className="flex flex-row items-center gap-2 py-3">
+            <div>
+              <Avatar visual={info.row.original.visual} />
+            </div>
+            <div className="flex-grow truncate">{info.getValue()}</div>
+          </div>
         </DataTable.CellContent>
       ),
       accessorFn: (row: RowData) => row.name,
@@ -83,7 +89,7 @@ export const SpaceActionsList = ({
       sortBy(serverViews, "server.name").map((serverView) => ({
         name: serverView.server.name,
         description: serverView.server.description,
-        icon: MCP_SERVER_ICONS[serverView.server.icon],
+        visual: getVisual(serverView.server),
       })) || [],
     [serverViews]
   );

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Button,
   CloudArrowLeftRightIcon,
   CommandLineIcon,
@@ -14,7 +15,7 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
-import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
@@ -651,7 +652,7 @@ const SpaceActionItem = ({
     <Tree.Item
       type="leaf"
       label={action.server.name}
-      visual={MCP_SERVER_ICONS[action.server.icon]}
+      visual={() => <Avatar visual={getVisual(action.server)} size="xs" />}
       areActionsFading={false}
     />
   );

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -765,7 +765,7 @@ const SpaceActionsSubMenu = ({
     >
       {isExpanded && (
         <Tree isLoading={isMCPServerViewsLoading}>
-          {sortBy(serverViews, "name").map((serverView) => (
+          {sortBy(serverViews, "server.name").map((serverView) => (
             <SpaceActionItem
               action={serverView}
               key={serverView.server.name}

--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -19,7 +20,7 @@ import {
 import _ from "lodash";
 import { useState } from "react";
 
-import { MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { sendRequestActionsAccessEmail } from "@app/lib/email";
 import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_server_views";
@@ -121,9 +122,12 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                           <Button
                             variant="outline"
                             label={selectedMcpServer.server.name}
-                            icon={
-                              MCP_SERVER_ICONS[selectedMcpServer.server.icon]
-                            }
+                            icon={() => (
+                              <Avatar
+                                visual={getVisual(selectedMcpServer.server)}
+                                size="xs"
+                              />
+                            )}
                           />
                         ) : (
                           <Button
@@ -139,7 +143,9 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                           <DropdownMenuItem
                             key={v.id}
                             label={v.server.name}
-                            icon={MCP_SERVER_ICONS[v.server.icon]}
+                            icon={() => (
+                              <Avatar visual={getVisual(v.server)} size="xs" />
+                            )}
                             onClick={() => setSelectedMcpServer(v)}
                           />
                         ))}

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -1,4 +1,3 @@
-import { MCPServerType } from "@app/lib/api/mcp";
 import {
   CommandIcon,
   FolderTableIcon,
@@ -8,6 +7,8 @@ import {
   RocketIcon,
 } from "@dust-tt/sparkle";
 import React from "react";
+
+import type { MCPServerType } from "@app/lib/api/mcp";
 
 export const MCP_SERVER_ICONS: Record<AllowedIconType, React.ComponentType> = {
   command: CommandIcon,

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -1,3 +1,4 @@
+import { MCPServerType } from "@app/lib/api/mcp";
 import {
   CommandIcon,
   FolderTableIcon,
@@ -6,6 +7,7 @@ import {
   RobotIcon,
   RocketIcon,
 } from "@dust-tt/sparkle";
+import React from "react";
 
 export const MCP_SERVER_ICONS: Record<AllowedIconType, React.ComponentType> = {
   command: CommandIcon,
@@ -30,3 +32,12 @@ export type AllowedIconType = (typeof ALLOWED_ICONS)[number];
 
 export const isAllowedIconType = (icon: string): icon is AllowedIconType =>
   ALLOWED_ICONS.includes(icon as AllowedIconType);
+
+export const getVisual = (mcpServer: MCPServerType) => {
+  if (mcpServer.avatar) {
+    return mcpServer.avatar;
+  }
+  return React.createElement(
+    MCP_SERVER_ICONS[mcpServer.icon || DEFAULT_MCP_SERVER_ICON]
+  );
+};

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -35,10 +35,11 @@ export const isAllowedIconType = (icon: string): icon is AllowedIconType =>
   ALLOWED_ICONS.includes(icon as AllowedIconType);
 
 export const getVisual = (mcpServer: MCPServerType) => {
-  if (mcpServer.avatar) {
-    return mcpServer.avatar;
+  if (isAllowedIconType(mcpServer.visual)) {
+    return React.createElement(
+      MCP_SERVER_ICONS[mcpServer.visual || DEFAULT_MCP_SERVER_ICON]
+    );
   }
-  return React.createElement(
-    MCP_SERVER_ICONS[mcpServer.icon || DEFAULT_MCP_SERVER_ICON]
-  );
+
+  return mcpServer.visual;
 };

--- a/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
@@ -15,6 +15,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description: "Demo server showing a basic interaction with a child agent.",
   icon: "robot",
+  avatar: null,
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
@@ -14,8 +14,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   name: "ask_agent",
   version: "1.0.0",
   description: "Demo server showing a basic interaction with a child agent.",
-  icon: "robot",
-  avatar: null,
+  visual: "robot",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_source_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_source_utils.ts
@@ -20,6 +20,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description:
     "Demo server showing a basic interaction with a data source configuration.",
   icon: "command",
+  avatar: null,
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_source_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_source_utils.ts
@@ -19,8 +19,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with a data source configuration.",
-  icon: "command",
-  avatar: null,
+  visual: "command",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -15,8 +15,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     provider: "github" as const,
     use_case: "platform_actions" as const,
   },
-  avatar: null,
-  icon: "github",
+  visual: "github",
 };
 
 const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -15,6 +15,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     provider: "github" as const,
     use_case: "platform_actions" as const,
   },
+  avatar: null,
   icon: "github",
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/hello_world.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hello_world.ts
@@ -14,7 +14,8 @@ const serverInfo: InternalMCPServerDefinitionType = {
     provider,
     use_case: "connection" as const,
   },
-  icon: "rocket",
+  icon: null,
+  avatar: "https://dust.tt/static/droidavatar/Droid_Pink_1.jpg",
 };
 
 const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/hello_world.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hello_world.ts
@@ -14,8 +14,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     provider,
     use_case: "connection" as const,
   },
-  icon: null,
-  avatar: "https://dust.tt/static/droidavatar/Droid_Pink_1.jpg",
+  visual: "https://dust.tt/static/droidavatar/Droid_Pink_1.jpg",
 };
 
 const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation_dalle.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation_dalle.ts
@@ -11,6 +11,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description: "Generate images with the Dall-E v3 model from OpenAI.",
   icon: "image",
+  avatar: null,
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation_dalle.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation_dalle.ts
@@ -10,8 +10,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   name: "image_generation_dalle",
   version: "1.0.0",
   description: "Generate images with the Dall-E v3 model from OpenAI.",
-  icon: "image",
-  avatar: null,
+  visual: "image",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/table_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/table_utils.ts
@@ -10,8 +10,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with a table configuration.",
-  icon: "table",
-  avatar: null,
+  visual: "table",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/table_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/table_utils.ts
@@ -11,6 +11,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description:
     "Demo server showing a basic interaction with a table configuration.",
   icon: "table",
+  avatar: null,
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -186,6 +186,7 @@ export function extractMetadataFromServerVersion(
         "icon" in r && typeof r.icon === "string" && isAllowedIconType(r.icon)
           ? r.icon
           : DEFAULT_MCP_ACTION_ICON,
+      avatar: "avatar" in r && typeof r.avatar === "string" ? r.avatar : null,
     };
   }
 
@@ -194,6 +195,7 @@ export function extractMetadataFromServerVersion(
     version: DEFAULT_MCP_ACTION_VERSION,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,
     icon: DEFAULT_MCP_ACTION_ICON,
+    avatar: null,
     authorization: null,
   };
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -13,7 +13,6 @@ import {
 } from "@app/lib/actions/constants";
 import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { isAllowedIconType } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_local";
 import apiConfig from "@app/lib/api/config";
@@ -182,11 +181,10 @@ export function extractMetadataFromServerVersion(
         "description" in r && typeof r.description === "string" && r.description
           ? r.description
           : DEFAULT_MCP_ACTION_DESCRIPTION,
-      icon:
-        "icon" in r && typeof r.icon === "string" && isAllowedIconType(r.icon)
-          ? r.icon
+      visual:
+        "visual" in r && typeof r.visual === "string"
+          ? r.visual
           : DEFAULT_MCP_ACTION_ICON,
-      avatar: "avatar" in r && typeof r.avatar === "string" ? r.avatar : null,
     };
   }
 
@@ -194,8 +192,7 @@ export function extractMetadataFromServerVersion(
     name: DEFAULT_MCP_ACTION_NAME,
     version: DEFAULT_MCP_ACTION_VERSION,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,
-    icon: DEFAULT_MCP_ACTION_ICON,
-    avatar: null,
+    visual: DEFAULT_MCP_ACTION_ICON,
     authorization: null,
   };
 }

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -20,7 +20,8 @@ export type MCPServerType = {
   name: string;
   version: string;
   description: string;
-  icon: AllowedIconType;
+  icon: AllowedIconType | null;
+  avatar: string | null;
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   isDefault: boolean;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -20,8 +20,7 @@ export type MCPServerType = {
   name: string;
   version: string;
   description: string;
-  icon: AllowedIconType | null;
-  avatar: string | null;
+  visual: AllowedIconType | string;
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   isDefault: boolean;

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -283,8 +283,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       name: this.name,
       description: this.description,
       version: this.version,
-      icon: this.icon,
-      avatar: null,
+      visual: this.icon,
       tools: this.cachedTools,
 
       cachedName: this.cachedName,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -284,6 +284,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       description: this.description,
       version: this.version,
       icon: this.icon,
+      avatar: null,
       tools: this.cachedTools,
 
       cachedName: this.cachedName,

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -15,6 +15,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 
 export type GetMCPServersResponseBody = {
   success: boolean;
@@ -127,7 +128,7 @@ async function handler(
           cachedName: metadata.name,
           cachedDescription: metadata.description,
           cachedTools: metadata.tools,
-          icon: metadata.icon,
+          icon: metadata.icon ?? DEFAULT_MCP_SERVER_ICON,
           version: metadata.version,
         });
 

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -3,7 +3,10 @@ import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
-import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
+import {
+  DEFAULT_MCP_SERVER_ICON,
+  isAllowedIconType,
+} from "@app/lib/actions/mcp_icons";
 import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -128,7 +131,9 @@ async function handler(
           cachedName: metadata.name,
           cachedDescription: metadata.description,
           cachedTools: metadata.tools,
-          icon: metadata.icon ?? DEFAULT_MCP_SERVER_ICON,
+          icon: isAllowedIconType(metadata.visual)
+            ? metadata.visual
+            : DEFAULT_MCP_SERVER_ICON,
           version: metadata.version,
         });
 

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -3,6 +3,7 @@ import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -15,7 +16,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 
 export type GetMCPServersResponseBody = {
   success: boolean;


### PR DESCRIPTION
## Description

Internal actions can defined either an avatar or an icon

<img width="546" alt="Screenshot 2025-04-10 at 10 24 12" src="https://github.com/user-attachments/assets/05fcafbc-5565-4d1f-b376-93975bcbd477" />

<img width="291" alt="Screenshot 2025-04-10 at 10 12 05" src="https://github.com/user-attachments/assets/0e2b1ee2-c6f3-4e16-8f35-d2544299e8a1" />

<img width="673" alt="Screenshot 2025-04-10 at 11 04 19" src="https://github.com/user-attachments/assets/a2a2150a-1e31-46cf-852f-0a7a69a1a6f1" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
