### PR TITLE
[front] sec: restrict user from doing global space actions

### DIFF
--- a/front/components/spaces/FoldersHeaderMenu.tsx
+++ b/front/components/spaces/FoldersHeaderMenu.tsx
@@ -110,29 +110,31 @@ const AddDataDropDownButton = ({
           disabled={!canWriteInSpace}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <DropdownMenuItem
-          icon={DocumentTextIcon}
-          onClick={() => {
-            contentActionsRef.current?.callAction("DocumentUploadOrEdit");
-          }}
-          label="Create a document"
-        />
-        <DropdownMenuItem
-          icon={TableIcon}
-          onClick={() => {
-            contentActionsRef.current?.callAction("TableUploadOrEdit");
-          }}
-          label="Create a table"
-        />
-        <DropdownMenuItem
-          icon={CloudArrowUpIcon}
-          onClick={() => {
-            contentActionsRef.current?.callAction("MultipleDocumentsUpload");
-          }}
-          label="Upload multiple documents"
-        />
-      </DropdownMenuContent>
+      {canWriteInSpace && (
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            icon={DocumentTextIcon}
+            onClick={() => {
+              contentActionsRef.current?.callAction("DocumentUploadOrEdit");
+            }}
+            label="Create a document"
+          />
+          <DropdownMenuItem
+            icon={TableIcon}
+            onClick={() => {
+              contentActionsRef.current?.callAction("TableUploadOrEdit");
+            }}
+            label="Create a table"
+          />
+          <DropdownMenuItem
+            icon={CloudArrowUpIcon}
+            onClick={() => {
+              contentActionsRef.current?.callAction("MultipleDocumentsUpload");
+            }}
+            label="Upload multiple documents"
+          />
+        </DropdownMenuContent>
+      )}
     </DropdownMenu>
   );
 };

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -105,6 +105,7 @@ export const SpaceActionsList = ({
                 label: "Remove tools from space",
                 onClick: async () => onRemoveServer(info.row.original.id),
                 kind: "item",
+                disabled: !isAdmin && space.kind === "global",
               },
             ]}
           />

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -146,7 +146,7 @@ const AppHashChecker = ({ owner, app, registryApp }: AppHashCheckerProps) => {
 };
 
 interface SpaceAppsListProps {
-  canWriteInSpace: boolean;
+  isBuilder: boolean;
   onSelect: (sId: string) => void;
   owner: LightWorkspaceType;
   space: SpaceType;
@@ -155,7 +155,7 @@ interface SpaceAppsListProps {
 
 export const SpaceAppsList = ({
   owner,
-  canWriteInSpace,
+  isBuilder,
   space,
   onSelect,
   registryApps,
@@ -208,7 +208,7 @@ export const SpaceAppsList = ({
 
   const actionButtons = (
     <>
-      {canWriteInSpace && (
+      {isBuilder && (
         <>
           <Button
             label="New App"
@@ -240,7 +240,7 @@ export const SpaceAppsList = ({
         <div className="flex h-36 w-full max-w-4xl items-center justify-center gap-2 rounded-lg bg-muted-background dark:bg-muted-background-night">
           <Button
             label="Create App"
-            disabled={!canWriteInSpace}
+            disabled={!isBuilder}
             onClick={() => {
               setIsCreateAppModalOpened(true);
             }}

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -187,7 +187,7 @@ export const SpaceCategoriesList = ({
             label="Scrape a website"
           />
           <DropdownMenuItem
-            disabled={!isBuilder}
+            disabled={!isBuilder && !canWriteInSpace}
             href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps`}
             icon={CommandLineIcon}
             label="Create a Dust App"

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -187,7 +187,7 @@ export const SpaceCategoriesList = ({
             label="Scrape a website"
           />
           <DropdownMenuItem
-            disabled={!isBuilder && !canWriteInSpace}
+            disabled={!isBuilder || !canWriteInSpace}
             href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps`}
             icon={CommandLineIcon}
             label="Create a Dust App"

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -89,6 +89,7 @@ const getTableColumns = () => {
 
 type SpaceCategoriesListProps = {
   isAdmin: boolean;
+  isBuilder: boolean;
   canWriteInSpace: boolean;
   onButtonClick?: () => void;
   onSelect: (category: string) => void;
@@ -98,6 +99,7 @@ type SpaceCategoriesListProps = {
 
 export const SpaceCategoriesList = ({
   isAdmin,
+  isBuilder,
   onButtonClick,
   canWriteInSpace,
   onSelect,
@@ -185,7 +187,7 @@ export const SpaceCategoriesList = ({
             label="Scrape a website"
           />
           <DropdownMenuItem
-            disabled={!canWriteInSpace}
+            disabled={!isBuilder}
             href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps`}
             icon={CommandLineIcon}
             label="Create a Dust App"

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -32,7 +32,6 @@ export interface SpaceLayoutPageProps {
   category?: DataSourceViewCategory;
   dataSourceView?: DataSourceViewType;
   isAdmin: boolean;
-  isBuilder: boolean;
   owner: WorkspaceType;
   parentId?: string;
   plan: PlanType;

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -32,6 +32,7 @@ export interface SpaceLayoutPageProps {
   category?: DataSourceViewCategory;
   dataSourceView?: DataSourceViewType;
   isAdmin: boolean;
+  isBuilder: boolean;
   owner: WorkspaceType;
   parentId?: string;
   plan: PlanType;

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -180,6 +180,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
       const { req, res, workspace, globalGroup, user } =
         await createPrivateApiMockRequest({
           method: "POST",
+          role: "admin",
         });
       const space = await SpaceFactory.global(workspace, t);
       await GroupSpaceFactory.associate(space, globalGroup);

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
@@ -87,6 +87,16 @@ async function handler(
       }
       dataSourceToUse = dataSource;
 
+      if (!dataSourceToUse.canWrite(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message: "You are not authorized to upsert to this data source.",
+          },
+        });
+      }
+
       const rUpsert = await processAndUpsertToDataSource(
         auth,
         dataSourceToUse,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -37,7 +37,7 @@ async function handler(
         ),
       });
     case "POST":
-      if (!space.canWrite(auth)) {
+      if (!space.canWrite(auth) || !auth.isBuilder()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -77,6 +77,16 @@ async function handler(
         });
       }
 
+      if (!auth.isAdmin() && space.kind === "global") {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "mcp_auth_error",
+            message:
+              "You are not authorized to remove tools from a space.",
+          },
+        });
+      }
       await r.value.delete(auth, { hardDelete: true });
 
       return res.status(200).json({

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -77,13 +77,12 @@ async function handler(
         });
       }
 
-      if (!auth.isAdmin() && space.kind === "global") {
+      if (!space.canWrite(auth)) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
             type: "mcp_auth_error",
-            message:
-              "You are not authorized to remove tools from a space.",
+            message: "User is not authorized to remove tools from a space.",
           },
         });
       }

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
@@ -14,6 +14,7 @@ import type { DataSourceViewCategory, SpaceType } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
   SpaceLayoutPageProps & {
+    isBuilder: boolean;
     category: DataSourceViewCategory;
     registryApps: ActionApp[] | null;
     space: SpaceType;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
@@ -15,7 +15,6 @@ import type { DataSourceViewCategory, SpaceType } from "@app/types";
 export const getServerSideProps = withDefaultUserAuthRequirements<
   SpaceLayoutPageProps & {
     category: DataSourceViewCategory;
-    isAdmin: boolean;
     registryApps: ActionApp[] | null;
     space: SpaceType;
   }
@@ -69,7 +68,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 });
 
 export default function Space({
-  canWriteInSpace,
+  isBuilder,
   owner,
   space,
   registryApps,
@@ -80,7 +79,7 @@ export default function Space({
     <SpaceAppsList
       owner={owner}
       space={space}
-      canWriteInSpace={canWriteInSpace}
+      isBuilder={isBuilder}
       onSelect={(sId) => {
         void router.push(`/w/${owner.sId}/spaces/${space.sId}/apps/${sId}`);
       }}

--- a/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
@@ -45,12 +45,14 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   }
 
   const canWriteInSpace = space.canWrite(auth);
+  const isBuilder = auth.isBuilder();
 
   return {
     props: {
       canReadInSpace: space.canRead(auth),
       canWriteInSpace,
       isAdmin,
+      isBuilder,
       owner,
       plan,
       space: space.toJSON(),
@@ -62,6 +64,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 
 export default function Space({
   isAdmin,
+  isBuilder,
   canWriteInSpace,
   owner,
   userId,
@@ -105,6 +108,7 @@ export default function Space({
           );
         }}
         isAdmin={isAdmin}
+        isBuilder={isBuilder}
         onButtonClick={() => setShowSpaceEditionModal(true)}
       />
       <CreateOrEditSpaceModal

--- a/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
@@ -13,7 +13,11 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
-  SpaceLayoutPageProps & { userId: string; canWriteInSpace: boolean }
+  SpaceLayoutPageProps & {
+    userId: string;
+    canWriteInSpace: boolean;
+    isBuilder: boolean;
+  }
 >(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.subscription();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Fixing https://github.com/dust-tt/dust/issues/12144
Restricting some actions for user roles in the company space.

NB: if editing an app, user need to be able to write in space AND to be a builder

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand. Actions stated in the H1 report are not feasible anymore. Also restricted users to remove a mcp server view from the company data space

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Mess up a permission, and don't completely solve the issue. Should be fine. Safe to rollback

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front