### PR TITLE
[Agent Discovery] Create Group / Agent relationship

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -67,8 +67,8 @@ import {
 import { DustAppSecret } from "@app/lib/models/dust_app_secret";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
-import { MembershipInvitation } from "@app/lib/models/membership_invitation";
 import { LabsPersonalSalesforceConnection } from "@app/lib/models/labs_personal_salesforce_connection";
+import { MembershipInvitation } from "@app/lib/models/membership_invitation";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
 import { WorkspaceHasDomain } from "@app/lib/models/workspace_has_domain";

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -58,6 +58,7 @@ import {
   MessageReaction,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
+import { GroupAgentModel } from "@app/lib/models/assistant/group_agent";
 import {
   TrackerConfigurationModel,
   TrackerDataSourceConfigurationModel,
@@ -153,6 +154,7 @@ async function main() {
   await AgentConfiguration.sync({ alter: true });
   await AgentUserRelation.sync({ alter: true });
   await GlobalAgentSettings.sync({ alter: true });
+  await GroupAgentModel.sync({ alter: true });
 
   await RemoteMCPServerModel.sync({ alter: true });
   await MCPServerViewModel.sync({ alter: true });

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -795,8 +795,8 @@ export async function createAgentConfiguration(
     if (templateId) {
       template = await TemplateResource.fetchByExternalId(templateId);
     }
-    const [agent, created] = await frontSequelize.transaction(
-      async (t): Promise<[AgentConfiguration, boolean]> => {
+    const agent = await frontSequelize.transaction(
+      async (t): Promise<AgentConfiguration> => {
         let created = false;
         if (agentConfigurationId) {
           const [existing, userRelation] = await Promise.all([
@@ -905,7 +905,7 @@ export async function createAgentConfiguration(
           }
         }
 
-        return [agentConfigurationInstance, created];
+        return agentConfigurationInstance;
       }
     );
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -874,17 +874,20 @@ export async function createAgentConfiguration(
         if (created) {
           const user = auth.getNonNullableUser();
           // Create a default group for the agent and add the author to it.
-          const defaultGroup = await GroupResource.makeNew({
-            workspaceId: owner.id,
-            name: `Group for Agent ${agentConfigurationInstance.name}`,
-            kind: "regular",
-          });
+          const defaultGroup = await GroupResource.makeNew(
+            {
+              workspaceId: owner.id,
+              name: `Group for Agent ${agentConfigurationInstance.name}`,
+              kind: "regular",
+            },
+            { transaction: t }
+          );
 
           // Add user to the newly created group
           const addMemberResult = await defaultGroup.addMember(
             auth,
-            user.toJSON()
-            // Transaction is handled internally by addMember if needed via auth
+            user.toJSON(),
+            { transaction: t }
           );
           if (addMemberResult.isErr()) {
             // Throw error to trigger transaction rollback

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -892,12 +892,12 @@ export async function createAgentConfiguration(
           }
 
           // Associate the group with the agent configuration.
-          const groupAgentResult = await addGroupToAgentConfiguration(
+          const groupAgentResult = await addGroupToAgentConfiguration({
             auth,
-            defaultGroup,
-            agentConfigurationInstance,
-            t
-          );
+            group: defaultGroup,
+            agentConfiguration: agentConfigurationInstance,
+            transaction: t,
+          });
           // If association fails, the transaction will automatically rollback.
           if (groupAgentResult.isErr()) {
             // Explicitly throw error to ensure rollback
@@ -1540,12 +1540,17 @@ export async function unsafeHardDeleteAgentConfiguration(
 /**
  * Associates a group with an agent configuration.
  */
-export async function addGroupToAgentConfiguration(
-  auth: Authenticator,
-  group: GroupResource,
-  agentConfiguration: AgentConfiguration,
-  transaction?: Transaction
-): Promise<Result<void, Error>> {
+export async function addGroupToAgentConfiguration({
+  auth,
+  group,
+  agentConfiguration,
+  transaction,
+}: {
+  auth: Authenticator;
+  group: GroupResource;
+  agentConfiguration: AgentConfiguration;
+  transaction?: Transaction;
+}): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
   if (
     owner.id !== group.workspaceId ||
@@ -1579,12 +1584,17 @@ export async function addGroupToAgentConfiguration(
 /**
  * Removes the association between a group and an agent configuration.
  */
-export async function removeGroupFromAgentConfiguration(
-  auth: Authenticator,
-  group: GroupResource,
-  agentConfiguration: AgentConfiguration,
-  transaction?: Transaction
-): Promise<Result<void, Error>> {
+export async function removeGroupFromAgentConfiguration({
+  auth,
+  group,
+  agentConfiguration,
+  transaction,
+}: {
+  auth: Authenticator;
+  group: GroupResource;
+  agentConfiguration: AgentConfiguration;
+  transaction?: Transaction;
+}): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
   if (
     owner.id !== group.workspaceId ||

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -61,9 +61,7 @@ import { GroupAgentModel } from "@app/lib/models/assistant/group_agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import type {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -876,7 +876,7 @@ export async function createAgentConfiguration(
           // Create a default group for the agent and add the author to it.
           const defaultGroup = await GroupResource.makeNew({
             workspaceId: owner.id,
-            name: `${agentConfigurationInstance.name} group`,
+            name: `Group for Agent ${agentConfigurationInstance.name}`,
             kind: "regular",
           });
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1571,6 +1571,7 @@ export async function addGroupToAgentConfiguration({
       {
         groupId: group.id,
         agentConfigurationId: agentConfiguration.id,
+        workspaceId: owner.id,
       },
       { transaction }
     );

--- a/front/lib/models/assistant/group_agent.ts
+++ b/front/lib/models/assistant/group_agent.ts
@@ -1,0 +1,91 @@
+import type {
+  BelongsToGetAssociationMixin,
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { frontSequelize } from "@app/lib/resources/storage";
+
+export class GroupAgentModel extends Model<
+  InferAttributes<GroupAgentModel>,
+  InferCreationAttributes<GroupAgentModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare groupId: ForeignKey<GroupModel["id"]>;
+  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+
+  declare getGroup: BelongsToGetAssociationMixin<GroupModel>;
+  declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfiguration>;
+}
+
+GroupAgentModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    // Foreign keys are defined in the associations section below
+  },
+  {
+    modelName: "group_agents",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["groupId", "agentConfigurationId"],
+      },
+      { fields: ["agentConfigurationId"] },
+    ],
+  }
+);
+
+// Define associations
+GroupModel.belongsToMany(AgentConfiguration, {
+  through: GroupAgentModel,
+  foreignKey: "groupId",
+  otherKey: "agentConfigurationId",
+  as: "agentConfigurations",
+});
+AgentConfiguration.belongsToMany(GroupModel, {
+  through: GroupAgentModel,
+  foreignKey: "agentConfigurationId",
+  otherKey: "groupId",
+  as: "groups",
+});
+
+GroupAgentModel.belongsTo(GroupModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  targetKey: "id",
+});
+GroupAgentModel.belongsTo(AgentConfiguration, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  targetKey: "id",
+});
+
+GroupModel.hasMany(GroupAgentModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  sourceKey: "id",
+});
+AgentConfiguration.hasMany(GroupAgentModel, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  sourceKey: "id",
+});

--- a/front/lib/models/assistant/group_agent.ts
+++ b/front/lib/models/assistant/group_agent.ts
@@ -2,28 +2,26 @@ import type {
   BelongsToGetAssociationMixin,
   CreationOptional,
   ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
 } from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 
-export class GroupAgentModel extends Model<
-  InferAttributes<GroupAgentModel>,
-  InferCreationAttributes<GroupAgentModel>
-> {
+export class GroupAgentModel extends WorkspaceAwareModel<GroupAgentModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare groupId: ForeignKey<GroupModel["id"]>;
   declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  // workspaceId is inherited from WorkspaceAwareModel
 
   declare getGroup: BelongsToGetAssociationMixin<GroupModel>;
   declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfiguration>;
+  // getWorkspace is inherited
 }
 
 GroupAgentModel.init(
@@ -43,7 +41,15 @@ GroupAgentModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    // Foreign keys are defined in the associations section below
+    groupId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    agentConfigurationId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    // workspaceId is automatically added by WorkspaceAwareModel.init
   },
   {
     modelName: "group_agents",
@@ -59,6 +65,28 @@ GroupAgentModel.init(
 );
 
 // Define associations
+
+// Association with Group
+GroupAgentModel.belongsTo(GroupModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  targetKey: "id",
+});
+GroupModel.hasMany(GroupAgentModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  sourceKey: "id",
+});
+
+// Association with AgentConfiguration
+GroupAgentModel.belongsTo(AgentConfiguration, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  targetKey: "id",
+});
+AgentConfiguration.hasMany(GroupAgentModel, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  sourceKey: "id",
+});
+
+// Many-to-Many between Group and AgentConfiguration (ensure FKs match)
 GroupModel.belongsToMany(AgentConfiguration, {
   through: GroupAgentModel,
   foreignKey: "groupId",
@@ -72,20 +100,4 @@ AgentConfiguration.belongsToMany(GroupModel, {
   as: "groups",
 });
 
-GroupAgentModel.belongsTo(GroupModel, {
-  foreignKey: { name: "groupId", allowNull: false },
-  targetKey: "id",
-});
-GroupAgentModel.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-  targetKey: "id",
-});
-
-GroupModel.hasMany(GroupAgentModel, {
-  foreignKey: { name: "groupId", allowNull: false },
-  sourceKey: "id",
-});
-AgentConfiguration.hasMany(GroupAgentModel, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-  sourceKey: "id",
-});
+// Workspace association is handled by WorkspaceAwareModel.init

--- a/front/lib/models/assistant/group_agent.ts
+++ b/front/lib/models/assistant/group_agent.ts
@@ -8,8 +8,8 @@ import type {
 import { DataTypes, Model } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
 
 export class GroupAgentModel extends Model<
   InferAttributes<GroupAgentModel>,

--- a/front/lib/models/assistant/group_agent.ts
+++ b/front/lib/models/assistant/group_agent.ts
@@ -27,7 +27,7 @@ export class GroupAgentModel extends WorkspaceAwareModel<GroupAgentModel> {
 GroupAgentModel.init(
   {
     id: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.BIGINT,
       autoIncrement: true,
       primaryKey: true,
     },
@@ -42,11 +42,11 @@ GroupAgentModel.init(
       defaultValue: DataTypes.NOW,
     },
     groupId: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.BIGINT,
       allowNull: false,
     },
     agentConfigurationId: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.BIGINT,
       allowNull: false,
     },
     // workspaceId is automatically added by WorkspaceAwareModel.init

--- a/front/lib/models/assistant/group_agent.ts
+++ b/front/lib/models/assistant/group_agent.ts
@@ -74,6 +74,7 @@ GroupAgentModel.belongsTo(GroupModel, {
 GroupModel.hasMany(GroupAgentModel, {
   foreignKey: { name: "groupId", allowNull: false },
   sourceKey: "id",
+  as: "groupAgentLinks",
 });
 
 // Association with AgentConfiguration
@@ -84,6 +85,7 @@ GroupAgentModel.belongsTo(AgentConfiguration, {
 AgentConfiguration.hasMany(GroupAgentModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   sourceKey: "id",
+  as: "agentGroupLinks",
 });
 
 // Many-to-Many between Group and AgentConfiguration (ensure FKs match)

--- a/front/migrations/db/migration_211.sql
+++ b/front/migrations/db/migration_211.sql
@@ -1,0 +1,32 @@
+-- Migration created on Apr 12, 2025
+-- Create the group_agents table
+
+CREATE TABLE IF NOT EXISTS "group_agents" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "groupId" BIGINT NOT NULL,
+    "agentConfigurationId" BIGINT NOT NULL,
+    "workspaceId" BIGINT NOT NULL,
+
+    -- Foreign key constraints
+    CONSTRAINT "group_agents_groupId_fkey"
+        FOREIGN KEY ("groupId")
+        REFERENCES "groups"("id")
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "group_agents_agentConfigurationId_fkey"
+        FOREIGN KEY ("agentConfigurationId")
+        REFERENCES "agent_configurations"("id")
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "group_agents_workspaceId_fkey"
+        FOREIGN KEY ("workspaceId")
+        REFERENCES "workspaces"("id")
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+
+    -- Unique constraint for the combination of group and agent
+    CONSTRAINT "group_agents_unique_group_agent"
+        UNIQUE ("groupId", "agentConfigurationId")
+);
+
+-- Index for faster lookups by agentConfigurationId
+CREATE INDEX IF NOT EXISTS "group_agents_agentConfigurationId_idx" ON "group_agents"("agentConfigurationId");


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2462

## Description

This PR implements the foundational database and API changes for the new agent editor permission system, as outlined in the ["Agent Discovery & Management" design doc](Design%20Doc%20Sharing%20and%20searching%20agents%201b428599d941809f8dcbe0863399573c.md).

Specifically, it introduces:
1.  A new Sequelize model `GroupAgentModel` (`front/lib/models/assistant/group_agent.ts`) to establish a many-to-many relationship between `AgentConfiguration` and `GroupModel`. This table (`group_agents`) will store which groups are associated with (and thus can edit) which agents.
2.  Two utility functions in `front/lib/api/assistant/configuration.ts`:
    *   `addGroupToAgentConfiguration`: Associates a given group with an agent configuration.
    *   `removeGroupFromAgentConfiguration`: Removes the association between a group and an agent configuration.
3.  Modification to the `createAgentConfiguration` function:
    *   When a new agent configuration is created, it now automatically:
        *   Creates a new standard `GroupModel` specific to this agent.
        *   Adds the agent's author (creator) as a member of this new group via `MembershipResource`.
        *   Links this new group to the agent configuration using `addGroupToAgentConfiguration`.

This work lays the groundwork for replacing the existing `scope`-based permission (`private`/`workspace`/`published`) with a more granular editor list managed via groups.

## Risks

*   **Low Risk:** These changes primarily add new structures and modify the agent creation flow within a transaction. The core functionality of existing agents is unaffected.
*   **Agent Creation:** There's a minor risk that errors during the new group creation or association process within the `createAgentConfiguration` transaction could cause agent creation to fail unexpectedly. The transaction *should* roll back cleanly, but testing is needed.
*   **Database Migration:** Requires a database migration to create the `group_agents` table and its constraints/indexes. An error during migration could impact deployment.

## Tests

*   **Manual Verification:** Manually create a new agent and verify through database inspection that:
    *   A corresponding `groups` row is created.
    *   A `memberships` row linking the author to the new group is created.
    *   A `group_agents` row linking the new group to the new agent configuration is created.


## Deploy Plan
- run migration
- deploy front

