### PR TITLE
[sparkle] - fix(ScrollArea): responsiveness

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.474",
+  "version": "0.2.475",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.474",
+      "version": "0.2.475",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.474",
+  "version": "0.2.475",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -6,10 +6,10 @@ import { useRef } from "react";
 import { DoubleIcon } from "@sparkle/components/DoubleIcon";
 import { Icon } from "@sparkle/components/Icon";
 import { LinkWrapper, LinkWrapperProps } from "@sparkle/components/LinkWrapper";
+import { ScrollArea } from "@sparkle/components/ScrollArea";
 import { SearchInput, SearchInputProps } from "@sparkle/components/SearchInput";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
-import { ScrollArea } from "@sparkle/components/ScrollArea";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -203,12 +203,28 @@ DropdownMenuSubTrigger.displayName =
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
-    className={cn(menuStyleClasses.container, "s-shadow-lg", className)}
+    className={cn(
+      menuStyleClasses.container,
+      "s-flex s-flex-col s-p-0 s-shadow-lg",
+      className
+    )}
     {...props}
-  />
+  >
+    <ScrollArea
+      className="s-w-full s-flex-1"
+      hideScrollBar={false}
+      orientation="vertical"
+      viewportClassName={cn(
+        "s-flex-1",
+        "s-max-h-[calc(var(--radix-dropdown-menu-content-available-height)-var(--header-height,20px))]"
+      )}
+    >
+      <div className="s-p-1">{children}</div>
+    </ScrollArea>
+  </DropdownMenuPrimitive.SubContent>
 ));
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName;
@@ -254,7 +270,7 @@ const DropdownMenuContent = React.forwardRef<
           className="s-w-full s-flex-1"
           viewportClassName={cn(
             "s-flex-1",
-            "s-max-h-[var(--radix-dropdown-menu-content-available-height)]"
+            "s-max-h-[calc(var(--radix-dropdown-menu-content-available-height)-var(--header-height,20px))]"
           )}
         >
           {children}

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -247,7 +247,7 @@ const DropdownMenuContent = React.forwardRef<
         )}
         {...props}
       >
-        <div className="s-sticky s-top-0 s-z-10 s-bg-background dark:s-bg-background-night">
+        <div className="s-sticky s-top-0 s-bg-background dark:s-bg-background-night">
           {dropdownHeaders && dropdownHeaders}
         </div>
         <ScrollArea

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -249,7 +249,7 @@ const DropdownMenuContent = React.forwardRef<
       >
         {dropdownHeaders && dropdownHeaders}
         <ScrollArea
-          className="s-w-full"
+          className="s-w-full s-h-full"
           viewportClassName={cn(
             "s-max-h-[var(--radix-dropdown-menu-content-available-height)]"
           )}

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -217,6 +217,7 @@ interface DropdownMenuContentProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> {
   mountPortal?: boolean;
   mountPortalContainer?: HTMLElement;
+  dropdownHeaders?: React.ReactNode;
 }
 
 const DropdownMenuContent = React.forwardRef<
@@ -229,6 +230,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset = 4,
       mountPortal = true,
       mountPortalContainer,
+      dropdownHeaders,
       children,
       ...props
     },
@@ -245,6 +247,7 @@ const DropdownMenuContent = React.forwardRef<
         )}
         {...props}
       >
