### PR TITLE
[front] - chore: update @dust-tt/sparkle and @dust-tt/client packages

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.464",
+        "@dust-tt/sparkle": "^0.2.466",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -168,7 +168,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9",
@@ -1043,9 +1043,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.464",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.464.tgz",
-      "integrity": "sha512-IGoxFGrW5Iwipp0n7uRN3nAOROzRqy0caz9/8HUUYNsODL5+TP39uT5lRjDzkP7IGlNvNB24whLDNYxz1kV63Q==",
+      "version": "0.2.466",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.466.tgz",
+      "integrity": "sha512-xTKIozzBc/gMqfXZ9h0sDXzk+3Mra6Tz8Ts3oknAxT2miJhTboGDQBJf0++kIXbNa9mGqyqeedkNed678wSYFg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.464",
+    "@dust-tt/sparkle": "^0.2.466",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

 - Bump @dust-tt/sparkle package version to 0.2.466 for the latest features and fixes
 - Upgrade @dust-tt/client package to version 1.0.41 to incorporate latest SDK changes

## Risk

Low

## Deploy Plan

Deploy front