### PR TITLE
Make extract schema optional; Remove old schema field; Make extract a…

### DIFF
--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -208,3 +208,84 @@ export async function uploadFileToConversationDataSource({
     }
   }
 }
+
+/**
+ * Generate a JSON file and a snippet of the file.
+ * Save the file to the database and return the file and the snippet.
+ */
+export async function generateJSONFileAndSnippet(
+  auth: Authenticator,
+  {
+    title,
+    conversationId,
+    data,
+  }: {
+    title: string;
+    conversationId: string;
+    data: unknown;
+  }
+): Promise<{
+  jsonFile: FileResource;
+  jsonSnippet: string;
+}> {
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.user();
+
+  const jsonOutput = JSON.stringify(data, null, 2);
+  const jsonFile = await FileResource.makeNew({
+    workspaceId: workspace.id,
+    userId: user?.id ?? null,
+    contentType: "application/json",
+    fileName: title,
+    fileSize: Buffer.byteLength(jsonOutput),
+    useCase: "tool_output",
+    useCaseMetadata: {
+      conversationId,
+    },
+  });
+
+  // Generate a snippet of the JSON for display in the conversation
+  // The snippet will show only the first few entries if it's an array
+  // or a truncated version if it's an object
+  let jsonSnippet = "";
+  if (Array.isArray(data)) {
+    const displayItems = data.slice(0, 5);
+    const remainingCount = data.length > 5 ? data.length - 5 : 0;
+    jsonSnippet = JSON.stringify(displayItems, null, 2);
+    if (remainingCount > 0) {
+      jsonSnippet += `\n\n... ${remainingCount} more items`;
+    }
+  } else {
+    jsonSnippet = JSON.stringify(data, null, 2);
+    // Truncate if too long
+    if (jsonSnippet.length > 1000) {
+      jsonSnippet = jsonSnippet.substring(0, 1000) + "... (truncated)";
+    }
+  }
+
+  await processAndStoreFile(auth, {
+    file: jsonFile,
+    content: {
+      type: "string",
+      value: jsonOutput,
+    },
+  });
+
+  return { jsonFile, jsonSnippet };
+}
+
+export function getJSONFileAttachment({
+  jsonFileId,
+  jsonFileSnippet,
+  title,
+}: {
+  jsonFileId: string | null;
+  jsonFileSnippet: string | null;
+  title: string;
+}): string | null {
+  if (!jsonFileId || !jsonFileSnippet) {
+    return null;
+  }
+
+  return `<file id="${jsonFileId}" type="application/json" title="${title}">\n${jsonFileSnippet}\n</file>`;
+}

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -37,6 +37,10 @@ export const DEFAULT_CONVERSATION_SEARCH_ACTION_NAME =
   "search_conversation_files";
 export const DEFAULT_CONVERSATION_SEARCH_ACTION_DATA_DESCRIPTION = `Search within the 'searchable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``;
 
+export const DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME =
+  "extract_conversation_files";
+export const DEFAULT_CONVERSATION_EXTRACT_ACTION_DATA_DESCRIPTION = `Extract structured data from the 'extractable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``;
+
 export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
   "__dust_conversation_history";
 

