### PR TITLE
[connectors] feat(webcrawler): Setup custom http client for CheerioCrawler

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -30,7 +30,7 @@
         "blake3": "^2.1.7",
         "body-parser": "^1.20.2",
         "cls-hooked": "^4.2.2",
-        "crawlee": "^3.10.1",
+        "crawlee": "^3.13.3-beta.10",
         "dd-trace": "^5.1.0",
         "eventsource-parser": "^1.0.0",
         "express": "^4.18.2",
@@ -90,13 +90,15 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.40",
+      "version": "1.0.42",
       "license": "ISC",
       "dependencies": {
+        "@types/json-schema": "^7.0.15",
         "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.5"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",
@@ -121,21 +123,21 @@
       }
     },
     "node_modules/@apify/consts": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.27.0.tgz",
-      "integrity": "sha512-GjaZ74vDmg0XBwN7sY+LxezOP9zWPgKamc97LH2GhZhPz6gFQclKK+PM/uRqBZwWXkyElScz+Nrm4UPX3uSPcg=="
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.40.0.tgz",
+      "integrity": "sha512-2coaQ97ddsQ4+QRybqGbPE4irqfmkSaUPlbUPQvIcmT+PLdFT1t1iSU61Yy2T1UW5wN3K6UDAqFWNIqxxb0apg=="
     },
     "node_modules/@apify/datastructures": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@apify/datastructures/-/datastructures-2.0.2.tgz",
-      "integrity": "sha512-IN9A0s2SCHoZZE1tf4xKgk4fxHM5/0I/UrXhWbn/rSv7E5sA2o0NyHdwcMY2Go9f5qd+E7VAbX6WnESTE6GLeA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@apify/datastructures/-/datastructures-2.0.3.tgz",
+      "integrity": "sha512-E6yQyc/XZDqJopbaGmhzZXMJqwGf96ELtDANZa0t68jcOAJZS+pF7YUfQOLszXq6JQAdnRvTH2caotL6urX7HA=="
     },
     "node_modules/@apify/log": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.1.tgz",
-      "integrity": "sha512-Rtmdow2LlI+ViGhfgpg2K+ntI+5VEaEiLA4vZUCFhJc+TWiVH1T53HhOJS/PKzo4mlKu74HVEcmBb1PK3jWeww==",
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.17.tgz",
+      "integrity": "sha512-1L/iiHRxyc8e0EuFfZ1raZLWC4mQYrTPy9JzF1hwwhsRSlyHNFQrfNzF0vbF3/8XpLwEBSasAA3fclQhDbUn/Q==",
       "dependencies": {
-        "@apify/consts": "^2.27.0",
+        "@apify/consts": "^2.40.0",
         "ansi-colors": "^4.1.1"
       }
     },
@@ -154,27 +156,43 @@
       }
     },
     "node_modules/@apify/pseudo_url": {
-      "version": "2.0.41",
-      "resolved": "https://registry.npmjs.org/@apify/pseudo_url/-/pseudo_url-2.0.41.tgz",
-      "integrity": "sha512-SFUh+0Wl3CRJLACazcrZoqUeayMp/lk+KjWqLgbkuxSC1wVYeWVtwsskUkBaCHaZjClf16GUkdGuK5dcQ1/p5g==",
+      "version": "2.0.58",
+      "resolved": "https://registry.npmjs.org/@apify/pseudo_url/-/pseudo_url-2.0.58.tgz",
+      "integrity": "sha512-a0F94mEhwZJe6UUO3JGVbvufNqSQkP3uc0nLAAJA7Bydwe5PMRrWGLQ8+/EW8pEnrYCFVTuI9+uXtJideQpinA==",
       "dependencies": {
-        "@apify/log": "^2.5.1",
-        "@sapphire/shapeshift": "^3.6.0"
+        "@apify/log": "^2.5.17"
       }
     },
     "node_modules/@apify/timeout": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.3.1.tgz",
-      "integrity": "sha512-sLIuOqfySki/7AXiQ1yZoCI07vX6aYFLgP6YaJ8e8YLn8CFsRERma/Crxcz0zyCaxhc7C7EPgcs1O+p/djZchw=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.3.2.tgz",
+      "integrity": "sha512-JnOLIOpqfm366q7opKrA6HrL0iYRpYYDn8Mi77sMR2GZ1fPbwMWCVzN23LJWfJV7izetZbCMrqRUXsR1etZ7dA=="
     },
     "node_modules/@apify/utilities": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.10.2.tgz",
-      "integrity": "sha512-kHv6g+v8cRzcH3i4dlydUBseA/ol1MWkHrmyEmIteK6VGl+xqbs/BsgCiS0G9STcdTMS+drAO2oYYhhdD3ESUA==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.15.4.tgz",
+      "integrity": "sha512-uM1kLJAE3bnDApGPqdD0xWeo/2HCE9KyAxeBdtRNaHVOu8DvRf8ioOlif75AZbMCXCo3g0zNmkznjtR6hrglJw==",
       "dependencies": {
-        "@apify/consts": "^2.27.0",
-        "@apify/log": "^2.5.1"
+        "@apify/consts": "^2.40.0",
+        "@apify/log": "^2.5.17"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.2.tgz",
+      "integrity": "sha512-nwgc7jPn3LpZ4JWsoHtuwBsad1qSSLDDX634DdG0PBJofIuIEtSWk4KkRmuXyu178tjuHAbwiMNNzwqIyLYxZw==",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.2",
+        "@csstools/css-color-parser": "^3.0.8",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -1280,16 +1298,16 @@
       }
     },
     "node_modules/@crawlee/basic": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/basic/-/basic-3.10.1.tgz",
-      "integrity": "sha512-nRvZNWU4ZD2UDR7QcNlFxqKCRARqT4cF8TS0tDtGaQd0BQYdW9FpYa4niQFs5GLQYjNRt+HtIiCp380oyEZC5A==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/basic/-/basic-3.13.3-beta.10.tgz",
+      "integrity": "sha512-/x5pqsppUPypXv3aY1kkzvE10oYlYXjYPcKanjMZidZaAlczTdZ+1eTQRpR6KKsf0KvImhgane2/yXXN3GZUxw==",
       "dependencies": {
         "@apify/log": "^2.4.0",
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/core": "3.10.1",
-        "@crawlee/types": "3.10.1",
-        "@crawlee/utils": "3.10.1",
+        "@crawlee/core": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
         "csv-stringify": "^6.2.0",
         "fs-extra": "^11.0.0",
         "got-scraping": "^4.0.0",
@@ -1303,9 +1321,9 @@
       }
     },
     "node_modules/@crawlee/basic/node_modules/type-fest": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.3.tgz",
