### PR TITLE
feat(salesforce): proper support for datetimes and function calls

### DIFF
--- a/core/bin/salesforce.rs
+++ b/core/bin/salesforce.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let db = get_remote_database(&args.connection_string).await?;
 
-    let r = db
+    let _r = db
         .authorize_and_execute_query(
             &vec![Table::new(
                 Project::new_from_id(0),

--- a/core/src/databases/remote_databases/salesforce/sandbox/extract.rs
+++ b/core/src/databases/remote_databases/salesforce/sandbox/extract.rs
@@ -158,7 +158,7 @@ impl ObjectExtractor for Aggregate {
 mod tests {
     use crate::databases::remote_databases::salesforce::sandbox::structured_query::{
         Aggregate, AggregateFilter, AggregateFunction, Filter, GroupBy, HavingClause,
-        LogicalOperator, OrderBy, OrderDirection, ParentField, Relationship, WhereClause,
+        LogicalOperator, OrderBy, OrderDirection, ParentField, Relationship, TypedValue, WhereClause,
     };
 
     use super::*;
@@ -283,7 +283,7 @@ mod tests {
                 filters: vec![Filter::Condition {
                     field: "Owner.Department".to_string(),
                     operator: "=".to_string(),
-                    value: json!("Sales"),
+                    value: TypedValue::Regular(json!("Sales")),
                 }],
             }),
             order_by: vec![],
@@ -374,7 +374,7 @@ mod tests {
                 filters: vec![AggregateFilter {
                     field: "Hello.World".to_string(),
                     operator: "=".to_string(),
-                    value: json!("Sales"),
+                    value: TypedValue::Regular(json!("Sales")),
                     function: AggregateFunction::Count,
                 }],
             }),

--- a/core/src/databases/remote_databases/salesforce/sandbox/extract.rs
+++ b/core/src/databases/remote_databases/salesforce/sandbox/extract.rs
@@ -1,6 +1,6 @@
 use super::structured_query::{
-    Aggregate, Filter, GroupBy, HavingClause, ParentField, Relationship, StructuredQuery,
-    WhereClause,
+    Aggregate, FieldExpression, Filter, GroupBy, HavingClause, ParentField, Relationship, StructuredQuery,
+    TypedValue, WhereClause,
 };
 use std::collections::HashSet;
 
@@ -10,7 +10,7 @@ pub fn extract_objects(query: &StructuredQuery) -> Vec<String> {
     objects.into_iter().collect()
 }
 
-fn extract_objects_from_field(field: &str, objects: &mut HashSet<String>) {
+fn extract_objects_from_field_str(field: &str, objects: &mut HashSet<String>) {
     let parts: Vec<&str> = field.split('.').collect();
     if parts.len() <= 1 {
         return;
@@ -19,6 +19,29 @@ fn extract_objects_from_field(field: &str, objects: &mut HashSet<String>) {
     // insert each part of the path (except the last, which is a field, not an object)
     for relationship in parts.iter().take(parts.len() - 1) {
         objects.insert(relationship.to_string());
+    }
+}
+
+fn extract_objects_from_field(field: &FieldExpression, objects: &mut HashSet<String>) {
+    match field {
+        FieldExpression::Field(field_str) => {
+            extract_objects_from_field_str(field_str, objects);
+        }
+        FieldExpression::Function { arguments, .. } => {
+            // Extract objects from each function argument
+            for arg in arguments {
+                extract_objects_from_field_str(arg, objects);
+            }
+        }
+    }
+}
+
+fn extract_objects_from_typed_value(value: &TypedValue, objects: &mut HashSet<String>) {
+    if let TypedValue::Function { arguments, .. } = value {
+        // Extract objects from each function argument
+        for arg in arguments {
+            extract_objects_from_field_str(arg, objects);
+        }
     }
 }
 
@@ -84,8 +107,9 @@ impl ObjectExtractor for WhereClause {
 impl ObjectExtractor for Filter {
     fn extract_objects(&self, objects: &mut HashSet<String>) {
         match self {
-            Filter::Condition { field, .. } => {
+            Filter::Condition { field, value, .. } => {
                 extract_objects_from_field(field, objects);
+                extract_objects_from_typed_value(value, objects);
             }
             Filter::NestedCondition(where_clause) => {
                 where_clause.extract_objects(objects);
@@ -133,7 +157,7 @@ impl ObjectExtractor for GroupBy {
         match self {
             GroupBy::Simple(fields) | GroupBy::Advanced { fields, .. } => {
                 for field in fields {
-                    extract_objects_from_field(field, objects);
+                    extract_objects_from_field_str(field, objects);
                 }
             }
         }
@@ -143,22 +167,24 @@ impl ObjectExtractor for GroupBy {
 impl ObjectExtractor for HavingClause {
     fn extract_objects(&self, objects: &mut HashSet<String>) {
         for filter in &self.filters {
-            extract_objects_from_field(&filter.field, objects);
+            extract_objects_from_field_str(&filter.field, objects);
+            extract_objects_from_typed_value(&filter.value, objects);
         }
     }
 }
 
 impl ObjectExtractor for Aggregate {
     fn extract_objects(&self, objects: &mut HashSet<String>) {
-        extract_objects_from_field(&self.field, objects);
+        extract_objects_from_field_str(&self.field, objects);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::databases::remote_databases::salesforce::sandbox::structured_query::{
-        Aggregate, AggregateFilter, AggregateFunction, Filter, GroupBy, HavingClause,
+        Aggregate, AggregateFilter, AggregateFunction, FieldExpression, Filter, GroupBy, HavingClause,
         LogicalOperator, OrderBy, OrderDirection, ParentField, Relationship, TypedValue, WhereClause,
+        FunctionType,
     };
 
     use super::*;
@@ -168,7 +194,10 @@ mod tests {
     fn test_extract_main_object() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec!["Id".to_string(), "Name".to_string()],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()), 
+                FieldExpression::Field("Name".to_string())
+            ],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -189,9 +218,9 @@ mod tests {
         let query = StructuredQuery {
             object: "Account".to_string(),
             fields: vec![
-                "Id".to_string(),
-                "Name".to_string(),
-                "Owner.Department".to_string(),
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+                FieldExpression::Field("Owner.Department".to_string()),
             ],
             where_clause: None,
             order_by: vec![],
@@ -216,7 +245,7 @@ mod tests {
     fn test_extract_parent_fields() {
         let query = StructuredQuery {
             object: "Contact".to_string(),
-            fields: vec!["Id".to_string(), "Name".to_string()],
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -224,7 +253,7 @@ mod tests {
             relationships: vec![],
             parent_fields: vec![ParentField {
                 relationship: "Account".to_string(),
-                fields: vec!["Name".to_string(), "Industry".to_string()],
+                fields: vec![FieldExpression::Field("Name".to_string()), FieldExpression::Field("Industry".to_string())],
             }],
             aggregates: vec![],
             group_by: None,
@@ -243,7 +272,7 @@ mod tests {
     fn test_extract_relationships() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec!["Id".to_string(), "Name".to_string()],
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -251,9 +280,9 @@ mod tests {
             relationships: vec![Relationship {
                 relationship_name: "Contacts".to_string(),
                 fields: vec![
-                    "Id".to_string(),
-                    "FirstName".to_string(),
-                    "LastName".to_string(),
+                    FieldExpression::Field("Id".to_string()),
+                    FieldExpression::Field("FirstName".to_string()),
+                    FieldExpression::Field("LastName".to_string()),
                 ],
                 where_clause: None,
                 order_by: vec![],
@@ -277,11 +306,11 @@ mod tests {
     fn test_extract_where_clause() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec!["Id".to_string(), "Name".to_string()],
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
             where_clause: Some(WhereClause {
                 condition: LogicalOperator::And,
                 filters: vec![Filter::Condition {
-                    field: "Owner.Department".to_string(),
+                    field: FieldExpression::Field("Owner.Department".to_string()),
                     operator: "=".to_string(),
                     value: TypedValue::Regular(json!("Sales")),
                 }],
@@ -308,10 +337,10 @@ mod tests {
     fn test_extract_order_by() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec!["Id".to_string(), "Name".to_string()],
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
             where_clause: None,
             order_by: vec![OrderBy {
-                field: "Dust.DoIt".to_string(),
+                field: FieldExpression::Field("Dust.DoIt".to_string()),
                 direction: OrderDirection::Asc,
                 nulls: None,
             }],
@@ -336,7 +365,7 @@ mod tests {
     fn test_extract_group_by() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec!["Id".to_string(), "Name".to_string()],
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -360,7 +389,7 @@ mod tests {
     fn test_extract_having() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec!["Id".to_string(), "Name".to_string()],
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -392,7 +421,7 @@ mod tests {
     fn test_extract_aggregate_function() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec!["Id".to_string(), "Name".to_string()],
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
             aggregates: vec![Aggregate {
                 field: "Hello.World".to_string(),
                 function: AggregateFunction::Count,
@@ -410,6 +439,116 @@ mod tests {
 
         let objects = extract_objects(&query);
         let expected = HashSet::from(["Account", "Hello"]);
+        assert_eq!(
+            objects.iter().map(|s| s.as_str()).collect::<HashSet<_>>(),
+            expected
+        );
+    }
+    
+    #[test]
+    fn test_extract_function_field() {
+        let query = StructuredQuery {
+            object: "Account".to_string(),
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Function {
+                    function: "DAY_ONLY".to_string(),
+                    arguments: vec!["Contact.CreatedDate".to_string()],
+                },
+                FieldExpression::Function {
+                    function: "CALENDAR_MONTH".to_string(),
+                    arguments: vec!["Opportunity.CloseDate".to_string()],
+                },
+            ],
+            where_clause: None,
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            relationships: vec![],
+            parent_fields: vec![],
+            aggregates: vec![],
+            group_by: None,
+            having: None,
+        };
+
+        let objects = extract_objects(&query);
+        let expected = HashSet::from(["Account", "Contact", "Opportunity"]);
+        assert_eq!(
+            objects.iter().map(|s| s.as_str()).collect::<HashSet<_>>(),
+            expected
+        );
+    }
+    
+    #[test]
+    fn test_extract_function_where_clause() {
+        let query = StructuredQuery {
+            object: "Case".to_string(),
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Subject".to_string())],
+            where_clause: Some(WhereClause {
+                condition: LogicalOperator::And,
+                filters: vec![
+                    Filter::Condition {
+                        field: FieldExpression::Function {
+                            function: "CALENDAR_YEAR".to_string(),
+                            arguments: vec!["User.CreatedDate".to_string()],
+                        },
+                        operator: "=".to_string(),
+                        value: TypedValue::Regular(json!(2023)),
+                    },
+                    Filter::Condition {
+                        field: FieldExpression::Field("Status".to_string()),
+                        operator: "=".to_string(),
+                        value: TypedValue::Function {
+                            value_type: FunctionType::Function,
+                            function: "DAY_ONLY".to_string(),
+                            arguments: vec!["Account.LastModifiedDate".to_string()],
+                        },
+                    }
+                ],
+            }),
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            relationships: vec![],
+            parent_fields: vec![],
+            aggregates: vec![],
+            group_by: None,
+            having: None,
+        };
+
+        let objects = extract_objects(&query);
+        let expected = HashSet::from(["Case", "User", "Account"]);
+        assert_eq!(
+            objects.iter().map(|s| s.as_str()).collect::<HashSet<_>>(),
+            expected
+        );
+    }
+    
+    #[test]
+    fn test_extract_function_order_by() {
+        let query = StructuredQuery {
+            object: "Contact".to_string(),
+            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            where_clause: None,
+            order_by: vec![OrderBy {
+                field: FieldExpression::Function {
+                    function: "CALENDAR_MONTH".to_string(),
+                    arguments: vec!["Campaign.StartDate".to_string()],
+                },
+                direction: OrderDirection::Asc,
+                nulls: None,
+            }],
+            limit: None,
+            offset: None,
+            relationships: vec![],
+            parent_fields: vec![],
+            aggregates: vec![],
+            group_by: None,
+            having: None,
+        };
+
+        let objects = extract_objects(&query);
+        let expected = HashSet::from(["Contact", "Campaign"]);
         assert_eq!(
             objects.iter().map(|s| s.as_str()).collect::<HashSet<_>>(),
             expected

--- a/core/src/databases/remote_databases/salesforce/sandbox/extract.rs
+++ b/core/src/databases/remote_databases/salesforce/sandbox/extract.rs
@@ -1,6 +1,6 @@
 use super::structured_query::{
-    Aggregate, FieldExpression, Filter, GroupBy, HavingClause, ParentField, Relationship, StructuredQuery,
-    TypedValue, WhereClause,
+    Aggregate, FieldExpression, Filter, GroupBy, HavingClause, ParentField, Relationship,
+    StructuredQuery, TypedValue, WhereClause,
 };
 use std::collections::HashSet;
 
@@ -28,7 +28,6 @@ fn extract_objects_from_field(field: &FieldExpression, objects: &mut HashSet<Str
             extract_objects_from_field_str(field_str, objects);
         }
         FieldExpression::Function { arguments, .. } => {
-            // Extract objects from each function argument
             for arg in arguments {
                 extract_objects_from_field_str(arg, objects);
             }
@@ -38,7 +37,6 @@ fn extract_objects_from_field(field: &FieldExpression, objects: &mut HashSet<Str
 
 fn extract_objects_from_typed_value(value: &TypedValue, objects: &mut HashSet<String>) {
     if let TypedValue::Function { arguments, .. } = value {
-        // Extract objects from each function argument
         for arg in arguments {
             extract_objects_from_field_str(arg, objects);
         }
@@ -182,9 +180,9 @@ impl ObjectExtractor for Aggregate {
 #[cfg(test)]
 mod tests {
     use crate::databases::remote_databases::salesforce::sandbox::structured_query::{
-        Aggregate, AggregateFilter, AggregateFunction, FieldExpression, Filter, GroupBy, HavingClause,
-        LogicalOperator, OrderBy, OrderDirection, ParentField, Relationship, TypedValue, WhereClause,
-        FunctionType,
+        Aggregate, AggregateFilter, AggregateFunction, FieldExpression, Filter, FunctionType,
+        GroupBy, HavingClause, LogicalOperator, OrderBy, OrderDirection, ParentField, Relationship,
+        TypedValue, WhereClause,
     };
 
     use super::*;
@@ -195,8 +193,8 @@ mod tests {
         let query = StructuredQuery {
             object: "Account".to_string(),
             fields: vec![
-                FieldExpression::Field("Id".to_string()), 
-                FieldExpression::Field("Name".to_string())
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
             ],
             where_clause: None,
             order_by: vec![],
@@ -245,7 +243,10 @@ mod tests {
     fn test_extract_parent_fields() {
         let query = StructuredQuery {
             object: "Contact".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+            ],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -253,7 +254,10 @@ mod tests {
             relationships: vec![],
             parent_fields: vec![ParentField {
                 relationship: "Account".to_string(),
-                fields: vec![FieldExpression::Field("Name".to_string()), FieldExpression::Field("Industry".to_string())],
+                fields: vec![
+                    FieldExpression::Field("Name".to_string()),
+                    FieldExpression::Field("Industry".to_string()),
+                ],
             }],
             aggregates: vec![],
             group_by: None,
@@ -272,7 +276,10 @@ mod tests {
     fn test_extract_relationships() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+            ],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -306,7 +313,10 @@ mod tests {
     fn test_extract_where_clause() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+            ],
             where_clause: Some(WhereClause {
                 condition: LogicalOperator::And,
                 filters: vec![Filter::Condition {
@@ -337,7 +347,10 @@ mod tests {
     fn test_extract_order_by() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+            ],
             where_clause: None,
             order_by: vec![OrderBy {
                 field: FieldExpression::Field("Dust.DoIt".to_string()),
@@ -365,7 +378,10 @@ mod tests {
     fn test_extract_group_by() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+            ],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -389,7 +405,10 @@ mod tests {
     fn test_extract_having() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+            ],
             where_clause: None,
             order_by: vec![],
             limit: None,
@@ -421,7 +440,10 @@ mod tests {
     fn test_extract_aggregate_function() {
         let query = StructuredQuery {
             object: "Account".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+            ],
             aggregates: vec![Aggregate {
                 field: "Hello.World".to_string(),
                 function: AggregateFunction::Count,
@@ -444,7 +466,7 @@ mod tests {
             expected
         );
     }
-    
+
     #[test]
     fn test_extract_function_field() {
         let query = StructuredQuery {
@@ -478,12 +500,15 @@ mod tests {
             expected
         );
     }
-    
+
     #[test]
     fn test_extract_function_where_clause() {
         let query = StructuredQuery {
             object: "Case".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Subject".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Subject".to_string()),
+            ],
             where_clause: Some(WhereClause {
                 condition: LogicalOperator::And,
                 filters: vec![
@@ -503,7 +528,7 @@ mod tests {
                             function: "DAY_ONLY".to_string(),
                             arguments: vec!["Account.LastModifiedDate".to_string()],
                         },
-                    }
+                    },
                 ],
             }),
             order_by: vec![],
@@ -523,12 +548,15 @@ mod tests {
             expected
         );
     }
-    
+
     #[test]
     fn test_extract_function_order_by() {
         let query = StructuredQuery {
             object: "Contact".to_string(),
-            fields: vec![FieldExpression::Field("Id".to_string()), FieldExpression::Field("Name".to_string())],
+            fields: vec![
+                FieldExpression::Field("Id".to_string()),
+                FieldExpression::Field("Name".to_string()),
+            ],
             where_clause: None,
             order_by: vec![OrderBy {
                 field: FieldExpression::Function {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -131,7 +131,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "b4f205e453",
       appHash:
-        "23af3a3afe52e008fbd21ca71ac2d4f60b8e6042f6498fd100e8ac8654d4f411",
+        "d0929a9d9d4855298875752495b8b8a7c296827d2eff56bf60c48c64cc3bb660",
     },
     config: {
       MODEL: {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -131,7 +131,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "b4f205e453",
       appHash:
-        "d6c762512b6d716f7e13151cf2c245bf51e1923f54859303ca7b144d4ac6dc3f",
+        "23af3a3afe52e008fbd21ca71ac2d4f60b8e6042f6498fd100e8ac8654d4f411",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

This PR improves our Salesforce JSON-based DSL and associated toolchain that validates queries and convert them to SOQL.

Notably:
- Add support for Datetimes -> this required moving to a structured enum for field expression. We support ISO dates / datetimes and also the Salesfore datetime literals like "TODAY" "NEXT_WEEK" etc... This also includes the parametrized literals such as `NEXT_N_FISCAL_YEARS:2`
- Add support for calling functions (in SELECT, WHERE, ORDER BY etc...)

I have updated the registry to point tables query to a new version of the dust apps that includes a new prompt for Salesforce DBs.

## Tests

Many tests included

## Risk

Risk to break current Salesforce agents (which are few in alpha)

## Deploy Plan

Deploy `core` and `front`