### PR TITLE
[front] chore(space): Remove redundant SpaceResource fetch

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -15,7 +15,7 @@ import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { SidebarNavigation } from "@app/components/navigation/config";
-import { getTopNavigationTabs } from "@app/components/navigation/config";
+import { useTopNavigationTabs } from "@app/components/navigation/config";
 import { HelpDropdown } from "@app/components/navigation/HelpDropdown";
 import { UserMenu } from "@app/components/UserMenu";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
@@ -61,7 +61,7 @@ export const NavigationSidebar = React.forwardRef<
   }, [router.route, router.isReady]);
 
   // TODO(2024-06-19 flav): Fix issue with AppLayout changing between pagesg
-  const navs = useMemo(() => getTopNavigationTabs(owner), [owner]);
+  const navs = useTopNavigationTabs(owner);
   const currentTab = useMemo(
     () => navs.find((n) => n.isCurrent(activePath)),
     [navs, activePath]

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -13,6 +13,7 @@ import {
 } from "@dust-tt/sparkle";
 
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
+import { useLastSpaceViewed } from "@app/lib/swr/spaces";
 import type { AppType, WhitelistableFeature, WorkspaceType } from "@app/types";
 import { isAdmin, isBuilder } from "@app/types";
 
@@ -104,8 +105,10 @@ export type SidebarNavigation = {
   menus: AppLayoutNavigation[];
 };
 
-export const getTopNavigationTabs = (owner: WorkspaceType) => {
+export const useTopNavigationTabs = (owner: WorkspaceType) => {
   const nav: TabAppLayoutNavigation[] = [];
+
+  const { lastViewedSpace } = useLastSpaceViewed({ owner });
 
   nav.push({
     id: "conversations",
@@ -125,7 +128,9 @@ export const getTopNavigationTabs = (owner: WorkspaceType) => {
     id: "data_sources",
     label: "Knowledge",
     icon: BookOpenIcon,
-    href: `/w/${owner.sId}/spaces`,
+    href: lastViewedSpace
+      ? `/w/${owner.sId}/spaces/${lastViewedSpace}`
+      : `/w/${owner.sId}/spaces`,
     isCurrent: (currentRoute: string) =>
       currentRoute.startsWith("/w/[wId]/spaces/"),
     sizing: "hug",

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -31,6 +31,7 @@ import type {
   PostSpaceSearchRequestBody,
   PostSpaceSearchResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/search";
+import type { GetLastViewedSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/last_viewed";
 import type {
   ContentNodesViewType,
   DataSourceViewCategoryWithoutApps,
@@ -863,5 +864,28 @@ export function useSpacesSearchWithInfiniteScroll({
     nextPage: useCallback(async () => {
       await setSize((size) => size + 1);
     }, [setSize]),
+  };
+}
+
+export function useLastSpaceViewed({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const lastSpaceFetcher: Fetcher<GetLastViewedSpaceResponseBody> = fetcher;
+
+  const { data, isLoading, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/spaces/last_viewed`,
+    lastSpaceFetcher,
+    { disabled }
+  );
+
+  return {
+    lastViewedSpace: data?.success ? data.lastSpaceId : undefined,
+    isLastViewedSpaceLoading: isLoading,
+    isLastViewedSpaceError: error,
+    mutate,
   };
 }

--- a/front/pages/api/w/[wId]/spaces/last_viewed.ts
+++ b/front/pages/api/w/[wId]/spaces/last_viewed.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getPersistedNavigationSelection } from "@app/lib/persisted_navigation_selection";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type GetLastViewedSpaceResponseBody =
+  | {
+      success: true;
+      lastSpaceId: string;
+    }
+  | {
+      success: false;
+    };
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetLastViewedSpaceResponseBody>>,
+  auth: Authenticator
+) {
+  const { method } = req;
+
+  switch (method) {
+    case "GET": {
+      const selection = await getPersistedNavigationSelection(
+        auth.getNonNullableUser()
+      );
+      if (selection.lastSpaceId) {
+        return res.status(200).json({
+          success: true,
+          lastSpaceId: selection.lastSpaceId,
+        });
+      }
+      return res.status(200).json({
+        success: false,
+      });
+    }
+    default: {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected",
+        },
+      });
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/w/[wId]/spaces/index.tsx
+++ b/front/pages/w/[wId]/spaces/index.tsx
@@ -19,15 +19,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements(
       auth.getNonNullableUser()
     );
     if (selection.lastSpaceId) {
-      const space = await SpaceResource.fetchById(auth, selection.lastSpaceId);
-      if (space && space.canReadOrAdministrate(auth)) {
-        return {
-          redirect: {
-            destination: `/w/${owner.sId}/spaces/${space.sId}`,
-            permanent: false,
-          },
-        };
-      }
+      return {
+        redirect: {
+          destination: `/w/${owner.sId}/spaces/${selection.lastSpaceId}`,
+          permanent: false,
+        },
+      };
     }
 
     // Fall back to the global space.


### PR DESCRIPTION
## Description
- In a attempt to make loading "Knowledge" a bit faster, remove the redundant call to SpaceResource in the `DefaultSpace` page (which act as a redirect page), as the `[spaceId]/index.tsx` page does the same checks.
- Also add a swr hook to fetch proactively the last viewed space so we can put the space link directly in the tabs.

## Tests
- Locally & in Front-edge, click on "Knowledge", getting properly redirected to the default space or the last viewed one.

## Risk
- User getting redirect to a bad space if they have a spaceId stored in their metadata that either as been deleted or they've been removed from it. Risk is low because the next page (`[spaceId]/index.tsx`) still does the check and would give a 404 anyway.

## Deploy Plan
Deploy front.
