### PR TITLE
fix: include deleted when deleting spaces

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -481,7 +481,8 @@ export async function deleteSpacesActivity({
     // Soft delete all the data source views of the space.
     const dataSourceViews = await DataSourceViewResource.listBySpace(
       auth,
-      space
+      space,
+      { includeDeleted: true }
     );
     for (const ds of dataSourceViews) {
       await ds.delete(auth, { hardDelete: false });


### PR DESCRIPTION
## Description

We're getting errors "can't find space" when trying to delete a ds view for which the space has already been soft-deleted

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
