### PR TITLE
Builder selectAll button selects only

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -103,17 +103,27 @@ const getNodesFromConfig = (
     {}
   );
 
-const updateSelection = (
-  item: DataSourceViewContentNode,
-  prevState: DataSourceViewSelectionConfigurations,
-  selectionMode: "checkbox" | "radio" = "checkbox"
-): DataSourceViewSelectionConfigurations => {
+const updateSelection = ({
+  item,
+  prevState,
+  selectionMode = "checkbox",
+  onlyAdd = false,
+}: {
+  item: DataSourceViewContentNode;
+  prevState: DataSourceViewSelectionConfigurations;
+  selectionMode: "checkbox" | "radio";
+  onlyAdd?: boolean;
+}): DataSourceViewSelectionConfigurations => {
   const { dataSourceView: dsv } = item;
   const prevConfig = prevState[dsv.sId] ?? defaultSelectionConfiguration(dsv);
 
   const exists = prevConfig.selectedResources.some(
     (r) => r.internalId === item.internalId
   );
+
+  if (onlyAdd && exists) {
+    return _.cloneDeep(prevState);
+  }
 
   if (item.mimeType === DATA_SOURCE_MIME_TYPE) {
     return {
@@ -320,7 +330,13 @@ export function DataSourceViewsSelector({
     // Update all selections in a single state update.
     setSelectionConfigurations((prevState) => {
       const newState = searchResultNodes.reduce(
-        (acc, item) => updateSelection(item, acc, selectionMode),
+        (acc, item) =>
+          updateSelection({
+            item,
+            prevState: acc,
+            selectionMode,
+            onlyAdd: true,
+          }),
         prevState
       );
       return newState;
@@ -355,7 +371,11 @@ export function DataSourceViewsSelector({
           setSearchResult(item);
           setSearchSpaceText("");
           setSelectionConfigurations((prevState) =>
-            updateSelection(item, prevState, selectionMode)
+            updateSelection({
+              item,
+              prevState,
+              selectionMode,
+            })
           );
         }}
         displayItemCount={useCase === "assistantBuilder"}
@@ -372,7 +392,11 @@ export function DataSourceViewsSelector({
                 setSearchResult(item);
                 setSearchSpaceText("");
                 setSelectionConfigurations((prevState) =>
-                  updateSelection(item, prevState, selectionMode)
+                  updateSelection({
+                    item,
+                    prevState,
+                    selectionMode,
+                  })
                 );
               }}
             >

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -168,13 +168,15 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.41",
+      "version": "1.0.42",
       "license": "ISC",
       "dependencies": {
+        "@types/json-schema": "^7.0.15",
         "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.5"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",


### PR DESCRIPTION
## Description

The Select All button that we display on the builder (Salesforce only) should only Select results, not select or unselect depending on the previous state (discussed with @pinotalexandre)

## Tests

Locally.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 