### PR TITLE
Fix scrolling in the `AssistantPicker` in `ChildAgentConfigurationSection`

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -25,6 +25,7 @@ interface AssistantPickerProps {
   showFooterButtons?: boolean;
   size?: "xs" | "sm" | "md";
   isLoading?: boolean;
+  mountPortal?: boolean;
 }
 
 export function AssistantPicker({
@@ -35,6 +36,7 @@ export function AssistantPicker({
   showFooterButtons = true,
   size = "md",
   isLoading = false,
+  mountPortal = true,
 }: AssistantPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -65,7 +67,11 @@ export function AssistantPicker({
           />
         )}
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-96" align="end">
+      <DropdownMenuContent
+        className="w-96"
+        align="end"
+        mountPortal={mountPortal}
+      >
         <DropdownMenuSearchbar
           autoFocus
           name="search-assistants"

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -106,6 +106,7 @@ export function ChildAgentConfigurationSection({
                   />
                 }
                 showFooterButtons={false}
+                mountPortal={false}
               />
             </div>
           </div>
@@ -127,6 +128,7 @@ export function ChildAgentConfigurationSection({
                 />
               }
               showFooterButtons={false}
+              mountPortal={false}
             />
           </div>
         </Card>

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -45,7 +45,7 @@ export function ChildAgentConfigurationSection({
     );
   }
 
-  if (agentConfigurations.length === 0) {
+  if (!isAgentConfigurationsLoading && agentConfigurations.length === 0) {
     return (
       <ContentMessage
         title="No agents available"


### PR DESCRIPTION
## Description

- The scrolling was not working at all in the `AssistantPicker` found in `ChildAgentConfigurationSection`; the scrollbar appeared and we could click on it to scroll but the touchpad/mouse scroll did not have any effect.
- This PR fixes that by introducing a prop `mountPortal` propagated from the `AssistantPicker` to the `DropdownMenuContent`, by default `true` and only set to false in the `ChildAgentConfigurationSection`.
- This PR also fixes another issue in the `ChildAgentConfigurationSection`, where the message warning the user that there were no agent available appeared instead of the loading spinner.

This is the component:
<img width="581" alt="Screenshot 2025-04-18 at 10 05 30 AM" src="https://github.com/user-attachments/assets/cd8d4d4a-0378-4de1-9bc6-4b4940dbd809" />

## Tests

- Checked locally, checked the other Assistant pickers.

## Risk

- N/A.

## Deploy Plan

- Deploy front.