### PR TITLE
fix(Gong): prevent 400 on `/calls/extensive` on empty `callIds`

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -314,6 +314,14 @@ export class GongClient {
     callIds: string[];
     pageCursor?: string | null;
   }) {
+    // Calling the endpoint with an empty array of callIds causes a 400 error.
+    if (callIds.length === 0) {
+      return {
+        callsMetadata: [],
+        nextPageCursor: null,
+      };
+    }
+
     try {
       const callsMetadata = await this.postRequest(
         `/calls/extensive`,

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -128,6 +128,9 @@ export async function gongSyncTranscriptsActivity({
       (t) => !transcriptsInDbMap.has(t.callId)
     );
   }
+  if (transcriptsToSync.length === 0) {
+    return { nextPageCursor: null };
+  }
 
   const callsMetadata = await getTranscriptsMetadata({
     callIds: transcriptsToSync.map((t) => t.callId),


### PR DESCRIPTION
## Description

- Fixes https://dust4ai.slack.com/archives/C05F84CFP0E/p1745311460611589
- This PR prevents 400 on the `/calls/extensive` endpoint `filter.callIds: must not be empty but can be null or can be omitted`.
- This error has started to occur because of an optimization where we would filter the call IDs that were already synced in db, causing us to call the API with an empty array of `callIds`.
- This PR adds an early return in this situation + prevents the call in `gong_api.ts`.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.