+        {dropdownHeaders && dropdownHeaders}
         <ScrollArea
           className="s-w-full"
           viewportClassName={cn(

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -242,15 +242,18 @@ const DropdownMenuContent = React.forwardRef<
         sideOffset={sideOffset}
         className={cn(
           menuStyleClasses.container,
-          "s-h-fit s-p-0 s-shadow-md",
+          "s-flex s-flex-col s-p-0 s-shadow-md",
           className
         )}
         {...props}
       >
-        {dropdownHeaders && dropdownHeaders}
+        <div className="s-sticky s-top-0 s-z-10 s-bg-background dark:s-bg-background-night">
+          {dropdownHeaders && dropdownHeaders}
+        </div>
         <ScrollArea
-          className="s-w-full s-h-full"
+          className="s-w-full s-flex-1"
           viewportClassName={cn(
+            "s-flex-1",
             "s-max-h-[var(--radix-dropdown-menu-content-available-height)]"
           )}
         >

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -9,6 +9,7 @@ import { LinkWrapper, LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import { SearchInput, SearchInputProps } from "@sparkle/components/SearchInput";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
+import { ScrollArea } from "@sparkle/components/ScrollArea";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 
@@ -21,7 +22,7 @@ export const menuStyleClasses = {
     "s-border s-border-border dark:s-border-border-night",
     "s-bg-background dark:s-bg-muted-background-night",
     "s-text-foreground dark:s-text-foreground-night",
-    "s-z-50 s-min-w-[8rem] s-overflow-hidden",
+    "s-z-50 s-min-w-[8rem]",
     "data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 data-[side=bottom]:s-slide-in-from-top-2 data-[side=left]:s-slide-in-from-right-2 data-[side=right]:s-slide-in-from-left-2 data-[side=top]:s-slide-in-from-bottom-2"
   ),
   item: cva(
@@ -228,6 +229,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset = 4,
       mountPortal = true,
       mountPortalContainer,
+      children,
       ...props
     },
     ref
@@ -236,9 +238,22 @@ const DropdownMenuContent = React.forwardRef<
       <DropdownMenuPrimitive.Content
         ref={ref}
         sideOffset={sideOffset}
-        className={cn(menuStyleClasses.container, "s-shadow-md", className)}
+        className={cn(
+          menuStyleClasses.container,
+          "s-h-fit s-p-0 s-shadow-md",
+          className
+        )}
         {...props}
-      />
+      >
+        <ScrollArea
+          className="s-w-full"
+          viewportClassName={cn(
+            "s-max-h-[var(--radix-dropdown-menu-content-available-height)]"
+          )}
+        >
+          {children}
+        </ScrollArea>
+      </DropdownMenuPrimitive.Content>
     );
 
     const [container, setContainer] = React.useState<Element | undefined>(

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuStaticItem,
   DropdownMenuSub,
@@ -555,42 +556,42 @@ function AttachFileDemo() {
         <DropdownMenuTrigger asChild>
           <Button icon={RobotIcon} variant="outline" size="sm" isSelect />
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="s-w-[380px]">
-          <div className="s-flex s-gap-1.5 s-p-1.5">
-            <SearchInput
+        <DropdownMenuContent
+          className="s-h-96 s-w-[380px]"
+          dropdownHeaders={
+            <DropdownMenuSearchbar
               ref={agentsSearchInputRef}
               name="search"
               onChange={() => {}}
               onKeyDown={() => {}}
               placeholder="Search Agents"
               value=""
+              button={<Button icon={PlusIcon} label="Create" />}
             />
-            <Button icon={PlusIcon} label="Create" />
-          </div>
+          }
+        >
           <DropdownMenuSeparator />
-          <ScrollArea className="s-h-[380px]">
-            {filteredAgents.map((agent) => {
-              return (
-                <DropdownMenuItem
-                  key={agent.name}
-                  label={agent.name}
-                  description={agent.description}
-                  icon={() => (
-                    <Avatar
-                      size="sm"
-                      emoji={agent.emoji}
-                      backgroundColor={agent.backgroundColor}
-                    />
-                  )}
-                  onClick={() => {
-                    setSelectedItem(agent.name);
-                    setSearchText("");
-                  }}
-                  truncateText
-                />
-              );
-            })}
-          </ScrollArea>
+          {filteredAgents.map((agent) => {
+            return (
+              <DropdownMenuItem
+                key={agent.name}
+                label={agent.name}
+                description={agent.description}
+                icon={() => (
+                  <Avatar
+                    size="sm"
+                    emoji={agent.emoji}
+                    backgroundColor={agent.backgroundColor}
+                  />
+                )}
+                onClick={() => {
+                  setSelectedItem(agent.name);
+                  setSearchText("");
+                }}
+                truncateText
+              />
+            );
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu open={openToolsets} onOpenChange={setOpenToolsets}>

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -155,6 +155,14 @@ function ComplexDropdownDemo() {
                 />
                 <DropdownMenuSeparator />
                 <DropdownMenuItem icon={UserIcon} label="More..." />
+                <DropdownMenuItem icon={UserIcon} label="More.." />
+                <DropdownMenuItem icon={UserIcon} label="More..." />
+                <DropdownMenuItem icon={UserIcon} label="More.." />
+                <DropdownMenuItem icon={UserIcon} label="More" />
+                <DropdownMenuItem icon={UserIcon} label="More....." />
+                <DropdownMenuItem icon={UserIcon} label="More.." />
+                <DropdownMenuItem icon={UserIcon} label="More" />
+                <DropdownMenuItem icon={UserIcon} label="More...." />
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -56,7 +56,6 @@ import {
   MagnifyingGlassIcon,
   PlusIcon,
   RobotIcon,
-  ScrollArea,
   SearchInput,
   SuitcaseIcon,
   UserGroupIcon,
@@ -519,37 +518,35 @@ function AttachFileDemo() {
             <Button icon={ArrowUpOnSquareIcon} label="Upload File" />
           </div>
           <DropdownMenuSeparator />
-          <ScrollArea className="s-h-[380px]">
-            {searchText ? (
-              filteredItems.map((item) => {
-                const randomMainIcon =
-                  mainIcons[Math.floor(Math.random() * mainIcons.length)];
-                const randomExtraIcon =
-                  extraIcons[Math.floor(Math.random() * extraIcons.length)];
-                return (
-                  <DropdownMenuItem
-                    key={item}
-                    label={item}
-                    description="Company Space/Notion"
-                    icon={randomMainIcon}
-                    extraIcon={randomExtraIcon}
-                    onClick={() => {
-                      setSelectedItem(item);
-                      setSearchText("");
-                    }}
-                    truncateText
-                  />
-                );
-              })
-            ) : (
-              <div className="s-flex s-h-full s-w-full s-items-center s-justify-center s-py-8">
-                <div className="s-flex s-flex-col s-items-center s-justify-center s-gap-0 s-text-center s-text-base s-font-semibold s-text-primary-400">
-                  <Icon visual={MagnifyingGlassIcon} size="sm" />
-                  Search in Dust
-                </div>
+          {searchText ? (
+            filteredItems.map((item) => {
+              const randomMainIcon =
+                mainIcons[Math.floor(Math.random() * mainIcons.length)];
+              const randomExtraIcon =
+                extraIcons[Math.floor(Math.random() * extraIcons.length)];
+              return (
+                <DropdownMenuItem
+                  key={item}
+                  label={item}
+                  description="Company Space/Notion"
+                  icon={randomMainIcon}
+                  extraIcon={randomExtraIcon}
+                  onClick={() => {
+                    setSelectedItem(item);
+                    setSearchText("");
+                  }}
+                  truncateText
+                />
+              );
+            })
+          ) : (
+            <div className="s-flex s-h-full s-w-full s-items-center s-justify-center s-py-8">
+              <div className="s-flex s-flex-col s-items-center s-justify-center s-gap-0 s-text-center s-text-base s-font-semibold s-text-primary-400">
+                <Icon visual={MagnifyingGlassIcon} size="sm" />
+                Search in Dust
               </div>
-            )}
-          </ScrollArea>
+            </div>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu open={openAgents} onOpenChange={setOpenAgents}>
@@ -603,36 +600,36 @@ function AttachFileDemo() {
             size="sm"
           />
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="s-w-[380px]">
-          <div className="s-flex s-gap-1.5 s-p-1.5">
-            <SearchInput
+        <DropdownMenuContent
+          className="s-h-96 s-w-[380px]"
+          dropdownHeaders={
+            <DropdownMenuSearchbar
               ref={toolsetsSearchInputRef}
               name="search"
               onChange={() => {}}
               onKeyDown={() => {}}
               placeholder="Search Tools"
               value=""
+              button={<Button icon={PlusIcon} label="Add MCP Server" />}
             />
-            <Button icon={PlusIcon} label="Add MCP Server" />
-          </div>
+          }
+        >
           <DropdownMenuSeparator />
-          <ScrollArea className="s-h-[380px]">
-            {filteredToolsetList.map((toolset) => {
-              return (
-                <DropdownMenuItem
-                  key={toolset.name}
-                  label={toolset.name}
-                  description={toolset.description}
-                  icon={() => <Avatar size="sm" icon={toolset.icon} />}
-                  onClick={() => {
-                    setSelectedItem(toolset.name);
-                    setSearchText("");
-                  }}
-                  truncateText
-                />
-              );
-            })}
-          </ScrollArea>
+          {filteredToolsetList.map((toolset) => {
+            return (
+              <DropdownMenuItem
+                key={toolset.name}
+                label={toolset.name}
+                description={toolset.description}
+                icon={() => <Avatar size="sm" icon={toolset.icon} />}
+                onClick={() => {
+                  setSelectedItem(toolset.name);
+                  setSearchText("");
+                }}
+                truncateText
+              />
+            );
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
## Description

This PR aims at making the `DropdownMenu` component smart enough to expand based on its content and available height. When available height is smaller than its content it becomes scrollable, leveraging our `ScrollArea` component, ensuring style consistency.

## Risk

Low

## Deploy Plan

- Publish sparkle
- Update front and ditch all manually implemented scrolling behaviour