### PR TITLE
enh(Zendesk): improve logging relative to the rate limit hits

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -27,7 +27,7 @@ function extractMetadataFromZendeskUrl(url: string): {
   subdomain: string;
   endpoint: string;
 } {
-  const regex = /^https?:\/\/(.*)\.zendesk\.com(.*)/;
+  const regex = /^https?:\/\/(.*)\.zendesk\.com(.*)\??.*/;
   return {
     subdomain: url.replace(regex, "$1"),
     endpoint: url.replace(regex, "$2"),


### PR DESCRIPTION
## Description

- Upon hitting a rate limit on Zendesk API, we currently log the endpoint and the subdomain that are affected.
- When logging the endpoint, we include the parameter (parsed from the URL).
- This PR remove this to get the clean endpoint.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.