### PR TITLE
fix: conv resource getOptions leads to broken query

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash";
 import type {
   CreationAttributes,
   InferAttributes,
@@ -64,13 +64,17 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   private static getOptions(
     options?: FetchConversationOptions
   ): ResourceFindOptions<ConversationModel> {
-    const result: ResourceFindOptions<ConversationModel> = {
+    if (options?.includeDeleted) {
+      return {
+        where: {},
+      };
+    }
+
+    return {
       where: {
-        visibility: options?.includeDeleted ? {} : { [Op.ne]: "deleted" },
+        visibility: { [Op.ne]: "deleted" },
       },
     };
-
-    return result;
   }
 
   private static async baseFetch(


### PR DESCRIPTION
## Description

When `includeDeleted` is true, we currently pass `where: {visibility: {}}` which is invalid. Should just return an empty where here.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
