### PR TITLE
Add: tool to generate and convert file formats + handling of file outputs

### DIFF
--- a/front/components/actions/mcp/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/MCPActionDetails.tsx
@@ -83,7 +83,7 @@ export function MCPActionDetails({
                 return (
                   <div key={file.fileId}>
                     <a
-                      href={file.fileId}
+                      href={`/api/w/${owner.sId}/files/${file.fileId}`}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -477,7 +477,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         const r = await processAndStoreFromUrl(auth, {
           url: c.resource.uri,
           useCase: "conversation",
-          fileName: "generated-image.png",
+          fileName: c.resource.uri.split("/").pop() ?? "generated-file",
           contentType: c.resource.mimeType,
         });
         if (r.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -8,7 +8,8 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "table_utils",
   "github",
   "ask_agent",
-  "image_generation_dalle",
+  "generate_image",
+  "generate_file",
 ] as const;
 
 export const INTERNAL_MCP_SERVERS: Record<
@@ -39,7 +40,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     isDefault: false,
     flag: "mcp_actions",
   },
-  image_generation_dalle: {
+  generate_image: {
     id: 5,
     isDefault: true,
     flag: "mcp_actions",
@@ -47,6 +48,11 @@ export const INTERNAL_MCP_SERVERS: Record<
   ask_agent: {
     id: 6,
     isDefault: false,
+    flag: "mcp_actions",
+  },
+  generate_file: {
+    id: 7,
+    isDefault: true,
     flag: "mcp_actions",
   },
 };

--- a/front/lib/actions/mcp_internal_actions/servers/generate_file.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/generate_file.ts
@@ -1,0 +1,221 @@
+import { Readable } from "node:stream";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { UploadResult } from "convertapi";
+import ConvertAPI from "convertapi";
+import { z } from "zod";
+
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import { cacheWithRedis } from "@app/lib/utils/cache";
+import type { SupportedFileContentType } from "@app/types";
+import { assertNever, validateUrl } from "@app/types";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "generate_file",
+  version: "1.0.0",
+  description: "Generate and convert files on demand.",
+  authorization: null,
+  visual: "https://dust.tt/static/droidavatar/Droid_Green_1.jpg",
+};
+
+const OUTPUT_FORMATS = [
+  "csv",
+  "doc",
+  "docx",
+  "gif",
+  "html",
+  "jpg",
+  "md",
+  "pdf",
+  "png",
+  "pptx",
+  "txt",
+  "webp",
+  "xls",
+  "xlsx",
+  "xml",
+] as const;
+
+const createServer = (): McpServer => {
+  const server = new McpServer(serverInfo);
+  server.tool(
+    "get_source_format_to_convert_to",
+    "Get the source format to convert to a given format.",
+    {
+      output_format: z.enum(OUTPUT_FORMATS).describe("The format to check."),
+    },
+    async ({ output_format }) => {
+      const formats = await cacheWithRedis(
+        async () => {
+          const r = await fetch(
+            `https://v2.convertapi.com/info/*/to/${output_format}`
+          );
+          const data: { SourceFileFormats: string[] }[] = await r.json();
+          const formats = data.flatMap((f) => f.SourceFileFormats);
+          return formats;
+        },
+        () => `get_source_format_to_convert_to_${output_format}`,
+        60 * 60 * 24 * 1000
+      )();
+
+      return {
+        isError: false,
+        content: [
+          {
+            type: "text",
+            text:
+              "Here are the formats you can use to convert to " +
+              output_format +
+              ": " +
+              // The output format is included because it's always possible to convert to it.
+              [...formats, output_format].join(", "),
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    "generate_file",
+    "Generate a file",
+    {
+      file_name: z
+        .string()
+        .describe(
+          "The name of the file to generate. Must be a valid filename without the format extension."
+        ),
+      input: z
+        .string()
+        .max(64000)
+        .describe(
+          "The content of the file to generate. You can either provide a url to a file or the content directly."
+        ),
+      source_format: z
+        .string()
+        .describe(
+          "The format of the source file. Use the `get_source_format_to_convert_to` tool to get the list of formats you can use."
+        ),
+      output_format: z
+        .enum(OUTPUT_FORMATS)
+        .describe("The format of the output file."),
+    },
+    async ({ file_name, input, source_format, output_format }) => {
+      if (!process.env.CONVERTAPI_API_KEY) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "Missing environment variable.",
+            },
+          ],
+        };
+      }
+
+      let contentType: SupportedFileContentType | null;
+      switch (output_format) {
+        case "md":
+          contentType = "text/markdown";
+          break;
+        case "gif":
+          contentType = "image/gif";
+          break;
+        case "pdf":
+          contentType = "application/pdf";
+          break;
+        case "doc":
+          contentType = "application/msword";
+          break;
+        case "docx":
+          contentType =
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+          break;
+        case "pptx":
+          contentType =
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+          break;
+        case "csv":
+          contentType = "text/csv";
+          break;
+        case "txt":
+          contentType = "text/plain";
+          break;
+        case "html":
+          contentType = "text/html";
+          break;
+        case "jpg":
+          contentType = "image/jpeg";
+          break;
+        case "png":
+          contentType = "image/png";
+          break;
+        case "xml":
+          contentType = "text/xml";
+          break;
+        case "xls":
+          contentType = "application/vnd.ms-excel";
+          break;
+        case "xlsx":
+          contentType =
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+          break;
+        case "webp":
+          contentType = "image/webp";
+          break;
+
+        default:
+          assertNever(output_format);
+      }
+
+      const convertapi = new ConvertAPI(process.env.CONVERTAPI_API_KEY);
+      let url: string | UploadResult = input;
+      if (!validateUrl(input).valid) {
+        url = await convertapi.upload(
+          Readable.from(input),
+          `${file_name}.${source_format}`
+        );
+      }
+
+      try {
+        const result = await convertapi.convert(
+          output_format,
+          {
+            File: url,
+          },
+          source_format
+        );
+
+        const content = result.files.map((file) => ({
+          type: "resource" as const,
+          resource: {
+            mimeType: contentType,
+            uri: file.url,
+            text: `Your file was generated successfully.`,
+          },
+        }));
+
+        return {
+          isError: false,
+          content,
+        };
+      } catch (e) {
+        if (typeof e === "object" && e !== null && "message" in e) {
+          return {
+            isError: false,
+            content: [
+              {
+                type: "text",
+                text: `There was an error generating your file: ${e.message}, maybe you can chain multiple conversions to get the result you want, pay attention to the source format you use.`,
+              },
+            ],
+          };
+        }
+        throw e;
+      }
+    }
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/generate_image.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/generate_image.ts
@@ -7,7 +7,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { dustManagedCredentials } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "image_generation_dalle",
+  name: "generate_image",
   version: "1.0.0",
   description: "Generate images with the Dall-E v3 model from OpenAI.",
   visual: "image",
@@ -70,7 +70,7 @@ const createServer = (auth: Authenticator): McpServer => {
         resource: {
           mimeType: "image/png",
           uri: image.url!,
-          text: `Here is the image's url: ${image.url}`,
+          text: `Your image was generated successfully.`,
         },
       }));
 

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -3,9 +3,10 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { default as askAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/ask_agent";
 import { default as dataSourceUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/data_source_utils";
+import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/generate_file";
+import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/generate_image";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
 import { default as helloWorldServer } from "@app/lib/actions/mcp_internal_actions/servers/hello_world";
-import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation_dalle";
 import { default as tableUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/table_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types";
@@ -29,10 +30,12 @@ export function getInternalMCPServer(
       return tableUtilsServer();
     case "github":
       return githubServer(auth, mcpServerId);
-    case "image_generation_dalle":
+    case "generate_image":
       return imageGenerationDallEServer(auth);
     case "ask_agent":
       return askAgentServer();
+    case "generate_file":
+      return generateFileServer();
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -45,6 +45,7 @@
         "class-variance-authority": "^0.7.0",
         "cls-hooked": "^4.2.2",
         "cmdk": "^1.0.0",
+        "convertapi": "^1.15.0",
         "cron-parser": "^4.9.0",
         "csv-parse": "^5.5.2",
         "csv-stringify": "^6.4.5",
@@ -11004,6 +11005,14 @@
       "version": "1.9.0",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/convertapi": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/convertapi/-/convertapi-1.15.0.tgz",
+      "integrity": "sha512-wu1pJ27SuIc/mNlbjs8lP1hAsEN16AmKzMZNo9Qx/Z3CrH1ozGQYF2jGXaceXWSRNvKFoCuF0m5ek+vz8Nswrw==",
+      "dependencies": {
+        "axios": "^1.6.2"
+      }
     },
     "node_modules/cookie": {
       "version": "0.7.2",

--- a/front/package.json
+++ b/front/package.json
@@ -59,6 +59,7 @@
     "class-variance-authority": "^0.7.0",
     "cls-hooked": "^4.2.2",
     "cmdk": "^1.0.0",
+    "convertapi": "^1.15.0",
     "cron-parser": "^4.9.0",
     "csv-parse": "^5.5.2",
     "csv-stringify": "^6.4.5",


### PR DESCRIPTION
## Description

- Added support for displaying generated non image files (with the same "citation" design for now).
- Added POC action to generate / convert files

<img width="851" alt="image" src="https://github.com/user-attachments/assets/9084ea3d-7b6e-4568-a4b8-a5a72f66d86e" />

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Already added a testing API token for convert api. Deploy `front`