### PR TITLE
feat: Admin can add actions from a space

### DIFF
--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -101,19 +101,8 @@ export const SpaceActionsList = ({
   });
 
   const onAddServer = async (server: MCPServerType) => {
-    const res = await addToSpace(server, space);
-    if (res.success) {
-      await mutateMCPServerViews(async (prev) => {
-        if (!prev) {
-          return prev;
-        }
-
-        return {
-          ...prev,
-          serverViews: prev.serverViews.concat([res.serverView]),
-        };
-      });
-    }
+    await addToSpace(server, space);
+    await mutateMCPServerViews();
   };
 
   if (isMCPServerViewsLoading) {

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -1,24 +1,26 @@
 import {
   Avatar,
-  Button,
   DataTable,
-  PlusIcon,
   Spinner,
   usePaginationFromUrl,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { sortBy } from "lodash";
-import { useRouter } from "next/router";
 import * as React from "react";
 
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import { getVisual } from "@app/lib/actions/mcp_icons";
-import { useMCPServerViews } from "@app/lib/swr/mcp_server_views";
+import type { MCPServerType } from "@app/lib/api/mcp";
+import {
+  useAddMCPServerToSpace,
+  useMCPServerViews,
+} from "@app/lib/swr/mcp_server_views";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 import { RequestActionsModal } from "./mcp/RequestActionsModal";
+import SpaceManagedActionsViewsModel from "./SpaceManagedActionsViewsModal";
 
 type RowData = {
   name: string;
@@ -70,15 +72,15 @@ export const SpaceActionsList = ({
   isAdmin,
   space,
 }: SpaceActionsListProps) => {
-  const router = useRouter();
-
   const { q: searchParam } = useQueryParams(["q"]);
   const searchTerm = searchParam.value || "";
 
-  const { serverViews, isMCPServerViewsLoading } = useMCPServerViews({
-    owner,
-    space,
-  });
+  const { serverViews, isMCPServerViewsLoading, mutateMCPServerViews } =
+    useMCPServerViews({
+      owner,
+      space,
+    });
+  const { addToSpace } = useAddMCPServerToSpace(owner);
 
   const { pagination, setPagination } = usePaginationFromUrl({
     urlPrefix: "table",
@@ -98,6 +100,22 @@ export const SpaceActionsList = ({
     containerId: ACTION_BUTTONS_CONTAINER_ID,
   });
 
+  const onAddServer = async (server: MCPServerType) => {
+    const res = await addToSpace(server, space);
+    if (res.success) {
+      await mutateMCPServerViews(async (prev) => {
+        if (!prev) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          serverViews: prev.serverViews.concat([res.serverView]),
+        };
+      });
+    }
+  };
+
   if (isMCPServerViewsLoading) {
     return (
       <div className="mt-8 flex justify-center">
@@ -113,15 +131,13 @@ export const SpaceActionsList = ({
   const actionButton = (
     <>
       {isAdmin ? (
-        <Button
-          label="Add Action"
-          variant="primary"
-          icon={PlusIcon}
-          size="sm"
-          onClick={() => {
-            void router.push(`/w/${owner.sId}/actions/`);
-          }}
-        />
+        <>
+          <SpaceManagedActionsViewsModel
+            space={space}
+            owner={owner}
+            onAddServer={onAddServer}
+          />
+        </>
       ) : (
         <RequestActionsModal owner={owner} space={space} />
       )}

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -1,0 +1,91 @@
+import {
+  Avatar,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuTrigger,
+  PlusIcon,
+  ScrollArea,
+} from "@dust-tt/sparkle";
+import React, { useState } from "react";
+
+import {
+  DEFAULT_MCP_SERVER_ICON,
+  MCP_SERVER_ICONS,
+} from "@app/lib/actions/mcp_icons";
+import type { MCPServerType } from "@app/lib/api/mcp";
+import { filterMCPServer } from "@app/lib/mcp";
+import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_server_views";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
+
+type SpaceManagedActionsViewsModelProps = {
+  owner: LightWorkspaceType;
+  space: SpaceType;
+  onAddServer: (server: MCPServerType) => void;
+};
+
+export default function SpaceManagedActionsViewsModel({
+  owner,
+  space,
+  onAddServer,
+}: SpaceManagedActionsViewsModelProps) {
+  const [searchText, setSearchText] = useState("");
+  const { serverViews } = useMCPServerViewsNotActivated({
+    owner,
+    space,
+  });
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          label="Add Action"
+          variant="primary"
+          icon={PlusIcon}
+          size="sm"
+        />
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent className="w-[500px]">
+        <div className="flex flex-row items-center gap-2">
+          <DropdownMenuSearchbar
+            className="flex-grow"
+            placeholder="Search actions..."
+            name="search"
+            value={searchText}
+            onChange={setSearchText}
+          />
+        </div>
+        <ScrollArea className="max-h-[500px]">
+          {serverViews.length <= 0 && (
+            <DropdownMenuItem label="No more actions to add" disabled />
+          )}
+          {serverViews
+            .filter((s) => filterMCPServer(s.server, searchText))
+            .map((serverView) => (
+              <DropdownMenuItem
+                key={serverView.id}
+                label={serverView.server.name}
+                icon={() => (
+                  <Avatar
+                    visual={React.createElement(
+                      MCP_SERVER_ICONS[
+                        serverView.server.icon || DEFAULT_MCP_SERVER_ICON
+                      ]
+                    )}
+                    size="xs"
+                  />
+                )}
+                description={serverView.server.description}
+                onClick={() => {
+                  onAddServer(serverView.server);
+                }}
+              />
+            ))}
+        </ScrollArea>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -14,7 +14,7 @@ import React, { useState } from "react";
 import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
-import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_server_views";
+import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 type SpaceManagedActionsViewsModelProps = {
@@ -29,7 +29,7 @@ export default function SpaceManagedActionsViewsModel({
   onAddServer,
 }: SpaceManagedActionsViewsModelProps) {
   const [searchText, setSearchText] = useState("");
-  const { serverViews } = useMCPServerViewsNotActivated({
+  const { availableMCPServers } = useAvailableMCPServers({
     owner,
     space,
   });
@@ -56,21 +56,19 @@ export default function SpaceManagedActionsViewsModel({
           />
         </div>
         <ScrollArea className="max-h-[500px]">
-          {serverViews.length <= 0 && (
+          {availableMCPServers.length <= 0 && (
             <DropdownMenuItem label="No more actions to add" disabled />
           )}
-          {serverViews
-            .filter((s) => filterMCPServer(s.server, searchText))
-            .map((serverView) => (
+          {availableMCPServers
+            .filter((s) => filterMCPServer(s, searchText))
+            .map((server) => (
               <DropdownMenuItem
-                key={serverView.id}
-                label={serverView.server.name}
-                icon={() => (
-                  <Avatar visual={getVisual(serverView.server)} size="xs" />
-                )}
-                description={serverView.server.description}
+                key={server.id}
+                label={server.name}
+                icon={() => <Avatar visual={getVisual(server)} size="xs" />}
+                description={server.description}
                 onClick={() => {
-                  onAddServer(serverView.server);
+                  onAddServer(server);
                 }}
               />
             ))}

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -11,10 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
-import {
-  DEFAULT_MCP_SERVER_ICON,
-  MCP_SERVER_ICONS,
-} from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_server_views";
@@ -69,14 +66,7 @@ export default function SpaceManagedActionsViewsModel({
                 key={serverView.id}
                 label={serverView.server.name}
                 icon={() => (
-                  <Avatar
-                    visual={React.createElement(
-                      MCP_SERVER_ICONS[
-                        serverView.server.icon || DEFAULT_MCP_SERVER_ICON
-                      ]
-                    )}
-                    size="xs"
-                  />
+                  <Avatar visual={getVisual(serverView.server)} size="xs" />
                 )}
                 description={serverView.server.description}
                 onClick={() => {

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -20,7 +20,7 @@ import type {
   GetConnectionsResponseBody,
   PostConnectionResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/connections";
-import type { LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 /**
  * Hook to fetch a specific remote MCP server by ID
@@ -61,12 +61,16 @@ export function useMCPServer({
 
 export function useAvailableMCPServers({
   owner,
+  space,
 }: {
   owner: LightWorkspaceType;
+  space?: SpaceType;
 }) {
   const configFetcher: Fetcher<GetMCPServersResponseBody> = fetcher;
 
-  const url = `/api/w/${owner.sId}/mcp/available`;
+  const url = space
+    ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp/available`
+    : `/api/w/${owner.sId}/mcp/available`;
 
   const { data, error } = useSWRWithDefaults(url, configFetcher);
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { MCPServerType } from "@app/lib/api/mcp";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type GetMCPServersResponseBody = {
+  success: boolean;
+  servers: MCPServerType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMCPServersResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  const { method } = req;
+
+  switch (method) {
+    // We get the server that are:
+    // - installed in the workspace but not in global (so can be restricted but not yet assign to spaces)
+    // - not in the current space
+    case "GET": {
+      const workspaceServerViews =
+        await MCPServerViewResource.listByWorkspace(auth);
+      const globalServersId = workspaceServerViews
+        .filter((s) => s.space.kind === "global")
+        .map((s) => s.toJSON().server.id);
+
+      const workspaceInstalledServer =
+        await InternalMCPServerInMemoryResource.listByWorkspace(auth);
+
+      const spaceServerViews = await MCPServerViewResource.listBySpace(
+        auth,
+        space
+      );
+      const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.id);
+
+      const availableServer = workspaceInstalledServer.filter(
+        (s) => !spaceServersId.includes(s.id) && !globalServersId.includes(s.id)
+      );
+
+      return res.status(200).json({
+        success: true,
+        servers: availableServer.map((s) => s.toJSON()),
+      });
+    }
+
+    default: {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, { space: { requireCanRead: true } })
+);


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2600
- Allow admin to add actions directly from spaces using a dropdown
- Fetches the available server for the given space that
  - not in the current space
  - installed in the workspace but in the global space (so restricted to zero or more space)
- Display a message if there is no server that can be installed
- Use existing admin swr hook to fetch available servers to be added to the workspace, but add an optional space.

## Tests
- Locally check as an admin that in a space (not company data), can I add servers that are not in the current space or restricted to zero or more other spaces. 
<img width="1129" alt="Capture d’écran 2025-04-10 à 15 29 28" src="https://github.com/user-attachments/assets/f7d4d981-45b9-4e64-88b5-a47911ac6481" />
<img width="1230" alt="Capture d’écran 2025-04-10 à 14 47 49" src="https://github.com/user-attachments/assets/5f1e7ea0-3aa4-46d7-b8be-ae901f2c72b9" />
<img width="965" alt="Capture d’écran 2025-04-10 à 14 48 23" src="https://github.com/user-attachments/assets/f91804a8-dcbc-4aba-ad4b-f649aa5675cd" />

## Risk
Small, we could just show the wrong list of spaces

## Deploy Plan
Deploy on front.
