### PR TITLE
Add: when editing an existing MCP tool in AB, remove the picker

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -407,6 +407,7 @@ export default function ActionsScreen({
         isOpen={pendingAction.action !== null}
         builderState={builderState}
         initialAction={pendingAction.action}
+        isEditing={!!pendingAction.previousActionName}
         spacesUsedInActions={spaceIdToActions}
         onSave={(newAction) => {
           setEdited(true);
@@ -626,6 +627,7 @@ type NewActionModalProps = {
   isOpen: boolean;
   builderState: AssistantBuilderState;
   initialAction: AssistantBuilderActionConfigurationWithId | null;
+  isEditing: boolean;
   spacesUsedInActions: SpaceIdToActions;
   onSave: (newAction: AssistantBuilderActionConfigurationWithId) => void;
   onClose: () => void;
@@ -642,6 +644,7 @@ type NewActionModalProps = {
 function NewActionModal({
   isOpen,
   initialAction,
+  isEditing,
   spacesUsedInActions,
   onSave,
   onClose,
@@ -796,6 +799,7 @@ function NewActionModal({
             {newActionConfig && (
               <ActionEditor
                 action={newActionConfig}
+                isEditing={isEditing}
                 spacesUsedInActions={spacesUsedInActions}
                 updateAction={updateAction}
                 owner={owner}
@@ -891,6 +895,7 @@ function ActionCard({
 interface ActionConfigEditorProps {
   owner: WorkspaceType;
   action: AssistantBuilderActionConfigurationWithId;
+  isEditing: boolean;
   spacesUsedInActions: SpaceIdToActions;
   instructions: string | null;
   updateAction: (args: {
@@ -908,6 +913,7 @@ interface ActionConfigEditorProps {
 function ActionConfigEditor({
   owner,
   action,
+  isEditing,
   spacesUsedInActions,
   instructions,
   updateAction,
@@ -995,6 +1001,7 @@ function ActionConfigEditor({
         <MCPAction
           owner={owner}
           action={action}
+          isEditing={isEditing}
           allowedSpaces={allowedSpaces}
           updateAction={updateAction}
           setEdited={setEdited}
@@ -1053,6 +1060,7 @@ function ActionConfigEditor({
 
 interface ActionEditorProps {
   action: AssistantBuilderActionConfigurationWithId;
+  isEditing: boolean;
   spacesUsedInActions: SpaceIdToActions;
   showInvalidActionNameError: string | null;
   showInvalidActionDescError: string | null;
@@ -1073,6 +1081,7 @@ interface ActionEditorProps {
 
 function ActionEditor({
   action,
+  isEditing,
   spacesUsedInActions,
   showInvalidActionNameError,
   showInvalidActionDescError,
@@ -1166,6 +1175,7 @@ function ActionEditor({
         <ActionConfigEditor
           owner={owner}
           action={action}
+          isEditing={isEditing}
           spacesUsedInActions={spacesUsedInActions}
           instructions={builderState.instructions}
           updateAction={updateAction}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -158,6 +158,7 @@ export default function AssistantBuilder({
   const [pendingAction, setPendingAction] =
     useState<AssistantBuilderPendingAction>({
       action: null,
+      previousActionName: null,
     });
 
   const {
@@ -316,7 +317,7 @@ export default function AssistantBuilder({
           previousActionName: p.action.name,
         });
       } else if (p.type === "clear_pending") {
-        setPendingAction({ action: null });
+        setPendingAction({ action: null, previousActionName: null });
       } else if (p.type === "insert") {
         if (builderState.actions.some((a) => a.name === p.action.name)) {
           return;

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -8,6 +8,7 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
+import { MCPToolsList } from "@app/components/assistant_builder/actions/MCPToolsList";
 import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -50,13 +51,17 @@ export function MCPServerSelector({
   }, [mcpServerViews, allowedSpaces]);
 
   return (
-    <>
+    <div>
       <div className="text-sm text-foreground dark:text-foreground-night">
         The agent will be able to execute tools from the{" "}
         <a className="font-bold" href="https://docs.dust.tt" target="_blank">
           Toolset
         </a>{" "}
         made available to you by your Admin.
+      </div>
+      <MCPToolsList tools={selectedMCPServerView?.server.tools ?? []} />
+      <div className="flex-grow pt-4 text-sm font-semibold text-foreground dark:text-foreground-night">
+        Pick a Toolset
       </div>
       {isSpacesLoading ? (
         <Spinner />
@@ -133,6 +138,6 @@ export function MCPServerSelector({
           }}
         />
       )}
-    </>
+    </div>
   );
 }

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -5,6 +5,7 @@ import { AdditionalConfigurationSection } from "@app/components/assistant_builde
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/actions/configuration/AssistantBuilderDataSourceModal";
 import { ChildAgentConfigurationSection } from "@app/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection";
 import DataSourceSelectionSection from "@app/components/assistant_builder/actions/configuration/DataSourceSelectionSection";
+import { MCPToolsList } from "@app/components/assistant_builder/actions/MCPToolsList";
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import { MCPServerSelector } from "@app/components/assistant_builder/MCPServerSelector";
 import type {
@@ -27,7 +28,7 @@ interface NoActionAvailableProps {
 function NoActionAvailable({ owner }: NoActionAvailableProps) {
   return (
     <ContentMessage
-      title="You don't have any Actions available"
+      title="You don't have any Tools available"
       icon={InformationCircleIcon}
       variant="warning"
     >
@@ -65,6 +66,7 @@ interface MCPActionProps {
   owner: LightWorkspaceType;
   allowedSpaces: SpaceType[];
   action: AssistantBuilderActionConfiguration;
+  isEditing: boolean;
   updateAction: (args: {
     actionName: string;
     actionDescription: string;
@@ -79,6 +81,7 @@ export function MCPAction({
   owner,
   allowedSpaces,
   action,
+  isEditing,
   updateAction,
   setEdited,
 }: MCPActionProps) {
@@ -246,19 +249,41 @@ export function MCPAction({
         />
       )}
       {/* Server selection */}
-      {isDefaultMCPServer ? (
-        <div className="text-sm text-foreground dark:text-foreground-night">
-          {selectedMCPServerView?.server.description}
+      {isEditing ? (
+        <div>
+          <div className="text-sm text-foreground dark:text-foreground-night">
+            <div>{selectedMCPServerView?.server.description}</div>
+
+            {isDefaultMCPServer ? (
+              ""
+            ) : (
+              <div>
+                Available to you via{" "}
+                <b>
+                  {
+                    allowedSpaces.find(
+                      (space) => space.sId === selectedMCPServerView?.spaceId
+                    )?.name
+                  }
+                </b>{" "}
+                space.
+              </div>
+            )}
+          </div>
+          <MCPToolsList tools={selectedMCPServerView?.server.tools ?? []} />
         </div>
       ) : (
-        <MCPServerSelector
-          owner={owner}
-          allowedSpaces={allowedSpaces}
-          mcpServerViews={mcpServerViews}
-          selectedMCPServerView={selectedMCPServerView}
-          handleServerSelection={handleServerSelection}
-        />
+        <>
+          <MCPServerSelector
+            owner={owner}
+            allowedSpaces={allowedSpaces}
+            mcpServerViews={mcpServerViews}
+            selectedMCPServerView={selectedMCPServerView}
+            handleServerSelection={handleServerSelection}
+          />
+        </>
       )}
+
       {/* Configurable blocks */}
       {requirements.requiresDataSourceConfiguration && (
         <DataSourceSelectionSection

--- a/front/components/assistant_builder/actions/MCPToolsList.tsx
+++ b/front/components/assistant_builder/actions/MCPToolsList.tsx
@@ -1,0 +1,60 @@
+import { cn, CollapsibleComponent } from "@dust-tt/sparkle";
+
+import { asDisplayName } from "@app/types";
+
+export function MCPToolsList({
+  tools,
+}: {
+  tools: { name: string; description: string }[];
+}) {
+  return (
+    <>
+      <div className="flex-grow pt-4 text-sm font-semibold text-foreground dark:text-foreground-night">
+        Available tools
+      </div>
+      {tools && tools.length > 0 ? (
+        <CollapsibleComponent
+          triggerChildren={
+            <div
+              className={cn(
+                "text-sm font-normal text-foreground dark:text-foreground-night",
+                "flex flex-row items-center gap-x-2"
+              )}
+            >
+              View details of {tools.length} tool{tools.length === 1 ? "" : "s"}
+              .
+            </div>
+          }
+          contentChildren={
+            <div className="space-y-0">
+              {tools.map(
+                (
+                  tool: { name: string; description: string },
+                  index: number
+                ) => {
+                  return (
+                    <div
+                      key={index}
+                      className="flex flex-col gap-1 border-b border-border py-1 last:border-b-0 last:pb-0"
+                    >
+                      <h4 className="flex-grow text-foreground dark:text-foreground-night">
+                        {asDisplayName(tool.name)}
+                      </h4>
+                      {tool.description && (
+                        <p className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+                          {tool.description}
+                        </p>
+                      )}
+                    </div>
+                  );
+                }
+              )}
+            </div>
+          }
+        />
+      ) : (
+        <p className="text-sm text-faint">No tools available</p>
+      )}
+    </>
+  );
+}

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -211,6 +211,7 @@ export type AssistantBuilderPendingAction =
     }
   | {
       action: null;
+      previousActionName: null;
     };
 
 export type AssistantBuilderState = {

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -110,7 +110,10 @@ export function asDisplayName(name?: string | null) {
     return "";
   }
 
-  return name.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+  return name
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 // UUID utils.


### PR DESCRIPTION
## Description

Do not allow to change selection once a MCP tool has been added + show tools details.

(not the best design ever, will ask @Duncid to do a pass)

## Tests

Local

<img width="624" alt="image" src="https://github.com/user-attachments/assets/a98f066f-d5ed-424e-84a2-4879a2a6aac0" />
<img width="662" alt="image" src="https://github.com/user-attachments/assets/d88112da-ca60-46e7-9e50-bce45a21ebb4" />
<img width="749" alt="image" src="https://github.com/user-attachments/assets/6ea71f0a-fd47-4529-8864-e007f4abcd15" />
<img width="603" alt="image" src="https://github.com/user-attachments/assets/8bc2169b-2308-4f6d-958f-6b5d7eace259" />


## Risk

Low, mostly UI.

## Deploy Plan

Deploy `front`