### PR TITLE
[front] - fix(AgentPreview): unique constraint group

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -897,7 +897,7 @@ export async function createAgentConfiguration(
         }
 
         if (created) {
-          await GroupResource.makeNewAgentEditorsGroup(
+          await GroupResource.findOrCreateAgentEditorsGroup(
             auth,
             agentConfigurationInstance,
             { transaction: t }


### PR DESCRIPTION
## Description

When trying to draft the same agent multiple times, we hit a SQL error due to a unique constraint violation in the `group_agents` table. The error occurs when attempting to create duplicate group-agent associations.

**References:**
- https://github.com/dust-tt/tasks/issues/2667

## Risk

Low

## Deploy Plan

Deploy front