### PR TITLE
fix(MCP): fix the input schemas for primitive types

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -52,9 +52,18 @@ export const ConfigurableToolInputSchemas = {
     uri: z.string().regex(CHILD_AGENT_CONFIGURATION_URI_PATTERN),
     mimeType: z.literal(INTERNAL_MIME_TYPES.CONFIGURATION.CHILD_AGENT),
   }),
-  [INTERNAL_MIME_TYPES.CONFIGURATION.STRING]: z.string(),
-  [INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER]: z.number(),
-  [INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN]: z.boolean(),
+  [INTERNAL_MIME_TYPES.CONFIGURATION.STRING]: z.object({
+    value: z.string(),
+    mimeType: z.literal(INTERNAL_MIME_TYPES.CONFIGURATION.STRING),
+  }),
+  [INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER]: z.object({
+    value: z.number(),
+    mimeType: z.literal(INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER),
+  }),
+  [INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN]: z.object({
+    value: z.boolean(),
+    mimeType: z.literal(INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN),
+  }),
   // We use a satisfies here to ensure that all the InternalConfigurationMimeType are covered whilst preserving the type
   // inference in tools definitions (server.tool is templated).
 } as const satisfies Record<InternalConfigurationMimeType, z.ZodSchema>;
@@ -153,7 +162,7 @@ export function generateConfiguredInput({
           `Expected string value for key ${lastKey}, got ${typeof value}`
         );
       }
-      return value;
+      return { value, mimeType };
     }
 
     case INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER: {
@@ -167,7 +176,7 @@ export function generateConfiguredInput({
           `Expected number value for key ${lastKey}, got ${typeof value}`
         );
       }
-      return value;
+      return { value, mimeType };
     }
 
     case INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN: {
@@ -181,7 +190,7 @@ export function generateConfiguredInput({
           `Expected boolean value for key ${lastKey}, got ${typeof value}`
         );
       }
-      return value;
+      return { value, mimeType };
     }
 
     default:


### PR DESCRIPTION
## Description

The input schemas for primitive types we are trying to detect as pre-configurable blocks did not contain the mime type so we were wrongly considering any string/boolean/number as configurable blocks.

## Tests

## Risk

## Deploy Plan

- Deploy front.