### PR TITLE
[Agent Discovery] New group kind "agent_editors"

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -386,7 +386,8 @@ export class GroupResource extends BaseResource<GroupModel> {
       ],
       where: {
         kind: {
-          // as is tautological but required by TS who does not understand
+          // The 'as' clause is tautological but required by TS who does not
+          // understand that groupKinds.filter() returns a GroupKind[]
           [Op.in]: groupKinds.filter((k) => k !== "global") as GroupKind[],
         },
       },

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -38,7 +38,10 @@ GroupModel.init(
   {
     modelName: "groups",
     sequelize: frontSequelize,
-    indexes: [{ unique: true, fields: ["workspaceId", "name"] }],
+    indexes: [
+      { unique: true, fields: ["workspaceId", "name"] },
+      { fields: ["workspaceId", "kind"] },
+    ],
   }
 );
 

--- a/front/migrations/db/migration_213.sql
+++ b/front/migrations/db/migration_213.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 15, 2025
+CREATE INDEX "groups_workspace_id_kind" ON "groups" ("workspaceId", "kind");

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -1,19 +1,25 @@
 import type { ModelId } from "./shared/model_id";
 
 /**
- * system group:
- * Accessible by no-one other than our system API keys.
- * Has access to the system Space which holds the connected data sources.
+ * system group: Accessible by no-one other than our system API keys. Has access
+ * to the system Space which holds the connected data sources.
  *
- * global group:
- * Contains all users from the workspace.
- * Has access to the global Space which holds all existing datasource created before spaces.
+ * global group: Contains all users from the workspace. Has access to the global
+ * Space which holds all existing datasource created before spaces.
  *
- * regular group:
- * Contains specific users added by workspace admins.
- * Has access to the list of spaces configured by workspace admins.
+ * regular group: Contains specific users added by workspace admins. Has access
+ * to the list of spaces configured by workspace admins.
+ *
+ * agent_editors group: Group specific to represent agent editors, tied to an
+ *  agent. Has special permissions: not restricted only to admins. Users can
+ *  create, and members of the group can update it.
  */
-export const GROUP_KINDS = ["regular", "global", "system"] as const;
+export const GROUP_KINDS = [
+  "regular",
+  "global",
+  "system",
+  "agent_editors",
+] as const;
 export type GroupKind = (typeof GROUP_KINDS)[number];
 
 export function isGroupKind(value: unknown): value is GroupKind {
@@ -26,9 +32,16 @@ export function isGlobalGroupKind(value: GroupKind): boolean {
   return value === "global";
 }
 
+export function isAgentEditorGroupKind(value: GroupKind): boolean {
+  return value === "agent_editors";
+}
+
 export function prettifyGroupName(group: GroupType) {
   if (group.kind === "global") {
     return "Company Data";
+  }
+  if (group.kind === "agent_editors") {
+    return group.name.replace("Group for Agent ", "");
   }
   return group.name.replace("Group for Space ", "");
 }


### PR DESCRIPTION
Description
---
Groups tied to an agent representing the editors of the agent.

See discussion
[here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1744642619009059?thread_ts=1744641193.604689&cid=C050SM8NSPK) and comments in code

Logic to create such groups is implemented in another PR reverting group/agent model

Risks
---
standard

Deploy
---
migration 213
front