-      "integrity": "sha512-Q08/0IrpvM+NMY9PA2rti9Jb+JejTddwmwmVQGskAlhtcrw1wsRzoR6ode6mR+OAabNa75w/dxedSUY2mlphaQ==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
       "engines": {
         "node": ">=16"
       },
@@ -1314,32 +1332,44 @@
       }
     },
     "node_modules/@crawlee/browser": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/browser/-/browser-3.10.1.tgz",
-      "integrity": "sha512-FgQbWQcIe787w8HhKYGjf4j3E64OmOJYkoKJa/KdWfSJ03PozAc3Bu8Kw1dSO8J0OOK8JpoBO5SnqazXcbjuzg==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/browser/-/browser-3.13.3-beta.10.tgz",
+      "integrity": "sha512-L5JKzJD88VH+gvgFuU7U//fkjOSgiqhD0wNJpv1jvp9DEiFUeVu1+ZhlzkvIplcyxVZHgQe/AaAbK0Q09YIBeQ==",
       "dependencies": {
         "@apify/timeout": "^0.3.0",
-        "@crawlee/basic": "3.10.1",
-        "@crawlee/browser-pool": "3.10.1",
-        "@crawlee/types": "3.10.1",
-        "@crawlee/utils": "3.10.1",
+        "@crawlee/basic": "3.13.3-beta.10",
+        "@crawlee/browser-pool": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
         "ow": "^0.28.1",
         "tslib": "^2.4.0",
         "type-fest": "^4.0.0"
       },
       "engines": {
         "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "puppeteer": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "puppeteer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@crawlee/browser-pool": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/browser-pool/-/browser-pool-3.10.1.tgz",
-      "integrity": "sha512-J1PkxkEF4HoVMBaP5q3lgymYACmnfUxxzUgyTEx9gUC8c404CO0fkblFbqHw7K7d+4WLlakDYRhBx5d20OmgNg==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/browser-pool/-/browser-pool-3.13.3-beta.10.tgz",
+      "integrity": "sha512-0V0volP4g5eTUhgKfBY+g0sVnLEemzJqV9Xwi+WSwhMiSu0n22VQE56JUrghhWhEZOTNwSR4VBpECeJFCygz3w==",
       "dependencies": {
         "@apify/log": "^2.4.0",
         "@apify/timeout": "^0.3.0",
-        "@crawlee/core": "3.10.1",
-        "@crawlee/types": "3.10.1",
+        "@crawlee/core": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
         "fingerprint-generator": "^2.0.6",
         "fingerprint-injector": "^2.0.5",
         "lodash.merge": "^4.6.2",
@@ -1368,9 +1398,9 @@
       }
     },
     "node_modules/@crawlee/browser/node_modules/type-fest": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.3.tgz",
-      "integrity": "sha512-Q08/0IrpvM+NMY9PA2rti9Jb+JejTddwmwmVQGskAlhtcrw1wsRzoR6ode6mR+OAabNa75w/dxedSUY2mlphaQ==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
       "engines": {
         "node": ">=16"
       },
@@ -1379,14 +1409,14 @@
       }
     },
     "node_modules/@crawlee/cheerio": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/cheerio/-/cheerio-3.10.1.tgz",
-      "integrity": "sha512-WtBW+QAON+5nv8KootnpA4Fy0AOSoy+O8wuu/heLIKmAEClxUP/HQer1Z7gf89xDZYYemobBZLoM1uO0e2V5lQ==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/cheerio/-/cheerio-3.13.3-beta.10.tgz",
+      "integrity": "sha512-ofFDdF+lMwUVhSYi3o9epYkBBHHqsORChzCuf7rCKMuBSxt6w4yBhkwZ6zOPig9SyxalsVjslZvkRmAQd7p+YA==",
       "dependencies": {
-        "@crawlee/http": "3.10.1",
-        "@crawlee/types": "3.10.1",
-        "@crawlee/utils": "3.10.1",
-        "cheerio": "^1.0.0-rc.12",
+        "@crawlee/http": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
+        "cheerio": "1.0.0-rc.12",
         "htmlparser2": "^9.0.0",
         "tslib": "^2.4.0"
       },
@@ -1395,11 +1425,11 @@
       }
     },
     "node_modules/@crawlee/cli": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.10.1.tgz",
-      "integrity": "sha512-33ZRzQW6u9+iiDulu36ZdfHyQTvW6e2VrG3a155gdElm2XPBazn4h97Go2mxcPGnJ5YwW4XxfETxZsesSOy1aQ==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.13.3-beta.10.tgz",
+      "integrity": "sha512-tAIlx9HhBG7ysp/bTN2Lq1OcLInRKu1UfLP+iRKbkGaZ68kr4OaNITw0uXEqkbsjpsfGPuR06ORqh0nEPFAWQA==",
       "dependencies": {
-        "@crawlee/templates": "3.10.1",
+        "@crawlee/templates": "3.13.3-beta.10",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^11.0.0",
         "inquirer": "^8.2.4",
@@ -1415,9 +1445,9 @@
       }
     },
     "node_modules/@crawlee/core": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.10.1.tgz",
-      "integrity": "sha512-2i7DFQRE8csxG/4r76KUpqc4I2msCeFp6s42Ytk7Q/Fm+WkjOs5DqmJO9pb76E6AFsmGtSZpt6SGLqwuPHp4AQ==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.13.3-beta.10.tgz",
+      "integrity": "sha512-ZN4D8SfppIthDwn37xnubE5SWd59uVTh1244/Dz6VV25bfu0ygoBTAuEyUjyledQOU+pmQgH/A6DxHEODADWtA==",
       "dependencies": {
         "@apify/consts": "^2.20.0",
         "@apify/datastructures": "^2.0.0",
@@ -1425,11 +1455,10 @@
         "@apify/pseudo_url": "^2.0.30",
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/memory-storage": "3.10.1",
-        "@crawlee/types": "3.10.1",
-        "@crawlee/utils": "3.10.1",
+        "@crawlee/memory-storage": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
         "@sapphire/async-queue": "^1.5.1",
-        "@types/tough-cookie": "^4.0.2",
         "@vladfrangu/async_event_emitter": "^2.2.2",
         "csv-stringify": "^6.2.0",
         "fs-extra": "^11.0.0",
@@ -1437,10 +1466,9 @@
         "json5": "^2.2.3",
         "minimatch": "^9.0.0",
         "ow": "^0.28.1",
-        "stream-chain": "^2.2.5",
-        "stream-json": "^1.7.4",
+        "stream-json": "^1.8.0",
         "tldts": "^6.0.0",
-        "tough-cookie": "^4.0.0",
+        "tough-cookie": "^5.0.0",
         "tslib": "^2.4.0",
         "type-fest": "^4.0.0"
       },
