### PR TITLE
[front] feat(api/space): Fix race condition on space creation

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -1,3 +1,4 @@
+import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
@@ -29,7 +30,16 @@ import type {
   WorkspaceSegmentationType,
   WorkspaceType,
 } from "@app/types";
-import { ACTIVE_ROLES, assertNever, Err, Ok, removeNulls } from "@app/types";
+import {
+  ACTIVE_ROLES,
+  assertNever,
+  Err,
+  md5,
+  Ok,
+  removeNulls,
+} from "@app/types";
+
+import { frontSequelize } from "../resources/storage";
 
 export async function getWorkspaceInfos(
   wId: string
@@ -605,4 +615,35 @@ export async function checkSeatCountForWorkspace(
     return new Ok(`Correctly found ${activeSeats} active seats on Stripe.`);
   }
   return new Err(new Error(`${REPORT_USAGE_METADATA_KEY} metadata not found.`));
+}
+
+/**
+ * Advisory lock to be used in admin related request on workspace
+ *
+ * To avoid deadlocks when using Postgresql advisory locks, please make sure to not issue any other
+ * SQL query outside of the transaction `t` that is holding the lock.
+ * Otherwise, the other query will be competing for a connection in the database connection pool,
+ * resulting in a potential deadlock when the pool is fully occupied.
+ */
+export async function getWorkspaceAdministrationVersionLock(
+  workspace: WorkspaceType,
+  t: Transaction
+) {
+  const now = new Date();
+
+  const hash = md5(`workspace_admininsation_${workspace.id}`);
+  const lockKey = parseInt(hash, 16) % 9999999999;
+  await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
+    transaction: t,
+    replacements: { key: lockKey },
+  });
+
+  logger.info(
+    {
+      workspaceId: workspace.id,
+      duration: new Date().getTime() - now.getTime(),
+      lockKey,
+    },
+    "[WORKSPACE_TRACE] Advisory lock acquired"
+  );
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -631,7 +631,7 @@ export async function getWorkspaceAdministrationVersionLock(
 ) {
   const now = new Date();
 
-  const hash = md5(`workspace_admininsation_${workspace.id}`);
+  const hash = md5(`workspace_administration_${workspace.id}`);
   const lockKey = parseInt(hash, 16) % 9999999999;
   await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
     transaction: t,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -168,7 +168,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       order,
       where,
       includeDeleted,
-    }: ResourceFindOptions<SpaceModel> = {}
+    }: ResourceFindOptions<SpaceModel> = {},
+    t?: Transaction
   ) {
     const includeClauses: Includeable[] = [
       {
@@ -186,6 +187,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       limit,
       order,
       includeDeleted,
+      transaction: t,
     });
 
     return spacesModels.map(this.fromModel);
@@ -193,11 +195,16 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   static async listWorkspaceSpaces(
     auth: Authenticator,
-    options?: { includeConversationsSpace?: boolean; includeDeleted?: boolean }
+    options?: { includeConversationsSpace?: boolean; includeDeleted?: boolean },
+    t?: Transaction
   ): Promise<SpaceResource[]> {
-    const spaces = await this.baseFetch(auth, {
-      includeDeleted: options?.includeDeleted,
-    });
+    const spaces = await this.baseFetch(
+      auth,
+      {
+        includeDeleted: options?.includeDeleted,
+      },
+      t
+    );
 
     if (!options?.includeConversationsSpace) {
       return spaces.filter((s) => !s.isConversations());
@@ -327,7 +334,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   static async isNameAvailable(
     auth: Authenticator,
-    name: string
+    name: string,
+    t?: Transaction
   ): Promise<boolean> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -336,6 +344,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         name,
         workspaceId: owner.id,
       },
+      transaction: t,
     });
 
     return !space;


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/dust/issues/12140
- Add transaction level lock when creating a new space

## Tests
- Wrote that [piece of code](https://gist.github.com/johnoppenheimer/730d5326e181cdc9baea310be8124832) to use internal API
- It would properly throw error if we go over the space limit in one of the request.

## Risk
- If wrong, issue can stay the same, or limit too much space creation. Easy to rollback if necessary.

## Deploy Plan
- Deploy front
