### PR TITLE
[front] Update icons, use icon picker

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -11,7 +11,7 @@ import { useMemo, useState } from "react";
 
 import { AddActionMenu } from "@app/components/actions/mcp/AddActionMenu";
 import { CreateMCPServerModal } from "@app/components/actions/mcp/CreateMCPServerModal";
-import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
 import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
@@ -210,18 +210,7 @@ export const AdminActionsList = ({
         },
       };
     })
-    .sort((a, b) => {
-      const { serverType: aServerType } = getServerTypeAndIdFromSId(
-        a.mcpServer.id
-      );
-      const { serverType: bServerType } = getServerTypeAndIdFromSId(
-        b.mcpServer.id
-      );
-      if (aServerType === bServerType) {
-        return a.mcpServer.name.localeCompare(b.mcpServer.name);
-      }
-      return aServerType < bServerType ? -1 : 1;
-    });
+    .sort(mcpServersSortingFn);
   const columns = getTableColumns();
 
   const [filter, setFilter] = useState("");

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -11,6 +11,7 @@ import { useMemo, useState } from "react";
 
 import { AddActionMenu } from "@app/components/actions/mcp/AddActionMenu";
 import { CreateMCPServerModal } from "@app/components/actions/mcp/CreateMCPServerModal";
+import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
@@ -208,6 +209,18 @@ export const AdminActionsList = ({
           }
         },
       };
+    })
+    .sort((a, b) => {
+      const { serverType: aServerType } = getServerTypeAndIdFromSId(
+        a.mcpServer.id
+      );
+      const { serverType: bServerType } = getServerTypeAndIdFromSId(
+        b.mcpServer.id
+      );
+      if (aServerType === bServerType) {
+        return a.mcpServer.name.localeCompare(b.mcpServer.name);
+      }
+      return aServerType < bServerType ? -1 : 1;
     });
   const columns = getTableColumns();
 
