### PR TITLE
[front] feat(mcp/space): Return non default numbers of actions

### DIFF
--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -56,10 +56,10 @@ async function handler(
         space
       );
       const apps = await AppResource.listBySpace(auth, space);
-      const actionsCount = await MCPServerViewResource.countBySpace(
-        auth,
-        space
-      );
+      const actions = await MCPServerViewResource.listBySpace(auth, space);
+      const actionsCount = actions.filter(
+        (a) => !a.toJSON().server.isDefault
+      ).length;
 
       const categories: { [key: string]: SpaceCategoryInfo } = {};
       for (const category of DATA_SOURCE_VIEW_CATEGORIES) {


### PR DESCRIPTION
## Description
Inside space, when getting the SpaceInfo, return the number of actions that aren't default. Had to not use the count method as SQL has no idea the internal server info, so get the actions by spaces and filter out the defaults.

## Tests
- Locally check that no default action are counted.

## Risk
Low risk.

## Deploy Plan
Deploy on front
