### PR TITLE
fix: use transaction when checking for views

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -407,6 +407,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
           [Op.is]: null,
         },
       },
+      transaction,
     });
 
     if (dataSourceViews.length > 0) {


### PR DESCRIPTION
## Description

When deleting a space, we first soft delete dsviews and datasources in a tx.
In the ds soft-deletion flow, we check if all dsviews were properly soft-deleted first, but we don't use the transaction which causes the dsviews to appear as non-deleted in the context of space deletion


## Tests

Local

## Risk

NA

## Deploy Plan

deploy front