### PR TITLE
[front] - fix(subscription): change subscription cancellation to end

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -359,6 +359,23 @@ export async function cancelSubscriptionImmediately({
 }
 
 /**
+ * Cancel a subscription at the end of the current period,
+ * allowing users to retain access until that time.
+ */
+export async function cancelSubscriptionAtPeriodEnd({
+  stripeSubscriptionId,
+}: {
+  stripeSubscriptionId: string;
+}) {
+  const stripe = getStripeClient();
+  await stripe.subscriptions.update(stripeSubscriptionId, {
+    cancel_at_period_end: true,
+  });
+
+  return true;
+}
+
+/**
  * Checks that a subscription created in Stripe is usable by Dust, returns an
  * error otherwise.
  */

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  cancelSubscriptionImmediately,
+  getStripeClient,
   skipSubscriptionFreeTrial,
 } from "@app/lib/plans/stripe";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -160,8 +160,9 @@ async function handler(
             });
           }
 
-          await cancelSubscriptionImmediately({
-            stripeSubscriptionId: subscription.stripeSubscriptionId,
+          const stripe = getStripeClient();
+          await stripe.subscriptions.update(subscription.stripeSubscriptionId, {
+            cancel_at_period_end: true,
           });
           break;
         case "pay_now":

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  getStripeClient,
+  cancelSubscriptionAtPeriodEnd,
   skipSubscriptionFreeTrial,
 } from "@app/lib/plans/stripe";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -160,9 +160,8 @@ async function handler(
             });
           }
 
-          const stripe = getStripeClient();
-          await stripe.subscriptions.update(subscription.stripeSubscriptionId, {
-            cancel_at_period_end: true,
+          await cancelSubscriptionAtPeriodEnd({
+            stripeSubscriptionId: subscription.stripeSubscriptionId,
           });
           break;
         case "pay_now":


### PR DESCRIPTION
## Description

This PR replaces immediate subscription cancellation with setting it to cancel at the end of the billing period for free trial.

**References:**
- https://github.com/dust-tt/tasks/issues/2646

## Risk

Moderate, touches subscription and stripe.

## Deploy Plan

Deploy front