### PR TITLE
fix: expire content fragments linked to dsview on delete

### DIFF
--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -152,7 +152,7 @@ export function contentFragmentToAttachmentCitation(
       ),
     };
   }
-  
+
   if (contentFragment.contentNodeData) {
     const { provider, nodeType } = contentFragment.contentNodeData;
     const logo = getConnectorProviderLogoWithFallback({ provider });

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -138,6 +138,21 @@ export function AttachmentCitation({
 export function contentFragmentToAttachmentCitation(
   contentFragment: ContentFragmentType
 ): AttachmentCitation {
+  // Handle expired content fragments
+  if (contentFragment.expiredReason) {
+    return {
+      type: "file",
+      id: contentFragment.sId,
+      title: `${contentFragment.title} (no longer available)`,
+      sourceUrl: null,
+      visual: (
+        <span className="flex items-center justify-center">
+          <Icon visual={DocumentIcon} size="md" className="text-gray-400" />
+        </span>
+      ),
+    };
+  }
+  
   if (contentFragment.contentNodeData) {
     const { provider, nodeType } = contentFragment.contentNodeData;
     const logo = getConnectorProviderLogoWithFallback({ provider });

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -107,7 +107,14 @@ export async function softDeleteDataSourceAndLaunchScrubWorkflow(
   await concurrentExecutor(
     views,
     async (view) => {
-      await view.delete(auth, { transaction, hardDelete: false });
+      const r = await view.delete(auth, { transaction, hardDelete: false });
+      if (r.isErr()) {
+        logger.error(
+          { viewId: view.id, error: r.error },
+          "Error deleting data source view"
+        );
+        throw r.error;
+      }
     },
     {
       concurrency: 8,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -100,6 +100,21 @@ export async function softDeleteDataSourceAndLaunchScrubWorkflow(
     });
   }
 
+  // Soft delete all ds views for that data source.
+  const views = await DataSourceViewResource.listForDataSources(auth, [
+    dataSource,
+  ]);
+  await concurrentExecutor(
+    views,
+    async (view) => {
+      await view.delete(auth, { transaction, hardDelete: false });
+    },
+    {
+      concurrency: 8,
+    }
+  );
+
+  // Soft delete the data source.
   await dataSource.delete(auth, { transaction, hardDelete: false });
 
   // The scrubbing workflow will delete associated resources and hard delete the data source.

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -614,6 +614,19 @@ export async function renderLightContentFragmentForModel(
     throw new Error(`Content fragment not found for message ${sId}`);
   }
 
+  if (contentFragment.expiredReason) {
+    return {
+      role: "content_fragment",
+      name: `attach_${contentType}`,
+      content: [
+        {
+          type: "text",
+          text: `The content of this file is no longer available. Reason: ${contentFragment.expiredReason}`,
+        },
+      ],
+    };
+  }
+
   const { fileId: fileModelId } = contentFragment;
 
   const fileStringId = fileModelId
@@ -622,6 +635,7 @@ export async function renderLightContentFragmentForModel(
         workspaceId: conversation.owner.id,
       })
     : null;
+
   if (fileStringId && isSupportedImageContentType(contentType)) {
     if (excludeImages || !model.supportsVision) {
       return {

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -351,6 +351,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       contentFragmentId: this.sId,
       contentFragmentVersion: this.version,
       contentNodeData,
+      expiredReason: this.expiredReason,
     };
   }
 }

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -398,19 +398,12 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<number, Error>> {
-    // Directly delete the DataSourceViewModel here to avoid a circular dependency.
-    await DataSourceViewModel.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        dataSourceId: this.id,
-      },
-      transaction,
-      hardDelete: false,
-    });
+    // We assume the data source views are already soft-deleted here.
 
     const deletedCount = await this.model.destroy({
       where: {
         id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
       transaction,
     });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -22,6 +22,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -596,10 +597,34 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     return new Ok(deletedCount);
   }
 
+  async expireContentFragments(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<void> {
+    // Mark all content fragments that reference this data source view as expired.
+    await ContentFragmentModel.update(
+      {
+        nodeId: null,
+        nodeDataSourceViewId: null,
+        expiredReason: "data_source_deleted",
+      },
+      {
+        where: {
+          nodeDataSourceViewId: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      }
+    );
+  }
+
   async hardDelete(
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<number, Error>> {
+    // First expire any content fragments that reference this data source view
+    await this.expireContentFragments(auth, transaction);
+
     // Delete agent configurations elements pointing to this data source view.
     await AgentDataSourceConfiguration.destroy({
       where: {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -585,6 +585,9 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<number, Error>> {
+    // Mark all content fragments that reference this data source view as expired.
+    await this.expireContentFragments(auth, transaction);
+
     const deletedCount = await DataSourceViewModel.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -622,9 +625,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<number, Error>> {
-    // First expire any content fragments that reference this data source view
-    await this.expireContentFragments(auth, transaction);
-
     // Delete agent configurations elements pointing to this data source view.
     await AgentDataSourceConfiguration.destroy({
       where: {

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -7,6 +7,7 @@ import { FileModel } from "@app/lib/resources/storage/models/files";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
+  ContentFragmentExpiredReason,
   ContentFragmentVersion,
   ContentNodeType,
   SupportedContentFragmentType,
@@ -39,6 +40,7 @@ export class ContentFragmentModel extends WorkspaceAwareModel<ContentFragmentMod
   declare nodeType: ContentNodeType | null;
 
   declare version: ContentFragmentVersion;
+  declare expiredReason: ContentFragmentExpiredReason | null;
 }
 
 ContentFragmentModel.init(
@@ -99,6 +101,10 @@ ContentFragmentModel.init(
       allowNull: true,
     },
     nodeType: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    expiredReason: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/front/migrations/db/migration_211.sql
+++ b/front/migrations/db/migration_211.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 15, 2025
+ALTER TABLE "public"."content_fragments" ADD COLUMN "expiredReason" VARCHAR(255);

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -6,6 +6,8 @@ import type { DataSourceViewContentNode } from "./data_source_view";
 import type { SupportedFileContentType } from "./files";
 import type { ModelId } from "./shared/model_id";
 
+export type ContentFragmentExpiredReason = "data_source_deleted";
+
 export type ContentFragmentContextType = {
   username: string | null;
   fullName: string | null;
@@ -50,6 +52,7 @@ export type ContentFragmentType = {
   contentFragmentId: string;
   contentFragmentVersion: ContentFragmentVersion;
   contentNodeData: ContentFragmentNodeData | null;
+  expiredReason: ContentFragmentExpiredReason | null;
 };
 
 export type UploadedContentFragment = {
@@ -82,4 +85,12 @@ export function isContentNodeAttachment(
   nodeType: ContentNodeType;
 } {
   return !!arg.nodeId && !!arg.nodeDataSourceViewId;
+}
+
+export function isExpiredContentFragment(
+  arg: ContentFragmentType
+): arg is ContentFragmentType & {
+  expiredReason: ContentFragmentExpiredReason;
+} {
+  return !!arg.expiredReason;
 }

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -86,11 +86,3 @@ export function isContentNodeAttachment(
 } {
   return !!arg.nodeId && !!arg.nodeDataSourceViewId;
 }
-
-export function isExpiredContentFragment(
-  arg: ContentFragmentType
-): arg is ContentFragmentType & {
-  expiredReason: ContentFragmentExpiredReason;
-} {
-  return !!arg.expiredReason;
-}


### PR DESCRIPTION
## Description

### Current Issue
When deleting a data source view, we run into an issue with content fragments that reference this dsview. The problem occurs because:
1.  Hard deleting a dsview fails when there's a reference from a content fragment
2.  We can't simply remove the reference, as it would leave a CF without any file or dsview reference
3.  We can't delete the CF as it would break the conversation structure
4.  We can't delete the message as it would create a rank gap in the conversation

### Fix
Implement a new behavior for content fragments when their referenced data source view is deleted:
1.  Allow content fragments to exist without being linked to anything
2.  Treat these unlinked content fragments as "expired"
3.  When rendering the conversation, display "This content is no longer available" for expired content fragments
4.  Modify the content fragment deletion logic to:
   •   Keep the content fragment structure intact
   •   Set its content as expired
   •   Remove the dsview reference

## Tests

Manual

## Risk

Migration + always risky touching to deletes / soft deletes
## Deploy Plan

apply migration then deploy