### PR TITLE
[front] Don't ask login prompt by default

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -85,8 +85,12 @@ export default function LandingLayout({
               size="sm"
               label="Sign in"
               icon={LoginIcon}
-              onClick={() => {
-                window.location.href = `/api/auth/login?prompt=login&returnTo=${postLoginReturnToUrl}`;
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                if (e.shiftKey) {
+                  window.location.href = `/api/auth/login?prompt=login&returnTo=${postLoginReturnToUrl}`;
+                } else {
+                  window.location.href = `/api/auth/login?returnTo=${postLoginReturnToUrl}`;
+                }
               }}
             />
           </div>


### PR DESCRIPTION
## Description

Users complain that clicking on login send them through the whole login process+mfa even if they are logged on sso. Forcing login prompt was mainly added for us to be able to use multiple accounts (especially to switch from us to eu) - since most users don't need that and prefer to be logged immediately, revert to original behaviour  but allows to force login prompt as an hidden feature by shift-clicking on login.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

minimal

## Deploy Plan

deploy front