--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 
 import {
+  DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
   DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
   DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
@@ -29,6 +30,7 @@ export type BaseConversationAttachmentType = {
   isIncludable: boolean;
   isSearchable: boolean;
   isQueryable: boolean;
+  isExtractable: boolean;
 };
 
 export type ConversationFileType = BaseConversationAttachmentType & {
@@ -115,6 +117,7 @@ export class ConversationListFilesActionType extends BaseAction {
       `// includable: full content can be retrieved using \`${DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME}\`\n` +
       `// queryable: represents tabular data that can be queried alongside other queryable files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`\n` +
       `// searchable: content can be searched alongside other searchable files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
+      `// extractable: files can also be processed to extract structured data using \`${DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME}\`\n` +
       `Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files mime types to decide which tool to use on which file.`;
     for (const f of this.files) {
       content += `<file id="${conversationAttachmentId(f)}" name="${_.escape(f.title)}" type="${f.contentType}" includable="${f.isIncludable}" queryable="${f.isQueryable}" searchable="${f.isSearchable}"`;

--- a/front/lib/actions/process.ts
+++ b/front/lib/actions/process.ts
@@ -1,9 +1,15 @@
 import _ from "lodash";
 
 import {
+  generateJSONFileAndSnippet,
+  getJSONFileAttachment,
+  uploadFileToConversationDataSource,
+} from "@app/lib/actions/action_file_helpers";
+import {
   DEFAULT_PROCESS_ACTION_NAME,
   PROCESS_ACTION_TOP_K,
 } from "@app/lib/actions/constants";
+import { getExtractFileTitle } from "@app/lib/actions/process/utils";
 import type {
   DataSourceConfiguration,
   RetrievalTimeframe,
@@ -14,10 +20,15 @@ import {
   retrievalTagsInputSpecification,
 } from "@app/lib/actions/retrieval";
 import { runActionStreamed } from "@app/lib/actions/server";
-import type { ExtractActionBlob } from "@app/lib/actions/types";
+import type {
+  ActionGeneratedFileType,
+  ExtractActionBlob,
+} from "@app/lib/actions/types";
 import type { BaseActionRunParams } from "@app/lib/actions/types";
-import { BaseAction } from "@app/lib/actions/types";
-import { BaseActionConfigurationServerRunner } from "@app/lib/actions/types";
+import {
+  BaseAction,
+  BaseActionConfigurationServerRunner,
+} from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
@@ -35,7 +46,13 @@ import type {
   TimeFrame,
   UserMessageType,
 } from "@app/types";
-import { Ok, parseTimeFrame, timeFrameFromNow } from "@app/types";
+import {
+  Ok,
+  parseTimeFrame,
+  removeNulls,
+  safeParseJSON,
+  timeFrameFromNow,
+} from "@app/types";
 
 export const PROCESS_SCHEMA_ALLOWED_TYPES = [
   "string",
@@ -43,6 +60,8 @@ export const PROCESS_SCHEMA_ALLOWED_TYPES = [
   "boolean",
 ] as const;
 import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+import { FileResource } from "@app/lib/resources/file_resource";
 
 // Properties in the process configuration table are stored as an array of objects.
 export type ProcessSchemaPropertyType = {
@@ -119,9 +138,11 @@ export class ProcessActionType extends BaseAction {
   readonly functionCallName: string | null;
   readonly step: number;
   readonly type = "process_action";
+  readonly jsonFileId: string | null;
+  readonly jsonFileSnippet: string | null;
 
   constructor(blob: ProcessActionBlob) {
-    super(blob.id, blob.type);
+    super(blob.id, blob.type, blob.generatedFiles);
 
     this.agentMessageId = blob.agentMessageId;
     this.params = blob.params;
@@ -130,6 +151,8 @@ export class ProcessActionType extends BaseAction {
     this.functionCallId = blob.functionCallId;
     this.functionCallName = blob.functionCallName;
     this.step = blob.step;
+    this.jsonFileId = blob.jsonFileId ?? null;
+    this.jsonFileSnippet = blob.jsonFileSnippet ?? null;
   }
 
   renderForFunctionCall(): FunctionCallType {
@@ -151,6 +174,18 @@ export class ProcessActionType extends BaseAction {
       } else {
         for (const o of this.outputs.data) {
           content += `${JSON.stringify(o)}\n`;
+        }
+
+        const jsonAttachment = getJSONFileAttachment({
+          jsonFileId: this.jsonFileId,
+          jsonFileSnippet: this.jsonFileSnippet,
+          title: getExtractFileTitle({
+            schema: this.jsonSchema,
+          }),
+        });
+
+        if (jsonAttachment) {
+          content += `${jsonAttachment}\n`;
         }
       }
     } else if (this.outputs === null) {
@@ -240,6 +275,14 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
         relativeTimeFrame = parseTimeFrame(rawInputs.relativeTimeFrame);
       }
     }
+    if (!actionConfiguration.jsonSchema) {
+      if (rawInputs.schema && typeof rawInputs.schema === "string") {
+        const res = safeParseJSON(rawInputs.schema);
+        if (res.isOk()) {
+          actionConfiguration.jsonSchema = res.value;
+        }
+      }
+    }
 
     let globalTagsIn: string[] | null = null;
     let globalTagsNot: string[] | null = null;
@@ -307,6 +350,8 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
         step: action.step,
         type: "process_action",
         generatedFiles: [],
+        jsonFileId: null,
+        jsonFileSnippet: null,
       }),
     };
 
@@ -460,9 +505,58 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
       }
     }
 
+    const generatedFiles: ActionGeneratedFileType[] = [];
+    let jsonFileSId: string | null = null;
+    let jsonFileSnippet: string | null = null;
+
+    const updateParams: {
+      jsonFileId: number | null;
+      jsonFileSnippet: string | null;
+      outputs: ProcessActionOutputsType | null;
+      runId?: string;
+    } = {
+      jsonFileId: null,
+      jsonFileSnippet: null,
+      outputs: outputs,
+    };
+
+    if (outputs) {
+      // Generate the JSON file with extraction results
+      const fileTitle = getExtractFileTitle({
+        schema: actionConfiguration.jsonSchema,
+      });
+      const { jsonFile, jsonSnippet } = await generateJSONFileAndSnippet(auth, {
+        title: fileTitle,
+        conversationId: conversation.sId,
+        data: outputs.data,
+      });
+
+      // Upload the file to the conversation data source.
+      // This step is critical for file persistence across sessions.
+      await uploadFileToConversationDataSource({
+        auth,
+        file: jsonFile,
+      });
+
+      generatedFiles.push({
+        fileId: jsonFile.sId,
+        title: fileTitle,
+        contentType: jsonFile.contentType,
+        snippet: jsonSnippet,
+      });
+
+      // Update the parameters with numeric IDs for database
+      updateParams.jsonFileId = jsonFile.id;
+      updateParams.jsonFileSnippet = jsonSnippet;
+
+      // Save references for the yield statement with string IDs for UI
+      jsonFileSId = jsonFile.sId;
+      jsonFileSnippet = jsonSnippet;
+    }
+
     // Update ProcessAction with the output of the last block.
     await action.update({
-      outputs,
+      ...updateParams,
       runId: await dustRunId,
     });
 
@@ -494,7 +588,9 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
         functionCallName: action.functionCallName,
         step: action.step,
         type: "process_action",
-        generatedFiles: [],
+        generatedFiles,
+        jsonFileId: jsonFileSId,
+        jsonFileSnippet,
       }),
     };
   }
