### PR TITLE
[Agent Discovery] Editors UX becomes functional

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -15,7 +15,7 @@ import {
   useSendNotification,
 } from "@dust-tt/sparkle";
 import assert from "assert";
-import { initial, uniqueId } from "lodash";
+import { uniqueId } from "lodash";
 import { useRouter } from "next/router";
 import React, {
   useCallback,
@@ -551,6 +551,7 @@ export default function AssistantBuilder({
                         setEdited={setEdited}
                         assistantHandleError={assistantHandleError}
                         descriptionError={descriptionError}
+                        agentConfigurationId={agentConfigurationId}
                       />
                     );
                   default:

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -550,7 +550,7 @@ export default function AssistantBuilder({
                         setEdited={setEdited}
                         assistantHandleError={assistantHandleError}
                         descriptionError={descriptionError}
-                        currentUserId={user?.sId ?? null}
+                        currentUser={user}
                       />
                     );
                   default:

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -78,6 +78,7 @@ import {
   isBuilder,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
+import { useEditors } from "@app/lib/swr/editors";
 
 function isValidTab(tab: string): tab is BuilderScreen {
   return BUILDER_SCREENS.includes(tab as BuilderScreen);
@@ -159,6 +160,8 @@ export default function AssistantBuilder({
           },
         }
   );
+
+  const { mutateEditors } = useEditors({ owner, agentConfigurationId });
 
   const [pendingAction, setPendingAction] =
     useState<AssistantBuilderPendingAction>({
@@ -396,6 +399,7 @@ export default function AssistantBuilder({
           type: "error",
         });
       } else {
+        void mutateEditors();
         if (slackDataSource) {
           await mutateSlackChannels();
         }
@@ -547,7 +551,6 @@ export default function AssistantBuilder({
                         setEdited={setEdited}
                         assistantHandleError={assistantHandleError}
                         descriptionError={descriptionError}
-                        agentConfigurationId={agentConfigurationId}
                         currentUserId={user?.sId ?? null}
                       />
                     );

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -235,10 +235,10 @@ export default function AssistantBuilder({
       );
     }
     if (!agentConfigurationId) {
-      setBuilderState({
-        ...builderState,
-        editors: [...(builderState.editors ?? []), user],
-      });
+      setBuilderState((state) => ({
+        ...state,
+        editors: [...(state.editors ?? []), user],
+      }));
     }
   }, [
     isUserLoading,
@@ -246,7 +246,6 @@ export default function AssistantBuilder({
     user,
     agentConfigurationId,
     initialBuilderState,
-    builderState,
   ]);
 
   const openRightPanelTab = (tabName: AssistantBuilderRightPanelTab) => {

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -228,18 +228,14 @@ export default function AssistantBuilder({
     }
     if (agentConfigurationId && initialBuilderState?.editors) {
       assert(
-        initialBuilderState.editors.get(user.sId),
+        initialBuilderState.editors.some((m) => m.sId === user.sId),
         "Unreachable: User is not in editors"
       );
     }
     if (!agentConfigurationId) {
-      if (!builderState.editors) {
-        builderState.editors = new Map<string, UserType>();
-      }
-      builderState.editors.set(user.sId, user);
       setBuilderState({
         ...builderState,
-        editors: builderState.editors,
+        editors: [...(builderState.editors ?? []), user],
       });
     }
   }, [

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -552,6 +552,7 @@ export default function AssistantBuilder({
                         assistantHandleError={assistantHandleError}
                         descriptionError={descriptionError}
                         agentConfigurationId={agentConfigurationId}
+                        currentUserId={user?.sId ?? null}
                       />
                     );
                   default:

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -69,6 +69,7 @@ import type {
   AgentConfigurationScope,
   AssistantBuilderRightPanelStatus,
   AssistantBuilderRightPanelTab,
+  UserType,
 } from "@app/types";
 import {
   assertNever,
@@ -225,14 +226,21 @@ export default function AssistantBuilder({
     if (isUserError || isUserLoading || !user) {
       return;
     }
-    if (agentConfigurationId && initialBuilderState) {
+    if (agentConfigurationId && initialBuilderState?.editors) {
       assert(
         user.sId in initialBuilderState.editors,
         "Unreachable: User is not in editors"
       );
     }
     if (!agentConfigurationId) {
+      if (!builderState.editors) {
+        builderState.editors = new Map<string, UserType>();
+      }
       builderState.editors.set(user.sId, user);
+      setBuilderState({
+        ...builderState,
+        editors: builderState.editors,
+      });
     }
   }, [
     isUserLoading,

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -228,7 +228,7 @@ export default function AssistantBuilder({
     }
     if (agentConfigurationId && initialBuilderState?.editors) {
       assert(
-        user.sId in initialBuilderState.editors,
+        initialBuilderState.editors.get(user.sId),
         "Unreachable: User is not in editors"
       );
     }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -62,6 +62,7 @@ import {
   AppLayoutSimpleSaveCancelTitle,
 } from "@app/components/sparkle/AppLayoutTitle";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { useEditors } from "@app/lib/swr/editors";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
 import { useUser } from "@app/lib/swr/user";
@@ -69,7 +70,6 @@ import type {
   AgentConfigurationScope,
   AssistantBuilderRightPanelStatus,
   AssistantBuilderRightPanelTab,
-  UserType,
 } from "@app/types";
 import {
   assertNever,
@@ -78,7 +78,6 @@ import {
   isBuilder,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
-import { useEditors } from "@app/lib/swr/editors";
 
 function isValidTab(tab: string): tab is BuilderScreen {
   return BUILDER_SCREENS.includes(tab as BuilderScreen);
@@ -247,6 +246,7 @@ export default function AssistantBuilder({
     user,
     agentConfigurationId,
     initialBuilderState,
+    builderState,
   ]);
 
   const openRightPanelTab = (tabName: AssistantBuilderRightPanelTab) => {

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -625,12 +625,8 @@ function EditorsMembersList({
 }) {
   const editorsData = useEditors({ owner, agentConfigurationId });
 
-  const members = useMemo(() => {
-    const members = editorsData.editorsMap
-      ? [...editorsData.editorsMap.values()]
-      : [];
-    return members.map((m) => ({ ...m, workspaces: [owner] }));
-  }, []);
+  const members =
+    editorsData.editors?.map((m) => ({ ...m, workspaces: [owner] })) ?? [];
 
   const membersData = {
     members,
@@ -653,10 +649,12 @@ function EditorsMembersList({
         currentUserId={currentUserId ?? "current-user-not-loaded"}
         membersData={membersData}
         onRowClick={() => {}}
-        onRemoveMemberClick={(member) =>
+        onRemoveMemberClick={(removed) =>
           setBuilderState((s) => ({
             ...s,
-            editors: s.editors?.delete(member.sId),
+            editors: s.editors
+              ? s.editors.filter((m) => m.sId != removed.sId)
+              : [],
           }))
         }
         showColumns={["name", "email", "remove"]}

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -516,6 +516,7 @@ export default function NamingScreen({
               currentUserId={currentUserId}
               owner={owner}
               agentConfigurationId={agentConfigurationId}
+              setBuilderState={setBuilderState}
             />
           </>
         )}
@@ -613,10 +614,14 @@ function EditorsMembersList({
   currentUserId,
   owner,
   agentConfigurationId,
+  setBuilderState,
 }: {
   currentUserId: string | null;
   owner: WorkspaceType;
   agentConfigurationId: string | null;
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
 }) {
   const editorsData = useEditors({ owner, agentConfigurationId });
 
@@ -648,7 +653,12 @@ function EditorsMembersList({
         currentUserId={currentUserId ?? "current-user-not-loaded"}
         membersData={membersData}
         onRowClick={() => {}}
-        onRemoveMemberClick={() => {}}
+        onRemoveMemberClick={(member) =>
+          setBuilderState((s) => ({
+            ...s,
+            editors: s.editors?.delete(member.sId),
+          }))
+        }
         showColumns={["name", "email", "remove"]}
       />
     </div>

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -48,13 +48,9 @@ import type {
   BuilderSuggestionsType,
   Result,
   UserType,
-  UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { useEditors } from "@app/lib/swr/editors";
-import { LightAgentConfigurationType } from "@dust-tt/client";
-import { m } from "motion/react";
 
 export function removeLeadingAt(handle: string) {
   return handle.startsWith("@") ? handle.slice(1) : handle;
@@ -628,7 +624,7 @@ function EditorsMembersList({
   const members = useMemo(
     () =>
       builderState.editors?.map((m) => ({ ...m, workspaces: [owner] })) ?? [],
-    [builderState]
+    [builderState, owner]
   );
 
   const membersData = {

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -690,7 +690,6 @@ function AddEditorDropdown({
 }) {
   const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const searchInputRef = React.useRef<HTMLInputElement>(null);
   const itemsContainerRef = React.useRef<HTMLDivElement>(null);
 
   const { members: workspaceMembers, isLoading: isWorkspaceMembersLoading } =
@@ -718,10 +717,9 @@ function AddEditorDropdown({
       <DropdownMenuContent className="w-[380px]">
         <div className="flex gap-1.5 p-1.5">
           <SearchInput
-            ref={searchInputRef}
             name="search"
             onChange={(value) => setSearchTerm(value)}
-            placeholder="Search members"
+            placeholder="Search by email"
             value={searchTerm}
           />
           <Button icon={PlusIcon} label="Create" />

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -150,7 +150,7 @@ export default function NamingScreen({
   setEdited,
   assistantHandleError,
   descriptionError,
-  currentUserId,
+  currentUser,
 }: {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
@@ -161,7 +161,7 @@ export default function NamingScreen({
   setEdited: (edited: boolean) => void;
   assistantHandleError: string | null;
   descriptionError: string | null;
-  currentUserId: string | null;
+  currentUser: UserType | null;
 }) {
   const confirm = useContext(ConfirmContext);
   const sendNotification = useSendNotification();
@@ -508,7 +508,7 @@ export default function NamingScreen({
               </div>
             </div>
             <EditorsMembersList
-              currentUserId={currentUserId}
+              currentUser={currentUser}
               owner={owner}
               builderState={builderState}
               setBuilderState={setBuilderState}
@@ -607,13 +607,13 @@ async function fetchWithErr<T>(
 }
 
 function EditorsMembersList({
-  currentUserId,
+  currentUser,
   owner,
   builderState,
   setBuilderState,
   setEdited,
 }: {
-  currentUserId: string | null;
+  currentUser: UserType | null;
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
   setBuilderState: (
@@ -655,7 +655,7 @@ function EditorsMembersList({
         />
       </div>
       <MembersList
-        currentUserId={currentUserId ?? "current-user-not-loaded"}
+        currentUser={currentUser}
         membersData={membersData}
         onRowClick={() => {}}
         onRemoveMemberClick={(removed) => {

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -154,6 +154,7 @@ export default function NamingScreen({
   assistantHandleError,
   descriptionError,
   agentConfigurationId,
+  currentUserId,
 }: {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
@@ -165,6 +166,7 @@ export default function NamingScreen({
   assistantHandleError: string | null;
   descriptionError: string | null;
   agentConfigurationId: string | null;
+  currentUserId: string | null;
 }) {
   const confirm = useContext(ConfirmContext);
   const sendNotification = useSendNotification();
@@ -511,7 +513,7 @@ export default function NamingScreen({
               </div>
             </div>
             <EditorsMembersList
-              currentUserId={"mock1"}
+              currentUserId={currentUserId}
               owner={owner}
               agentConfigurationId={agentConfigurationId}
             />
@@ -612,66 +614,10 @@ function EditorsMembersList({
   owner,
   agentConfigurationId,
 }: {
-  currentUserId: string;
+  currentUserId: string | null;
   owner: WorkspaceType;
   agentConfigurationId: string | null;
 }) {
-  const mockMembersData = {
-    members: [
-      {
-        sId: "mock1",
-        fullName: "Mock User 1",
-        email: "mock1@test.com",
-        image: "https://example.com/image.png",
-        workspaces: [
-          {
-            role: "admin" as const,
-            sId: "mock1",
-            name: "Mock Workspace 1",
-            id: 1,
-            segmentation: null,
-            whiteListedProviders: null,
-            defaultEmbeddingProvider: null,
-            metadata: null,
-          },
-        ],
-        id: 1,
-        createdAt: 0,
-        provider: null,
-        username: "mock1",
-        firstName: "Mock",
-        lastName: "User 1",
-      },
-      {
-        sId: "mock2",
-        fullName: "Mock User 2",
-        email: "mock2@test.com",
-        image: "https://example.com/image.png",
-        workspaces: [
-          {
-            role: "admin" as const,
-            sId: "mock1",
-            name: "Mock Workspace 1",
-            id: 1,
-            segmentation: null,
-            whiteListedProviders: null,
-            defaultEmbeddingProvider: null,
-            metadata: null,
-          },
-        ],
-        id: 2,
-        createdAt: 0,
-        provider: null,
-        username: "mock2",
-        firstName: "Mock",
-        lastName: "User 2",
-      },
-    ],
-    totalMembersCount: 2,
-    isLoading: false,
-    mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
-  };
-
   const editorsData = useEditors({ owner, agentConfigurationId });
 
   const members = useMemo(() => {
@@ -699,7 +645,7 @@ function EditorsMembersList({
         />
       </div>
       <MembersList
-        currentUserId={currentUserId}
+        currentUserId={currentUserId ?? "current-user-not-loaded"}
         membersData={membersData}
         onRowClick={() => {}}
         onRemoveMemberClick={() => {}}

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -154,7 +154,6 @@ export default function NamingScreen({
   setEdited,
   assistantHandleError,
   descriptionError,
-  agentConfigurationId,
   currentUserId,
 }: {
   owner: WorkspaceType;
@@ -166,7 +165,6 @@ export default function NamingScreen({
   setEdited: (edited: boolean) => void;
   assistantHandleError: string | null;
   descriptionError: string | null;
-  agentConfigurationId: string | null;
   currentUserId: string | null;
 }) {
   const confirm = useContext(ConfirmContext);
@@ -518,6 +516,7 @@ export default function NamingScreen({
               owner={owner}
               builderState={builderState}
               setBuilderState={setBuilderState}
+              setEdited={setEdited}
             />
           </>
         )}
@@ -616,6 +615,7 @@ function EditorsMembersList({
   owner,
   builderState,
   setBuilderState,
+  setEdited,
 }: {
   currentUserId: string | null;
   owner: WorkspaceType;
@@ -623,6 +623,7 @@ function EditorsMembersList({
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
+  setEdited: (edited: boolean) => void;
 }) {
   const members = useMemo(
     () =>
@@ -653,6 +654,7 @@ function EditorsMembersList({
               ...s,
               editors: [...(s.editors ?? []), added],
             }));
+            setEdited(true);
           }}
         />
       </div>
@@ -660,14 +662,15 @@ function EditorsMembersList({
         currentUserId={currentUserId ?? "current-user-not-loaded"}
         membersData={membersData}
         onRowClick={() => {}}
-        onRemoveMemberClick={(removed) =>
+        onRemoveMemberClick={(removed) => {
           setBuilderState((s) => ({
             ...s,
             editors: s.editors
               ? s.editors.filter((m) => m.sId != removed.sId)
               : [],
-          }))
-        }
+          }));
+          setEdited(true);
+        }}
         showColumns={["name", "email", "remove"]}
       />
     </div>

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -644,12 +644,16 @@ function EditorsMembersList({
         <div className="flex flex-grow" />
         <AddEditorDropdown
           owner={owner}
-          onAddEditor={(added) =>
+          editors={builderState.editors ?? []}
+          onAddEditor={(added) => {
+            if (builderState.editors?.some((e) => e.sId === added.sId)) {
+              return;
+            }
             setBuilderState((s) => ({
               ...s,
               editors: [...(s.editors ?? []), added],
-            }))
-          }
+            }));
+          }}
         />
       </div>
       <MembersList
@@ -672,9 +676,11 @@ function EditorsMembersList({
 
 function AddEditorDropdown({
   owner,
+  editors,
   onAddEditor,
 }: {
   owner: WorkspaceType;
+  editors: UserType[];
   onAddEditor: (member: UserType) => void;
 }) {
   const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
@@ -731,6 +737,7 @@ function AddEditorDropdown({
                     onAddEditor(member);
                   }}
                   truncateText
+                  disabled={editors.some((e) => e.sId === member.sId)}
                 />
               );
             })

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -19,6 +19,7 @@ import type {
   RetrievalTimeframe,
 } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
+import editors from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 import type {
   AgentConfigurationType,
   DataSourceViewSelectionConfigurations,
@@ -97,8 +98,8 @@ export async function submitAssistantBuilderForm({
   Result<LightAgentConfigurationType | AgentConfigurationType, Error>
 > {
   const { selectedSlackChannels, slackChannelsLinkedWithAgent } = slackData;
-  let { handle, description, instructions, avatarUrl } = builderState;
-  if (!handle || !description || !instructions || !avatarUrl) {
+  let { handle, description, instructions, avatarUrl, editors } = builderState;
+  if (!handle || !description || !instructions || !avatarUrl || !editors) {
     if (!isDraft) {
       // Should be unreachable, we keep this for TS
       throw new Error("Form not valid (unreachable)");
@@ -107,6 +108,7 @@ export async function submitAssistantBuilderForm({
       description = description?.trim() || "Preview";
       instructions = instructions?.trim() || "Preview";
       avatarUrl = avatarUrl ?? "";
+      editors = [];
     }
   }
 
@@ -322,6 +324,7 @@ export async function submitAssistantBuilderForm({
       visualizationEnabled: builderState.visualizationEnabled,
       templateId: builderState.templateId,
       tags: builderState.tags,
+      editors: editors.map((e) => ({ sId: e.sId })),
     },
   };
 

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -19,7 +19,6 @@ import type {
   RetrievalTimeframe,
 } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
-import editors from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 import type {
   AgentConfigurationType,
   DataSourceViewSelectionConfigurations,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -28,6 +28,7 @@ import type {
   SubscriptionType,
   SupportedModel,
   TimeframeUnit,
+  UserType,
   WorkspaceType,
 } from "@app/types";
 import {
@@ -231,6 +232,7 @@ export type AssistantBuilderState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
+  editors: Map<string, UserType>;
 };
 
 export type AssistantBuilderInitialState = {
@@ -249,6 +251,7 @@ export type AssistantBuilderInitialState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
+  editors: Map<string, UserType>;
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
@@ -271,6 +274,7 @@ export function getDefaultAssistantState() {
     visualizationEnabled: true,
     templateId: null,
     tags: [],
+    editors: new Map<string, UserType>(),
   } satisfies AssistantBuilderState;
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -232,7 +232,7 @@ export type AssistantBuilderState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors?: Map<string, UserType>;
+  editors?: UserType[];
 };
 
 export type AssistantBuilderInitialState = {
@@ -251,7 +251,7 @@ export type AssistantBuilderInitialState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors?: Map<string, UserType>;
+  editors?: UserType[];
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
@@ -274,7 +274,7 @@ export function getDefaultAssistantState() {
     visualizationEnabled: true,
     templateId: null,
     tags: [],
-    editors: new Map<string, UserType>(),
+    editors: [],
   } satisfies AssistantBuilderState;
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -232,7 +232,7 @@ export type AssistantBuilderState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors: Map<string, UserType>;
+  editors?: Map<string, UserType>;
 };
 
 export type AssistantBuilderInitialState = {
@@ -251,7 +251,7 @@ export type AssistantBuilderInitialState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors: Map<string, UserType>;
+  editors?: Map<string, UserType>;
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -14,6 +14,7 @@ import type { KeyedMutator } from "swr";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
+import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 
 type RowData = {
   icon: string;
@@ -55,7 +56,9 @@ type MembersData = {
   members: UserTypeWithWorkspaces[];
   totalMembersCount: number;
   isLoading: boolean;
-  mutateRegardlessOfQueryParams: KeyedMutator<SearchMembersResponseBody>;
+  mutateRegardlessOfQueryParams:
+    | KeyedMutator<SearchMembersResponseBody>
+    | KeyedMutator<GetAgentEditorsResponseBody>;
 };
 
 const memberColumns = [

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -103,10 +103,14 @@ const memberColumns = [
     header: "",
     cell: (info: Info) => (
       <DataTable.CellContent>
-        <IconButton
-          icon={XMarkIcon}
-          onClick={info.row.original.onRemoveMemberClick}
-        />
+        {info.row.original.isCurrentUser ? (
+          <></>
+        ) : (
+          <IconButton
+            icon={XMarkIcon}
+            onClick={info.row.original.onRemoveMemberClick}
+          />
+        )}
       </DataTable.CellContent>
     ),
     meta: {

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -13,7 +13,7 @@ import type { KeyedMutator } from "swr";
 
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
-import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
+import type { RoleType, UserType, UserTypeWithWorkspaces } from "@app/types";
 
 type RowData = {
   icon: string;
@@ -122,13 +122,13 @@ const memberColumns = [
 ];
 
 export function MembersList({
-  currentUserId,
+  currentUser,
   membersData,
   onRowClick,
   onRemoveMemberClick,
   showColumns,
 }: {
-  currentUserId: string;
+  currentUser: UserType | null;
   membersData: MembersData;
   onRowClick: (user: UserTypeWithWorkspaces) => void;
   onRemoveMemberClick?: (user: UserTypeWithWorkspaces) => void;
@@ -158,9 +158,9 @@ export function MembersList({
       allUsers: filteredMembers,
       onClick: onRowClick,
       onRemoveMemberClick,
-      currentUserId,
+      currentUserId: currentUser?.sId ?? "current-user-not-loaded",
     });
-  }, [members, onRowClick, onRemoveMemberClick, currentUserId]);
+  }, [members, onRowClick, onRemoveMemberClick, currentUser]);
 
   return (
     <>

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -14,7 +14,6 @@ import type { KeyedMutator } from "swr";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
-import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 
 type RowData = {
   icon: string;

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -58,7 +58,7 @@ type MembersData = {
   isLoading: boolean;
   mutateRegardlessOfQueryParams:
     | KeyedMutator<SearchMembersResponseBody>
-    | KeyedMutator<GetAgentEditorsResponseBody>;
+    | (() => void);
 };
 
 const memberColumns = [

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -916,7 +916,7 @@ export async function createAgentConfiguration(
             agentConfigurationInstance,
             { transaction: t }
           );
-          await group.setMembers(auth, editors, { transaction });
+          await group.setMembers(auth, editors, { transaction: t });
         } else {
           const groupRes = await GroupResource.fetchByAgentConfiguration(
             auth,
@@ -938,7 +938,7 @@ export async function createAgentConfiguration(
                 `Error adding group to agent ${existingAgent.sId}: ${result.error}`
               );
             }
-            await group.setMembers(auth, editors, { transaction });
+            await group.setMembers(auth, editors, { transaction: t });
           } else {
             logger.warn(
               {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -763,6 +763,7 @@ export async function createAgentConfiguration(
     templateId,
     requestedGroupIds,
     tags,
+    editors,
   }: {
     name: string;
     description: string;
@@ -777,6 +778,7 @@ export async function createAgentConfiguration(
     templateId: string | null;
     requestedGroupIds: number[][];
     tags: TagType[];
+    editors: UserType[];
   },
   transaction?: Transaction
 ): Promise<Result<LightAgentConfigurationType, Error>> {
@@ -904,19 +906,25 @@ export async function createAgentConfiguration(
       }
 
       if (status === "active") {
+        assert(
+          editors.some((e) => e.sId === auth.user()?.sId),
+          "Unexpected: current user must be in editor group"
+        );
         if (!existingAgent) {
-          await GroupResource.makeNewAgentEditorsGroup(
+          const group = await GroupResource.makeNewAgentEditorsGroup(
             auth,
             agentConfigurationInstance,
             { transaction: t }
           );
+          group.setMembers(auth, editors, { transaction });
         } else {
-          const group = await GroupResource.fetchByAgentConfiguration(
+          const groupRes = await GroupResource.fetchByAgentConfiguration(
             auth,
             existingAgent
           );
-          if (group.isOk()) {
-            const result = await group.value.addGroupToAgentConfiguration({
+          if (groupRes.isOk()) {
+            const group = groupRes.value;
+            const result = await group.addGroupToAgentConfiguration({
               auth,
               agentConfiguration: agentConfigurationInstance,
               transaction: t,
@@ -930,13 +938,14 @@ export async function createAgentConfiguration(
                 `Error adding group to agent ${existingAgent.sId}: ${result.error}`
               );
             }
+            group.setMembers(auth, editors, { transaction });
           } else {
             logger.warn(
               {
                 workspaceId: owner.id,
                 agentConfigurationId: existingAgent.sId,
               },
-              `Error fetching group for agent ${existingAgent.sId}: ${group.error}`
+              `Error fetching group for agent ${existingAgent.sId}: ${groupRes.error}`
             );
           }
         }

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -916,7 +916,7 @@ export async function createAgentConfiguration(
             agentConfigurationInstance,
             { transaction: t }
           );
-          group.setMembers(auth, editors, { transaction });
+          await group.setMembers(auth, editors, { transaction });
         } else {
           const groupRes = await GroupResource.fetchByAgentConfiguration(
             auth,
@@ -938,7 +938,7 @@ export async function createAgentConfiguration(
                 `Error adding group to agent ${existingAgent.sId}: ${result.error}`
               );
             }
-            group.setMembers(auth, editors, { transaction });
+            await group.setMembers(auth, editors, { transaction });
           } else {
             logger.warn(
               {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -25,6 +25,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
+  AgentConfigurationType,
   GroupKind,
   GroupType,
   LightAgentConfigurationType,
@@ -397,7 +398,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async fetchByAgentConfiguration(
     auth: Authenticator,
-    agentConfiguration: AgentConfiguration
+    agentConfiguration: AgentConfiguration | AgentConfigurationType
   ): Promise<Result<GroupResource, DustError>> {
     const workspace = auth.getNonNullableWorkspace();
     const groupAgent = await GroupAgentModel.findOne({

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -3,33 +3,26 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import {
-  isTemplateAgentConfiguration,
-  UserType,
-  type LightAgentConfigurationType,
-  type LightWorkspaceType,
-  type TemplateAgentConfigurationType,
-} from "@app/types";
-import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
+import type { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
+import type { UserType } from "@app/types";
+import type { LightWorkspaceType } from "@app/types";
 
 export function useEditors({
   owner,
-  agentConfiguration,
+  agentConfigurationId,
   disabled,
 }: {
   owner: LightWorkspaceType;
-  agentConfiguration:
-    | LightAgentConfigurationType
-    | TemplateAgentConfigurationType
-    | null;
+  agentConfigurationId: string | null;
   disabled?: boolean;
 }) {
   const editorsFetcher: Fetcher<GetAgentEditorsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    !agentConfiguration || isTemplateAgentConfiguration(agentConfiguration)
-      ? null
-      : `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/editors`,
+    agentConfigurationId
+      ? `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/editors`
+      : null,
+
     editorsFetcher,
     {
       disabled,

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -3,11 +3,13 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type {
-  LightAgentConfigurationType,
-  LightWorkspaceType,
+import {
+  isTemplateAgentConfiguration,
+  UserType,
+  type LightAgentConfigurationType,
+  type LightWorkspaceType,
+  type TemplateAgentConfigurationType,
 } from "@app/types";
-import type { TagType } from "@app/types/tag";
 import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 
 export function useEditors({
@@ -16,13 +18,18 @@ export function useEditors({
   disabled,
 }: {
   owner: LightWorkspaceType;
-  agentConfiguration: LightAgentConfigurationType;
+  agentConfiguration:
+    | LightAgentConfigurationType
+    | TemplateAgentConfigurationType
+    | null;
   disabled?: boolean;
 }) {
   const editorsFetcher: Fetcher<GetAgentEditorsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/editors`,
+    !agentConfiguration || isTemplateAgentConfiguration(agentConfiguration)
+      ? null
+      : `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/editors`,
     editorsFetcher,
     {
       disabled,
@@ -30,7 +37,16 @@ export function useEditors({
   );
 
   return {
-    editors: useMemo(() => (data ? data.editors : []), [data]),
+    editorsMap: useMemo(
+      () =>
+        data
+          ? data.editors.reduce(
+              (acc, val) => acc.set(val.sId, val),
+              new Map<string, UserType>()
+            )
+          : undefined,
+      [data]
+    ),
     isEditorsLoading: !error && !data && !disabled,
     isEditorsError: !!error,
     mutateEditors: mutate,

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -1,4 +1,3 @@
-import { useSendNotification } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -1,0 +1,38 @@
+import { useSendNotification } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  LightAgentConfigurationType,
+  LightWorkspaceType,
+} from "@app/types";
+import type { TagType } from "@app/types/tag";
+import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
+
+export function useEditors({
+  owner,
+  agentConfiguration,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  agentConfiguration: LightAgentConfigurationType;
+  disabled?: boolean;
+}) {
+  const editorsFetcher: Fetcher<GetAgentEditorsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/editors`,
+    editorsFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    editors: useMemo(() => (data ? data.editors : []), [data]),
+    isEditorsLoading: !error && !data && !disabled,
+    isEditorsError: !!error,
+    mutateEditors: mutate,
+  };
+}

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -3,7 +3,6 @@ import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
-import type { UserType } from "@app/types";
 import type { LightWorkspaceType } from "@app/types";
 
 export function useEditors({
@@ -29,16 +28,7 @@ export function useEditors({
   );
 
   return {
-    editorsMap: useMemo(
-      () =>
-        data
-          ? data.editors.reduce(
-              (acc, val) => acc.set(val.sId, val),
-              new Map<string, UserType>()
-            )
-          : undefined,
-      [data]
-    ),
+    editors: useMemo(() => (data ? data.editors : undefined), [data]),
     isEditorsLoading: !error && !data && !disabled,
     isEditorsError: !!error,
     mutateEditors: mutate,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -47,6 +47,7 @@ async function createTestAgent(
   const providerId = overrides.model?.providerId ?? "openai";
   const modelId = overrides.model?.modelId ?? "gpt-4-turbo";
   const temperature = overrides.model?.temperature ?? 0.7;
+  const user = auth.user()?.toJSON();
 
   const result = await createAgentConfiguration(
     auth,
@@ -67,6 +68,7 @@ async function createTestAgent(
       templateId: null,
       requestedGroupIds: [], // Let createAgentConfiguration handle group creation
       tags: [], // Added missing tags property
+      editors: user ? [user] : [],
     },
     t
   );

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -11,10 +11,10 @@ import {
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentStatus, WithAPIErrorResponse } from "@app/types";
-import { GroupResource } from "@app/lib/resources/group_resource";
 
 export const PostAgentScopeRequestBodySchema = t.type({
   scope: t.union([

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -14,6 +14,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentStatus, WithAPIErrorResponse } from "@app/types";
+import { GroupResource } from "@app/lib/resources/group_resource";
 
 export const PostAgentScopeRequestBodySchema = t.type({
   scope: t.union([
@@ -92,6 +93,27 @@ async function handler(
         }
       }
 
+      // This won't stay long since Agent Discovery initiative removes the scope
+      // endpoint.
+      const groupRes = await GroupResource.fetchByAgentConfiguration(
+        auth,
+        assistant
+      );
+
+      if (groupRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "assistant_saving_error",
+            message: `Error fetching group for agent ${assistant.sId}: ${groupRes.error}`,
+          },
+        });
+      }
+
+      const group = groupRes.value;
+
+      const editors = await group.getActiveMembers(auth);
+
       // Cast the assistant to ensure TypeScript understands the correct types.
       const typedAssistant = {
         ...assistant,
@@ -110,6 +132,7 @@ async function handler(
 
           return action;
         }),
+        editors,
       };
 
       const agentConfigurationRes = await createOrUpgradeAgentConfiguration({

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -21,6 +21,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -37,7 +38,6 @@ import {
   Ok,
   PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@app/types";
-import { UserResource } from "@app/lib/resources/user_resource";
 
 export type GetAgentConfigurationsResponseBody = {
   agentConfigurations: LightAgentConfigurationType[];

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -37,6 +37,7 @@ import {
   Ok,
   PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@app/types";
+import { UserResource } from "@app/lib/resources/user_resource";
 
 export type GetAgentConfigurationsResponseBody = {
   agentConfigurations: LightAgentConfigurationType[];
@@ -318,6 +319,10 @@ export async function createOrUpgradeAgentConfiguration({
     }
   }
 
+  const editors = (
+    await UserResource.fetchByIds(assistant.editors.map((e) => e.sId))
+  ).map((e) => e.toJSON());
+
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name: assistant.name,
     description: assistant.description,
@@ -335,6 +340,7 @@ export async function createOrUpgradeAgentConfiguration({
       actions
     ),
     tags: assistant.tags,
+    editors,
   });
 
   if (agentConfigurationRes.isErr()) {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -17,6 +17,7 @@ import config from "@app/lib/api/config";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { useEditors } from "@app/lib/swr/editors";
 import type {
   AgentConfigurationType,
   AppType,
@@ -27,7 +28,6 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
-import { useEditors } from "@app/lib/swr/editors";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   actions: AssistantBuilderInitialState["actions"];
@@ -124,7 +124,7 @@ export default function EditAssistant({
 
   const { editorsMap } = useEditors({
     owner,
-    agentConfiguration,
+    agentConfigurationId: agentConfiguration.sId,
   });
 
   if (agentConfiguration.scope === "global") {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -122,7 +122,7 @@ export default function EditAssistant({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   throwIfInvalidAgentConfiguration(agentConfiguration);
 
-  const { editorsMap } = useEditors({
+  const { editors } = useEditors({
     owner,
     agentConfigurationId: agentConfiguration.sId,
   });
@@ -167,7 +167,7 @@ export default function EditAssistant({
           maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           templateId: agentConfiguration.templateId,
           tags: agentConfiguration.tags,
-          editors: editorsMap,
+          editors,
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -27,6 +27,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { useEditors } from "@app/lib/swr/editors";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   actions: AssistantBuilderInitialState["actions"];
@@ -121,6 +122,11 @@ export default function EditAssistant({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   throwIfInvalidAgentConfiguration(agentConfiguration);
 
+  const { editorsMap } = useEditors({
+    owner,
+    agentConfiguration,
+  });
+
   if (agentConfiguration.scope === "global") {
     throw new Error("Cannot edit global agent");
   }
@@ -161,7 +167,7 @@ export default function EditAssistant({
           maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           templateId: agentConfiguration.templateId,
           tags: agentConfiguration.tags,
-          editors: new Map<string, UserType>(),
+          editors: editorsMap,
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -25,7 +25,6 @@ import type {
   PlanType,
   SpaceType,
   SubscriptionType,
-  UserType,
   WorkspaceType,
 } from "@app/types";
 

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -24,6 +24,7 @@ import type {
   PlanType,
   SpaceType,
   SubscriptionType,
+  UserType,
   WorkspaceType,
 } from "@app/types";
 
@@ -160,6 +161,7 @@ export default function EditAssistant({
           maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           templateId: agentConfiguration.templateId,
           tags: agentConfiguration.tags,
+          editors: new Map<string, UserType>(),
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -157,7 +157,7 @@ export default function CreateAssistant({
   templateId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({ templateId });
-  const { editorsMap } = useEditors({
+  const { editors } = useEditors({
     owner,
     agentConfigurationId:
       agentConfiguration && !isTemplateAgentConfiguration(agentConfiguration)
@@ -214,7 +214,7 @@ export default function CreateAssistant({
                 visualizationEnabled: agentConfiguration.visualizationEnabled,
                 templateId: templateId,
                 tags: agentConfiguration.tags,
-                editors: editorsMap,
+                editors,
               }
             : null
         }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import type { ParsedUrlQuery } from "querystring";
-import { useMemo } from "react";
 
 import AssistantBuilder from "@app/components/assistant_builder/AssistantBuilder";
 import { AssistantBuilderProvider } from "@app/components/assistant_builder/AssistantBuilderContext";
@@ -22,18 +21,17 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
 import { useEditors } from "@app/lib/swr/editors";
-import {
-  isTemplateAgentConfiguration,
-  type AgentConfigurationType,
-  type AppType,
-  type DataSourceViewType,
-  type PlanType,
-  type SpaceType,
-  type SubscriptionType,
-  type TemplateAgentConfigurationType,
-  type UserType,
-  type WorkspaceType,
+import type {
+  AgentConfigurationType,
+  AppType,
+  DataSourceViewType,
+  PlanType,
+  SpaceType,
+  SubscriptionType,
+  TemplateAgentConfigurationType,
+  WorkspaceType,
 } from "@app/types";
+import { isTemplateAgentConfiguration } from "@app/types";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -30,6 +30,9 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { useEditors } from "@app/lib/swr/editors";
+import _ from "lodash";
+import { useMemo } from "react";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;
@@ -153,6 +156,10 @@ export default function CreateAssistant({
   templateId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({ templateId });
+  const { editorsMap } = useEditors({
+    owner,
+    agentConfiguration,
+  });
 
   if (agentConfiguration) {
     throwIfInvalidAgentConfiguration(agentConfiguration);
@@ -203,7 +210,7 @@ export default function CreateAssistant({
                 visualizationEnabled: agentConfiguration.visualizationEnabled,
                 templateId: templateId,
                 tags: agentConfiguration.tags,
-                editors: new Map<string, UserType>(),
+                editors: editorsMap,
               }
             : null
         }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import type { ParsedUrlQuery } from "querystring";
 

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -27,6 +27,7 @@ import type {
   SpaceType,
   SubscriptionType,
   TemplateAgentConfigurationType,
+  UserType,
   WorkspaceType,
 } from "@app/types";
 
@@ -202,6 +203,7 @@ export default function CreateAssistant({
                 visualizationEnabled: agentConfiguration.visualizationEnabled,
                 templateId: templateId,
                 tags: agentConfiguration.tags,
+                editors: new Map<string, UserType>(),
               }
             : null
         }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -1,5 +1,7 @@
+import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import type { ParsedUrlQuery } from "querystring";
+import { useMemo } from "react";
 
 import AssistantBuilder from "@app/components/assistant_builder/AssistantBuilder";
 import { AssistantBuilderProvider } from "@app/components/assistant_builder/AssistantBuilderContext";
@@ -19,20 +21,19 @@ import config from "@app/lib/api/config";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
-import type {
-  AgentConfigurationType,
-  AppType,
-  DataSourceViewType,
-  PlanType,
-  SpaceType,
-  SubscriptionType,
-  TemplateAgentConfigurationType,
-  UserType,
-  WorkspaceType,
-} from "@app/types";
 import { useEditors } from "@app/lib/swr/editors";
-import _ from "lodash";
-import { useMemo } from "react";
+import {
+  isTemplateAgentConfiguration,
+  type AgentConfigurationType,
+  type AppType,
+  type DataSourceViewType,
+  type PlanType,
+  type SpaceType,
+  type SubscriptionType,
+  type TemplateAgentConfigurationType,
+  type UserType,
+  type WorkspaceType,
+} from "@app/types";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;
@@ -158,7 +159,10 @@ export default function CreateAssistant({
   const { assistantTemplate } = useAssistantTemplate({ templateId });
   const { editorsMap } = useEditors({
     owner,
-    agentConfiguration,
+    agentConfigurationId:
+      agentConfiguration && !isTemplateAgentConfiguration(agentConfiguration)
+        ? agentConfiguration.sId
+        : null,
   });
 
   if (agentConfiguration) {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -247,7 +247,7 @@ export default function WorkspaceAdmin({
         </div>
         <InvitationsList owner={owner} searchText={searchTerm} />
         <WorkspaceMembersList
-          currentUserId={user.sId}
+          currentUser={user}
           owner={owner}
           searchTerm={searchTerm}
         />
@@ -345,11 +345,11 @@ function DomainAutoJoinModal({
 }
 
 function WorkspaceMembersList({
-  currentUserId,
+  currentUser,
   owner,
   searchTerm,
 }: {
-  currentUserId: string;
+  currentUser: UserType | null;
   owner: WorkspaceType;
   searchTerm: string;
 }) {
@@ -367,7 +367,7 @@ function WorkspaceMembersList({
     <div className="flex flex-col gap-2">
       <Page.H variant="h5">Members</Page.H>
       <MembersList
-        currentUserId={currentUserId}
+        currentUser={currentUser}
         membersData={membersData}
         onRowClick={(user) => setSelectedMember(user)}
         showColumns={["name", "email", "role"]}

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -216,6 +216,10 @@ const TagSchema = t.type({
   name: t.string,
 });
 
+const EditorSchema = t.type({
+  sId: t.string,
+});
+
 export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
   assistant: t.type({
     name: t.string,
@@ -238,6 +242,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     maxStepsPerRun: t.union([t.number, t.undefined]),
     visualizationEnabled: t.boolean,
     tags: t.array(TagSchema),
+    editors: t.array(EditorSchema),
   }),
 });
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -161,6 +161,19 @@ export interface TemplateAgentConfigurationType {
   tags: TagType[];
 }
 
+export function isTemplateAgentConfiguration(
+  agentConfiguration:
+    | LightAgentConfigurationType
+    | TemplateAgentConfigurationType
+    | null
+): agentConfiguration is TemplateAgentConfigurationType {
+  return !!(
+    agentConfiguration &&
+    "isTemplate" in agentConfiguration &&
+    agentConfiguration.isTemplate === true
+  );
+}
+
 export const DEFAULT_MAX_STEPS_USE_PER_RUN = 8;
 export const MAX_STEPS_USE_PER_RUN_LIMIT = 12;
 


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2467

## Description

Follows #12132 that was only UX. Makes the UX functional
- editors field added to builder state
- useEditors swr hook
- add remove button to editors
- update group appropriately when saving agent configuration

## Risk
standard. Behind ff. Tested locally

## Deploy Plan
front
