### PR TITLE
[Agent editors] Fix: associate editor group to new agent version

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -69,6 +69,7 @@ import {
 } from "@app/lib/resources/string_ids";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
+import logger from "@app/logger/logger";
 import type {
   AgentConfigurationScope,
   AgentConfigurationType,
@@ -810,9 +811,9 @@ export async function createAgentConfiguration(
     const performCreation = async (
       t: Transaction
     ): Promise<AgentConfiguration> => {
-      let created = false;
+      let existingAgent = null;
       if (agentConfigurationId) {
-        const [existing, userRelation] = await Promise.all([
+        const [agentConfiguration, userRelation] = await Promise.all([
           AgentConfiguration.findOne({
             where: {
               sId: agentConfigurationId,
@@ -833,9 +834,11 @@ export async function createAgentConfiguration(
           }),
         ]);
 
-        if (existing) {
+        existingAgent = agentConfiguration;
+
+        if (existingAgent) {
           // Bump the version of the agent.
-          version = existing.version + 1;
+          version = existingAgent.version + 1;
         }
 
         await AgentConfiguration.update(
@@ -849,9 +852,6 @@ export async function createAgentConfiguration(
           }
         );
         userFavorite = userRelation?.favorite ?? false;
-      } else {
-        // Only set created to true if we are not updating an existing agent
-        created = true;
       }
 
       const sId = agentConfigurationId || generateRandomModelSId();
@@ -898,12 +898,34 @@ export async function createAgentConfiguration(
         }
       }
 
-      if (created && status === "active") {
-        await GroupResource.makeNewAgentEditorsGroup(
-          auth,
-          agentConfigurationInstance,
-          { transaction: t }
-        );
+      if (status === "active") {
+        if (!existingAgent) {
+          await GroupResource.makeNewAgentEditorsGroup(
+            auth,
+            agentConfigurationInstance,
+            { transaction: t }
+          );
+        } else {
+          const group = await GroupResource.fetchByAgentConfiguration(
+            auth,
+            existingAgent
+          );
+          if (group.isOk()) {
+            await group.value.addGroupToAgentConfiguration({
+              auth,
+              agentConfiguration: agentConfigurationInstance,
+              transaction: t,
+            });
+          } else {
+            logger.warn(
+              {
+                workspaceId: owner.id,
+                agentConfigurationId: existingAgent.sId,
+              },
+              `Error fetching group for agent ${existingAgent.sId}: ${group.error}`
+            );
+          }
+        }
       }
 
       return agentConfigurationInstance;

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -819,7 +819,7 @@ export async function createAgentConfiguration(
               sId: agentConfigurationId,
               workspaceId: owner.id,
             },
-            attributes: ["scope", "version"],
+            attributes: ["scope", "version", "id", "sId"],
             order: [["version", "DESC"]],
             transaction: t,
             limit: 1,
@@ -911,11 +911,20 @@ export async function createAgentConfiguration(
             existingAgent
           );
           if (group.isOk()) {
-            await group.value.addGroupToAgentConfiguration({
+            const result = await group.value.addGroupToAgentConfiguration({
               auth,
               agentConfiguration: agentConfigurationInstance,
               transaction: t,
             });
+            if (result.isErr()) {
+              logger.warn(
+                {
+                  workspaceId: owner.id,
+                  agentConfigurationId: existingAgent.sId,
+                },
+                `Error adding group to agent ${existingAgent.sId}: ${result.error}`
+              );
+            }
           } else {
             logger.warn(
               {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -364,7 +364,9 @@ export class GroupResource extends BaseResource<GroupModel> {
       return new Err(new DustError("resource_not_found", "Group not found"));
     }
 
-    return new Ok(new this(GroupModel, await groupAgent.getGroup()));
+    const group = await groupAgent.getGroup();
+
+    return new Ok(new this(GroupModel, group.get()));
   }
 
   static async fetchWorkspaceSystemGroup(

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -339,6 +339,34 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(groups);
   }
 
+  static async fetchByAgentConfiguration(
+    auth: Authenticator,
+    agentConfiguration: AgentConfiguration
+  ): Promise<Result<GroupResource, DustError>> {
+    const workspace = auth.getNonNullableWorkspace();
+    const groupAgent = await GroupAgentModel.findOne({
+      where: {
+        agentConfigurationId: agentConfiguration.id,
+        workspaceId: workspace.id,
+      },
+      include: [
+        {
+          model: GroupModel,
+          where: {
+            workspaceId: workspace.id,
+          },
+          required: true,
+        },
+      ],
+    });
+
+    if (!groupAgent) {
+      return new Err(new DustError("resource_not_found", "Group not found"));
+    }
+
+    return new Ok(new this(GroupModel, await groupAgent.getGroup()));
+  }
+
   static async fetchWorkspaceSystemGroup(
     auth: Authenticator
   ): Promise<Result<GroupResource, DustError>> {


### PR DESCRIPTION
Description
---
Issue

Also:
- removes the created flag, redundant with existing (renamed existingAgent)
- if group doesn't exist, warns

The second case should happen a lot until we backfill, then stop happening.

After the backfill we can turn the warn into an error and return an error here

Risk
---
standard

Deploy plan
---
front
