### PR TITLE
[front] feat(webcrawler): More crawling security

### DIFF
--- a/connectors/src/connectors/webcrawler/lib/http.ts
+++ b/connectors/src/connectors/webcrawler/lib/http.ts
@@ -52,6 +52,7 @@ export class DustHttpClient extends GotScrapingHttpClient {
     return super.sendRequest({
       ...request,
       url: res.value,
+      followRedirect: false,
     });
   }
 
@@ -72,6 +73,7 @@ export class DustHttpClient extends GotScrapingHttpClient {
       {
         ...request,
         url: res.value,
+        followRedirect: false,
       },
       handleRedirect
     );
@@ -118,7 +120,7 @@ export class DustHttpClient extends GotScrapingHttpClient {
 
       try {
         const response = await fetch(url, {
-          method: "HEAD",
+          method: "GET",
           redirect: "manual",
           signal: controller.signal,
         });


### PR DESCRIPTION
## Description
- Get redirection header using GET instead of HEAD, it limit the risk of getting tricked with bad response only on HEAD.
- Don't follow redirect in `gotScraping` as we're the one navigating the final location

## Tests
Manually check

## Risk
Navigating less url, no more risk than before.

## Deploy Plan
Deploy connectors.
