### PR TITLE
feat(Zendesk): add option to hide customer details

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,37 @@
   "rust-analyzer.inlayHints.parameterHints.enable": false,
   "rust-analyzer.inlayHints.typeHints.enable": false,
   "rust-analyzer.lens.implementations.enable": false,
-  "git.ignoreLimitWarning": true
+  "git.ignoreLimitWarning": true,
+  "sqltools.connections": [
+    {
+      "previewLimit": 50,
+      "server": "localhost",
+      "port": 5432,
+      "driver": "PostgreSQL",
+      "name": "connectors",
+      "database": "dust_connectors",
+      "username": "dev",
+      "password": "dev"
+    },
+    {
+      "previewLimit": 50,
+      "server": "localhost",
+      "port": 5432,
+      "driver": "PostgreSQL",
+      "name": "front",
+      "database": "dust_front",
+      "username": "dev",
+      "password": "dev"
+    },
+    {
+      "previewLimit": 50,
+      "server": "localhost",
+      "port": 5432,
+      "driver": "PostgreSQL",
+      "name": "core",
+      "database": "dust_api",
+      "username": "dev",
+      "password": "dev"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,37 +21,5 @@
   "rust-analyzer.inlayHints.parameterHints.enable": false,
   "rust-analyzer.inlayHints.typeHints.enable": false,
   "rust-analyzer.lens.implementations.enable": false,
-  "git.ignoreLimitWarning": true,
-  "sqltools.connections": [
-    {
-      "previewLimit": 50,
-      "server": "localhost",
-      "port": 5432,
-      "driver": "PostgreSQL",
-      "name": "connectors",
-      "database": "dust_connectors",
-      "username": "dev",
-      "password": "dev"
-    },
-    {
-      "previewLimit": 50,
-      "server": "localhost",
-      "port": 5432,
-      "driver": "PostgreSQL",
-      "name": "front",
-      "database": "dust_front",
-      "username": "dev",
-      "password": "dev"
-    },
-    {
-      "previewLimit": 50,
-      "server": "localhost",
-      "port": 5432,
-      "driver": "PostgreSQL",
-      "name": "core",
-      "database": "dust_api",
-      "username": "dev",
-      "password": "dev"
-    }
-  ]
+  "git.ignoreLimitWarning": true
 }

--- a/connectors/migrations/db/migration_65.sql
+++ b/connectors/migrations/db/migration_65.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 19, 2025
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "hideCustomerDetails" BOOLEAN NOT NULL DEFAULT false;

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -574,7 +574,6 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       }
     }
 
-
     return new Ok(undefined);
   }
 

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -563,7 +563,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       }
     }
 
