### PR TITLE
[front,extension] - fix(InputBarAttachment): use CitationGrid

### DIFF
--- a/extension/ui/components/input_bar/InputBarAttachment.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachment.tsx
@@ -15,7 +15,7 @@ import {
 import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
 import type { DataSourceViewContentNodeType } from "@dust-tt/client";
 import { isFolder, isWebsite } from "@dust-tt/client";
-import { DoubleIcon, Icon } from "@dust-tt/sparkle";
+import { CitationGrid, DoubleIcon, Icon } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 interface FileAttachmentsProps {
@@ -102,7 +102,7 @@ export function InputBarAttachments({
   }
 
   return (
-    <div className="mr-3 flex gap-2 overflow-auto border-b border-separator pb-3 pt-3">
+    <CitationGrid className="mr-3 border-b border-separator pb-3 pt-3">
       {allAttachments.map((attachment) => {
         const attachmentCitation = attachmentToAttachmentCitation(attachment);
         return (
@@ -113,6 +113,6 @@ export function InputBarAttachments({
           />
         );
       })}
-    </div>
+    </CitationGrid>
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -1,5 +1,5 @@
 import { isFolder, isWebsite } from "@dust-tt/client";
-import { DoubleIcon, Icon } from "@dust-tt/sparkle";
+import { CitationGrid, DoubleIcon, Icon } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 import type {
@@ -106,7 +106,7 @@ export function InputBarAttachments({
   }
 
   return (
-    <div className="mr-3 flex gap-2 overflow-auto border-b border-separator pb-3 pt-3">
+    <CitationGrid className="mr-3 border-b border-separator pb-3 pt-3">
       {allAttachments.map((attachment) => {
         const attachmentCitation = attachmentToAttachmentCitation(attachment);
         return (
@@ -117,6 +117,6 @@ export function InputBarAttachments({
           />
         );
       })}
-    </div>
+    </CitationGrid>
   );
 }


### PR DESCRIPTION
## Description

This `InputBarAttachments` used to expand depending on the title's length, we now use a `CitationGrid`, as done for the `UserMessage`.

Before:
![Screenshot 2025-04-22 at 18 21 38](https://github.com/user-attachments/assets/c2a2f859-9c8c-4295-8690-6a2d2e41df97)

After:
![Screenshot 2025-04-22 at 18 21 16](https://github.com/user-attachments/assets/25f41dd8-3c45-4e11-a5c8-859f01fa8183)

**References:**
- https://github.com/dust-tt/tasks/issues/2703

## Risk

Low

## Deploy Plan

Deploy front