### PR TITLE
[front] feat(mcp): bug squash

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
   PlusIcon,
   ScrollArea,
+  Spinner,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 import React from "react";
@@ -33,9 +34,10 @@ export const AddActionMenu = ({
   createRemoteMCPServer,
 }: AddActionMenuProps) => {
   const [searchText, setSearchText] = useState("");
-  const { availableMCPServers } = useAvailableMCPServers({
-    owner,
-  });
+  const { availableMCPServers, isAvailableMCPServersLoading } =
+    useAvailableMCPServers({
+      owner,
+    });
 
   return (
     <DropdownMenu modal={false}>
@@ -50,6 +52,7 @@ export const AddActionMenu = ({
             name="search"
             value={searchText}
             onChange={setSearchText}
+            disabled={isAvailableMCPServersLoading}
           />
           <Button
             icon={PlusIcon}
@@ -58,6 +61,11 @@ export const AddActionMenu = ({
           />
         </div>
         <ScrollArea className="max-h-[500px]">
+          {isAvailableMCPServersLoading && (
+            <div className="flex justify-center py-4">
+              <Spinner size="sm" />{" "}
+            </div>
+          )}
           {availableMCPServers
             .filter((mcpServer) => !enabledMCPServers.includes(mcpServer.id))
             .filter((mcpServer) => filterMCPServer(mcpServer, searchText))

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
   PlusIcon,
   ScrollArea,
+  Spinner,
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
@@ -29,10 +30,11 @@ export default function SpaceManagedActionsViewsModel({
   onAddServer,
 }: SpaceManagedActionsViewsModelProps) {
   const [searchText, setSearchText] = useState("");
-  const { availableMCPServers } = useAvailableMCPServers({
-    owner,
-    space,
-  });
+  const { availableMCPServers, isAvailableMCPServersLoading } =
+    useAvailableMCPServers({
+      owner,
+      space,
+    });
 
   return (
     <DropdownMenu modal={false}>
@@ -48,10 +50,16 @@ export default function SpaceManagedActionsViewsModel({
             name="search"
             value={searchText}
             onChange={setSearchText}
+            disabled={isAvailableMCPServersLoading}
           />
         </div>
         <ScrollArea className="max-h-[500px]">
-          {availableMCPServers.length <= 0 && (
+          {isAvailableMCPServersLoading && (
+            <div className="flex justify-center py-4">
+              <Spinner size="sm" />{" "}
+            </div>
+          )}
+          {!isAvailableMCPServersLoading && availableMCPServers.length <= 0 && (
             <DropdownMenuItem label="No more tools to add" disabled />
           )}
           {availableMCPServers

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
@@ -25,17 +25,18 @@ async function handler(
 
   switch (method) {
     // We get the server that are:
-    // - installed in the workspace but not in global (so can be restricted but not yet assign to spaces)
+    // - not in global (so can be restricted but not yet assign to spaces)
     // - not in the current space
     case "GET": {
+      const internalServers =
+        await InternalMCPServerInMemoryResource.listAvailableInternalMCPServers(
+          auth
+        );
       const workspaceServerViews =
         await MCPServerViewResource.listByWorkspace(auth);
       const globalServersId = workspaceServerViews
         .filter((s) => s.space.kind === "global")
         .map((s) => s.toJSON().server.id);
-
-      const workspaceInstalledServer =
-        await InternalMCPServerInMemoryResource.listByWorkspace(auth);
 
       const spaceServerViews = await MCPServerViewResource.listBySpace(
         auth,
@@ -43,7 +44,7 @@ async function handler(
       );
       const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.id);
 
-      const availableServer = workspaceInstalledServer.filter(
+      const availableServer = internalServers.filter(
         (s) => !spaceServersId.includes(s.id) && !globalServersId.includes(s.id)
       );
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
@@ -6,6 +6,7 @@ import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -28,12 +29,14 @@ async function handler(
     // - not in global (so can be restricted but not yet assign to spaces)
     // - not in the current space
     case "GET": {
-      const internalServers =
-        await InternalMCPServerInMemoryResource.listAvailableInternalMCPServers(
-          auth
-        );
+      const internalInstalledServers =
+        await InternalMCPServerInMemoryResource.listByWorkspace(auth);
+      const remoteInstalledServers =
+        await RemoteMCPServerResource.listByWorkspace(auth);
+
       const workspaceServerViews =
         await MCPServerViewResource.listByWorkspace(auth);
+
       const globalServersId = workspaceServerViews
         .filter((s) => s.space.kind === "global")
         .map((s) => s.toJSON().server.id);
@@ -44,13 +47,29 @@ async function handler(
       );
       const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.id);
 
-      const availableServer = internalServers.filter(
-        (s) => !spaceServersId.includes(s.id) && !globalServersId.includes(s.id)
-      );
+      const availableServer: MCPServerType[] = [];
+
+      for (const srv of internalInstalledServers) {
+        if (
+          !spaceServersId.includes(srv.id) &&
+          !globalServersId.includes(srv.id)
+        ) {
+          availableServer.push(srv.toJSON());
+        }
+      }
+
+      for (const srv of remoteInstalledServers) {
+        if (
+          !spaceServersId.includes(srv.sId) &&
+          !globalServersId.includes(srv.sId)
+        ) {
+          availableServer.push(srv.toJSON());
+        }
+      }
 
       return res.status(200).json({
         success: true,
-        servers: availableServer.map((s) => s.toJSON()),
+        servers: availableServer,
       });
     }
 


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2668
- Add Spinner when loading available MCP (in a given space and in the global workspace)
- In a given space, show the list of MCP servers that are NOT in the global space and NOT in the current space

## Tests
Tested locally

## Risk
Low, could give the wrong list or available mcp

## Deploy Plan
Deploy on front