@@ -1457,9 +1485,9 @@
       }
     },
     "node_modules/@crawlee/core/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1471,9 +1499,9 @@
       }
     },
     "node_modules/@crawlee/core/node_modules/type-fest": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.3.tgz",
-      "integrity": "sha512-Q08/0IrpvM+NMY9PA2rti9Jb+JejTddwmwmVQGskAlhtcrw1wsRzoR6ode6mR+OAabNa75w/dxedSUY2mlphaQ==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
       "engines": {
         "node": ">=16"
       },
@@ -1482,17 +1510,17 @@
       }
     },
     "node_modules/@crawlee/http": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/http/-/http-3.10.1.tgz",
-      "integrity": "sha512-Cu4jC/CiS0aOAK15CotbKG1+yUQSupJJCeA8x1eBy1E+81WCt0c8afDoJmZ/3VeazGWWOABJblJUw1in8TJqPA==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/http/-/http-3.13.3-beta.10.tgz",
+      "integrity": "sha512-7pgdHmhzMirIAxmzrJqwOf3cOWtpItvjtFOb2qNeo1aGwZzcC/lw/2HdFspJk0VOVV/u6rr/GiswlMo26H82nQ==",
       "dependencies": {
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/basic": "3.10.1",
-        "@crawlee/types": "3.10.1",
-        "@crawlee/utils": "3.10.1",
+        "@crawlee/basic": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
         "@types/content-type": "^1.1.5",
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "content-type": "^1.0.4",
         "got-scraping": "^4.0.0",
         "iconv-lite": "^0.6.3",
@@ -1506,9 +1534,9 @@
       }
     },
     "node_modules/@crawlee/http/node_modules/type-fest": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.3.tgz",
-      "integrity": "sha512-Q08/0IrpvM+NMY9PA2rti9Jb+JejTddwmwmVQGskAlhtcrw1wsRzoR6ode6mR+OAabNa75w/dxedSUY2mlphaQ==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
       "engines": {
         "node": ">=16"
       },
@@ -1517,17 +1545,18 @@
       }
     },
     "node_modules/@crawlee/jsdom": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.10.1.tgz",
-      "integrity": "sha512-h86ELozseskARx1sPhIdsgxy1l8AH5gkLBp3X8KT46iGjEyX5R0B9ffdxn2ZgDCHNa03wEkf77tJ7/sLBN7Lwg==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.13.3-beta.10.tgz",
+      "integrity": "sha512-xY0ytiPVj6kuhb4fnkLm+CGwnW3BgpMq4k2+T3oVeV+3IfBPLhOykHBv94ialmW3vaO/yeejbmx9GjNZnn57Xg==",
       "dependencies": {
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/http": "3.10.1",
-        "@crawlee/types": "3.10.1",
+        "@crawlee/http": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
         "@types/jsdom": "^21.0.0",
-        "cheerio": "^1.0.0-rc.12",
-        "jsdom": "^24.0.0",
+        "cheerio": "1.0.0-rc.12",
+        "jsdom": "^26.0.0",
         "ow": "^0.28.2",
         "tslib": "^2.4.0"
       },
@@ -1536,14 +1565,14 @@
       }
     },
     "node_modules/@crawlee/linkedom": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/linkedom/-/linkedom-3.10.1.tgz",
-      "integrity": "sha512-eRTt93tJIkAIGfI+zM3eVaYGe7e0xswObpdb2ZNyqhDYy9NjGJGv4alKi+4lptAm92qPPWg/bHLVvMXHXAnCEA==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/linkedom/-/linkedom-3.13.3-beta.10.tgz",
+      "integrity": "sha512-fWHzXKBouP3hlfkxdz3XlGW52kkNZuuRCb9+nsvCzi22k3XhUvfIxqI6hOZv9evGkNQk1cKAExLLaXbuxCcKBg==",
       "dependencies": {
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/http": "3.10.1",
-        "@crawlee/types": "3.10.1",
+        "@crawlee/http": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
         "linkedom": "^0.18.0",
         "ow": "^0.28.2",
         "tslib": "^2.4.0"
@@ -1553,12 +1582,12 @@
       }
     },
     "node_modules/@crawlee/memory-storage": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.10.1.tgz",
-      "integrity": "sha512-+4kU98H3DdnAtrqQCGmkvWwQJ4jIDk497rQfi9IfwU+8f6wItBgR9uIU/+vx2EL2tYrbGQyc4lGwbznA4k46gw==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.13.3-beta.10.tgz",
+      "integrity": "sha512-ZvD6BqdaZAjwUdY8j2sHDeoCTr1Eu1+fKm1q/lyb353IZtkXukc63auCqa9UIhGzWjFoX4Xbm55UfzCFWB8SSw==",
       "dependencies": {
         "@apify/log": "^2.4.0",
-        "@crawlee/types": "3.10.1",
+        "@crawlee/types": "3.13.3-beta.10",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/shapeshift": "^3.0.0",
         "content-type": "^1.0.4",
@@ -1573,23 +1602,24 @@
       }
     },
     "node_modules/@crawlee/playwright": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/playwright/-/playwright-3.10.1.tgz",
-      "integrity": "sha512-NjYlqSVJO31zwoKrjIgce23BYl1rs9+nLPAM9Ppf5fFtEgMPONRCrHSg8WzICXrqT3yX0vU2lxKLTF2qwBdsGQ==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/playwright/-/playwright-3.13.3-beta.10.tgz",
+      "integrity": "sha512-csI8PzDyFtLj4oAns2waMcozfsn5TERucpgH7PSNZUW7igmqSvZnYA8kEvNbMeC8j4ZZ7uknxDP6RLG3LOYv/A==",
       "dependencies": {
         "@apify/datastructures": "^2.0.0",
         "@apify/log": "^2.4.0",
         "@apify/timeout": "^0.3.1",
-        "@crawlee/browser": "3.10.1",
-        "@crawlee/browser-pool": "3.10.1",
-        "@crawlee/core": "3.10.1",
-        "@crawlee/types": "3.10.1",
-        "@crawlee/utils": "3.10.1",
-        "cheerio": "^1.0.0-rc.12",
+        "@crawlee/browser": "3.13.3-beta.10",
+        "@crawlee/browser-pool": "3.13.3-beta.10",
+        "@crawlee/core": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
+        "cheerio": "1.0.0-rc.12",
         "idcac-playwright": "^0.1.2",
         "jquery": "^3.6.0",
         "lodash.isequal": "^4.5.0",
         "ml-logistic-regression": "^2.0.0",
+        "ml-matrix": "^6.11.0",
         "ow": "^0.28.1",
         "string-comparison": "^1.3.0",
         "tslib": "^2.4.0"
@@ -1607,17 +1637,17 @@
       }
     },
     "node_modules/@crawlee/puppeteer": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/puppeteer/-/puppeteer-3.10.1.tgz",
