### PR TITLE
enh(MCP): improve `ChildAgentSelector` visually

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -17,14 +17,7 @@ import { useEffect, useState } from "react";
 import { filterAndSortAgents } from "@app/lib/utils";
 import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
 
-export function AssistantPicker({
-  owner,
-  assistants,
-  onItemClick,
-  pickerButton,
-  showFooterButtons = true,
-  size = "md",
-}: {
+interface AssistantPickerProps {
   owner: WorkspaceType;
   assistants: LightAgentConfigurationType[];
   onItemClick: (assistant: LightAgentConfigurationType) => void;
@@ -32,7 +25,16 @@ export function AssistantPicker({
   showMoreDetailsButtons?: boolean;
   showFooterButtons?: boolean;
   size?: "xs" | "sm" | "md";
-}) {
+}
+
+export function AssistantPicker({
+  owner,
+  assistants,
+  onItemClick,
+  pickerButton,
+  showFooterButtons = true,
+  size = "md",
+}: AssistantPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [searchedAssistants, setSearchedAssistants] = useState<
     LightAgentConfigurationType[]

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { AdditionalConfigurationSection } from "@app/components/assistant_builder/actions/configuration/AdditionalConfigurationSection";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/actions/configuration/AssistantBuilderDataSourceModal";
-import { ChildAgentSelector } from "@app/components/assistant_builder/actions/configuration/ChildAgentSelector";
+import { ChildAgentConfigurationSection } from "@app/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection";
 import DataSourceSelectionSection from "@app/components/assistant_builder/actions/configuration/DataSourceSelectionSection";
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
@@ -283,7 +283,7 @@ export function MCPAction({
         />
       )}
       {requirements.requiresChildAgentConfiguration && (
-        <ChildAgentSelector
+        <ChildAgentConfigurationSection
           onAgentSelect={handleChildAgentConfigUpdate}
           selectedAgentId={actionConfiguration.childAgentId}
           owner={owner}

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -74,6 +74,9 @@ export function ChildAgentConfigurationSection({
 
   return (
     <div className="flex flex-col gap-2">
+      <div className="flex-grow pt-4 text-sm font-semibold text-foreground dark:text-foreground-night">
+        Selected Agent
+      </div>
       {selectedAgent ? (
         <Card size="sm" className="w-full">
           <div className="flex w-full p-3">

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -89,7 +89,9 @@ export function ChildAgentConfigurationSection({
           </div>
           <AssistantPicker
             owner={owner}
-            assistants={agentConfigurations}
+            assistants={agentConfigurations.filter(
+              (agent) => agent.sId !== selectedAgentId
+            )}
             onItemClick={(agent) => {
               onAgentSelect(agent.sId);
             }}
@@ -112,9 +114,7 @@ export function ChildAgentConfigurationSection({
         >
           <AssistantPicker
             owner={owner}
-            assistants={agentConfigurations.filter(
-              (agent) => agent.sId !== selectedAgentId
-            )}
+            assistants={agentConfigurations}
             onItemClick={(agent) => {
               onAgentSelect(agent.sId);
             }}

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -16,7 +16,7 @@ interface ChildAgentSelectorProps {
   onAgentSelect: (agentId: string) => void;
 }
 
-export function ChildAgentSelector({
+export function ChildAgentConfigurationSection({
   owner,
   selectedAgentId,
   onAgentSelect,

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -76,8 +76,8 @@ export function ChildAgentConfigurationSection({
     <div className="flex flex-col gap-2">
       {selectedAgent ? (
         <Card size="sm" className="w-full">
-          <div className="flex flex-col gap-2 p-3">
-            <div className="flex items-center justify-between">
+          <div className="flex w-full p-3">
+            <div className="flex w-full flex-grow flex-col gap-2">
               <div className="flex items-center gap-2">
                 <Avatar
                   size="sm"
@@ -86,6 +86,12 @@ export function ChildAgentConfigurationSection({
                 />
                 <div className="text-md font-medium">{selectedAgent.name}</div>
               </div>
+              <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                <span className="font-medium">Description:</span>{" "}
+                {selectedAgent.description || "No description available"}
+              </div>
+            </div>
+            <div className="ml-4 flex items-center">
               <AssistantPicker
                 owner={owner}
                 assistants={agentConfigurations.filter(
@@ -103,10 +109,6 @@ export function ChildAgentConfigurationSection({
                 }
                 showFooterButtons={false}
               />
-            </div>
-            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              <span className="font-medium">Description:</span>{" "}
-              {selectedAgent.description || "No description available"}
             </div>
           </div>
         </Card>

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -80,7 +80,7 @@ export function ChildAgentConfigurationSection({
       {selectedAgent ? (
         <Card size="sm" className="w-full">
           <div className="flex w-full p-3">
-            <div className="flex w-full flex-grow flex-col gap-2">
+            <div className="flex w-full flex-grow flex-col gap-2 overflow-hidden">
               <div className="flex items-center gap-2">
                 <Avatar
                   size="sm"
@@ -89,11 +89,11 @@ export function ChildAgentConfigurationSection({
                 />
                 <div className="text-md font-medium">{selectedAgent.name}</div>
               </div>
-              <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              <div className="max-h-24 overflow-y-auto text-sm text-muted-foreground dark:text-muted-foreground-night">
                 {selectedAgent.description || "No description available"}
               </div>
             </div>
-            <div className="ml-4 flex items-center">
+            <div className="ml-4 flex-shrink-0 self-start">
               <AssistantPicker
                 owner={owner}
                 assistants={agentConfigurations.filter(

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -45,16 +45,6 @@ export function ChildAgentConfigurationSection({
     );
   }
 
-  if (isAgentConfigurationsLoading) {
-    return (
-      <Card size="sm" className="h-36 w-full">
-        <div className="flex h-full w-full items-center justify-center">
-          <Spinner />
-        </div>
-      </Card>
-    );
-  }
-
   if (agentConfigurations.length === 0) {
     return (
       <ContentMessage
@@ -77,7 +67,13 @@ export function ChildAgentConfigurationSection({
       <div className="flex-grow pt-4 text-sm font-semibold text-foreground dark:text-foreground-night">
         Selected Agent
       </div>
-      {selectedAgent ? (
+      {isAgentConfigurationsLoading ? (
+        <Card size="sm" className="h-36 w-full">
+          <div className="flex h-full w-full items-center justify-center">
+            <Spinner />
+          </div>
+        </Card>
+      ) : selectedAgent ? (
         <Card size="sm" className="w-full">
           <div className="flex w-full p-3">
             <div className="flex w-full flex-grow flex-col gap-2 overflow-hidden">

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -1,6 +1,7 @@
 import {
   Avatar,
   Button,
+  Card,
   ContentMessage,
   InformationCircleIcon,
   Spinner,
@@ -9,7 +10,6 @@ import React from "react";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
-import { classNames } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types";
 
 interface ChildAgentSelectorProps {
@@ -47,14 +47,11 @@ export function ChildAgentConfigurationSection({
 
   if (isAgentConfigurationsLoading) {
     return (
-      <div
-        className={classNames(
-          "flex h-36 w-full items-center justify-center rounded-xl",
-          "bg-muted-background dark:bg-muted-background-night"
-        )}
-      >
-        <Spinner />
-      </div>
+      <Card variant="secondary" size="sm" className="h-36 w-full">
+        <div className="flex h-full w-full items-center justify-center">
+          <Spinner />
+        </div>
+      </Card>
     );
   }
 
@@ -78,63 +75,61 @@ export function ChildAgentConfigurationSection({
   return (
     <div className="flex flex-col gap-2">
       {selectedAgent ? (
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Avatar
-              size="xs"
-              name={selectedAgent.name}
-              visual={selectedAgent.pictureUrl}
-            />
-            <div className="text-sm font-medium">{selectedAgent.name}</div>
+        <Card size="sm" className="w-full">
+          <div className="flex flex-col gap-2 p-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Avatar
+                  size="sm"
+                  name={selectedAgent.name}
+                  visual={selectedAgent.pictureUrl}
+                />
+                <div className="text-md font-medium">{selectedAgent.name}</div>
+              </div>
+              <AssistantPicker
+                owner={owner}
+                assistants={agentConfigurations.filter(
+                  (agent) => agent.sId !== selectedAgentId
+                )}
+                onItemClick={(agent) => {
+                  onAgentSelect(agent.sId);
+                }}
+                pickerButton={
+                  <Button
+                    size="sm"
+                    label="Select another agent"
+                    isLoading={isAgentConfigurationsLoading}
+                  />
+                }
+                showFooterButtons={false}
+              />
+            </div>
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              <span className="font-medium">Description:</span>{" "}
+              {selectedAgent.description || "No description available"}
+            </div>
           </div>
-          <AssistantPicker
-            owner={owner}
-            assistants={agentConfigurations.filter(
-              (agent) => agent.sId !== selectedAgentId
-            )}
-            onItemClick={(agent) => {
-              onAgentSelect(agent.sId);
-            }}
-            pickerButton={
-              <Button
-                size="sm"
-                label="Select another agent"
-                isLoading={isAgentConfigurationsLoading}
-              />
-            }
-            showFooterButtons={false}
-          />
-        </div>
+        </Card>
       ) : (
-        <div
-          className={classNames(
-            "flex h-36 w-full items-center justify-center rounded-xl",
-            "bg-muted-background dark:bg-muted-background-night"
-          )}
-        >
-          <AssistantPicker
-            owner={owner}
-            assistants={agentConfigurations}
-            onItemClick={(agent) => {
-              onAgentSelect(agent.sId);
-            }}
-            pickerButton={
-              <Button
-                size="sm"
-                label="Select Agent"
-                isLoading={isAgentConfigurationsLoading}
-              />
-            }
-            showFooterButtons={false}
-          />
-        </div>
-      )}
-
-      {selectedAgent && (
-        <div className="text-element-600 mt-2 text-xs">
-          <span className="font-medium">Description:</span>{" "}
-          {selectedAgent.description || "No description available"}
-        </div>
+        <Card size="sm" className="h-36 w-full">
+          <div className="flex h-full w-full items-center justify-center">
+            <AssistantPicker
+              owner={owner}
+              assistants={agentConfigurations}
+              onItemClick={(agent) => {
+                onAgentSelect(agent.sId);
+              }}
+              pickerButton={
+                <Button
+                  size="sm"
+                  label="Select Agent"
+                  isLoading={isAgentConfigurationsLoading}
+                />
+              }
+              showFooterButtons={false}
+            />
+          </div>
+        </Card>
       )}
     </div>
   );

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -90,7 +90,6 @@ export function ChildAgentConfigurationSection({
                 <div className="text-md font-medium">{selectedAgent.name}</div>
               </div>
               <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                <span className="font-medium">Description:</span>{" "}
                 {selectedAgent.description || "No description available"}
               </div>
             </div>

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -47,7 +47,7 @@ export function ChildAgentConfigurationSection({
 
   if (isAgentConfigurationsLoading) {
     return (
-      <Card variant="secondary" size="sm" className="h-36 w-full">
+      <Card size="sm" className="h-36 w-full">
         <div className="flex h-full w-full items-center justify-center">
           <Spinner />
         </div>

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -47,8 +47,13 @@ export function ChildAgentConfigurationSection({
 
   if (isAgentConfigurationsLoading) {
     return (
-      <div className="text-element-600 py-2 text-sm">
-        Loading available agents...
+      <div
+        className={classNames(
+          "flex h-36 w-full items-center justify-center rounded-xl",
+          "bg-muted-background dark:bg-muted-background-night"
+        )}
+      >
+        <Spinner />
       </div>
     );
   }

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -3,11 +3,13 @@ import {
   Button,
   ContentMessage,
   InformationCircleIcon,
+  Spinner,
 } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import { classNames } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types";
 
 interface ChildAgentSelectorProps {
@@ -97,23 +99,30 @@ export function ChildAgentConfigurationSection({
           />
         </div>
       ) : (
-        <AssistantPicker
-          owner={owner}
-          assistants={agentConfigurations.filter(
-            (agent) => agent.sId !== selectedAgentId
+        <div
+          className={classNames(
+            "flex h-36 w-full items-center justify-center rounded-xl",
+            "bg-muted-background dark:bg-muted-background-night"
           )}
-          onItemClick={(agent) => {
-            onAgentSelect(agent.sId);
-          }}
-          pickerButton={
-            <Button
-              size="sm"
-              label="Select Agent"
-              isLoading={isAgentConfigurationsLoading}
-            />
-          }
-          showFooterButtons={false}
-        />
+        >
+          <AssistantPicker
+            owner={owner}
+            assistants={agentConfigurations.filter(
+              (agent) => agent.sId !== selectedAgentId
+            )}
+            onItemClick={(agent) => {
+              onAgentSelect(agent.sId);
+            }}
+            pickerButton={
+              <Button
+                size="sm"
+                label="Select Agent"
+                isLoading={isAgentConfigurationsLoading}
+              />
+            }
+            showFooterButtons={false}
+          />
+        </div>
       )}
 
       {selectedAgent && (

--- a/front/components/assistant_builder/actions/configuration/ChildAgentSelector.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentSelector.tsx
@@ -88,7 +88,6 @@ export function ChildAgentSelector({
             }}
             pickerButton={
               <Button
-                variant="secondary"
                 size="sm"
                 label="Select another agent"
                 isLoading={isAgentConfigurationsLoading}
@@ -108,7 +107,6 @@ export function ChildAgentSelector({
           }}
           pickerButton={
             <Button
-              variant="secondary"
               size="sm"
               label="Select Agent"
               isLoading={isAgentConfigurationsLoading}

--- a/front/components/assistant_builder/actions/configuration/ChildAgentSelector.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentSelector.tsx
@@ -90,7 +90,7 @@ export function ChildAgentSelector({
               <Button
                 variant="secondary"
                 size="sm"
-                label="Change Agent"
+                label="Select another agent"
                 isLoading={isAgentConfigurationsLoading}
               />
             }

--- a/front/components/assistant_builder/actions/configuration/ChildAgentSelector.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentSelector.tsx
@@ -94,6 +94,7 @@ export function ChildAgentSelector({
                 isLoading={isAgentConfigurationsLoading}
               />
             }
+            showFooterButtons={false}
           />
         </div>
       ) : (
@@ -111,6 +112,7 @@ export function ChildAgentSelector({
               isLoading={isAgentConfigurationsLoading}
             />
           }
+          showFooterButtons={false}
         />
       )}
 

--- a/front/components/assistant_builder/actions/configuration/ChildAgentSelector.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentSelector.tsx
@@ -100,7 +100,9 @@ export function ChildAgentSelector({
       ) : (
         <AssistantPicker
           owner={owner}
-          assistants={agentConfigurations}
+          assistants={agentConfigurations.filter(
+            (agent) => agent.sId !== selectedAgentId
+          )}
           onItemClick={(agent) => {
             onAgentSelect(agent.sId);
           }}


### PR DESCRIPTION
## Description

This PR improves the component `ChildAgentSelector` visually, making it more aligned with the other components (see screenshots below).

Configuring tables            |  Configuring a child agent
:-------------------------:|:-------------------------:
<img width="350" alt="Screenshot 2025-04-14 at 5 58 13 PM" src="https://github.com/user-attachments/assets/9e89d5da-38bb-4f1c-8926-e9214170dfec" />
  <img width="350" alt="Screenshot 2025-04-14 at 5 59 28 PM" src="https://github.com/user-attachments/assets/0c8ae38a-44ab-4b45-a549-b1a711b84bdf" />

Agent not selected yet            |  Agent selected
:-------------------------:|:-------------------------:
<img width="350" alt="Screenshot 2025-04-14 at 5 59 28 PM" src="https://github.com/user-attachments/assets/0c8ae38a-44ab-4b45-a549-b1a711b84bdf" />
<img width="350" alt="Screenshot 2025-04-14 at 6 01 12 PM" src="https://github.com/user-attachments/assets/c121447d-14f7-4ab1-bc77-ff6a3e76990a" />



## Tests

- Checked locally.

## Risk

- N/A, only UI changes.

## Deploy Plan

- Deploy front.
