### PR TITLE
Fix Local MCP Clients heartbeat

### DIFF
--- a/front/components/assistant/conversation/co_edition/CoEditionProvider.tsx
+++ b/front/components/assistant/conversation/co_edition/CoEditionProvider.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { CoEditionContext } from "@app/components/assistant/conversation/co_edition/context";
-import { useCoEditionServer } from "@app/components/assistant/conversation/co_edition/useCoEditionMcpServer";
+import { useCoEditionMcpServer } from "@app/components/assistant/conversation/co_edition/useCoEditionMcpServer";
 import { isMobile } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types";
 
@@ -17,7 +17,7 @@ export function CoEditionProvider({
   hasCoEditionFeatureFlag = false,
 }: CoEditionProviderProps) {
   const { closeCoEdition, isCoEditionOpen, isConnected, server, serverId } =
-    useCoEditionServer({
+    useCoEditionMcpServer({
       owner,
       hasCoEditionFeatureFlag,
     });

--- a/front/components/assistant/conversation/co_edition/transport.ts
+++ b/front/components/assistant/conversation/co_edition/transport.ts
@@ -3,7 +3,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
 const logger = console;
 
-const HEARTBEAT_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes.
+const HEARTBEAT_INTERVAL_MS = 4 * 60 * 1000; // 4 minutes.
 const RECONNECT_DELAY_MS = 5 * 1000; // 5 seconds.
 
 /**

--- a/front/components/assistant/conversation/co_edition/useCoEditionMcpServer.ts
+++ b/front/components/assistant/conversation/co_edition/useCoEditionMcpServer.ts
@@ -9,7 +9,7 @@ interface UseCoEditionServerProps {
   owner: LightWorkspaceType;
 }
 
-export function useCoEditionServer({
+export function useCoEditionMcpServer({
   hasCoEditionFeatureFlag = true,
   owner,
 }: UseCoEditionServerProps) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See Slack [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1744718790777759).

We were using two different timeouts for client-side MCP. When a client-side MCP server is first registered it's only registered for 5 minutes and without heartbeat won't be usable anymore, the client-side was actually heart bitting every 15 minutes.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