-      "integrity": "sha512-BpJgI7nYIeQSiqRnZNMd4Edxo0A9jC1cmWrPPunBhFwFbUUeC+j9nfjI97TrDW7hafSKwByQaePTlboXr8vt6g==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/puppeteer/-/puppeteer-3.13.3-beta.10.tgz",
+      "integrity": "sha512-xhMlhwKFJpNVRwSo52f7bUf8SZdETQPBC5RiexU9uz2FSqWxa3PUrYUDGqyUCtZO5JcwvCp1Q3OjjThfCTYmqw==",
       "dependencies": {
         "@apify/datastructures": "^2.0.0",
         "@apify/log": "^2.4.0",
-        "@crawlee/browser": "3.10.1",
-        "@crawlee/browser-pool": "3.10.1",
-        "@crawlee/types": "3.10.1",
-        "@crawlee/utils": "3.10.1",
-        "cheerio": "^1.0.0-rc.12",
+        "@crawlee/browser": "3.13.3-beta.10",
+        "@crawlee/browser-pool": "3.13.3-beta.10",
+        "@crawlee/types": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
+        "cheerio": "1.0.0-rc.12",
         "devtools-protocol": "*",
         "idcac-playwright": "^0.1.2",
         "jquery": "^3.6.0",
@@ -1637,9 +1667,9 @@
       }
     },
     "node_modules/@crawlee/templates": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.10.1.tgz",
-      "integrity": "sha512-Yh652LHRkR1sTQtHXM45KCh6q4/atLMOlZl8Sq7XhrSo4PRmd1ZJQeKP1R+paI30oMv6ZxtFP39kODFV+VSAdQ==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.13.3-beta.10.tgz",
+      "integrity": "sha512-p+ZVQh8Z73PzMEMWQjxEPB90yq7iYtvtQkpixy6NVVevguOI/ejTLb5ExiaNFsg6xozYco16w0XsoK9TkC5aAA==",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "inquirer": "^9.0.0",
@@ -1651,17 +1681,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@crawlee/templates/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@crawlee/templates/node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -1671,25 +1690,22 @@
       }
     },
     "node_modules/@crawlee/templates/node_modules/inquirer": {
-      "version": "9.2.22",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.22.tgz",
-      "integrity": "sha512-SqLLa/Oe5rZUagTR9z+Zd6izyatHglbmbvVofo1KzuVB54YHleWzeHNLoR7FOICGOeQSqeLh1cordb3MzhGcEw==",
+      "version": "9.3.7",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.7.tgz",
+      "integrity": "sha512-LJKFHCSeIRq9hanN14IlOtPSTe3lNES7TYDTE2xxdAy1LS5rYphajK1qtwvj3YmQXvvk0U2Vbmcni8P9EIQW9w==",
       "dependencies": {
-        "@inquirer/figures": "^1.0.2",
-        "@ljharb/through": "^2.3.13",
+        "@inquirer/figures": "^1.0.3",
         "ansi-escapes": "^4.3.2",
-        "chalk": "^5.3.0",
-        "cli-cursor": "^3.1.0",
         "cli-width": "^4.1.0",
         "external-editor": "^3.1.0",
-        "lodash": "^4.17.21",
         "mute-stream": "1.0.0",
         "ora": "^5.4.1",
         "run-async": "^3.0.0",
         "rxjs": "^7.8.1",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0"
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
         "node": ">=18"
@@ -1725,9 +1741,9 @@
       }
     },
     "node_modules/@crawlee/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-7iBRCCTgzhgzvRV2YuAMDajHr9KqyKrExWoxrsB4NNklmLCuDzZau4u2+wNm4TtolZSd9WyFQ8JH6HCreruiDA==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.13.3-beta.10.tgz",
+      "integrity": "sha512-Z7oVVcM72ltLt/PK0LnJS1C1EcgRXox1gEfXEILva2gnkNqB3MW/Juwo3Hj353PQ6xV1o/ntHkNgZcgn1UHaYA==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -1736,24 +1752,130 @@
       }
     },
     "node_modules/@crawlee/utils": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.10.1.tgz",
-      "integrity": "sha512-nzoscoD8x5Qmm6kE9wFmlgn2S+SgKJVGh5QdZjtqgiHvVA7oy9DWU/MASIgo0LQR9iwrPTDOp1SREVKhJHiQJQ==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.13.3-beta.10.tgz",
+      "integrity": "sha512-YwtJxxQNza21u+t7p35BqeB0RE9rpbmsb7WUdny6iCpLp+peMGlxFInhxNtNUd8FAdg63uVjuj5JuKBndLTnUg==",
       "dependencies": {
         "@apify/log": "^2.4.0",
         "@apify/ps-tree": "^1.2.0",
-        "@crawlee/types": "3.10.1",
+        "@crawlee/types": "3.13.3-beta.10",
         "@types/sax": "^1.2.7",
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
+        "file-type": "^20.0.0",
         "got-scraping": "^4.0.3",
         "ow": "^0.28.1",
         "robots-parser": "^3.0.1",
-        "sax": "^1.3.0",
+        "sax": "^1.4.1",
         "tslib": "^2.4.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.2.tgz",
+      "integrity": "sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.8.tgz",
+      "integrity": "sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -2752,9 +2874,9 @@
       "dev": true
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.2.tgz",
-      "integrity": "sha512-4F1MBwVr3c/m4bAUef6LgkvBfSjzwH+OfldgHqcuacWwSUetFebM2wi58WfG9uk1rR98U6GwLed4asLJbwdV5w==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
       "engines": {
         "node": ">=18"
       }
@@ -2959,17 +3081,6 @@
       },
       "peerDependencies": {
         "tslib": "2"
-      }
-    },
-    "node_modules/@ljharb/through": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
-      "integrity": "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==",
-      "dependencies": {
-        "call-bind": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/@microsoft/microsoft-graph-client": {
@@ -4105,9 +4216,9 @@
       ]
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.2.tgz",
-      "integrity": "sha512-7X7FFAA4DngXUl95+hYbUF19bp1LGiffjJtu7ygrZrbdCSsdDDBaSjB7Akw0ZbOu6k0xpXyljnJ6/RZUvLfRdg==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -4137,11 +4248,11 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
     },
     "node_modules/@sindresorhus/is": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.3.1.tgz",
