### PR TITLE
[front] - chore(prompt): limit tool usage in meta prompt

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -30,6 +30,7 @@ import type {
 } from "@app/types";
 import {
   assertNever,
+  DEFAULT_MAX_STEPS_USE_PER_RUN,
   Err,
   isAgentMessageType,
   isContentFragmentMessageTypeModel,
@@ -137,7 +138,12 @@ export async function constructPromptMultiActions(
   }
 
   if (hasAvailableActions) {
-    const toolMetaPrompt = model.toolUseMetaPrompt;
+    const toolMetaPrompt = model.toolUseMetaPrompt?.replace(
+      "MAX_STEPS_USE_PER_RUN",
+      (
+        agentConfiguration.maxStepsPerRun || DEFAULT_MAX_STEPS_USE_PER_RUN
+      ).toString()
+    );
     if (toolMetaPrompt) {
       additionalInstructions += `\n${toolMetaPrompt}\n`;
     }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -30,7 +30,6 @@ import type {
 } from "@app/types";
 import {
   assertNever,
-  DEFAULT_MAX_STEPS_USE_PER_RUN,
   Err,
   isAgentMessageType,
   isContentFragmentMessageTypeModel,
@@ -138,11 +137,13 @@ export async function constructPromptMultiActions(
   }
 
   if (hasAvailableActions) {
+    const maxStepsPerRun =
+      agentConfiguration.maxStepsPerRun > 1
+        ? agentConfiguration.maxStepsPerRun - 1
+        : agentConfiguration.maxStepsPerRun;
     const toolMetaPrompt = model.toolUseMetaPrompt?.replace(
       "MAX_STEPS_USE_PER_RUN",
-      (
-        agentConfiguration.maxStepsPerRun || DEFAULT_MAX_STEPS_USE_PER_RUN
-      ).toString()
+      maxStepsPerRun.toString()
     );
     if (toolMetaPrompt) {
       additionalInstructions += `\n${toolMetaPrompt}\n`;

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -512,6 +512,7 @@ const ANTHROPIC_DELIMITERS_CONFIGURATION = {
 const ANTHROPIC_TOOL_USE_META_PROMPT =
   `Immediately before using a tool, think for one short bullet point in \`<thinking>\` tags about ` +
   `how it evaluates against the criteria for a good and bad tool use. ` +
+  `You are restricted to a maximum of MAX_STEPS_USE_PER_RUN tool uses per run. ` +
   `After using a tool, think for one short bullet point in \`<thinking>\` tags to evaluate ` +
   `whether the tools results are enough to answer the user's question. ` +
   `The response to the user must be in \`<response>\` tags. ` +


### PR DESCRIPTION
## Description

This PR adds an instruction to claude models, to specify the number of tools they can use.

**References:**
- https://github.com/dust-tt/tasks/issues/2661

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
