### PR TITLE
Renaming actions to tools & polish

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1118,7 +1118,7 @@ function ActionEditor({
       <ActionModeSection show={true}>
         <div className="flex w-full flex-row items-center justify-between px-1">
           <Page.Header
-            title={actionDisplayName(action) || "Select an action"}
+            title={actionDisplayName(action) || "Select a Toolset"}
             icon={ACTION_SPECIFICATIONS[action.type].cardIcon}
           />
           {shouldDisplayAdvancedSettings && (

--- a/front/components/assistant_builder/AssistantBuilderContext.tsx
+++ b/front/components/assistant_builder/AssistantBuilderContext.tsx
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 
+import { mcpServerViewSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { AppType, DataSourceViewType, SpaceType } from "@app/types";
 
@@ -33,7 +34,7 @@ export function AssistantBuilderProvider({
         dustApps,
         dataSourceViews,
         spaces,
-        mcpServerViews,
+        mcpServerViews: mcpServerViews.sort(mcpServerViewSortingFn),
       }}
     >
       {children}

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -7,7 +7,6 @@ import {
   Separator,
   Spinner,
 } from "@dust-tt/sparkle";
-import { sortBy } from "lodash";
 import React, { useMemo } from "react";
 
 import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
@@ -86,7 +85,7 @@ export function MCPServerSelector({
 
             return (
               <RadioGroup defaultValue={selectedMCPServerView?.id}>
-                {sortBy(mcpServerViewsInSpace, "server.name")
+                {mcpServerViewsInSpace
                   // Default servers can be added as capabilities or in the first level of the Add actions list
                   .filter((view) => !view.server.isDefault)
                   .map((mcpServerView, idx, arr) => (

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -86,7 +86,7 @@ export function MCPServerSelector({
             return (
               <RadioGroup defaultValue={selectedMCPServerView?.id}>
                 {mcpServerViewsInSpace
-                  // Default servers can be added as capabilities or in the first level of the Add actions list
+                  // Default servers can be added as capabilities or in the first level of the "Add tools" list
                   .filter((view) => !view.server.isDefault)
                   .map((mcpServerView, idx, arr) => (
                     <React.Fragment key={mcpServerView.id}>

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -54,11 +54,11 @@ export function MCPServerSelector({
   return (
     <>
       <div className="text-sm text-foreground dark:text-foreground-night">
-        The agent will execute an{" "}
+        The agent will be able to execute tools from the{" "}
         <a className="font-bold" href="https://docs.dust.tt" target="_blank">
-          Action
+          Toolset
         </a>{" "}
-        made available to you.
+        made available to you by your Admin.
       </div>
       {isSpacesLoading ? (
         <Spinner />
@@ -81,7 +81,7 @@ export function MCPServerSelector({
               mcpServerViewsInSpace.length === 0 ||
               hasNoMCPServerViewsInAllowedSpaces
             ) {
-              return <>No Actions available.</>;
+              return <>No Toolsets available.</>;
             }
 
             return (

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -38,8 +38,8 @@ function NoActionAvailable({ owner }: NoActionAvailableProps) {
               return (
                 <div>
                   <strong>
-                    Visit the "Actions" section in the Admins panel to add an
-                    Action.
+                    Visit the "Tools" section in the Knowledge panel to add a
+                    Toolset.
                   </strong>
                 </div>
               );
@@ -47,7 +47,7 @@ function NoActionAvailable({ owner }: NoActionAvailableProps) {
             case "user":
               return (
                 <div>
-                  <strong>Ask your Admins to add an Action.</strong>
+                  <strong>Ask your Admins to add a Toolset.</strong>
                 </div>
               );
             case "none":

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -5,7 +5,6 @@ import {
   usePaginationFromUrl,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
-import { sortBy } from "lodash";
 import * as React from "react";
 
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
@@ -89,7 +88,7 @@ export const SpaceActionsList = ({
 
   const rows: RowData[] = React.useMemo(
     () =>
-      sortBy(serverViews, "server.name").map((serverView) => ({
+      serverViews.map((serverView) => ({
         name: serverView.server.name,
         description: serverView.server.description,
         visual: getVisual(serverView.server),

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -194,7 +194,7 @@ export const SpaceCategoriesList = ({
             disabled={!isAdmin}
             href={`/w/${owner.sId}/spaces/${space.sId}/categories/actions`}
             icon={ACTION_SPECIFICATIONS["MCP"].cardIcon}
-            label="Actions"
+            label="Tools"
           />
         </DropdownMenuContent>
       </DropdownMenu>

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -771,7 +771,7 @@ const SpaceActionsSubMenu = ({
     >
       {isExpanded && (
         <Tree isLoading={isMCPServerViewsLoading}>
-          {sortBy(serverViews, "server.name").map((serverView) => (
+          {serverViews.map((serverView) => (
             <SpaceActionItem
               action={serverView}
               key={serverView.server.name}

--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -26,6 +26,7 @@ import { sendRequestActionsAccessEmail } from "@app/lib/email";
 import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_server_views";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
+import { asDisplayName } from "@app/types";
 
 interface RequestActionsModal {
   owner: LightWorkspaceType;
@@ -89,12 +90,12 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <Button label="Request Action" icon={PlusIcon} />
+        <Button label="Request Tool" icon={PlusIcon} />
       </SheetTrigger>
       <SheetContent size="lg">
         <SheetHeader>
           <SheetTitle>
-            Requesting Access to {selectedMcpServer?.server.name}
+            Requesting Access to {asDisplayName(selectedMcpServer?.server.name)}
           </SheetTitle>
         </SheetHeader>
         <SheetContainer>
@@ -106,7 +107,8 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                 {!isLoading && serverViews.length === 0 && (
                   <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                     <p>
-                      You have no actions set up. Ask an admin to set one up.
+                      There are no extra tools set up that you can request
+                      access to. Ask an admin to set one up.
                     </p>
                   </label>
                 )}
@@ -114,14 +116,14 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                 {serverViews.length >= 1 && (
                   <>
                     <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
-                      <p>Which actions you want to get access to?</p>
+                      <p>Which tools you want to get access to?</p>
                     </label>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         {selectedMcpServer ? (
                           <Button
                             variant="outline"
-                            label={selectedMcpServer.server.name}
+                            label={asDisplayName(selectedMcpServer.server.name)}
                             icon={() => (
                               <Avatar
                                 visual={getVisual(selectedMcpServer.server)}
@@ -131,7 +133,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                           />
                         ) : (
                           <Button
-                            label="Pick your MCP Server"
+                            label="Pick a Toolset"
                             variant="outline"
                             size="sm"
                             isSelect
@@ -142,7 +144,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                         {serverViews.map((v) => (
                           <DropdownMenuItem
                             key={v.id}
-                            label={v.server.name}
+                            label={asDisplayName(v.server.name)}
                             icon={() => (
                               <Avatar visual={getVisual(v.server)} size="xs" />
                             )}
@@ -161,8 +163,9 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                     {_.capitalize(
                       selectedMcpServer.editedByUser?.fullName ?? ""
                     )}{" "}
-                    is the administrator for the {selectedMcpServer.server.name}{" "}
-                    action within Dust. Send an email to{" "}
+                    is the administrator for the{" "}
+                    {asDisplayName(selectedMcpServer.server.name)} tool within
+                    Dust. Send an email to{" "}
                     {_.capitalize(
                       selectedMcpServer.editedByUser?.fullName ?? ""
                     )}

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -1,6 +1,10 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { MCPServerType, RemoteMCPServerType } from "@app/lib/api/mcp";
+import type {
+  MCPServerType,
+  MCPServerViewType,
+  RemoteMCPServerType,
+} from "@app/lib/api/mcp";
 import {
   getResourceNameAndIdFromSId,
   makeSId,
@@ -56,6 +60,13 @@ export const remoteMCPServerNameToSId = ({
     id: remoteMCPServerId,
     workspaceId,
   });
+};
+
+export const mcpServerViewSortingFn = (
+  a: MCPServerViewType,
+  b: MCPServerViewType
+) => {
+  return mcpServersSortingFn({ mcpServer: a.server }, { mcpServer: b.server });
 };
 
 export const mcpServersSortingFn = (

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -1,11 +1,11 @@
 import type { Icon } from "@dust-tt/sparkle";
 import {
   ChatBubbleThoughtIcon,
-  CommandIcon,
   CommandLineIcon,
   MagnifyingGlassIcon,
   PlanetIcon,
   ScanIcon,
+  SuitcaseIcon,
   TableIcon,
   TimeIcon,
 } from "@dust-tt/sparkle";
@@ -86,10 +86,10 @@ export const ACTION_SPECIFICATIONS: Record<
     flag: null,
   },
   MCP: {
-    label: "Run an Action",
-    description: "Run an action, then reply",
-    cardIcon: CommandIcon,
-    dropDownIcon: CommandIcon,
+    label: "More...",
+    description: "Pick from Toolsets added by your Admin",
+    cardIcon: SuitcaseIcon,
+    dropDownIcon: SuitcaseIcon,
     flag: "mcp_actions",
   },
 };

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -128,7 +128,7 @@ export const CATEGORY_DETAILS: {
     icon: CommandLineIcon,
   },
   actions: {
-    label: "Actions",
+    label: "Tools",
     icon: ACTION_SPECIFICATIONS["MCP"].cardIcon,
     flag: "mcp_actions",
   },

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -121,7 +121,10 @@ export function useMCPServerViewsNotActivated({
       disabled,
     }
   );
-  const serverViews = useMemo(() => (data ? data.serverViews : []), [data]);
+  const serverViews = useMemo(
+    () => (data ? data.serverViews.sort(mcpServerViewSortingFn) : []),
+    [data]
+  );
   return {
     serverViews,
     isMCPServerViewsLoading: !error && !data && !disabled,

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -2,6 +2,7 @@ import { useSendNotification } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
+import { mcpServerViewSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -28,7 +29,10 @@ export function useMCPServerViews({
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
     disabled,
   });
-  const serverViews = useMemo(() => (data ? data.serverViews : []), [data]);
+  const serverViews = useMemo(
+    () => (data ? data.serverViews.sort(mcpServerViewSortingFn) : []),
+    [data]
+  );
   return {
     serverViews,
     isMCPServerViewsLoading: !error && !data && !disabled,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -2,6 +2,7 @@ import { useSendNotification } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
+import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
@@ -74,7 +75,15 @@ export function useAvailableMCPServers({
 
   const { data, error } = useSWRWithDefaults(url, configFetcher);
 
-  const availableMCPServers = useMemo(() => (data ? data.servers : []), [data]);
+  const availableMCPServers = useMemo(
+    () =>
+      data
+        ? data.servers.sort((a, b) =>
+            mcpServersSortingFn({ mcpServer: a }, { mcpServer: b })
+          )
+        : [],
+    [data]
+  );
 
   return {
     availableMCPServers,

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -102,7 +102,7 @@ async function handler(
   const result = await sendEmailWithTemplate({
     to: userRecipient.email,
     from: { name: "Dust team", email: "support@dust.help" },
-    subject: `[Dust] Request Action from ${emailRequester}`,
+    subject: `[Dust] Request Toolset from ${emailRequester}`,
     body,
   });
 


### PR DESCRIPTION
## Description

Renamed "actions" to tools or toolsets everywhere (I might have missed a few spots).
Apply the same sorting everywhere.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`