### PR TITLE
Add indexes on `connectorId` on `notion_pages` and `notion_databases`

### DIFF
--- a/connectors/migrations/db/migration_64.sql
+++ b/connectors/migrations/db/migration_64.sql
@@ -1,0 +1,3 @@
+-- Migration created on Apr 10, 2025
+CREATE INDEX CONCURRENTLY "notion_pages_connector_id" ON "notion_pages" ("connectorId");
+CREATE INDEX CONCURRENTLY "notion_databases_connector_id" ON "notion_databases" ("connectorId");

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -126,6 +126,7 @@ NotionPage.init(
   {
     sequelize: sequelizeConnection,
     indexes: [
+      { fields: ["connectorId"], concurrently: true },
       { fields: ["notionPageId", "connectorId"], unique: true },
       { fields: ["connectorId", "lastSeenTs"], concurrently: true },
       { fields: ["parentId"] },
@@ -227,6 +228,7 @@ NotionDatabase.init(
   {
     sequelize: sequelizeConnection,
     indexes: [
+      { fields: ["connectorId"], concurrently: true },
       { fields: ["notionDatabaseId", "connectorId"], unique: true },
       { fields: ["connectorId", "skipReason"] },
       { fields: ["lastSeenTs"] },


### PR DESCRIPTION
## Description

We have some queries that would be sped up by adding these indexes, for instance [here](https://console.cloud.google.com/sql/instances/cell-00001-connectors-db/insights;database=connectors;duration=PT1H;trace=546d5a4d4160d2e0f2a31899b7df2cac;span=662fd956aaf20ae1;query_hash=8960598734190683314;sort_by=TOTAL_EXEC_TIME/executed?invt=AbuX-A&project=prj-dust-europe-west1).
The indexes are already here in the US and are missing from our Sequelize model, which is why there were not created when initializing the db in EU.

## Tests

## Risk

- N/A.

## Deploy Plan

- Run `migration_64.sql` in EU.