### PR TITLE
[File API] Fix vulnerability: access permission checks

### DIFF
--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -88,6 +88,9 @@ export const DocumentUploadOrEditModal = ({
   const fileUploaderService = useFileUploaderService({
     owner,
     useCase: "folders_document",
+    useCaseMetadata: {
+      spaceId: dataSourceView.spaceId,
+    },
   });
 
   const [editionStatus, setEditionStatus] = useState({

--- a/front/components/data_source/MultipleDocumentsUpload.tsx
+++ b/front/components/data_source/MultipleDocumentsUpload.tsx
@@ -62,6 +62,9 @@ export const MultipleDocumentsUpload = ({
   const fileUploaderService = useFileUploaderService({
     owner,
     useCase: "folders_document",
+    useCaseMetadata: {
+      spaceId: dataSourceView.spaceId,
+    },
   });
 
   const doUpsertFileAsDataSourceEntry = useUpsertFileAsDatasourceEntry(

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -56,7 +56,10 @@ export function useFileUploaderService({
 }: {
   owner: LightWorkspaceType;
   useCase: FileUseCase;
-  useCaseMetadata?: FileUseCaseMetadata;
+  useCaseMetadata?: {
+    conversationId?: string;
+    spaceId?: string;
+  };
 }) {
   const [fileBlobs, setFileBlobs] = useState<FileBlob[]>([]);
   const [isProcessingFiles, setIsProcessingFiles] = useState(false);

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -56,10 +56,7 @@ export function useFileUploaderService({
 }: {
   owner: LightWorkspaceType;
   useCase: FileUseCase;
-  useCaseMetadata?: {
-    conversationId?: string;
-    spaceId?: string;
-  };
+  useCaseMetadata?: FileUseCaseMetadata;
 }) {
   const [fileBlobs, setFileBlobs] = useState<FileBlob[]>([]);
   const [isProcessingFiles, setIsProcessingFiles] = useState(false);

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -9,15 +9,13 @@ import {
   processAndUpsertToDataSource,
 } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isPublicySupportedUseCase } from "@app/types";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import { ConversationError } from "@app/types";
-import { DustError } from "@app/lib/error";
 
 export const config = {
   api: {

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -85,10 +85,10 @@ async function handler(
       !ConversationResource.canAccessConversation(auth, conversation)
     ) {
       return apiError(req, res, {
-        status_code: 403,
+        status_code: 404,
         api_error: {
-          type: "conversation_access_restricted",
-          message: "You don't have access to this file.",
+          type: "file_not_found",
+          message: "File not found.",
         },
       });
     }
@@ -103,10 +103,10 @@ async function handler(
     );
     if (!space || !space.canRead(auth)) {
       return apiError(req, res, {
-        status_code: 403,
+        status_code: 404,
         api_error: {
-          type: "conversation_access_restricted",
-          message: "You don't have access to this file.",
+          type: "file_not_found",
+          message: "File not found.",
         },
       });
     }

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -82,7 +82,10 @@ async function handler(
       auth,
       file.useCaseMetadata.conversationId
     );
-    if (!conversation) {
+    if (
+      !conversation ||
+      !ConversationResource.canAccessConversation(auth, conversation)
+    ) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {
@@ -99,7 +102,7 @@ async function handler(
       auth,
       file.useCaseMetadata.spaceId
     );
-    if (!space) {
+    if (!space || !space.canRead(auth)) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -9,8 +9,10 @@ import {
   processAndUpsertToDataSource,
 } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileVersion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -72,6 +74,40 @@ async function handler(
         message: "File not found.",
       },
     });
+  }
+
+  // Check permissions based on useCase and useCaseMetadata
+  if (file.useCase === "conversation" && file.useCaseMetadata?.conversationId) {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      file.useCaseMetadata.conversationId
+    );
+    if (!conversation) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "File not found.",
+        },
+      });
+    }
+  } else if (
+    file.useCase === "folders_document" &&
+    file.useCaseMetadata?.spaceId
+  ) {
+    const space = await SpaceResource.fetchById(
+      auth,
+      file.useCaseMetadata.spaceId
+    );
+    if (!space) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "File not found.",
+        },
+      });
+    }
   }
 
   switch (req.method) {

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -15,25 +15,37 @@ import { ensureFileSize, isSupportedFileContentType } from "@app/types";
 
 // File upload form validation.
 
-const FileUploadUrlRequestSchema = t.type({
-  contentType: t.string,
-  fileName: t.string,
-  fileSize: t.number,
-  useCase: t.union([
-    t.literal("conversation"),
-    t.literal("avatar"),
-    t.literal("upsert_document"),
-    t.literal("folders_document"),
-    t.literal("upsert_table"),
-  ]),
-  useCaseMetadata: t.union([
-    t.undefined,
-    t.type({
+const FileUploadUrlRequestSchema = t.union([
+  t.type({
+    contentType: t.string,
+    fileName: t.string,
+    fileSize: t.number,
+    useCase: t.literal("conversation"),
+    useCaseMetadata: t.type({
       conversationId: t.string,
+    }),
+  }),
+  t.type({
+    contentType: t.string,
+    fileName: t.string,
+    fileSize: t.number,
+    useCase: t.literal("folders_document"),
+    useCaseMetadata: t.type({
       spaceId: t.string,
     }),
-  ]),
-});
+  }),
+  t.type({
+    contentType: t.string,
+    fileName: t.string,
+    fileSize: t.number,
+    useCase: t.union([
+      t.literal("avatar"),
+      t.literal("upsert_document"),
+      t.literal("upsert_table"),
+    ]),
+    useCaseMetadata: t.undefined,
+  }),
+]);
 
 export interface FileUploadRequestResponseBody {
   file: FileTypeWithUploadUrl;

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -26,7 +26,13 @@ const FileUploadUrlRequestSchema = t.type({
     t.literal("folders_document"),
     t.literal("upsert_table"),
   ]),
-  useCaseMetadata: t.union([t.undefined, t.type({ conversationId: t.string })]),
+  useCaseMetadata: t.union([
+    t.undefined,
+    t.type({
+      conversationId: t.string,
+      spaceId: t.string,
+    }),
+  ]),
 });
 
 export interface FileUploadRequestResponseBody {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -23,7 +23,8 @@ export type FileUseCase =
   | "upsert_table";
 
 export type FileUseCaseMetadata = {
-  conversationId: string;
+  conversationId?: string;
+  spaceId?: string;
   generatedTables?: string[];
 };
 


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2606

## Description

This PR implements security checks for file access based on the file's `useCase` and `useCaseMetadata`. It ensures that users can only access files they have permission to view, based on their permissions in conversations or spaces.

### Security Impact
This fix addresses a critical security vulnerability where:
1. Files associated with conversations could be accessed without verifying conversation permissions
2. Files associated with spaces could be accessed without verifying space membership

The changes ensure that:
- Only users with access to a conversation can access files associated with that conversation
- Only users with access to a space can access files associated with that space
- Proper error handling and user feedback is provided when access is denied


List of changes:

#### 1. File Access Endpoint (`front/pages/api/v1/w/[wId]/files/[fileId].ts` and internal counterpart)
- Added permission checks based on file's `useCase` and `useCaseMetadata`
- For `useCase: "conversation"`, verifies user has access to the conversation
- For `useCase: "folders_document"`, verifies user has access to the space
- Returns appropriate error responses (403) when access is denied

#### 2. File Upload Schema (`front/pages/api/w/[wId]/files/index.ts`)
- Updated `FileUploadUrlRequestSchema` to include `spaceId` in `useCaseMetadata`
- Ensures proper metadata is provided during file uploads

#### 3. File Uploader Service (`front/hooks/useFileUploaderService.ts`)
- Modified to handle both conversation and space-based uploads
- Added support for `spaceId` in `useCaseMetadata`

#### 4. Frontend Components
- Updated `DocumentUploadOrEditModal.tsx` to include `spaceId` in upload metadata
- Updated `MultipleDocumentsUpload.tsx` to include `spaceId` in upload metadata

##  Risks
Standard

## Deploy Plan
front
