### PR TITLE
[core] Avoid call to table_type

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -232,7 +232,7 @@ impl Table {
         databases_store: Box<dyn DatabasesStore + Sync + Send>,
         search_store: Option<Box<dyn SearchStore + Sync + Send>>,
     ) -> Result<()> {
-        if self.table_type()? == TableType::Local {
+        if self.remote_database_table_id().is_none() {
             // Invalidate the databases that use the table.
             try_join_all(
                 (store


### PR DESCRIPTION
## Description

Quick fix to unstick datasource deletion : for remote table table_type() returns a RemoteTable object that require connectionId, which is not set here for salesforce personal connections when trying to delete it

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy core
