### PR TITLE
feat: tools icon on dropdown

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1523,12 +1523,10 @@ function Capabilities({
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          label={
-            totalCapabilities
-              ? `Capabilities (${totalCapabilities})`
-              : "Capabilities"
-          }
+          label={"Capabilities"}
           size="sm"
+          isCounter={totalCapabilities > 0}
+          counterValue={`${totalCapabilities}`}
           isSelect
         />
       </DropdownMenuTrigger>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionGlobeAltIcon,
   Avatar,
   BookOpenIcon,
   Button,
@@ -35,6 +36,7 @@ import {
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import assert from "assert";
 import { uniqueId } from "lodash";
+import { BarChartIcon, LightbulbIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import React, {
   useCallback,
@@ -1434,12 +1436,14 @@ function Capabilities({
     name,
     description,
     enabled,
+    icon,
     onEnable,
     onDisable,
   }: {
     name: string;
     description: string;
     enabled: boolean;
+    icon?: React.ComponentType;
     onEnable: () => void;
     onDisable: () => void;
   }) => {
@@ -1449,7 +1453,7 @@ function Capabilities({
         onCheckedChange={enabled ? onDisable : onEnable}
         className="mb-0 mt-0 pb-0 pr-0 pt-0"
       >
-        <DropdownMenuItem label={name} description={description} />
+        <DropdownMenuItem icon={icon} label={name} description={description} />
       </DropdownMenuCheckboxItem>
     );
   };
@@ -1535,6 +1539,7 @@ function Capabilities({
           <Capability
             name="Web search & browse"
             description="Agent can search (Google) and retrieve information from specific websites."
+            icon={() => <Avatar icon={ActionGlobeAltIcon} size="sm" />}
             enabled={isWebNavigationEnabled}
             onEnable={() => {
               setEdited(true);
@@ -1558,6 +1563,7 @@ function Capabilities({
         <Capability
           name="Data visualization"
           description="Agent can generate charts and graphs."
+          icon={() => <Avatar icon={BarChartIcon} size="sm" />}
           enabled={builderState.visualizationEnabled}
           onEnable={() => {
             setEdited(true);
@@ -1579,6 +1585,7 @@ function Capabilities({
           <Capability
             name="Reasoning"
             description="Agent can decide to trigger a reasoning model for complex tasks"
+            icon={() => <Avatar icon={LightbulbIcon} size="sm" />}
             enabled={isReasoningEnabled}
             onEnable={() => {
               setEdited(true);
@@ -1603,6 +1610,7 @@ function Capabilities({
           return (
             <Capability
               key={view.id}
+              icon={() => getAvatar(view.server)}
               name={asDisplayName(view.server.name)}
               description={view.server.description}
               enabled={


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2689
- Add icons for capabilities in the assistant builder
  - For capabilities coming from MCP:  use the server's icon
  - For the others, manually added an icon based on task.
- Use counter button element instead of adding it in the content

## Tests
<img width="1329" alt="Capture d’écran 2025-04-18 à 11 17 10" src="https://github.com/user-attachments/assets/a6cbd8ac-c6f0-4246-a45d-27b577e3ccba" />

## Risk
Low, could just show the wrong icon

## Deploy Plan
Deploy on Front
