### PR TITLE
enh(Zendesk)- Improve handling of rate limits

### DIFF
--- a/connectors/migrations/20250110_investigate_zendesk_hc.ts
+++ b/connectors/migrations/20250110_investigate_zendesk_hc.ts
@@ -43,9 +43,6 @@ makeScript({}, async ({ execute }, logger) => {
         accessToken,
         subdomain,
       });
-      if (!brandSubdomain) {
-        throw new Error("Brand not found.");
-      }
 
       let couldFetchCategories;
       try {

--- a/connectors/migrations/20250110_investigate_zendesk_hc.ts
+++ b/connectors/migrations/20250110_investigate_zendesk_hc.ts
@@ -4,9 +4,9 @@ import { isZendeskNotFoundError } from "@connectors/connectors/zendesk/lib/error
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   fetchZendeskBrand,
-  fetchZendeskCategoriesInBrand,
   fetchZendeskCurrentUser,
   getZendeskBrandSubdomain,
+  listZendeskCategoriesInBrand,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -49,7 +49,7 @@ makeScript({}, async ({ execute }, logger) => {
 
       let couldFetchCategories;
       try {
-        await fetchZendeskCategoriesInBrand(accessToken, {
+        await listZendeskCategoriesInBrand(accessToken, {
           brandSubdomain,
           pageSize: ZENDESK_BATCH_SIZE,
         });

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -47,7 +47,6 @@
         "micromark-extension-gfm": "^3.0.0",
         "minimist": "^1.2.8",
         "morgan": "^1.10.0",
-        "node-zendesk": "^5.0.13",
         "octokit": "^3.1.2",
         "p-queue": "^7.3.4",
         "pg": "^8.8.0",
@@ -7451,15 +7450,6 @@
         }
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -12435,24 +12425,6 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
-    },
-    "node_modules/node-zendesk": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/node-zendesk/-/node-zendesk-5.0.13.tgz",
-      "integrity": "sha512-NT+57ZsfZBcMZ8xxX2krKKpHrroDlL7/NQkaStHI4un7W1HV8YWzm405k9D1etkt7tE2LHjU6Zd9y3Efwre/2g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/blakmatrix/node-zendesk?sponsor=1"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/normalize-url": {
       "version": "8.0.1",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -55,7 +55,6 @@
     "micromark-extension-gfm": "^3.0.0",
     "minimist": "^1.2.8",
     "morgan": "^1.10.0",
-    "node-zendesk": "^5.0.13",
     "octokit": "^3.1.2",
     "p-queue": "^7.3.4",
     "pg": "^8.8.0",

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -4,8 +4,8 @@ import {
   fetchZendeskBrand,
   fetchZendeskCurrentUser,
   fetchZendeskTicket,
-  fetchZendeskTicketCount,
   getZendeskBrandSubdomain,
+  getZendeskTicketCount,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { syncZendeskBrandActivity } from "@connectors/connectors/zendesk/temporal/activities";
 import {
@@ -104,7 +104,7 @@ export const zendesk = async ({
         throw new Error(`Brand ${brandId} not found in Zendesk.`);
       }
 
-      const ticketCount = await fetchZendeskTicketCount({
+      const ticketCount = await getZendeskTicketCount({
         brandSubdomain,
         accessToken,
         retentionPeriodDays,

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -100,9 +100,6 @@ export const zendesk = async ({
         subdomain,
         accessToken,
       });
-      if (!brandSubdomain) {
-        throw new Error(`Brand ${brandId} not found in Zendesk.`);
-      }
 
       const ticketCount = await getZendeskTicketCount({
         brandSubdomain,
@@ -191,12 +188,6 @@ export const zendesk = async ({
         subdomain,
         accessToken,
       });
-      if (!brandSubdomain) {
-        return {
-          ticket: null,
-          isTicketOnDb: ticketOnDb !== null,
-        };
-      }
 
       const ticket = await fetchZendeskTicket({
         accessToken,

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -229,9 +229,6 @@ async function getHelpCenterChildren({
       subdomain,
       accessToken,
     });
-    if (!brandSubdomain) {
-      throw new Error(`Brand ${brandId} not found in Zendesk.`);
-    }
 
     const categories = await listZendeskCategories({
       accessToken,

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -1,11 +1,11 @@
 import TurndownService from "turndown";
 
+import { getArticleInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import type {
   ZendeskFetchedArticle,
   ZendeskFetchedSection,
   ZendeskFetchedUser,
-} from "@connectors/@types/node-zendesk";
-import { getArticleInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
+} from "@connectors/connectors/zendesk/lib/types";
 import {
   deleteDataSourceDocument,
   renderDocumentTitleAndContent,
@@ -15,8 +15,7 @@ import {
 import logger from "@connectors/logger/logger";
 import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskArticleResource } from "@connectors/resources/zendesk_resources";
-import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -1,9 +1,9 @@
-import type { ZendeskFetchedCategory } from "@connectors/@types/node-zendesk";
 import {
   getArticleInternalId,
   getCategoryInternalId,
   getHelpCenterInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
+import type { ZendeskFetchedCategory } from "@connectors/connectors/zendesk/lib/types";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   deleteDataSourceDocument,
@@ -14,8 +14,7 @@ import {
   ZendeskArticleResource,
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
-import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 /**

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -1,12 +1,12 @@
 import TurndownService from "turndown";
 
+import { filterCustomTags } from "@connectors/connectors/shared/tags";
+import { getTicketInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import type {
   ZendeskFetchedTicket,
   ZendeskFetchedTicketComment,
   ZendeskFetchedUser,
-} from "@connectors/@types/node-zendesk";
-import { filterCustomTags } from "@connectors/connectors/shared/tags";
-import { getTicketInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
+} from "@connectors/connectors/zendesk/lib/types";
 import {
   deleteDataSourceDocument,
   renderDocumentTitleAndContent,
@@ -16,8 +16,7 @@ import {
 import logger from "@connectors/logger/logger";
 import type { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
-import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();
@@ -127,7 +126,7 @@ export async function syncTicket({
     ticketInDb.lastUpsertedTs < updatedAtDate;
 
   // Tickets can be created without a subject using the API or by email,
-  // if they were never attended in the Agent Workspace their subject is not populated.
+  // if they were never attended in the Agent Workspace, their subject is not populated.
   ticket.subject ||= "No subject";
 
   const ticketUrl = apiUrlToDocumentUrl(ticket.url);

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -1,6 +1,4 @@
-import type { ZendeskClientOptions } from "node-zendesk";
-
-interface ZendeskFetchedBrand {
+export interface ZendeskFetchedBrand {
   url: string;
   id: number;
   name: string;
@@ -19,13 +17,7 @@ interface ZendeskFetchedBrand {
   updated_at: string;
 }
 
-interface Response {
-  status: number;
-  headers: object;
-  statusText: string;
-}
-
-interface ZendeskFetchedSection {
+export interface ZendeskFetchedSection {
   category_id?: number;
   created_at?: string;
   description?: string;
@@ -42,7 +34,7 @@ interface ZendeskFetchedSection {
   url?: string;
 }
 
-interface ZendeskFetchedCategory {
+export interface ZendeskFetchedCategory {
   id: number;
   url: string;
   html_url: string;
@@ -85,7 +77,7 @@ export interface ZendeskFetchedArticle {
   user_segment_ids: number[];
 }
 
-interface ZendeskFetchedTicket {
+export interface ZendeskFetchedTicket {
   assignee_id: number;
   collaborator_ids: number[];
   created_at: string; // ISO 8601 date string
@@ -128,7 +120,7 @@ interface ZendeskFetchedTicket {
   };
 }
 
-interface ZendeskFetchedTicketComment {
+export interface ZendeskFetchedTicketComment {
   id: number;
   body: string;
   html_body: string;
@@ -143,7 +135,7 @@ interface ZendeskFetchedTicketComment {
   }[];
 }
 
-interface ZendeskFetchedUser {
+export interface ZendeskFetchedUser {
   active: boolean;
   alias: string;
   chat_only: boolean;
@@ -184,64 +176,4 @@ interface ZendeskFetchedUser {
   updated_at: string; // ISO 8601 date string
   url: string;
   verified: boolean;
-}
-
-declare module "node-zendesk" {
-  interface Client {
-    config: ZendeskClientOptions;
-    brand: {
-      list: () => Promise<{
-        response: Response;
-        result: ZendeskFetchedBrand[];
-      }>;
-      show: (brandId: number) => Promise<{
-        response: Response;
-        result: { brand: ZendeskFetchedBrand };
-      }>;
-    };
-    helpcenter: {
-      categories: {
-        list: () => Promise<ZendeskFetchedCategory[]>;
-        show: (
-          categoryId: number
-        ) => Promise<{ response: Response; result: ZendeskFetchedCategory }>;
-      };
-      sections: {
-        list: () => Promise<ZendeskFetchedSection[]>;
-        listByCategory: (
-          categoryId: number
-        ) => Promise<ZendeskFetchedSection[]>;
-        show: (
-          sectionId: number
-        ) => Promise<{ response: Response; result: ZendeskFetchedSection }>;
-      };
-      articles: {
-        list: () => Promise<ZendeskFetchedArticle[]>;
-        show: (
-          articleId: number
-        ) => Promise<{ response: Response; result: ZendeskFetchedArticle }>;
-        listByCategory: (
-          categoryId: number
-        ) => Promise<ZendeskFetchedArticle[]>;
-        listSinceStartTime: (
-          startTime: number
-        ) => Promise<ZendeskFetchedArticle[]>;
-      };
-    };
-    tickets: {
-      list: () => Promise<ZendeskFetchedTicket[]>;
-      show: (
-        ticketId: number
-      ) => Promise<{ response: Response; result: ZendeskFetchedTicket }>;
-      getComments: (ticketId: number) => Promise<ZendeskFetchedTicketComment[]>;
-    };
-    users: {
-      list: () => Promise<ZendeskFetchedUser[]>;
-      show: (
-        userId: number
-      ) => Promise<{ response: Response; result: ZendeskFetchedUser }>;
-    };
-  }
-
-  export function createClient(options: object): Client;
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -218,6 +218,40 @@ export async function fetchZendeskBrand({
 }
 
 /**
+ * Fetches all the brands available in the Zendesk API.
+ */
+export async function listZendeskBrands({
+  subdomain,
+  accessToken,
+}: {
+  subdomain: string;
+  accessToken: string;
+}): Promise<ZendeskFetchedBrand[]> {
+  let url = `https://${subdomain}.zendesk.com/api/v2/brands`;
+  const brands = [];
+  let hasMore = true;
+
+  do {
+    try {
+      const response = await fetchFromZendeskWithRetries({
+        url,
+        accessToken,
+      });
+      brands.push(...response.brands);
+      hasMore = response.meta.has_more;
+      url = response.links.next;
+    } catch (e) {
+      if (isZendeskNotFoundError(e)) {
+        return brands;
+      }
+      throw e;
+    }
+  } while (hasMore);
+
+  return brands;
+}
+
+/**
  * Fetches a single article from the Zendesk API.
  */
 export async function fetchZendeskArticle({

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -1,5 +1,9 @@
 import _ from "lodash";
 
+import {
+  isZendeskNotFoundError,
+  ZendeskApiError,
+} from "@connectors/connectors/zendesk/lib/errors";
 import type {
   ZendeskFetchedArticle,
   ZendeskFetchedBrand,
@@ -9,10 +13,6 @@ import type {
   ZendeskFetchedTicketComment,
   ZendeskFetchedUser,
 } from "@connectors/connectors/zendesk/lib/types";
-import {
-  isZendeskNotFoundError,
-  ZendeskApiError,
-} from "@connectors/connectors/zendesk/lib/errors";
 import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import logger from "@connectors/logger/logger";
 import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_resources";

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -35,6 +35,7 @@ function extractMetadataFromZendeskUrl(url: string): {
 
 /**
  * Retrieves a brand's subdomain from the database if it exists, fetches it from the Zendesk API otherwise.
+ * Throws if the brand is not found neither in DB nor in Zendesk.
  */
 export async function getZendeskBrandSubdomain({
   connectorId,
@@ -46,7 +47,7 @@ export async function getZendeskBrandSubdomain({
   brandId: number;
   subdomain: string;
   accessToken: string;
-}): Promise<string | null> {
+}): Promise<string> {
   const brandInDb = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -56,7 +57,7 @@ export async function getZendeskBrandSubdomain({
   }
   const brand = await fetchZendeskBrand({ subdomain, accessToken, brandId });
   if (!brand) {
-    return null;
+    throw new Error(`Brand ${brandId} not found in Zendesk.`);
   }
   return brand.subdomain;
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -8,7 +8,7 @@ import type {
   ZendeskFetchedTicket,
   ZendeskFetchedTicketComment,
   ZendeskFetchedUser,
-} from "@connectors/@types/node-zendesk";
+} from "@connectors/connectors/zendesk/lib/types";
 import {
   isZendeskNotFoundError,
   ZendeskApiError,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -27,7 +27,7 @@ function extractMetadataFromZendeskUrl(url: string): {
   subdomain: string;
   endpoint: string;
 } {
-  const regex = /^https?:\/\/(.*)\.zendesk\.com(.*)\??.*/;
+  const regex = /^https?:\/\/(.*)\.zendesk\.com([^?]*).*/;
   return {
     subdomain: url.replace(regex, "$1"),
     endpoint: url.replace(regex, "$2"),

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -204,8 +204,8 @@ export async function listZendeskBrands({
         accessToken,
       });
       brands.push(...response.brands);
-      hasMore = response.meta.has_more;
-      url = response.links.next;
+      hasMore = response.next_page !== null && response.articles.length !== 0;
+      url = response.next_page;
     } catch (e) {
       if (isZendeskNotFoundError(e)) {
         return brands;

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -356,9 +356,6 @@ export async function syncZendeskCategoryBatchActivity({
     accessToken,
     subdomain,
   });
-  if (!brandSubdomain) {
-    throw new Error(`Brand ${brandId} not found in Zendesk.`);
-  }
 
   const brandInDb = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
@@ -450,9 +447,6 @@ export async function syncZendeskCategoryActivity({
     subdomain,
     brandId,
   });
-  if (!brandSubdomain) {
-    throw new Error(`Brand ${brandId} not found in Zendesk.`);
-  }
 
   // if the category is not on Zendesk anymore, we remove its permissions
   const fetchedCategory = await fetchZendeskCategory({
@@ -552,9 +546,6 @@ export async function syncZendeskArticleBatchActivity({
     accessToken,
     subdomain,
   });
-  if (!brandSubdomain) {
-    throw new Error(`Brand ${brandId} not found in Zendesk.`);
-  }
 
   const { articles, hasMore, nextLink } = await listZendeskArticlesInCategory(
     category,
@@ -643,9 +634,6 @@ export async function syncZendeskTicketBatchActivity({
     accessToken,
     subdomain,
   });
-  if (!brandSubdomain) {
-    throw new Error(`Brand ${brandId} not found in Zendesk.`);
-  }
 
   const startTime =
     Math.floor(currentSyncDateMs / 1000) -

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -154,9 +154,6 @@ export async function removeMissingArticleBatchActivity({
     accessToken,
     subdomain,
   });
-  if (!brandSubdomain) {
-    throw new Error(`Brand ${brandId} not found in Zendesk.`);
-  }
 
   // not deleting in batch for now, assuming we won't have that many articles to delete at once
   await concurrentExecutor(

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -110,9 +110,6 @@ export async function syncZendeskArticleUpdateBatchActivity({
     subdomain,
     accessToken,
   });
-  if (!brandSubdomain) {
-    throw new Error(`Brand ${brandId} not found in Zendesk.`);
-  }
 
   const { articles, hasMore, endTime } = await listRecentlyUpdatedArticles({
     subdomain,
@@ -247,9 +244,6 @@ export async function syncZendeskTicketUpdateBatchActivity({
     subdomain,
     accessToken,
   });
-  if (!brandSubdomain) {
-    throw new Error(`Brand ${brandId} not found in Zendesk.`);
-  }
 
   const { tickets, hasMore, nextLink } = await listZendeskTickets(
     accessToken,


### PR DESCRIPTION
## Description

This PR removes `connectors`' dependency on the library `node-zendesk`, replacing every use of the SDK with our own Zendesk API client in order to get a unified handling of rate limits across the Zendesk connectors.

Our Zendesk API client already logs occurrences of rate limits, and acts accordingly to the retry-after provided by the API.

## Tests

- Tested locally.

## Risk

- N/A, we don't rely on any specific behavior from the lib,  everything it does we do better.

## Deploy Plan

- Deploy connectors.
