### PR TITLE
fix: Change remote tables column type to TEXT, rm VARCHAR(255) limit

### DIFF
--- a/connectors/migrations/db/migration_66.sql
+++ b/connectors/migrations/db/migration_66.sql
@@ -1,0 +1,7 @@
+-- Migration created on Apr 23, 2025
+
+ALTER TABLE "remote_tables" 
+  ALTER COLUMN "internalId" TYPE TEXT,
+  ALTER COLUMN "name" TYPE TEXT,
+  ALTER COLUMN "database_name" TYPE TEXT, 
+  ALTER COLUMN "schema_name" TYPE TEXT;

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -117,19 +117,19 @@ export class RemoteTableModel extends ConnectorBaseModel<RemoteTableModel> {
 RemoteTableModel.init(
   {
     internalId: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     schemaName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     databaseName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     permission: {


### PR DESCRIPTION
## Description

Changes some of the column types on `remote_tables` from varchar(255) to text, removing the length limit.

## Tests

N/A

## Risk

N/A

## Deploy Plan

I will apply the new SQL migration file on prodbox after pulling the changes. Hopefully this is detailed enough for the danger check to pass.