### PR TITLE
Skip schemas which cant be fetched

### DIFF
--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -114,7 +114,9 @@ pub async fn get_tables_schema(
                 .zip(schemas.iter())
                 .map(|(table, schema)| {
                     let table_id = table.table_id_for_dbml().replace("__DUST_DOT__", ".");
-                    schema.render_dbml(&table_id, table.description())
+                    schema
+                        .as_ref()
+                        .map(|s| s.render_dbml(&table_id, table.description()))
                 })
                 .collect::<Vec<_>>();
 
@@ -123,10 +125,16 @@ pub async fn get_tables_schema(
                 schemas
                     .into_iter()
                     .zip(dbmls.into_iter())
-                    .map(|(schema, dbml)| GetTableSchemaResult {
-                        schema: Some(schema),
-                        dbml,
-                        head: None,
+                    .filter_map(|(schema, dbml)| {
+                        if let (Some(schema), Some(dbml)) = (schema, dbml) {
+                            Some(GetTableSchemaResult {
+                                schema: Some(schema),
+                                dbml,
+                                head: None,
+                            })
+                        } else {
+                            None
+                        }
                     })
                     .collect::<Vec<_>>(),
             ))

--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -352,7 +352,7 @@ impl RemoteDatabase for BigQueryRemoteDatabase {
         self.execute_query(query).await
     }
 
-    async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<TableSchema>> {
+    async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<Option<TableSchema>>> {
         let bq_tables: Vec<gcp_bigquery_client::model::table::Table> =
             try_join_all(opaque_ids.iter().map(|opaque_id| async move {
                 let parts: Vec<&str> = opaque_id.split('.').collect();
@@ -372,10 +372,10 @@ impl RemoteDatabase for BigQueryRemoteDatabase {
             }))
             .await?;
 
-        let schemas: Vec<TableSchema> = bq_tables
+        let schemas: Vec<Option<TableSchema>> = bq_tables
             .into_iter()
-            .map(|table| TableSchema::try_from(&table.schema))
-            .collect::<Result<Vec<TableSchema>>>()?;
+            .map(|table| TableSchema::try_from(&table.schema).map(Some))
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(schemas)
     }

--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -30,7 +30,7 @@ pub trait RemoteDatabase {
         tables: &Vec<Table>,
         query: &str,
     ) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError>;
-    async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<TableSchema>>;
+    async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<Option<TableSchema>>>;
 }
 
 pub async fn get_remote_database(

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -381,7 +381,7 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
         self.execute_query(&session, query).await
     }
 
-    async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<TableSchema>> {
+    async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<Option<TableSchema>>> {
         // Construct a "DESCRIBE TABLE" query for each opaque table ID.
         let queries: Vec<String> = opaque_ids
             .iter()
@@ -425,7 +425,7 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
                         )
                     })?;
 
-                Ok(TableSchema::from_columns(columns))
+                Ok(Some(TableSchema::from_columns(columns)))
             })
             .collect()
     }


### PR DESCRIPTION
## Description

This is changing the get_tables_schema to return an optional TableSchema for each id - returning none if table can't be read, instead of sending an error. Results are then filtered out and only readable schemas are returned

## Tests

Tested locally with dust-app and tables-query

# Risk

should not affect other database, as long as schemas a readable

## Deploy Plan

deploy core
