### PR TITLE
[sparkle] - feat(Tree): add `Tooltip` for truncated labels

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.465",
+  "version": "0.2.466",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.465",
+      "version": "0.2.466",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.465",
+  "version": "0.2.466",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -41,7 +41,7 @@ export const TreeExample = () => {
   return (
     <div className="s-flex s-flex-col s-gap-10">
       <div className="s-flex s-gap-10">
-        <div className="s-flex s-flex-col s-gap-3">
+        <div className="s-flex s-w-44 s-flex-col s-gap-3">
           <div className="s-text-xl">Tree</div>
           <div>
             <Tree>


### PR DESCRIPTION
## Description

This PR adds a `Tooltip` to `Tree.Item` with truncated label.

![Screenshot 2025-04-15 at 09 40 39](https://github.com/user-attachments/assets/fa0c6eee-b1c5-4d66-aa14-11602b817329)

**References:**
- https://github.com/dust-tt/tasks/issues/2618

## Risk

Low

## Deploy Plan

Publish sparkle