### PR TITLE
Upg: prefix all tools with the server name before presenting to the server and handle datasource or tables descriptions

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -89,9 +89,12 @@ export type LocalMCPToolConfigurationType = Omit<
   inputSchema: JSONSchema;
 };
 
-export type MCPToolConfigurationType =
+export type MCPToolConfigurationType = (
   | PlatformMCPToolConfigurationType
-  | LocalMCPToolConfigurationType;
+  | LocalMCPToolConfigurationType
+) & {
+  originalName: string;
+};
 
 type MCPApproveExecutionEvent = {
   type: "tool_approve_execution";


### PR DESCRIPTION
## Description

Present tools to the model prefixed with the server name, it avoid conflict and give some context (that's what claude code does).
If the server has one tool, a description and datasources or tables configuration, append the user edited description like we do today for retrieval etc..

## Tests

Locally, inspected the functions presented to the model and executed some tools.

## Risk

Low

## Deploy Plan

Deploy `front`