### PR TITLE
fix: pass fetchDataSourceViewOptions.includeDeleted to DataSourceResource

### DIFF
--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -107,10 +107,9 @@ export function ZendeskConfigView({
       >
         <ContextItem.Description>
           <div className="text-muted-foreground dark:text-muted-foreground-night">
-            If activated, Dust will also sync the unresolved tickets.
-            This may significantly increase the number of
-            synced tickets, potentially negatively affecting the response
-            quality due to the added noise.
+            If activated, Dust will also sync the unresolved tickets. This may
+            significantly increase the number of synced tickets, potentially
+            negatively affecting the response quality due to the added noise.
           </div>
         </ContextItem.Description>
       </ContextItem>

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -239,6 +239,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       dataSourceIds,
       {
         includeEditedBy: fetchDataSourceViewOptions?.includeEditedBy,
+        includeDeleted,
       }
     );
 


### PR DESCRIPTION
## Description

We're hit with an `unreachable: space not found` due to the option not being properly passed down to the DataSourceResource fetch, causing a soft-deleted space to not be returned.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
