### PR TITLE
Fix mcp/actions should use oauth provider not connector provider

### DIFF
--- a/front/pages/api/w/[wId]/mcp/connections/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/index.ts
@@ -10,13 +10,13 @@ import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { apiError } from "@app/logger/withlogging";
-import { ConnectorProviderCodec } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type { WithAPIErrorResponse } from "@app/types";
+import { OauthProviderCodec } from "@app/types";
 
 const PostConnectionBodySchema = t.type({
   connectionId: t.string,
   mcpServerId: t.string,
-  provider: ConnectorProviderCodec,
+  provider: OauthProviderCodec,
 });
 export type PostConnectionBodyType = t.TypeOf<typeof PostConnectionBodySchema>;
 

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -27,6 +27,18 @@ export const OAUTH_PROVIDERS = [
   "hubspot",
 ] as const;
 
+// Sorcery: Create a union type with at least two elements to satisfy t.union
+function getOauthProviderCodec(): t.Mixed {
+  const [first, second, ...rest] = OAUTH_PROVIDERS;
+  return t.union([
+    t.literal(first),
+    t.literal(second),
+    ...rest.map((value) => t.literal(value)),
+  ]);
+}
+
+export const OauthProviderCodec = getOauthProviderCodec();
+
 export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
   confluence: "Confluence",
   github: "GitHub",


### PR DESCRIPTION
## Description

This https://github.com/dust-tt/dust/pull/12169/files#diff-0acebf3526e499b6dcd54a7771be6cc568ce3adac620d37da324b12734030f02 broke the hubspot MCP action cause it uses connector provider instead of oauth provider. 

## Tests

Locally.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 