### PR TITLE
fix(MCP): handle repetitions of the same configurable type

### DIFF
--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -451,18 +451,13 @@ export function hasErrorActionMCP(
       return "Please select a child agent.";
     }
     for (const key in requirements.requiredStrings) {
-      if (key in action.configuration.additionalConfiguration) {
-        return `Please fill in the required string field "${key}".`;
+      if (!(key in action.configuration.additionalConfiguration)) {
+        return `Please fill in the required string field.`;
       }
     }
     for (const key in requirements.requiredNumbers) {
-      if (key in action.configuration.additionalConfiguration) {
-        return `Please fill in the required number field "${key}".`;
-      }
-    }
-    for (const key in requirements.requiredBooleans) {
-      if (key in action.configuration.additionalConfiguration) {
-        return `Please fill in the required boolean field "${key}".`;
+      if (!(key in action.configuration.additionalConfiguration)) {
+        return `Please fill in the required numeric fields.`;
       }
     }
 

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -451,17 +451,17 @@ export function hasErrorActionMCP(
       return "Please select a child agent.";
     }
     for (const key in requirements.requiredStrings) {
-      if (!action.configuration.additionalConfiguration[key]) {
+      if (key in action.configuration.additionalConfiguration) {
         return `Please fill in the required string field "${key}".`;
       }
     }
     for (const key in requirements.requiredNumbers) {
-      if (!action.configuration.additionalConfiguration[key]) {
+      if (key in action.configuration.additionalConfiguration) {
         return `Please fill in the required number field "${key}".`;
       }
     }
     for (const key in requirements.requiredBooleans) {
-      if (!action.configuration.additionalConfiguration[key]) {
+      if (key in action.configuration.additionalConfiguration) {
         return `Please fill in the required boolean field "${key}".`;
       }
     }

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -453,12 +453,12 @@ export function hasErrorActionMCP(
     }
     for (const key in requirements.requiredStrings) {
       if (!(key in action.configuration.additionalConfiguration)) {
-        return `Please fill in the required string field.`;
+        return `Please fill in all fields.`;
       }
     }
     for (const key in requirements.requiredNumbers) {
       if (!(key in action.configuration.additionalConfiguration)) {
-        return `Please fill in the required numeric fields.`;
+        return `Please fill in all required numeric fields.`;
       }
     }
 

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -114,7 +114,8 @@ export function MCPAction({
           dataSourceConfigurations: null,
           tablesConfigurations: null,
           childAgentId: null,
-          additionalConfiguration: {},
+          // We initialize with the default values for required booleans since these can be left unset.
+          additionalConfiguration: requirements.requiredBooleans,
         }),
       });
     },

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -311,7 +311,11 @@ export function augmentInputsWithConfiguration({
         : [];
 
       const fullPath = [...parentPath, missingProp];
-      const propSchema = findSchemaAtPath(inputSchema, fullPath);
+      let propSchema = findSchemaAtPath(inputSchema, fullPath);
+      // If the schema we found is a reference, follow it.
+      if (propSchema?.$ref) {
+        propSchema = followInternalRef(inputSchema, propSchema.$ref);
+      }
 
       // If we found a schema and it has a matching MIME type, inject the value
       if (propSchema) {

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -16,6 +16,7 @@ import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import {
   findMatchingSchemaKeys,
   findSchemaAtPath,
+  followInternalRef,
   isJSONSchemaObject,
   schemasAreEqual,
   setValueAtPath,
@@ -206,9 +207,18 @@ export function hideInternalConfiguration(inputSchema: JSONSchema): JSONSchema {
       let shouldInclude = true;
 
       if (isJSONSchemaObject(property)) {
-        // Check if this property has a matching mimeType.
         for (const schema of Object.values(ConfigurableToolInputJSONSchemas)) {
-          if (schemasAreEqual(property, schema)) {
+          // Check if the property matches the schema, following references if $ref points to a schema internally.
+          let schemasMatch = schemasAreEqual(property, schema);
+
+          if (!schemasMatch && property.$ref) {
+            const refSchema = followInternalRef(inputSchema, property.$ref);
+            if (refSchema) {
+              schemasMatch = schemasAreEqual(refSchema, schema);
+            }
+          }
+
+          if (schemasMatch) {
             shouldInclude = false;
             // Track removed properties that were in the required array.
             if (resultingSchema.required?.includes(key)) {

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -62,13 +62,7 @@ export function findMatchingSchemaKeys(
         // Following references within the main schema.
         // zodToJsonSchema generates references if the same subSchema is repeated.
         if (propSchema.$ref) {
-          const refSchema = findSchemaAtPath(
-            inputSchema,
-            propSchema.$ref
-              .replace("#/", "")
-              .split("/")
-              .filter((key) => key != "properties")
-          );
+          const refSchema = followInternalRef(inputSchema, propSchema.$ref);
           if (refSchema && schemasAreEqual(refSchema, targetSubSchema)) {
             matchingKeys.push(key);
           }
@@ -156,6 +150,22 @@ export function findMatchingSchemaKeys(
   // since we entirely hide the configuration from the agent.
 
   return matchingKeys;
+}
+
+/**
+ * Finds the schema for a property given a $ref to it.
+ */
+export function followInternalRef(
+  schema: JSONSchema,
+  ref: string
+): JSONSchema | null {
+  return findSchemaAtPath(
+    schema,
+    ref
+      .replace("#/", "")
+      .split("/")
+      .filter((key) => key != "properties")
+  );
 }
 
 /**

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -59,6 +59,25 @@ export function findMatchingSchemaKeys(
           matchingKeys.push(key);
         }
 
+        // Following references within the main schema.
+        // zodToJsonSchema generates references if the same subSchema is repeated.
+        if (propSchema.$ref) {
+          const refSchema = findSchemaAtPath(
+            inputSchema,
+            propSchema.$ref.replace("#/properties/", "").split("/")
+          );
+          logger.info(
+            {
+              refSchema,
+              path: propSchema.$ref.replace("#/properties/", "").split("/"),
+            },
+            "refSchema"
+          );
+          if (refSchema && schemasAreEqual(refSchema, targetSubSchema)) {
+            matchingKeys.push(key);
+          }
+        }
+
         // Recursively check this property's schema
         const nestedMatches = findMatchingSchemaKeys(
           propSchema,

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -64,14 +64,10 @@ export function findMatchingSchemaKeys(
         if (propSchema.$ref) {
           const refSchema = findSchemaAtPath(
             inputSchema,
-            propSchema.$ref.replace("#/properties/", "").split("/")
-          );
-          logger.info(
-            {
-              refSchema,
-              path: propSchema.$ref.replace("#/properties/", "").split("/"),
-            },
-            "refSchema"
+            propSchema.$ref
+              .replace("#/", "")
+              .split("/")
+              .filter((key) => key != "properties")
           );
           if (refSchema && schemasAreEqual(refSchema, targetSubSchema)) {
             matchingKeys.push(key);


### PR DESCRIPTION
## Description

- Using the same type of configurable block in the input schema of a tool results in only one of them being actually configurable.
- This behavior is due to the fact that `zod-to-json-schema` automatically creates internal references within the JSONSchema for repeated sub-schemas.
- This PR adds handling of such references.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