@@ -518,6 +614,10 @@ async function processActionSpecification({
       " This is used to guide the tool to extract the right data based on the user request.",
     type: "string" as const,
   });
+
+  if (!actionConfiguration.jsonSchema) {
+    inputs.push(retrievalSchemaInputSpecification());
+  }
 
   if (actionConfiguration.relativeTimeFrame === "auto") {
     inputs.push(retrievalAutoTimeFrameInputSpecification());
@@ -562,6 +662,20 @@ export async function processActionTypesFromAgentMessageIds(
         unit: action.relativeTimeFrameUnit,
       };
     }
+    let jsonFile: ActionGeneratedFileType | null = null;
+    if (action.jsonFileId && action.jsonFileSnippet) {
+      jsonFile = {
+        fileId: FileResource.modelIdToSId({
+          id: action.jsonFileId,
+          workspaceId: action.workspaceId,
+        }),
+        title: getExtractFileTitle({
+          schema: action.jsonSchema,
+        }),
+        contentType: "application/json",
+        snippet: action.jsonFileSnippet,
+      };
+    }
 
     return new ProcessActionType({
       id: action.id,
@@ -576,8 +690,39 @@ export async function processActionTypesFromAgentMessageIds(
       functionCallId: action.functionCallId,
       functionCallName: action.functionCallName,
       step: action.step,
+      jsonFileId: jsonFile?.fileId ?? null,
+      jsonFileSnippet: action.jsonFileSnippet,
       type: "process_action",
-      generatedFiles: [],
+      generatedFiles: removeNulls([jsonFile]),
     });
   });
