### PR TITLE
Poké: display 50 feature flags per page

### DIFF
--- a/front/components/poke/features/table.tsx
+++ b/front/components/poke/features/table.tsx
@@ -46,6 +46,7 @@ export function FeatureFlagsDataTable({
           featureFlags,
           whitelistableFeatures
         )}
+        pageSize={50}
       />
     </div>
   );


### PR DESCRIPTION
## Description

50 flags per page on Poké to gain some time. 

## Tests

/ 

## Risk

/

## Deploy Plan

/