### PR TITLE
[front] feat(mcp/webtools): Avoid confusion with duplicate web capability

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -90,6 +90,7 @@ import {
   isDefaultActionName,
 } from "@app/components/assistant_builder/types";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -1499,6 +1500,24 @@ function Capabilities({
     builderState.actions,
   ]);
 
+  // Users should see the old web Capabilities only if
+  // their agents has it selected in the past or
+  // if they don't have mcp_actions activated
+  const shouldShowOldWebCapabilities = useMemo(() => {
+    // this is to catch any changes in the name
+    const webtoolsV2ServerName: InternalMCPServerNameType =
+      "web_search_&_browse_v2";
+
+    const webtoolsServer = mcpServerViews.find(
+      (view) => view.server.name === webtoolsV2ServerName
+    );
+    if (webtoolsServer != null) {
+      return isWebNavigationEnabled;
+    }
+
+    return true;
+  }, [isWebNavigationEnabled, mcpServerViews]);
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -1514,27 +1533,29 @@ function Capabilities({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <Capability
-          name="Web search & browse"
-          description="Agent can search (Google) and retrieve information from specific websites."
-          enabled={isWebNavigationEnabled}
-          onEnable={() => {
-            setEdited(true);
-            const defaultWebNavigationAction =
-              getDefaultActionConfiguration("WEB_NAVIGATION");
-            assert(defaultWebNavigationAction);
-            setAction({
-              type: "insert",
-              action: defaultWebNavigationAction,
-            });
-          }}
-          onDisable={() => {
-            const defaultWebNavigationAction =
-              getDefaultActionConfiguration("WEB_NAVIGATION");
-            assert(defaultWebNavigationAction);
-            deleteAction(defaultWebNavigationAction.name);
-          }}
-        />
+        {shouldShowOldWebCapabilities && (
+          <Capability
+            name="Web search & browse"
+            description="Agent can search (Google) and retrieve information from specific websites."
+            enabled={isWebNavigationEnabled}
+            onEnable={() => {
+              setEdited(true);
+              const defaultWebNavigationAction =
+                getDefaultActionConfiguration("WEB_NAVIGATION");
+              assert(defaultWebNavigationAction);
+              setAction({
+                type: "insert",
+                action: defaultWebNavigationAction,
+              });
+            }}
+            onDisable={() => {
+              const defaultWebNavigationAction =
+                getDefaultActionConfiguration("WEB_NAVIGATION");
+              assert(defaultWebNavigationAction);
+              deleteAction(defaultWebNavigationAction.name);
+            }}
+          />
+        )}
 
         <Capability
           name="Data visualization"

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -16,7 +16,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "tables_debugger",
   "child_agent_debugger",
   "primitive_types_debugger",
-  "web_search_&_browse",
+  "web_search_&_browse_v2",
 ] as const;
 
 export const INTERNAL_MCP_SERVERS: Record<
@@ -49,6 +49,11 @@ export const INTERNAL_MCP_SERVERS: Record<
     isDefault: true,
     flag: "mcp_actions",
   },
+  "web_search_&_browse_v2": {
+    id: 1005,
+    isDefault: true,
+    flag: "mcp_actions",
+  },
 
   // Dev
   data_sources_debugger: {
@@ -74,11 +79,6 @@ export const INTERNAL_MCP_SERVERS: Record<
   primitive_types_debugger: {
     id: 1004,
     isDefault: false,
-    flag: "dev_mcp_actions",
-  },
-  "web_search_&_browse": {
-    id: 1005,
-    isDefault: true,
     flag: "dev_mcp_actions",
   },
 };

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -40,7 +40,7 @@ export function getInternalMCPServer(
       return askAgentServer();
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer();
-    case "web_search_&_browse":
+    case "web_search_&_browse_v2":
       return webtoolsServer();
     default:
       assertNever(internalMCPServerName);

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -10,7 +10,7 @@ import type { OAuthProvider } from "@app/types";
 
 export const provider: OAuthProvider = "google_drive" as const;
 export const serverInfo: MCPServerDefinitionType = {
-  name: "web_search_&_browse",
+  name: "web_search_&_browse_v2",
   version: "1.0.0",
   description:
     "Agent can search (Google) and retrieve information from specific websites.",


### PR DESCRIPTION
## Description
- Put mcp webtools behind `mcp_actions` feature flags (instead of `dev_mcp_actions`. No change in `id`.
- Add **V2** suffix to make it clearer.
- Continue to show old web capability if agent already has it or if workspace has no mcp server views for the mcp webtools
- Hide it in any other cases.

## Tests
<figure>
<img width="1315" alt="Capture d’écran 2025-04-16 à 14 15 33" src="https://github.com/user-attachments/assets/d007792e-0904-4308-a834-8bb2d621ce06" />
<figcaption>When workspace has no MCP servers</figcaption>
</figure>

<figure>
<img width="1354" alt="Capture d’écran 2025-04-16 à 14 09 31" src="https://github.com/user-attachments/assets/a2dabae0-a6bc-4dbd-8ea1-94c52fb34d0b" />
<figcaption><strong>Show both</strong>: when workspace has MCP servers and agent has old web capability activated</figcaption>
</figure>

<figure>
<img width="1331" alt="Capture d’écran 2025-04-16 à 14 09 16" src="https://github.com/user-attachments/assets/bb1f0198-bb1b-4432-8bc3-34f4950549c9" />
<figcaption>When workspace has MCP servers but agent has not old web capability activated<figcaption>
</figure>

## Risk
Low, could show old web capability even though it shouldn't. But the V2 suffix help.

## Deploy Plan
Deploy on front.
