### PR TITLE
[Agent Discovery] Builder Editors Management UX

### DIFF
--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -38,6 +38,7 @@ import { TagsSelector } from "@app/components/assistant_builder/TagsSelector";
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
 import { ConfirmContext } from "@app/components/Confirm";
 import { MembersList } from "@app/components/members/MembersList";
+import { useSearchMembers } from "@app/lib/swr/memberships";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { debounce } from "@app/lib/utils/debounce";
 import type {
@@ -49,7 +50,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { useSearchMembers } from "@app/lib/swr/memberships";
 
 export function removeLeadingAt(handle: string) {
   return handle.startsWith("@") ? handle.slice(1) : handle;
@@ -701,10 +701,6 @@ function AddEditorDropdown({
       pageSize: 25,
     });
 
-  const addEditor = useCallback(async () => {
-    // TODO: use new endpoint
-  }, []);
-
   return (
     <DropdownMenu
       open={isEditorPickerOpen}
@@ -719,8 +715,8 @@ function AddEditorDropdown({
           label="Add editor"
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="s-w-[380px]">
-        <div className="s-flex s-gap-1.5 s-p-1.5">
+      <DropdownMenuContent className="w-[380px]">
+        <div className="flex gap-1.5 p-1.5">
           <SearchInput
             ref={searchInputRef}
             name="search"
@@ -731,7 +727,7 @@ function AddEditorDropdown({
           <Button icon={PlusIcon} label="Create" />
         </div>
         <DropdownMenuSeparator />
-        <ScrollArea className="s-h-[380px]" ref={itemsContainerRef}>
+        <ScrollArea className="h-[380px]" ref={itemsContainerRef}>
           {isWorkspaceMembersLoading ? (
             <Spinner size="sm" />
           ) : (
@@ -743,7 +739,6 @@ function AddEditorDropdown({
                   description={member.email}
                   icon={() => <Avatar size="sm" visual={member.image} />}
                   onClick={async () => {
-                    await addEditor(member);
                     setSearchTerm("");
                     setIsEditorPickerOpen(false);
                     await onAddEditor(member);

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -1,16 +1,19 @@
-import { Chip, DataTable, Page, Spinner } from "@dust-tt/sparkle";
+import {
+  Chip,
+  DataTable,
+  IconButton,
+  Spinner,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 import type { CellContext, PaginationState } from "@tanstack/react-table";
 import _ from "lodash";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
+import type { KeyedMutator } from "swr";
 
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
-import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
-import { useSearchMembers } from "@app/lib/swr/memberships";
-import type {
-  RoleType,
-  UserTypeWithWorkspaces,
-  WorkspaceType,
-} from "@app/types";
+import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
+import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
+import assert from "assert";
 
 type RowData = {
   icon: string;
@@ -18,112 +21,143 @@ type RowData = {
   userId: string;
   email: string;
   role: RoleType;
+  isCurrentUser: boolean;
   onClick: () => void;
+  onRemoveMemberClick?: () => void;
 };
 
 type Info = CellContext<RowData, string>;
 
-function getTableRows(
-  allUsers: UserTypeWithWorkspaces[],
-  onClick: (user: UserTypeWithWorkspaces) => void
-): RowData[] {
+function getTableRows({
+  allUsers,
+  onClick,
+  onRemoveMemberClick,
+  currentUserId,
+}: {
+  allUsers: UserTypeWithWorkspaces[];
+  onClick: (user: UserTypeWithWorkspaces) => void;
+  onRemoveMemberClick?: (user: UserTypeWithWorkspaces) => void;
+  currentUserId: string;
+}): RowData[] {
   return allUsers.map((user) => ({
     icon: user.image ?? "",
     name: user.fullName,
     userId: user.sId,
     email: user.email ?? "",
     role: user.workspaces[0].role,
+    isCurrentUser: user.sId === currentUserId,
     onClick: () => onClick(user),
+    onRemoveMemberClick: () => onRemoveMemberClick?.(user),
   }));
 }
 
+type MembersData = {
+  members: UserTypeWithWorkspaces[];
+  totalMembersCount: number;
+  isLoading: boolean;
+  mutateRegardlessOfQueryParams: KeyedMutator<SearchMembersResponseBody>;
+};
+
+const memberColumns = [
+  {
+    id: "name" as const,
+    header: "Name",
+    cell: (info: Info) => (
+      <DataTable.CellContent avatarUrl={info.row.original.icon}>
+        {info.row.original.name}{" "}
+        {info.row.original.isCurrentUser ? " (you)" : ""}
+      </DataTable.CellContent>
+    ),
+    enableSorting: false,
+  },
+  {
+    id: "email" as const,
+    accessorKey: "email",
+    header: "Email",
+    cell: (info: Info) => (
+      <DataTable.CellContent>{info.row.original.email}</DataTable.CellContent>
+    ),
+  },
+  {
+    id: "role" as const,
+    header: "Role",
+    accessorFn: (row: RowData) => row.role,
+    cell: (info: Info) => (
+      <DataTable.CellContent>
+        <Chip
+          label={_.capitalize(displayRole(info.row.original.role))}
+          color={
+            info.row.original.role !== "none"
+              ? ROLES_DATA[info.row.original.role]["color"]
+              : undefined
+          }
+        />
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-32",
+    },
+  },
+  {
+    id: "remove" as const,
+    header: "",
+    cell: (info: Info) => (
+      <DataTable.CellContent>
+        <IconButton
+          icon={XMarkIcon}
+          onClick={info.row.original.onRemoveMemberClick}
+        />
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-12",
+    },
+  },
+];
+
 export function MembersList({
-  owner,
   currentUserId,
-  searchText,
+  membersData,
+  onRowClick,
+  onRemoveMemberClick,
+  showColumns,
 }: {
-  owner: WorkspaceType;
   currentUserId: string;
-  searchText: string;
+  membersData: MembersData;
+  onRowClick: (user: UserTypeWithWorkspaces) => void;
+  onRemoveMemberClick?: (user: UserTypeWithWorkspaces) => void;
+  showColumns: ("name" | "email" | "role" | "remove")[];
 }) {
+  assert(
+    !showColumns.includes("remove") || onRemoveMemberClick,
+    "onRemoveMemberClick is required if remove column is shown"
+  );
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
     pageSize: 25,
   });
   useEffect(() => {
     setPagination({ pageIndex: 0, pageSize: 25 });
-  }, [searchText, setPagination]);
+  }, [setPagination]);
 
-  const [selectedMember, setSelectedMember] =
-    useState<UserTypeWithWorkspaces | null>(null);
-  const {
-    members,
-    totalMembersCount,
-    isLoading,
-    mutateRegardlessOfQueryParams: mutateMembers,
-  } = useSearchMembers({
-    workspaceId: owner.sId,
-    searchTerm: searchText,
-    pageIndex: pagination.pageIndex,
-    pageSize: pagination.pageSize,
-  });
-  const columns = [
-    {
-      id: "name",
-      header: "Name",
-      cell: (info: Info) => (
-        <DataTable.CellContent avatarUrl={info.row.original.icon}>
-          {info.row.original.name}{" "}
-          {info.row.original.userId === currentUserId ? " (you)" : ""}
-        </DataTable.CellContent>
-      ),
-      enableSorting: false,
-    },
-    {
-      id: "email",
-      accessorKey: "email",
-      header: "Email",
-      cell: (info: Info) => (
-        <DataTable.CellContent>{info.row.original.email}</DataTable.CellContent>
-      ),
-    },
-    {
-      id: "role",
-      header: "Role",
-      accessorFn: (row: RowData) => row.role,
-      cell: (info: Info) => (
-        <DataTable.CellContent>
-          <Chip
-            label={_.capitalize(displayRole(info.row.original.role))}
-            color={
-              info.row.original.role !== "none"
-                ? ROLES_DATA[info.row.original.role]["color"]
-                : undefined
-            }
-          />
-        </DataTable.CellContent>
-      ),
-      meta: {
-        className: "w-32",
-      },
-    },
-  ];
+  const { members, totalMembersCount, isLoading } = membersData;
+
+  const columns = memberColumns.filter((c) => showColumns.includes(c.id));
 
   const rows = useMemo(() => {
     const filteredMembers = members.filter(
       (m) => m.workspaces[0].role !== "none"
     );
-    return getTableRows(
-      filteredMembers,
-      (user: UserTypeWithWorkspaces | null) => {
-        setSelectedMember(user);
-      }
-    );
-  }, [members]);
+    return getTableRows({
+      allUsers: filteredMembers,
+      onClick: onRowClick,
+      onRemoveMemberClick,
+      currentUserId,
+    });
+  }, [members, onRowClick, onRemoveMemberClick, currentUserId]);
 
   return (
-    <div className="flex flex-col gap-2">
-      <Page.H variant="h5">Members</Page.H>
+    <>
       {isLoading ? (
         <div className="flex items-center justify-center py-8">
           <Spinner size="lg" />
@@ -137,11 +171,6 @@ export function MembersList({
           totalRowCount={totalMembersCount}
         />
       )}
-      <ChangeMemberModal
-        onClose={() => setSelectedMember(null)}
-        member={selectedMember}
-        mutateMembers={mutateMembers}
-      />
-    </div>
+    </>
   );
 }

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -6,6 +6,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type { CellContext, PaginationState } from "@tanstack/react-table";
+import assert from "assert";
 import _ from "lodash";
 import React, { useEffect, useMemo } from "react";
 import type { KeyedMutator } from "swr";
@@ -13,7 +14,6 @@ import type { KeyedMutator } from "swr";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
-import assert from "assert";
 
 type RowData = {
   icon: string;

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -23,6 +23,7 @@ import { InvitationsList } from "@app/components/members/InvitationsList";
 import { MembersList } from "@app/components/members/MembersList";
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
 import type { EnterpriseConnectionStrategyDetails } from "@app/components/workspace/connection";
 import { EnterpriseConnectionDetails } from "@app/components/workspace/connection";
 import config from "@app/lib/api/config";
@@ -37,6 +38,7 @@ import {
 } from "@app/lib/api/workspace";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { useSearchMembers } from "@app/lib/swr/memberships";
 import type {
   PlanType,
   SubscriptionPerSeatPricing,
@@ -46,8 +48,6 @@ import type {
   WorkspaceDomain,
   WorkspaceType,
 } from "@app/types";
-import { useSearchMembers } from "@app/lib/swr/memberships";
-import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;


### PR DESCRIPTION
Part of https://github.com/dust-tt/tasks/issues/2467

Description
---
- refactors MembersList for reuse
- creates WorkspaceMembersList for admin workspace management (was memberslist before)
- creates EditorsMembersList for editors

This PR is only refactoring and mock UX. Functionality for editors is in a follwing PR.
![image](https://github.com/user-attachments/assets/db9d7610-d55b-4c64-91c4-82e6ec99bf9c)

Risk
---
standard. feature flagged for the mock editor part

Deploy
---
front
