### PR TITLE
enh(Gong): log headers on rate limit hits

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -138,7 +138,7 @@ export class GongClient {
       // Handle rate limiting
       // https://gong.app.gong.io/settings/api/documentation#overview
       if (response.status === 429) {
-        const xHeaders = Object.fromEntries(
+        const headers = Object.fromEntries(
           Array.from(response.headers.entries()).filter(
             ([key]) =>
               key.toLowerCase().startsWith("x-") ||
@@ -146,12 +146,12 @@ export class GongClient {
           )
         );
 
-        if (Object.keys(xHeaders).length > 0) {
+        if (Object.keys(headers).length > 0) {
           logger.info(
             {
               connectorId: this.connectorId,
               endpoint,
-              xHeaders,
+              headers,
             },
             "Rate limit hit on Gong API."
           );

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -8,6 +8,7 @@ import {
   HTTPError,
   isNotFoundError,
 } from "@connectors/lib/error";
+import logger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 
 // Pass-through codec that is used to allow unknown properties.
@@ -137,7 +138,22 @@ export class GongClient {
       // Handle rate limiting
       // https://gong.app.gong.io/settings/api/documentation#overview
       if (response.status === 429) {
-        // TODO(2025-03-04) - Implement this, we can read the Retry-After header.
+        const xHeaders = Object.fromEntries(
+          Array.from(response.headers.entries()).filter(([key]) =>
+            key.toLowerCase().startsWith("x-")
+          )
+        );
+
+        if (Object.keys(xHeaders).length > 0) {
+          logger.info(
+            {
+              connectorId: this.connectorId,
+              endpoint,
+              xHeaders,
+            },
+            "Rate limit hit on Gong API."
+          );
+        }
       }
 
       if (response.status === 404) {

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -140,7 +140,7 @@ export class GongClient {
       if (response.status === 429) {
         const xHeaders = Object.fromEntries(
           Array.from(response.headers.entries()).filter(([key]) =>
-            key.toLowerCase().startsWith("x-")
+            key.toLowerCase().startsWith("x-") || key.toLowerCase().startsWith("rate-")
           )
         );
 

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -139,8 +139,10 @@ export class GongClient {
       // https://gong.app.gong.io/settings/api/documentation#overview
       if (response.status === 429) {
         const xHeaders = Object.fromEntries(
-          Array.from(response.headers.entries()).filter(([key]) =>
-            key.toLowerCase().startsWith("x-") || key.toLowerCase().startsWith("rate-")
+          Array.from(response.headers.entries()).filter(
+            ([key]) =>
+              key.toLowerCase().startsWith("x-") ||
+              key.toLowerCase().startsWith("rate-")
           )
         );
 


### PR DESCRIPTION
## Description

- We have seen rate limit hits on Gong API.
- In order to track those, this PR adds some logging around it, including possible useful headers (`x-retry-after` notably).

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.