### PR TITLE
Add logic to sync files directly "shared with me"

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -229,14 +229,6 @@ export async function syncFiles(
   if (nextPageToken === undefined && !isSharedWithMe) {
     // On the first page of a folder id, we can check if we already visited it
 
-    // add log statement here
-    logger.info(
-      {
-        connectorId,
-        folderId: driveFolderId,
-      },
-      "Checking if folder has been visited"
-    );
     const visitedFolder = await GoogleDriveFiles.findOne({
       where: {
         connectorId: connectorId,
@@ -265,9 +257,8 @@ export async function syncFiles(
   let driveParams: drive_v3.Params$Resource$Files$List = {
     corpora: "allDrives",
     pageSize: 200,
-    includeItemsFromAllDrives:
-      driveFolderId !== GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
-    supportsAllDrives: driveFolderId !== GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
+    includeItemsFromAllDrives: true,
+    supportsAllDrives: true,
     includeLabels: labels.map((l) => l.id).join(","),
     fields: `nextPageToken, files(${FILE_ATTRIBUTES_TO_FETCH.join(",")})`,
     q: `'${driveFolder.id}' in parents and (${mimeTypesSearchString}) and trashed=false`,

--- a/connectors/src/types/google_drive.ts
+++ b/connectors/src/types/google_drive.ts
@@ -17,7 +17,7 @@ export type GoogleDriveObjectType = {
   driveId: string;
   isInSharedDrive: boolean;
   labels: string[];
-  sharedWithMeTime?: string | null; // TODO: can potentially remove.
+  sharedWithMeTime?: string | null;
 };
 
 export const FILE_ATTRIBUTES_TO_FETCH = [

--- a/connectors/src/types/google_drive.ts
+++ b/connectors/src/types/google_drive.ts
@@ -17,6 +17,7 @@ export type GoogleDriveObjectType = {
   driveId: string;
   isInSharedDrive: boolean;
   labels: string[];
+  sharedWithMeTime?: string | null; // TODO: can potentially remove.
 };
 
 export const FILE_ATTRIBUTES_TO_FETCH = [
@@ -33,6 +34,7 @@ export const FILE_ATTRIBUTES_TO_FETCH = [
   "trashed",
   "webViewLink",
   "labelInfo",
+  "sharedWithMeTime",
 ] as const;
 
 // Get the Table ID for a sheet within a Google Spreadsheet from the


### PR DESCRIPTION
## Description

* Enabling files that are directly "shared with me" via Google Drive to be synced and selectable to add to a space
* The current behavior is that that these files must be inside a folder and then each folder manually selected to be synced
* This is not a real google drive folder, but a fake "virtual" folder concept, so custom logic is required

## Tests

<img width="755" alt="Screenshot 2025-04-15 at 8 30 54 PM" src="https://github.com/user-attachments/assets/d26316d7-5e83-4e76-a985-dfde4bc7ffe0" />

<img width="596" alt="Screenshot 2025-04-15 at 8 32 42 PM" src="https://github.com/user-attachments/assets/b44c387f-39ed-4134-a432-17d2aace420c" />


## Risk

* Safe to rollback

## Deploy Plan

Github actions