### PR TITLE
enh(MCP): improve UI for configuration of primitive types

### DIFF
--- a/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
@@ -47,15 +47,17 @@ function BooleanConfigurationSection({
   return Object.entries(requiredBooleans).map(([key, defaultValue]) => {
     const value = (additionalConfiguration[key] as boolean) ?? defaultValue;
     return (
-      <div key={key} className="flex items-center gap-2">
-        <Checkbox
-          id={`boolean-${key}`}
-          checked={value}
-          onCheckedChange={(checked) => onConfigUpdate(key, !!checked)}
-        />
-        <Label htmlFor={`boolean-${key}`} className="text-sm font-medium">
+      <div key={key} className="mb-2 flex items-center gap-1">
+        <Label htmlFor={`boolean-${key}`} className="w-1/5 text-sm font-medium">
           {formatKeyForDisplay(key)}
         </Label>
+        <div className="w-full flex-1">
+          <Checkbox
+            id={`boolean-${key}`}
+            checked={value}
+            onCheckedChange={(checked) => onConfigUpdate(key, !!checked)}
+          />
+        </div>
       </div>
     );
   });
@@ -79,8 +81,8 @@ function NumberConfigurationSection({
   return Object.entries(requiredNumbers).map(([key, defaultValue]) => {
     const value = additionalConfiguration[key] ?? defaultValue;
     return (
-      <div key={key} className="flex flex-col gap-2">
-        <Label htmlFor={`number-${key}`} className="text-sm font-medium">
+      <div key={key} className="mb-2 flex items-center gap-1">
+        <Label htmlFor={`number-${key}`} className="w-1/5 text-sm font-medium">
           {formatKeyForDisplay(key)}
         </Label>
         <Input
@@ -113,8 +115,8 @@ function StringConfigurationSection({
   return Object.entries(requiredStrings).map(([key, defaultValue]) => {
     const value = additionalConfiguration[key] ?? defaultValue;
     return (
-      <div key={key} className="flex flex-col gap-2">
-        <Label htmlFor={`string-${key}`} className="text-sm font-medium">
+      <div key={key} className="mb-2 flex items-center gap-1">
+        <Label htmlFor={`string-${key}`} className="w-1/5 text-sm font-medium">
           {formatKeyForDisplay(key)}
         </Label>
         <Input
@@ -156,13 +158,13 @@ function GroupedConfigurationSection({
   }
 
   return (
-    <div className="mb-6">
+    <div className="mb-6 w-full">
       {prefix && (
         <Label className="mb-4 block text-lg font-medium text-foreground dark:text-foreground-night">
           {asDisplayName(prefix)}
         </Label>
       )}
-      <div className="space-y-4">
+      <div className="w-full space-y-4">
         <StringConfigurationSection
           requiredStrings={requiredStrings}
           additionalConfiguration={additionalConfiguration}
@@ -236,7 +238,7 @@ export const AdditionalConfigurationSection: React.FC<
 
   return (
     <>
-      <div className="mt-6">
+      <div className="mt-6 w-full">
         <Label className="text-lg font-medium text-foreground dark:text-foreground-night">
           Additional configuration
         </Label>

--- a/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import { asDisplayName } from "@app/types";
 
 const formatKeyForDisplay = (key: string): string => {
-  const lastPart = key.split(".").pop() || key;
-  return asDisplayName(lastPart);
+  const segments = key.split(".").map(asDisplayName);
+  return segments.join(" > ");
 };
 
 interface BooleanConfigurationSectionProps {

--- a/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
@@ -1,10 +1,11 @@
 import { Checkbox, Input, Label } from "@dust-tt/sparkle";
 import React from "react";
 
+import { asDisplayName } from "@app/types";
+
 const formatKeyForDisplay = (key: string): string => {
   const lastPart = key.split(".").pop() || key;
-  const withSpaces = lastPart.replace("_", " ").replace("-", " ");
-  return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+  return asDisplayName(lastPart);
 };
 
 interface BooleanConfigurationSectionProps {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -15,6 +15,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "authentication_debugger",
   "tables_debugger",
   "child_agent_debugger",
+  "primitive_types_debugger",
 ] as const;
 
 export const INTERNAL_MCP_SERVERS: Record<
@@ -66,6 +67,11 @@ export const INTERNAL_MCP_SERVERS: Record<
   },
   tables_debugger: {
     id: 1003,
+    isDefault: false,
+    flag: "dev_mcp_actions",
+  },
+  primitive_types_debugger: {
+    id: 1004,
     isDefault: false,
     flag: "dev_mcp_actions",
   },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -7,6 +7,7 @@ import { default as dataSourceUtilsServer } from "@app/lib/actions/mcp_internal_
 import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/file_generator";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
 import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generator";
+import { default as primitiveTypesDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/primitive_types_debugger";
 import { default as tableUtilsServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_debugger";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types";
@@ -36,6 +37,8 @@ export function getInternalMCPServer(
       return generateFileServer();
     case "child_agent_debugger":
       return askAgentServer();
+    case "primitive_types_debugger":
+      return primitiveTypesDebuggerServer();
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -1,0 +1,64 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "primitive_types_debugger",
+  version: "1.0.0",
+  description:
+    "Demo server showing a basic interaction with various configurable blocks.",
+  visual: "table",
+  authorization: null,
+};
+
+function createServer(): McpServer {
+  const server = new McpServer(serverInfo);
+
+  server.tool(
+    "pass_through",
+    "Super useful tool that should be used at all times.",
+    {
+      query: z.string(),
+      nested: z.object({
+        disabled:
+          ConfigurableToolInputSchemas[
+            INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN
+          ],
+        name2:
+          ConfigurableToolInputSchemas[
+            INTERNAL_MIME_TYPES.CONFIGURATION.STRING
+          ],
+        count:
+          ConfigurableToolInputSchemas[
+            INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER
+          ],
+      }),
+      enabled:
+        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN],
+      first_name:
+        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.STRING],
+      last_name:
+        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.STRING],
+      count2:
+        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER],
+    },
+    async (params) => {
+      return {
+        isError: false,
+        content: [
+          {
+            type: "text",
+            text: `Found the following configuration: ${JSON.stringify(params)}.`,
+          },
+        ],
+      };
+    }
+  );
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -22,28 +22,27 @@ function createServer(): McpServer {
     "Super useful tool that should be used at all times.",
     {
       query: z.string(),
-      nested: z.object({
-        disabled:
+      user: z.object({
+        first_name:
           ConfigurableToolInputSchemas[
             INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN
           ],
-        name2:
+        last_name:
           ConfigurableToolInputSchemas[
             INTERNAL_MIME_TYPES.CONFIGURATION.STRING
           ],
-        count:
+        age: ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER
+        ],
+        admin:
           ConfigurableToolInputSchemas[
-            INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER
+            INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN
           ],
       }),
+      location:
+        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.STRING],
       enabled:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.BOOLEAN],
-      first_name:
-        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.STRING],
-      last_name:
-        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.STRING],
-      count2:
-        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.CONFIGURATION.NUMBER],
     },
     async (params) => {
       return {


### PR DESCRIPTION
## Description

This PR improves the overall UI for configuring blocks of primitive types (string, boolean, number).
- Show the complete path of each key.
- Group configuration blocks that belong to the same parent object (if you have `user.name`, `user.age`, the two blocks for configuring `user` will be together).

This PR also adds a debug server.

<img width="600" alt="Screenshot 2025-04-14 at 1 11 38 PM" src="https://github.com/user-attachments/assets/59e4eaed-f92e-42ea-8006-76a3144fc4d0" />

## Tests

- Tested locally.

## Risk

- N/A, only UI changes for dev MCP servers.

## Deploy Plan

- Deploy front.