### PR TITLE
refactor(MCP): reorganize the component `MCPAction`

### DIFF
--- a/front/components/actions/mcp/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/MCPActionDetails.tsx
@@ -18,7 +18,7 @@ export function MCPActionDetails({
       defaultOpen={defaultOpen}
       visual={ACTION_SPECIFICATIONS["MCP"].cardIcon}
     >
-      <div className="flex flex-col gap-1 gap-4 py-4 pl-6">
+      <div className="flex flex-col gap-4 py-4 pl-6">
         <CollapsibleComponent
           rootProps={{ defaultOpen: !action.generatedFiles.length }}
           triggerChildren={

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1118,7 +1118,7 @@ function ActionEditor({
       <ActionModeSection show={true}>
         <div className="flex w-full flex-row items-center justify-between px-1">
           <Page.Header
-            title={actionDisplayName(action)}
+            title={actionDisplayName(action) || "Select an action"}
             icon={ACTION_SPECIFICATIONS[action.type].cardIcon}
           />
           {shouldDisplayAdvancedSettings && (

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -37,13 +37,9 @@ export function MCPServerSelector({
 }: MCPServerSelectorProps) {
   return (
     <>
-      <div className="text-element-700 text-sm">
+      <div className="text-sm text-foreground dark:text-foreground-night">
         The agent will execute an{" "}
-        <a
-          className="font-bold"
-          href="https://docs.dust.tt"
-          target="_blank"
-        >
+        <a className="font-bold" href="https://docs.dust.tt" target="_blank">
           Action
         </a>{" "}
         made available to you.
@@ -62,8 +58,7 @@ export function MCPServerSelector({
           renderChildren={(space) => {
             const mcpServerViewsInSpace = space
               ? mcpServerViews.filter(
-                  (mcpServerView) =>
-                    mcpServerView.spaceId === space.sId
+                  (mcpServerView) => mcpServerView.spaceId === space.sId
                 )
               : mcpServerViews;
             if (
@@ -78,62 +73,51 @@ export function MCPServerSelector({
                 {sortBy(mcpServerViewsInSpace, "server.name")
                   // Default servers can be added as capabilities or in the first level of the Add actions list
                   .filter((view) => !view.server.isDefault)
-                  .map((mcpServerView, idx, arr) => {
-                    return (
-                      <React.Fragment key={mcpServerView.id}>
-                        <RadioGroupCustomItem
-                          value={mcpServerView.id}
-                          id={mcpServerView.id}
-                          iconPosition="start"
-                          customItem={
-                            <Label
-                              htmlFor={mcpServerView.id}
-                              className="font-normal"
+                  .map((mcpServerView, idx, arr) => (
+                    <React.Fragment key={mcpServerView.id}>
+                      <RadioGroupCustomItem
+                        value={mcpServerView.id}
+                        id={mcpServerView.id}
+                        iconPosition="start"
+                        customItem={
+                          <Label
+                            htmlFor={mcpServerView.id}
+                            className="font-normal"
+                          >
+                            <Card
+                              variant="tertiary"
+                              size="sm"
+                              onClick={() => {
+                                handleServerSelection(mcpServerView);
+                              }}
                             >
-                              <Card
-                                variant="tertiary"
-                                size="sm"
-                                onClick={() => {
-                                  handleServerSelection(
-                                    mcpServerView
-                                  );
-                                }}
-                              >
-                                <div className="flex flex-row items-center gap-2">
-                                  <div>
-                                    <Avatar
-                                      visual={getVisual(
-                                        mcpServerView.server
-                                      )}
-                                    />
-                                  </div>
-                                  <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
-                                    <div className="flex flex-col gap-1">
-                                      <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                                        {asDisplayName(
-                                          mcpServerView.server.name
-                                        )}
-                                      </div>
-                                      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                                        {
-                                          mcpServerView.server
-                                            .description
-                                        }
-                                      </div>
+                              <div className="flex flex-row items-center gap-2">
+                                <div>
+                                  <Avatar
+                                    visual={getVisual(mcpServerView.server)}
+                                  />
+                                </div>
+                                <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
+                                  <div className="flex flex-col gap-1">
+                                    <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                                      {asDisplayName(mcpServerView.server.name)}
+                                    </div>
+                                    <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                                      {mcpServerView.server.description}
                                     </div>
                                   </div>
                                 </div>
-                              </Card>
-                            </Label>
-                          }
-                          onClick={() => {
-                            handleServerSelection(mcpServerView);
-                          }}
-                        ></RadioGroupCustomItem>
-                        {idx !== arr.length - 1 && <Separator />}
-                      </React.Fragment>
-                    );
-                  })}
+                              </div>
+                            </Card>
+                          </Label>
+                        }
+                        onClick={() => {
+                          handleServerSelection(mcpServerView);
+                        }}
+                      ></RadioGroupCustomItem>
+                      {idx !== arr.length - 1 && <Separator />}
+                    </React.Fragment>
+                  ))}
               </RadioGroup>
             );
           }}

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -1,0 +1,144 @@
+import {
+  Avatar,
+  Card,
+  Label,
+  RadioGroup,
+  RadioGroupCustomItem,
+  Separator,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { sortBy } from "lodash";
+import React from "react";
+
+import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
+import { getVisual } from "@app/lib/actions/mcp_icons";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { SpaceType } from "@app/types";
+import { asDisplayName } from "@app/types";
+
+interface MCPServerSelectorProps {
+  isSpacesLoading: boolean;
+  filteredSpaces: SpaceType[];
+  allowedSpaces: SpaceType[];
+  mcpServerViews: MCPServerViewType[];
+  selectedMCPServerView: MCPServerViewType | null;
+  hasNoMCPServerViewsInAllowedSpaces: boolean;
+  handleServerSelection: (mcpServerView: MCPServerViewType) => void;
+}
+
+export function MCPServerSelector({
+  isSpacesLoading,
+  filteredSpaces,
+  allowedSpaces,
+  mcpServerViews,
+  selectedMCPServerView,
+  hasNoMCPServerViewsInAllowedSpaces,
+  handleServerSelection,
+}: MCPServerSelectorProps) {
+  return (
+    <>
+      <div className="text-element-700 text-sm">
+        The agent will execute an{" "}
+        <a
+          className="font-bold"
+          href="https://docs.dust.tt"
+          target="_blank"
+        >
+          Action
+        </a>{" "}
+        made available to you.
+      </div>
+      {isSpacesLoading ? (
+        <Spinner />
+      ) : (
+        <SpaceSelector
+          spaces={filteredSpaces}
+          allowedSpaces={allowedSpaces}
+          defaultSpace={
+            selectedMCPServerView
+              ? selectedMCPServerView.spaceId
+              : allowedSpaces[0].sId
+          }
+          renderChildren={(space) => {
+            const mcpServerViewsInSpace = space
+              ? mcpServerViews.filter(
+                  (mcpServerView) =>
+                    mcpServerView.spaceId === space.sId
+                )
+              : mcpServerViews;
+            if (
+              mcpServerViewsInSpace.length === 0 ||
+              hasNoMCPServerViewsInAllowedSpaces
+            ) {
+              return <>No Actions available.</>;
+            }
+
+            return (
+              <RadioGroup defaultValue={selectedMCPServerView?.id}>
+                {sortBy(mcpServerViewsInSpace, "server.name")
+                  // Default servers can be added as capabilities or in the first level of the Add actions list
+                  .filter((view) => !view.server.isDefault)
+                  .map((mcpServerView, idx, arr) => {
+                    return (
+                      <React.Fragment key={mcpServerView.id}>
+                        <RadioGroupCustomItem
+                          value={mcpServerView.id}
+                          id={mcpServerView.id}
+                          iconPosition="start"
+                          customItem={
+                            <Label
+                              htmlFor={mcpServerView.id}
+                              className="font-normal"
+                            >
+                              <Card
+                                variant="tertiary"
+                                size="sm"
+                                onClick={() => {
+                                  handleServerSelection(
+                                    mcpServerView
+                                  );
+                                }}
+                              >
+                                <div className="flex flex-row items-center gap-2">
+                                  <div>
+                                    <Avatar
+                                      visual={getVisual(
+                                        mcpServerView.server
+                                      )}
+                                    />
+                                  </div>
+                                  <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
+                                    <div className="flex flex-col gap-1">
+                                      <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                                        {asDisplayName(
+                                          mcpServerView.server.name
+                                        )}
+                                      </div>
+                                      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                                        {
+                                          mcpServerView.server
+                                            .description
+                                        }
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </Card>
+                            </Label>
+                          }
+                          onClick={() => {
+                            handleServerSelection(mcpServerView);
+                          }}
+                        ></RadioGroupCustomItem>
+                        {idx !== arr.length - 1 && <Separator />}
+                      </React.Fragment>
+                    );
+                  })}
+              </RadioGroup>
+            );
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -13,9 +13,9 @@ import React, { useMemo } from "react";
 import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
 import { getVisual } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 import { asDisplayName } from "@app/types";
-import { useSpaces } from "@app/lib/swr/spaces";
 
 interface MCPServerSelectorProps {
   allowedSpaces: SpaceType[];

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -3,15 +3,14 @@ import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { AdditionalConfigurationSection } from "@app/components/assistant_builder/actions/configuration/AdditionalConfigurationSection";
 import { ChildAgentSelector } from "@app/components/assistant_builder/actions/configuration/ChildAgentSelector";
-import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
+import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
-
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -116,12 +115,6 @@ export function MCPAction({
           mcpServerView.id === actionConfiguration.mcpServerViewId
       ) ?? null
     );
-
-  // MCPServerView on default MCP server will not allow switching to another one.
-  const isDefaultMCPServer = useMemo(
-    () => !!selectedMCPServerView?.server.isDefault,
-    [selectedMCPServerView]
-  );
 
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [showTablesModal, setShowTablesModal] = useState(false);
@@ -264,25 +257,17 @@ export function MCPAction({
         {noMCPServerView ? (
           <NoActionAvailable owner={owner} />
         ) : (
-          <>
-            {isDefaultMCPServer ? (
-              <div className="text-element-700 text-sm">
-                {selectedMCPServerView?.server.description}
-              </div>
-            ) : (
-              <MCPServerSelector
-                isSpacesLoading={isSpacesLoading}
-                filteredSpaces={filteredSpaces}
-                allowedSpaces={allowedSpaces}
-                mcpServerViews={mcpServerViews}
-                selectedMCPServerView={selectedMCPServerView}
-                hasNoMCPServerViewsInAllowedSpaces={
-                  hasNoMCPServerViewsInAllowedSpaces
-                }
-                handleServerSelection={handleServerSelection}
-              />
-            )}
-          </>
+          <MCPServerSelector
+            isSpacesLoading={isSpacesLoading}
+            filteredSpaces={filteredSpaces}
+            allowedSpaces={allowedSpaces}
+            mcpServerViews={mcpServerViews}
+            selectedMCPServerView={selectedMCPServerView}
+            hasNoMCPServerViewsInAllowedSpaces={
+              hasNoMCPServerViewsInAllowedSpaces
+            }
+            handleServerSelection={handleServerSelection}
+          />
         )}
       </>
       {requirements.requiresDataSourceConfiguration && (

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -217,6 +217,7 @@ export function MCPAction({
 
   return (
     <>
+      {/* Additional modals for selecting data sources */}
       {requirements.requiresDataSourceConfiguration && (
         <AssistantBuilderDataSourceModal
           isOpen={showDataSourcesModal}
@@ -245,6 +246,7 @@ export function MCPAction({
           viewType="table"
         />
       )}
+      {/* Server selection */}
       {isDefaultMCPServer ? (
         <div className="text-sm text-foreground dark:text-foreground-night">
           {selectedMCPServerView?.server.description}
@@ -258,6 +260,7 @@ export function MCPAction({
           handleServerSelection={handleServerSelection}
         />
       )}
+      {/* Configurable blocks */}
       {requirements.requiresDataSourceConfiguration && (
         <DataSourceSelectionSection
           owner={owner}

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -211,6 +211,10 @@ export function MCPAction({
 
   const requirements = getMCPServerRequirements(selectedMCPServerView);
 
+  if (noMCPServerView) {
+    return <NoActionAvailable owner={owner} />;
+  }
+
   return (
     <>
       {requirements.requiresDataSourceConfiguration && (
@@ -241,27 +245,19 @@ export function MCPAction({
           viewType="table"
         />
       )}
-      <>
-        {noMCPServerView ? (
-          <NoActionAvailable owner={owner} />
-        ) : (
-          <>
-            {isDefaultMCPServer ? (
-              <div className="text-sm text-foreground dark:text-foreground-night">
-                {selectedMCPServerView?.server.description}
-              </div>
-            ) : (
-              <MCPServerSelector
-                owner={owner}
-                allowedSpaces={allowedSpaces}
-                mcpServerViews={mcpServerViews}
-                selectedMCPServerView={selectedMCPServerView}
-                handleServerSelection={handleServerSelection}
-              />
-            )}
-          </>
-        )}
-      </>
+      {isDefaultMCPServer ? (
+        <div className="text-sm text-foreground dark:text-foreground-night">
+          {selectedMCPServerView?.server.description}
+        </div>
+      ) : (
+        <MCPServerSelector
+          owner={owner}
+          allowedSpaces={allowedSpaces}
+          mcpServerViews={mcpServerViews}
+          selectedMCPServerView={selectedMCPServerView}
+          handleServerSelection={handleServerSelection}
+        />
+      )}
       {requirements.requiresDataSourceConfiguration && (
         <DataSourceSelectionSection
           owner={owner}

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -3,15 +3,14 @@ import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { AdditionalConfigurationSection } from "@app/components/assistant_builder/actions/configuration/AdditionalConfigurationSection";
 import { ChildAgentSelector } from "@app/components/assistant_builder/actions/configuration/ChildAgentSelector";
-import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
+import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
-
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type {

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -3,14 +3,15 @@ import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { AdditionalConfigurationSection } from "@app/components/assistant_builder/actions/configuration/AdditionalConfigurationSection";
 import { ChildAgentSelector } from "@app/components/assistant_builder/actions/configuration/ChildAgentSelector";
+import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
-import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
+
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -115,6 +116,12 @@ export function MCPAction({
           mcpServerView.id === actionConfiguration.mcpServerViewId
       ) ?? null
     );
+
+  // MCPServerView on default MCP server will not allow switching to another one.
+  const isDefaultMCPServer = useMemo(
+    () => !!selectedMCPServerView?.server.isDefault,
+    [selectedMCPServerView]
+  );
 
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [showTablesModal, setShowTablesModal] = useState(false);
@@ -257,17 +264,25 @@ export function MCPAction({
         {noMCPServerView ? (
           <NoActionAvailable owner={owner} />
         ) : (
-          <MCPServerSelector
-            isSpacesLoading={isSpacesLoading}
-            filteredSpaces={filteredSpaces}
-            allowedSpaces={allowedSpaces}
-            mcpServerViews={mcpServerViews}
-            selectedMCPServerView={selectedMCPServerView}
-            hasNoMCPServerViewsInAllowedSpaces={
-              hasNoMCPServerViewsInAllowedSpaces
-            }
-            handleServerSelection={handleServerSelection}
-          />
+          <>
+            {isDefaultMCPServer ? (
+              <div className="text-element-700 text-sm">
+                {selectedMCPServerView?.server.description}
+              </div>
+            ) : (
+              <MCPServerSelector
+                isSpacesLoading={isSpacesLoading}
+                filteredSpaces={filteredSpaces}
+                allowedSpaces={allowedSpaces}
+                mcpServerViews={mcpServerViews}
+                selectedMCPServerView={selectedMCPServerView}
+                hasNoMCPServerViewsInAllowedSpaces={
+                  hasNoMCPServerViewsInAllowedSpaces
+                }
+                handleServerSelection={handleServerSelection}
+              />
+            )}
+          </>
         )}
       </>
       {requirements.requiresDataSourceConfiguration && (

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -14,7 +14,6 @@ import type {
 
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useSpaces } from "@app/lib/swr/spaces";
 import type {
   DataSourceViewSelectionConfigurations,
   LightWorkspaceType,
@@ -88,26 +87,8 @@ export function MCPAction({
     action.configuration as AssistantBuilderMCPServerConfiguration;
 
   const { mcpServerViews } = useContext(AssistantBuilderContext);
-  const { spaces, isSpacesLoading } = useSpaces({ workspaceId: owner.sId });
-  const filteredSpaces = useMemo(
-    () =>
-      spaces.filter((space) =>
-        mcpServerViews.some(
-          (mcpServerView) => mcpServerView.spaceId === space.sId
-        )
-      ),
-    [spaces, mcpServerViews]
-  );
 
   const noMCPServerView = mcpServerViews.length === 0;
-
-  const hasNoMCPServerViewsInAllowedSpaces = useMemo(() => {
-    // No n^2 complexity.
-    const allowedSet = new Set(allowedSpaces.map((space) => space.sId));
-    return mcpServerViews.every(
-      (mcpServerView) => !allowedSet.has(mcpServerView.spaceId)
-    );
-  }, [mcpServerViews, allowedSpaces]);
 
   const [selectedMCPServerView, setSelectedMCPServerView] =
     useState<MCPServerViewType | null>(
@@ -271,14 +252,10 @@ export function MCPAction({
               </div>
             ) : (
               <MCPServerSelector
-                isSpacesLoading={isSpacesLoading}
-                filteredSpaces={filteredSpaces}
+                owner={owner}
                 allowedSpaces={allowedSpaces}
                 mcpServerViews={mcpServerViews}
                 selectedMCPServerView={selectedMCPServerView}
-                hasNoMCPServerViewsInAllowedSpaces={
-                  hasNoMCPServerViewsInAllowedSpaces
-                }
                 handleServerSelection={handleServerSelection}
               />
             )}

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -1,28 +1,17 @@
-import {
-  Avatar,
-  Card,
-  ContentMessage,
-  InformationCircleIcon,
-  Label,
-  RadioGroup,
-  RadioGroupCustomItem,
-  Separator,
-  Spinner,
-} from "@dust-tt/sparkle";
-import { sortBy } from "lodash";
+import { ContentMessage, InformationCircleIcon } from "@dust-tt/sparkle";
 import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { AdditionalConfigurationSection } from "@app/components/assistant_builder/actions/configuration/AdditionalConfigurationSection";
 import { ChildAgentSelector } from "@app/components/assistant_builder/actions/configuration/ChildAgentSelector";
+import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
-import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -31,7 +20,7 @@ import type {
   LightWorkspaceType,
   SpaceType,
 } from "@app/types";
-import { asDisplayName, assertNever, slugify } from "@app/types";
+import { assertNever, slugify } from "@app/types";
 
 interface MCPActionProps {
   owner: LightWorkspaceType;
@@ -271,110 +260,17 @@ export function MCPAction({
                 {selectedMCPServerView?.server.description}
               </div>
             ) : (
-              <>
-                <div className="text-element-700 text-sm">
-                  The agent will execute an{" "}
-                  <a
-                    className="font-bold"
-                    href="https://docs.dust.tt"
-                    target="_blank"
-                  >
-                    Action
-                  </a>{" "}
-                  made available to you.
-                </div>
-                {isSpacesLoading ? (
-                  <Spinner />
-                ) : (
-                  <SpaceSelector
-                    spaces={filteredSpaces}
-                    allowedSpaces={allowedSpaces}
-                    defaultSpace={
-                      selectedMCPServerView
-                        ? selectedMCPServerView.spaceId
-                        : allowedSpaces[0].sId
-                    }
-                    renderChildren={(space) => {
-                      const mcpServerViewsInSpace = space
-                        ? mcpServerViews.filter(
-                            (mcpServerView) =>
-                              mcpServerView.spaceId === space.sId
-                          )
-                        : mcpServerViews;
-                      if (
-                        mcpServerViewsInSpace.length === 0 ||
-                        hasNoMCPServerViewsInAllowedSpaces
-                      ) {
-                        return <>No Actions available.</>;
-                      }
-
-                      return (
-                        <RadioGroup defaultValue={selectedMCPServerView?.id}>
-                          {sortBy(mcpServerViewsInSpace, "server.name")
-                            // Default servers can be added as capabilities or in the first level of the Add actions list
-                            .filter((view) => !view.server.isDefault)
-                            .map((mcpServerView, idx, arr) => {
-                              return (
-                                <React.Fragment key={mcpServerView.id}>
-                                  <RadioGroupCustomItem
-                                    value={mcpServerView.id}
-                                    id={mcpServerView.id}
-                                    iconPosition="start"
-                                    customItem={
-                                      <Label
-                                        htmlFor={mcpServerView.id}
-                                        className="font-normal"
-                                      >
-                                        <Card
-                                          variant="tertiary"
-                                          size="sm"
-                                          onClick={() => {
-                                            handleServerSelection(
-                                              mcpServerView
-                                            );
-                                          }}
-                                        >
-                                          <div className="flex flex-row items-center gap-2">
-                                            <div>
-                                              <Avatar
-                                                visual={getVisual(
-                                                  mcpServerView.server
-                                                )}
-                                              />
-                                            </div>
-                                            <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
-                                              <div className="flex flex-col gap-1">
-                                                <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                                                  {asDisplayName(
-                                                    mcpServerView.server.name
-                                                  )}
-                                                </div>
-                                                <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                                                  {
-                                                    mcpServerView.server
-                                                      .description
-                                                  }
-                                                </div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </Card>
-                                      </Label>
-                                    }
-                                    onClick={() => {
-                                      handleServerSelection(mcpServerView);
-                                    }}
-                                  ></RadioGroupCustomItem>
-                                  {idx !== arr.length - 1 && <Separator />}
-                                </React.Fragment>
-                              );
-                            })}
-                        </RadioGroup>
-                      );
-                    }}
-                  />
-                )}
-              </>
+              <MCPServerSelector
+                isSpacesLoading={isSpacesLoading}
+                filteredSpaces={filteredSpaces}
+                allowedSpaces={allowedSpaces}
+                mcpServerViews={mcpServerViews}
+                selectedMCPServerView={selectedMCPServerView}
+                hasNoMCPServerViewsInAllowedSpaces={
+                  hasNoMCPServerViewsInAllowedSpaces
+                }
+                handleServerSelection={handleServerSelection}
+              />
             )}
           </>
         )}

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -266,7 +266,7 @@ export function MCPAction({
         ) : (
           <>
             {isDefaultMCPServer ? (
-              <div className="text-element-700 text-sm">
+              <div className="text-sm text-foreground dark:text-foreground-night">
                 {selectedMCPServerView?.server.description}
               </div>
             ) : (

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -22,6 +22,47 @@ import type {
 } from "@app/types";
 import { assertNever, slugify } from "@app/types";
 
+interface NoActionAvailableProps {
+  owner: LightWorkspaceType;
+}
+
+function NoActionAvailable({ owner }: NoActionAvailableProps) {
+  return (
+    <ContentMessage
+      title="You don't have any Actions available"
+      icon={InformationCircleIcon}
+      variant="warning"
+    >
+      <div className="flex flex-col gap-y-3">
+        {(() => {
+          switch (owner.role) {
+            case "admin":
+              return (
+                <div>
+                  <strong>
+                    Visit the "Actions" section in the Admins panel to add an
+                    Action.
+                  </strong>
+                </div>
+              );
+            case "builder":
+            case "user":
+              return (
+                <div>
+                  <strong>Ask your Admins to add an Action.</strong>
+                </div>
+              );
+            case "none":
+              return <></>;
+            default:
+              assertNever(owner.role);
+          }
+        })()}
+      </div>
+    </ContentMessage>
+  );
+}
+
 interface MCPActionProps {
   owner: LightWorkspaceType;
   allowedSpaces: SpaceType[];
@@ -221,38 +262,7 @@ export function MCPAction({
       )}
       <>
         {noMCPServerView ? (
-          <ContentMessage
-            title="You don't have any Actions available"
-            icon={InformationCircleIcon}
-            variant="warning"
-          >
-            <div className="flex flex-col gap-y-3">
-              {(() => {
-                switch (owner.role) {
-                  case "admin":
-                    return (
-                      <div>
-                        <strong>
-                          Visit the "Actions" section in the Admins panel to add
-                          an Action.
-                        </strong>
-                      </div>
-                    );
-                  case "builder":
-                  case "user":
-                    return (
-                      <div>
-                        <strong>Ask your Admins to add an Action.</strong>
-                      </div>
-                    );
-                  case "none":
-                    return <></>;
-                  default:
-                    assertNever(owner.role);
-                }
-              })()}
-            </div>
-          </ContentMessage>
+          <NoActionAvailable owner={owner} />
         ) : (
           <>
             {isDefaultMCPServer ? (


### PR DESCRIPTION
## Description

- Split down the `MCPAction` component into multiple smaller ones.
- Add a default title in the modal to prevent having the whole screen move down when selecting one.
- Introduce various minor improvements (remove unnecessary divs, fix classes for text color).

## Tests

- Visual output checked locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