+}
+
+function retrievalSchemaInputSpecification() {
+  return {
+    name: "schema",
+    description:
+      "A JSON schema that will be embedded in the following JSON schema:" +
+      "\n```\n" +
+      "{\n" +
+      '  "name": "extract_data",\n' +
+      '  "description": "Call this function with an array of extracted data points",\n' +
+      '  "parameters": {\n' +
+      '    "type": "object",\n' +
+      '    "properties": {\n' +
+      '      "data_points": {\n' +
+      '         "type": "array",\n' +
+      '         "items": $SCHEMA,\n' +
+      '          "description": "The data points extracted from provided documents, as many as required to follow instructions."\n' +
+      "        }\n" +
+      "      },\n" +
+      '      "required": ["data_points"]\n' +
+      "    }\n" +
+      "  }\n" +
+      "}\n" +
+      "```\n\n" +
+      "Must be a valid JSON schema. Use only standard JSON Schema 7 core fields (type, properties, required, description) and avoid custom keywords or extensions that are not part of the core specification.\n\n" +
+      "This schema will be used as signature to extract the relevant information based on selected documents to properly follow instructions.",
+    type: "string" as const,
+  };
 }

--- a/front/lib/actions/process/utils.ts
+++ b/front/lib/actions/process/utils.ts
@@ -1,0 +1,18 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+/**
+ * Generates a title for an extract results JSON file based on the schema
+ *
+ * @param schema - The JSON schema used for extraction
+ * @returns A formatted file title string with .json extension
+ */
+export function getExtractFileTitle({
+  schema,
+}: {
+  schema: JSONSchema | null;
+}): string {
+  const schemaNames = Object.keys(schema?.properties ?? {}).join("_");
+  const title = schema?.title || schemaNames || "extract_results";
+  // Make sure title is truncated to 100 characters
+  return `${title.substring(0, 100)}.json`;
+}

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -69,6 +69,15 @@ function isSearchableContentType(
   return true;
 }
 
