### PR TITLE
[front] - enh(pickers): revamp `InputBarAttachmentsPicker` & `AssistantPicker`

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -55,7 +55,7 @@ export function AssistantPicker({
       open={isOpen}
       onOpenChange={(open) => {
         setIsOpen(open);
-        if (!open) {
+        if (open) {
           setSearchText("");
         }
       }}

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -4,15 +4,15 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   PlusIcon,
   RobotIcon,
   ScrollArea,
   ScrollBar,
+  SearchInput,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { filterAndSortAgents } from "@app/lib/utils";
 import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
@@ -22,9 +22,9 @@ interface AssistantPickerProps {
   assistants: LightAgentConfigurationType[];
   onItemClick: (assistant: LightAgentConfigurationType) => void;
   pickerButton?: React.ReactNode;
-  showMoreDetailsButtons?: boolean;
   showFooterButtons?: boolean;
   size?: "xs" | "sm" | "md";
+  isLoading?: boolean;
 }
 
 export function AssistantPicker({
@@ -34,24 +34,32 @@ export function AssistantPicker({
   pickerButton,
   showFooterButtons = true,
   size = "md",
+  isLoading = false,
 }: AssistantPickerProps) {
   const [searchText, setSearchText] = useState("");
-  const [searchedAssistants, setSearchedAssistants] = useState<
-    LightAgentConfigurationType[]
-  >([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    setSearchedAssistants(filterAndSortAgents(assistants, searchText));
-  }, [searchText, assistants]);
-
-  const searchbarRef = (element: HTMLInputElement) => {
-    if (element) {
-      element.focus();
+    if (isOpen) {
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 0);
     }
-  };
+  }, [isOpen]);
+
+  const searchedAssistants = filterAndSortAgents(assistants, searchText);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) {
+          setSearchText("");
+        }
+      }}
+    >
       <DropdownMenuTrigger asChild>
         {pickerButton ? (
           pickerButton
@@ -62,51 +70,57 @@ export function AssistantPicker({
             isSelect
             size={size}
             tooltip="Pick an agent"
+            disabled={isLoading}
           />
         )}
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="min-w-[300px]">
-        <DropdownMenuSearchbar
-          ref={searchbarRef}
-          placeholder="Search"
-          name="input"
-          value={searchText}
-          onChange={setSearchText}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && searchedAssistants.length > 0) {
-              onItemClick(searchedAssistants[0]);
-              setSearchText("");
-              close();
-            }
-          }}
-        />
-        <DropdownMenuSeparator />
-        <ScrollArea className="flex max-h-[300px] flex-col" hideScrollBar>
-          {searchedAssistants.map((c) => (
-            <DropdownMenuItem
-              key={`assistant-picker-${c.sId}`}
-              icon={() => <Avatar size="xs" visual={c.pictureUrl} />}
-              label={c.name}
-              onClick={() => {
-                onItemClick(c);
+      <DropdownMenuContent className="w-96" align="end">
+        <div className="flex gap-1.5 p-1.5">
+          <SearchInput
+            ref={searchInputRef}
+            name="search-assistants"
+            placeholder="Search Agents"
+            value={searchText}
+            onChange={setSearchText}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && searchedAssistants.length > 0) {
+                onItemClick(searchedAssistants[0]);
                 setSearchText("");
-              }}
-            />
-          ))}
-          <ScrollBar className="py-0" />
-        </ScrollArea>
-        <DropdownMenuSeparator />
-        {showFooterButtons && (
-          <div className="flex justify-end p-1">
+                setIsOpen(false);
+              }
+            }}
+          />
+          {showFooterButtons && (
             <Button
               label="Create"
-              size="xs"
-              variant="primary"
               icon={PlusIcon}
               href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
             />
-          </div>
-        )}
+          )}
+        </div>
+        <DropdownMenuSeparator />
+        <ScrollArea className="h-96">
+          {searchedAssistants.length > 0 ? (
+            searchedAssistants.map((c) => (
+              <DropdownMenuItem
+                key={`assistant-picker-${c.sId}`}
+                icon={() => <Avatar size="xs" visual={c.pictureUrl} />}
+                label={c.name}
+                truncateText
+                onClick={() => {
+                  onItemClick(c);
+                  setSearchText("");
+                  setIsOpen(false);
+                }}
+              />
+            ))
+          ) : (
+            <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+              No results found
+            </div>
+          )}
+          <ScrollBar className="py-0" />
+        </ScrollArea>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -125,10 +125,10 @@ export const InputBarAttachmentsPicker = ({
     <DropdownMenu
       open={isOpen}
       onOpenChange={(open) => {
-        if (!open) {
+        setIsOpen(open);
+        if (open) {
           setSearch("");
         }
-        setIsOpen(open);
       }}
     >
       <DropdownMenuTrigger asChild>

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -5,15 +5,17 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Icon,
   Input,
+  MagnifyingGlassIcon,
   ScrollArea,
   ScrollBar,
+  SearchInput,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { useDebounce } from "@app/hooks/useDebounce";
@@ -52,6 +54,15 @@ export const InputBarAttachmentsPicker = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const itemsContainerRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 0);
+    }
+  }, [isOpen]);
 
   const {
     inputValue: search,
@@ -87,10 +98,6 @@ export const InputBarAttachmentsPicker = ({
     [spaces]
   );
 
-  /**
-   * Nodes can belong to multiple spaces. This is not of interest to the user,
-   * so we pick a space according to a priority order.
-   */
   const pickedSpaceNodes: DataSourceViewContentNode[] = useMemo(() => {
     return searchResultNodes.map((node) => {
       const { dataSourceViews, ...rest } = node;
@@ -112,12 +119,6 @@ export const InputBarAttachmentsPicker = ({
     });
   }, [searchResultNodes, spacesMap]);
 
-  const searchbarRef = (element: HTMLInputElement) => {
-    if (element) {
-      element.focus();
-    }
-  };
-
   const showLoader = isSearchLoading || isSearchValidating || isDebouncing;
 
   return (
@@ -127,6 +128,7 @@ export const InputBarAttachmentsPicker = ({
         if (!open) {
           setSearch("");
         }
+        setIsOpen(open);
       }}
     >
       <DropdownMenuTrigger asChild>
@@ -139,8 +141,9 @@ export const InputBarAttachmentsPicker = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="w-100"
+        className="w-[380px]"
         side="bottom"
+        align="end"
         onInteractOutside={() => setIsOpen(false)}
       >
         <Input
@@ -156,72 +159,71 @@ export const InputBarAttachmentsPicker = ({
           }}
           multiple={true}
         />
-        <DropdownMenuItem
-          key="upload-item"
-          label="Upload file"
-          icon={CloudArrowUpIcon}
-          onClick={() => fileInputRef.current?.click()}
-        />
+        <div className="flex gap-1.5 p-1.5">
+          <SearchInput
+            ref={searchInputRef}
+            name="search-files"
+            placeholder="Search knowledge"
+            value={search}
+            onChange={setSearch}
+            disabled={isLoading}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                const firstMenuItem =
+                  itemsContainerRef.current?.querySelector('[role="menuitem"]');
+                (firstMenuItem as HTMLElement)?.focus();
+              }
+            }}
+          />
+          <Button
+            icon={CloudArrowUpIcon}
+            label="Upload File"
+            onClick={() => fileInputRef.current?.click()}
+          />
+        </div>
         <DropdownMenuSeparator />
-        <DropdownMenuSearchbar
-          ref={searchbarRef}
-          name="search-files"
-          placeholder="Search knowledge"
-          value={search}
-          onChange={setSearch}
-          disabled={isLoading}
-          onKeyDown={(e) => {
-            if (e.key === "ArrowDown") {
-              e.preventDefault();
-              const firstMenuItem =
-                itemsContainerRef.current?.querySelector('[role="menuitem"]');
-              (firstMenuItem as HTMLElement)?.focus();
-            }
-          }}
-        />
-        {searchQuery && (
-          <>
-            <DropdownMenuSeparator />
-            <ScrollArea className="flex max-h-96 flex-col" hideScrollBar>
-              <div ref={itemsContainerRef}>
-                {pickedSpaceNodes.map((item, index) => (
-                  <DropdownMenuItem
-                    key={index}
-                    label={item.title}
-                    icon={() =>
-                      getVisualForDataSourceViewContentNode(item)({
-                        className: "min-w-4",
-                      })
-                    }
-                    extraIcon={
-                      isWebsite(item.dataSourceView.dataSource) ||
-                      isFolder(item.dataSourceView.dataSource)
-                        ? undefined
-                        : getConnectorProviderLogoWithFallback({
-                            provider:
-                              item.dataSourceView.dataSource.connectorProvider,
-                          })
-                    }
-                    disabled={attachedNodes.some(
-                      (attachedNode) =>
-                        attachedNode.internalId === item.internalId &&
-                        attachedNode.dataSourceView.dataSource.sId ===
-                          item.dataSourceView.dataSource.sId
-                    )}
-                    description={`${getLocationForDataSourceViewContentNode(item)}`}
-                    onClick={() => {
-                      setSearch("");
-                      onNodeSelect(item);
-                      setIsOpen(false);
-                    }}
-                  />
-                ))}
-                {pickedSpaceNodes.length === 0 && !showLoader && (
-                  <div className="flex items-center justify-center py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    No results found
-                  </div>
-                )}
-              </div>
+        <ScrollArea className="h-[380px]">
+          {searchQuery ? (
+            <div ref={itemsContainerRef}>
+              {pickedSpaceNodes.map((item, index) => (
+                <DropdownMenuItem
+                  key={index}
+                  label={item.title}
+                  icon={() =>
+                    getVisualForDataSourceViewContentNode(item)({
+                      className: "min-w-4",
+                    })
+                  }
+                  extraIcon={
+                    isWebsite(item.dataSourceView.dataSource) ||
+                    isFolder(item.dataSourceView.dataSource)
+                      ? undefined
+                      : getConnectorProviderLogoWithFallback({
+                          provider:
+                            item.dataSourceView.dataSource.connectorProvider,
+                        })
+                  }
+                  disabled={attachedNodes.some(
+                    (attachedNode) =>
+                      attachedNode.internalId === item.internalId &&
+                      attachedNode.dataSourceView.dataSource.sId ===
+                        item.dataSourceView.dataSource.sId
+                  )}
+                  description={`${getLocationForDataSourceViewContentNode(item)}`}
+                  onClick={() => {
+                    setSearch("");
+                    onNodeSelect(item);
+                    setIsOpen(false);
+                  }}
+                  truncateText
+                />
+              ))}
+              {pickedSpaceNodes.length === 0 && !showLoader && (
+                <div className="flex items-center justify-center py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  No results found
+                </div>
+              )}
               <InfiniteScroll
                 nextPage={nextPage}
                 hasMore={hasMore}
@@ -232,10 +234,17 @@ export const InputBarAttachmentsPicker = ({
                   </div>
                 }
               />
-              <ScrollBar className="py-0" />
-            </ScrollArea>
-          </>
-        )}
+            </div>
+          ) : (
+            <div className="flex h-full w-full items-center justify-center py-8">
+              <div className="flex flex-col items-center justify-center gap-0 text-center text-base font-semibold text-primary-400">
+                <Icon visual={MagnifyingGlassIcon} size="sm" />
+                Search knowledge
+              </div>
+            </div>
+          )}
+          <ScrollBar className="py-0" />
+        </ScrollArea>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -141,8 +141,7 @@ export const InputBarAttachmentsPicker = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="w-[380px]"
-        side="bottom"
+        className="w-96"
         align="end"
         onInteractOutside={() => setIsOpen(false)}
       >
@@ -183,7 +182,7 @@ export const InputBarAttachmentsPicker = ({
           />
         </div>
         <DropdownMenuSeparator />
-        <ScrollArea className="h-[380px]">
+        <ScrollArea className="h-96">
           {searchQuery ? (
             <div ref={itemsContainerRef}>
               {pickedSpaceNodes.map((item, index) => (


### PR DESCRIPTION
## Description

This PR improves the UX of two picker components to follow the design implemented in storybook:
- `InputBarAttachmentsPicker`: Enhances the file/knowledge search experience with a new layout featuring a full-width search bar, better handling of long titles/descriptions, and improved keyboard navigation
- `AssistantPicker`: Revamps the agent selection UI with a wider dropdown (384px), automatic search focus on open, and cleaner item display
![Screenshot 2025-04-16 at 13 59 22](https://github.com/user-attachments/assets/d94fb4e7-ce4b-41f8-a289-e015da607239)

**References:**
- https://github.com/dust-tt/dust/issues/12004

## Risk

Low, mainly UX

## Deploy Plan

Deploy front
