### PR TITLE
fix(github): stop iteration if more than 100 pages of issues

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -57,6 +57,7 @@ import {
 
 const API_PAGE_SIZE = 100;
 const REPOSITORIES_API_PAGE_SIZE = 25;
+const MAX_ISSUES_PAGE_SIZE = 100;
 
 type GithubOrg = {
   id: number;
@@ -199,6 +200,19 @@ export async function getRepoIssuesPage(
 ): Promise<GithubIssue[]> {
   try {
     const octokit = await getOctokit(connector);
+
+    if (page >= MAX_ISSUES_PAGE_SIZE) {
+      logger.warn(
+        {
+          repoName,
+          login,
+          connectorId: connector.id,
+          page,
+        },
+        `We cannot obtain more than ${MAX_ISSUES_PAGE_SIZE} pages of issues with the GitHub REST API.`
+      );
+      return [];
+    }
 
     const issues = (
       await octokit.rest.issues.listForRepo({


### PR DESCRIPTION
## Description

Obtaining more than the last 10k issues in a repo requires moving to the cursor-based pagination, which requires using their graphQL API. 
It's not a trivial change, and will be a workflow breaking change. 

For now this change stops the iteration at 100 result pages.

## Tests


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
