### PR TITLE
[front] fix(space/mcp): Hide default actions

### DIFF
--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -747,6 +747,7 @@ const SpaceActionsSubMenu = ({
     owner,
     space,
   });
+  const filteredServerViews = serverViews.filter((s) => !s.server.isDefault);
 
   return (
     <Tree.Item
@@ -761,11 +762,15 @@ const SpaceActionsSubMenu = ({
       onChevronClick={() => setIsExpanded(!isExpanded)}
       visual={categoryDetails.icon}
       areActionsFading={false}
-      type={isMCPServerViewsLoading || serverViews.length > 0 ? "node" : "leaf"}
+      type={
+        isMCPServerViewsLoading || filteredServerViews.length > 0
+          ? "node"
+          : "leaf"
+      }
     >
       {isExpanded && (
         <Tree isLoading={isMCPServerViewsLoading}>
-          {sortBy(serverViews, "server.name").map((serverView) => (
+          {sortBy(filteredServerViews, "server.name").map((serverView) => (
             <SpaceActionItem
               action={serverView}
               key={serverView.server.name}

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -747,7 +747,6 @@ const SpaceActionsSubMenu = ({
     owner,
     space,
   });
-  const filteredServerViews = serverViews.filter((s) => !s.server.isDefault);
 
   return (
     <Tree.Item
@@ -762,15 +761,11 @@ const SpaceActionsSubMenu = ({
       onChevronClick={() => setIsExpanded(!isExpanded)}
       visual={categoryDetails.icon}
       areActionsFading={false}
-      type={
-        isMCPServerViewsLoading || filteredServerViews.length > 0
-          ? "node"
-          : "leaf"
-      }
+      type={isMCPServerViewsLoading || serverViews.length > 0 ? "node" : "leaf"}
     >
       {isExpanded && (
         <Tree isLoading={isMCPServerViewsLoading}>
-          {sortBy(filteredServerViews, "server.name").map((serverView) => (
+          {sortBy(serverViews, "server.name").map((serverView) => (
             <SpaceActionItem
               action={serverView}
               key={serverView.server.name}

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -47,9 +47,9 @@ async function handler(
       );
       return res.status(200).json({
         success: true,
-        serverViews: mcpServerViews.map((mcpServerView) =>
-          mcpServerView.toJSON()
-        ),
+        serverViews: mcpServerViews
+          .map((mcpServerView) => mcpServerView.toJSON())
+          .filter((s) => !s.server.isDefault),
       });
     }
     case "POST": {


### PR DESCRIPTION
## Description
- Fix [#2612](https://github.com/dust-tt/tasks/issues/2612)
- Hide default actions from actions section in knowledge for spaces.

## Tests
- Locally checked that the default actions are not showing up

## Risk
None

## Deploy Plan
Deploy to front.
