### PR TITLE
Restrict Private IP Ranges

### DIFF
--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -130,12 +130,16 @@ export async function getIpAddressForUrl(url: string) {
 }
 
 export function isPrivateIp(ip: string) {
-  const privatePrefixes = ["0.", "127.", "10.", "192.168.", "169.254"];
-  for (const prefix of privatePrefixes) {
-    if (ip.startsWith(prefix)) {
-      return true;
-    }
-  }
+  // Simple patterns for common private ranges.
+  const simpleRanges = /^(0|127|10|192\.168|169\.254)\./;
 
-  return false;
+  // 172.16.0.0/12 range (172.16-31.x.x).
+  // Only 172.16 through 172.31 are private.
+  const range172 = /^172\.(1[6-9]|2[0-9]|3[0-1])\./;
+
+  // 100.64.0.0/10 range (100.64-127.x.x).
+  // Only 100.64 through 100.127 are Carrier-grade NAT.
+  const range100 = /^100\.(6[4-9]|7[0-9]|8[0-9]|9[0-9]|1[01][0-9]|12[0-7])\./;
+
+  return simpleRanges.test(ip) || range172.test(ip) || range100.test(ip);
 }

--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -99,10 +99,17 @@ impl HttpRequest {
         .into_iter()
         .map(|ip| {
             lazy_static! {
-                static ref RE: Regex = Regex::new(r"^(0|127|10|192\.168|169\.254)\..*").unwrap();
+                // Simple patterns that match single ranges
+                static ref SIMPLE_RANGES: Regex = Regex::new(r"^(0|127|10|192\.168|169\.254)\..*").unwrap();
+
+                // 172.16-31.x.x range
+                static ref RANGE_172: Regex = Regex::new(r"^172\.(1[6-9]|2[0-9]|3[0-1])\..*").unwrap();
+
+                // 100.64-127.x.x range
+                static ref RANGE_100: Regex = Regex::new(r"^100\.(6[4-9]|7[0-9]|8[0-9]|9[0-9]|1[01][0-9]|12[0-7])\..*").unwrap();
             }
             // println!("IP {}", ip.to_string());
-            match RE.is_match(ip.to_string().as_str()) {
+            match SIMPLE_RANGES.is_match(ip.to_string().as_str()) || RANGE_172.is_match(ip.to_string().as_str()) || RANGE_100.is_match(ip.to_string().as_str()) {
                 true => Err(anyhow!("Forbidden IP range"))?,
                 false => Ok(ip),
             }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/11981, to restrict even more the private IP ranges by covering:
- 172.16.0.0/12 range (172.16-31.x.x) - Private IP range
- 100.64.0.0/10 range (100.64-127.x.x) - Carrier-grade NAT

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested in the curl block from the Dust app.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
