### PR TITLE
[Attach/Knowledge] Log search queries

### DIFF
--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -13,6 +13,7 @@ import type {
   SearchWarningCode,
   WithAPIErrorResponse,
 } from "@app/types";
+import logger from "@app/logger/logger";
 
 export type DataSourceContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
@@ -53,6 +54,13 @@ async function handler(
     });
   }
 
+  logger.info(
+    {
+      workspaceId: auth.workspace()?.sId,
+      params: bodyValidation.right,
+    },
+    "Search knowledge (global)"
+  );
   const searchResult = await handleSearch(req, auth, bodyValidation.right);
 
   if (searchResult.isErr()) {

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { handleSearch, SearchRequestBody } from "@app/lib/api/search";
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
   ContentNodeWithParent,
@@ -13,7 +14,6 @@ import type {
   SearchWarningCode,
   WithAPIErrorResponse,
 } from "@app/types";
-import logger from "@app/logger/logger";
 
 export type DataSourceContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -11,6 +11,7 @@ import { searchContenNodesInSpace } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
   DataSourceViewContentNode,
@@ -18,7 +19,6 @@ import type {
   WithAPIErrorResponse,
 } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
-import logger from "@app/logger/logger";
 
 const SearchRequestBody = t.type({
   // Optional array of data source view IDs to search in.

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search.ts
@@ -18,6 +18,7 @@ import type {
   WithAPIErrorResponse,
 } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
+import logger from "@app/logger/logger";
 
 const SearchRequestBody = t.type({
   // Optional array of data source view IDs to search in.
@@ -121,6 +122,15 @@ async function handler(
       },
     });
   }
+
+  logger.info(
+    {
+      workspaceId: auth.workspace()?.sId,
+      params: bodyValidation.right,
+      spaceId: space.sId,
+    },
+    "Search knowledge (single space)"
+  );
 
   const searchRes = await searchContenNodesInSpace(
     auth,


### PR DESCRIPTION
Description
---
This is to allow understanding what people search, among which whether they paste document URLs in searches, as was discussed during the attach project

Risk
---
Too much logs. But since search is debounced, it should be fine. That'd be #dailyUsers*#dailySearches so likely a few thousands logs per day

Deploy
---
front
