### PR TITLE
[front/components] - fix: ensure text wrapping in UI dialogs

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -72,7 +72,9 @@ export function ConfirmDialog({
           <DialogTitle>{confirmData?.title ?? ""}</DialogTitle>
         </DialogHeader>
         <DialogContainer>
-          <DialogDescription>{confirmData?.message ?? ""}</DialogDescription>
+          <DialogDescription className="whitespace-normal break-words">
+            {confirmData?.message ?? ""}
+          </DialogDescription>
         </DialogContainer>
         <DialogFooter
           leftButtonProps={{

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -830,7 +830,7 @@ function ErrorMessage({
           }
           content={
             <div className="flex flex-col gap-3">
-              <div className="text-sm font-normal text-warning-800">
+              <div className="whitespace-normal break-words text-sm font-normal text-warning-800">
                 {fullMessage}
               </div>
               <div className="self-end">


### PR DESCRIPTION
## Description

This PR apply text wrapping to agent message error display and confirm dialog, to ensure that long words do not overflow.

![Screenshot 2025-04-17 at 16 12 24](https://github.com/user-attachments/assets/004cadd6-a29e-45da-88e8-da84d72aa5e5)

**References:**
- https://github.com/dust-tt/tasks/issues/2683

## Risk

Low

## Deploy Plan

Deploy front