### PR TITLE
feat: switch to firecrawl for web browsing

### DIFF
--- a/front/lib/utils/webbrowse.ts
+++ b/front/lib/utils/webbrowse.ts
@@ -41,7 +41,7 @@ export const browseUrl = async (
     apiKey: credentials.FIRECRAWL_API_KEY,
   });
 
-  const scrapeResult = (await fc.scrapeUrl("firecrawl.dev", {
+  const scrapeResult = (await fc.scrapeUrl(url, {
     formats: ["markdown"],
   })) as ScrapeResponse;
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
         "@hookform/resolvers": "^3.3.4",
+        "@mendable/firecrawl-js": "^1.24.0",
         "@modelcontextprotocol/sdk": "1.5.0",
         "@octokit/core": "^6.1.4",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -2858,6 +2859,21 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/@mendable/firecrawl-js": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-1.24.0.tgz",
+      "integrity": "sha512-UWcyeZm23OmfskRamaT0MERn6jAmVjFsDh9/FIuj4YmG8VCZw9FvLGEioXKhTAITZ8uCeGTGarcybF86txIpkA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.8",
+        "typescript-event-target": "^1.1.1",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@mermaid-js/parser": {
@@ -25016,6 +25032,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typescript-event-target": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
+      "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
+      "license": "MIT"
     },
     "node_modules/uc.micro": {
       "version": "2.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -26,6 +26,7 @@
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",
     "@hookform/resolvers": "^3.3.4",
+    "@mendable/firecrawl-js": "^1.24.0",
     "@modelcontextprotocol/sdk": "1.5.0",
     "@octokit/core": "^6.1.4",
     "@radix-ui/react-dialog": "^1.0.5",
@@ -88,6 +89,7 @@
     "marked": "^14.1.3",
     "minimist": "^1.2.8",
     "moment-timezone": "^0.5.43",
+    "motion": "^12.7.3",
     "next": "^14.2.25",
     "next-swagger-doc": "^0.4.0",
     "openai": "^4.28.0",
@@ -127,8 +129,7 @@
     "uuid": "^9.0.0",
     "yargs": "^17.7.2",
     "zod": "^3.23.8",
-    "zod-validation-error": "^3.4.0",
-    "motion": "^12.7.3"
+    "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.3.0",

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -13,6 +13,7 @@ const {
   DUST_MANAGED_TOGETHERAI_API_KEY = "",
   DUST_MANAGED_DEEPSEEK_API_KEY = "",
   DUST_MANAGED_FIREWORKS_API_KEY = "",
+  DUST_MANAGED_FIRECRAWL_API_KEY = "",
 } = process.env;
 
 export const credentialsFromProviders = (
@@ -70,6 +71,9 @@ export const credentialsFromProviders = (
       case "fireworks":
         credentials["FIREWORKS_API_KEY"] = config.api_key;
         break;
+      case "firecrawl":
+        credentials["FIRECRAWL_API_KEY"] = config.api_key;
+        break;
     }
   });
   return credentials;
@@ -89,5 +93,6 @@ export const dustManagedCredentials = (): CredentialsType => {
     TOGETHERAI_API_KEY: DUST_MANAGED_TOGETHERAI_API_KEY,
     DEEPSEEK_API_KEY: DUST_MANAGED_DEEPSEEK_API_KEY,
     FIREWORKS_API_KEY: DUST_MANAGED_FIREWORKS_API_KEY,
+    FIRECRAWL_API_KEY: DUST_MANAGED_FIRECRAWL_API_KEY,
   };
 };

--- a/front/types/provider.ts
+++ b/front/types/provider.ts
@@ -19,4 +19,5 @@ export type CredentialsType = {
   TOGETHERAI_API_KEY?: string;
   DEEPSEEK_API_KEY?: string;
   FIREWORKS_API_KEY?: string;
+  FIRECRAWL_API_KEY?: string;
 };


### PR DESCRIPTION
## Description

Firecrawl improves our browse actions by:
- reducing latency
- reducing non-useful tokens count (clean markdown format instead of whole HTML dom)
- adding support for other document formats such as PDF


## Tests

Local

## Risk

Blast radius fairly large (all assistants using browse action)


## Deploy Plan

I already added the new env var. Deploying front should be enough.