### PR TITLE
[front] fix(conversation): Fix scroll agent messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -342,6 +342,13 @@ export function AgentMessage({
             default:
               assertNever(event);
           }
+
+          if (isAtBottom.current) {
+            bottomRef.current?.scrollIntoView({
+              behavior: "auto",
+              block: "center",
+            });
+          }
           setLastAgentStateClassification("thinking");
           break;
         }
@@ -393,7 +400,7 @@ export function AgentMessage({
       ([entry]) => {
         isAtBottom.current = entry.isIntersecting;
       },
-      { threshold: 1 }
+      { rootMargin: "20px", threshold: 0.5 }
     );
 
     const currentBottomRef = bottomRef.current;

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -343,7 +343,7 @@ export function AgentMessage({
               assertNever(event);
           }
 
-          if (isAtBottom.current) {
+          if (isAtBottom.current && isLastMessage) {
             bottomRef.current?.scrollIntoView({
               behavior: "auto",
               block: "center",
@@ -357,7 +357,13 @@ export function AgentMessage({
           assertNever(event);
       }
     },
-    [conversationId, message.sId, owner.sId, showValidationDialog]
+    [
+      conversationId,
+      message.sId,
+      owner.sId,
+      showValidationDialog,
+      isLastMessage,
+    ]
   );
 
   useEventSource(


### PR DESCRIPTION
## Description
- Fix scroll agent by making sure we scroll to the `bottomRef` when we receive a new token
- Also increase the intersection margin to be more flexible in how much the bottomRef is visible.

## Tests
Tested locally to write 100s lines of messages

## Risk
Low, could scroll too much or not scroll

## Deploy Plan
Deploy on front edge so other users can test. Then deploy on front.
