### PR TITLE
[front] mcp(validation): fix validation re-streaming

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -16,6 +16,7 @@ import type {
   MCPValidationOutputType,
 } from "@app/lib/actions/constants";
 import type { MCPActionType } from "@app/lib/actions/mcp";
+import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 
 type ActionValidationContextType = {
   showValidationDialog: (validationRequest: {
@@ -94,6 +95,8 @@ export function ActionValidationProvider({
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useNavigationLock(isDialogOpen);
 
   const sendCurrentValidation = useCallback(
     async (approved: MCPValidationOutputType) => {

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -11,12 +11,12 @@ import {
 } from "@dust-tt/sparkle";
 import { createContext, useCallback, useEffect, useState } from "react";
 
+import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 import type {
   MCPToolStakeLevelType,
   MCPValidationOutputType,
 } from "@app/lib/actions/constants";
 import type { MCPActionType } from "@app/lib/actions/mcp";
-import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 
 type ActionValidationContextType = {
   showValidationDialog: (validationRequest: {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -96,7 +96,7 @@ export type MCPToolConfigurationType = (
   originalName: string;
 };
 
-export type MCPApproveExecutionEvent = {
+type MCPApproveExecutionEvent = {
   type: "tool_approve_execution";
   created: number;
   configurationId: string;
@@ -105,6 +105,12 @@ export type MCPApproveExecutionEvent = {
   inputs: Record<string, unknown>;
   stake?: MCPToolStakeLevelType;
 };
+
+export function isMCPApproveExecutionEvent(
+  event: MCPActionRunningEvents
+): event is MCPApproveExecutionEvent {
+  return event.type === "tool_approve_execution";
+}
 
 type MCPParamsEvent = {
   type: "tool_params";

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -96,7 +96,7 @@ export type MCPToolConfigurationType = (
   originalName: string;
 };
 
-type MCPApproveExecutionEvent = {
+export type MCPApproveExecutionEvent = {
   type: "tool_approve_execution";
   created: number;
   configurationId: string;

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -1,5 +1,5 @@
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
-import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp";
+import { isMCPApproveExecutionEvent } from "@app/lib/actions/mcp";
 import {
   getMessageChannelId,
   publishEvent,
@@ -49,14 +49,11 @@ export async function validateAction({
     }),
   });
 
-  void getRedisHybridManager().removeEvent((event) => {
+  await getRedisHybridManager().removeEvent((event) => {
     const payload = JSON.parse(event.message["payload"]);
-    const { action } = payload as MCPApproveExecutionEvent;
-    if (!action) {
-      return false;
-    }
-    const { id } = action;
-    return actionId === id;
+    return isMCPApproveExecutionEvent(payload)
+      ? payload.action.id === actionId
+      : false;
   }, getMessageChannelId(messageId));
 
   logger.info(

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -1,4 +1,3 @@
-import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp";
 import type { AgentActionSpecificEvent } from "@app/lib/actions/types/agent";
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisClient } from "@app/lib/api/redis";
@@ -587,14 +586,9 @@ export async function* getMessagesEvents(
 
   try {
     for (const event of history) {
-      const data = JSON.parse(event.message.payload);
-      if (data satisfies MCPApproveExecutionEvent) {
-        continue;
-      }
-
       yield {
         eventId: event.id,
-        data,
+        data: JSON.parse(event.message.payload),
       };
     }
 
@@ -635,7 +629,7 @@ function getConversationChannelId(channelId: string) {
   return `conversation-${channelId}`;
 }
 
-function getMessageChannelId(messageId: string) {
+export function getMessageChannelId(messageId: string) {
   return `message-${messageId}`;
 }
 

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -1,3 +1,4 @@
+import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp";
 import type { AgentActionSpecificEvent } from "@app/lib/actions/types/agent";
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisClient } from "@app/lib/api/redis";
@@ -38,7 +39,6 @@ import {
   postUserMessage,
   retryAgentMessage,
 } from "./conversation";
-import { MCPActionRunningEvents } from "@app/lib/actions/mcp";
 
 export async function postUserMessageWithPubSub(
   auth: Authenticator,
@@ -588,7 +588,7 @@ export async function* getMessagesEvents(
   try {
     for (const event of history) {
       const data = JSON.parse(event.message.payload);
-      if (data satisfies MCPActionRunningEvents) {
+      if (data satisfies MCPApproveExecutionEvent) {
         continue;
       }
 

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -586,9 +586,14 @@ export async function* getMessagesEvents(
 
   try {
     for (const event of history) {
+      const data = JSON.parse(event.message.payload);
+      if (data.type === "tool_approve_execution") {
+        continue;
+      }
+
       yield {
         eventId: event.id,
-        data: JSON.parse(event.message.payload),
+        data,
       };
     }
 

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -38,6 +38,7 @@ import {
   postUserMessage,
   retryAgentMessage,
 } from "./conversation";
+import { MCPActionRunningEvents } from "@app/lib/actions/mcp";
 
 export async function postUserMessageWithPubSub(
   auth: Authenticator,
@@ -587,7 +588,7 @@ export async function* getMessagesEvents(
   try {
     for (const event of history) {
       const data = JSON.parse(event.message.payload);
-      if (data.type === "tool_approve_execution") {
+      if (data satisfies MCPActionRunningEvents) {
         continue;
       }
 

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -2,7 +2,6 @@ import type { RedisClientType } from "redis";
 import { createClient } from "redis";
 
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 
 type EventCallback = (event: EventPayload | "close") => void;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Leaving a conversation while a message is being streamed, and re-entering the conversation, leads to re-streaming the event messages. For the MCP tool execution validation, we don't want to include the messages in the history, as the validation modal would pop back up.

We avoid re-streaming the message corresponding to a MCP tool validation.
We prevent the user from reloading the page if a validation modal is running.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks, safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.
