### PR TITLE
Fix internal MCP server ID clash

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -59,7 +59,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     flag: "dev_mcp_actions", // Putting this behind the dev flag for now to allow shipping without it.
   },
   "web_search_&_browse_v2": {
-    id: 4,
+    id: 5,
     isDefault: true,
     flag: "mcp_actions",
   },


### PR DESCRIPTION
## Description

There are currently two internal MCP servers with the same ID.
This PR fixes that.
There are no other clashes.

## Tests

## Risk

- N/A assuming no one has already set it up.

## Deploy Plan

- Deploy front.
