### PR TITLE
[Discovery] Create GroupAgent model (rerevert+update)

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -58,6 +58,7 @@ import {
   MessageReaction,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
+import { GroupAgentModel } from "@app/lib/models/assistant/group_agent";
 import { TagAgentModel } from "@app/lib/models/assistant/tag_agent";
 import {
   TrackerConfigurationModel,
@@ -67,8 +68,8 @@ import {
 import { DustAppSecret } from "@app/lib/models/dust_app_secret";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
-import { MembershipInvitation } from "@app/lib/models/membership_invitation";
 import { LabsPersonalSalesforceConnection } from "@app/lib/models/labs_personal_salesforce_connection";
+import { MembershipInvitation } from "@app/lib/models/membership_invitation";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { TagModel } from "@app/lib/models/tags";
 import { Workspace } from "@app/lib/models/workspace";
@@ -157,6 +158,7 @@ async function main() {
   await AgentUserRelation.sync({ alter: true });
   await GlobalAgentSettings.sync({ alter: true });
   await TagAgentModel.sync({ alter: true });
+  await GroupAgentModel.sync({ alter: true });
 
   await RemoteMCPServerModel.sync({ alter: true });
   await MCPServerViewModel.sync({ alter: true });

--- a/front/lib/models/assistant/group_agent.ts
+++ b/front/lib/models/assistant/group_agent.ts
@@ -1,0 +1,105 @@
+import type {
+  BelongsToGetAssociationMixin,
+  CreationOptional,
+  ForeignKey,
+} from "sequelize";
+import { DataTypes } from "sequelize";
+
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+
+export class GroupAgentModel extends WorkspaceAwareModel<GroupAgentModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare groupId: ForeignKey<GroupModel["id"]>;
+  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  // workspaceId is inherited from WorkspaceAwareModel
+
+  declare getGroup: BelongsToGetAssociationMixin<GroupModel>;
+  declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfiguration>;
+  // getWorkspace is inherited
+}
+
+GroupAgentModel.init(
+  {
+    id: {
+      type: DataTypes.BIGINT,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    groupId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    agentConfigurationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    // workspaceId is automatically added by WorkspaceAwareModel.init
+  },
+  {
+    modelName: "group_agents",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["groupId", "agentConfigurationId"],
+      },
+      { fields: ["agentConfigurationId"] },
+    ],
+  }
+);
+
+// Define associations
+
+// Association with Group
+GroupAgentModel.belongsTo(GroupModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  targetKey: "id",
+});
+GroupModel.hasMany(GroupAgentModel, {
+  foreignKey: { name: "groupId", allowNull: false },
+  sourceKey: "id",
+  as: "groupAgentLinks",
+});
+
+// Association with AgentConfiguration
+GroupAgentModel.belongsTo(AgentConfiguration, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  targetKey: "id",
+});
+AgentConfiguration.hasMany(GroupAgentModel, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  sourceKey: "id",
+  as: "agentGroupLinks",
+});
+
+// Many-to-Many between Group and AgentConfiguration (ensure FKs match)
+GroupModel.belongsToMany(AgentConfiguration, {
+  through: GroupAgentModel,
+  foreignKey: "groupId",
+  otherKey: "agentConfigurationId",
+  as: "agentConfigurations",
+});
+AgentConfiguration.belongsToMany(GroupModel, {
+  through: GroupAgentModel,
+  foreignKey: "agentConfigurationId",
+  otherKey: "groupId",
+  as: "groups",
+});
+
+// Workspace association is handled by WorkspaceAwareModel.init

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -44,8 +44,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     super(GroupModel, blob);
   }
 
-  static async makeNew(blob: CreationAttributes<GroupModel>) {
-    const group = await GroupModel.create(blob);
+  static async makeNew(
+    blob: CreationAttributes<GroupModel>,
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
+    const group = await GroupModel.create(blob, { transaction });
 
     return new this(GroupModel, group.get());
   }
@@ -438,7 +441,8 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   async addMembers(
     auth: Authenticator,
-    users: UserType[]
+    users: UserType[],
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, DustError>> {
     if (!this.canWrite(auth)) {
       return new Err(
@@ -514,7 +518,8 @@ export class GroupResource extends BaseResource<GroupModel> {
         userId: user.id,
         workspaceId: owner.id,
         startAt: new Date(),
-      }))
+      })),
+      { transaction }
     );
 
     return new Ok(undefined);
