### PR TITLE
fix: Race condition when creating users' invites

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -136,9 +136,11 @@ export async function getMembers(
   {
     roles,
     activeOnly,
+    transaction,
   }: {
     roles?: MembershipRoleType[];
     activeOnly?: boolean;
+    transaction?: Transaction;
   } = {},
   paginationParams?: MembershipsPaginationParams
 ): Promise<{
@@ -156,11 +158,13 @@ export async function getMembers(
         workspace: owner,
         roles,
         paginationParams,
+        transaction,
       })
     : await MembershipResource.getLatestMemberships({
         workspace: owner,
         roles,
         paginationParams,
+        transaction,
       });
 
   const usersWithWorkspaces = await Promise.all(
@@ -180,7 +184,7 @@ export async function getMembers(
 
       let user: UserResource | null;
       if (!m.user) {
-        user = await UserResource.fetchByModelId(m.userId);
+        user = await UserResource.fetchByModelId(m.userId, transaction);
       } else {
         user = new UserResource(UserModel, m.user);
       }


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/dust/issues/12140
- Setup transaction lock when creating new invitations
- Add transaction params to necessary functions.

## Tests
- Use that [code](https://gist.github.com/johnoppenheimer/8b7ceb1e6f632f89e4de8ac1a3e4ca2b) to locally make request to blast API with invitation request

## Risk
- Could limit more than necessary the invitation. At worst would do the same as before.

## Deploy Plan
- Deploy front
