### PR TITLE
Fix code block spacing

### DIFF
--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -91,14 +91,14 @@ export function ContentBlockWrapper({
     <div
       id="BlockWrapper"
       className={cn(
-        "s-relative s-mt-11 s-w-full !s-overflow-visible",
+        "s-relative s-w-full !s-overflow-visible",
         className
       )}
     >
-      <div className="s-sticky s-top-11 s-z-[1] s-h-0">
+      <div className="s-sticky s-top-0 s-z-[1] s-w-full">
         <div
           id="BlockActions"
-          className="s-absolute s-bottom-0 s-right-2 s-flex s-h-11 s-items-center s-gap-1 s-py-2"
+          className="s-absolute s-right-2 s-top-2 s-z-50 s-flex s-gap-2"
         >
           {actions && actions}
           {getContentToDownload && (


### PR DESCRIPTION
## Description

* Removing extra spacing at top of conversation code blocks

## Tests

<img width="703" alt="Screenshot 2025-04-18 at 4 15 28 PM" src="https://github.com/user-attachments/assets/12258072-1413-4e31-bc8a-76b126586baa" />

## Risk

N/a
## Deploy Plan

Github