-      "integrity": "sha512-FX4MfcifwJyFOI2lPoX7PQxCqx8BG1HCho7WdiXwpEQx1Ycij0JxkfYtGK7yqNScrZGSlt6RE6sw8QYoH7eKnQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.0.1.tgz",
+      "integrity": "sha512-QWLl2P+rsCJeofkDNIT3WFmb6NrRud1SUYW8dIhXK/46XFV8Q/g7Bsvib0Askb0reRLe+WYPeeE+l5cH7SlkuQ==",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -5317,6 +5428,28 @@
         "@temporalio/proto": "1.10.1"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -5443,9 +5576,9 @@
       }
     },
     "node_modules/@types/jsdom": {
-      "version": "21.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
-      "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
@@ -5991,9 +6124,9 @@
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
-      "integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -6200,11 +6333,11 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.12.tgz",
-      "integrity": "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -6940,32 +7073,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -7412,22 +7519,22 @@
       }
     },
     "node_modules/crawlee": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.10.1.tgz",
-      "integrity": "sha512-5BrjHZrXQWvsFi/IYpKQbL3f4ZY2u8t3hDQW0RjBaug3rNcO2GXdqeyWNoWAX5hi7RE9epjY6/qBruFJiPspfQ==",
+      "version": "3.13.3-beta.10",
+      "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.13.3-beta.10.tgz",
+      "integrity": "sha512-xklZwD0vlQjVu2/xTmxnixXSCHbcNOcZ6dDLZH2M4CeYGacmxmEcEvMXwVoAn6+q18+qiN/7h1Uq3g9s6DzoKQ==",
       "dependencies": {
-        "@crawlee/basic": "3.10.1",
-        "@crawlee/browser": "3.10.1",
-        "@crawlee/browser-pool": "3.10.1",
-        "@crawlee/cheerio": "3.10.1",
-        "@crawlee/cli": "3.10.1",
-        "@crawlee/core": "3.10.1",
-        "@crawlee/http": "3.10.1",
-        "@crawlee/jsdom": "3.10.1",
-        "@crawlee/linkedom": "3.10.1",
-        "@crawlee/playwright": "3.10.1",
-        "@crawlee/puppeteer": "3.10.1",
-        "@crawlee/utils": "3.10.1",
+        "@crawlee/basic": "3.13.3-beta.10",
+        "@crawlee/browser": "3.13.3-beta.10",
+        "@crawlee/browser-pool": "3.13.3-beta.10",
+        "@crawlee/cheerio": "3.13.3-beta.10",
+        "@crawlee/cli": "3.13.3-beta.10",
+        "@crawlee/core": "3.13.3-beta.10",
+        "@crawlee/http": "3.13.3-beta.10",
+        "@crawlee/jsdom": "3.13.3-beta.10",
+        "@crawlee/linkedom": "3.13.3-beta.10",
+        "@crawlee/playwright": "3.13.3-beta.10",
+        "@crawlee/puppeteer": "3.13.3-beta.10",
+        "@crawlee/utils": "3.13.3-beta.10",
         "import-local": "^3.1.0",
         "tslib": "^2.4.0"
       },
@@ -7511,20 +7618,16 @@
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
     },
     "node_modules/cssstyle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
-      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.0.tgz",
+      "integrity": "sha512-6r0NiY0xizYqfBvWp1G7WXJ06/bZyrk7Dc6PHql82C/pKGUTKu4yAX4Y8JPamb1ob9nBKuxWzCGTRuGwU3yxJQ==",
       "dependencies": {
-        "rrweb-cssom": "^0.6.0"
+        "@asamuzakjp/css-color": "^3.1.1",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
     },
     "node_modules/csv-parse": {
       "version": "5.6.0",
@@ -7670,9 +7773,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
@@ -7848,9 +7951,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1306150",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1306150.tgz",
-      "integrity": "sha512-ldV6MeOcYtDDLjP4SJHgs2Jlh4iUsdEtyPR6zHTEfPy/BGnhIcjgcZDBh+u/BRgtWB09kpmTe/Tz00Fqf5OVqw=="
+      "version": "0.0.1448144",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1448144.tgz",
+      "integrity": "sha512-1Hdy4TNgTa5Evd6nCUDQAddpINzjJmMOH5QYidogfnLmEltn+JQx54S935Pw/meHug2QEObZU8YaLmXizEFHgA=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -7920,9 +8023,9 @@
       "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -8853,10 +8956,15 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    },
     "node_modules/figlet": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.7.0.tgz",
-      "integrity": "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.1.tgz",
+      "integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==",
       "bin": {
         "figlet": "bin/index.js"
       },
@@ -8896,6 +9004,23 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.4.1.tgz",
+      "integrity": "sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -8964,12 +9089,12 @@
       }
     },
     "node_modules/fingerprint-generator": {
-      "version": "2.1.51",
-      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.51.tgz",
-      "integrity": "sha512-3lMIsP83DweaavTRW5TN0YXxi1n3RZit7B2sh/invInZRHDzYLFKhDpZ9X307I/FOUM2itdX1cT87p76uV54MQ==",
+      "version": "2.1.64",
+      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.64.tgz",
+      "integrity": "sha512-jpm/XdZC8uJyoAJqBcc8d4DX1bdTtUtit3MoEHhojl4wom1ulHf/M7K5zmObRNMGWx6Qu1NeWKLQe0teGdiIwQ==",
       "dependencies": {
-        "generative-bayesian-network": "^2.1.51",
-        "header-generator": "^2.1.51",
+        "generative-bayesian-network": "^2.1.64",
+        "header-generator": "^2.1.64",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -8977,11 +9102,11 @@
       }
     },
     "node_modules/fingerprint-injector": {
-      "version": "2.1.51",
-      "resolved": "https://registry.npmjs.org/fingerprint-injector/-/fingerprint-injector-2.1.51.tgz",
-      "integrity": "sha512-Ov9iVw/Bwmzr113ie3O5p3Nsd7lKc9kV6A7pRngBj0H0IubeFkAImYioDj+Qu6dn0WIgZwm7RjRHovYoCEKqSw==",
+      "version": "2.1.64",
+      "resolved": "https://registry.npmjs.org/fingerprint-injector/-/fingerprint-injector-2.1.64.tgz",
+      "integrity": "sha512-vLA5Y5CBOyvwOJnwae8UAwIoeOD0Aj8WFjV1gsySRVKyQcCPlInx40Fao1K3piIv3jPly5gqeEmePlU7eD/COQ==",
       "dependencies": {
-        "fingerprint-generator": "^2.1.51",
+        "fingerprint-generator": "^2.1.64",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -9258,9 +9383,9 @@
       }
     },
     "node_modules/generative-bayesian-network": {
-      "version": "2.1.51",
-      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.51.tgz",
-      "integrity": "sha512-QClDFgAlz6T064oH2TAgev5wNWJJBvJ6O9cyHkambU/Y0pCqJ7pOuX5A3ht1SBxNfTmG3JFFSqjH6TwHyfOJEg==",
+      "version": "2.1.64",
+      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.64.tgz",
+      "integrity": "sha512-TllJQ+WCNnvesb7L6nC6JiIVgOF5m+WCMTsPP9T1tscf4vwkEC7K8Jq2PTKLSLUPe1/nLuSHHPVDcBMHgnhSnQ==",
       "dependencies": {
         "adm-zip": "^0.5.9",
         "tslib": "^2.4.0"
@@ -9318,11 +9443,26 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9541,21 +9681,21 @@
       }
     },
     "node_modules/got": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.3.0.tgz",