-    const result = await launchZendeskTicketReSyncWorkflow(connector);
+    const result = await launchZendeskTicketReSyncWorkflow(connector, {
+      forceResync: true,
+    });
     if (result.isErr()) {
       return result;
     }

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -13,7 +13,8 @@ import {
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
 import logger from "@connectors/logger/logger";
-import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_resources";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ZendeskCategoryResource, ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskArticleResource } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
@@ -45,9 +46,7 @@ export async function deleteArticle(
 /**
  * Syncs an article from Zendesk to the postgres db and to the data sources.
  */
-export async function syncArticle({
-  connectorId,
-  article,
+export async function syncArticle(article: ZendeskFetchedArticle, connector: ConnectorResource, configuration: ZendeskConfigurationResource, {
   category,
   section,
   user,
@@ -56,9 +55,7 @@ export async function syncArticle({
   dataSourceConfig,
   loggerArgs,
 }: {
-  connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
-  article: ZendeskFetchedArticle;
   section: ZendeskFetchedSection | null;
   category: ZendeskCategoryResource;
   user: ZendeskFetchedUser | null;
@@ -66,6 +63,7 @@ export async function syncArticle({
   currentSyncDateMs: number;
   loggerArgs: Record<string, string | number | null>;
 }) {
+  const connectorId = connector.id;
   let articleInDb = await ZendeskArticleResource.fetchByArticleId({
     connectorId,
     brandId: category.brandId,

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -14,7 +14,10 @@ import {
 } from "@connectors/lib/data_sources";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ZendeskCategoryResource, ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
+import type {
+  ZendeskCategoryResource,
+  ZendeskConfigurationResource,
+} from "@connectors/resources/zendesk_resources";
 import { ZendeskArticleResource } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
@@ -46,23 +49,28 @@ export async function deleteArticle(
 /**
  * Syncs an article from Zendesk to the postgres db and to the data sources.
  */
-export async function syncArticle(article: ZendeskFetchedArticle, connector: ConnectorResource, configuration: ZendeskConfigurationResource, {
-  category,
-  section,
-  user,
-  currentSyncDateMs,
-  helpCenterIsAllowed,
-  dataSourceConfig,
-  loggerArgs,
-}: {
-  dataSourceConfig: DataSourceConfig;
-  section: ZendeskFetchedSection | null;
-  category: ZendeskCategoryResource;
-  user: ZendeskFetchedUser | null;
-  helpCenterIsAllowed: boolean;
-  currentSyncDateMs: number;
-  loggerArgs: Record<string, string | number | null>;
-}) {
+export async function syncArticle(
+  article: ZendeskFetchedArticle,
+  connector: ConnectorResource,
+  configuration: ZendeskConfigurationResource,
+  {
+    category,
+    section,
+    user,
+    currentSyncDateMs,
+    helpCenterIsAllowed,
+    dataSourceConfig,
+    loggerArgs,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+    section: ZendeskFetchedSection | null;
+    category: ZendeskCategoryResource;
+    user: ZendeskFetchedUser | null;
+    helpCenterIsAllowed: boolean;
+    currentSyncDateMs: number;
+    loggerArgs: Record<string, string | number | null>;
+  }
+) {
   const connectorId = connector.id;
   let articleInDb = await ZendeskArticleResource.fetchByArticleId({
     connectorId,

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -49,28 +49,29 @@ export async function deleteArticle(
 /**
  * Syncs an article from Zendesk to the postgres db and to the data sources.
  */
-export async function syncArticle(
-  article: ZendeskFetchedArticle,
-  connector: ConnectorResource,
-  configuration: ZendeskConfigurationResource,
-  {
-    category,
-    section,
-    user,
-    currentSyncDateMs,
-    helpCenterIsAllowed,
-    dataSourceConfig,
-    loggerArgs,
-  }: {
-    dataSourceConfig: DataSourceConfig;
-    section: ZendeskFetchedSection | null;
-    category: ZendeskCategoryResource;
-    user: ZendeskFetchedUser | null;
-    helpCenterIsAllowed: boolean;
-    currentSyncDateMs: number;
-    loggerArgs: Record<string, string | number | null>;
-  }
-) {
+export async function syncArticle({
+  article,
+  connector,
+  configuration,
+  category,
+  section,
+  user,
+  currentSyncDateMs,
+  helpCenterIsAllowed,
+  dataSourceConfig,
+  loggerArgs,
+}: {
+  article: ZendeskFetchedArticle;
+  connector: ConnectorResource;
+  configuration: ZendeskConfigurationResource;
+  dataSourceConfig: DataSourceConfig;
+  section: ZendeskFetchedSection | null;
+  category: ZendeskCategoryResource;
+  user: ZendeskFetchedUser | null;
+  helpCenterIsAllowed: boolean;
+  currentSyncDateMs: number;
+  loggerArgs: Record<string, string | number | null>;
+}) {
   const connectorId = connector.id;
   let articleInDb = await ZendeskArticleResource.fetchByArticleId({
     connectorId,

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -131,7 +131,9 @@ export async function syncArticle(
     `CATEGORY: ${category.name} ${category?.description ? ` - ${category.description}` : ""}`,
     section &&
       `SECTION: ${section.name} ${section?.description ? ` - ${section.description}` : ""}`,
-    user && `USER: ${user.name} ${user?.email ? ` - ${user.email}` : ""}`,
+    !configuration.hideCustomerDetails &&
+      user &&
+      `USER: ${user.name} ${user?.email ? ` - ${user.email}` : ""}`,
     `SUM OF VOTES: ${article.vote_sum}`,
     article.label_names?.length ? `LABELS: ${article.label_names.join()}` : "",
   ]

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -90,28 +90,29 @@ export async function deleteTicket({
 /**
  * Syncs a ticket in the db and upserts it to the data sources.
  */
-export async function syncTicket(
-  ticket: ZendeskFetchedTicket,
-  connector: ConnectorResource,
-  configuration: ZendeskConfigurationResource,
-  {
-    brandId,
-    currentSyncDateMs,
-    dataSourceConfig,
-    loggerArgs,
-    forceResync,
-    comments,
-    users,
-  }: {
-    dataSourceConfig: DataSourceConfig;
-    brandId: number;
-    currentSyncDateMs: number;
-    loggerArgs: Record<string, string | number | null>;
-    forceResync: boolean;
-    comments: ZendeskFetchedTicketComment[];
-    users: ZendeskFetchedUser[];
-  }
-) {
+export async function syncTicket({
+  ticket,
+  connector,
+  configuration,
+  brandId,
+  currentSyncDateMs,
+  dataSourceConfig,
+  loggerArgs,
+  forceResync,
+  comments,
+  users,
+}: {
+  ticket: ZendeskFetchedTicket;
+  connector: ConnectorResource;
+  configuration: ZendeskConfigurationResource;
+  dataSourceConfig: DataSourceConfig;
+  brandId: number;
+  currentSyncDateMs: number;
+  loggerArgs: Record<string, string | number | null>;
+  forceResync: boolean;
+  comments: ZendeskFetchedTicketComment[];
+  users: ZendeskFetchedUser[];
+}) {
   const connectorId = connector.id;
 
   let ticketInDb = await ZendeskTicketResource.fetchByTicketId({

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -14,6 +14,7 @@ import {
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
 import logger from "@connectors/logger/logger";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
@@ -89,27 +90,30 @@ export async function deleteTicket({
 /**
  * Syncs a ticket in the db and upserts it to the data sources.
  */
-export async function syncTicket({
-  connectorId,
-  ticket,
-  brandId,
-  currentSyncDateMs,
-  dataSourceConfig,
-  loggerArgs,
-  forceResync,
-  comments,
-  users,
-}: {
-  connectorId: ModelId;
-  dataSourceConfig: DataSourceConfig;
-  ticket: ZendeskFetchedTicket;
-  brandId: number;
-  currentSyncDateMs: number;
-  loggerArgs: Record<string, string | number | null>;
-  forceResync: boolean;
-  comments: ZendeskFetchedTicketComment[];
-  users: ZendeskFetchedUser[];
-}) {
+export async function syncTicket(
+  ticket: ZendeskFetchedTicket,
+  connector: ConnectorResource,
+  configuration: ZendeskConfigurationResource,
+  {
+    brandId,
+    currentSyncDateMs,
+    dataSourceConfig,
+    loggerArgs,
+    forceResync,
+    comments,
+    users,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+    brandId: number;
+    currentSyncDateMs: number;
+    loggerArgs: Record<string, string | number | null>;
+    forceResync: boolean;
+    comments: ZendeskFetchedTicketComment[];
+    users: ZendeskFetchedUser[];
+  }
+) {
+  const connectorId = connector.id;
+
   let ticketInDb = await ZendeskTicketResource.fetchByTicketId({
     connectorId,
     brandId,

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -202,7 +202,7 @@ export async function syncTicket({
           ""
         );
         if (configuration.hideCustomerDetails) {
-          return `[${comment?.created_at}]:\n${commentContent}`;
+          return `[${comment?.created_at}] User ${comment.author_id}:\n${commentContent}`;
         }
         return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${commentContent}`;
       })

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -195,7 +195,15 @@ export async function syncTicket(
           );
           author = null;
         }
-        return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${(comment.plain_body || comment.body).replace(/[\u2028\u2029]/g, "")}`; // removing line and paragraph separators
+        // Remove line and paragraph separators.
+        const commentContent = (comment.plain_body || comment.body).replace(
+          /[\u2028\u2029]/g,
+          ""
+        );
+        if (configuration.hideCustomerDetails) {
+          return `[${comment?.created_at}]:\n${commentContent}`;
+        }
+        return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${commentContent}`;
       })
       .join("\n")}
 `.trim();

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -186,8 +186,6 @@ export async function syncTicket({
 
     const ticketContent = `Conversation:\n${comments
       .map((comment) => {
-        const author =
-          users.find((user) => user.id === comment.author_id) ?? null;
         // Remove line and paragraph separators.
         const commentContent = (comment.plain_body || comment.body).replace(
           /[\u2028\u2029]/g,
@@ -196,6 +194,8 @@ export async function syncTicket({
         if (configuration.hideCustomerDetails) {
           return `[${comment?.created_at}] User ${comment.author_id}:\n${commentContent}`;
         }
+        const author =
+          users.find((user) => user.id === comment.author_id) ?? null;
         return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${commentContent}`;
       })
       .join("\n")}`.trim();

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -198,8 +198,7 @@ export async function syncTicket({
         }
         return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${commentContent}`;
       })
-      .join("\n")}
-`.trim();
+      .join("\n")}`.trim();
 
     const ticketContentInMarkdown = turndownService.turndown(ticketContent);
 

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -186,16 +186,8 @@ export async function syncTicket({
 
     const ticketContent = `Conversation:\n${comments
       .map((comment) => {
-        let author;
-        try {
-          author = users.find((user) => user.id === comment.author_id);
-        } catch (e) {
-          logger.warn(
-            { connectorId, e, usersType: typeof users, ...loggerArgs },
-            "[Zendesk] Error finding the author of a comment."
-          );
-          author = null;
-        }
+        const author =
+          users.find((user) => user.id === comment.author_id) ?? null;
         // Remove line and paragraph separators.
         const commentContent = (comment.plain_body || comment.body).replace(
           /[\u2028\u2029]/g,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -684,10 +684,8 @@ export async function syncZendeskTicketBatchActivity({
         );
       }
 
-      return syncTicket({
-        connectorId,
+      return syncTicket(ticket, connector, configuration, {
         brandId,
-        ticket,
         dataSourceConfig,
         currentSyncDateMs,
         loggerArgs,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -577,7 +577,10 @@ export async function syncZendeskArticleBatchActivity({
   await concurrentExecutor(
     articles,
     (article) =>
-      syncArticle(article, connector, configuration, {
+      syncArticle({
+        article,
+        connector,
+        configuration,
         category,
         section:
           sections.find((section) => section.id === article.section_id) || null,
@@ -687,7 +690,10 @@ export async function syncZendeskTicketBatchActivity({
         );
       }
 
-      return syncTicket(ticket, connector, configuration, {
+      return syncTicket({
+        ticket,
+        connector,
+        configuration,
         brandId,
         dataSourceConfig,
         currentSyncDateMs,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -519,6 +519,11 @@ export async function syncZendeskArticleBatchActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
     workspaceId: dataSourceConfig.workspaceId,
@@ -572,10 +577,8 @@ export async function syncZendeskArticleBatchActivity({
   await concurrentExecutor(
     articles,
     (article) =>
-      syncArticle({
-        connectorId,
+      syncArticle(article, connector, configuration, {
         category,
-        article,
         section:
           sections.find((section) => section.id === article.section_id) || null,
         user: users.find((user) => user.id === article.author_id) || null,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -568,11 +568,13 @@ export async function syncZendeskArticleBatchActivity({
     brandSubdomain,
     categoryId,
   });
-  const users = await listZendeskUsers({
-    accessToken,
-    brandSubdomain,
-    userIds: articles.map((article) => article.author_id),
-  });
+  const users = configuration.hideCustomerDetails
+    ? []
+    : await listZendeskUsers({
+        accessToken,
+        brandSubdomain,
+        userIds: articles.map((article) => article.author_id),
+      });
 
   await concurrentExecutor(
     articles,
@@ -583,8 +585,8 @@ export async function syncZendeskArticleBatchActivity({
         configuration,
         category,
         section:
-          sections.find((section) => section.id === article.section_id) || null,
-        user: users.find((user) => user.id === article.author_id) || null,
+          sections.find((section) => section.id === article.section_id) ?? null,
+        user: users.find((user) => user.id === article.author_id) ?? null,
         dataSourceConfig,
         helpCenterIsAllowed,
         currentSyncDateMs,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -671,15 +671,17 @@ export async function syncZendeskTicketBatchActivity({
       }),
     { concurrency: 3, onBatchComplete: heartbeat }
   );
-  const users = await listZendeskUsers({
-    accessToken,
-    brandSubdomain,
-    userIds: [
-      ...new Set(
-        comments2d.flatMap((comments) => comments.map((c) => c.author_id))
-      ),
-    ],
-  });
+  const users = configuration.hideCustomerDetails
+    ? []
+    : await listZendeskUsers({
+        accessToken,
+        brandSubdomain,
+        userIds: [
+          ...new Set(
+            comments2d.flatMap((comments) => comments.map((c) => c.author_id))
+          ),
+        ],
+      });
 
   const res = await concurrentExecutor(
     _.zip(ticketsToSync, comments2d),

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -272,9 +272,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
           brandSubdomain,
           userIds: comments.map((c) => c.author_id),
         });
-        return syncTicket({
-          connectorId,
-          ticket,
+        return syncTicket(ticket, connector, configuration, {
           brandId,
           users,
           comments,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -87,6 +87,12 @@ export async function syncZendeskArticleUpdateBatchActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
+
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
     workspaceId: dataSourceConfig.workspaceId,
@@ -182,10 +188,8 @@ export async function syncZendeskArticleUpdateBatchActivity({
           category &&
           (category.permission === "read" || hasHelpCenterPermissions)
         ) {
-          return syncArticle({
-            connectorId,
+          return syncArticle(article, connector, configuration, {
             category,
-            article,
             section,
             user,
             helpCenterIsAllowed: hasHelpCenterPermissions,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -132,11 +132,13 @@ export async function syncZendeskArticleUpdateBatchActivity({
         brandSubdomain,
         sectionId: article.section_id,
       });
-      const user = await fetchZendeskUser({
-        accessToken,
-        brandSubdomain,
-        userId: article.author_id,
-      });
+      const user = configuration.hideCustomerDetails
+        ? null
+        : await fetchZendeskUser({
+            accessToken,
+            brandSubdomain,
+            userId: article.author_id,
+          });
 
       if (section && section.category_id) {
         let category = await ZendeskCategoryResource.fetchByCategoryId({

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -274,11 +274,15 @@ export async function syncZendeskTicketUpdateBatchActivity({
           brandSubdomain,
           ticketId: ticket.id,
         });
-        const users = await listZendeskUsers({
-          accessToken,
-          brandSubdomain,
-          userIds: comments.map((c) => c.author_id),
-        });
+        // If we hide customer details, we don't need to fetch the users at all.
+        // Also guarantees that user information is not included in the ticket content.
+        const users = configuration.hideCustomerDetails
+          ? []
+          : await listZendeskUsers({
+              accessToken,
+              brandSubdomain,
+              userIds: comments.map((c) => c.author_id),
+            });
         return syncTicket({
           ticket,
           connector,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -188,7 +188,10 @@ export async function syncZendeskArticleUpdateBatchActivity({
           category &&
           (category.permission === "read" || hasHelpCenterPermissions)
         ) {
-          return syncArticle(article, connector, configuration, {
+          return syncArticle({
+            article,
+            connector,
+            configuration,
             category,
             section,
             user,
@@ -276,7 +279,10 @@ export async function syncZendeskTicketUpdateBatchActivity({
           brandSubdomain,
           userIds: comments.map((c) => c.author_id),
         });
-        return syncTicket(ticket, connector, configuration, {
+        return syncTicket({
+          ticket,
+          connector,
+          configuration,
           brandId,
           users,
           comments,

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -49,6 +49,7 @@ export class ZendeskConfigurationModel extends ConnectorBaseModel<ZendeskConfigu
   declare subdomain: string;
   declare retentionPeriodDays: number;
   declare syncUnresolvedTickets: boolean;
+  declare hideCustomerDetails: boolean;
 }
 
 ZendeskConfigurationModel.init(
@@ -73,6 +74,11 @@ ZendeskConfigurationModel.init(
       defaultValue: 180, // approximately 6 months
     },
     syncUnresolvedTickets: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    hideCustomerDetails: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
-import type { APIError, DataSourceType, WorkspaceType } from "@app/types";
+import type { DataSourceType, WorkspaceType } from "@app/types";
 
 export function ZendeskConfigView({
   owner,
@@ -24,19 +24,37 @@ export function ZendeskConfigView({
 }) {
   const { isDark } = useTheme();
 
-  const configKey = "zendeskSyncUnresolvedTicketsEnabled";
+  const unresolvedTicketsConfigKey = "zendeskSyncUnresolvedTicketsEnabled";
+  const hideCustomerDetailsConfigKey = "zendeskHideCustomerDetails";
 
-  const { configValue, mutateConfig } = useConnectorConfig({
+  const {
+    configValue: syncUnresolvedTicketsConfigValue,
+    mutateConfig: mutateSyncUnresolvedTicketsConfig,
+  } = useConnectorConfig({
     owner,
     dataSource,
-    configKey,
+    configKey: unresolvedTicketsConfigKey,
   });
-  const syncUnresolvedTicketsEnabled = configValue === "true";
+  const {
+    configValue: hideCustomerDetailsConfigValue,
+    mutateConfig: mutateHideCustomerDetailsConfig,
+  } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey: hideCustomerDetailsConfigKey,
+  });
+
+  const syncUnresolvedTicketsEnabled =
+    syncUnresolvedTicketsConfigValue === "true";
+  const hideCustomerDetailsEnabled = hideCustomerDetailsConfigValue === "true";
 
   const sendNotification = useSendNotification();
   const [loading, setLoading] = useState(false);
 
-  const handleSetNewConfig = async (configValue: boolean) => {
+  const handleSetNewConfig = async (
+    configKey: string,
+    configValue: boolean
+  ) => {
     setLoading(true);
     const res = await fetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
@@ -47,15 +65,16 @@ export function ZendeskConfigView({
       }
     );
     if (res.ok) {
-      await mutateConfig();
+      await mutateSyncUnresolvedTicketsConfig();
+      await mutateHideCustomerDetailsConfig();
       setLoading(false);
     } else {
       setLoading(false);
-      const err = (await res.json()) as { error: APIError };
+      const err = await res.json();
       sendNotification({
         type: "error",
         title: "Failed to edit Zendesk configuration",
-        description: err.error.message,
+        description: err.error?.message || "An unknown error occurred",
       });
     }
     return true;
@@ -75,7 +94,10 @@ export function ZendeskConfigView({
             <SliderToggle
               size="xs"
               onClick={async () => {
-                await handleSetNewConfig(!syncUnresolvedTicketsEnabled);
+                await handleSetNewConfig(
+                  unresolvedTicketsConfigKey,
+                  !syncUnresolvedTicketsEnabled
+                );
               }}
               selected={syncUnresolvedTicketsEnabled}
               disabled={readOnly || !isAdmin || loading}
@@ -89,6 +111,38 @@ export function ZendeskConfigView({
             <br /> Be aware that this may significantly increase the number of
             synced tickets, potentially negatively affecting the response
             quality due to the added noise.
+          </div>
+        </ContextItem.Description>
+      </ContextItem>
+
+      <ContextItem
+        title="Hide Customer Information"
+        visual={
+          <ContextItem.Visual
+            visual={isDark ? ZendeskWhiteLogo : ZendeskLogo}
+          />
+        }
+        action={
+          <div className="relative">
+            <SliderToggle
+              size="xs"
+              onClick={async () => {
+                await handleSetNewConfig(
+                  hideCustomerDetailsConfigKey,
+                  !hideCustomerDetailsEnabled
+                );
+              }}
+              selected={hideCustomerDetailsEnabled}
+              disabled={readOnly || !isAdmin || loading}
+            />
+          </div>
+        }
+      >
+        <ContextItem.Description>
+          <div className="text-muted-foreground dark:text-muted-foreground-night">
+            Enable this option to prevent customer names and email addresses
+            from being synced with Dust. This does not impact data within
+            tickets, only the metadata attached to tickets.
           </div>
         </ContextItem.Description>
       </ContextItem>

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -108,7 +108,7 @@ export function ZendeskConfigView({
         <ContextItem.Description>
           <div className="text-muted-foreground dark:text-muted-foreground-night">
             If activated, Dust will also sync the unresolved tickets.
-            <br /> Be aware that this may significantly increase the number of
+            This may significantly increase the number of
             synced tickets, potentially negatively affecting the response
             quality due to the added noise.
           </div>

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -75,7 +75,7 @@ async function handler(
   }
 
   // We only allow setting and retrieving `botEnabled` (Slack), `codeSyncEnabled` (GitHub),
-  // `intercomConversationsNotesSyncEnabled` (Intercom) and `zendeskSyncUnresolvedTicketsEnabled` (Zendesk).
+  // `intercomConversationsNotesSyncEnabled` (Intercom), `zendeskSyncUnresolvedTicketsEnabled` and `zendeskHideCustomerDetails`.
   // This is mainly to prevent users from enabling other configs that are not released (e.g., google_drive `pdfEnabled`).
   if (
     ![
@@ -83,6 +83,7 @@ async function handler(
       "codeSyncEnabled",
       "intercomConversationsNotesSyncEnabled",
       "zendeskSyncUnresolvedTicketsEnabled",
+      "zendeskHideCustomerDetails",
       "gongRetentionPeriodDays",
     ].includes(configKey)
   ) {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2678.
- Add option to hide customer names and email in ingested ticket metadata.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Run `migration_65.sql`.
- Deploy connectors.
- Deploy front.
- Update documentation.