@@ -522,14 +527,16 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   async addMember(
     auth: Authenticator,
-    user: UserType
+    user: UserType,
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, DustError>> {
-    return this.addMembers(auth, [user]);
+    return this.addMembers(auth, [user], { transaction });
   }
 
   async removeMembers(
     auth: Authenticator,
-    users: UserType[]
+    users: UserType[],
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, DustError>> {
     if (!this.canWrite(auth)) {
       return new Err(
@@ -605,6 +612,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           startAt: { [Op.lte]: new Date() },
           [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
         },
+        transaction,
       }
     );
 
@@ -613,14 +621,16 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   async removeMember(
     auth: Authenticator,
-    users: UserType
+    users: UserType,
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, DustError>> {
-    return this.removeMembers(auth, [users]);
+    return this.removeMembers(auth, [users], { transaction });
   }
 
   async setMembers(
     auth: Authenticator,
-    users: UserType[]
+    users: UserType[],
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, DustError>> {
     if (!this.canWrite(auth)) {
       return new Err(
@@ -640,7 +650,9 @@ export class GroupResource extends BaseResource<GroupModel> {
       (user) => !currentMemberIds.includes(user.sId)
     );
     if (usersToAdd.length > 0) {
-      const addResult = await this.addMembers(auth, usersToAdd);
+      const addResult = await this.addMembers(auth, usersToAdd, {
+        transaction,
+      });
       if (addResult.isErr()) {
         return addResult;
       }
@@ -651,7 +663,9 @@ export class GroupResource extends BaseResource<GroupModel> {
       .filter((currentMember) => !userIds.includes(currentMember.sId))
       .map((m) => m.toJSON());
     if (usersToRemove.length > 0) {
-      const removeResult = await this.removeMembers(auth, usersToRemove);
+      const removeResult = await this.removeMembers(auth, usersToRemove, {
+        transaction,
+      });
       if (removeResult.isErr()) {
         return removeResult;
       }

--- a/front/migrations/db/migration_214.sql
+++ b/front/migrations/db/migration_214.sql
@@ -1,0 +1,33 @@
+-- Migration created on Apr 12, 2025
+-- Create the group_agents table
+
+CREATE TABLE IF NOT EXISTS "group_agents" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "groupId" BIGINT NOT NULL,
+    "agentConfigurationId" BIGINT NOT NULL,
+    "workspaceId" BIGINT NOT NULL,
+
+    -- Foreign key constraints
+    CONSTRAINT "group_agents_groupId_fkey"
+        FOREIGN KEY ("groupId")
+        REFERENCES "groups"("id")
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "group_agents_agentConfigurationId_fkey"
+        FOREIGN KEY ("agentConfigurationId")
+        REFERENCES "agent_configurations"("id")
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "group_agents_workspaceId_fkey"
+        FOREIGN KEY ("workspaceId")
+        REFERENCES "workspaces"("id")
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+
+    -- Unique constraint for the combination of group and agent
+    CONSTRAINT "group_agents_unique_group_agent"
+        UNIQUE ("groupId", "agentConfigurationId")
+);
+
+-- Index for faster lookups by agentConfigurationId
+CREATE INDEX IF NOT EXISTS "group_agents_agentConfigurationId_idx" ON "group_agents"("agentConfigurationId");
+


### PR DESCRIPTION
## Description
Revert of #11957 which is a revert of #11938 . See those PR descriptions for details.

PR is a direct re-revert, then a commit to leverage the new "agent_editors" group kind: group creation will have this kind + auto-add the creating user as part of members

## Risk
- safe to rollback
- standard risk, at agent creation
- tested

## Deploy Plan
- migration 214
Note: due to revert, has been executed as migration 211 in prod
- front
