### PR TITLE
[front] Prevent connectionId leak

### DIFF
--- a/front/components/actions/mcp/CreateMCPServerModal.tsx
+++ b/front/components/actions/mcp/CreateMCPServerModal.tsx
@@ -94,6 +94,7 @@ export function CreateMCPServerModal({
           await createMCPServerConnection({
             connectionId: cRes.value.connection_id,
             mcpServerId: createServerRes.server.id,
+            provider: authorization.provider,
           });
         } else {
           sendNotification({

--- a/front/hooks/useMCPConnectionManagement.ts
+++ b/front/hooks/useMCPConnectionManagement.ts
@@ -45,6 +45,7 @@ export const useMCPConnectionManagement = ({
       return createMCPServerConnection({
         connectionId: cRes.value.connection_id,
         mcpServerId,
+        provider: authorizationInfo.provider,
       });
     },
     [owner, sendNotification, createMCPServerConnection]

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -283,7 +283,7 @@ export async function augmentDataSourceWithConnectorDetails(
       fetchConnectorError = true;
       fetchConnectorErrorMessage = statusRes.error.message;
     } else {
-      connector = statusRes.value;
+      connector = { ...statusRes.value, connectionId: null };
     }
   } catch (e) {
     // Probably means `connectors` is down, we don't fail to avoid a 500 when just displaying

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -2,15 +2,20 @@ import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
 import config from "@app/lib/api/config";
-import { augmentDataSourceWithConnectorDetails } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { isManaged } from "@app/lib/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
-import type { OAuthAPIError, OAuthConnectionType, Result } from "@app/types";
-import type { OAuthProvider, OAuthUseCase } from "@app/types";
+import type {
+  OAuthAPIError,
+  OAuthConnectionType,
+  OAuthProvider,
+  OAuthUseCase,
+  Result,
+} from "@app/types";
 import {
+  ConnectorsAPI,
   Err,
   isValidSalesforceDomain,
   isValidZendeskSubdomain,
@@ -439,16 +444,23 @@ const PROVIDER_STRATEGIES: Record<
         if (!isManaged(dataSource)) {
           return null;
         }
-        const augmentedDataSource =
-          await augmentDataSourceWithConnectorDetails(dataSource);
-        if (!augmentedDataSource.connector) {
+
+        const connectorsAPI = new ConnectorsAPI(
+          config.getConnectorsAPIConfig(),
+          logger
+        );
+        const connectorRes =
+          await connectorsAPI.getConnectorFromDataSource(dataSource);
+        if (connectorRes.isErr()) {
           return null;
         }
+
+        const connector = connectorRes.value;
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
           provider: "salesforce",
-          connectionId: augmentedDataSource.connector.connectionId,
+          connectionId: connector.connectionId,
         });
         if (connectionRes.isErr()) {
           return null;

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -642,3 +642,24 @@ export async function finalizeConnection(
 
   return new Ok(cRes.value.connection);
 }
+
+export async function checkConnectionOwnership(
+  auth: Authenticator,
+  provider: OAuthProvider,
+  connectionId: string
+) {
+  // Ensure the connectionId has been created by the current user and is not being stolen.
+  const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+  const connectionRes = await oauthAPI.getAccessToken({
+    provider,
+    connectionId,
+  });
+  if (
+    connectionRes.isErr() ||
+    connectionRes.value.connection.metadata.user_id !== auth.user()?.sId
+  ) {
+    return new Err(new Error("Invalid connection"));
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -54,7 +54,10 @@ async function searchPokeConnectors(
   );
   const cRes = await connectorsAPI.getConnector(searchTerm);
   if (cRes.isOk()) {
-    const connector: ConnectorType = cRes.value;
+    const connector: ConnectorType = {
+      ...cRes.value,
+      connectionId: null,
+    };
 
     return [
       {

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -334,7 +334,6 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     return {
       id: this.id,
       workspaceId: this.workspaceId,
-      connectionId: this.connectionId,
       provider: this.provider,
       agentConfigurationId: this.agentConfigurationId,
       isActive: this.isActive,

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -213,7 +213,6 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       sId: this.sId,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
-      connectionId: this.connectionId,
       connectionType: this.connectionType,
       serverType: this.serverType,
       internalMCPServerId: this.internalMCPServerId,
@@ -243,7 +242,6 @@ export interface MCPServerConnectionType {
     email: string | null;
     userId: string | null;
   };
-  connectionId: string;
   connectionType: string;
   serverType: string;
   remoteMCPServerId: string | null;

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -22,7 +22,7 @@ import type {
   GetConnectionsResponseBody,
   PostConnectionResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/connections";
-import type { LightWorkspaceType, SpaceType } from "@app/types";
+import type { LightWorkspaceType, OAuthProvider, SpaceType } from "@app/types";
 /**
  * Hook to fetch a specific remote MCP server by ID
  */
@@ -346,9 +346,11 @@ export function useCreateMCPServerConnection({
   const createMCPServerConnection = async ({
     connectionId,
     mcpServerId,
+    provider,
   }: {
     connectionId: string;
     mcpServerId: string;
+    provider: OAuthProvider;
   }): Promise<PostConnectionResponseBody> => {
     const response = await fetch(`/api/w/${owner.sId}/mcp/connections`, {
       method: "POST",
@@ -358,6 +360,7 @@ export function useCreateMCPServerConnection({
       body: JSON.stringify({
         connectionId,
         mcpServerId,
+        provider,
       }),
     });
     if (response.ok) {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/connector.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/connector.ts
@@ -69,7 +69,12 @@ async function handler(
         });
       }
 
-      res.status(200).json({ connector: connectorRes.value });
+      res.status(200).json({
+        connector: {
+          ...connectorRes.value,
+          connectionId: null,
+        },
+      });
       return;
     }
 

--- a/front/pages/api/w/[wId]/mcp/connections/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[cId]/index.ts
@@ -1,4 +1,3 @@
-import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -7,11 +6,6 @@ import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_conn
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-
-export const PostConnectionBodySchema = t.type({
-  connectionId: t.string,
-  internalMCPServerId: t.string,
-});
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/mcp/connections/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/index.ts
@@ -5,15 +5,20 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
+import { ConnectorProviderCodec } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type { WithAPIErrorResponse } from "@app/types";
+import { OAuthAPI } from "@app/types";
 
 const PostConnectionBodySchema = t.type({
   connectionId: t.string,
   mcpServerId: t.string,
+  provider: ConnectorProviderCodec,
 });
 export type PostConnectionBodyType = t.TypeOf<typeof PostConnectionBodySchema>;
 
@@ -58,7 +63,28 @@ async function handler(
       }
 
       const validatedBody = bodyValidation.right;
-      const { connectionId, mcpServerId } = validatedBody;
+      const { connectionId, mcpServerId, provider } = validatedBody;
+
+      if (connectionId) {
+        // Ensure the connectionId has been created by the current user and is not being stolen.
+        const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthAPI.getAccessToken({
+          provider,
+          connectionId,
+        });
+        if (
+          connectionRes.isErr() ||
+          connectionRes.value.connection.metadata.user_id !== auth.user()?.sId
+        ) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Failed to get the access token for the connector.",
+            },
+          });
+        }
+      }
 
       const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -42,7 +42,6 @@ import {
   dustManagedCredentials,
   EMBEDDING_CONFIGS,
   ioTsParsePayload,
-  OAuthAPI,
   sendUserOperationMessage,
   WebCrawlerConfigurationTypeSchema,
 } from "@app/types";

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -133,7 +133,10 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       dataSource.connectorId
     );
     if (connectorRes.isOk()) {
-      connector = connectorRes.value;
+      connector = {
+        ...connectorRes.value,
+        connectionId: null,
+      };
       const temporalClient = await getTemporalConnectorsNamespaceConnection();
 
       const res = temporalClient.workflow.list({

--- a/front/pages/poke/connectors/[connectorId]/index.tsx
+++ b/front/pages/poke/connectors/[connectorId]/index.tsx
@@ -25,7 +25,10 @@ export const getServerSideProps = withSuperUserAuthRequirements<object>(
       };
     }
 
-    const connector: ConnectorType = cRes.value;
+    const connector: ConnectorType = {
+      ...cRes.value,
+      connectionId: null,
+    };
 
     return {
       redirect: {

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -86,7 +86,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       dataSourceView.dataSource.connectorId
     );
     if (connectorRes.isOk()) {
-      connector = connectorRes.value;
+      connector = {
+        ...connectorRes.value,
+        connectionId: null,
+      };
     }
   }
 

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -3,7 +3,7 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import type { Logger } from "@app/logger/logger";
-import type { ConnectorType } from "@app/types";
+import type { ConnectorType, InternalConnectorType } from "@app/types";
 import { ConnectorsAPI, getOAuthConnectionAccessToken } from "@app/types";
 
 const getGongAccessToken = async (connectionId: string, logger: Logger) => {
@@ -30,7 +30,7 @@ const getGongAccessToken = async (connectionId: string, logger: Logger) => {
 const getGongConnectorFromAuth = async (
   auth: Authenticator,
   localLogger: Logger
-): Promise<ConnectorType | null> => {
+): Promise<InternalConnectorType | null> => {
   const allDataSources = await getDataSources(auth);
 
   const dataSource = allDataSources.find(

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -66,7 +66,7 @@ export function isConnectorError(val: string): val is ConnectorErrorType {
   return (CONNECTORS_ERROR_TYPES as unknown as string[]).includes(val);
 }
 
-export type ConnectorType = {
+export type InternalConnectorType = {
   id: string;
   type: ConnectorProvider;
   workspaceId: string;
@@ -179,7 +179,7 @@ export class ConnectorsAPI {
     dataSourceId: string;
     connectionId: string;
     configuration: ConnectorConfiguration;
-  }): Promise<ConnectorsAPIResponse<ConnectorType>> {
+  }): Promise<ConnectorsAPIResponse<InternalConnectorType>> {
     const res = await this._fetchWithError(
       `${this._url}/connectors/create/${encodeURIComponent(provider)}`,
       {
@@ -204,7 +204,7 @@ export class ConnectorsAPI {
   }: {
     connectorId: string;
     configuration: UpdateConnectorConfigurationType;
-  }): Promise<ConnectorsAPIResponse<ConnectorType>> {
+  }): Promise<ConnectorsAPIResponse<InternalConnectorType>> {
     const res = await this._fetchWithError(
       `${this._url}/connectors/${encodeURIComponent(
         connectorId
@@ -408,7 +408,7 @@ export class ConnectorsAPI {
 
   async getConnector(
     connectorId: string
-  ): Promise<ConnectorsAPIResponse<ConnectorType>> {
+  ): Promise<ConnectorsAPIResponse<InternalConnectorType>> {
     const parsedId = parseInt(connectorId, 10);
     if (isNaN(parsedId)) {
       const err: ConnectorsAPIError = {
@@ -432,7 +432,7 @@ export class ConnectorsAPI {
   // TODO(jules): remove after debugging
   async getConnectorFromDataSource(
     dataSource: DataSourceType
-  ): Promise<ConnectorsAPIResponse<ConnectorType>> {
+  ): Promise<ConnectorsAPIResponse<InternalConnectorType>> {
     const res = await this._fetchWithError(
       `${this._url}/connectors/${encodeURIComponent(
         dataSource.connectorId ?? ""
@@ -449,7 +449,7 @@ export class ConnectorsAPI {
   async getConnectors(
     provider: ConnectorProvider,
     connectorIds: string[]
-  ): Promise<ConnectorsAPIResponse<ConnectorType[]>> {
+  ): Promise<ConnectorsAPIResponse<InternalConnectorType[]>> {
     if (connectorIds.length === 0) {
       return new Ok([]);
     }

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -1,8 +1,4 @@
-import type { ConnectorConfiguration } from "@app/types/connectors/configuration";
-import type {
-  ConnectorErrorType,
-  ConnectorSyncStatus,
-} from "@app/types/connectors/connectors_api";
+import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
 
 import type { DataSourceViewType } from "./data_source_view";
 import type { ModelId } from "./shared/model_id";
@@ -51,23 +47,8 @@ export type WithConnector = {
   connectorId: string;
 };
 
-export type ConnectorType = {
-  id: string;
-  type: ConnectorProvider;
-  workspaceId: string;
-  dataSourceId: string;
+export type ConnectorType = Omit<InternalConnectorType, "connectionId"> & {
   connectionId?: null;
-  useProxy: boolean;
-  lastSyncStatus?: ConnectorSyncStatus;
-  lastSyncStartTime?: number;
-  lastSyncFinishTime?: number;
-  lastSyncSuccessfulTime?: number;
-  firstSuccessfulSyncTime?: number;
-  firstSyncProgress?: string;
-  errorType?: ConnectorErrorType;
-  configuration: ConnectorConfiguration;
-  pausedAt?: number;
-  updatedAt: number;
 };
 
 export type ConnectorStatusDetails = {

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -1,4 +1,9 @@
-import type { ConnectorType } from "./connectors/connectors_api";
+import type { ConnectorConfiguration } from "@app/types/connectors/configuration";
+import type {
+  ConnectorErrorType,
+  ConnectorSyncStatus,
+} from "@app/types/connectors/connectors_api";
+
 import type { DataSourceViewType } from "./data_source_view";
 import type { ModelId } from "./shared/model_id";
 import type { Result } from "./shared/result";
@@ -44,6 +49,25 @@ export type DataSourceType = {
 export type WithConnector = {
   connectorProvider: ConnectorProvider;
   connectorId: string;
+};
+
+export type ConnectorType = {
+  id: string;
+  type: ConnectorProvider;
+  workspaceId: string;
+  dataSourceId: string;
+  connectionId?: null;
+  useProxy: boolean;
+  lastSyncStatus?: ConnectorSyncStatus;
+  lastSyncStartTime?: number;
+  lastSyncFinishTime?: number;
+  lastSyncSuccessfulTime?: number;
+  firstSuccessfulSyncTime?: number;
+  firstSyncProgress?: string;
+  errorType?: ConnectorErrorType;
+  configuration: ConnectorConfiguration;
+  pausedAt?: number;
+  updatedAt: number;
 };
 
 export type ConnectorStatusDetails = {

--- a/front/types/labs.ts
+++ b/front/types/labs.ts
@@ -25,7 +25,6 @@ export type LabsConnectionType = (typeof labsConnections)[number];
 export type LabsTranscriptsConfigurationType = {
   id: ModelId;
   workspaceId: ModelId;
-  connectionId: string | null;
   provider: LabsTranscriptsProviderType;
   agentConfigurationId: string | null;
   isActive: boolean;


### PR DESCRIPTION

fixes: [#12137](https://github.com/dust-tt/dust/issues/12137)

## Description

- Prevent connectionId leak by using a public type which do not have the connectionId, keeping InternalConnectionType for the return of connectors api with connectionId
- Prevent re-use of stolen connectionId by checking the userId in metadata - you can only use  a connectionId you created. This impact MCP connection  and datasource creations

## Tests

Tested multiple data source creation + mcp server connection
Checked return in connections endpoint, no connectionId anymore

## Risk

Break connection creation

## Deploy Plan

deploy front
