### PR TITLE
Fix: check enable or not dynamically for internal servers

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -72,7 +72,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   // Dev
   data_sources_debugger: {
     id: 1000,
-    isDefault: true,
+    isDefault: false,
     flag: "dev_mcp_actions",
   },
   child_agent_debugger: {

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -50,6 +50,11 @@ export class InternalMCPServerInMemoryResource {
       return null;
     }
 
+    const isEnabled = await isEnabledForWorkspace(auth, r.value.name);
+    if (!isEnabled) {
+      return null;
+    }
+
     const server = new InternalMCPServerInMemoryResource(id);
 
     // Getting the metadata is a relatively long operation, so we cache it for 5 minutes


### PR DESCRIPTION
## Description

Dynamically check if the server flag is still enabled for a workspace when fetching internal servers.
Fixes situations when an internal server was made available by mistake.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`