-      "integrity": "sha512-vZkrXdq5BtPWTXqvjXSpl6zky3zpHaOVfSug/RfFHu3YrtSsvYzopVMDqrh2do77WnGoCSSRCHW25zXOSAQ9zw==",
+      "version": "14.4.7",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.4.7.tgz",
+      "integrity": "sha512-DI8zV1231tqiGzOiOzQWDhsBmncFW7oQDH6Zgy6pDPrqJuVZMtoSgPLLsBZQj8Jg4JFfwoOsDA8NGtLQLnIx2g==",
       "dependencies": {
-        "@sindresorhus/is": "^6.3.1",
+        "@sindresorhus/is": "^7.0.1",
         "@szmarczak/http-timer": "^5.0.1",
         "cacheable-lookup": "^7.0.0",
         "cacheable-request": "^12.0.1",
         "decompress-response": "^6.0.0",
         "form-data-encoder": "^4.0.2",
-        "get-stream": "^8.0.1",
         "http2-wrapper": "^2.2.1",
         "lowercase-keys": "^3.0.0",
         "p-cancelable": "^4.0.1",
-        "responselike": "^3.0.0"
+        "responselike": "^3.0.0",
+        "type-fest": "^4.26.1"
       },
       "engines": {
         "node": ">=20"
@@ -9565,9 +9705,9 @@
       }
     },
     "node_modules/got-scraping": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/got-scraping/-/got-scraping-4.0.6.tgz",
-      "integrity": "sha512-bfL/sxJ+HnT2FFVDOs74PbPuWNg/xOX9BWefn7a5CVF5hI1cXUHaa/6y4tm6i1T0KDqomQ/hOKVdpGqSWIBuhA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/got-scraping/-/got-scraping-4.1.1.tgz",
+      "integrity": "sha512-MbT+NMMU4VgvOg2tFIPOSIrMfH986fm0LJ17RxBLKlyTs3gh3xIMETpe+zdPaXY7tH1j6YYeqtfG0TnVMx6V2g==",
       "dependencies": {
         "got": "^14.2.1",
         "header-generator": "^2.1.41",
@@ -9593,9 +9733,9 @@
       }
     },
     "node_modules/got-scraping/node_modules/callsites": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-4.1.0.tgz",
-      "integrity": "sha512-aBMbD1Xxay75ViYezwT40aQONfr+pSXTHwNKvIXhXD6+LY3F1dLIcceoC5OZKBVHbXcysz1hL9D2w0JJIMXpUw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-4.2.0.tgz",
+      "integrity": "sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==",
       "engines": {
         "node": ">=12.20"
       },
@@ -9636,9 +9776,9 @@
       }
     },
     "node_modules/got-scraping/node_modules/quick-lru": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.0.tgz",
-      "integrity": "sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.1.tgz",
+      "integrity": "sha512-kLjThirJMkWKutUKbZ8ViqFc09tDQhlbQo2MNuVeLWbRauqYP96Sm6nzlQ24F0HFjUNZ4i9+AgldJ9H6DZXi7g==",
       "engines": {
         "node": ">=18"
       },
@@ -9652,6 +9792,17 @@
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "engines": {
         "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/got/node_modules/type-fest": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9796,12 +9947,12 @@
       }
     },
     "node_modules/header-generator": {
-      "version": "2.1.51",
-      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.51.tgz",
-      "integrity": "sha512-3KdYYOPcFaQ8539nxxsuR8Pr1PYw/rx2ju40rVTKVR0PBKVnVPaz1acBzsLfofYlWNZgf/2rJcd0trj9Ss5kuw==",
+      "version": "2.1.64",
+      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.64.tgz",
+      "integrity": "sha512-dE8xL2pwXAZIZ87Nu023gnKOQax1yux4JkPXeVyQixZ2GJ6fGMIdyTMbXz2YQKqLkf4phNj4e4/TqGgh51VloQ==",
       "dependencies": {
         "browserslist": "^4.21.1",
-        "generative-bayesian-network": "^2.1.51",
+        "generative-bayesian-network": "^2.1.64",
         "ow": "^0.28.1",
         "tslib": "^2.4.0"
       },
@@ -10029,9 +10180,9 @@
       }
     },
     "node_modules/idcac-playwright": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/idcac-playwright/-/idcac-playwright-0.1.2.tgz",
-      "integrity": "sha512-1YeecryHQC3SzDagSjqJTCDDs6F0x/9LaR8TPIN6x60myYAs7oALxZJdwNITeoR3wL0KeTZF3knVTRJ4gki5NQ=="
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/idcac-playwright/-/idcac-playwright-0.1.3.tgz",
+      "integrity": "sha512-VVYQ4sv6OrUJKVzYaIP1hq0qAHd1O22HW5LnL1Wf6zkrLStQ/QEg4iJ0rllIOEpd+Rmm+635AJD59A+Vw+2PgQ=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -10230,6 +10381,18 @@
         "io-ts": "^2.0.0",
         "monocle-ts": "^2.0.0",
         "newtype-ts": "^0.3.2"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -10735,38 +10898,42 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
     "node_modules/jsdom": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.0.tgz",
