### PR TITLE
[front] - chore(DatasetView): buttons

### DIFF
--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -607,26 +607,24 @@ export default function DatasetView({
                           />
                         </div>
                         {!readOnly ? (
-                          <>
+                          <div className="flex flex-initial space-x-1 pr-1">
                             {datasetKeys.length > 1 ? (
-                              <div className="flex w-4 flex-initial">
-                                <XCircleIcon
-                                  className="hidden h-4 w-4 cursor-pointer text-gray-400 hover:text-red-500 group-hover:block"
-                                  onClick={() => {
-                                    handleDeleteKey(j);
-                                  }}
-                                />
-                              </div>
-                            ) : null}
-                            <div className="mr-2 flex w-4 flex-initial">
-                              <PlusCircleIcon
-                                className="hidden h-4 w-4 cursor-pointer text-gray-400 hover:text-emerald-500 group-hover:block"
+                              <Button
+                                size="mini"
+                                icon={XCircleIcon}
                                 onClick={() => {
-                                  handleNewKey(j);
+                                  handleDeleteKey(j);
                                 }}
                               />
-                            </div>
-                          </>
+                            ) : null}
+                            <Button
+                              size="mini"
+                              icon={PlusCircleIcon}
+                              onClick={() => {
+                                handleNewKey(j);
+                              }}
+                            />
+                          </div>
                         ) : null}
                       </div>
                     </div>

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -8,7 +8,6 @@ import {
   Label,
   PlusCircleIcon,
   PlusIcon,
-  Tooltip,
   useSendNotification,
   XCircleIcon,
 } from "@dust-tt/sparkle";
@@ -611,37 +610,26 @@ export default function DatasetView({
                           <div className="flex space-x-1 px-1">
                             {datasetKeys.length > 1 ? (
                               <>
-                                <Tooltip
-                                  trigger={
-                                    <Button
-                                      size="mini"
-                                      variant="ghost"
-                                      className="text-muted-foreground"
-                                      icon={XCircleIcon}
-                                    />
-                                  }
-                                  content="Delete property"
-                                  side="top"
-                                  align="center"
-                                  label="Delete property"
+                                <Button
+                                  size="mini"
+                                  variant="ghost"
+                                  className="text-muted-foreground"
+                                  icon={XCircleIcon}
+                                  tooltip="Delete property"
+                                  onClick={() => {
+                                    handleDeleteKey(j);
+                                  }}
                                 />
 
-                                <Tooltip
-                                  trigger={
-                                    <Button
-                                      size="mini"
-                                      variant="ghost"
-                                      className="text-muted-foreground"
-                                      icon={PlusCircleIcon}
-                                      onClick={() => {
-                                        handleNewKey(j);
-                                      }}
-                                    />
-                                  }
-                                  content="Add property after"
-                                  side="top"
-                                  align="center"
-                                  label="Add property after"
+                                <Button
+                                  size="mini"
+                                  variant="ghost"
+                                  className="text-muted-foreground"
+                                  icon={PlusCircleIcon}
+                                  onClick={() => {
+                                    handleNewKey(j);
+                                  }}
+                                  tooltip="Add property after"
                                 />
                               </>
                             ) : null}

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -607,7 +607,7 @@ export default function DatasetView({
                           />
                         </div>
                         {!readOnly ? (
-                          <div className="flex flex-initial space-x-1 pr-1">
+                          <div className="flex space-x-1 px-1">
                             {datasetKeys.length > 1 ? (
                               <Button
                                 size="mini"

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -8,6 +8,7 @@ import {
   Label,
   PlusCircleIcon,
   PlusIcon,
+  Tooltip,
   useSendNotification,
   XCircleIcon,
 } from "@dust-tt/sparkle";
@@ -609,21 +610,41 @@ export default function DatasetView({
                         {!readOnly ? (
                           <div className="flex space-x-1 px-1">
                             {datasetKeys.length > 1 ? (
-                              <Button
-                                size="mini"
-                                icon={XCircleIcon}
-                                onClick={() => {
-                                  handleDeleteKey(j);
-                                }}
-                              />
+                              <>
+                                <Tooltip
+                                  trigger={
+                                    <Button
+                                      size="mini"
+                                      variant="ghost"
+                                      className="text-muted-foreground"
+                                      icon={XCircleIcon}
+                                    />
+                                  }
+                                  content="Delete property"
+                                  side="top"
+                                  align="center"
+                                  label="Delete property"
+                                />
+
+                                <Tooltip
+                                  trigger={
+                                    <Button
+                                      size="mini"
+                                      variant="ghost"
+                                      className="text-muted-foreground"
+                                      icon={PlusCircleIcon}
+                                      onClick={() => {
+                                        handleNewKey(j);
+                                      }}
+                                    />
+                                  }
+                                  content="Add property after"
+                                  side="top"
+                                  align="center"
+                                  label="Add property after"
+                                />
+                              </>
                             ) : null}
-                            <Button
-                              size="mini"
-                              icon={PlusCircleIcon}
-                              onClick={() => {
-                                handleNewKey(j);
-                              }}
-                            />
                           </div>
                         ) : null}
                       </div>
@@ -783,6 +804,7 @@ export default function DatasetView({
                           <Button
                             icon={XCircleIcon}
                             size="mini"
+                            variant="ghost"
                             onClick={() => {
                               handleDeleteEntry(i);
                             }}
@@ -791,6 +813,7 @@ export default function DatasetView({
                         <Button
                           icon={PlusCircleIcon}
                           size="mini"
+                          variant="ghost"
                           onClick={() => {
                             handleNewEntry(i);
                           }}

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -634,7 +634,7 @@ export default function DatasetView({
                           {datasetTypes[j] ? datasetTypes[j] : "string"}
                         </span>
                       ) : (
-                        <div className="inline-flex" role="group">
+                        <div className="inline-flex px-1" role="group">
                           {DATASET_DATA_TYPES.map((type) => (
                             <Button
                               key={type}
@@ -778,25 +778,23 @@ export default function DatasetView({
                       </div>
                     ))}
                     {!readOnly ? (
-                      <div className="flex items-center justify-end text-xs">
+                      <div className="flex items-center justify-end gap-1 p-1 text-xs">
                         {datasetData.length > 1 ? (
-                          <div className="flex-initial">
-                            <XCircleIcon
-                              className="h-5 w-5 cursor-pointer text-gray-300 hover:text-red-500 dark:text-gray-300-night"
-                              onClick={() => {
-                                handleDeleteEntry(i);
-                              }}
-                            />
-                          </div>
-                        ) : null}
-                        <div className="flex-initial">
-                          <PlusCircleIcon
-                            className="h-5 w-5 cursor-pointer text-gray-300 hover:text-emerald-500 dark:text-gray-300-night"
+                          <Button
+                            icon={XCircleIcon}
+                            size="mini"
                             onClick={() => {
-                              handleNewEntry(i);
+                              handleDeleteEntry(i);
                             }}
                           />
-                        </div>
+                        ) : null}
+                        <Button
+                          icon={PlusCircleIcon}
+                          size="mini"
+                          onClick={() => {
+                            handleNewEntry(i);
+                          }}
+                        />
                       </div>
                     ) : null}
                   </li>


### PR DESCRIPTION
## Description

This PR updates the `DatasetView` component to use `Button` instead of icons to manage entries.

![Screenshot 2025-04-14 at 15 37 53](https://github.com/user-attachments/assets/b438b8b1-1254-4b91-9437-917f934b41c8)

## Risk

Low

## Deploy Plan

- Deploy front