### PR TITLE
Slack: reduce call to Slack to reduce rate limit errors when joining channels

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -183,7 +183,7 @@ export async function joinChannel(
             connectorId,
             error: e,
           },
-          `Slack can't join the channel. Missing scope.`
+          "Slack can't join the channel. Missing scope."
         );
         return new Err(
           new Error(
@@ -198,7 +198,7 @@ export async function joinChannel(
             channelId,
             error: e,
           },
-          `Slack can't join the channel. Rate limit exceeded.`
+          "Slack can't join the channel. Rate limit exceeded."
         );
         return new Err(
           new Error(

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -156,6 +156,9 @@ export async function joinChannel(
   const client = await getSlackClient(connector.id);
   try {
     const channelInfo = await client.conversations.info({ channel: channelId });
+    if (!channelInfo.ok || !channelInfo.channel?.name) {
+      return new Err(new Error("Could not get the Slack channel information."));
+    }
     if (!channelInfo.channel) {
       return new Err(new Error("Channel not found."));
     }
@@ -180,11 +183,26 @@ export async function joinChannel(
             connectorId,
             error: e,
           },
-          "Could not join the channel because of a missing scope. Please re-authorize your Slack connection and try again."
+          `Slack can't join the channel. Missing scope.`
         );
         return new Err(
           new Error(
-            "Could not join the channel because of a missing scope. Please re-authorize your Slack connection and try again."
+            `@Dust could not join the channel ${channelId} because of a missing scope. Please re-authorize your Slack connection and try again.`
+          )
+        );
+      }
+      if (e.data.error === "ratelimited") {
+        logger.error(
+          {
+            connectorId,
+            channelId,
+            error: e,
+          },
+          `Slack can't join the channel. Rate limit exceeded.`
+        );
+        return new Err(
+          new Error(
+            `@Dust could not join the channel ${channelId} because of a rate limit exceeded. Please try again in a few minutes.`
           )
         );
       }
@@ -194,7 +212,7 @@ export async function joinChannel(
           channelId,
           error: e,
         },
-        "Can't join the channel"
+        `Slack can't join the channel. Unknown Slack API Platform error.`
       );
 
       return new Err(e);
@@ -206,7 +224,7 @@ export async function joinChannel(
         channelId,
         error: e,
       },
-      "Can't join the channel. Unknown error."
+      "Slack can't join the channel. Unknown error."
     );
 
     return new Err(new Error(`Can't join the channel`));


### PR DESCRIPTION
## Description

Last week a client hit Slack rate limit when trying to add a lot of channels. 
https://app.datadoghq.eu/logs?query=%22Can%27t%20join%20the%20channel%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZY0X98ysE2-BQAAABhBWlkwWC1POUFBQ3BiMGppbmpHS3V3QVAAAAAkMDE5NjM0NjEtOTYxMy00ZDgyLWEzZDItMjRjMzg4M2FhNzY3AAADvQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1743510573602&to_ts=1744806573602&live=true

The error displayed in the UI is scary ("please re-authorize"). 

Done in this PR: 
- Divide by 2 the number of calls to [conversations.info](https://api.slack.com/methods/conversations.info) for new channels -> it's a tier3 call so 50+ requests per minute. 
- Display a better error message when we hit it. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Rollback is safe. 

## Deploy Plan

Deploy connectors. 