### PR TITLE
Refine production check on paused connectors

### DIFF
--- a/front/lib/production_checks/checks/check_paused_connectors.ts
+++ b/front/lib/production_checks/checks/check_paused_connectors.ts
@@ -41,7 +41,8 @@ export const checkPausedConnectors: CheckFunction = async (
         COALESCE("plans"."code", 'NO_PLAN') AS "planCode"
         FROM "workspaces"
         LEFT JOIN "subscriptions" ON "workspaces"."id" = "subscriptions"."workspaceId"
-        LEFT JOIN "plans" ON "subscriptions"."planId" = "plans"."id" AND "subscriptions"."status" = 'active'`,
+        LEFT JOIN "plans" ON "subscriptions"."planId" = "plans"."id" AND "subscriptions"."status" = 'active'
+        WHERE ("workspaces"."metadata" ->> 'maintenance' IS NULL)`, // Exclude workspaces in maintenance mode (relocation or relocation done).
     {
       type: QueryTypes.SELECT,
       replacements: {

--- a/front/lib/production_checks/checks/check_paused_connectors.ts
+++ b/front/lib/production_checks/checks/check_paused_connectors.ts
@@ -55,7 +55,7 @@ export const checkPausedConnectors: CheckFunction = async (
   for (const connector of pausedConnectors) {
     logger.info(
       { connector },
-      "Connector is paused. Checking if worskpace has a valid subscription."
+      "Connector is paused. Checking if workspace has a valid subscription."
     );
 
     const workspaceSubscription = workspaceSubscriptions.find(


### PR DESCRIPTION
## Description

This PR excludes the relocated workspaces from the production check "Paused connectors for a workspace with a subscription for more than 15 days.".

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy front.