### PR TITLE
fix Server-side request forgery http.get() dataSourceId

### DIFF
--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -2018,6 +2018,10 @@ export class CoreAPI {
     dataSourceId: string;
     folderId: string;
   }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
+    if (!this._isValidId(projectId) || !this._isValidId(dataSourceId) || !this._isValidId(folderId)) {
+      throw new Error("Invalid input: projectId, dataSourceId, or folderId is not valid.");
+    }
+
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
@@ -2030,6 +2034,12 @@ export class CoreAPI {
     );
 
     return this._resultFromResponse(response);
+  }
+
+  private _isValidId(id: string): boolean {
+    // Example validation: ensure the ID is alphanumeric and between 1-64 characters
+    const idRegex = /^[a-zA-Z0-9_-]{1,64}$/;
+    return idRegex.test(id);
   }
   private async _fetchWithError(
     url: string,


### PR DESCRIPTION
https://github.com/dust-tt/dust/blob/5200ee2a57e149ccab941d645bf5dd5df5974898/front/types/core/core_api.ts#L2047-L2047

fix the SSRF vulnerability need to validate the user-provided values (`projectId`, `dataSourceId`, and `folderId`) against a strict allow-list or a set of expected patterns. This ensures that only legitimate and expected values are used to construct the URL. 

1. Introduce a validation function to check that `projectId`, `dataSourceId`, and `folderId` conform to expected formats (e.g., alphanumeric strings or UUIDs).
2. Reject any input that does not pass validation, returning an appropriate error response.
3. Apply this validation in the `deleteDataSourceFolder` method before constructing the URL.


Directly incorporating user input in the URL of an outgoing HTTP request can enable a request forgery attack, in which the request is altered to target an unintended API endpoint or resource. If the server performing the request is connected to an internal network, this can give an attacker the means to bypass the network boundary and make requests against internal services. A forged request may perform an unintended action on behalf of the attacker, or cause information leak if redirected to an external server or if the request response is fed back to the user. It may also compromise the server making the request, if the request response is handled in an unsafe way.

## POC
The following shows an HTTP request parameter being used directly in the URL of a request without validating the input, which facilitates an SSRF attack. The request `http.get(...)` is vulnerable since attackers can choose the value of `target` to be anything they want. For instance, the attacker can choose `"internal.example.com/#"` as the target, causing the URL used in the request to be `"https://internal.example.com/#.example.com/data"`.

A request to `https://internal.dust.tt` may be problematic if that server is not meant to be directly accessible from the attacker's machine.
```ts
import http from 'http';

const server = http.createServer(function(req, res) {
    const target = new URL(req.url, "http://redacted.com").searchParams.get("target");

    // BAD: `target` is controlled by the attacker
    http.get('https://' + target + ".example.com/data/", res => {
        // process request response ...
    });

});
```
One way to remedy the problem is to use the user input to select a known fixed string before performing the request:
```ts
import http from 'http';

const server = http.createServer(function(req, res) {
    const target = new URL(req.url, "http://example.com").searchParams.get("target");

    let subdomain;
    if (target === 'EU') {
        subdomain = "europe"
    } else {
        subdomain = "world"
    }

    // GOOD: `subdomain` is controlled by the server
    http.get('https://' + subdomain + ".example.com/data/", res => {
        // process request response ...
    });

});
```

## References
[SSRF](https://www.owasp.org/index.php/Server_Side_Request_Forgery)
[CWE-918](https://cwe.mitre.org/data/definitions/918.html)