### PR TITLE
enh(AssistantBuilder): Make the content of the "Add a tool" dropdown scrollable

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1343,7 +1343,7 @@ function AddAction({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent>
-        <ScrollArea className="max-h-[40vh] overflow-y-auto">
+        <ScrollArea className="flex max-h-[40vh] flex-col">
           <DropdownMenuGroup>
             <DropdownMenuLabel label="Knowledge" />
             {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1343,7 +1343,7 @@ function AddAction({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent>
-        <ScrollArea>
+        <ScrollArea className="max-h-[40vh] overflow-y-auto">
           <DropdownMenuGroup>
             <DropdownMenuLabel label="Knowledge" />
             {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -23,6 +23,7 @@ import {
   Page,
   PlusIcon,
   Popover,
+  ScrollArea,
   Sheet,
   SheetContainer,
   SheetContent,
@@ -1342,73 +1343,75 @@ function AddAction({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent>
-        <DropdownMenuGroup>
-          <DropdownMenuLabel label="Knowledge" />
-          {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
-            const spec = ACTION_SPECIFICATIONS[key];
-            if (!hasFeature(spec.flag)) {
-              return null;
-            }
-            const defaultAction = getDefaultActionConfiguration(key);
-            if (!defaultAction) {
-              return null;
-            }
+        <ScrollArea>
+          <DropdownMenuGroup>
+            <DropdownMenuLabel label="Knowledge" />
+            {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
+              const spec = ACTION_SPECIFICATIONS[key];
+              if (!hasFeature(spec.flag)) {
+                return null;
+              }
+              const defaultAction = getDefaultActionConfiguration(key);
+              if (!defaultAction) {
+                return null;
+              }
 
-            return (
-              <DropdownMenuItem
-                key={key}
-                onClick={() => onAddAction(defaultAction)}
-                icon={spec.dropDownIcon}
-                label={spec.label}
-                description={spec.description}
-              />
-            );
-          })}
-          {mcpServerViews
-            .filter((view) => isUsableInKnowledge(view.id, mcpServerViews))
-            .map((view) => {
               return (
                 <DropdownMenuItem
-                  key={view.id}
-                  icon={() => (
-                    <Avatar visual={getAvatar(view.server)} size="xs" />
-                  )}
-                  label={asDisplayName(view.server.name)}
-                  description={view.server.description}
-                  onClick={() =>
-                    onAddAction({
-                      ...getDefaultMCPServerActionConfiguration(view),
-                      id: uniqueId(),
-                    })
-                  }
+                  key={key}
+                  onClick={() => onAddAction(defaultAction)}
+                  icon={spec.dropDownIcon}
+                  label={spec.label}
+                  description={spec.description}
                 />
               );
             })}
-        </DropdownMenuGroup>
-        <DropdownMenuSeparator />
-        <DropdownMenuGroup>
-          <DropdownMenuLabel label="Advanced" />
-          {ADVANCED_ACTION_CATEGORIES.map((key) => {
-            const spec = ACTION_SPECIFICATIONS[key];
-            if (!hasFeature(spec.flag)) {
-              return null;
-            }
-            const defaultAction = getDefaultActionConfiguration(key);
-            if (!defaultAction) {
-              return null;
-            }
+            {mcpServerViews
+              .filter((view) => isUsableInKnowledge(view.id, mcpServerViews))
+              .map((view) => {
+                return (
+                  <DropdownMenuItem
+                    key={view.id}
+                    icon={() => (
+                      <Avatar visual={getAvatar(view.server)} size="xs" />
+                    )}
+                    label={asDisplayName(view.server.name)}
+                    description={view.server.description}
+                    onClick={() =>
+                      onAddAction({
+                        ...getDefaultMCPServerActionConfiguration(view),
+                        id: uniqueId(),
+                      })
+                    }
+                  />
+                );
+              })}
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuLabel label="Advanced" />
+            {ADVANCED_ACTION_CATEGORIES.map((key) => {
+              const spec = ACTION_SPECIFICATIONS[key];
+              if (!hasFeature(spec.flag)) {
+                return null;
+              }
+              const defaultAction = getDefaultActionConfiguration(key);
+              if (!defaultAction) {
+                return null;
+              }
 
-            return (
-              <DropdownMenuItem
-                key={key}
-                onClick={() => onAddAction(defaultAction)}
-                icon={spec.dropDownIcon}
-                label={spec.label}
-                description={spec.description}
-              />
-            );
-          })}
-        </DropdownMenuGroup>
+              return (
+                <DropdownMenuItem
+                  key={key}
+                  onClick={() => onAddAction(defaultAction)}
+                  icon={spec.dropDownIcon}
+                  label={spec.label}
+                  description={spec.description}
+                />
+              );
+            })}
+          </DropdownMenuGroup>
+        </ScrollArea>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2687
- This PR makes the content of the "Add a tool" dropdown in the `AssistantBuilder` scrollable, specifically for small screens.

https://github.com/user-attachments/assets/4fda923f-9479-4231-8de6-dca40b318982


## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy front.