### PR TITLE
Fix: slow performance when loading mcp servers for UI

### DIFF
--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Typecheck and Lint
         working-directory: front
         run: npm install && npm run tsc && npm run lint && npm run format:check && npm run docs:check
+      - name: Install Redis
+        uses: chenjuneking/redis-setup-action@v1
+        with:
+          version: "7.2.5"
+          hostPort: 5434
+          containerPort: 6379
       - name: Install Postgres
         uses: dust-tt/postgresql-action@6730e69fe23f4f2989c19edf9e6e0d7ffeb0a05c
         with:
@@ -42,6 +48,7 @@ jobs:
         working-directory: front
         env:
           FRONT_DATABASE_URI: "postgres://test:test@localhost:5433/front_test"
+          REDIS_CACHE_URI: "redis://localhost:5434"
           NODE_ENV: test
         run: npx tsx admin/db.ts && npm run test:ci
       - name: Build Tests Report

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -126,8 +126,7 @@ export async function fetchMCPServerActionConfigurations(
       serverName = "Missing";
       serverDescription = "Missing";
     } else {
-      const { name, description } =
-        await mcpServerView.getMCPServerMetadata(auth);
+      const { name, description } = await mcpServerView.toJSON().server;
 
       serverName = name;
       serverDescription = description;

--- a/front/lib/models/assistant/actions/mcp_server_view.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view.ts
@@ -24,6 +24,7 @@ export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServ
 
   declare editedByUser: NonAttribute<UserModel>;
   declare space: NonAttribute<SpaceModel>;
+  declare remoteMCPServer: NonAttribute<RemoteMCPServerModel>;
 }
 MCPServerViewModel.init(
   {
@@ -133,12 +134,12 @@ MCPServerViewModel.belongsTo(SpaceModel, {
 });
 
 RemoteMCPServerModel.hasMany(MCPServerViewModel, {
-  as: "remoteMCPServerForView",
+  as: "remoteMCPServer",
   foreignKey: { name: "remoteMCPServerId", allowNull: false },
   onDelete: "RESTRICT",
 });
 MCPServerViewModel.belongsTo(RemoteMCPServerModel, {
-  as: "remoteMCPServerForView",
+  as: "remoteMCPServer",
   foreignKey: { name: "remoteMCPServerId", allowNull: false },
 });
 

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -22,6 +22,7 @@ export default async function setup() {
 
     // Add any other essential vars you need to keep
     FRONT_DATABASE_URI: process.env.FRONT_DATABASE_URI,
+    REDIS_CACHE_URI: process.env.REDIS_CACHE_URI,
     NEXT_PUBLIC_DUST_CLIENT_FACING_URL: "http://fake-url",
     DUST_US_URL: "http://fake-url",
     LOG_LEVEL: process.env.TEST_LOG_LEVEL ?? "silent",


### PR DESCRIPTION
## Description

Fix performance issues with MCP servers (views) in UI.

We were doing some unneeded lookups:
- When using remote servers, we were doing a separate query per server => now we include them alongside the related views
- Internal actions are verified to be valid by checking if they exist in the system space => skip this check for **default** internal actions that are always available anyway
- Cache internal servers metadata for UI (5 minutes TTL, could be increased) as it's cheap but not "free" to retrieve them via the MCP client <-> server communication.

## Tests

Locally, seen a big performance boost.

## Risk

Low, worst case it breaks something for people with MCP actions enabled.

## Deploy Plan

Deploy `front` and monitor