### PR TITLE
Handle missing servers, unitfy naming of internal servers

### DIFF
--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -368,7 +368,7 @@ export function hasErrorActionMCP(
         mcpServerView.id === action.configuration.mcpServerViewId
     );
     if (!mcpServerView) {
-      return "Please select a MCP configuration.";
+      return "Please select a tool.";
     }
 
     const requirements = getRequirements(mcpServerView);
@@ -393,5 +393,5 @@ export function hasErrorActionMCP(
 
     return null;
   }
-  return "Please select a MCP configuration.";
+  return "Please select a tool.";
 }

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -15,6 +15,7 @@ import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/ac
 import { Workspace } from "@app/lib/models/workspace";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types";
 
 export async function fetchMCPServerActionConfigurations(
@@ -115,15 +116,22 @@ export async function fetchMCPServerActionConfigurations(
       auth,
       mcpServerViewId
     );
+    let serverName: string | null = null;
+    let serverDescription: string | null = null;
+
     if (!mcpServerView) {
-      throw new Error(
+      logger.warn(
         `MCPServerView with mcpServerViewId ${mcpServerViewId} not found.`
       );
+      serverName = "Missing";
+      serverDescription = "Missing";
+    } else {
+      const { name, description } =
+        await mcpServerView.getMCPServerMetadata(auth);
+
+      serverName = name;
+      serverDescription = description;
     }
-
-    const { name: serverName, description: serverDescription } =
-      await mcpServerView.getMCPServerMetadata(auth);
-
     if (!actionsByConfigurationId.has(agentConfigurationId)) {
       actionsByConfigurationId.set(agentConfigurationId, []);
     }
@@ -136,7 +144,7 @@ export async function fetchMCPServerActionConfigurations(
         type: "mcp_server_configuration",
         name: config.name ?? serverName,
         description: config.singleToolDescriptionOverride ?? serverDescription,
-        mcpServerViewId: mcpServerView.sId,
+        mcpServerViewId: mcpServerView?.sId ?? "",
         dataSources: dataSourceConfigurations.map(
           renderDataSourceConfiguration
         ),

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -3,13 +3,17 @@ import type { ModelId, Result, WhitelistableFeature } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
-  "data_source_utils",
-  "hello_world",
-  "table_utils",
+  // Note:
+  // Names should reflect the purpose of the server, but not directly the tools it contains.
+  // We'll prefix all tools with the server name to avoid conflicts.
+  // It's okay to change the name of the server as we don't refer to it directly.
+  "image_generator",
+  "file_generator",
   "github",
-  "ask_agent",
-  "generate_image",
-  "generate_file",
+  "data_sources_debugger",
+  "authentication_debugger",
+  "tables_debugger",
+  "child_agent_debugger",
 ] as const;
 
 export const INTERNAL_MCP_SERVERS: Record<
@@ -20,40 +24,49 @@ export const INTERNAL_MCP_SERVERS: Record<
     flag: WhitelistableFeature | null;
   }
 > = {
-  hello_world: {
+  // Notes:
+  // ids should be stable, do not change them for production internal servers as it would break existing agents.
+  // Let's start dev actions at 1000 to avoid conflicts with production actions.
+  // flag "mcp_actions" for actions that are part of the MCP actions feature.
+  // flag "dev_mcp_actions" for actions that are only used internally for dev and testing.
+
+  // Production
+  github: {
     id: 1,
     isDefault: false,
     flag: "mcp_actions",
   },
-  data_source_utils: {
+  image_generator: {
     id: 2,
-    isDefault: false,
+    isDefault: true,
     flag: "mcp_actions",
   },
-  table_utils: {
+  file_generator: {
     id: 3,
-    isDefault: false,
-    flag: "mcp_actions",
-  },
-  github: {
-    id: 4,
-    isDefault: false,
-    flag: "mcp_actions",
-  },
-  generate_image: {
-    id: 5,
     isDefault: true,
     flag: "mcp_actions",
   },
-  ask_agent: {
-    id: 6,
+
+  // Dev
+  data_sources_debugger: {
+    id: 1000,
     isDefault: false,
-    flag: "mcp_actions",
+    flag: "dev_mcp_actions",
   },
-  generate_file: {
-    id: 7,
-    isDefault: true,
-    flag: "mcp_actions",
+  child_agent_debugger: {
+    id: 1001,
+    isDefault: false,
+    flag: "dev_mcp_actions",
+  },
+  authentication_debugger: {
+    id: 1002,
+    isDefault: false,
+    flag: "dev_mcp_actions",
+  },
+  tables_debugger: {
+    id: 1003,
+    isDefault: false,
+    flag: "dev_mcp_actions",
   },
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/authentication_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/authentication_debugger.ts
@@ -7,7 +7,7 @@ import type { OAuthProvider } from "@app/types";
 
 const provider: OAuthProvider = "google_drive" as const;
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "hello_world",
+  name: "authentication_debugger",
   version: "1.0.0",
   description: "You are a helpful server that can say hello to the user.",
   authorization: {

--- a/front/lib/actions/mcp_internal_actions/servers/child_agent_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/child_agent_debugger.ts
@@ -11,7 +11,7 @@ import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "ask_agent",
+  name: "child_agent_debugger",
   version: "1.0.0",
   description: "Demo server showing a basic interaction with a child agent.",
   visual: "robot",

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_debugger.ts
@@ -15,7 +15,7 @@ import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "data_source_utils",
+  name: "data_sources_debugger",
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with a data source configuration.",

--- a/front/lib/actions/mcp_internal_actions/servers/file_generator.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generator.ts
@@ -11,7 +11,7 @@ import type { SupportedFileContentType } from "@app/types";
 import { assertNever, normalizeError, validateUrl } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "generate_file",
+  name: "file_generator",
   version: "1.0.0",
   description: "Generate and convert files on demand.",
   authorization: null,

--- a/front/lib/actions/mcp_internal_actions/servers/image_generator.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generator.ts
@@ -7,9 +7,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { dustManagedCredentials } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "generate_image",
+  name: "image_generator",
   version: "1.0.0",
-  description: "Generate images with the Dall-E v3 model from OpenAI.",
+  description: "Generate images with Dall-E v3.",
   visual: "image",
   authorization: null,
 };

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -1,13 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { default as askAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/ask_agent";
-import { default as dataSourceUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/data_source_utils";
-import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/generate_file";
-import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/generate_image";
+import { default as helloWorldServer } from "@app/lib/actions/mcp_internal_actions/servers/authentication_debugger";
+import { default as askAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/child_agent_debugger";
+import { default as dataSourceUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_debugger";
+import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/file_generator";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
-import { default as helloWorldServer } from "@app/lib/actions/mcp_internal_actions/servers/hello_world";
-import { default as tableUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/table_utils";
+import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generator";
+import { default as tableUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_debugger";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types";
 
@@ -22,20 +22,20 @@ export function getInternalMCPServer(
   }
 ): McpServer {
   switch (internalMCPServerName) {
-    case "hello_world":
+    case "authentication_debugger":
       return helloWorldServer(auth, mcpServerId);
-    case "data_source_utils":
+    case "data_sources_debugger":
       return dataSourceUtilsServer();
-    case "table_utils":
+    case "tables_debugger":
       return tableUtilsServer();
     case "github":
       return githubServer(auth, mcpServerId);
-    case "generate_image":
+    case "image_generator":
       return imageGenerationDallEServer(auth);
-    case "ask_agent":
-      return askAgentServer();
-    case "generate_file":
+    case "file_generator":
       return generateFileServer();
+    case "child_agent_debugger":
+      return askAgentServer();
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/tables_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_debugger.ts
@@ -6,7 +6,7 @@ import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_acti
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "table_utils",
+  name: "tables_debugger",
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with a table configuration.",

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -23,6 +23,9 @@ export type DustErrorCode =
   | "user_already_member"
   | "user_not_found"
   | "user_not_member"
+  // MCP Server errors
+  | "remote_server_not_found"
+  | "internal_server_not_found"
   // Space errors
   | "space_already_exists";
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -65,21 +65,47 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     this.editedByUser = editedByUser;
   }
 
-  private async init(auth: Authenticator) {
-    this.remoteMCPServer =
-      (this.remoteMCPServerId &&
-        (await RemoteMCPServerResource.findByPk(
-          auth,
-          this.remoteMCPServerId
-        ))) ||
-      undefined;
-    this.internalMCPServer =
-      (this.internalMCPServerId &&
-        (await InternalMCPServerInMemoryResource.fetchById(
-          auth,
-          this.internalMCPServerId
-        ))) ||
-      undefined;
+  private async init(auth: Authenticator): Promise<Result<void, DustError>> {
+    if (this.remoteMCPServerId) {
+      const remoteServer = await RemoteMCPServerResource.findByPk(
+        auth,
+        this.remoteMCPServerId
+      );
+      if (!remoteServer) {
+        return new Err(
+          new DustError(
+            "remote_server_not_found",
+            "Remote server not found, should never happen as we are suppose to clear the view when deleting a remote server."
+          )
+        );
+      }
+      this.remoteMCPServer = remoteServer;
+      return new Ok(undefined);
+    }
+
+    if (this.internalMCPServerId) {
+      const internalServer = await InternalMCPServerInMemoryResource.fetchById(
+        auth,
+        this.internalMCPServerId
+      );
+      if (!internalServer) {
+        return new Err(
+          new DustError(
+            "internal_server_not_found",
+            "Internal server not found, it might have been deleted from the list of internal servers. Action: clear the mcp server views of orphan internal servers."
+          )
+        );
+      }
+      this.internalMCPServer = internalServer;
+      return new Ok(undefined);
+    }
+
+    return new Err(
+      new DustError(
+        "internal_error",
+        "We could not find the server because it was of an unknown type, this should never happen."
+      )
+    );
   }
 
   private static async makeNew(
@@ -115,11 +141,14 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       { transaction }
     );
 
-    const res = new this(MCPServerViewResource.model, server.get(), space);
+    const resource = new this(MCPServerViewResource.model, server.get(), space);
 
-    await res.init(auth);
+    const r = await resource.init(auth);
+    if (r.isErr()) {
+      throw r.error;
+    }
 
-    return res;
+    return resource;
   }
 
   public static async create(
@@ -165,10 +194,14 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       ],
     });
 
+    const filteredViews: MCPServerViewResource[] = [];
     for (const view of views) {
-      await view.init(auth);
+      const r = await view.init(auth);
+      if (r.isOk()) {
+        filteredViews.push(view);
+      }
     }
-    return views;
+    return filteredViews;
   }
 
   static async fetchById(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect } from "vitest";
 
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -38,14 +39,16 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
     const regularSpace = await SpaceFactory.regular(workspace, t);
 
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    const mcpServerId = internalMCPServerNameToSId({
-      name: "hello_world",
-      workspaceId: workspace.id,
-    });
+
+    const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+      auth,
+      "authentication_debugger",
+      t
+    );
 
     const serverView = await MCPServerViewFactory.create(
       workspace,
-      mcpServerId,
+      internalServer.id,
       regularSpace
     );
     req.query.svId = serverView.sId;
@@ -91,7 +94,7 @@ describe("Method Support /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => 
   itInTransaction("only supports DELETE method", async (t) => {
     const { req, res, workspace, space } = await setupTest(t, "admin", "GET");
     const mcpServerId = internalMCPServerNameToSId({
-      name: "hello_world",
+      name: "authentication_debugger",
       workspaceId: workspace.id,
     });
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -21,6 +21,7 @@ export const WHITELISTABLE_FEATURES = [
   "force_gdrive_labels_scope",
   "claude_3_7_reasoning",
   "mcp_actions",
+  "dev_mcp_actions",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -813,6 +813,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "force_gdrive_labels_scope"
   | "claude_3_7_reasoning"
   | "mcp_actions"
+  | "dev_mcp_actions"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Make the code resilient to missing servers.
Rename internal servers to prepare for upcoming PR that will prefix tool with server names when exposed to the agent.
Separate debug servers from real servers with 2 features flags.

## Tests

Local

## Risk

Low, behind FF.

## Deploy Plan

Deploy `front`