### PR TITLE
Improve prompt for tools to avoid unnecessary conversion

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -80,7 +80,7 @@ const createServer = (auth: Authenticator): McpServer => {
 
   server.tool(
     "generate_file",
-    "Generate a file",
+    "Generate a file by converting between formats. Only use this tool when the source_format differs from the output_format. If the formats are the same, the file can be used directly.",
     {
       file_name: z
         .string()
@@ -91,7 +91,7 @@ const createServer = (auth: Authenticator): McpServer => {
         .string()
         .max(64000)
         .describe(
-          "The content of the file to generate. You can either provide the id of a file in the conversation, the url to a file or the content directly."
+          "The content of the file to generate. You can either provide the id of a file in the conversation (note: if the file ID is already in the desired format, no conversion is needed), the url to a file or the content directly."
         ),
       source_format: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -25,7 +25,7 @@ const createServer = (auth: Authenticator): McpServer => {
 
   server.tool(
     "generate_image",
-    "Generate an image from a text prompt",
+    "Generate an image in PNG format from a text prompt",
     {
       prompt: z
         .string()


### PR DESCRIPTION
## Description

Improve prompts of file generation and image generation to avoid unecessary conversion (happened to me, asked claude how to improve tools descriptions to avoid it).

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`