### PR TITLE
[front] Replace visual by avatar

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -12,7 +12,7 @@ import {
 import { useState } from "react";
 import React from "react";
 
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
@@ -66,7 +66,7 @@ export const AddActionMenu = ({
               <DropdownMenuItem
                 key={mcpServer.id}
                 label={asDisplayName(mcpServer.name)}
-                icon={() => <Avatar visual={getVisual(mcpServer)} size="xs" />}
+                icon={() => <Avatar icon={getIcon(mcpServer)} size="xs" />}
                 description={mcpServer.description}
                 onClick={async () => {
                   createInternalMCPServer(mcpServer);

--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -12,7 +11,7 @@ import {
 import { useState } from "react";
 import React from "react";
 
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
@@ -66,7 +65,7 @@ export const AddActionMenu = ({
               <DropdownMenuItem
                 key={mcpServer.id}
                 label={asDisplayName(mcpServer.name)}
-                icon={() => <Avatar icon={getIcon(mcpServer)} size="xs" />}
+                icon={() => getAvatar(mcpServer, "xs")}
                 description={mcpServer.description}
                 onClick={async () => {
                   createInternalMCPServer(mcpServer);

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Chip, classNames, DataTable, Spinner } from "@dust-tt/sparkle";
+import { Chip, classNames, DataTable, Spinner } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
 
@@ -7,7 +7,7 @@ import { CreateMCPServerModal } from "@app/components/actions/mcp/CreateMCPServe
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { getSpaceIcon } from "@app/lib/spaces";
@@ -39,9 +39,7 @@ const NameCell = ({ row }: { row: RowData }) => {
           mcpServerView ? "" : "opacity-50"
         )}
       >
-        <div>
-          <Avatar icon={getIcon(mcpServer)} />
-        </div>
+        <div>{getAvatar(mcpServer)}</div>
         <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
           <div className="flex flex-col gap-1">
             <div className="text-sm font-semibold text-foreground dark:text-foreground-night">

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -7,7 +7,7 @@ import { CreateMCPServerModal } from "@app/components/actions/mcp/CreateMCPServe
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { getSpaceIcon } from "@app/lib/spaces";
@@ -40,7 +40,7 @@ const NameCell = ({ row }: { row: RowData }) => {
         )}
       >
         <div>
-          <Avatar visual={getVisual(mcpServer)} />
+          <Avatar icon={getIcon(mcpServer)} />
         </div>
         <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
           <div className="flex flex-col gap-1">

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Button,
   Chip,
   classNames,
@@ -28,7 +27,7 @@ import { MCPServerDetailsInfo } from "@app/components/actions/mcp/MCPServerDetai
 import { MCPServerDetailsSharing } from "@app/components/actions/mcp/MCPServerDetailsSharing";
 import { useMCPConnectionManagement } from "@app/hooks/useMCPConnectionManagement";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
   useDeleteMCPServer,
@@ -145,9 +144,7 @@ export function MCPServerDetails({
               <SheetTitle />
             </VisuallyHidden>
             <div className="flex flex-col items-center gap-3 sm:flex-row">
-              {effectiveMCPServer && (
-                <Avatar icon={getIcon(effectiveMCPServer)} />
-              )}
+              {effectiveMCPServer && getAvatar(effectiveMCPServer)}
               <div className="flex grow flex-col gap-1">
                 <div
                   className={classNames(

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -28,7 +28,7 @@ import { MCPServerDetailsInfo } from "@app/components/actions/mcp/MCPServerDetai
 import { MCPServerDetailsSharing } from "@app/components/actions/mcp/MCPServerDetailsSharing";
 import { useMCPConnectionManagement } from "@app/hooks/useMCPConnectionManagement";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
   useDeleteMCPServer,
@@ -146,7 +146,7 @@ export function MCPServerDetails({
             </VisuallyHidden>
             <div className="flex flex-col items-center gap-3 sm:flex-row">
               {effectiveMCPServer && (
-                <Avatar visual={getVisual(effectiveMCPServer)} />
+                <Avatar icon={getIcon(effectiveMCPServer)} />
               )}
               <div className="flex grow flex-col gap-1">
                 <div

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -57,7 +57,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
     defaultValues: {
       name: asDisplayName(mcpServer.name),
       description: mcpServer.description,
-      icon: mcpServer.visual,
+      icon: mcpServer.icon,
     },
   });
 

--- a/front/components/assistant/details/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/AssistantToolsSection.tsx
@@ -12,7 +12,7 @@ import React from "react";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import {
   isBrowseConfiguration,
@@ -55,7 +55,7 @@ export function AssistantToolsSection({
   if (agentConfiguration.visualizationEnabled) {
     actions.push({
       title: "Visualize",
-      visual: <BarChartIcon />,
+      icon: BarChartIcon,
       order: 0,
     });
   }
@@ -95,7 +95,7 @@ export function AssistantToolsSection({
                 className="flex flex-row items-center gap-2"
                 key={action.title}
               >
-                <Avatar visual={action.visual} size="xs" />
+                <Avatar icon={action.icon} size="xs" />
                 <div>{asDisplayName(action.title)}</div>
               </div>
             ))}
@@ -114,9 +114,7 @@ export function AssistantToolsSection({
                 key={model.modelId}
               >
                 <Avatar
-                  visual={React.createElement(
-                    getModelProviderLogo(model.providerId, isDark)
-                  )}
+                  icon={getModelProviderLogo(model.providerId, isDark)}
                   size="xs"
                 />
                 <div>{model.displayName}</div>
@@ -134,21 +132,21 @@ function renderOtherAction(
   mcpServers: MCPServerTypeWithViews[]
 ) {
   if (isDustAppRunConfiguration(action)) {
-    return { title: action.name, visual: <CommandIcon />, order: 2 };
+    return { title: action.name, icon: CommandIcon, order: 2 };
   } else if (isProcessConfiguration(action)) {
     return {
       title: "Extract from documents",
-      visual: <ScanIcon />,
+      icon: ScanIcon,
       order: 0,
     };
   } else if (isWebsearchConfiguration(action)) {
     return {
       title: "Web Search & Navigation",
-      visual: <GlobeAltIcon />,
+      icon: GlobeAltIcon,
       order: 0,
     };
   } else if (isReasoningConfiguration(action)) {
-    return { title: "Reasoning", visual: <ChatBubbleThoughtIcon />, order: 0 };
+    return { title: "Reasoning", icon: ChatBubbleThoughtIcon, order: 0 };
   } else if (isPlatformMCPServerConfiguration(action)) {
     const mcpServer = mcpServers.find((s) =>
       s.views.some((v) => v.id === action.mcpServerViewId)
@@ -157,14 +155,14 @@ function renderOtherAction(
       return null;
     }
     const { serverType } = getServerTypeAndIdFromSId(mcpServer.id);
-    const visual = getVisual(mcpServer);
+    const icon = getIcon(mcpServer);
     return {
       title: action.name,
-      visual,
+      icon,
       order: serverType === "internal" ? 1 : 3,
     };
   } else if (isMCPServerConfiguration(action)) {
-    return { title: action.name, visual: <CommandIcon />, order: 3 };
+    return { title: action.name, icon: CommandIcon, order: 3 };
   } else if (isBrowseConfiguration(action)) {
     return null;
   } else if (isRetrievalConfiguration(action)) {

--- a/front/components/assistant/details/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/AssistantToolsSection.tsx
@@ -12,7 +12,7 @@ import React from "react";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import {
   isBrowseConfiguration,
@@ -55,7 +55,7 @@ export function AssistantToolsSection({
   if (agentConfiguration.visualizationEnabled) {
     actions.push({
       title: "Visualize",
-      icon: BarChartIcon,
+      avatar: <Avatar icon={BarChartIcon} size="xs" />,
       order: 0,
     });
   }
@@ -95,7 +95,7 @@ export function AssistantToolsSection({
                 className="flex flex-row items-center gap-2"
                 key={action.title}
               >
-                <Avatar icon={action.icon} size="xs" />
+                {action.avatar}
                 <div>{asDisplayName(action.title)}</div>
               </div>
             ))}
@@ -132,21 +132,29 @@ function renderOtherAction(
   mcpServers: MCPServerTypeWithViews[]
 ) {
   if (isDustAppRunConfiguration(action)) {
-    return { title: action.name, icon: CommandIcon, order: 2 };
+    return {
+      title: action.name,
+      avatar: <Avatar icon={CommandIcon} size="xs" />,
+      order: 2,
+    };
   } else if (isProcessConfiguration(action)) {
     return {
       title: "Extract from documents",
-      icon: ScanIcon,
+      avatar: <Avatar icon={ScanIcon} size="xs" />,
       order: 0,
     };
   } else if (isWebsearchConfiguration(action)) {
     return {
       title: "Web Search & Navigation",
-      icon: GlobeAltIcon,
+      avatar: <Avatar icon={GlobeAltIcon} size="xs" />,
       order: 0,
     };
   } else if (isReasoningConfiguration(action)) {
-    return { title: "Reasoning", icon: ChatBubbleThoughtIcon, order: 0 };
+    return {
+      title: "Reasoning",
+      avatar: <Avatar icon={ChatBubbleThoughtIcon} size="xs" />,
+      order: 0,
+    };
   } else if (isPlatformMCPServerConfiguration(action)) {
     const mcpServer = mcpServers.find((s) =>
       s.views.some((v) => v.id === action.mcpServerViewId)
@@ -155,14 +163,18 @@ function renderOtherAction(
       return null;
     }
     const { serverType } = getServerTypeAndIdFromSId(mcpServer.id);
-    const icon = getIcon(mcpServer);
+    const avatar = getAvatar(mcpServer, "xs");
     return {
       title: action.name,
-      icon,
+      avatar,
       order: serverType === "internal" ? 1 : 3,
     };
   } else if (isMCPServerConfiguration(action)) {
-    return { title: action.name, icon: CommandIcon, order: 3 };
+    return {
+      title: action.name,
+      avatar: <Avatar icon={CommandIcon} size="xs" />,
+      order: 3,
+    };
   } else if (isBrowseConfiguration(action)) {
     return null;
   } else if (isRetrievalConfiguration(action)) {

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -89,7 +89,7 @@ import {
   getDefaultMCPServerActionConfiguration,
   isDefaultActionName,
 } from "@app/components/assistant_builder/types";
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -202,10 +202,12 @@ function actionIcon(
     )?.server;
 
     if (server) {
-      return getIcon(server);
+      return getAvatar(server, "xs");
     }
   }
-  return ACTION_SPECIFICATIONS[action.type].cardIcon;
+  return (
+    <Avatar icon={ACTION_SPECIFICATIONS[action.type].cardIcon} size="xs" />
+  );
 }
 
 function actionDisplayName(action: AssistantBuilderActionConfiguration) {
@@ -858,7 +860,7 @@ function ActionCard({
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
-          <Avatar size="xs" icon={actionIcon(action, mcpServerViews)} />
+          {actionIcon(action, mcpServerViews)}
           <div className="w-full truncate">{actionDisplayName(action)}</div>
         </div>
         {isLegacyConfig ? (

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -89,7 +89,7 @@ import {
   getDefaultMCPServerActionConfiguration,
   isDefaultActionName,
 } from "@app/components/assistant_builder/types";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -202,10 +202,10 @@ function actionIcon(
     )?.server;
 
     if (server) {
-      return getVisual(server);
+      return getIcon(server);
     }
   }
-  return React.createElement(ACTION_SPECIFICATIONS[action.type].cardIcon);
+  return ACTION_SPECIFICATIONS[action.type].cardIcon;
 }
 
 function actionDisplayName(action: AssistantBuilderActionConfiguration) {
@@ -858,7 +858,7 @@ function ActionCard({
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
-          <Avatar size="xs" visual={actionIcon(action, mcpServerViews)} />
+          <Avatar size="xs" icon={actionIcon(action, mcpServerViews)} />
           <div className="w-full truncate">{actionDisplayName(action)}</div>
         </div>
         {isLegacyConfig ? (

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Card,
   Label,
   RadioGroup,
@@ -10,7 +9,7 @@ import {
 import React, { useMemo } from "react";
 
 import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
@@ -107,7 +106,7 @@ export function MCPServerSelector({
                               }}
                             >
                               <div className="flex flex-row items-center gap-2">
-                                <Avatar icon={getIcon(mcpServerView.server)} />
+                                {getAvatar(mcpServerView.server)}
                                 <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
                                   <div className="flex flex-col gap-1">
                                     <div className="text-sm font-semibold text-foreground dark:text-foreground-night">

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -10,7 +10,7 @@ import {
 import React, { useMemo } from "react";
 
 import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
@@ -107,9 +107,7 @@ export function MCPServerSelector({
                               }}
                             >
                               <div className="flex flex-row items-center gap-2">
-                                <Avatar
-                                  visual={getVisual(mcpServerView.server)}
-                                />
+                                <Avatar icon={getIcon(mcpServerView.server)} />
                                 <div className="flex flex-grow items-center justify-between overflow-hidden truncate">
                                   <div className="flex flex-col gap-1">
                                     <div className="text-sm font-semibold text-foreground dark:text-foreground-night">

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -1,16 +1,11 @@
-import {
-  Avatar,
-  DataTable,
-  Spinner,
-  usePaginationFromUrl,
-} from "@dust-tt/sparkle";
+import { DataTable, Spinner, usePaginationFromUrl } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import * as React from "react";
 
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
   useAddMCPServerToSpace,
@@ -25,7 +20,7 @@ import SpaceManagedActionsViewsModel from "./SpaceManagedActionsViewsModal";
 type RowData = {
   name: string;
   description: string;
-  icon: React.ComponentType<{ className?: string }>;
+  avatar: React.ReactNode;
   onClick?: () => void;
 };
 
@@ -36,9 +31,7 @@ const getTableColumns = (): ColumnDef<RowData, string>[] => {
       cell: (info: CellContext<RowData, string>) => (
         <DataTable.CellContent>
           <div className="flex flex-row items-center gap-2 py-3">
-            <div>
-              <Avatar icon={info.row.original.icon} />
-            </div>
+            <div>{info.row.original.avatar}</div>
             <div className="flex-grow truncate">{info.getValue()}</div>
           </div>
         </DataTable.CellContent>
@@ -91,7 +84,7 @@ export const SpaceActionsList = ({
       serverViews.map((serverView) => ({
         name: serverView.server.name,
         description: serverView.server.description,
-        icon: getIcon(serverView.server),
+        avatar: getAvatar(serverView.server),
       })) || [],
     [serverViews]
   );

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
   useAddMCPServerToSpace,
@@ -25,7 +25,7 @@ import SpaceManagedActionsViewsModel from "./SpaceManagedActionsViewsModal";
 type RowData = {
   name: string;
   description: string;
-  visual: string | React.ReactNode;
+  icon: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
 };
 
@@ -37,7 +37,7 @@ const getTableColumns = (): ColumnDef<RowData, string>[] => {
         <DataTable.CellContent>
           <div className="flex flex-row items-center gap-2 py-3">
             <div>
-              <Avatar visual={info.row.original.visual} />
+              <Avatar icon={info.row.original.icon} />
             </div>
             <div className="flex-grow truncate">{info.getValue()}</div>
           </div>
@@ -91,7 +91,7 @@ export const SpaceActionsList = ({
       serverViews.map((serverView) => ({
         name: serverView.server.name,
         description: serverView.server.description,
-        visual: getVisual(serverView.server),
+        icon: getIcon(serverView.server),
       })) || [],
     [serverViews]
   );

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -11,7 +10,7 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
@@ -61,7 +60,7 @@ export default function SpaceManagedActionsViewsModel({
               <DropdownMenuItem
                 key={server.id}
                 label={asDisplayName(server.name)}
-                icon={() => <Avatar icon={getIcon(server)} size="xs" />}
+                icon={() => getAvatar(server, "xs")}
                 description={server.description}
                 onClick={() => {
                   onAddServer(server);

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -11,7 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
@@ -61,7 +61,7 @@ export default function SpaceManagedActionsViewsModel({
               <DropdownMenuItem
                 key={server.id}
                 label={asDisplayName(server.name)}
-                icon={() => <Avatar visual={getVisual(server)} size="xs" />}
+                icon={() => <Avatar icon={getIcon(server)} size="xs" />}
                 description={server.description}
                 onClick={() => {
                   onAddServer(server);

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -17,7 +17,7 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
@@ -658,7 +658,7 @@ const SpaceActionItem = ({
     <Tree.Item
       type="leaf"
       label={asDisplayName(action.server.name)}
-      visual={() => <Avatar visual={getVisual(action.server)} size="xs" />}
+      visual={() => <Avatar icon={getIcon(action.server)} size="xs" />}
       areActionsFading={false}
     />
   );

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Button,
   CloudArrowLeftRightIcon,
   CommandLineIcon,
@@ -17,7 +16,7 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
@@ -658,7 +657,7 @@ const SpaceActionItem = ({
     <Tree.Item
       type="leaf"
       label={asDisplayName(action.server.name)}
-      visual={() => <Avatar icon={getIcon(action.server)} size="xs" />}
+      visual={() => getAvatar(action.server, "xs")}
       areActionsFading={false}
     />
   );

--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -20,7 +20,7 @@ import {
 import _ from "lodash";
 import { useState } from "react";
 
-import { getVisual } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { sendRequestActionsAccessEmail } from "@app/lib/email";
 import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_server_views";
@@ -126,7 +126,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                             label={asDisplayName(selectedMcpServer.server.name)}
                             icon={() => (
                               <Avatar
-                                visual={getVisual(selectedMcpServer.server)}
+                                icon={getIcon(selectedMcpServer.server)}
                                 size="xs"
                               />
                             )}
@@ -146,7 +146,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                             key={v.id}
                             label={asDisplayName(v.server.name)}
                             icon={() => (
-                              <Avatar visual={getVisual(v.server)} size="xs" />
+                              <Avatar icon={getIcon(v.server)} size="xs" />
                             )}
                             onClick={() => setSelectedMcpServer(v)}
                           />

--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -20,7 +19,7 @@ import {
 import _ from "lodash";
 import { useState } from "react";
 
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { sendRequestActionsAccessEmail } from "@app/lib/email";
 import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_server_views";
@@ -124,12 +123,9 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                           <Button
                             variant="outline"
                             label={asDisplayName(selectedMcpServer.server.name)}
-                            icon={() => (
-                              <Avatar
-                                icon={getIcon(selectedMcpServer.server)}
-                                size="xs"
-                              />
-                            )}
+                            icon={() =>
+                              getAvatar(selectedMcpServer.server, "xs")
+                            }
                           />
                         ) : (
                           <Button
@@ -145,9 +141,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                           <DropdownMenuItem
                             key={v.id}
                             label={asDisplayName(v.server.name)}
-                            icon={() => (
-                              <Avatar icon={getIcon(v.server)} size="xs" />
-                            )}
+                            icon={() => getAvatar(v.server, "xs")}
                             onClick={() => setSelectedMcpServer(v)}
                           />
                         ))}

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -1,5 +1,7 @@
+import { Avatar } from "@dust-tt/sparkle";
 import { ActionIcons, GithubLogo } from "@dust-tt/sparkle";
 import type React from "react";
+import type { ComponentProps } from "react";
 
 import type { MCPServerType } from "@app/lib/api/mcp";
 
@@ -29,12 +31,13 @@ export const isInternalAllowedIcon = (
   typeof icon === "string" &&
   INTERNAL_ALLOWED_ICONS.includes(icon as InternalAllowedIconType);
 
-export const getIcon = (
-  mcpServer: MCPServerType
-): React.ComponentType<{ className?: string }> => {
+export const getAvatar = (
+  mcpServer: MCPServerType,
+  size: ComponentProps<typeof Avatar>["size"] = "sm"
+): React.ReactNode => {
   if (isRemoteAllowedIconType(mcpServer.icon)) {
-    return ActionIcons[mcpServer.icon];
+    return <Avatar icon={ActionIcons[mcpServer.icon]} size={size} />;
   }
 
-  return InternalActionIcons[mcpServer.icon];
+  return <Avatar icon={InternalActionIcons[mcpServer.icon]} size={size} />;
 };

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -1,24 +1,40 @@
-import { ActionIcons } from "@dust-tt/sparkle";
-import React from "react";
+import { ActionIcons, GithubLogo } from "@dust-tt/sparkle";
+import type React from "react";
 
 import type { MCPServerType } from "@app/lib/api/mcp";
 
 export const DEFAULT_MCP_SERVER_ICON = "ActionCommand1Icon" as const;
 
-export const ALLOWED_ICONS = Object.keys(ActionIcons);
+export const REMOTE_ALLOWED_ICONS = Object.keys(ActionIcons);
 
-export type AllowedIconType = keyof typeof ActionIcons;
+export const InternalActionIcons = {
+  GithubLogo,
+};
 
-export const isAllowedIconType = (icon: string): icon is AllowedIconType =>
-  ALLOWED_ICONS.includes(icon as AllowedIconType);
+export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);
 
-export const isValidIconUrl = (icon: string): icon is `https://${string}` =>
-  icon.startsWith("https://");
+export type RemoteAllowedIconType = keyof typeof ActionIcons;
 
-export const getVisual = (mcpServer: MCPServerType) => {
-  if (isAllowedIconType(mcpServer.visual)) {
-    return React.createElement(ActionIcons[mcpServer.visual]);
+export const isRemoteAllowedIconType = (
+  icon: string
+): icon is RemoteAllowedIconType =>
+  typeof icon === "string" &&
+  REMOTE_ALLOWED_ICONS.includes(icon as RemoteAllowedIconType);
+
+export type InternalAllowedIconType = keyof typeof InternalActionIcons;
+
+export const isInternalAllowedIcon = (
+  icon: string
+): icon is InternalAllowedIconType =>
+  typeof icon === "string" &&
+  INTERNAL_ALLOWED_ICONS.includes(icon as InternalAllowedIconType);
+
+export const getIcon = (
+  mcpServer: MCPServerType
+): React.ComponentType<{ className?: string }> => {
+  if (isRemoteAllowedIconType(mcpServer.icon)) {
+    return ActionIcons[mcpServer.icon];
   }
 
-  return mcpServer.visual;
+  return InternalActionIcons[mcpServer.icon];
 };

--- a/front/lib/actions/mcp_internal_actions/servers/authentication_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/authentication_debugger.ts
@@ -14,7 +14,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     provider,
     use_case: "connection" as const,
   },
-  visual: "https://dust.tt/static/droidavatar/Droid_Green_1.jpg",
+  icon: "GithubLogo",
 };
 
 const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/child_agent_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/child_agent_debugger.ts
@@ -14,7 +14,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   name: "child_agent_debugger",
   version: "1.0.0",
   description: "Demo server showing a basic interaction with a child agent.",
-  visual: "https://dust.tt/static/droidavatar/Droid_Purple_2.jpg",
+  icon: "GithubLogo",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_debugger.ts
@@ -19,7 +19,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with a data source configuration.",
-  visual: "https://dust.tt/static/droidavatar/Droid_Yellow_3.jpg",
+  icon: "GithubLogo",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/file_generator.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generator.ts
@@ -15,7 +15,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description: "Generate and convert files on demand.",
   authorization: null,
-  visual: "https://dust.tt/static/spiritavatar/Spirit_Cream_3.jpg",
+  icon: "GithubLogo",
 };
 
 const OUTPUT_FORMATS = [

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -17,7 +17,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     provider: "github" as const,
     use_case: "platform_actions" as const,
   },
-  visual: "https://dust.tt/static/systemavatar/github_avatar_full.png",
+  icon: "GithubLogo",
 };
 
 const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/image_generator.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generator.ts
@@ -10,7 +10,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   name: "image_generator",
   version: "1.0.0",
   description: "Generate images with Dall-E v3.",
-  visual: "https://dust.tt/static/spiritavatar/Spirit_Black_2.jpg",
+  icon: "GithubLogo",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -10,7 +10,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with various configurable blocks.",
-  visual: "https://dust.tt/static/spiritavatar/Spirit_Green_2.jpg",
+  icon: "GithubLogo",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/tables_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_debugger.ts
@@ -10,7 +10,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description:
     "Demo server showing a basic interaction with a table configuration.",
-  visual: "https://dust.tt/static/droidavatar/Droid_Indigo_1.jpg",
+  icon: "GithubLogo",
   authorization: null,
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -14,7 +14,7 @@ export const serverInfo: MCPServerDefinitionType = {
   version: "1.0.0",
   description:
     "Agent can search (Google) and retrieve information from specific websites.",
-  visual: "https://dust.tt/static/droidavatar/Droid_Teal_7.jpg",
+  icon: "GithubLogo",
   authorization: {
     provider,
     use_case: "connection" as const,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -14,8 +14,8 @@ import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
   DEFAULT_MCP_SERVER_ICON,
-  isAllowedIconType,
-  isValidIconUrl,
+  isInternalAllowedIcon,
+  isRemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_local";
@@ -185,11 +185,11 @@ export function extractMetadataFromServerVersion(
         "description" in r && typeof r.description === "string" && r.description
           ? r.description
           : DEFAULT_MCP_ACTION_DESCRIPTION,
-      visual:
-        "visual" in r &&
-        typeof r.visual === "string" &&
-        (isAllowedIconType(r.visual) || isValidIconUrl(r.visual))
-          ? r.visual
+      icon:
+        "icon" in r &&
+        typeof r.icon === "string" &&
+        (isRemoteAllowedIconType(r.icon) || isInternalAllowedIcon(r.icon))
+          ? r.icon
           : DEFAULT_MCP_SERVER_ICON,
     };
   }
@@ -198,7 +198,7 @@ export function extractMetadataFromServerVersion(
     name: DEFAULT_MCP_ACTION_NAME,
     version: DEFAULT_MCP_ACTION_VERSION,
     description: DEFAULT_MCP_ACTION_DESCRIPTION,
-    visual: DEFAULT_MCP_SERVER_ICON,
+    icon: DEFAULT_MCP_SERVER_ICON,
     authorization: null,
   };
 }

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -1,7 +1,10 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import type { AllowedIconType } from "@app/lib/actions/mcp_icons";
+import type {
+  InternalAllowedIconType,
+  RemoteAllowedIconType,
+} from "@app/lib/actions/mcp_icons";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { EditedByUser } from "@app/types";
@@ -26,7 +29,7 @@ export type MCPServerType = {
   name: string;
   version: string;
   description: string;
-  visual: AllowedIconType | `https://${string}`;
+  icon: RemoteAllowedIconType | InternalAllowedIconType;
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   isDefault: boolean;
@@ -38,7 +41,7 @@ export type RemoteMCPServerType = MCPServerType & {
   cachedDescription?: string | null;
   sharedSecret?: string;
   lastSyncAt?: Date | null;
-  visual: AllowedIconType; // We enforce that we pass an icon here (among the ones we allow).
+  icon: RemoteAllowedIconType; // We enforce that we pass an icon here (among the ones we allow).
 };
 
 export interface MCPServerViewType {
@@ -57,7 +60,7 @@ export type MCPServerDefinitionType = Omit<
 
 type InternalMCPServerType = MCPServerType & {
   name: InternalMCPServerNameType;
-  visual: `https://${string}`; // We enforce that we pass a URL here.
+  icon: InternalAllowedIconType; // We enforce that we pass an icon here.
 };
 
 export type InternalMCPServerDefinitionType = Omit<

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -2,7 +2,7 @@ import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { DEFAULT_MCP_ACTION_VERSION } from "@app/lib/actions/constants";
-import type { AllowedIconType } from "@app/lib/actions/mcp_icons";
+import type { RemoteAllowedIconType } from "@app/lib/actions/mcp_icons";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { MCPToolType } from "@app/lib/api/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -15,7 +15,7 @@ export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerMod
   declare url: string;
   declare name: string;
   declare description: string;
-  declare icon: AllowedIconType;
+  declare icon: RemoteAllowedIconType;
   declare version: string;
 
   declare cachedName: string;

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -243,7 +243,6 @@ export class InternalMCPServerInMemoryResource {
 
   // Serialization.
   toJSON(): MCPServerType {
-    console.log(this.metadata);
     return {
       id: this.id,
       ...this.metadata,

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -243,6 +243,7 @@ export class InternalMCPServerInMemoryResource {
 
   // Serialization.
   toJSON(): MCPServerType {
+    console.log(this.metadata);
     return {
       id: this.id,
       ...this.metadata,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_MCP_ACTION_NAME,
 } from "@app/lib/actions/constants";
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
-import type { AllowedIconType } from "@app/lib/actions/mcp_icons";
+import type { RemoteAllowedIconType } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
@@ -239,7 +239,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     }: {
       name?: string;
       description?: string;
-      icon?: AllowedIconType;
+      icon?: RemoteAllowedIconType;
       sharedSecret?: string;
       cachedName?: string;
       cachedDescription?: string;
@@ -283,7 +283,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       name: this.name,
       description: this.description,
       version: this.version,
-      visual: this.icon,
+      icon: this.icon,
       tools: this.cachedTools,
 
       cachedName: this.cachedName,

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -5,7 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import {
   DEFAULT_MCP_SERVER_ICON,
-  isAllowedIconType,
+  isRemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
@@ -131,8 +131,8 @@ async function handler(
           cachedName: metadata.name,
           cachedDescription: metadata.description,
           cachedTools: metadata.tools,
-          icon: isAllowedIconType(metadata.visual)
-            ? metadata.visual
+          icon: isRemoteAllowedIconType(metadata.icon)
+            ? metadata.icon
             : DEFAULT_MCP_SERVER_ICON,
           version: metadata.version,
         });


### PR DESCRIPTION
## Description

We'll use avatar + icon & background for internal actions, not images.
- We directly return an avatar, not an icon, so that we can eventually add a bgcolor
- The list of allowed icon need to be in an object that will be available to the client ( `InternalActionIcons` ). Icon is then referenced by name in internal action metadata. This is not ideal, but we can't put an component type here as it won't be serialized to the client. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy front