### PR TITLE
[front] mcp(validation): add stakeLevel for internal tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,4 +1,4 @@
-import type { MCPToolNameWithStakeLevelType } from "@app/lib/api/mcp";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import type { ModelId, Result, WhitelistableFeature } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -72,14 +72,11 @@ export const INTERNAL_MCP_SERVERS: Record<
 };
 
 export const INTERNAL_TOOLS_STAKE_LEVEL: Partial<
-  Record<InternalMCPServerNameType, MCPToolNameWithStakeLevelType[]>
+  Record<InternalMCPServerNameType, Record<string, MCPToolStakeLevelType>>
 > = {
-  authentication_debugger: [
-    {
-      name: "hello_world",
-      stakeLevel: "low",
-    },
-  ],
+  authentication_debugger: {
+    hello_world: "low",
+  },
 };
 
 export type InternalMCPServerNameType =

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,3 +1,4 @@
+import type { MCPToolNameWithStakeLevelType } from "@app/lib/api/mcp";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import type { ModelId, Result, WhitelistableFeature } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -68,6 +69,17 @@ export const INTERNAL_MCP_SERVERS: Record<
     isDefault: false,
     flag: "dev_mcp_actions",
   },
+};
+
+export const INTERNAL_TOOLS_STAKE_LEVEL: Partial<
+  Record<InternalMCPServerNameType, MCPToolNameWithStakeLevelType[]>
+> = {
+  authentication_debugger: [
+    {
+      name: "hello_world",
+      stakeLevel: "low",
+    },
+  ],
 };
 
 export type InternalMCPServerNameType =

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -21,11 +21,6 @@ export type MCPToolWithStakeLevelType = MCPToolWithIsDefaultType & {
   toolServerId?: string;
 };
 
-export type MCPToolNameWithStakeLevelType = {
-  name: string;
-  stakeLevel: MCPToolStakeLevelType;
-};
-
 export type MCPServerType = {
   id: string;
   name: string;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -21,6 +21,11 @@ export type MCPToolWithStakeLevelType = MCPToolWithIsDefaultType & {
   toolServerId?: string;
 };
 
+export type MCPToolNameWithStakeLevelType = {
+  name: string;
+  stakeLevel: MCPToolStakeLevelType;
+};
+
 export type MCPServerType = {
   id: string;
   name: string;

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -8,6 +8,7 @@ import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_ac
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
   getInternalMCPServerNameAndWorkspaceId,
+  INTERNAL_TOOLS_STAKE_LEVEL,
   isDefaultInternalMCPServerByName,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -16,7 +17,10 @@ import {
   extractMetadataFromServerVersion,
   extractMetadataFromTools,
 } from "@app/lib/actions/mcp_metadata";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type {
+  MCPServerType,
+  MCPToolNameWithStakeLevelType,
+} from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerConnection } from "@app/lib/models/assistant/actions/mcp_server_connection";
@@ -226,6 +230,17 @@ export class InternalMCPServerInMemoryResource {
     );
 
     return removeNulls(resources);
+  }
+
+  static getToolsConfigByServerId(
+    serverId: string
+  ): MCPToolNameWithStakeLevelType[] | undefined {
+    const r = getInternalMCPServerNameAndWorkspaceId(serverId);
+    if (r.isErr()) {
+      throw new Error(`Internal MCP server not found for id ${serverId}`);
+    }
+    const server = r.value.name;
+    return INTERNAL_TOOLS_STAKE_LEVEL[server];
   }
 
   // Serialization.

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -17,10 +18,7 @@ import {
   extractMetadataFromServerVersion,
   extractMetadataFromTools,
 } from "@app/lib/actions/mcp_metadata";
-import type {
-  MCPServerType,
-  MCPToolNameWithStakeLevelType,
-} from "@app/lib/api/mcp";
+import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerConnection } from "@app/lib/models/assistant/actions/mcp_server_connection";
@@ -234,13 +232,13 @@ export class InternalMCPServerInMemoryResource {
 
   static getToolsConfigByServerId(
     serverId: string
-  ): MCPToolNameWithStakeLevelType[] | undefined {
+  ): Record<string, MCPToolStakeLevelType> {
     const r = getInternalMCPServerNameAndWorkspaceId(serverId);
     if (r.isErr()) {
       throw new Error(`Internal MCP server not found for id ${serverId}`);
     }
     const server = r.value.name;
-    return INTERNAL_TOOLS_STAKE_LEVEL[server];
+    return INTERNAL_TOOLS_STAKE_LEVEL[server] || {};
   }
 
   // Serialization.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR aims at implementing the possibility to set the stake level of an internal action.
Those are now shown in the edit action modal. Those are not modifiable by the workspace admin.

_Recap of the whole Context :_

An Admin sets "high stake" or "low stake" for each tool of each action. All actions will default to high stake for security reason.
If stake is high :
- user can choose between approve or reject execution

If stake is low :
- user can choose between approve / approve and don't ask again / reject
- user can click on a button in the profile submenu (in the bottom left), like "reset action approvals" to delete the approval metadata

For internal servers, this value is hard-coded, but the behavior for the user is the same.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Hand tested.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks, safe to rollback, behind ff.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.