### PR TITLE
poke: skip getConnector if not modelId in search

### DIFF
--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -48,24 +48,27 @@ async function searchPokeWorkspaces(
 async function searchPokeConnectors(
   searchTerm: string
 ): Promise<PokeItemBase[]> {
-  const connectorsAPI = new ConnectorsAPI(
-    config.getConnectorsAPIConfig(),
-    logger
-  );
-  const cRes = await connectorsAPI.getConnector(searchTerm);
-  if (cRes.isOk()) {
-    const connector: ConnectorType = {
-      ...cRes.value,
-      connectionId: null,
-    };
+  const connectorModelId = parseInt(searchTerm);
+  if (!isNaN(connectorModelId)) {
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+    const cRes = await connectorsAPI.getConnector(searchTerm);
+    if (cRes.isOk()) {
+      const connector: ConnectorType = {
+        ...cRes.value,
+        connectionId: null,
+      };
 
-    return [
-      {
-        id: parseInt(connector.id),
-        name: "Connector",
-        link: `${config.getClientFacingUrl()}/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
-      },
-    ];
+      return [
+        {
+          id: parseInt(connector.id),
+          name: "Connector",
+          link: `${config.getClientFacingUrl()}/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
+        },
+      ];
+    }
   }
 
   return [];


### PR DESCRIPTION
## Description

If not a modelId format (number) do not attempt getConnector on it.

Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1745342537244009

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `front`