+function isExtractableContentType(
+  contentType: SupportedContentFragmentType
+): boolean {
+  if (isSupportedImageContentType(contentType)) {
+    return false;
+  }
+  return true;
+}
+
 function isListableContentType(
   contentType: SupportedContentFragmentType
 ): boolean {
@@ -105,16 +114,19 @@ export function listFiles(
           // Tables from knowledge are not materialized as raw content. As such, they cannot be
           // included.
           !isContentNodeTable;
+        // Tables from knowledge are not materialized as raw content. As such, they cannot be
+        // searched--except for notion databases, that may have children.
+        const isTableMaterializable =
+          isContentNodeTable &&
+          m.contentType !== CONTENT_NODE_MIME_TYPES.NOTION.DATABASE;
         const isSearchable =
           canDoJIT &&
           isSearchableContentType(m.contentType) &&
-          // Tables from knowledge are not materialized as raw content. As such, they cannot be
-          // searched--except for notion databases, that may have children.
-          !(
-            isContentNodeTable &&
-            m.contentType !== CONTENT_NODE_MIME_TYPES.NOTION.DATABASE
-          );
-
+          isTableMaterializable;
+        const isExtractable =
+          canDoJIT &&
+          isExtractableContentType(m.contentType) &&
+          isTableMaterializable;
         const baseAttachment: BaseConversationAttachmentType = {
           title: m.title,
           contentType: m.contentType,
@@ -135,6 +147,7 @@ export function listFiles(
           isIncludable,
           isQueryable,
           isSearchable,
+          isExtractable,
         };
 
         if (isContentNodeAttachment(m)) {
@@ -164,6 +177,8 @@ export function listFiles(
         );
         const isQueryable = canDoJIT && isQueryableContentType(f.contentType);
         const isSearchable = canDoJIT && isSearchableContentType(f.contentType);
+        const isExtractable =
+          canDoJIT && isExtractableContentType(f.contentType);
 
         files.push({
           fileId: f.fileId,
@@ -176,6 +191,7 @@ export function listFiles(
           isIncludable,
           isQueryable,
           isSearchable,
+          isExtractable,
         });
       }
     }

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -1,14 +1,12 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import type { CreationOptional, ForeignKey } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type {
-  ProcessActionOutputsType,
-  ProcessSchemaPropertyType,
-} from "@app/lib/actions/process";
+import type { ProcessActionOutputsType } from "@app/lib/actions/process";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { TimeframeUnit } from "@app/types";
 
@@ -24,9 +22,6 @@ export class AgentProcessConfiguration extends WorkspaceAwareModel<AgentProcessC
   declare relativeTimeFrameDuration: number | null;
   declare relativeTimeFrameUnit: TimeframeUnit | null;
 
-  // Maintained for backward compatibility for old version of the process action
-  // All saved process actions will used jsonSchema from now on
-  declare schema: ProcessSchemaPropertyType[] | null;
   declare jsonSchema: JSONSchema | null;
 
   declare name: string | null;
@@ -62,24 +57,9 @@ AgentProcessConfiguration.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
-    schema: {
-      type: DataTypes.JSONB,
-      allowNull: true,
-    },
     jsonSchema: {
       type: DataTypes.JSONB,
       allowNull: true,
-      get() {
-        const rawSchema = this.getDataValue("schema");
-        const jsonSchema = this.getDataValue("jsonSchema");
-
-        return (
-          jsonSchema ||
-          (rawSchema
-            ? renderSchemaPropertiesAsJSONSchema(rawSchema || [])
-            : null)
-        );
-      },
     },
     name: {
       type: DataTypes.STRING,
@@ -142,9 +122,6 @@ export class AgentProcessAction extends WorkspaceAwareModel<AgentProcessAction> 
   declare tagsIn: string[] | null;
   declare tagsNot: string[] | null;
 
-  // Maintained for backward compatibility for old version of the process action
-  // All saved process actions will used jsonSchema from now on
-  declare schema: ProcessSchemaPropertyType[] | null;
   declare jsonSchema: JSONSchema | null;
   declare outputs: ProcessActionOutputsType | null;
   declare functionCallId: string | null;
@@ -153,6 +130,10 @@ export class AgentProcessAction extends WorkspaceAwareModel<AgentProcessAction> 
   declare step: number;
 
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
+
+  declare jsonFileId: ForeignKey<FileModel["id"]> | null;
+  declare jsonFileSnippet: string | null;
+  declare jsonFile: NonAttribute<FileModel>;
 }
 AgentProcessAction.init(
   {
@@ -190,24 +171,9 @@ AgentProcessAction.init(
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
     },
-    schema: {
-      type: DataTypes.JSONB,
-      allowNull: true,
-      defaultValue: null,
-    },
     jsonSchema: {
       type: DataTypes.JSONB,
       allowNull: true,
-      get() {
-        const rawSchema = this.getDataValue("schema");
-        const jsonSchema = this.getDataValue("jsonSchema");
-        return (
-          jsonSchema ||
-          (rawSchema
-            ? renderSchemaPropertiesAsJSONSchema(rawSchema || [])
-            : null)
-        );
-      },
     },
     outputs: {
       type: DataTypes.JSONB,
@@ -225,6 +191,10 @@ AgentProcessAction.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
+    jsonFileSnippet: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
   },
   {
     modelName: "agent_process_action",
@@ -232,6 +202,10 @@ AgentProcessAction.init(
     indexes: [
       {
         fields: ["agentMessageId"],
+        concurrently: true,
+      },
+      {
+        fields: ["jsonFileId"],
         concurrently: true,
       },
     ],
@@ -258,32 +232,12 @@ AgentMessage.hasMany(AgentProcessAction, {
   foreignKey: { name: "agentMessageId", allowNull: false },
 });
 
-function renderSchemaPropertiesAsJSONSchema(
-  schema: ProcessSchemaPropertyType[]
-): { type: string; properties: Record<string, object>; required: string[] } {
-  let properties: { [name: string]: { type: string; description: string } } =
-    {};
-  if (schema.length > 0) {
-    schema.forEach((f) => {
-      properties[f.name] = {
-        type: f.type,
-        description: f.description,
-      };
-    });
-  } else {
-    // Default schema for extraction.
-    properties = {
-      required_data: {
-        type: "string",
-        description:
-          "Minimal (short and concise) piece of information extracted to follow instructions",
-      },
-    };
-  }
-
-  return {
-    type: "object",
-    properties: properties,
-    required: Object.keys(properties),
-  };
-}
+FileModel.hasMany(AgentProcessAction, {
+  foreignKey: { name: "jsonFileId", allowNull: true },
+  onDelete: "SET NULL",
+});
+AgentProcessAction.belongsTo(FileModel, {
+  as: "jsonFile",
+  foreignKey: { name: "jsonFileId", allowNull: true },
+  onDelete: "SET NULL",
+});

--- a/front/migrations/20250418_convert_schemas_to_jsonschema.ts
+++ b/front/migrations/20250418_convert_schemas_to_jsonschema.ts
@@ -1,0 +1,121 @@
+import { QueryTypes } from "sequelize";
+
+import type { ProcessSchemaPropertyType } from "@app/lib/actions/process";
+import { frontSequelize } from "@app/lib/resources/storage";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 1024;
+
+function renderSchemaPropertiesAsJSONSchema(
+  schema: ProcessSchemaPropertyType[]
+): { type: string; properties: Record<string, object>; required: string[] } {
+  let properties: { [name: string]: { type: string; description: string } } =
+    {};
+  if (schema.length > 0) {
+    schema.forEach((f) => {
+      properties[f.name] = {
+        type: f.type,
+        description: f.description,
+      };
+    });
+  } else {
+    // Default schema for extraction.
+    properties = {
+      required_data: {
+        type: "string",
+        description:
+          "Minimal (short and concise) piece of information extracted to follow instructions",
+      },
+    };
+  }
+
+  return {
+    type: "object",
+    properties: properties,
+    required: Object.keys(properties),
+  };
+}
+
+async function migrateTableSchemas({
+  execute,
+  logger,
+  tableName,
+}: {
+  execute: boolean;
+  logger: typeof Logger;
+  tableName: string;
+}) {
+  let nextId = 0;
+  let records: { id: number; schema: ProcessSchemaPropertyType[] }[];
+
+  do {
+    records = await frontSequelize.query<{
+      id: number;
+      schema: ProcessSchemaPropertyType[];
+    }>(
+      `SELECT id, schema
+       FROM ${tableName}
+       WHERE id > :nextId
+         AND schema IS NOT NULL
+         AND \"jsonSchema\" IS NULL
+       ORDER BY id
+       LIMIT :batchSize`,
+      {
+        replacements: { nextId, batchSize: BATCH_SIZE },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    if (records.length === 0) {
+      break;
+    }
+
+    logger.info(
+      `Processing ${records.length} items for table ${tableName}, ids ranging from ${records[0].id} to ${records[records.length - 1].id}`
+    );
+
+    if (execute) {
+      for (const record of records) {
+        const jsonSchema = renderSchemaPropertiesAsJSONSchema(record.schema);
+
+        await frontSequelize.query(
+          `UPDATE ${tableName}
+           SET \"jsonSchema\" = :jsonSchema
+           WHERE id = :id`,
+          {
+            replacements: {
+              id: record.id,
+              jsonSchema: JSON.stringify(jsonSchema),
+            },
+            type: QueryTypes.UPDATE,
+          }
+        );
+      }
+    }
+
+    nextId = records[records.length - 1].id;
+  } while (records.length === BATCH_SIZE);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info("Starting schema to JSONSchema conversion");
+
+  // Process AgentProcessConfiguration records
+  logger.info("Converting schemas in AgentProcessConfiguration records");
+  await migrateTableSchemas({
+    execute,
+    logger,
+    tableName: "agent_process_configurations",
+  });
+
+  // Process AgentProcessAction records
+  logger.info("Converting schemas in AgentProcessAction records");
+  await migrateTableSchemas({
+    execute,
+    logger,
+    tableName: "agent_process_actions",
+  });
+
+  logger.info("Schema to JSONSchema conversion completed");
+});

--- a/front/migrations/db/migration_218.sql
+++ b/front/migrations/db/migration_218.sql
@@ -1,27 +1,4 @@
--- -- This migration is dependant on a backfill script
--- -- The backfill script is: 20250418_convert_schemas_to_jsonschema.ts
--- -- run psql with --set=backfilled=1 argument if you have rune the script.
-
-CREATE OR REPLACE FUNCTION perform_migration(backfilled boolean DEFAULT false)
-RETURNS VARCHAR AS $$
-BEGIN
-    IF NOT backfilled THEN
-        RAISE NOTICE 'The backfill script: 20250418_convert_schemas_to_jsonschema.ts is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.';
-    END IF;
-
--- Migration created on Apr 18, 2025
-ALTER TABLE "public"."agent_process_configurations" DROP COLUMN "schema";
-ALTER TABLE "public"."agent_process_actions" DROP COLUMN "schema";
-
-    RETURN 'success';
-END;
-$$ LANGUAGE plpgsql;
-
-\if :{?backfilled}
-   SELECT perform_migration(:'backfilled'::boolean);
-\else
-    \echo '!! Migration was NOT applied !!'
-    \echo 'The backfill script: 20250418_convert_schemas_to_jsonschema.ts is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.'
-\endif
-
-DROP FUNCTION perform_migration(boolean);
+-- Migration created on Apr 20, 2025
+ALTER TABLE "public"."agent_process_actions" ADD COLUMN "jsonFileSnippet" TEXT;
+ALTER TABLE "public"."agent_process_actions" ADD COLUMN "jsonFileId" BIGINT REFERENCES "files" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX CONCURRENTLY "agent_process_actions_json_file_id" ON "agent_process_actions" ("jsonFileId");

--- a/front/migrations/db/migration_218.sql
+++ b/front/migrations/db/migration_218.sql
@@ -1,0 +1,27 @@
+-- -- This migration is dependant on a backfill script
+-- -- The backfill script is: 20250418_convert_schemas_to_jsonschema.ts
+-- -- run psql with --set=backfilled=1 argument if you have rune the script.
+
+CREATE OR REPLACE FUNCTION perform_migration(backfilled boolean DEFAULT false)
+RETURNS VARCHAR AS $$
+BEGIN
+    IF NOT backfilled THEN
+        RAISE NOTICE 'The backfill script: 20250418_convert_schemas_to_jsonschema.ts is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.';
+    END IF;
+
+-- Migration created on Apr 18, 2025
+ALTER TABLE "public"."agent_process_configurations" DROP COLUMN "schema";
+ALTER TABLE "public"."agent_process_actions" DROP COLUMN "schema";
+
+    RETURN 'success';
+END;
+$$ LANGUAGE plpgsql;
+
+\if :{?backfilled}
+   SELECT perform_migration(:'backfilled'::boolean);
+\else
+    \echo '!! Migration was NOT applied !!'
+    \echo 'The backfill script: 20250418_convert_schemas_to_jsonschema.ts is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.'
+\endif
+
+DROP FUNCTION perform_migration(boolean);

--- a/front/migrations/db/migration_219.sql
+++ b/front/migrations/db/migration_219.sql
@@ -1,0 +1,4 @@
+-- Migration created on Apr 20, 2025
+ALTER TABLE "public"."agent_process_actions" ADD COLUMN "jsonFileSnippet" TEXT;
+ALTER TABLE "public"."agent_process_actions" ADD COLUMN "jsonFileId" BIGINT REFERENCES "files" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX CONCURRENTLY "agent_process_actions_json_file_id" ON "agent_process_actions" ("jsonFileId");

--- a/front/migrations/db/migration_219.sql
+++ b/front/migrations/db/migration_219.sql
@@ -1,4 +1,0 @@
--- Migration created on Apr 20, 2025
-ALTER TABLE "public"."agent_process_actions" ADD COLUMN "jsonFileSnippet" TEXT;
-ALTER TABLE "public"."agent_process_actions" ADD COLUMN "jsonFileId" BIGINT REFERENCES "files" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
-CREATE INDEX CONCURRENTLY "agent_process_actions_json_file_id" ON "agent_process_actions" ("jsonFileId");


### PR DESCRIPTION
## Description

* Making extract schema optional
* Moving extract schema under advanced settings in extract builder details page
* Allowing extract to be used as a JIT action (with a dynamic schema and dynamic timeframe)
* Saving extract files to conversations. Showing preview in extract results side panel.
* Removing the old schema field for the process action tables now that it is not used at all. This includes a migration to convert the existing schema values to the jsonSchema entity. 

## Tests

<img width="391" alt="Screenshot 2025-04-22 at 3 24 59 PM" src="https://github.com/user-attachments/assets/02b0f85c-9dda-46a7-871f-f4d89ff246ff" />
<img width="501" alt="Screenshot 2025-04-22 at 3 25 12 PM" src="https://github.com/user-attachments/assets/3d6f8ac4-7089-4f3d-9ee2-a17b557e55cd" />


## Risk

* This is removing the old schema field for the process action. This can be dangerous if there is an issue with the migration script

## Deploy Plan

1. Run migration 218
2. Run migration 219
3. Deploy front