### PR TITLE
Upg: show default assistants as capabilities or knowledge

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -5,11 +5,11 @@ import {
   Card,
   CardActionButton,
   CardGrid,
-  Checkbox,
   Chip,
   classNames,
   ContentMessage,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
@@ -33,6 +33,7 @@ import {
 } from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import assert from "assert";
+import { uniqueId } from "lodash";
 import type { ReactNode } from "react";
 import React, {
   useCallback,
@@ -47,8 +48,8 @@ import {
   isActionDustAppRunValid as hasErrorActionDustAppRun,
 } from "@app/components/assistant_builder/actions/DustAppRunAction";
 import {
-  ActionMCP,
   hasErrorActionMCP,
+  MCPAction,
 } from "@app/components/assistant_builder/actions/MCPAction";
 import {
   ActionProcess,
@@ -84,9 +85,10 @@ import type {
 } from "@app/components/assistant_builder/types";
 import {
   getDefaultActionConfiguration,
+  getDefaultMCPServerActionConfiguration,
   isDefaultActionName,
 } from "@app/components/assistant_builder/types";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getVisual, MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
 import { getRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -122,6 +124,36 @@ const CAPABILITIES_ACTION_CATEGORIES = [
   "WEB_NAVIGATION",
   "REASONING",
 ] as const satisfies Array<AssistantBuilderActionConfiguration["type"]>;
+
+const isUsableAsCapability = (
+  id: string,
+  mcpServerViews: MCPServerViewType[]
+) => {
+  const view = mcpServerViews.find((v) => v.id === id);
+  if (!view) {
+    return false;
+  }
+  const requirements = getRequirements(view);
+  return view.server.isDefault && requirements.noRequirements;
+};
+
+const isUsableInKnowledge = (
+  id: string,
+  mcpServerViews: MCPServerViewType[]
+) => {
+  const view = mcpServerViews.find((v) => v.id === id);
+  if (!view) {
+    return false;
+  }
+  return view.server.isDefault && !isUsableAsCapability(id, mcpServerViews);
+};
+
+// We reserve the name we use for capability actions, as these aren't
+// configurable via the "add tool" menu.
+const isReservedName = (name: string) =>
+  CAPABILITIES_ACTION_CATEGORIES.some(
+    (c) => getDefaultActionConfiguration(c)?.name === name
+  );
 
 function ActionModeSection({
   children,
@@ -217,8 +249,22 @@ export default function ActionsScreen({
     workspaceId: owner.sId,
   });
 
+  const isCapabilityAction = useCallback(
+    (action: AssistantBuilderActionConfiguration) => {
+      if (action.type === "MCP") {
+        return isUsableAsCapability(
+          action.configuration.mcpServerViewId,
+          mcpServerViews
+        );
+      }
+
+      return (CAPABILITIES_ACTION_CATEGORIES as string[]).includes(action.type);
+    },
+    [mcpServerViews]
+  );
+
   const configurableActions = builderState.actions.filter(
-    (a) => !(CAPABILITIES_ACTION_CATEGORIES as string[]).includes(a.type)
+    (a) => !isCapabilityAction(a)
   );
 
   const isLegacyConfig = isLegacyAssistantBuilderConfiguration(builderState);
@@ -264,12 +310,23 @@ export default function ActionsScreen({
               addActionToSpace(config.dataSourceView.spaceId);
             });
           }
-          if (action.configuration.mcpServerViewId) {
-            addActionToSpace(
-              mcpServerViews.find(
-                (v) => v.id === action.configuration.mcpServerViewId
-              )?.spaceId
+
+          if (action.configuration.tablesConfigurations) {
+            Object.values(action.configuration.tablesConfigurations).forEach(
+              (config) => {
+                addActionToSpace(config.dataSourceView.spaceId);
+              }
             );
+          }
+
+          if (action.configuration.mcpServerViewId) {
+            const mcpServerView = mcpServerViews.find(
+              (v) => v.id === action.configuration.mcpServerViewId
+            );
+            // Default MCP server themselves are not accounted for in the space restriction.
+            if (mcpServerView && !mcpServerView.server.isDefault) {
+              addActionToSpace(mcpServerView.spaceId);
+            }
           }
           break;
 
@@ -434,20 +491,25 @@ export default function ActionsScreen({
           </div>
           <div className="flex flex-row gap-2">
             {configurableActions.length > 0 && !isLegacyConfig && (
-              <div>
-                <AddAction
-                  onAddAction={(action) => {
-                    setAction({
-                      type: action.noConfigurationRequired
-                        ? "insert"
-                        : "pending",
-                      action,
-                    });
-                  }}
-                  hasFeature={hasFeature}
-                />
-              </div>
+              <AddAction
+                mcpServerViews={mcpServerViews}
+                onAddAction={(action) => {
+                  setAction({
+                    type: action.noConfigurationRequired ? "insert" : "pending",
+                    action,
+                  });
+                }}
+                hasFeature={hasFeature}
+              />
             )}
+            <Capabilities
+              builderState={builderState}
+              setBuilderState={setBuilderState}
+              setEdited={setEdited}
+              setAction={setAction}
+              deleteAction={deleteAction}
+              enableReasoningTool={enableReasoningTool}
+            />
 
             {!isLegacyConfig && (
               <>
@@ -520,6 +582,7 @@ export default function ActionsScreen({
               )}
             >
               <AddAction
+                mcpServerViews={mcpServerViews}
                 onAddAction={(action) => {
                   setAction({
                     type: action.noConfigurationRequired ? "insert" : "pending",
@@ -549,15 +612,6 @@ export default function ActionsScreen({
             ))}
           </CardGrid>
         </div>
-
-        <Capabilities
-          builderState={builderState}
-          setBuilderState={setBuilderState}
-          setEdited={setEdited}
-          setAction={setAction}
-          deleteAction={deleteAction}
-          enableReasoningTool={enableReasoningTool}
-        />
       </div>
     </>
   );
@@ -630,12 +684,8 @@ function NewActionModal({
     if (!/^[a-z0-9_]+$/.test(name)) {
       return "The name can only contain lowercase letters, numbers, and underscores (no spaces).";
     }
-    // We reserve the name we use for capability actions, as these aren't
-    // configurable via the "add tool" menu.
-    const isReservedName = CAPABILITIES_ACTION_CATEGORIES.some(
-      (c) => getDefaultActionConfiguration(c)?.name === name
-    );
-    if (isReservedName) {
+
+    if (isReservedName(name)) {
       return "This name is reserved for a system tool. Please use a different name.";
     }
 
@@ -937,7 +987,7 @@ function ActionConfigEditor({
 
     case "MCP":
       return (
-        <ActionMCP
+        <MCPAction
           owner={owner}
           action={action}
           allowedSpaces={allowedSpaces}
@@ -1264,11 +1314,16 @@ function AdvancedSettings({
 }
 
 interface AddActionProps {
+  mcpServerViews: MCPServerViewType[];
   onAddAction: (action: AssistantBuilderActionConfigurationWithId) => void;
   hasFeature: (feature: WhitelistableFeature | null | undefined) => boolean;
 }
 
-function AddAction({ onAddAction, hasFeature }: AddActionProps) {
+function AddAction({
+  mcpServerViews,
+  onAddAction,
+  hasFeature,
+}: AddActionProps) {
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
@@ -1283,7 +1338,7 @@ function AddAction({ onAddAction, hasFeature }: AddActionProps) {
 
       <DropdownMenuContent>
         <DropdownMenuGroup>
-          <DropdownMenuLabel label="Default" />
+          <DropdownMenuLabel label="Knowledge" />
           {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
             const spec = ACTION_SPECIFICATIONS[key];
             if (!hasFeature(spec.flag)) {
@@ -1304,6 +1359,24 @@ function AddAction({ onAddAction, hasFeature }: AddActionProps) {
               />
             );
           })}
+          {mcpServerViews
+            .filter((view) => isUsableInKnowledge(view.id, mcpServerViews))
+            .map((view) => {
+              return (
+                <DropdownMenuItem
+                  key={view.id}
+                  icon={MCP_SERVER_ICONS["command"]}
+                  label={asDisplayName(view.server.name)}
+                  description={view.server.description}
+                  onClick={() =>
+                    onAddAction({
+                      ...getDefaultMCPServerActionConfiguration(view),
+                      id: uniqueId(),
+                    })
+                  }
+                />
+              );
+            })}
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
@@ -1351,6 +1424,8 @@ function Capabilities({
   deleteAction: (name: string) => void;
   enableReasoningTool: boolean;
 }) {
+  const { mcpServerViews } = useContext(AssistantBuilderContext);
+
   const Capability = ({
     name,
     description,
@@ -1365,30 +1440,81 @@ function Capabilities({
     onDisable: () => void;
   }) => {
     return (
-      <div className="flex flex-row gap-2">
-        <Checkbox
-          checked={enabled}
-          onCheckedChange={enabled ? onDisable : onEnable}
-        />
-        <div>
-          <div className="flex text-sm font-semibold text-foreground dark:text-foreground-night">
-            {name}
-          </div>
-          <div className="text-sm text-muted-foreground">{description}</div>
-        </div>
-      </div>
+      <DropdownMenuCheckboxItem
+        checked={enabled}
+        onCheckedChange={enabled ? onDisable : onEnable}
+        className="mb-0 mt-0 pb-0 pr-0 pt-0"
+      >
+        <DropdownMenuItem label={name} description={description} />
+      </DropdownMenuCheckboxItem>
     );
   };
 
+  // Default servers with no configuration requirements are usable as capabilities
+  const mcpServerViewsCapabilities = useMemo(() => {
+    return mcpServerViews.filter((view) =>
+      isUsableAsCapability(view.id, mcpServerViews)
+    );
+  }, [mcpServerViews]);
+
+  const isWebNavigationEnabled = useMemo(() => {
+    return !!builderState.actions.find((a) => a.type === "WEB_NAVIGATION");
+  }, [builderState.actions]);
+
+  const isReasoningEnabled = useMemo(() => {
+    return !!builderState.actions.find((a) => a.type === "REASONING");
+  }, [builderState.actions]);
+
+  const totalCapabilities = useMemo(() => {
+    let total = 0;
+    if (isWebNavigationEnabled) {
+      total++;
+    }
+    if (isReasoningEnabled) {
+      total++;
+    }
+    if (builderState.visualizationEnabled) {
+      total++;
+    }
+
+    for (const view of mcpServerViewsCapabilities) {
+      if (
+        builderState.actions.find(
+          (a) => a.type === "MCP" && a.configuration.mcpServerViewId === view.id
+        )
+      ) {
+        total++;
+      }
+    }
+
+    return total;
+  }, [
+    isWebNavigationEnabled,
+    isReasoningEnabled,
+    builderState.visualizationEnabled,
+    mcpServerViewsCapabilities,
+    builderState.actions,
+  ]);
+
   return (
-    <>
-      <div className="mx-auto grid w-full grid-cols-1 gap-y-4 md:grid-cols-2">
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label={
+            totalCapabilities
+              ? `Capabilities (${totalCapabilities})`
+              : "Capabilities"
+          }
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
         <Capability
           name="Web search & browse"
           description="Agent can search (Google) and retrieve information from specific websites."
-          enabled={
-            !!builderState.actions.find((a) => a.type === "WEB_NAVIGATION")
-          }
+          enabled={isWebNavigationEnabled}
           onEnable={() => {
             setEdited(true);
             const defaultWebNavigationAction =
@@ -1431,7 +1557,7 @@ function Capabilities({
           <Capability
             name="Reasoning"
             description="Agent can decide to trigger a reasoning model for complex tasks"
-            enabled={!!builderState.actions.find((a) => a.type === "REASONING")}
+            enabled={isReasoningEnabled}
             onEnable={() => {
               setEdited(true);
               const defaultReasoningAction =
@@ -1450,7 +1576,41 @@ function Capabilities({
             }}
           />
         )}
-      </div>
-    </>
+
+        {mcpServerViewsCapabilities.map((view) => {
+          return (
+            <Capability
+              key={view.id}
+              name={asDisplayName(view.server.name)}
+              description={view.server.description}
+              enabled={
+                !!builderState.actions.find(
+                  (a) =>
+                    a.type === "MCP" &&
+                    a.configuration.mcpServerViewId === view.id
+                )
+              }
+              onEnable={() => {
+                setEdited(true);
+                const action = getDefaultMCPServerActionConfiguration(view);
+                assert(action);
+                setAction({
+                  type: "insert",
+                  action: {
+                    ...action,
+                    id: uniqueId(),
+                  },
+                });
+              }}
+              onDisable={() => {
+                const action = getDefaultMCPServerActionConfiguration(view);
+                assert(action);
+                deleteAction(action.name);
+              }}
+            />
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/front/components/assistant_builder/legacy_agent.ts
+++ b/front/components/assistant_builder/legacy_agent.ts
@@ -4,6 +4,8 @@ export function isLegacyAssistantBuilderConfiguration(
   builderState: AssistantBuilderState
 ): boolean {
   return (
-    builderState.actions.length === 1 && !builderState.actions[0].description
+    builderState.actions.length === 1 &&
+    builderState.actions[0].type !== "MCP" &&
+    !builderState.actions[0].description
   );
 }

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -13,7 +13,9 @@ import {
   DEFAULT_TABLES_QUERY_ACTION_NAME,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
+import { getRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ProcessSchemaPropertyType } from "@app/lib/actions/process";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type {
   AgentConfigurationScope,
@@ -361,19 +363,27 @@ export function getDefaultReasoningActionConfiguration(): AssistantBuilderAction
   } satisfies AssistantBuilderActionConfiguration;
 }
 
-export function getDefaultMCPServerActionConfiguration(): AssistantBuilderActionConfiguration {
+export function getDefaultMCPServerActionConfiguration(
+  mcpServerView?: MCPServerViewType
+): AssistantBuilderActionConfiguration {
+  const requirements = getRequirements(mcpServerView);
+
   return {
     type: "MCP",
     configuration: {
-      mcpServerViewId: "not-a-valid-sId",
+      mcpServerViewId: mcpServerView?.id ?? "not-a-valid-sId",
       dataSourceConfigurations: null,
       tablesConfigurations: null,
       childAgentId: null,
       additionalConfiguration: {},
     },
-    name: "",
-    description: "",
-    noConfigurationRequired: false,
+    name: mcpServerView?.server.name ?? "",
+    description:
+      requirements.requiresDataSourceConfiguration ||
+      requirements.requiresTableConfiguration
+        ? ""
+        : mcpServerView?.server.description ?? "",
+    noConfigurationRequired: requirements.noRequirements,
   };
 }
 export function getDefaultActionConfiguration(

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -51,7 +51,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   // Dev
   data_sources_debugger: {
     id: 1000,
-    isDefault: false,
+    isDefault: true,
     flag: "dev_mcp_actions",
   },
   child_agent_debugger: {

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -373,21 +373,33 @@ export function getRequirements(
       requiresDataSourceConfiguration: false,
       requiresTableConfiguration: false,
       requiresChildAgentConfiguration: false,
+      noRequirements: false,
     };
   }
   const { server } = mcpServerView;
+
+  const requiresDataSourceConfiguration = serverRequiresInternalConfiguration({
+    mcpServer: server,
+    mimeType: INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE,
+  });
+  const requiresTableConfiguration = serverRequiresInternalConfiguration({
+    mcpServer: server,
+    mimeType: INTERNAL_MIME_TYPES.CONFIGURATION.TABLE,
+  });
+  const requiresChildAgentConfiguration = serverRequiresInternalConfiguration({
+    mcpServer: server,
+    mimeType: INTERNAL_MIME_TYPES.CONFIGURATION.CHILD_AGENT,
+  });
+
   return {
-    requiresDataSourceConfiguration: serverRequiresInternalConfiguration({
-      mcpServer: server,
-      mimeType: INTERNAL_MIME_TYPES.CONFIGURATION.DATA_SOURCE,
-    }),
-    requiresTableConfiguration: serverRequiresInternalConfiguration({
-      mcpServer: server,
-      mimeType: INTERNAL_MIME_TYPES.CONFIGURATION.TABLE,
-    }),
-    requiresChildAgentConfiguration: serverRequiresInternalConfiguration({
-      mcpServer: server,
-      mimeType: INTERNAL_MIME_TYPES.CONFIGURATION.CHILD_AGENT,
-    }),
+    requiresDataSourceConfiguration,
+    requiresTableConfiguration,
+    requiresChildAgentConfiguration,
+
+    // Useful shortcut
+    noRequirements:
+      !requiresDataSourceConfiguration &&
+      !requiresTableConfiguration &&
+      !requiresChildAgentConfiguration,
   };
 }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -310,7 +310,7 @@ export async function createOrUpgradeAgentConfiguration({
     if (actionsWithoutDesc.length) {
       return new Err(
         Error(
-          `Every action must have a description. Missing names for: ${actionsWithoutDesc
+          `Every action must have a description. Missing descriptions for: ${actionsWithoutDesc
             .map((action) => action.type)
             .join(", ")}`
         )


### PR DESCRIPTION
## Description

This PR improve handling of the default internal servers (UX valided by @Duncid).

- Capabilities becomes a drop down with toggles
- Default servers + no knowledge configuration => Listed in capabilities
- Default servers + knowledge configuration => listed in the first level of the "Add tool" dropdown
- Default servers are ignored for the "one space per workspace".
- Default servers are filtered out from the picker.

Everything is behind a FF.

<img width="925" alt="image" src="https://github.com/user-attachments/assets/8ea44847-0523-44a5-9438-e8409cd1f35e" />

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/80ab6f22-0b65-48df-9944-73f08b16304b" />

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/4932b1d0-13f0-4c9d-98b6-7a9db3b1c812" />

<img width="1404" alt="image" src="https://github.com/user-attachments/assets/19ae44ce-068d-4c3a-b934-983afe65e120" />

## Tests

Local

## Risk

Low, behind FF but could have broke something in AB by mistake.

## Deploy Plan

Deploy `front`