### PR TITLE
[front] fix(data_sources): Limit race condition when upserting document

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -535,6 +535,12 @@ export async function upsertDocument({
       }
 
       return new Ok(upsertRes.value);
+    },
+    {
+      // If account has no limits of document OR is a request made by our system
+      // we can safely avoid the lock and let them upload
+      __dangerouslySkipLock:
+        plan.limits.dataSources.documents.count === -1 || auth.isSystemKey(),
     }
   );
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -450,7 +450,7 @@ export async function upsertDocument({
   const owner = auth.getNonNullableWorkspace();
 
   const result = await Lock.executeWithLock(
-    `upsert_documents_${owner.id}`,
+    `upsert_documents_${owner.id}_${dataSource.id}`,
     async () => {
       // Enforce plan limits: DataSource documents count.
       // We only load the number of documents if the limit is not -1 (unlimited).

--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import logger from "@app/logger/logger";
+
+import { getRedisClient } from "./api/redis";
+import { Lock } from "./lock";
+
+// Mock dependencies
+vi.mock("./api/redis", () => ({
+  getRedisClient: vi.fn(),
+}));
+
+vi.mock("@app/logger/logger", () => {
+  // Create mock functions for all logger methods
+  const mockLogger = {
+    warn: vi.fn(),
+    child: vi.fn(),
+  };
+
+  // Make child return a new logger instance with the same mock methods
+  mockLogger.child.mockImplementation(() => mockLogger);
+
+  // Return the mock as the default export
+  return {
+    default: mockLogger,
+  };
+});
+
+const LOCK_VALUE_REGEX = /^\d+-.+$/;
+
+describe("Lock", () => {
+  let mockRedisClient: {
+    set: ReturnType<typeof vi.fn>;
+    eval: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Setup Redis client mock
+    mockRedisClient = {
+      set: vi.fn(),
+      eval: vi.fn(),
+    };
+    (getRedisClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockRedisClient
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("should acquire lock, execute callback, and release lock", async () => {
+    // Mock successful lock acquisition
+    mockRedisClient.set.mockResolvedValue(true);
+    // Mock successful lock release
+    mockRedisClient.eval.mockResolvedValue(1);
+
+    const callback = vi.fn().mockResolvedValue("result");
+
+    const result = await Lock.executeWithLock("test-lock", callback);
+
+    // Verify lock acquisition
+    expect(getRedisClient).toHaveBeenCalledWith({ origin: "lock" });
+    expect(mockRedisClient.set).toHaveBeenCalledWith(
+      "lock:test-lock",
+      expect.stringMatching(LOCK_VALUE_REGEX),
+      { NX: true, PX: 30000 }
+    );
+
+    // Verify callback execution
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Verify lock release
+    expect(mockRedisClient.eval).toHaveBeenCalledWith(
+      expect.stringContaining('if redis.call("get", KEYS[1]) == ARGV[1]'),
+      {
+        keys: ["lock:test-lock"],
+        arguments: [expect.stringMatching(LOCK_VALUE_REGEX)],
+      }
+    );
+
+    // Verify result
+    expect(result).toBe("result");
+  });
+
+  test("should throw error when lock acquisition times out", async () => {
+    // Reset Date.now mock
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(1000) // Initial call
+      .mockReturnValueOnce(1000) // During lock acquisition
+      .mockReturnValueOnce(31001); // After timeout period
+
+    // Mock failed lock acquisition
+    mockRedisClient.set.mockResolvedValue(false);
+
+    const callback = vi.fn().mockResolvedValue("result");
+
+    // Use a small timeout to speed up the test
+    await expect(
+      Lock.executeWithLock("test-lock", callback, {
+        timeoutMs: 30000,
+        initialRetryDelayMs: 10, // Small initial delay for faster test
+      })
+    ).rejects.toThrow("Lock acquisition timed out for test-lock");
+
+    // Verify callback was never executed
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("should extend lock for long-running operations", async () => {
+    // Setup fake timers
+    vi.useFakeTimers();
+
+    // Mock successful lock acquisition
+    mockRedisClient.set.mockResolvedValue(true);
+    // Mock successful lock extension
+    mockRedisClient.eval.mockResolvedValue(1);
+
+    // Create a callback that will take some time to complete
+    const callback = vi.fn().mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), 15000);
+      });
+      return "result";
+    });
+
+    // Start the lock operation
+    const lockPromise = Lock.executeWithLock("test-lock", callback, {
+      timeoutMs: 30000,
+      enableLockExtension: true,
+    });
+
+    // Fast-forward time to trigger lock extension (30000/3 = 10000ms)
+    await vi.advanceTimersByTimeAsync(10000);
+
+    // Allow any pending promises to resolve
+    await vi.runAllTimersAsync();
+
+    // Verify lock extension was attempted
+    expect(mockRedisClient.eval).toHaveBeenCalledWith(
+      expect.stringContaining('if redis.call("get", KEYS[1]) == ARGV[1]'),
+      {
+        keys: ["lock:test-lock"],
+        arguments: [expect.stringMatching(LOCK_VALUE_REGEX), "30000"],
+      }
+    );
+
+    // Complete the operation
+    const result = await lockPromise;
+
+    // Verify result
+    expect(result).toBe("result");
+
+    // Verify lock was released
+    expect(mockRedisClient.eval).toHaveBeenCalledWith(
+      expect.stringContaining('return redis.call("del", KEYS[1])'),
+      expect.any(Object)
+    );
+
+    // Restore real timers
+    vi.useRealTimers();
+  });
+
+  test("should bypass lock when __dangerouslySkipLock is true", async () => {
+    const callback = vi.fn().mockResolvedValue("result");
+
+    const result = await Lock.executeWithLock("test-lock", callback, {
+      __dangerouslySkipLock: true,
+    });
+
+    // Verify Redis client was not used
+    expect(getRedisClient).not.toHaveBeenCalled();
+    expect(mockRedisClient.set).not.toHaveBeenCalled();
+    expect(mockRedisClient.eval).not.toHaveBeenCalled();
+
+    // Verify callback was executed
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Verify warning was logged
+    expect(logger.warn).toHaveBeenCalledWith(
+      { lockName: "test-lock", bypass: true },
+      "Bypassing lock: test-lock"
+    );
+
+    // Verify result
+    expect(result).toBe("result");
+  });
+
+  test("should release lock when callback throws an error", async () => {
+    // Mock successful lock acquisition
+    mockRedisClient.set.mockResolvedValue(true);
+    // Mock successful lock release
+    mockRedisClient.eval.mockResolvedValue(1);
+
+    const testError = new Error("Test error");
+    const callback = vi.fn().mockRejectedValue(testError);
+
+    // Execute with lock and expect error
+    await expect(Lock.executeWithLock("test-lock", callback)).rejects.toThrow(
+      testError
+    );
+
+    // Verify lock acquisition
+    expect(mockRedisClient.set).toHaveBeenCalledWith(
+      "lock:test-lock",
+      expect.stringMatching(LOCK_VALUE_REGEX), // timestamp-uuid
+      { NX: true, PX: 30000 }
+    );
+
+    // Verify callback was executed
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Verify lock release was attempted
+    expect(mockRedisClient.eval).toHaveBeenCalledWith(
+      expect.stringContaining('if redis.call("get", KEYS[1]) == ARGV[1]'),
+      {
+        keys: ["lock:test-lock"],
+        arguments: [expect.stringMatching(LOCK_VALUE_REGEX)],
+      }
+    );
+  });
+});

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,39 +1,199 @@
+import { randomUUID } from "crypto";
+
+import mainLogger from "@app/logger/logger";
+
 import { getRedisClient } from "./api/redis";
 
-const WAIT_BETWEEN_RETRIES = 100;
+const logger = mainLogger.child(
+  {
+    module: "Lock",
+  },
+  { msgPrefix: "[LOCK] " }
+);
+
+export type LockOptions = {
+  /**
+   * Maximum time to wait for lock acquisition in milliseconds
+   * @default 30000 (30 seconds)
+   */
+  timeoutMs?: number;
+
+  /**
+   * Initial delay between retry attempts in milliseconds
+   * @default 100
+   */
+  initialRetryDelayMs?: number;
+
+  /**
+   * Maximum delay between retry attempts in milliseconds
+   * @default 1000
+   */
+  maxRetryDelayMs?: number;
+
+  /**
+   * Whether to automatically extend the lock while the operation is running
+   * @default true for operations where timeout is longer than 1000ms
+   */
+  enableLockExtension?: boolean;
+
+  /**
+   * DANGER: Completely bypasses the lock mechanism when set to true.
+   * Only use this in specific scenarios where you understand the implications.
+   * @default false
+   */
+  __dangerouslySkipLock?: boolean;
+};
 
 export class Lock {
+  /**
+   * Execute a callback with Redis lock protection
+   *
+   * @param lockName Unique name for the lock
+   * @param callback Function to execute while holding the lock
+   * @param options Lock configuration options
+   * @returns Promise resolving to the callback result
+   * @throws Error if lock cannot be acquired within timeout
+   */
   static async executeWithLock<T>(
     lockName: string,
     callback: () => Promise<T>,
-    timeoutMs: number = 30000
+    options: LockOptions = {}
   ): Promise<T> {
-    const client = await getRedisClient({ origin: "lock" });
-    const lockKey = `lock:${lockName}`;
-    const lockValue = Date.now().toString();
-    const start = Date.now();
+    const {
+      timeoutMs = 30000,
+      initialRetryDelayMs = 100,
+      maxRetryDelayMs = 1000,
+      enableLockExtension = timeoutMs > 1000,
+      __dangerouslySkipLock = false,
+    } = options;
 
-    // Try to acquire the lock
-    while (
-      !(await client.set(lockKey, lockValue, { NX: true, PX: timeoutMs }))
-    ) {
-      // Check for timeout
-      if (Date.now() - start >= timeoutMs) {
-        throw new Error(`Lock acquisition timed out for ${lockName}`);
-      }
-      // Wait a bit before retrying
-      await new Promise((resolve) => setTimeout(resolve, WAIT_BETWEEN_RETRIES));
-    }
-
-    try {
+    if (__dangerouslySkipLock) {
+      logger.warn({ lockName, bypass: true }, `Bypassing lock: ${lockName}`);
       const result = await callback();
       return result;
-    } finally {
-      // Release the lock if we still own it
-      const currentValue = await client.get(lockKey);
-      if (currentValue === lockValue) {
-        await client.del(lockKey);
+    }
+
+    const client = await getRedisClient({ origin: "lock" });
+    const lockKey = `lock:${lockName}`;
+    const lockValue = `${Date.now()}-${randomUUID()}`;
+    const start = Date.now();
+
+    let acquired = false;
+    let retryDelay = initialRetryDelayMs;
+    let lockExtender: NodeJS.Timeout | null = null;
+
+    try {
+      while (
+        !(await client.set(lockKey, lockValue, { NX: true, PX: timeoutMs }))
+      ) {
+        if (Date.now() - start >= timeoutMs) {
+          throw new Error(`Lock acquisition timed out for ${lockName}`);
+        }
+
+        // Wait a bit with an exponential backoff
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        retryDelay = Math.min(retryDelay * 1.5, maxRetryDelayMs);
       }
+
+      acquired = true;
+
+      if (enableLockExtension) {
+        // Set the lock extender check to 1/3 of the timeout
+        const extensionInterval = Math.floor(timeoutMs / 3);
+
+        lockExtender = setInterval(async () => {
+          try {
+            // Extend the lock only if we still own it.
+            // Use script to also avoid race condition with redis calls
+            const script = `
+              if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("pexpire", KEYS[1], ARGV[2])
+              else
+                return 0
+              end
+            `;
+
+            const result = await client.eval(script, {
+              keys: [lockKey],
+              arguments: [lockValue, String(timeoutMs)],
+            });
+            if (result === 0) {
+              // we no longer own the lock
+              logger.warn(
+                { lockName },
+                `Lock "${lockName}" was lost during execution and could not be extended`
+              );
+              clearInterval(lockExtender!);
+              lockExtender = null;
+            }
+          } catch (err) {
+            logger.error(
+              { err, lockName },
+              `Failed to extend lock "${lockName}"`
+            );
+            clearInterval(lockExtender!);
+            lockExtender = null;
+          }
+        }, extensionInterval);
+      }
+
+      try {
+        const result = await callback();
+        return result;
+      } finally {
+        if (lockExtender) {
+          clearInterval(lockExtender);
+          lockExtender = null;
+        }
+
+        // Release the lock atomically if still own it
+        try {
+          const script = `
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+              return redis.call("del", KEYS[1])
+            else
+              return 0
+            end`;
+
+          await client.eval(script, {
+            keys: [lockKey],
+            arguments: [lockValue],
+          });
+        } catch (releaseError) {
+          logger.error(
+            { releaseError, lockName },
+            `Failed to release lock "${lockName}"`
+          );
+        }
+      }
+    } catch (err) {
+      // If we acquired the lock but an error ocurred before the finally block
+      if (acquired && lockExtender) {
+        clearInterval(lockExtender);
+      }
+
+      if (acquired) {
+        try {
+          const script = `
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+              return redis.call("del", KEYS[1])
+            else
+              return 0
+            end`;
+
+          await client.eval(script, {
+            keys: [lockName],
+            arguments: [lockValue],
+          });
+        } catch (releaseError) {
+          logger.error(
+            { releaseError, lockName },
+            `Failed to release lock "${lockName}"`
+          );
+        }
+      }
+
+      throw err;
     }
   }
 }


### PR DESCRIPTION
## Description
- Use redis based lock to limit doc upsert on Core above plan limit
- Improve redis lock:
  - avoid redis race condition using eval script to make atomic operation
  - use lock extender if we have long running operation
  - add option to disable lock dangerously if needed
  - add exponential retry backoff to avoid surcharging redis at the same
- Lock for the given data source (as the limit plan limit is per data source)
- Don't lock for plan with no documents limit
- Don't lock for system call
- https://github.com/dust-tt/dust/issues/12196

## Tests
- Locally run the following [code](https://gist.github.com/johnoppenheimer/67a688e2e7d643db2eba73fe502ce0e2), throw error when going above plan limit.
- Wrote tests for the lock

## Risk
- Sligthly slower upsert because of redis check (should be minimal). 
- Probably more failed upsert because or proper check
- Easy to rollback if needed
- Don't impact connectors has the lock is disable because its a system call

## Deploy Plan
- Deploy front
