### PR TITLE
[Attach - Notion] Allow search of notion databases

### DIFF
--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -113,8 +113,11 @@ export function listFiles(
           canDoJIT &&
           isSearchableContentType(m.contentType) &&
           // Tables from knowledge are not materialized as raw content. As such, they cannot be
-          // searched.
-          !isContentNodeTable;
+          // searched--except for notion databases, that may have children.
+          !(
+            isContentNodeTable &&
+            m.contentType !== CONTENT_NODE_MIME_TYPES.NOTION.DATABASE
+          );
 
         const baseAttachment: BaseConversationAttachmentType = {
           title: m.title,


### PR DESCRIPTION
Description
---
Notion databases were previously only table-queryable, but not searchable.

![Screenshot From 2025-04-10 21-54-58](https://github.com/user-attachments/assets/4f235ffe-727c-4535-bf82-94f5fbe26249)

This was an issue because many DBs have child pages. This PR fixes.
![Screenshot From 2025-04-10 21-59-29](https://github.com/user-attachments/assets/874ca6e3-2268-4cc1-8ba9-92b42fe37743)


Risk
---
low

Deploy
---
front

