### PR TITLE
feat(webtools v2): Add support for paginated web search results

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -32,18 +32,18 @@ const createServer = (): McpServer => {
         .describe(
           "The query used to perform the google search. If requested by the user, use the google syntax `site:` to restrict the the search to a particular website or domain."
         ),
-      offset: z
+      page: z
         .number()
         .optional()
         .describe(
-          "The offset of the search results. Should only be defined if necessary to go deeper into the search results for a specific query."
+          "A 1-indexed page number used to paginate through the search results. Should only be provided if page is stricly greater than 1 in order to go deeper into the search results for a specific query."
         ),
     },
-    async ({ query, offset }) => {
+    async ({ query, page }) => {
       const websearchRes = await webSearch({
         provider: "serpapi",
         query,
-        offset,
+        page,
       });
 
       if (websearchRes.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -32,9 +32,19 @@ const createServer = (): McpServer => {
         .describe(
           "The query used to perform the google search. If requested by the user, use the google syntax `site:` to restrict the the search to a particular website or domain."
         ),
+      offset: z
+        .number()
+        .optional()
+        .describe(
+          "The offset of the search results. Should only be defined if necessary to go deeper into the search results for a specific query."
+        ),
     },
-    async ({ query }) => {
-      const websearchRes = await webSearch({ provider: "serpapi", query });
+    async ({ query, offset }) => {
+      const websearchRes = await webSearch({
+        provider: "serpapi",
+        query,
+        offset,
+      });
 
       if (websearchRes.isErr()) {
         return {

--- a/front/lib/utils/websearch.ts
+++ b/front/lib/utils/websearch.ts
@@ -20,6 +20,7 @@ export type SerpapiParams = {
   location?: string;
   output?: "json" | "html";
   api_key?: string;
+  offset?: number;
 };
 
 export type SerperParams = {
@@ -47,7 +48,7 @@ export type SearchResponse = SearchResultItem[];
 
 const serpapiSearch = async (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  { provider, query, ...options }: BaseWebSearchParams & SerpapiParams
+  { provider, query, offset, ...options }: BaseWebSearchParams & SerpapiParams
 ): Promise<Result<SearchResponse, Error>> => {
   if (options.api_key == null) {
     return new Err(
@@ -59,6 +60,7 @@ const serpapiSearch = async (
     _.omitBy(
       {
         q: query,
+        start: offset,
         ...options,
       },
       _.isNil

--- a/front/lib/utils/websearch.ts
+++ b/front/lib/utils/websearch.ts
@@ -20,7 +20,7 @@ export type SerpapiParams = {
   location?: string;
   output?: "json" | "html";
   api_key?: string;
-  offset?: number;
+  page?: number;
 };
 
 export type SerperParams = {
@@ -28,14 +28,12 @@ export type SerperParams = {
   api_key: string;
 };
 
-const serpapiDefaultOptions: Omit<
-  BaseWebSearchParams & SerpapiParams,
-  "query"
-> = {
+const serpapiDefaultOptions = {
   provider: "serpapi",
   engine: "google",
   api_key: credentials.SERP_API_KEY,
-};
+  num: 10,
+} satisfies Omit<BaseWebSearchParams & SerpapiParams, "query">;
 
 export type SearchParams = BaseWebSearchParams & (SerpapiParams | SerperParams);
 
@@ -48,7 +46,7 @@ export type SearchResponse = SearchResultItem[];
 
 const serpapiSearch = async (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  { provider, query, offset, ...options }: BaseWebSearchParams & SerpapiParams
+  { provider, query, page, ...options }: BaseWebSearchParams & SerpapiParams
 ): Promise<Result<SearchResponse, Error>> => {
   if (options.api_key == null) {
     return new Err(
@@ -60,7 +58,10 @@ const serpapiSearch = async (
     _.omitBy(
       {
         q: query,
-        start: offset,
+        start: page
+          ? page * (options.num ?? serpapiDefaultOptions.num)
+          : undefined,
+        num: options.num ?? serpapiDefaultOptions.num,
         ...options,
       },
       _.isNil


### PR DESCRIPTION
## Description

Enhance the websearch tool of the webtools v2 toolset by adding an affordance for the agent to go deeper on search results for a specific query.
In practice this mean adding an "page" param to the tool, which is used to paginate through the search results.

## Tests

manual

## Risk

Only impacts v2 websearch

## Deploy Plan

Deploy front