### PR TITLE
Add support for link and dust file id in co-edition

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -25,7 +25,11 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import { useConversation } from "@app/lib/swr/conversations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { SubscriptionType, WorkspaceType } from "@app/types";
+import type {
+  LightWorkspaceType,
+  SubscriptionType,
+  WorkspaceType,
+} from "@app/types";
 
 export interface ConversationLayoutProps {
   baseUrl: string;
@@ -60,12 +64,19 @@ export default function ConversationLayout({
   );
 }
 
+interface ConversationLayoutContentProps {
+  baseUrl: string;
+  children: React.ReactNode;
+  owner: LightWorkspaceType;
+  subscription: SubscriptionType;
+}
+
 const ConversationLayoutContent = ({
   owner,
   subscription,
   baseUrl,
   children,
-}: any) => {
+}: ConversationLayoutContentProps) => {
   const router = useRouter();
   const { onOpenChange: onOpenChangeAssistantModal } =
     useURLSheet("assistantDetails");
@@ -123,7 +134,9 @@ const ConversationLayoutContent = ({
               owner={owner}
               hasCoEditionFeatureFlag={hasCoEditionFeatureFlag}
             >
-              <ConversationInnerLayout>{children}</ConversationInnerLayout>
+              <ConversationInnerLayout owner={owner}>
+                {children}
+              </ConversationInnerLayout>
             </CoEditionProvider>
           </>
         )}
@@ -134,9 +147,13 @@ const ConversationLayoutContent = ({
 
 interface ConversationInnerLayoutProps {
   children: React.ReactNode;
+  owner: LightWorkspaceType;
 }
 
-function ConversationInnerLayout({ children }: ConversationInnerLayoutProps) {
+function ConversationInnerLayout({
+  children,
+  owner,
+}: ConversationInnerLayoutProps) {
   const { isCoEditionOpen } = useCoEditionContext();
 
   return (
@@ -158,7 +175,7 @@ function ConversationInnerLayout({ children }: ConversationInnerLayoutProps) {
           defaultSize={50}
           className={isCoEditionOpen ? "" : "hidden"}
         >
-          {isCoEditionOpen && <CoEditionContainer />}
+          {isCoEditionOpen && <CoEditionContainer owner={owner} />}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/front/components/assistant/conversation/co_edition/CoEditionBubbleMenu.tsx
+++ b/front/components/assistant/conversation/co_edition/CoEditionBubbleMenu.tsx
@@ -1,0 +1,48 @@
+import { Button, cn } from "@dust-tt/sparkle";
+import type { Editor } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react";
+
+interface CoEditionBubbleMenuProps {
+  editor: Editor;
+}
+
+export function CoEditionBubbleMenu({ editor }: CoEditionBubbleMenuProps) {
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      tippyOptions={{ duration: 200 }}
+      className={cn(
+        "border-2 border-border-dark p-1 dark:border-border-dark-night",
+        "rounded-xl bg-background dark:bg-muted-background"
+      )}
+    >
+      <div className="flex flex-row gap-1">
+        <Button
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          className={editor.isActive("bold") ? "is-active" : ""}
+          label="Bold"
+          size="xs"
+          variant="ghost"
+        />
+        <Button
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          className={editor.isActive("italic") ? "is-active" : ""}
+          label="Italic"
+          size="xs"
+          variant="ghost"
+        />
+        <Button
+          onClick={() => editor.chain().focus().toggleStrike().run()}
+          className={editor.isActive("strike") ? "is-active" : ""}
+          label="Strike"
+          size="xs"
+          variant="ghost"
+        />
+      </div>
+    </BubbleMenu>
+  );
+}

--- a/front/components/assistant/conversation/co_edition/components/FileImageComponent.tsx
+++ b/front/components/assistant/conversation/co_edition/components/FileImageComponent.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@dust-tt/sparkle";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper } from "@tiptap/react";
+
+export const FileImageComponent = (props: NodeViewProps) => {
+  const { node, selected } = props;
+
+  const { workspaceId } = props.extension.options;
+  const src = `/api/w/${workspaceId}/files/${node.attrs.fileId}?action=view`;
+
+  return (
+    <NodeViewWrapper className="flex justify-center">
+      <div
+        className={cn(
+          "relative w-full max-w-2xl",
+          selected &&
+            "before:absolute before:inset-0 before:rounded-lg before:bg-gray-200/30"
+        )}
+      >
+        <img
+          src={node.attrs.src || src}
+          alt={node.attrs.alt || ""}
+          data-dust-file-id={node.attrs.fileId}
+          className={cn(
+            "w-full rounded-lg object-cover",
+            selected && "opacity-80"
+          )}
+          loading="lazy"
+        />
+        {node.attrs.alt && (
+          <div className="mt-1 text-center text-xs text-gray-500">
+            {node.attrs.alt}
+          </div>
+        )}
+      </div>
+    </NodeViewWrapper>
+  );
+};

--- a/front/components/assistant/conversation/co_edition/extensions/FileImageExtension.ts
+++ b/front/components/assistant/conversation/co_edition/extensions/FileImageExtension.ts
@@ -27,7 +27,6 @@ export const FileImageExtension = Node.create<FileImageOptions>({
       alt: {
         default: "",
       },
-      // We can compute the src here using the options.
       src: {
         default: null,
         // This gets called when the node is rendered.

--- a/front/components/assistant/conversation/co_edition/extensions/FileImageExtension.ts
+++ b/front/components/assistant/conversation/co_edition/extensions/FileImageExtension.ts
@@ -1,0 +1,80 @@
+import { Node } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+import { FileImageComponent } from "@app/components/assistant/conversation/co_edition/components/FileImageComponent";
+import type { CoEditionImageNode } from "@app/components/assistant/conversation/co_edition/tools/editor/types";
+
+interface FileImageOptions {
+  workspaceId: string;
+}
+
+export const FileImageExtension = Node.create<FileImageOptions>({
+  name: "fileImage",
+  group: "block",
+  atom: true,
+
+  addOptions() {
+    return {
+      workspaceId: "",
+    };
+  },
+
+  addAttributes() {
+    return {
+      fileId: {
+        default: null,
+      },
+      alt: {
+        default: "",
+      },
+      // We can compute the src here using the options.
+      src: {
+        default: null,
+        // This gets called when the node is rendered.
+        renderHTML: (attributes) => {
+          const fileId = attributes.fileId;
+          if (!fileId) {
+            return {};
+          }
+
+          // Access workspaceId from options.
+          const workspaceId = this.options.workspaceId;
+          return {
+            src: `/api/w/${workspaceId}/files/${fileId}?action=view`,
+          };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "img[data-dust-file-id]",
+        getAttrs: (node) => {
+          if (typeof node === "string") {
+            return false;
+          }
+          return {
+            fileId: node.getAttribute("data-dust-file-id"),
+            alt: node.getAttribute("alt"),
+          };
+        },
+      },
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FileImageComponent);
+  },
+});
+
+export function imageContentToNode(content: CoEditionImageNode) {
+  return {
+    type: "fileImage",
+    attrs: {
+      fileId: content.fileId,
+      alt: content.alt,
+    },
+  };
+}

--- a/front/components/assistant/conversation/co_edition/extensions/LinkExtension.tsx
+++ b/front/components/assistant/conversation/co_edition/extensions/LinkExtension.tsx
@@ -12,8 +12,9 @@ export function makeLinkExtension() {
     },
     isAllowedUri: (url, ctx) => {
       try {
-        // Construct URL.
-        const parsedUrl = url.includes(":")
+        // Check if the URL has a protocol.
+        const hasProtocol = url.includes("://");
+        const parsedUrl = hasProtocol
           ? new URL(url)
           : new URL(`${ctx.defaultProtocol}://${url}`);
 

--- a/front/components/assistant/conversation/co_edition/extensions/LinkExtension.tsx
+++ b/front/components/assistant/conversation/co_edition/extensions/LinkExtension.tsx
@@ -1,0 +1,49 @@
+import Link from "@tiptap/extension-link";
+
+export function makeLinkExtension() {
+  return Link.configure({
+    openOnClick: false,
+    autolink: true,
+    defaultProtocol: "https",
+    linkOnPaste: true,
+    protocols: ["http", "https"],
+    HTMLAttributes: {
+      class: "text-blue-500",
+    },
+    isAllowedUri: (url, ctx) => {
+      try {
+        // construct URL.
+        const parsedUrl = url.includes(":")
+          ? new URL(url)
+          : new URL(`${ctx.defaultProtocol}://${url}`);
+
+        // Use default validation.
+        if (!ctx.defaultValidate(parsedUrl.href)) {
+          return false;
+        }
+
+        // Disallowed protocols.
+        const disallowedProtocols = ["ftp", "file", "mailto"];
+        const protocol = parsedUrl.protocol.replace(":", "");
+
+        if (disallowedProtocols.includes(protocol)) {
+          return false;
+        }
+
+        // Only allow protocols specified in ctx.protocols.
+        const allowedProtocols = ctx.protocols.map((p) =>
+          typeof p === "string" ? p : p.scheme
+        );
+
+        if (!allowedProtocols.includes(protocol)) {
+          return false;
+        }
+
+        // All checks have passed.
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+}

--- a/front/components/assistant/conversation/co_edition/extensions/LinkExtension.tsx
+++ b/front/components/assistant/conversation/co_edition/extensions/LinkExtension.tsx
@@ -12,7 +12,7 @@ export function makeLinkExtension() {
     },
     isAllowedUri: (url, ctx) => {
       try {
-        // construct URL.
+        // Construct URL.
         const parsedUrl = url.includes(":")
           ? new URL(url)
           : new URL(`${ctx.defaultProtocol}://${url}`);
@@ -39,7 +39,6 @@ export function makeLinkExtension() {
           return false;
         }
 
-        // All checks have passed.
         return true;
       } catch {
         return false;

--- a/front/components/assistant/conversation/co_edition/server.tsx
+++ b/front/components/assistant/conversation/co_edition/server.tsx
@@ -2,13 +2,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Editor } from "@tiptap/react";
 
 import { registerEditorTools } from "@app/components/assistant/conversation/co_edition/tools/editor";
-import type { InitialNode } from "@app/components/assistant/conversation/co_edition/tools/toggle_co_edition";
+import type { CoEditionContent } from "@app/components/assistant/conversation/co_edition/tools/editor/types";
 import { registerToggleTool } from "@app/components/assistant/conversation/co_edition/tools/toggle_co_edition";
 import type { CoEditionTransport } from "@app/components/assistant/conversation/co_edition/transport";
 
 export interface CoEditionState {
   isEnabled: boolean;
-  initialNodes?: InitialNode[];
+  initialNodes?: CoEditionContent[];
 }
 
 export class CoEditionServer {
@@ -52,7 +52,7 @@ export class CoEditionServer {
 
   private handleToggle = async (
     enabled: boolean,
-    initialNodes?: InitialNode[]
+    initialNodes?: CoEditionContent[]
   ) => {
     if (this.state.isEnabled === enabled) {
       return;

--- a/front/components/assistant/conversation/co_edition/tools/editor/insert_node.ts
+++ b/front/components/assistant/conversation/co_edition/tools/editor/insert_node.ts
@@ -11,7 +11,7 @@ import {
 const InsertNodeSchema = z.object({
   position: z
     .number()
-    .describe("The position where to insert the new nodes (0-based index)"),
+    .describe("The position where to insert the new node (0-based index)"),
   node: CoEditionContentSchema,
 });
 

--- a/front/components/assistant/conversation/co_edition/tools/editor/insert_node.ts
+++ b/front/components/assistant/conversation/co_edition/tools/editor/insert_node.ts
@@ -2,38 +2,60 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Editor } from "@tiptap/react";
 import { z } from "zod";
 
-import { insertNodes } from "@app/components/assistant/conversation/co_edition/tools/editor/utils";
+import { CoEditionContentSchema } from "@app/components/assistant/conversation/co_edition/tools/editor/types";
+import {
+  contentToHtml,
+  getDocumentPositions,
+} from "@app/components/assistant/conversation/co_edition/tools/editor/utils";
 
 const InsertNodeSchema = z.object({
   position: z
     .number()
-    .describe("The position where to insert the new node (0-based index)"),
-  content: z
-    .string()
-    .describe(
-      "The content for the node. Supports plain text or HTML " +
-        "(e.g. '<p>Some <strong>bold</strong> text</p>'). Markdown is not supported."
-    ),
+    .describe("The position where to insert the new nodes (0-based index)"),
+  node: CoEditionContentSchema,
 });
 
 export function registerInsertNodeTool(server: McpServer, editor: Editor) {
   server.tool(
     "insert_node",
-    `Insert a new node at a specific position. IMPORTANT: Use this tool only after
-    analyzing the current content with getEditorContentForModel.
+    `Insert a single node at a specific position. IMPORTANT:
+    1. ALWAYS call getEditorContentForModel before using this tool to get the current editor state
+    2. Remember that each insertion can change the document structure and affect subsequent positions
+    3. For images, use the image reference format with a valid fileId (starts with 'fil_')
 
     Best used when:
     - You need to add new content between existing nodes
-    - You want to expand the document with additional information`,
+    - You want to expand the document with multiple paragraphs
+    - You want to insert an image with its file ID
+
+    DO NOT:
+    - Assume positions remain the same after previous insertions
+    - Use this tool without first getting the current editor content
+    - Use invalid file IDs for images`,
     { params: InsertNodeSchema },
     async ({ params }) => {
-      insertNodes(editor, params);
+      editor
+        .chain()
+        .focus()
+        .command(({ commands, tr }) => {
+          const positions = getDocumentPositions(tr.doc);
+          const targetPosition = positions[params.position];
+          const insertPos = targetPosition
+            ? targetPosition.pos
+            : tr.doc.content.size;
+
+          const n = contentToHtml(params.node);
+          commands.insertContentAt(insertPos, n);
+
+          return true;
+        })
+        .run();
 
       return {
         content: [
           {
             type: "text",
-            text: `Successfully inserted new node at position ${params.position}`,
+            text: `Successfully inserted node at position ${params.position}`,
           },
         ],
       };

--- a/front/components/assistant/conversation/co_edition/tools/editor/insert_node.ts
+++ b/front/components/assistant/conversation/co_edition/tools/editor/insert_node.ts
@@ -28,10 +28,9 @@ export function registerInsertNodeTool(server: McpServer, editor: Editor) {
     - You want to expand the document with multiple paragraphs
     - You want to insert an image with its file ID
 
-    DO NOT:
-    - Assume positions remain the same after previous insertions
-    - Use this tool without first getting the current editor content
-    - Use invalid file IDs for images`,
+    DO NOT assume positions remain the same after previous insertions
+    DO NOT use this tool without first getting the current editor content
+    DO NOT use invalid file IDs for images`,
     { params: InsertNodeSchema },
     async ({ params }) => {
       editor

--- a/front/components/assistant/conversation/co_edition/tools/editor/replace_text_range.ts
+++ b/front/components/assistant/conversation/co_edition/tools/editor/replace_text_range.ts
@@ -2,6 +2,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Editor } from "@tiptap/react";
 import { z } from "zod";
 
+import { CoEditionContentSchema } from "@app/components/assistant/conversation/co_edition/tools/editor/types";
+import { contentToHtml } from "@app/components/assistant/conversation/co_edition/tools/editor/utils";
+
 const ReplaceTextRangeSchema = z.object({
   nodeId: z
     .string()
@@ -10,12 +13,7 @@ const ReplaceTextRangeSchema = z.object({
     .number()
     .describe("The starting character offset within the node"),
   endOffset: z.number().describe("The ending character offset within the node"),
-  content: z
-    .string()
-    .describe(
-      "The new content to insert. Supports plain text or HTML (e.g. '<p>Some " +
-        "<strong>bold</strong> text</p>'). Markdown is not supported."
-    ),
+  node: CoEditionContentSchema,
 });
 
 export function registerReplaceTextRangeTool(
@@ -60,9 +58,10 @@ export function registerReplaceTextRangeTool(
               const absoluteTo = nodePos + 1 + relativePos + childNode.nodeSize;
 
               // Replace using absolute positions.
+              const content = contentToHtml(params.node);
               editor.commands.insertContentAt(
                 { from: absoluteFrom, to: absoluteTo },
-                params.content
+                content
               );
 
               return false; // Stop traversal once found.

--- a/front/components/assistant/conversation/co_edition/tools/editor/types.ts
+++ b/front/components/assistant/conversation/co_edition/tools/editor/types.ts
@@ -18,7 +18,7 @@ export const CoEditionTextNodeSchema = BaseNodeSchema.extend({
         "IMPORTANT:\n" +
         "- Markdown is NOT supported\n" +
         "- The HTML must be valid and properly closed\n" +
-        "- Multiple blocks should be properly separated"
+        "- Subsequent/Successive blocks should be properly separated"
     ),
 });
 

--- a/front/components/assistant/conversation/co_edition/tools/editor/types.ts
+++ b/front/components/assistant/conversation/co_edition/tools/editor/types.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+// Base node type.
+const BaseNodeSchema = z.object({
+  type: z.string(),
+});
+
+// Text node type.
+export const CoEditionTextNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("text"),
+  content: z
+    .string()
+    .describe(
+      "The content of the text node. This can be:\n" +
+        "1. Plain text (e.g. 'Hello world')\n" +
+        "2. HTML content (e.g. '<p>Hello <strong>world</strong></p>')\n" +
+        "3. Multiple HTML blocks (e.g. '<h1>Title</h1><p>Paragraph</p>')\n\n" +
+        "IMPORTANT:\n" +
+        "- Markdown is NOT supported\n" +
+        "- The HTML must be valid and properly closed\n" +
+        "- Multiple blocks should be properly separated"
+    ),
+});
+
+// Image node type.
+export const CoEditionImageNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("image"),
+  fileId: z
+    .string()
+    .describe("The file ID of the image to insert (starts with 'fil_')"),
+  alt: z.string().optional().describe("Optional alt text for the image"),
+});
+
+export type CoEditionTextNode = z.infer<typeof CoEditionTextNodeSchema>;
+export type CoEditionImageNode = z.infer<typeof CoEditionImageNodeSchema>;
+
+// Content schema for the editor.
+export const CoEditionContentSchema = z.union([
+  CoEditionTextNodeSchema,
+  CoEditionImageNodeSchema,
+]);
+export type CoEditionContent = z.infer<typeof CoEditionContentSchema>;

--- a/front/components/assistant/conversation/co_edition/tools/editor/types.ts
+++ b/front/components/assistant/conversation/co_edition/tools/editor/types.ts
@@ -27,6 +27,7 @@ export const CoEditionImageNodeSchema = BaseNodeSchema.extend({
   type: z.literal("image"),
   fileId: z
     .string()
+    .startsWith("fil_", { message: "File ID must start with 'fil_'" })
     .describe("The file ID of the image to insert (starts with 'fil_')"),
   alt: z.string().optional().describe("Optional alt text for the image"),
 });

--- a/front/components/assistant/conversation/co_edition/tools/editor/utils.ts
+++ b/front/components/assistant/conversation/co_edition/tools/editor/utils.ts
@@ -1,8 +1,7 @@
 import type { Editor } from "@tiptap/react";
 
 import { imageContentToNode } from "@app/components/assistant/conversation/co_edition/extensions/FileImageExtension";
-
-import type { CoEditionContent } from "./types";
+import type { CoEditionContent } from "@app/components/assistant/conversation/co_edition/tools/editor/types";
 
 // Simple utility function that works with all nodes.
 export function getDocumentPositions(doc: any) {

--- a/front/components/assistant/conversation/co_edition/tools/toggle_co_edition.ts
+++ b/front/components/assistant/conversation/co_edition/tools/toggle_co_edition.ts
@@ -1,13 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-// Simple content schema for initial content.
-const InitialNodeSchema = z.object({
-  type: z.enum(["text"]),
-  content: z.string(),
-});
-
-export type InitialNode = z.infer<typeof InitialNodeSchema>;
+import type { CoEditionContent } from "@app/components/assistant/conversation/co_edition/tools/editor/types";
+import { CoEditionContentSchema } from "@app/components/assistant/conversation/co_edition/tools/editor/types";
 
 const ToggleCoEditionSchema = z.object({
   enabled: z
@@ -18,25 +13,27 @@ const ToggleCoEditionSchema = z.object({
         "When disabled, the editor is closed and collaboration ends."
     ),
   initialNodes: z
-    .array(InitialNodeSchema)
+    .array(CoEditionContentSchema)
     .optional()
     .describe(
       "Optional initial content to add to the editor when enabling co-edition. " +
-        "Provide an array of text nodes that will form the initial document. " +
+        "Provide an array of nodes that will form the initial document. " +
         "Each node will be rendered as a separate block in the editor. " +
-        "IMPORTANT: Only raw text or HTML content is expected in the 'content' field. " +
+        "Supported node types:\n" +
+        "1. Text nodes: { type: 'text', content: '<h1>Title</h1>' }\n" +
+        "2. Image nodes: { type: 'image', fileId: 'fil_123', alt: 'Optional alt text' }\n" +
+        "IMPORTANT: Only raw text or HTML content is expected in text nodes. " +
         "Markdown formatting is NOT supported and will be displayed as plain text. " +
-        "\nExample:" +
-        "\n[" +
-        "\n  { type: 'text', content: '<h1>Project Proposal: AI Integration</h1>' }," +
-        "\n  { type: 'text', content: 'Let's start collaborating on this proposal.' }" +
-        "\n]"
+        "For images, provide a valid fileId that starts with 'fil_'."
     ),
 });
 
 export function registerToggleTool(
   server: McpServer,
-  onToggle: (enabled: boolean, initialNodes?: InitialNode[]) => Promise<void>
+  onToggle: (
+    enabled: boolean,
+    initialNodes?: CoEditionContent[]
+  ) => Promise<void>
 ): void {
   server.tool(
     "toggle_co_edition",
@@ -45,13 +42,17 @@ export function registerToggleTool(
       "collaborative workspace where both the agent and user can edit the same " +
       "document. The tool supports setting an initial content to start " +
       "the collaboration.\n\n" +
-      "This tool should be used when:\n" +
-      "1) The user wants to write, edit, or collaborate on any document\n" +
-      "2) The user mentions creating content together\n" +
-      "3) The user asks about writing something\n" +
-      "4) The user wants to work on text collaboratively\n" +
-      "5) The user needs to draft, revise, or finalize any written content\n\n" +
-      "Enable this tool proactively for any writing or collaboration task, even if not explicitly requested.",
+      "This tool should ONLY be used when:\n" +
+      "1) The user has shown clear intent for collaborative writing over multiple messages\n" +
+      "2) The user explicitly requests to work together on a document\n" +
+      "3) The conversation naturally evolves into a collaborative writing session\n\n" +
+      "DO NOT use this tool for:\n" +
+      "1) Single message responses or quick edits\n" +
+      "2) Simple text formatting or minor corrections\n" +
+      "3) When the user hasn't shown interest in collaborative writing\n" +
+      "4) As a default response to any writing-related request\n\n" +
+      "The tool should be used sparingly and only when there's clear evidence of an ongoing " +
+      "collaborative writing session or explicit request for co-editing.",
     { params: ToggleCoEditionSchema },
     async ({ params }) => {
       await onToggle(params.enabled, params.initialNodes);

--- a/front/components/assistant/conversation/co_edition/transport.ts
+++ b/front/components/assistant/conversation/co_edition/transport.ts
@@ -140,6 +140,11 @@ export class CoEditionTransport implements Transport {
 
     this.eventSource.onmessage = (event) => {
       try {
+        if (event.data === "done") {
+          // Ignore this event.
+          return;
+        }
+
         const eventData = JSON.parse(event.data);
 
         // Save the eventId for reconnection purposes

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -31,6 +31,8 @@
         "@temporalio/workflow": "^1.9.3",
         "@textea/json-viewer": "^3.1.1",
         "@tiptap/extension-character-count": "^2.4.0",
+        "@tiptap/extension-image": "^2.11.7",
+        "@tiptap/extension-link": "^2.11.7",
         "@tiptap/extension-mention": "^2.1.13",
         "@tiptap/extension-placeholder": "^2.1.13",
         "@tiptap/pm": "^2.1.13",
@@ -7317,44 +7319,9 @@
       "license": "MIT"
     },
     "node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "license": "MIT"
-    },
-    "node_modules/@remirror/core-helpers": {
       "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/types/node_modules/type-fest": {
-      "version": "2.19.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.30.1",
@@ -8058,14 +8025,15 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "2.1.13",
-      "license": "MIT",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-zN+NFFxLsxNEL8Qioc+DL6b8+Tt2bmRbXH22Gk6F6nD30x83eaUSFlSv3wqvgyCq3I1i1NO394So+Agmayx6rQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^2.0.0"
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -8247,6 +8215,18 @@
         "@tiptap/pm": "^2.0.0"
       }
     },
+    "node_modules/@tiptap/extension-image": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.11.7.tgz",
+      "integrity": "sha512-YvCmTDB7Oo+A56tR4S/gcNaYpqU4DDlSQcRp5IQvmQV5EekSe0lnEazGDoqOCwsit9qQhj4MPQJhKrnaWrJUrg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
     "node_modules/@tiptap/extension-italic": {
       "version": "2.1.13",
       "license": "MIT",
@@ -8256,6 +8236,22 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.11.7.tgz",
+      "integrity": "sha512-qKIowE73aAUrnQCIifYP34xXOHOsZw46cT/LBDlb0T60knVfQoKVE4ku08fJzAV+s6zqgsaaZ4HVOXkQYLoW7g==",
+      "dependencies": {
+        "linkifyjs": "^4.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
@@ -8339,27 +8335,28 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "2.1.13",
-      "license": "MIT",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.11.7.tgz",
+      "integrity": "sha512-7gEEfz2Q6bYKXM07vzLUD0vqXFhC5geWRA6LCozTiLdVFDdHWiBrvb2rtkL5T7mfLq03zc1QhH7rI3F6VntOEA==",
       "dependencies": {
-        "prosemirror-changeset": "^2.2.0",
-        "prosemirror-collab": "^1.3.0",
-        "prosemirror-commands": "^1.3.1",
-        "prosemirror-dropcursor": "^1.5.0",
-        "prosemirror-gapcursor": "^1.3.1",
-        "prosemirror-history": "^1.3.0",
-        "prosemirror-inputrules": "^1.2.0",
-        "prosemirror-keymap": "^1.2.0",
-        "prosemirror-markdown": "^1.10.1",
-        "prosemirror-menu": "^1.2.1",
-        "prosemirror-model": "^1.18.1",
-        "prosemirror-schema-basic": "^1.2.0",
-        "prosemirror-schema-list": "^1.2.2",
-        "prosemirror-state": "^1.4.1",
-        "prosemirror-tables": "^1.3.0",
-        "prosemirror-trailing-node": "^2.0.2",
-        "prosemirror-transform": "^1.7.0",
-        "prosemirror-view": "^1.28.2"
+        "prosemirror-changeset": "^2.2.1",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.23.0",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.37.0"
       },
       "funding": {
         "type": "github",
@@ -8981,14 +8978,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
-    "node_modules/@types/object.omit": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/object.pick": {
-      "version": "1.3.4",
-      "license": "MIT"
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "license": "MIT",
@@ -9147,10 +9136,6 @@
         "lil-gui": "~0.17.0",
         "meshoptimizer": "~0.18.1"
       }
-    },
-    "node_modules/@types/throttle-debounce": {
-      "version": "2.1.0",
-      "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -10566,16 +10551,6 @@
         "cargo-cp-artifact": "bin/cargo-cp-artifact.js"
       }
     },
-    "node_modules/case-anything": {
-      "version": "2.1.13",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "license": "MIT",
@@ -11822,10 +11797,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/dash-get": {
-      "version": "1.0.2",
-      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -16296,16 +16267,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "license": "MIT",
@@ -16426,16 +16387,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -16570,13 +16521,6 @@
       "version": "2.0.0",
       "devOptional": true,
       "license": "ISC"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -17185,6 +17129,11 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/linkifyjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.2.0.tgz",
+      "integrity": "sha512-pCj3PrQyATaoTYKHrgWRF3SJwsm61udVh+vuls/Rl6SptiDhgE7ziUIudAedRY9QEfynmM7/RmLEfPUyw1HPCw=="
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "license": "MIT",
@@ -17434,7 +17383,9 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
@@ -19309,26 +19260,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.omit": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.pick": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.1.7",
       "dev": true,
@@ -20483,12 +20414,13 @@
       }
     },
     "node_modules/prosemirror-commands": {
-      "version": "1.5.2",
-      "license": "MIT",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
+        "prosemirror-transform": "^1.10.2"
       }
     },
     "node_modules/prosemirror-dropcursor": {
@@ -20511,8 +20443,9 @@
       }
     },
     "node_modules/prosemirror-history": {
-      "version": "1.3.2",
-      "license": "MIT",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
+      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
       "dependencies": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
@@ -20521,8 +20454,9 @@
       }
     },
     "node_modules/prosemirror-inputrules": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.0.tgz",
+      "integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
@@ -20557,23 +20491,25 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.24.1.tgz",
-      "integrity": "sha512-YM053N+vTThzlWJ/AtPtF1j0ebO36nvbmDy4U7qA2XQB8JVaQp1FmB9Jhrps8s+z+uxhhVTny4m20ptUvhk0Mg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.0.tgz",
+      "integrity": "sha512-/8XUmxWf0pkj2BmtqZHYJipTBMHIdVjuvFzMvEoxrtyGNmfvdhBiRwYt/eFwy2wA9DtBW3RLqvZnjurEkHaFCw==",
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
     },
     "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.2",
-      "license": "MIT",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
       "dependencies": {
-        "prosemirror-model": "^1.19.0"
+        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -20590,42 +20526,45 @@
       }
     },
     "node_modules/prosemirror-tables": {
-      "version": "1.3.5",
-      "license": "MIT",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.7.0.tgz",
+      "integrity": "sha512-dc9+u4aqT+biw3J/v7p5LyH8uqqXSAjdszfLtrCnDbpMr1F+Gsjtkdiij/1p8qM1gBOCfQeiahhk2pOO9Aa8xA==",
       "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.25.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-transform": "^1.10.3",
+        "prosemirror-view": "^1.39.1"
       }
     },
     "node_modules/prosemirror-trailing-node": {
-      "version": "2.0.7",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
       "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-constants": "3.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
-        "prosemirror-model": "^1.19.0",
+        "prosemirror-model": "^1.22.1",
         "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.31.2"
+        "prosemirror-view": "^1.33.8"
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.8.0",
-      "license": "MIT",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.3.tgz",
+      "integrity": "sha512-Nhh/+1kZGRINbEHmVu39oynhcap4hWTs/BlU7NnxWj3+l0qi8I1mu67v6mMdEe/ltD8hHvU4FV6PHiCw2VSpMw==",
       "dependencies": {
-        "prosemirror-model": "^1.0.0"
+        "prosemirror-model": "^1.21.0"
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.32.6",
-      "license": "MIT",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.39.1.tgz",
+      "integrity": "sha512-GhLxH1xwnqa5VjhJ29LfcQITNDp+f1jzmMPXQfGW9oNrF0lfjPzKvV5y/bjIQkyKpwCX3Fp+GA4dBpMMk8g+ZQ==",
       "dependencies": {
-        "prosemirror-model": "^1.16.0",
+        "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
@@ -23415,13 +23354,6 @@
     "node_modules/three": {
       "version": "0.163.0",
       "license": "MIT"
-    },
-    "node_modules/throttle-debounce": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -31,7 +31,6 @@
         "@temporalio/workflow": "^1.9.3",
         "@textea/json-viewer": "^3.1.1",
         "@tiptap/extension-character-count": "^2.4.0",
-        "@tiptap/extension-image": "^2.11.7",
         "@tiptap/extension-link": "^2.11.7",
         "@tiptap/extension-mention": "^2.1.13",
         "@tiptap/extension-placeholder": "^2.1.13",
@@ -8213,18 +8212,6 @@
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
         "@tiptap/pm": "^2.0.0"
-      }
-    },
-    "node_modules/@tiptap/extension-image": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.11.7.tgz",
-      "integrity": "sha512-YvCmTDB7Oo+A56tR4S/gcNaYpqU4DDlSQcRp5IQvmQV5EekSe0lnEazGDoqOCwsit9qQhj4MPQJhKrnaWrJUrg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-italic": {

--- a/front/package.json
+++ b/front/package.json
@@ -45,7 +45,6 @@
     "@temporalio/workflow": "^1.9.3",
     "@textea/json-viewer": "^3.1.1",
     "@tiptap/extension-character-count": "^2.4.0",
-    "@tiptap/extension-image": "^2.11.7",
     "@tiptap/extension-link": "^2.11.7",
     "@tiptap/extension-mention": "^2.1.13",
     "@tiptap/extension-placeholder": "^2.1.13",

--- a/front/package.json
+++ b/front/package.json
@@ -45,6 +45,8 @@
     "@temporalio/workflow": "^1.9.3",
     "@textea/json-viewer": "^3.1.1",
     "@tiptap/extension-character-count": "^2.4.0",
+    "@tiptap/extension-image": "^2.11.7",
+    "@tiptap/extension-link": "^2.11.7",
     "@tiptap/extension-mention": "^2.1.13",
     "@tiptap/extension-placeholder": "^2.1.13",
     "@tiptap/pm": "^2.1.13",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds richer co-edition experience. It adds:
- support for both link and Dust file letting the agent add hyperlink and generated images hosted on our own file system
- contextual menu to style the text (more items will be added in this menu in a follow up PR)
- standardize content schema to always have a `type` either set to `text` or `images` (maybe more?)

Also took the opportunity to refine a bit the tool instructions to ensure the agent less often uses co-edition.

![CoEditionImagee](https://github.com/user-attachments/assets/54dcf9d6-2279-4eaa-b929-ff3e5a6c459b)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
