### PR TITLE
[Discovery] Editors endpoint

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -76,6 +76,7 @@ import type {
   AgentsGetViewType,
   AgentStatus,
   LightAgentConfigurationType,
+  ModelIdType,
   Result,
   WorkspaceType,
 } from "@app/types";
@@ -87,6 +88,7 @@ import {
   MAX_STEPS_USE_PER_RUN_LIMIT,
   Ok,
   removeNulls,
+  UserType,
 } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
@@ -1584,6 +1586,114 @@ export async function removeGroupFromAgentConfiguration({
 
     return new Ok(undefined);
   } catch (error) {
+    return new Err(error as Error);
+  }
+}
+
+/**
+ * Fetches the editor group associated with an agent configuration.
+ */
+export async function getAgentEditorGroup(
+  auth: Authenticator,
+  agentConfigurationId: ModelIdType
+): Promise<Result<GroupResource, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const agent = await AgentConfiguration.findByPk(agentConfigurationId, {
+    attributes: ["id"], // Only need the ID for the join query
+  });
+
+  if (!agent) {
+    return new Err(new Error("Agent configuration not found."));
+  }
+
+  const groupAgent = await GroupAgentModel.findOne({
+    where: {
+      agentConfigurationId: agent.id,
+      workspaceId: owner.id,
+    },
+  });
+
+  if (!groupAgent) {
+    return new Err(new Error("Editor group association not found for agent."));
+  }
+
+  const group = await GroupResource.fetchById(
+    auth,
+    GroupResource.modelIdToSId({
+      id: groupAgent.groupId,
+      workspaceId: owner.id,
+    })
+  );
+
+  if (group.isErr()) {
+    return new Err(
+      new Error(`Failed to fetch editor group: ${group.error.message}`)
+    );
+  }
+
+  if (group.value.kind !== "agent_editors") {
+    return new Err(
+      new Error("Associated group is not an agent_editors group.")
+    );
+  }
+
+  return group;
+}
+
+/**
+ * Updates the permissions (editors) for an agent configuration.
+ */
+export async function updateAgentPermissions(
+  auth: Authenticator,
+  {
+    agent,
+    usersToAdd,
+    usersToRemove,
+  }: {
+    agent: LightAgentConfigurationType;
+    usersToAdd: UserType[];
+    usersToRemove: UserType[];
+  }
+): Promise<Result<undefined, Error>> {
+  const editorGroupRes = await getAgentEditorGroup(auth, agent.id);
+  if (editorGroupRes.isErr()) {
+    return editorGroupRes;
+  }
+  const editorGroup = editorGroupRes.value;
+
+  // The canWrite check for agent_editors groups (allowing members and admins)
+  // is implicitly handled by addMembers and removeMembers.
+  try {
+    const result = await frontSequelize.transaction(async (t) => {
+      if (usersToAdd.length > 0) {
+        const addRes = await editorGroup.addMembers(auth, usersToAdd, {
+          transaction: t,
+        });
+        if (addRes.isErr()) {
+          // Throw error to trigger rollback
+          throw new Error(
+            `Failed to add agent editors: ${addRes.error.message}`
+          );
+        }
+      }
+
+      if (usersToRemove.length > 0) {
+        const removeRes = await editorGroup.removeMembers(auth, usersToRemove, {
+          transaction: t,
+        });
+        if (removeRes.isErr()) {
+          // Throw error to trigger rollback
+          throw new Error(
+            `Failed to remove agent editors: ${removeRes.error.message}`
+          );
+        }
+      }
+      return new Ok(undefined);
+    });
+    return result;
+  } catch (error) {
+    // Catch errors thrown from within the transaction
     return new Err(error as Error);
   }
 }

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1621,10 +1621,7 @@ export async function updateAgentPermissions(
           transaction: t,
         });
         if (addRes.isErr()) {
-          // Throw error to trigger rollback
-          throw new Error(
-            `Failed to add agent editors: ${addRes.error.message}`
-          );
+          return addRes;
         }
       }
 
