### PR TITLE
Add: ability to include generated images in the conversation.

### DIFF
--- a/core/src/providers/chat_messages.rs
+++ b/core/src/providers/chat_messages.rs
@@ -89,7 +89,7 @@ pub struct AssistantChatMessage {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct FunctionChatMessage {
-    pub content: String,
+    pub content: ContentBlock,
     pub function_call_id: String,
     pub name: Option<String>,
     pub role: ChatMessageRole,

--- a/core/src/providers/helpers.rs
+++ b/core/src/providers/helpers.rs
@@ -1,5 +1,5 @@
 use super::{
-    chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, UserChatMessage},
+    chat_messages::{AssistantChatMessage, ChatMessage, UserChatMessage},
     llm::ChatMessageRole,
 };
 
@@ -44,7 +44,7 @@ pub fn strip_tools_from_chat_history(messages: &Vec<ChatMessage>) -> Vec<ChatMes
             }
             ChatMessage::Function(message) => {
                 new_messages.push(ChatMessage::User(UserChatMessage {
-                    content: ContentBlock::Text(message.content.clone()),
+                    content: message.content.clone(),
                     role: ChatMessageRole::User,
                     name: message.name.clone(),
                 }));

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -366,7 +366,10 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
             if (m.role === "function") {
               return {
                 ...m,
-                content: m.content.slice(0, 200) + "...",
+                content:
+                  typeof m.content === "string"
+                    ? m.content.slice(0, 200) + "..."
+                    : m.content,
               };
             }
             return m;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -510,10 +510,15 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         c.resource.mimeType &&
         isSupportedFileContentType(c.resource.mimeType)
       ) {
+        const fileName =
+          "name" in c.resource && typeof c.resource.name === "string"
+            ? c.resource.name
+            : c.resource.uri.split("/").pop() ?? "generated-file";
+
         const r = await processAndStoreFromUrl(auth, {
           url: c.resource.uri,
           useCase: "conversation",
-          fileName: c.resource.uri.split("/").pop() ?? "generated-file",
+          fileName,
           contentType: c.resource.mimeType,
         });
         if (r.isErr()) {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -12,6 +12,7 @@ import {
   augmentInputsWithConfiguration,
   hideInternalConfiguration,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { isResourceWithName } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getMCPEvents } from "@app/lib/actions/pubsub";
 import type { DataSourceConfiguration } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
@@ -510,10 +511,11 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         c.resource.mimeType &&
         isSupportedFileContentType(c.resource.mimeType)
       ) {
-        const fileName =
-          "name" in c.resource && typeof c.resource.name === "string"
-            ? c.resource.name
-            : c.resource.uri.split("/").pop() ?? "generated-file";
+        let fileName = c.resource.uri.split("/").pop() ?? "generated-file";
+
+        if (isResourceWithName(c.resource)) {
+          fileName = c.resource.name;
+        }
 
         const r = await processAndStoreFromUrl(auth, {
           url: c.resource.uri,

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -1,0 +1,9 @@
+type ResourceWithName = {
+  name: string;
+};
+
+export const isResourceWithName = (
+  resource: object
+): resource is ResourceWithName => {
+  return "name" in resource && typeof resource.name === "string";
+};

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -33,6 +33,12 @@ const createServer = (auth: Authenticator): McpServer => {
         .describe(
           "A text description of the desired image(s). The maximum length is 4000 characters."
         ),
+      name: z
+        .string()
+        .max(32)
+        .describe(
+          "The name of the image. The maximum length is 32 characters."
+        ),
       quality: z
         .enum(["standard", "hd"])
         .optional()
@@ -55,7 +61,7 @@ const createServer = (auth: Authenticator): McpServer => {
           "The size of the generated images. Must be one of 1024x1024, 1792x1024, or 1024x1792"
         ),
     },
-    async ({ prompt, quality, style, size }) => {
+    async ({ prompt, name, quality, style, size }) => {
       // Crude way to rate limit the usage of the image generation tool.
       //
       const remaining = await rateLimiter({
@@ -92,12 +98,15 @@ const createServer = (auth: Authenticator): McpServer => {
         user: `workspace-${auth.getNonNullableWorkspace().sId}`,
       });
 
+      const fileName = name + ".png";
+
       const content = images.data.map((image) => ({
         type: "resource" as const,
         resource: {
           mimeType: "image/png",
           uri: image.url!,
-          text: `Your image was generated successfully.`,
+          text: `Your image ${fileName} was generated successfully.`,
+          name: fileName,
         },
       }));
 

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -25,10 +25,6 @@ import {
 function isConversationIncludableFileContentType(
   contentType: SupportedContentFragmentType
 ): boolean {
-  // We allow including everything except images.
-  if (isSupportedImageContentType(contentType)) {
-    return false;
-  }
   if (isDustMimeType(contentType)) {
     return isIncludableInternalMimeType(contentType);
   }

--- a/front/lib/api/assistant/utils.ts
+++ b/front/lib/api/assistant/utils.ts
@@ -6,12 +6,16 @@ export function getTextContentFromMessage(
 ): string {
   const { content } = message;
 
+  if (!content) {
+    return "";
+  }
+
   if (typeof content === "string") {
     return content;
   }
 
-  if (!content) {
-    return "";
+  if (isImageContent(content)) {
+    return content.image_url.url;
   }
 
   return content

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -19,7 +19,7 @@ export interface ImageContent {
   };
 }
 
-interface TextContent {
+export interface TextContent {
   type: "text";
   text: string;
 }
@@ -71,7 +71,7 @@ export interface FunctionMessageTypeModel {
   role: "function";
   name: string;
   function_call_id: string;
-  content: string;
+  content: string | Content[];
 }
 
 export type ModelMessageTypeMultiActions =


### PR DESCRIPTION
## Description

Added support to include images in the conversation.
- Expand function call return value type to include structured output (supported by claude and required for it to see images).
- Make images "includable".
- Improve handling of tool results by supporting structured output for claude.
- OpenAI do not support structured output but figure out what to do with the image url in the text content.

## Tests

Did several tests, also checked that it still directly read images when they are submitted by the user.

## Risk

Medium, but the API is backward compatible.

## Deploy Plan

Deploy `core` then `front`