### PR TITLE
perf(Gong): optimize the number of requests to the API

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -146,17 +146,15 @@ export class GongClient {
           )
         );
 
-        if (Object.keys(headers).length > 0) {
-          logger.info(
-            {
-              connectorId: this.connectorId,
-              endpoint,
-              headers,
-              provider: "gong",
-            },
-            "Rate limit hit on Gong API."
-          );
-        }
+        logger.info(
+          {
+            connectorId: this.connectorId,
+            endpoint,
+            headers,
+            provider: "gong",
+          },
+          "Rate limit hit on Gong API."
+        );
       }
 
       if (response.status === 404) {

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -152,6 +152,7 @@ export class GongClient {
               connectorId: this.connectorId,
               endpoint,
               headers,
+              provider: "gong",
             },
             "Rate limit hit on Gong API."
           );

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -133,12 +133,14 @@ export async function gongSyncTranscriptsActivity({
     callIds: transcriptsToSync.map((t) => t.callId),
     connector,
   });
+  const callsMetadataMap = new Map(
+    callsMetadata.map((c) => [c.metaData.id, c])
+  );
+
   await concurrentExecutor(
     transcriptsToSync,
     async (transcript) => {
-      const transcriptMetadata = callsMetadata.find(
-        (c) => c.metaData.id === transcript.callId
-      );
+      const transcriptMetadata = callsMetadataMap.get(transcript.callId);
       if (!transcriptMetadata) {
         logger.warn(
           { ...loggerArgs, callId: transcript.callId },

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -332,6 +332,20 @@ export class GongTranscriptResource extends BaseResource<GongTranscriptModel> {
     };
   }
 
+  static async fetchByCallIds(
+    callIds: string[],
+    connector: ConnectorResource
+  ): Promise<GongTranscriptResource[]> {
+    const transcripts = await GongTranscriptModel.findAll({
+      where: {
+        callId: callIds,
+        connectorId: connector.id,
+      },
+    });
+
+    return transcripts.map((t) => new this(this.model, t.get()));
+  }
+
   static async fetchByCallId(
     callId: string,
     connector: ConnectorResource


### PR DESCRIPTION
## Description

We have been hitting the rate limit on Gong API recently.
https://github.com/dust-tt/dust/pull/12077 introduces a change that prevents the transcripts that are not processed yet at the time of the sync from being skipped and forgotten, but also causes transcripts that were already processed from being fetched twice.

This PR aims at skipping the calls to `/v2/calls/extensive` and `/v2/users/{id}` for transcripts that are already synced by checking `connectors` db earlier.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.