@@ -1637,10 +1634,7 @@ export async function updateAgentPermissions(
           }
         );
         if (removeRes.isErr()) {
-          // Throw error to trigger rollback
-          throw new Error(
-            `Failed to remove agent editors: ${removeRes.error.message}`
-          );
+          return removeRes;
         }
       }
       return new Ok(undefined);

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1604,7 +1604,6 @@ export async function updateAgentPermissions(
     usersToRemove: UserType[];
   }
 ): Promise<Result<undefined, Error>> {
-  // Use the new static method from GroupResource, passing the agent object
   const editorGroupRes = await GroupResource.findEditorGroupForAgent(
     auth,
     agent

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -689,12 +689,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    // Users can only be added to regular groups.
-    if (this.kind !== "regular") {
+    if (this.kind !== "regular" && this.kind !== "agent_editors") {
       return new Err(
         new DustError(
           "system_or_global_group",
-          "Users can only be added to regular groups."
+          "Users can only be removed from regular or agent_editors groups."
         )
       );
     }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -32,6 +32,7 @@ import type {
   ModelId,
   ResourcePermission,
   Result,
+  RolePermission,
   UserType,
 } from "@app/types";
 import { Err, Ok, removeNulls } from "@app/types";
@@ -855,11 +856,19 @@ export class GroupResource extends BaseResource<GroupModel> {
    *
    * For agent_editors groups, the permissions are:
    * 1. Group-based: The group's members get read and write access
-   * 2. Role-based: Workspace admins get read and write access
+   * 2. Role-based: Workspace admins get read and write access. All users can
+   *    read "agent_editors" groups.
    *
-   * @returns Array of ResourcePermission objects defining the default access configuration
+   * @returns Array of ResourcePermission objects defining the default access
+   * configuration
    */
   requestedPermissions(): ResourcePermission[] {
+    const userReadPermissions: RolePermission[] = [
+      {
+        role: "user",
+        permissions: ["read"],
+      },
+    ];
     return [
       {
         groups: [
@@ -869,7 +878,10 @@ export class GroupResource extends BaseResource<GroupModel> {
               this.kind === "agent_editors" ? ["read", "write"] : ["read"],
           },
         ],
-        roles: [{ role: "admin", permissions: ["read", "write", "admin"] }],
+        roles: [
+          { role: "admin", permissions: ["read", "write", "admin"] },
+          ...(this.kind === "agent_editors" ? userReadPermissions : []),
+        ],
         workspaceId: this.workspaceId,
       },
     ];

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -451,7 +451,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   static async listUserGroupsInWorkspace({
     user,
     workspace,
-    groupKinds = ["global", "regular"],
+    groupKinds = ["global", "regular", "agent_editors"],
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -590,8 +590,8 @@ export class GroupResource extends BaseResource<GroupModel> {
         new DustError(
           "user_not_member",
           userIds.length === 1
-            ? "User is not a member of the workspace"
-            : "Users are not members of the workspace"
+            ? "Cannot add: user is not a member of the workspace"
+            : "Cannot add: users are not members of the workspace"
         )
       );
     }
@@ -617,8 +617,8 @@ export class GroupResource extends BaseResource<GroupModel> {
         new DustError(
           "user_already_member",
           alreadyActiveUserIds.length === 1
-            ? "User is already a member of the group"
-            : "Users are already members of the group"
+            ? "Cannot add: user is already a member of the group"
+            : "Cannot add: users are already members of the group"
         )
       );
     }
@@ -683,8 +683,8 @@ export class GroupResource extends BaseResource<GroupModel> {
         new DustError(
           "user_not_member",
           userIds.length === 1
-            ? "User is not a member of the workspace"
-            : "Users are not members of the workspace"
+            ? "Cannot remove: user is not a member of the workspace"
+            : "Cannot remove: users are not members of the workspace"
         )
       );
     }
@@ -709,8 +709,8 @@ export class GroupResource extends BaseResource<GroupModel> {
         new DustError(
           "user_not_member",
           notActiveUserIds.length === 1
-            ? "User is not a member of the group"
-            : "Users are not members of the group"
+            ? "Cannot remove: user is not a member of the group"
+            : "Cannot remove: users are not members of the group"
         )
       );
     }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -147,12 +147,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     );
 
     if (group.isErr()) {
-      // Propagate the error from fetchById (which could be not found or auth error)
       return group;
     }
 
     if (group.value.kind !== "agent_editors") {
       // Should not happen based on creation logic, but good to check.
+      // Might change when we allow other group kinds to be associated with agents.
       return new Err(
         new Error("Associated group is not an agent_editors group.")
       );
@@ -554,7 +554,10 @@ export class GroupResource extends BaseResource<GroupModel> {
   ): Promise<Result<undefined, DustError>> {
     if (!this.canWrite(auth)) {
       return new Err(
-        new DustError("unauthorized", "Only `admins` can administer groups")
+        new DustError(
+          "unauthorized",
+          "Only admins or group editors can change group members"
+        )
       );
     }
     const owner = auth.getNonNullableWorkspace();
@@ -648,7 +651,10 @@ export class GroupResource extends BaseResource<GroupModel> {
   ): Promise<Result<undefined, DustError>> {
     if (!this.canWrite(auth)) {
       return new Err(
-        new DustError("unauthorized", "Only `admins` can administer groups")
+        new DustError(
+          "unauthorized",
+          "Only admins or group editors can change group members"
+        )
       );
     }
     const owner = auth.getNonNullableWorkspace();

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -859,6 +859,10 @@ export class GroupResource extends BaseResource<GroupModel> {
    * 2. Role-based: Workspace admins get read and write access. All users can
    *    read "agent_editors" groups.
    *
+   * CAUTION: if / when editing, note that for role permissions, permissions are
+   * NOT inherited, i.e. if you set a permission for role "user", an "admin"
+   * will NOT have it
+   *
    * @returns Array of ResourcePermission objects defining the default access
    * configuration
    */
@@ -866,6 +870,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     const userReadPermissions: RolePermission[] = [
       {
         role: "user",
+        permissions: ["read"],
+      },
+      {
+        role: "builder",
         permissions: ["read"],
       },
     ];

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -125,7 +125,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   ): Promise<Result<GroupResource, Error>> {
     const owner = auth.getNonNullableWorkspace();
 
-    const groupAgent = await GroupAgentModel.findOne({
+    const groupAgents = await GroupAgentModel.findAll({
       where: {
         agentConfigurationId: agent.id,
         workspaceId: owner.id,
@@ -133,11 +133,19 @@ export class GroupResource extends BaseResource<GroupModel> {
       attributes: ["groupId"],
     });
 
-    if (!groupAgent) {
+    if (groupAgents.length === 0) {
       return new Err(
         new Error("Editor group association not found for agent.")
       );
     }
+
+    if (groupAgents.length > 1) {
+      return new Err(
+        new Error("Multiple editor group associations found for agent.")
+      );
+    }
+
+    const groupAgent = groupAgents[0];
 
     const group = await GroupResource.fetchById(
       auth,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -90,8 +90,8 @@ async function setupTest(
     method: method,
   });
   const requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    String(requestUser.id),
-    String(workspace.id)
+    requestUser.sId,
+    workspace.sId
   );
 
   // Create agent owner (might be the same as requestUser or different)
@@ -106,8 +106,8 @@ async function setupTest(
     agentOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, agentOwner, agentOwnerRole);
     agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      String(agentOwner.id),
-      String(workspace.id)
+      agentOwner.sId,
+      workspace.sId
     );
   }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -1,5 +1,5 @@
 import type { RequestMethod } from "node-mocks-http";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createAgentConfiguration,
@@ -206,7 +206,7 @@ describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () => 
 });
 
 describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () => {
-  it("admin should successfully add an editor", async (t) => {
+  it("admin should successfully add an editor", async () => {
     const { req, res, workspace, agentOwner } = await setupTest({
       requestUserRole: "admin",
       method: "PATCH",
@@ -226,7 +226,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     expect(editorIds).toContain(newEditor.sId);
   });
 
-  it("admin should successfully remove an editor", async (t) => {
+  it("admin should successfully remove an editor", async () => {
     const { req, res, workspace, agent, agentOwner } = await setupTest({
       requestUserRole: "admin",
       method: "PATCH",
@@ -255,7 +255,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     expect(data.editors[0].sId).toBe(editorToRemove.sId);
   });
 
-  it("editor should successfully add another editor", async (t) => {
+  it("editor should successfully add another editor", async () => {
     const { req, res, workspace, agentOwner } = await setupTest({
       agentOwnerRole: "builder", // Make agent owner a builder
       requestUserRole: "builder",
@@ -319,10 +319,11 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     req.body = { addEditorIds: ["some_user_sid"] }; // Body doesn't matter, auth fails first
 
     await handler(req, res);
+    console.log("res", res._getJSONData());
     expect(res._getStatusCode()).toBe(403);
     expect(res._getJSONData()).toEqual({
       error: {
-        type: "agent_configuration_auth_error",
+        type: "agent_group_permission_error",
         message:
           "Only editors of the agent or workspace admins can modify editors.",
       },

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -1,0 +1,523 @@
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect } from "vitest";
+
+import {
+  createAgentConfiguration,
+  updateAgentPermissions,
+} from "@app/lib/api/assistant/configuration";
+import { Authenticator } from "@app/lib/auth";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+import type {
+  LightAgentConfigurationType,
+  ModelIdType,
+  ModelProviderIdType,
+  UserType,
+} from "@app/types";
+
+import handler from "./editors";
+
+// Helper to create a test agent configuration
+async function createTestAgent(
+  auth: Authenticator,
+  overrides: Partial<{
+    name: string;
+    description: string;
+    scope: Exclude<LightAgentConfigurationType["scope"], "global">;
+    model: {
+      providerId: ModelProviderIdType;
+      modelId: ModelIdType;
+      temperature?: number;
+    };
+  }> = {}
+): Promise<LightAgentConfigurationType> {
+  const name = overrides.name ?? "Test Agent";
+  const description = overrides.description ?? "Test Agent Description";
+  const scope = overrides.scope ?? "workspace";
+  const providerId = overrides.model?.providerId ?? "openai";
+  const modelId = overrides.model?.modelId ?? "gpt-4-turbo";
+  const temperature = overrides.model?.temperature ?? 0.7;
+
+  const result = await createAgentConfiguration(auth, {
+    name,
+    description,
+    instructions: "Test Instructions",
+    maxStepsPerRun: 5,
+    visualizationEnabled: false,
+    pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+    status: "active",
+    scope,
+    model: {
+      providerId,
+      modelId,
+      temperature,
+    },
+    templateId: null,
+    requestedGroupIds: [], // Let createAgentConfiguration handle group creation
+    tags: [], // Added missing tags property
+  });
+
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  return result.value;
+}
+
+async function setupTest(
+  t: any,
+  options: {
+    agentOwnerRole?: "admin" | "builder" | "user";
+    requestUserRole?: "admin" | "builder" | "user";
+    method?: RequestMethod;
+  } = {}
+) {
+  const agentOwnerRole = options.agentOwnerRole ?? "admin";
+  const requestUserRole = options.requestUserRole ?? "admin";
+  const method = options.method ?? "GET";
+
+  // Create workspace, requesting user and auth based on requestUserRole
+  const {
+    req,
+    res,
+    workspace,
+    user: requestUser,
+  } = await createPrivateApiMockRequest({
+    role: requestUserRole,
+    method: method,
+  });
+  const requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    String(requestUser.id),
+    String(workspace.id)
+  );
+
+  // Create agent owner (might be the same as requestUser or different)
+  let agentOwner: UserResource;
+  let agentOwnerAuth: Authenticator;
+  if (requestUserRole === agentOwnerRole) {
+    // If roles match, assume owner is the request user for simplicity in most tests
+    // Specific tests requiring distinct owner/requestor will need custom setup
+    agentOwner = requestUser;
+    agentOwnerAuth = requestUserAuth;
+  } else {
+    agentOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, agentOwner, agentOwnerRole);
+    agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      String(agentOwner.id),
+      String(workspace.id)
+    );
+  }
+
+  // Create agent owned by agentOwner
+  const agent = await createTestAgent(agentOwnerAuth);
+
+  // Set up query parameters for the agent
+  req.query = { ...req.query, wId: workspace.sId, aId: agent.sId };
+
+  return {
+    req,
+    res,
+    workspace,
+    agentOwner,
+    agent,
+    requestUser, // This is the user making the request
+    requestUserAuth,
+    requestUserRole,
+  };
+}
+
+describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () => {
+  itInTransaction(
+    "should return 200 and the editor list for admin",
+    async (t) => {
+      const { req, res, agentOwner } = await setupTest(t, {
+        requestUserRole: "admin",
+      });
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data).toHaveProperty("editors");
+      expect(data.editors).toBeInstanceOf(Array);
+      expect(data.editors).toHaveLength(1); // Agent owner is the default editor
+      expect(data.editors[0].id).toBe(agentOwner.id);
+    }
+  );
+
+  itInTransaction(
+    "should return 200 and the editor list for editor",
+    async (t) => {
+      const { req, res, agentOwner } = await setupTest(t, {
+        agentOwnerRole: "builder",
+        requestUserRole: "builder",
+      });
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.editors).toHaveLength(1);
+      expect(data.editors[0].id).toBe(agentOwner.id);
+    }
+  );
+
+  itInTransaction("should return 403 for non-editor builder", async (t) => {
+    const { req, res } = await setupTest(t, {
+      requestUserRole: "builder",
+    });
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    // Assuming canRead requires editor/admin status
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "agent_configuration_auth_error", // Or could be 404 depending on perm check
+        message:
+          "Only editors of the agent or workspace admins can view or modify editors.",
+      },
+    });
+  });
+
+  itInTransaction("should return 403 for non-editor user", async (t) => {
+    const { req, res } = await setupTest(t, {
+      requestUserRole: "user",
+    });
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "agent_configuration_auth_error", // Or could be 404 depending on perm check
+        message:
+          "Only editors of the agent or workspace admins can view or modify editors.",
+      },
+    });
+  });
+
+  itInTransaction("should return 404 for non-existent agent", async (t) => {
+    const { req, res } = await setupTest(t);
+    req.query.aId = "non_existent_agent_sid";
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration was not found.",
+      },
+    });
+  });
+});
+
+describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () => {
+  itInTransaction("admin should successfully add an editor", async (t) => {
+    const { req, res, workspace, agent, agentOwner } = await setupTest(t, {
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    const newEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, newEditor, "builder");
+
+    req.body = { addEditorIds: [newEditor.sId] };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.editors).toHaveLength(2);
+    const editorIds = data.editors.map((e: UserType) => e.sId);
+    expect(editorIds).toContain(agentOwner.sId);
+    expect(editorIds).toContain(newEditor.sId);
+  });
+
+  itInTransaction("admin should successfully remove an editor", async (t) => {
+    const { req, res, workspace, agent, agentOwner } = await setupTest(t, {
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    // Add another editor first
+    const editorToRemove = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, editorToRemove, "builder");
+    const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      String(agentOwner.id),
+      String(workspace.id)
+    );
+    await updateAgentPermissions(agentOwnerAuth, {
+      agent,
+      usersToAdd: [editorToRemove.toJSON()],
+      usersToRemove: [],
+    });
+
+    // Now remove the agent owner (original editor)
+    req.body = { removeEditorIds: [agentOwner.sId] };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.editors).toHaveLength(1);
+    expect(data.editors[0].sId).toBe(editorToRemove.sId);
+  });
+
+  itInTransaction(
+    "editor should successfully add another editor",
+    async (t) => {
+      const { req, res, workspace, agent, agentOwner } = await setupTest(t, {
+        agentOwnerRole: "builder", // Make agent owner a builder
+        requestUserRole: "builder",
+        method: "PATCH",
+      });
+
+      const newEditor = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, newEditor, "user");
+
+      req.body = { addEditorIds: [newEditor.sId] };
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.editors).toHaveLength(2);
+      const editorIds = data.editors.map((e: UserType) => e.sId);
+      expect(editorIds).toContain(agentOwner.sId);
+      expect(editorIds).toContain(newEditor.sId);
+    }
+  );
+
+  itInTransaction(
+    "editor should successfully remove another editor",
+    async (t) => {
+      const { req, res, workspace, agent, agentOwner, requestUser } =
+        await setupTest(t, {
+          agentOwnerRole: "builder", // Make agent owner a builder
+          requestUserRole: "builder",
+          method: "PATCH",
+        });
+
+      // Add another editor first
+      const editorToRemove = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, editorToRemove, "admin");
+      const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        String(requestUser.id),
+        String(workspace.id)
+      );
+      await updateAgentPermissions(agentOwnerAuth, {
+        agent,
+        usersToAdd: [editorToRemove.toJSON()],
+        usersToRemove: [],
+      });
+
+      // Now remove the added editor
+      req.body = { removeEditorIds: [editorToRemove.sId] };
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.editors).toHaveLength(1);
+      expect(data.editors[0].sId).toBe(agentOwner.sId); // Only original editor remains
+    }
+  );
+
+  itInTransaction("should return 403 for non-editor user", async (t) => {
+    const { req, res } = await setupTest(t, {
+      requestUserRole: "user",
+      method: "PATCH",
+    });
+
+    req.body = { addEditorIds: ["some_user_sid"] }; // Body doesn't matter, auth fails first
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "agent_configuration_auth_error",
+        message:
+          "Only editors of the agent or workspace admins can modify editors.",
+      },
+    });
+  });
+
+  itInTransaction(
+    "should return 400 when adding existing editor",
+    async (t) => {
+      const { req, res, agentOwner } = await setupTest(t, {
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
+
+      req.body = { addEditorIds: [agentOwner.sId] }; // Try to re-add owner
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "invalid_request_error",
+          message:
+            "Failed to add agent editors: User is already a member of the group",
+        },
+      });
+    }
+  );
+
+  itInTransaction("should return 400 when removing non-editor", async (t) => {
+    const { req, res, workspace } = await setupTest(t, {
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    const nonEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, nonEditor, "user");
+
+    req.body = { removeEditorIds: [nonEditor.sId] };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "Failed to remove agent editors: User is not a member of the group",
+      },
+    });
+  });
+
+  itInTransaction(
+    "should return 404 when adding non-existent user",
+    async (t) => {
+      const { req, res } = await setupTest(t, {
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
+
+      req.body = { addEditorIds: ["user_not_exists_sid"] };
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "user_not_found",
+          message: "Some users were not found: user_not_exists_sid",
+        },
+      });
+    }
+  );
+
+  itInTransaction(
+    "should return 404 when removing non-existent user",
+    async (t) => {
+      const { req, res } = await setupTest(t, {
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
+
+      req.body = { removeEditorIds: ["user_not_exists_sid"] };
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "user_not_found",
+          message: "Some users were not found: user_not_exists_sid",
+        },
+      });
+    }
+  );
+
+  itInTransaction(
+    "should return 400 for invalid request body (empty)",
+    async (t) => {
+      const { req, res } = await setupTest(t, {
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
+
+      req.body = {};
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+      expect(res._getJSONData().error.message).toContain(
+        "Either addEditorIds or removeEditorIds must be provided"
+      );
+    }
+  );
+
+  itInTransaction(
+    "should return 400 for invalid request body (empty arrays)",
+    async (t) => {
+      const { req, res } = await setupTest(t, {
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
+
+      req.body = { addEditorIds: [], removeEditorIds: [] };
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+      expect(res._getJSONData().error.message).toContain(
+        "Either addEditorIds or removeEditorIds must be provided"
+      );
+    }
+  );
+
+  itInTransaction(
+    "should successfully add and remove editors in same request",
+    async (t) => {
+      const { req, res, workspace, agentOwner } = await setupTest(t, {
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
+
+      const editorToAdd = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, editorToAdd, "builder");
+
+      // Remove owner, add new editor
+      req.body = {
+        addEditorIds: [editorToAdd.sId],
+        removeEditorIds: [agentOwner.sId],
+      };
+
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.editors).toHaveLength(1);
+      expect(data.editors[0].sId).toBe(editorToAdd.sId);
+    }
+  );
+
+  itInTransaction("should return 404 for non-existent agent", async (t) => {
+    const { req, res } = await setupTest(t, { method: "PATCH" });
+    req.query.aId = "non_existent_agent_sid";
+    req.body = { addEditorIds: ["any_user_sid"] }; // Need a valid body
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration was not found.",
+      },
+    });
+  });
+});
+
+describe("Method Support /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () => {
+  itInTransaction("only supports GET and PATCH methods", async (t) => {
+    for (const method of ["POST", "PUT", "DELETE"] as const) {
+      const { req, res } = await setupTest(t, { method });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PATCH is expected.",
+        },
+      });
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -1,4 +1,5 @@
 import type { RequestMethod } from "node-mocks-http";
+import type { Transaction } from "sequelize";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -6,7 +7,7 @@ import {
   updateAgentPermissions,
 } from "@app/lib/api/assistant/configuration";
 import { Authenticator } from "@app/lib/auth";
-import { UserResource } from "@app/lib/resources/user_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -19,7 +20,6 @@ import type {
 } from "@app/types";
 
 import handler from "./editors";