-      "integrity": "sha512-6gpM7pRXCwIOKxX47cgOyvyQDN/Eh0f1MeKySBV2xGdKtqJBLj8P25eY3EVCWo2mglDDzozR2r2MW4T+JiNUZA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dependencies": {
-        "cssstyle": "^4.0.1",
+        "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
+        "decimal.js": "^10.5.0",
         "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.4",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.10",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.0",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.4",
+        "tough-cookie": "^5.1.1",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
-        "ws": "^8.17.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -10775,35 +10942,19 @@
       }
     },
     "node_modules/jsdom/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "engines": {
         "node": ">= 14"
       }
     },
-    "node_modules/jsdom/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/jsdom/node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -10811,9 +10962,9 @@
       }
     },
     "node_modules/jsdom/node_modules/tr46": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -10830,11 +10981,11 @@
       }
     },
     "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
-      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dependencies": {
-        "tr46": "^5.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
@@ -11035,15 +11186,44 @@
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "node_modules/linkedom": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.0.tgz",
-      "integrity": "sha512-Xtu+w437ENHrgggnSHssua47vYXX/a/MzNdo+AR3UuWoOAxGZNwDSvjRPnPbVRFoygT990HS+7BDVBE1MK6FLQ==",
+      "version": "0.18.9",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.9.tgz",
+      "integrity": "sha512-Pfvhwjs46nBrcQdauQjMXDJZqj6VwN7KStT84xQqmIgD9bPH6UVJ/ESW8y4VHVF2h7di0/P+f4Iln4U5emRcmg==",
       "dependencies": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",
         "html-escaper": "^3.0.3",
-        "htmlparser2": "^9.1.0",
+        "htmlparser2": "^10.0.0",
         "uhyphen": "^0.2.0"
+      }
+    },
+    "node_modules/linkedom/node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/linkedom/node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
       }
     },
     "node_modules/loader-runner": {
@@ -11093,7 +11273,8 @@
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -12177,9 +12358,9 @@
       }
     },
     "node_modules/ml-matrix": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.11.0.tgz",
-      "integrity": "sha512-7jr9NmFRkaUxbKslfRu3aZOjJd2LkSitCGv+QH9PF0eJoEG7jIpjXra1Vw8/kgao8+kHCSsJONG6vfWmXQ+/Eg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.1.tgz",
+      "integrity": "sha512-TJ+8eOFdp+INvzR4zAuwBQJznDUfktMtOB6g/hUcGh3rcyjxbz4Te57Pgri8Q9bhSQ7Zys4IYOGhFdnlgeB6Lw==",
       "dependencies": {
         "is-any-array": "^2.0.1",
         "ml-array-rescale": "^1.3.7"
@@ -12449,9 +12630,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-      "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ=="
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA=="
     },
     "node_modules/object-inspect": {
       "version": "1.13.1",
@@ -12900,22 +13081,22 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "dependencies": {
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -13016,6 +13197,18 @@
       "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
       "dependencies": {
         "through": "~2.3"
+      }
+    },
+    "node_modules/peek-readable": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
+      "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/pg": {
@@ -13409,10 +13602,12 @@
       }
     },
     "node_modules/proxy-chain": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-chain/-/proxy-chain-2.4.0.tgz",
-      "integrity": "sha512-fbFfzJDxWcLYYvI+yx0VXjTgJPfXsGdhFnCJN4rq/5GZSgn9CQpRgm1KC2iEJfhL8gkeZCWJYBAllmGMT356cg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/proxy-chain/-/proxy-chain-2.5.8.tgz",
+      "integrity": "sha512-TqKOYRD/1Gga/JhiwmdYHJoj0zMJkKGofQ9bHQuSm+vexczatt81fkUHTVMyci+2mWczXiTNv1Eom+2v3Da5og==",
       "dependencies": {
+        "socks": "^2.8.3",
+        "socks-proxy-agent": "^8.0.3",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -13423,11 +13618,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -13472,11 +13662,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -14054,11 +14239,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -14242,9 +14422,9 @@
       }
     },
     "node_modules/rrweb-cssom": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.0.tgz",
-      "integrity": "sha512-KlSv0pm9kgQSRxXEMgtivPJ4h826YHsuob8pSHcfSZsSXGtvpEAie8S0AnXuObEJ7nhikOb4ahwxDm0H2yW17g=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -14760,6 +14940,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/snowflake-sdk": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/snowflake-sdk/-/snowflake-sdk-2.0.2.tgz",
@@ -14886,6 +15075,40 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
@@ -14983,6 +15206,11 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
     "node_modules/stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
@@ -15038,9 +15266,9 @@
       }
     },
     "node_modules/stream-json": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.8.0.tgz",
