### PR TITLE
github actions: diff position handling

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -319,10 +319,6 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         // their defauilt response type)
         const pullDiff = diffWithPositions(diff.data as string);
 
-        console.log("======================================================");
-        console.log(pullDiff);
-        console.log("======================================================");
-
         const content =
           `TITLE: ${pullTitle}\n\n` +
           `BODY:\n` +


### PR DESCRIPTION
## Description

Injects diff "position" as accepted by the GitHub REST API to create pull request review comments: see https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request => parameters `comments`.

This enables the model to easily point the line it wants to comment on.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`