### PR TITLE
enh(TablesQuery): bump `TABLES_QUERY_MIN_TOKEN` from 28k to 50k

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/tables_query.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query.ts
@@ -38,8 +38,8 @@ import type {
 } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";
 
-// We need a model with at least 32k tokens to run tables_query.
-const TABLES_QUERY_MIN_TOKEN = 28_000;
+// We need a model with at least 54k tokens to run tables_query.
+const TABLES_QUERY_MIN_TOKEN = 50_000;
 const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 

--- a/front/lib/actions/tables_query.ts
+++ b/front/lib/actions/tables_query.ts
@@ -40,8 +40,8 @@ import type {
 } from "@app/types";
 import { assertNever, Ok, removeNulls } from "@app/types";
 
-// Need a model with at least 32k to run tables query.
-const TABLES_QUERY_MIN_TOKEN = 28_000;
+// Need a model with at least 54k to run tables query.
+const TABLES_QUERY_MIN_TOKEN = 50_000;
 const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/11950#discussion_r2049035933.
No agent to reconfigure according to https://dust.tt/w/0ec9852c2f/assistant/6m0bE6QVA7

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.