-      "integrity": "sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
@@ -15184,6 +15412,22 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
+    "node_modules/strtok3": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
+      "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/stubs": {
       "version": "3.0.0",
@@ -15427,20 +15671,20 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.23",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.23.tgz",
-      "integrity": "sha512-TWe4gW7LE1bPt6es6Pg3+pO/KwjWnxurZ5nUxHaMap7LFmKH+9th+JP0TsonIezcie0qJbzgtnA2CMWeS3q7Ig==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dependencies": {
-        "tldts-core": "^6.1.23"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.23",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.23.tgz",
-      "integrity": "sha512-NoYYa06h5WN9BU4wjpVK/bKg3fw2BlhZSB1omr+CkEygSzhe5Ojp8mTFae93eVV2mv7d/ootxPqVhW1GoCeogw=="
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
     },
     "node_modules/tlhunter-sorted-set": {
       "version": "0.1.0",
@@ -15479,6 +15723,22 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
+      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/toml": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
@@ -15490,25 +15750,14 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg=="
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -15792,6 +16041,17 @@
       "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
       "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
+      "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -16001,15 +16261,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/url-template": {
@@ -16630,10 +16881,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -16803,6 +17053,17 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -38,7 +38,7 @@
     "blake3": "^2.1.7",
     "body-parser": "^1.20.2",
     "cls-hooked": "^4.2.2",
-    "crawlee": "^3.10.1",
+    "crawlee": "^3.13.3-beta.10",
     "dd-trace": "^5.1.0",
     "eventsource-parser": "^1.0.0",
     "express": "^4.18.2",

--- a/connectors/src/connectors/webcrawler/lib/http.ts
+++ b/connectors/src/connectors/webcrawler/lib/http.ts
@@ -89,11 +89,11 @@ export class DustHttpClient extends GotScrapingHttpClient {
     let url = initUrl;
     let foundEndOfRedirect = false;
     let redirectCount = 0;
-    const visitedUrls = new Set<string | URL>();
+    const visitedUrls = new Set<string>();
 
     do {
       // Fail fast if it get into a loop
-      if (visitedUrls.has(url)) {
+      if (visitedUrls.has(url.toString())) {
         return new Err(
           new WebCrawlerError(
             "Invalid redirect: Circular redirect detected",
@@ -101,7 +101,7 @@ export class DustHttpClient extends GotScrapingHttpClient {
           )
         );
       }
-      visitedUrls.add(url);
+      visitedUrls.add(url.toString());
 
       // Prevent infinite loops
       if (redirectCount++ >= MAX_REDIRECTS) {
@@ -165,7 +165,7 @@ export class DustHttpClient extends GotScrapingHttpClient {
             return checkIpRes;
           }
 
-          url = redirectUrl;
+          url = resolvedUrl;
         } else {
           foundEndOfRedirect = true;
         }

--- a/connectors/src/connectors/webcrawler/lib/http.ts
+++ b/connectors/src/connectors/webcrawler/lib/http.ts
@@ -140,7 +140,13 @@ export class DustHttpClient extends GotScrapingHttpClient {
             );
           }
 
-          const resolvedUrl = new URL(redirectUrl);
+          let resolvedUrl: URL;
+          // relative redirect
+          if (redirectUrl.startsWith("/")) {
+            resolvedUrl = new URL(redirectUrl, url);
+          } else {
+            resolvedUrl = new URL(redirectUrl);
+          }
 
           if (
             new URL(initUrl).protocol === "https:" &&
@@ -180,7 +186,7 @@ export class DustHttpClient extends GotScrapingHttpClient {
     const { address, family } = await getIpAddressForUrl(url.toString());
     if (family !== 4) {
       return new Err(
-        new WebCrawlerError("IP address is not IPv4", "NOT_IP_V4")
+        new WebCrawlerError(`IP address is not IPv4: ${address}`, "NOT_IP_V4")
       );
     }
 

--- a/connectors/src/connectors/webcrawler/lib/http.ts
+++ b/connectors/src/connectors/webcrawler/lib/http.ts
@@ -1,0 +1,127 @@
+import { GotScrapingHttpClient } from "@crawlee/core";
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import type {
+  HttpRequest,
+  HttpResponse,
+  RedirectHandler,
+  ResponseTypes,
+  StreamingHttpResponse,
+} from "crawlee";
+import { NonRetryableError } from "crawlee";
+
+import {
+  getIpAddressForUrl,
+  isPrivateIp,
+} from "@connectors/connectors/webcrawler/lib/utils";
+
+export type WebCrawlerErrorName = "PRIVATE_IP" | "NOT_IP_V4";
+
+export class WebCrawlerError extends NonRetryableError {
+  constructor(
+    message: string,
+    readonly type: WebCrawlerErrorName,
+    readonly originalError?: Error
+  ) {
+    super(message);
+  }
+}
+
+export class DustHttpClient extends GotScrapingHttpClient {
+  /**
+   * @inheritDoc
+   */
+  async sendRequest<TResponseType extends keyof ResponseTypes>(
+    request: HttpRequest<TResponseType>
+  ): Promise<HttpResponse<TResponseType>> {
+    const res = await this.verifyRedirect(request.url);
+
+    if (res.isErr()) {
+      throw res.error;
+    }
+
+    return super.sendRequest({
+      ...request,
+      url: res.value,
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async stream(
+    request: HttpRequest,
+    handleRedirect?: RedirectHandler
+  ): Promise<StreamingHttpResponse> {
+    const res = await this.verifyRedirect(request.url);
+
+    if (res.isErr()) {
+      throw res.error;
+    }
+
+    return super.stream(
+      {
+        ...request,
+        url: res.value,
+      },
+      handleRedirect
+    );
+  }
+
+  /**
+   * Loop if needed on redirect location,
+   * throw a Result Err that would warrant
+   * a NonRetryableError. Otherwise return the last
+   * url that is not a redirect
+   */
+  async verifyRedirect(
+    initUrl: string | URL
+  ): Promise<Result<string | URL, WebCrawlerError>> {
+    let url = initUrl;
+    let foundEndOfRedirect = false;
+
+    do {
+      const response = await fetch(url, {
+        method: "HEAD",
+        redirect: "manual",
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        const redirectUrl = response.headers.get("location");
+        if (redirectUrl != null) {
+          const checkIpRes = await this.checkIp(redirectUrl);
+          if (checkIpRes.isErr()) {
+            return checkIpRes;
+          }
+
+          url = redirectUrl;
+          continue;
+        }
+      }
+
+      foundEndOfRedirect = true;
+    } while (!foundEndOfRedirect);
+
+    return new Ok(url);
+  }
+
+  /**
+   * Check if IP behind url is ipv4 and is not a private ip
+   */
+  async checkIp(url: string): Promise<Result<void, WebCrawlerError>> {
+    const { address, family } = await getIpAddressForUrl(url);
+    if (family !== 4) {
+      return new Err(
+        new WebCrawlerError("IP address is not IPv4", "NOT_IP_V4")
+      );
+    }
+
+    if (isPrivateIp(address)) {
+      return new Err(
+        new WebCrawlerError("Private IP adress detected", "PRIVATE_IP")
+      );
+    }
+
+    return new Ok(undefined);
+  }
+}


### PR DESCRIPTION
## Description
- Fix navigation skipping
- Created a `DustHttpClient` to override the one used in `CheerioCrawler`. Loop on redirection and check if IPs are ipv4 or private inside of it.
- Handle redirect loop
- Handle circular redirect
- Refuse localhost (could be allowed when in dev)
- Handle protocol downgrade (no redirection from https to http)
- Handle timeout when getting headers (5s)
- Sanitize location headers (handle case like `Location: https://legitimate.com\r\nSet-Cookie: malicious=value`)

## Tests
- Locally check with url [https://tinyurl.com/dustdemoredir](https://tinyurl.com/dustdemoredir), properly detected as a redirection.
- Locally check with tinyurl that target a internal IPs, it correctly skipped it.
- Checked locally with a local web server with the following [config](https://gist.github.com/johnoppenheimer/3b1133b6036c7cde6edba5e51cb122fe) that simulated different kind of redirection.

## Risk
Should be low, just adding a fetch HEAD query before checking IPs, in case it fails, crawler will just retry it. And if it skip too much, revert is easy.

## Deploy Plan
Deploy connectors
