### PR TITLE
[sparkle] Add SearchDropdownMenu component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.471",
+  "version": "0.2.472",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.471",
+      "version": "0.2.472",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.471",
+  "version": "0.2.472",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -215,26 +215,55 @@ DropdownMenuSubContent.displayName =
 interface DropdownMenuContentProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> {
   mountPortal?: boolean;
+  mountPortalContainer?: HTMLElement;
 }
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   DropdownMenuContentProps
->(({ className, sideOffset = 4, mountPortal = true, ...props }, ref) => {
-  const content = (
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(menuStyleClasses.container, "s-shadow-md", className)}
-      {...props}
-    />
-  );
-  return mountPortal ? (
-    <DropdownMenuPrimitive.Portal>{content}</DropdownMenuPrimitive.Portal>
-  ) : (
-    content
-  );
-});
+>(
+  (
+    {
+      className,
+      sideOffset = 4,
+      mountPortal = true,
+      mountPortalContainer,
+      ...props
+    },
+    ref
+  ) => {
+    const content = (
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(menuStyleClasses.container, "s-shadow-md", className)}
+        {...props}
+      />
+    );
+
+    const [container, setContainer] = React.useState<Element | undefined>(
+      mountPortalContainer
+    );
+
+    React.useEffect(() => {
+      if (mountPortal && !container) {
+        const dialogElements = document.querySelectorAll(
+          ".s-sheet[role=dialog][data-state=open]"
+        );
+        const defaultContainer = dialogElements[dialogElements.length - 1];
+        setContainer(defaultContainer);
+      }
+    }, []);
+
+    return mountPortal ? (
+      <DropdownMenuPrimitive.Portal container={container}>
+        {content}
+      </DropdownMenuPrimitive.Portal>
+    ) : (
+      content
+    );
+  }
+);
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 export type DropdownMenuItemProps = MutuallyExclusiveProps<

--- a/sparkle/src/components/SearchDropdownMenu.tsx
+++ b/sparkle/src/components/SearchDropdownMenu.tsx
@@ -1,0 +1,95 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  SearchInput,
+} from "@dust-tt/sparkle";
+import React from "react";
+import { useRef, useState } from "react";
+
+type SearchDropdownMenuProps = {
+  searchInputValue: string;
+  setSearchInputValue: (value: string) => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+  minLengthToOpen?: number;
+};
+
+export function SearchDropdownMenu({
+  searchInputValue,
+  setSearchInputValue,
+  disabled,
+  minLengthToOpen = 1,
+  children,
+}: SearchDropdownMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <DropdownMenu
+      open={isOpen && searchInputValue.length >= minLengthToOpen}
+      modal={false}
+      onOpenChange={(open) => {
+        if (!open) {
+          setIsOpen(open);
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <SearchInput
+          ref={searchInputRef}
+          name="search"
+          placeholder="Search"
+          value={searchInputValue}
+          disabled={disabled}
+          onFocus={() => {
+            if (!isOpen) {
+              setIsOpen(searchInputValue.length >= minLengthToOpen);
+              setTimeout(() => {
+                searchInputRef.current?.focus();
+              }, 0);
+            }
+          }}
+          onChange={(value) => {
+            setSearchInputValue(value);
+            setIsOpen(value.length >= minLengthToOpen);
+            setTimeout(() => {
+              searchInputRef.current?.focus();
+            }, 0);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              setIsOpen(false);
+            }
+            if (e.key === "Tab" || e.key === "ArrowDown") {
+              e.preventDefault();
+              const firstItem = document.querySelector('[role="menuitem"]');
+              if (firstItem instanceof HTMLElement) {
+                firstItem.focus();
+              }
+            }
+          }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side="bottom"
+        align="start"
+        className="s-w-[--radix-popper-anchor-width]"
+        onFocusOutside={(e) => {
+          // Prevent closing when search input is focused
+          if (e.target === searchInputRef.current) {
+            e.preventDefault();
+          }
+        }}
+        onInteractOutside={(e) => {
+          // Prevent closing when clicking on the search input
+          if (e.target === searchInputRef.current) {
+            e.preventDefault();
+          }
+        }}
+      >
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/sparkle/src/components/SearchDropdownMenu.tsx
+++ b/sparkle/src/components/SearchDropdownMenu.tsx
@@ -1,11 +1,12 @@
+import React from "react";
+import { useRef, useState } from "react";
+
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
-  SearchInput,
-} from "@dust-tt/sparkle";
-import React from "react";
-import { useRef, useState } from "react";
+} from "@sparkle/components/Dropdown";
+import { SearchInput } from "@sparkle/components/SearchInput";
 
 type SearchDropdownMenuProps = {
   searchInputValue: string;

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -222,7 +222,7 @@ function BaseSearchInputWithPopover<T>(
         mountPortalContainer={mountPortalContainer}
       >
         <div className="s-flex s-flex-col">
-          {items.length > 0 && (
+          {items.length > 0 && (displayItemCount || onSelectAll) && (
             <div className="s-flex s-items-center s-justify-between s-p-2 s-text-sm s-text-gray-500">
               <div>
                 {displayItemCount && (

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -118,6 +118,7 @@ export {
   ResizablePanelGroup,
 } from "./Resizable";
 export { ScrollArea, ScrollBar } from "./ScrollArea";
+export { SearchDropdownMenu } from "./SearchDropdownMenu";
 export { SearchInput, SearchInputWithPopover } from "./SearchInput";
 export { Separator } from "./Separator";
 export {


### PR DESCRIPTION
## Description

In order to replace SearchInputWithPopover :

<img width="581" alt="Screenshot 2025-04-18 at 18 22 29" src="https://github.com/user-attachments/assets/5f13303f-7218-44c2-b773-436c7bcd4e2b" />
<img width="698" alt="Screenshot 2025-04-18 at 18 22 10" src="https://github.com/user-attachments/assets/5d4d9702-f4a9-480b-8321-776d3e8f4888" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