@@ -257,7 +270,6 @@ export const AdminActionsList = ({
         </div>
       ) : (
         <DataTable
-          sorting={[{ id: "name", desc: false }]}
           data={rows}
           columns={columns}
           className="pb-4"

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -247,7 +247,6 @@ export function MCPServerDetails({
                   <MCPServerDetailsInfo
                     mcpServer={effectiveMCPServer}
                     owner={owner}
-                    onClose={onClose}
                   />
                 )}
                 {selectedTab === "sharing" && (

--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -6,19 +6,17 @@ import type { LightWorkspaceType } from "@app/types";
 type MCPServerDetailsInfoProps = {
   mcpServer: MCPServerType;
   owner: LightWorkspaceType;
-  onClose: () => void;
 };
 
 export function MCPServerDetailsInfo({
   mcpServer,
   owner,
-  onClose,
 }: MCPServerDetailsInfoProps) {
   const serverType = getServerTypeAndIdFromSId(mcpServer.id).serverType;
   return (
     <div className="flex flex-col gap-2">
       {serverType === "remote" && (
-        <RemoteMCPForm mcpServer={mcpServer} owner={owner} onSave={onClose} />
+        <RemoteMCPForm mcpServer={mcpServer} owner={owner} />
       )}
       <ToolsList
         owner={owner}

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -1,14 +1,17 @@
 import {
+  ActionBookOpenIcon,
+  ActionIcons,
   Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
+  ChevronDownIcon,
   EyeIcon,
   EyeSlashIcon,
+  IconPicker,
   Input,
   Label,
   Page,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
   Separator,
   useSendNotification,
   XMarkIcon,
@@ -20,10 +23,8 @@ import { z } from "zod";
 
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import {
-  ALLOWED_ICONS,
   DEFAULT_MCP_SERVER_ICON,
   isAllowedIconType,
-  MCP_SERVER_ICONS,
 } from "@app/lib/actions/mcp_icons";
 import type { RemoteMCPServerType } from "@app/lib/api/mcp";
 import {
@@ -37,27 +38,23 @@ import { asDisplayName } from "@app/types";
 interface RemoteMCPFormProps {
   owner: LightWorkspaceType;
   mcpServer: RemoteMCPServerType;
-  onSave: () => void;
 }
 
 const MCPFormSchema = z.object({
   name: z.string().min(1, "Name is required."),
   description: z.string().min(1, "Description is required."),
-  icon: z.enum(ALLOWED_ICONS, { required_error: "Icon is required." }),
+  icon: z.string({ required_error: "Icon is required." }),
 });
 
 export type MCPFormType = z.infer<typeof MCPFormSchema>;
 
-export function RemoteMCPForm({
-  owner,
-  mcpServer,
-  onSave,
-}: RemoteMCPFormProps) {
+export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
   const sendNotification = useSendNotification();
 
   const [isSynchronizing, setIsSynchronizing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
   const [isSecretVisible, setIsSecretVisible] = useState(false);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const form = useForm<MCPFormType>({
     resolver: zodResolver(MCPFormSchema),
@@ -158,6 +155,10 @@ export function RemoteMCPForm({
     setIsSecretVisible(!isSecretVisible);
   };
 
+  const closePopover = () => {
+    setIsPopoverOpen(false);
+  };
+
   return (
     <div className="space-y-6">
       {syncError && (
@@ -225,30 +226,40 @@ export function RemoteMCPForm({
             name="icon"
             render={({ field }) => {
               const currentIcon = field.value;
-              const Icon = MCP_SERVER_ICONS[currentIcon];
+              const CurrentIconComponent =
+                ActionIcons[currentIcon as keyof typeof ActionIcons] ||
+                ActionBookOpenIcon;
+
               return (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
+                <PopoverRoot open={isPopoverOpen}>
+                  <PopoverTrigger asChild>
                     <Button
-                      className="capitalize"
                       variant="outline"
-                      label={currentIcon}
-                      icon={Icon}
-                      isSelect
+                      size="sm"
+                      icon={() => (
+                        <>
+                          <CurrentIconComponent />
+                          <ChevronDownIcon />
+                        </>
+                      )}
+                      onClick={() => setIsPopoverOpen(true)}
                     />
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    {Object.entries(MCP_SERVER_ICONS).map(([value, Icon]) => (
-                      <DropdownMenuItem
-                        key={value}
-                        className="capitalize"
-                        label={value}
-                        icon={Icon}
-                        onClick={() => field.onChange(value)}
-                      />
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-fit py-0"
+                    onInteractOutside={closePopover}
+                    onEscapeKeyDown={closePopover}
+                  >
+                    <IconPicker
+                      icons={ActionIcons}
+                      selectedIcon={currentIcon}
+                      onIconSelect={(iconName: string) => {
+                        field.onChange(iconName);
+                        closePopover();
+                      }}
+                    />
+                  </PopoverContent>
+                </PopoverRoot>
               );
             }}
           />
@@ -278,20 +289,28 @@ export function RemoteMCPForm({
           )}
         />
       </div>
+      {form.formState.isDirty && (
+        <div className="flex flex-row items-end justify-end gap-2">
+          <Button
+            variant="outline"
+            label={"Cancel"}
+            disabled={form.formState.isSubmitting}
+            onClick={() => {
+              form.reset();
+            }}
+          />
 
-      <div className="flex flex-col items-end gap-2">
-        <Button
-          label={form.formState.isSubmitting ? "Saving..." : "Save"}
-          disabled={!form.formState.isDirty || form.formState.isSubmitting}
-          onClick={async (event: Event) => {
-            event.preventDefault();
-            void form.handleSubmit(onSubmit)();
-            if (form.formState.isValid) {
-              onSave();
-            }
-          }}
-        />
-      </div>
+          <Button
+            variant="highlight"
+            label={form.formState.isSubmitting ? "Saving..." : "Save"}
+            disabled={form.formState.isSubmitting}
+            onClick={async (event: Event) => {
+              event.preventDefault();
+              void form.handleSubmit(onSubmit)();
+            }}
+          />
+        </div>
+      )}
 
       <Separator className="my-4" />
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -10,8 +10,8 @@ import {
   ClipboardIcon,
   ContentMessage,
   ConversationMessage,
-  DocumentDuplicateIcon,
   DocumentIcon,
+  DocumentPileIcon,
   EyeIcon,
   Markdown,
   Page,
@@ -836,7 +836,7 @@ function ErrorMessage({
                 <Button
                   variant="ghost"
                   size="xs"
-                  icon={DocumentDuplicateIcon}
+                  icon={DocumentPileIcon}
                   label={"Copy"}
                   onClick={() =>
                     void navigator.clipboard.writeText(fullMessage)

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -7,6 +7,7 @@ import {
   CardGrid,
   Chip,
   classNames,
+  CommandIcon,
   ContentMessage,
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -88,7 +89,7 @@ import {
   getDefaultMCPServerActionConfiguration,
   isDefaultActionName,
 } from "@app/components/assistant_builder/types";
-import { getVisual, MCP_SERVER_ICONS } from "@app/lib/actions/mcp_icons";
+import { getVisual } from "@app/lib/actions/mcp_icons";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -1365,7 +1366,7 @@ function AddAction({
               return (
                 <DropdownMenuItem
                   key={view.id}
-                  icon={MCP_SERVER_ICONS["command"]}
+                  icon={CommandIcon}
                   label={asDisplayName(view.server.name)}
                   description={view.server.description}
                   onClick={() =>

--- a/front/components/assistant_builder/avatar_picker/AssistantBuilderEmojiPicker.tsx
+++ b/front/components/assistant_builder/avatar_picker/AssistantBuilderEmojiPicker.tsx
@@ -40,7 +40,7 @@ const AssistantBuilderEmojiPicker = React.forwardRef<
   const [selectedEmoji, setSelectedEmoji] = useState<SelectedEmojiType | null>(
     null
   );
-  const [selectedBgColor, setSelectedBgColor] = useState(
+  const [selectedBgColor, setSelectedBgColor] = useState<`bg-${string}`>(
     DEFAULT_BACKGROUND_COLOR
   );
 
@@ -111,11 +111,12 @@ const AssistantBuilderEmojiPicker = React.forwardRef<
           </PopoverTrigger>
           <PopoverContent mountPortal={false} className="p-4" fullWidth>
             <ColorPicker
+              selectedColor={selectedBgColor}
               colors={
                 generateTailwindBackgroundColors() as avatarUtils.AvatarBackgroundColorType[]
               }
               onColorSelect={(color) => {
-                setSelectedBgColor(color);
+                setSelectedBgColor(color as `bg-${string}`);
                 // We only mark as stale if an emoji has been selected.
                 if (selectedEmoji) {
                   onChange();

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -1,6 +1,6 @@
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
-  DocumentDuplicateIcon,
+  DocumentPileIcon,
   ExternalLinkIcon,
   EyeIcon,
   PencilSquareIcon,
@@ -268,7 +268,7 @@ export const getMenuItems = (
     actions.push({
       kind: "item",
       label: "Copy DataSource ID",
-      icon: DocumentDuplicateIcon,
+      icon: DocumentPileIcon,
       onClick: (e: ReactMouseEvent) => {
         e.stopPropagation();
         void navigator.clipboard.writeText(dataSourceView.dataSource.sId);

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -48,7 +48,6 @@ export const DEFAULT_MCP_ACTION_NAME = "mcp";
 export const DEFAULT_MCP_ACTION_VERSION = "1.0.0";
 export const DEFAULT_MCP_ACTION_DESCRIPTION =
   "Call a tool to answer a question.";
-export const DEFAULT_MCP_ACTION_ICON = "command";
 
 export const MCP_TOOL_STAKE_LEVELS = ["high", "low"] as const;
 export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVELS)[number];

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -1,5 +1,6 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { MCPServerType } from "@app/lib/api/mcp";
 import {
   getResourceNameAndIdFromSId,
   makeSId,
@@ -55,4 +56,16 @@ export const remoteMCPServerNameToSId = ({
     id: remoteMCPServerId,
     workspaceId,
   });
+};
+
+export const mcpServersSortingFn = (
+  a: { mcpServer: MCPServerType },
+  b: { mcpServer: MCPServerType }
+) => {
+  const { serverType: aServerType } = getServerTypeAndIdFromSId(a.mcpServer.id);
+  const { serverType: bServerType } = getServerTypeAndIdFromSId(b.mcpServer.id);
+  if (aServerType === bServerType) {
+    return a.mcpServer.name.localeCompare(b.mcpServer.name);
+  }
+  return aServerType < bServerType ? -1 : 1;
 };

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -1,44 +1,20 @@
-import {
-  CommandIcon,
-  FolderTableIcon,
-  GithubIcon,
-  ImageIcon,
-  RobotIcon,
-  RocketIcon,
-} from "@dust-tt/sparkle";
+import { ActionIcons } from "@dust-tt/sparkle";
 import React from "react";
 
 import type { MCPServerType } from "@app/lib/api/mcp";
 
-export const MCP_SERVER_ICONS: Record<AllowedIconType, React.ComponentType> = {
-  command: CommandIcon,
-  github: GithubIcon,
-  image: ImageIcon,
-  robot: RobotIcon,
-  rocket: RocketIcon,
-  table: FolderTableIcon,
-} as const;
+export const DEFAULT_MCP_SERVER_ICON = "ActionCommand1Icon" as const;
 
-export const DEFAULT_MCP_SERVER_ICON = "rocket" as const;
+export const ALLOWED_ICONS = Object.keys(ActionIcons);
 
-export const ALLOWED_ICONS = [
-  "command",
-  "github",
-  "image",
-  "robot",
-  "rocket",
-  "table",
-] as const;
-export type AllowedIconType = (typeof ALLOWED_ICONS)[number];
+export type AllowedIconType = keyof typeof ActionIcons;
 
 export const isAllowedIconType = (icon: string): icon is AllowedIconType =>
   ALLOWED_ICONS.includes(icon as AllowedIconType);
 
 export const getVisual = (mcpServer: MCPServerType) => {
   if (isAllowedIconType(mcpServer.visual)) {
-    return React.createElement(
-      MCP_SERVER_ICONS[mcpServer.visual || DEFAULT_MCP_SERVER_ICON]
-    );
+    return React.createElement(ActionIcons[mcpServer.visual]);
   }
 
   return mcpServer.visual;

--- a/front/lib/actions/mcp_internal_actions/servers/child_agent_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/child_agent_debugger.ts
@@ -14,7 +14,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   name: "child_agent_debugger",
   version: "1.0.0",
   description: "Demo server showing a basic interaction with a child agent.",
-  visual: "robot",
+  visual: "https://dust.tt/static/droidavatar/Droid_Green_1.jpg",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_debugger.ts
@@ -19,7 +19,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with a data source configuration.",
-  visual: "command",
+  visual: "https://dust.tt/static/droidavatar/Droid_Green_1.jpg",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -17,7 +17,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     provider: "github" as const,
     use_case: "platform_actions" as const,
   },
-  visual: "github",
+  visual: "https://dust.tt/static/droidavatar/Droid_Green_1.jpg",
 };
 
 const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/image_generator.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generator.ts
@@ -10,7 +10,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   name: "image_generator",
   version: "1.0.0",
   description: "Generate images with Dall-E v3.",
-  visual: "image",
+  visual: "https://dust.tt/static/droidavatar/Droid_Green_1.jpg",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/tables_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_debugger.ts
@@ -10,7 +10,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with a table configuration.",
-  visual: "table",
+  visual: "https://dust.tt/static/droidavatar/Droid_Green_1.jpg",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -7,12 +7,12 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import {
   DEFAULT_MCP_ACTION_DESCRIPTION,
-  DEFAULT_MCP_ACTION_ICON,
   DEFAULT_MCP_ACTION_NAME,
   DEFAULT_MCP_ACTION_VERSION,
 } from "@app/lib/actions/constants";
 import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_local";
 import apiConfig from "@app/lib/api/config";
@@ -184,7 +184,7 @@ export function extractMetadataFromServerVersion(
       visual:
         "visual" in r && typeof r.visual === "string"
           ? r.visual
-          : DEFAULT_MCP_ACTION_ICON,
+          : DEFAULT_MCP_SERVER_ICON,
     };
   }
 
@@ -192,7 +192,7 @@ export function extractMetadataFromServerVersion(
     name: DEFAULT_MCP_ACTION_NAME,
     version: DEFAULT_MCP_ACTION_VERSION,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,
-    visual: DEFAULT_MCP_ACTION_ICON,
+    visual: DEFAULT_MCP_SERVER_ICON,
     authorization: null,
   };
 }

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -90,12 +90,5 @@ RemoteMCPServerModel.init(
   {
     sequelize: frontSequelize,
     modelName: "remote_mcp_server",
-    // hooks: {
-    //   beforeValidate: (server: RemoteMCPServerModel) => {
-    //     if (server.icon && !Object.keys(ActionIcons).includes(server.icon)) {
-    //       throw new Error(`Invalid icon type: ${server.icon}`);
-    //     }
-    //   },
-    // },
   }
 );

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -3,7 +3,6 @@ import { DataTypes } from "sequelize";
 
 import { DEFAULT_MCP_ACTION_VERSION } from "@app/lib/actions/constants";
 import type { AllowedIconType } from "@app/lib/actions/mcp_icons";
-import { isAllowedIconType } from "@app/lib/actions/mcp_icons";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { MCPToolType } from "@app/lib/api/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -91,12 +90,12 @@ RemoteMCPServerModel.init(
   {
     sequelize: frontSequelize,
     modelName: "remote_mcp_server",
-    hooks: {
-      beforeValidate: (server: RemoteMCPServerModel) => {
-        if (server.icon && !isAllowedIconType(server.icon)) {
-          throw new Error(`Invalid icon type: ${server.icon}`);
-        }
-      },
-    },
+    // hooks: {
+    //   beforeValidate: (server: RemoteMCPServerModel) => {
+    //     if (server.icon && !Object.keys(ActionIcons).includes(server.icon)) {
+    //       throw new Error(`Invalid icon type: ${server.icon}`);
+    //     }
+    //   },
+    // },
   }
 );

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.459",
+        "@dust-tt/sparkle": "^0.2.464",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -167,7 +167,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.39",
+      "version": "1.0.40",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",
@@ -1042,9 +1042,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.459",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.459.tgz",
-      "integrity": "sha512-5kRVxchCH5v/sdEh789iybiNkXkHgrWOQV7EC7L0Dvw4KsSl+vSwy2RSXXbmIM5TgWaqh2zek+XO2NfjUgfbhw==",
+      "version": "0.2.464",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.464.tgz",
+      "integrity": "sha512-IGoxFGrW5Iwipp0n7uRN3nAOROzRqy0caz9/8HUUYNsODL5+TP39uT5lRjDzkP7IGlNvNB24whLDNYxz1kV63Q==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.459",
+    "@dust-tt/sparkle": "^0.2.464",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -698,6 +698,7 @@ function TemplatesPage({
               title="Background Color"
               picker={(handleSelect) => (
                 <ColorPicker
+                  selectedColor={form.getValues("backgroundColor")}
                   colors={generateTailwindBackgroundColors()}
                   onColorSelect={(color) => {
                     handleSelect(color);

--- a/front/tests/utils/RemoteMCPServerFactory.ts
+++ b/front/tests/utils/RemoteMCPServerFactory.ts
@@ -1,13 +1,11 @@
 import { faker } from "@faker-js/faker";
 
+import { DEFAULT_MCP_ACTION_VERSION } from "@app/lib/actions/constants";
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import type { MCPToolType } from "@app/lib/api/mcp";
 import { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { WorkspaceType } from "@app/types";
-import {
-  DEFAULT_MCP_ACTION_ICON,
-  DEFAULT_MCP_ACTION_VERSION,
-} from "@app/lib/actions/constants";
 
 export class RemoteMCPServerFactory {
   static async create(
@@ -33,7 +31,7 @@ export class RemoteMCPServerFactory {
       url,
       cachedDescription,
       cachedTools: tools,
-      icon: DEFAULT_MCP_ACTION_ICON,
+      icon: DEFAULT_MCP_SERVER_ICON,
       version: DEFAULT_MCP_ACTION_VERSION,
       authorization: null,
     });


### PR DESCRIPTION
## Description

- Use Action icons for remote mcp server
- Replace dropdown with picker
- Use images for internal servers
- Fixed sorting in AdminActionsList
- Hide save/cancel buttons when form is not dirty

## Tests


## Risk

ui only, sparkle package update

## Deploy Plan

- deploy front
- ok danger, no changes in model, no migration to deploy
