### PR TITLE
Allow  disabled message in EmptyCallToAction

### DIFF
--- a/front/components/EmptyCallToAction.tsx
+++ b/front/components/EmptyCallToAction.tsx
@@ -1,6 +1,10 @@
-import { Button } from "@dust-tt/sparkle";
+import {
+  Button,
+  ContentMessage,
+  InformationCircleIcon,
+} from "@dust-tt/sparkle";
 import Link from "next/link";
-import type { ComponentType, MouseEvent } from "react";
+import type { ComponentType, MouseEvent, ReactNode } from "react";
 import React from "react";
 
 import { classNames } from "@app/lib/utils";
@@ -11,12 +15,16 @@ export function EmptyCallToAction({
   icon,
   href,
   onClick,
+  disabledTitle,
+  disabledDescription,
 }: {
   label: string;
   disabled?: boolean;
   icon?: ComponentType;
   href?: string;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  disabledTitle?: string;
+  disabledDescription?: ReactNode;
 }) {
   const button = (
     <Button
@@ -35,7 +43,19 @@ export function EmptyCallToAction({
         "bg-muted-background dark:bg-muted-background-night"
       )}
     >
-      {href ? <Link href={href}>{button}</Link> : button}
+      {disabled && disabledTitle && disabledDescription ? (
+        <div className="flex w-full items-center justify-center">
+          <ContentMessage
+            title={disabledTitle}
+            icon={InformationCircleIcon}
+            variant="warning"
+          >
+            <div>{disabledDescription}</div>
+          </ContentMessage>
+        </div>
+      ) : (
+        <>{href ? <Link href={href}>{button}</Link> : button}</>
+      )}
     </div>
   );
 }

--- a/front/components/assistant_builder/actions/configuration/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/DataSourceSelectionSection.tsx
@@ -5,6 +5,7 @@ import {
   IconButton,
   Tree,
 } from "@dust-tt/sparkle";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 
@@ -93,7 +94,21 @@ export default function DataSourceSelectionSection({
           <EmptyCallToAction
             label={`Select ${viewTypeToLabel(viewType)}`}
             onClick={openDataSourceModal}
-            disabled={!canAddDataSource}
+            disabled={canAddDataSource}
+            disabledTitle="You don't have any Data Sources available"
+            disabledDescription={
+              <>
+                You need to connect Data Sources to Dust before you can use them
+                in your agents.{" "}
+                <Link
+                  href="https://docs.dust.tt/docs/data"
+                  target="_blank"
+                  className="underline"
+                >
+                  Learn more.
+                </Link>
+              </>
+            }
           />
         ) : (
           <Tree>


### PR DESCRIPTION
## Description

When no datasources are available when attaching a tool, display a more intelligible message
<img width="761" alt="Screenshot 2025-04-17 at 18 30 23" src="https://github.com/user-attachments/assets/7e184e77-7608-4d58-a2bb-7ff8e83d41ae" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
