### PR TITLE
Github tools: add_issue_to_project / update_issue_project_field

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -348,7 +348,6 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     }
   );
 
-  // Add a new tool to add issues to a GitHub project
   server.tool(
     "add_issue_to_project",
     "Add an existing issue to a GitHub project.",
@@ -367,6 +366,101 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .describe("The node ID of the GitHub project (GraphQL ID)."),
     },
     async ({ owner, repo, issueNumber, projectId }) => {
+      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
+        mcpServerId,
+        provider: "github",
+      });
+
+      const octokit = new Octokit({ auth: accessToken });
+
+      try {
+        // First, get the issue's node ID using GraphQL.
+        const issueQuery = `
+        query($owner: String!, $repo: String!, $issueNumber: Int!) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $issueNumber) {
+              id
+            }
+          }
+        }`;
+
+        const issue = (await octokit.graphql(issueQuery, {
+          owner,
+          repo,
+          issueNumber,
+        })) as {
+          repository: {
+            issue: {
+              id: string;
+            };
+          };
+        };
+
+        // Add the issue to the project using GraphQL mutation.
+        const mutation = `
+          mutation($projectId: ID!, $contentId: ID!) {
+            addProjectV2ItemById(input: {
+              projectId: $projectId
+              contentId: $contentId
+            }) {
+              item {
+                id
+              }
+            }
+          }`;
+
+        await octokit.graphql(mutation, {
+          projectId,
+          contentId: issue.repository.issue.id,
+        });
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: `Issue #${issueNumber} successfully added to the project.`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Error adding GitHub issue to project: ${normalizeError(e).message}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    "update_issue_project_field",
+    "Updates a GitHub project field associated with an issue",
+    {
+      owner: z
+        .string()
+        .describe(
+          "The owner of the repository (account or organization name)."
+        ),
+      repo: z.string().describe("The name of the repository."),
+      issueNumber: z
+        .number()
+        .describe("The issue number to add to the project."),
+      projectId: z
+        .string()
+        .describe("The node ID of the GitHub project (GraphQL ID)."),
+      fieldId: z
+        .string()
+        .describe("The ID of the field to update (GraphQL ID)."),
+      optionId: z
+        .string()
+        .describe("The ID of the option to update the field to (GraphQL ID)."),
+    },
+    async ({ owner, repo, issueNumber, projectId, fieldId, optionId }) => {
       const accessToken = await getAccessTokenForInternalMCPServer(auth, {
         mcpServerId,
         provider: "github",
@@ -397,14 +491,18 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           };
         };
 
-        // Add the issue to the project using GraphQL mutation
+        // Mutation to update the field value to specified option.
         const mutation = `
-          mutation($projectId: ID!, $contentId: ID!) {
-            addProjectV2ItemById(input: {
-              projectId: $projectId
-              contentId: $contentId
+          mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String) {
+            updateProjectV2ItemFieldValue(input: {
+              projectId: $projectId,
+              itemId: $itemId,
+              fieldId: $fieldId,
+              value: {
+                singleSelectOptionId: $optionId
+              }
             }) {
-              item {
+              projectV2Item {
                 id
               }
             }
@@ -412,7 +510,9 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
 
         await octokit.graphql(mutation, {
           projectId,
-          contentId: issue.repository.issue.id,
+          itemId: issue.repository.issue.id,
+          fieldId,
+          optionId,
         });
 
         return {
@@ -420,7 +520,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           content: [
             {
               type: "text",
-              text: `Issue #${issueNumber} successfully added to the project.`,
+              text: `Issue #${issueNumber} project field successfully updated.`,
             },
           ],
         };


### PR DESCRIPTION
## Description

Adds 2 actions to add issue to a project and update an issue project field. Will cover creation of eng runner tasks (with prompting of the project IDs and field optionId). To make it easier to use we might want to add tools to list projects, fields and options for each fields.

## Tests

Tested locally

## Risk

N/A

## Deploy Plan

- deploy `front`