### PR TITLE
Prevent folder selection for table data source

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -108,13 +108,11 @@ const updateSelection = ({
   prevState,
   selectionMode = "checkbox",
   onlyAdd = false,
-  viewType,
 }: {
   item: DataSourceViewContentNode;
   prevState: DataSourceViewSelectionConfigurations;
   selectionMode: "checkbox" | "radio";
   onlyAdd?: boolean;
-  viewType: ContentNodesViewType;
 }): DataSourceViewSelectionConfigurations => {
   const { dataSourceView: dsv } = item;
   const prevConfig = prevState[dsv.sId] ?? defaultSelectionConfiguration(dsv);
@@ -155,7 +153,7 @@ const updateSelection = ({
     };
   }
 
-  let newResources = exists
+  const newResources = exists
     ? prevConfig.selectedResources.filter(
         (r) => r.internalId !== item.internalId
       )
@@ -167,11 +165,6 @@ const updateSelection = ({
           parentInternalIds: item.parentInternalIds || [],
         },
       ];
-
-  // In table view, we cannot select folders.
-  if (viewType === "table" && item.type === "folder") {
-    newResources = newResources.filter((r) => r.type !== "folder");
-  }
 
   return {
     ...prevState,
@@ -343,7 +336,6 @@ export function DataSourceViewsSelector({
             prevState: acc,
             selectionMode,
             onlyAdd: true,
-            viewType,
           }),
         prevState
       );
@@ -383,7 +375,6 @@ export function DataSourceViewsSelector({
               item,
               prevState,
               selectionMode,
-              viewType,
             })
           );
         }}
@@ -405,7 +396,6 @@ export function DataSourceViewsSelector({
                     item,
                     prevState,
                     selectionMode,
-                    viewType,
                   })
                 );
               }}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -108,11 +108,13 @@ const updateSelection = ({
   prevState,
   selectionMode = "checkbox",
   onlyAdd = false,
+  viewType,
 }: {
   item: DataSourceViewContentNode;
   prevState: DataSourceViewSelectionConfigurations;
   selectionMode: "checkbox" | "radio";
   onlyAdd?: boolean;
+  viewType: ContentNodesViewType;
 }): DataSourceViewSelectionConfigurations => {
   const { dataSourceView: dsv } = item;
   const prevConfig = prevState[dsv.sId] ?? defaultSelectionConfiguration(dsv);
@@ -153,7 +155,7 @@ const updateSelection = ({
     };
   }
 
-  const newResources = exists
+  let newResources = exists
     ? prevConfig.selectedResources.filter(
         (r) => r.internalId !== item.internalId
       )
@@ -165,6 +167,11 @@ const updateSelection = ({
           parentInternalIds: item.parentInternalIds || [],
         },
       ];
+
+  // In table view, we cannot select folders.
+  if (viewType === "table" && item.type === "folder") {
+    newResources = newResources.filter((r) => r.type !== "folder");
+  }
 
   return {
     ...prevState,
@@ -336,6 +343,7 @@ export function DataSourceViewsSelector({
             prevState: acc,
             selectionMode,
             onlyAdd: true,
+            viewType,
           }),
         prevState
       );
@@ -375,6 +383,7 @@ export function DataSourceViewsSelector({
               item,
               prevState,
               selectionMode,
+              viewType,
             })
           );
         }}
@@ -396,6 +405,7 @@ export function DataSourceViewsSelector({
                     item,
                     prevState,
                     selectionMode,
+                    viewType,
                   })
                 );
               }}

--- a/front/lib/search.ts
+++ b/front/lib/search.ts
@@ -12,7 +12,7 @@ export function getCoreViewTypeFilter(viewType: ContentNodesViewType) {
     case "document":
       return ["folder", "document"];
     case "table":
-      return ["folder", "table"];
+      return ["table"];
     case "all":
       return ["folder", "table", "document"];
     default:


### PR DESCRIPTION
## Description
* Currently, if you select a folder via the search bar and save the configuration, the page will stall. This is because we do not allow folder data types to be written as table configuration
* Changing 'table' view type to only return table objects

## Tests
* Local testing

## Risk

N/a

## Deploy Plan

github