-import { Transaction } from "sequelize";
 
 // Mock this function
 vi.mock("@app/lib/api/assistant/recent_authors", () => ({

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -1,0 +1,225 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  getAgentConfiguration,
+  getAgentEditorGroup,
+  updateAgentPermissions,
+} from "@app/lib/api/assistant/configuration";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import type {
+  LightAgentConfigurationType,
+  UserType,
+  WithAPIErrorResponse,
+} from "@app/types";
+
+// Changed schema to accept optional add/remove lists
+export const PatchAgentEditorsRequestBodySchema = t.intersection([
+  t.type({}), // Ensures it's an object
+  t.partial({
+    addEditorIds: t.array(t.string),
+    removeEditorIds: t.array(t.string),
+  }),
+  // Refinement to ensure at least one of the arrays exists and is not empty
+  t.refinement(
+    t.type({
+      // Use t.type inside refinement for better type checking
+      addEditorIds: t.union([t.array(t.string), t.undefined]),
+      removeEditorIds: t.union([t.array(t.string), t.undefined]),
+    }),
+    (body) =>
+      (body.addEditorIds instanceof Array && body.addEditorIds.length > 0) ||
+      (body.removeEditorIds instanceof Array &&
+        body.removeEditorIds.length > 0),
+    "Either addEditorIds or removeEditorIds must be provided and contain at least one ID."
+  ),
+]);
+
+export interface GetAgentEditorsResponseBody {
+  editors: UserType[];
+}
+
+export interface PatchAgentEditorsResponseBody {
+  editors: UserType[];
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetAgentEditorsResponseBody | PatchAgentEditorsResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const agentConfigurationId = req.query.aId as string;
+
+  const agent = await getAgentConfiguration(
+    auth,
+    agentConfigurationId,
+    "light"
+  );
+  if (!agent) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration was not found.",
+      },
+    });
+  }
+
+  // TODO(FILOU): Implement canRead/canEdit checks based on new permission model (editors group + visible/hidden scope)
+  // For now, assuming a basic check exists or will be added.
+  const hasReadPermission = true; // Replace with actual check: await auth.canReadAgent(agent);
+  const hasEditPermission = true; // Replace with actual check: await auth.canEditAgent(agent);
+
+  if (!hasReadPermission) {
+    return apiError(req, res, {
+      status_code: 404, // Return 404 to avoid leaking existence of agent
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration was not found.",
+      },
+    });
+  }
+
+  const editorGroupRes = await getAgentEditorGroup(auth, agent.id);
+  if (editorGroupRes.isErr()) {
+    // Handle cases like group not found (might happen during creation race condition or deletion)
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve editor group: ${editorGroupRes.error.message}`,
+      },
+    });
+  }
+  const editorGroup = editorGroupRes.value;
+
+  switch (req.method) {
+    case "GET": {
+      const members = await editorGroup.getActiveMembers(auth);
+      const memberUsers = members.map((m) => m.toJSON());
+
+      return res.status(200).json({ editors: memberUsers });
+    }
+
+    case "PATCH": {
+      if (!hasEditPermission) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "agent_configuration_auth_error",
+            message:
+              "Only editors of the agent or workspace admins can modify editors.",
+          },
+        });
+      }
+
+      const bodyValidation = PatchAgentEditorsRequestBodySchema.decode(
+        req.body
+      );
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      // Use validated body with defaults for potentially missing arrays
+      const { addEditorIds = [], removeEditorIds = [] } = bodyValidation.right;
+
+      // Fetch user resources for both lists
+      const usersToAdd = await UserResource.fetchByIds(addEditorIds);
+      const usersToRemove = await UserResource.fetchByIds(removeEditorIds);
+
+      // Validate fetched users match requested IDs
+      if (
+        usersToAdd.length !== addEditorIds.length ||
+        usersToRemove.length !== removeEditorIds.length
+      ) {
+        const foundAddIds = new Set(usersToAdd.map((u) => u.sId));
+        const missingAddIds = addEditorIds.filter((id) => !foundAddIds.has(id));
+        const foundRemoveIds = new Set(usersToRemove.map((u) => u.sId));
+        const missingRemoveIds = removeEditorIds.filter(
+          (id) => !foundRemoveIds.has(id)
+        );
+        const missingIds = [...missingAddIds, ...missingRemoveIds];
+
+        // Check if any IDs were actually missing before returning error
+        if (missingIds.length > 0) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "user_not_found",
+              message: `Some users were not found: ${missingIds.join(", ")}`,
+            },
+          });
+        }
+      }
+
+      // Call the updated permission function
+      const updateRes = await updateAgentPermissions(auth, {
+        agent,
+        usersToAdd: usersToAdd.map((u) => u.toJSON()),
+        usersToRemove: usersToRemove.map((u) => u.toJSON()),
+      });
+
+      if (updateRes.isErr()) {
+        // Handle specific errors from updateAgentPermissions/setMembers if needed
+        if (
+          updateRes.error instanceof DustError &&
+          // Add specific error checks from addMembers/removeMembers if needed
+          (updateRes.error.code === "user_not_member" ||
+            updateRes.error.code === "user_already_member")
+        ) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: updateRes.error.message,
+            },
+          });
+        }
+        // Generic error
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to update agent editors: ${updateRes.error.message}`,
+          },
+        });
+      }
+
+      // Refetch members to return the updated list
+      const updatedMembers = await editorGroup.getActiveMembers(auth);
+      const updatedMemberUsers = updatedMembers.map((m) => m.toJSON());
+
+      // Use PatchAgentEditorsResponseBody type here
+      return res.status(200).json({ editors: updatedMemberUsers });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PATCH is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(withSessionAuthenticationForWorkspace(handler));

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -54,7 +54,7 @@ const API_ERROR_TYPES = [
   "connector_provider_not_supported",
   "connector_credentials_error",
   "agent_configuration_not_found",
-  "agent_configuration_auth_error",
+  "agent_group_permission_error",
   "agent_message_error",
   "message_not_found",
   "plan_message_limit_exceeded",

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -54,6 +54,7 @@ const API_ERROR_TYPES = [
   "connector_provider_not_supported",
   "connector_credentials_error",
   "agent_configuration_not_found",
+  "agent_configuration_auth_error",
   "agent_message_error",
   "message_not_found",
   "plan_message_limit_exceeded",

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -23,7 +23,7 @@ type GroupPermission = {
  * @property role - The type of role (RoleType)
  * @property permissions - Array of permissions granted to the role
  */
-type RolePermission = {
+export type RolePermission = {
   role: RoleType;
   permissions: PermissionType[];
 };


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2464

## Description

This PR implements the API endpoint for managing agent configuration editors as part of the Agent Discovery & Management feature (FT). It introduces endpoints to list editors and modify the editor list by adding or removing members.

**Key Changes:**

*   **New API Endpoint:** `front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts`
    *   `GET`: Retrieves the list of users who are editors for the specified agent configuration. Requires read permission on the editor group.
    *   `PATCH`: Modifies the list of editors. Accepts `{ addEditorIds?: string[], removeEditorIds?: string[] }` in the request body. Requires write permission on the editor group (granted to editors and admins).

*   **Helper Function:** Added `updateAgentPermissions` to `front/lib/api/assistant/configuration.ts`.
*   **Refactoring:**
    *   Created `GroupResource.findEditorGroupForAgent` static method in `front/lib/resources/group_resource.ts` to encapsulate the logic for finding the specific `agent_editors` group associated with an agent. This replaces a previous standalone helper function.
*   **Error Handling:**
    *   Added new API error type  `agent_group_permission_error` to `front/types/error.ts`.
    *
## Risks
standard

**Permissions:** Correct functionality relies heavily on the permission logic defined in `GroupResource.requestedPermissions()` for the `agent_editors` group kind and the `canRead`/`canWrite` checks within the API handler. Incorrect permission setup could lead to unauthorized access or modification of editor lists.


## Tests

The following scenarios should be tested:

*   **GET `/editors`:**
    *   Workspace admin can retrieve editors.
    *   Agent editor can retrieve editors.
    *   Non-editor user cannot retrieve editors (expect 403).
    *   Requesting editors for a non-existent agent (expect 404).
*   **PATCH `/editors`:**
    *   Admin can add a valid user as an editor.
    *   Admin can remove an existing editor.
    *   Editor can add a valid user as an editor.
    *   Editor can remove another existing editor.
    *   Non-editor user cannot add/remove editors (expect 403).
    *   Attempting to add an already present editor (expect 400 `user_already_member`).
    *   Attempting to remove a user who is not an editor (expect 400 `user_not_member`).
    *   Attempting to add/remove a user not belonging to the workspace (expect 400 `user_not_member`).
    *   Sending an invalid request body (e.g., empty arrays, invalid user IDs) (expect 400 `invalid_request_error` or 404 `user_not_found`).
    *   Adding and removing different users in the same request.
    
## Deploy
front
