### PR TITLE
fix(`AssistantBuilder`): remove MCP server selection for default ones

### DIFF
--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -8,7 +8,6 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
-import { MCPToolsList } from "@app/components/assistant_builder/actions/MCPToolsList";
 import { SpaceSelector } from "@app/components/assistant_builder/spaces/SpaceSelector";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -51,7 +50,7 @@ export function MCPServerSelector({
   }, [mcpServerViews, allowedSpaces]);
 
   return (
-    <div>
+    <>
       <div className="flex-grow pt-4 text-sm font-semibold text-foreground dark:text-foreground-night">
         Pick a set of tools
       </div>
@@ -130,7 +129,6 @@ export function MCPServerSelector({
           }}
         />
       )}
-      <MCPToolsList tools={selectedMCPServerView?.server.tools ?? []} />
-    </div>
+    </>
   );
 }

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -251,29 +251,24 @@ export function MCPAction({
       {/* Server selection */}
       {!selectedMCPServerView?.server.isDefault &&
         (isEditing ? (
-          <div>
-            <div className="text-sm text-foreground dark:text-foreground-night">
-              <div>{selectedMCPServerView?.server.description}</div>
+          <div className="text-sm text-foreground dark:text-foreground-night">
+            <div>{selectedMCPServerView?.server.description}</div>
 
-              {isDefaultMCPServer ? (
-                ""
-              ) : (
-                <div>
-                  Available to you via{" "}
-                  <b>
-                    {
-                      allowedSpaces.find(
-                        (space) => space.sId === selectedMCPServerView?.spaceId
-                      )?.name
-                    }
-                  </b>{" "}
-                  space.
-                </div>
-              )}
-            </div>
-            <div className="pt-2">
-              <MCPToolsList tools={selectedMCPServerView?.server.tools ?? []} />
-            </div>
+            {isDefaultMCPServer ? (
+              ""
+            ) : (
+              <div>
+                Available to you via{" "}
+                <b>
+                  {
+                    allowedSpaces.find(
+                      (space) => space.sId === selectedMCPServerView?.spaceId
+                    )?.name
+                  }
+                </b>{" "}
+                space.
+              </div>
+            )}
           </div>
         ) : (
           <>
@@ -287,7 +282,9 @@ export function MCPAction({
           </>
         ))}
       {/* List of tools */}
-      <MCPToolsList tools={selectedMCPServerView?.server.tools ?? []} />
+      {selectedMCPServerView && (
+        <MCPToolsList tools={selectedMCPServerView.server.tools} />
+      )}
       {/* Configurable blocks */}
       {requirements.requiresDataSourceConfiguration && (
         <DataSourceSelectionSection

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -249,42 +249,43 @@ export function MCPAction({
         />
       )}
       {/* Server selection */}
-      {isEditing ? (
-        <div>
-          <div className="text-sm text-foreground dark:text-foreground-night">
-            <div>{selectedMCPServerView?.server.description}</div>
+      {!selectedMCPServerView?.server.isDefault &&
+        (isEditing ? (
+          <div>
+            <div className="text-sm text-foreground dark:text-foreground-night">
+              <div>{selectedMCPServerView?.server.description}</div>
 
-            {isDefaultMCPServer ? (
-              ""
-            ) : (
-              <div>
-                Available to you via{" "}
-                <b>
-                  {
-                    allowedSpaces.find(
-                      (space) => space.sId === selectedMCPServerView?.spaceId
-                    )?.name
-                  }
-                </b>{" "}
-                space.
-              </div>
-            )}
+              {isDefaultMCPServer ? (
+                ""
+              ) : (
+                <div>
+                  Available to you via{" "}
+                  <b>
+                    {
+                      allowedSpaces.find(
+                        (space) => space.sId === selectedMCPServerView?.spaceId
+                      )?.name
+                    }
+                  </b>{" "}
+                  space.
+                </div>
+              )}
+            </div>
+            <div className="pt-2">
+              <MCPToolsList tools={selectedMCPServerView?.server.tools ?? []} />
+            </div>
           </div>
-          <div className="pt-2">
-            <MCPToolsList tools={selectedMCPServerView?.server.tools ?? []} />
-          </div>
-        </div>
-      ) : (
-        <>
-          <MCPServerSelector
-            owner={owner}
-            allowedSpaces={allowedSpaces}
-            mcpServerViews={mcpServerViews}
-            selectedMCPServerView={selectedMCPServerView}
-            handleServerSelection={handleServerSelection}
-          />
-        </>
-      )}
+        ) : (
+          <>
+            <MCPServerSelector
+              owner={owner}
+              allowedSpaces={allowedSpaces}
+              mcpServerViews={mcpServerViews}
+              selectedMCPServerView={selectedMCPServerView}
+              handleServerSelection={handleServerSelection}
+            />
+          </>
+        ))}
 
       {/* Configurable blocks */}
       {requirements.requiresDataSourceConfiguration && (

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -286,7 +286,8 @@ export function MCPAction({
             />
           </>
         ))}
-
+      {/* List of tools */}
+      <MCPToolsList tools={selectedMCPServerView?.server.tools ?? []} />
       {/* Configurable blocks */}
       {requirements.requiresDataSourceConfiguration && (
         <DataSourceSelectionSection


### PR DESCRIPTION
## Description

In the current flow for adding a `default` MCP server as a tool, the modal for configuring the MCP server shows all the other MCP servers although already selected.

Here is what we have in prod for the `Search` tool:

<img width="440" alt="Screenshot" src="https://github.com/user-attachments/assets/f1934957-e3c1-4f33-bd79-54a2e8162643">

<img width="250" alt="Screenshot" src="https://github.com/user-attachments/assets/78bb5f6b-945f-4e1c-a339-e6891922a5bc">

This PR removes the MCP server selection from this modal (`MCPAction`) for default servers.

<img width="250" alt="Screenshot" src="https://github.com/user-attachments/assets/5370a2e6-083a-4a10-90cd-eee38651e806">

The implementation is highly suboptimal because it relies on an intricate logic of where each server ends up being accessible from in the UI (`isUsableInKnowledge`, `isUsableAsCapability`) but this change is only temporary until this whole part is revamped.

This PR also prevents the "Available Tools" section from appearing when no tools are available.

## Tests

- Tested locally.

## Risk

- N/A, no change for users that do not have the `dev_mcp_actions` flag.

## Deploy Plan

- Deploy front.