### PR TITLE
enh: update Reasoning model selection Button

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -6,6 +6,7 @@ import {
   Card,
   CardActionButton,
   CardGrid,
+  ChevronDownIcon,
   Chip,
   classNames,
   CommandIcon,
@@ -1296,8 +1297,9 @@ function AdvancedSettings({
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button
-                      variant="primary"
+                      variant="outline"
                       label={reasoningModel?.displayName}
+                      icon={ChevronDownIcon}
                     />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -6,7 +6,6 @@ import {
   Card,
   CardActionButton,
   CardGrid,
-  ChevronDownIcon,
   Chip,
   classNames,
   CommandIcon,
@@ -1299,7 +1298,7 @@ function AdvancedSettings({
                     <Button
                       variant="outline"
                       label={reasoningModel?.displayName}
-                      icon={ChevronDownIcon}
+                      isSelect
                     />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent>


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2688.
- Change button variant from primary to outline in the dropdown menu.
- Add ChevronDownIcon to enhance visual indication of dropdown functionality.

Before/After

<img width="372" alt="Screenshot 2025-04-18 at 4 10 10 PM" src="https://github.com/user-attachments/assets/398e45ea-fa03-4aee-ad4b-3380220e91b4" />

<img width="372" alt="Screenshot 2025-04-18 at 4 18 20 PM" src="https://github.com/user-attachments/assets/588b7eba-714c-47d5-af1b-071b16f36e54" />

## Tests

- N/A

## Risk

- N/A

## Deploy Plan

- Deploy front.