### PR TITLE
Data retention workflow: Soft delete conversation and empty all content

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -72,7 +72,10 @@ async function destroyActionsRelatedResources(agentMessageIds: Array<ModelId>) {
   });
 }
 
-async function destroyMessageRelatedResources(messageIds: Array<ModelId>) {
+async function destroyMessageRelatedResources(
+  messageIds: Array<ModelId>,
+  softDeleteAndEmptyContent: boolean
+) {
   await MessageReaction.destroy({
     where: { messageId: messageIds },
   });
@@ -80,9 +83,11 @@ async function destroyMessageRelatedResources(messageIds: Array<ModelId>) {
     where: { messageId: messageIds },
   });
   // TODO: We should also destroy the parent message
-  await Message.destroy({
-    where: { id: messageIds },
-  });
+  if (!softDeleteAndEmptyContent) {
+    await Message.destroy({
+      where: { id: messageIds },
+    });
+  }
 }
 
 async function destroyContentFragments(
@@ -247,7 +252,7 @@ export async function destroyConversation(
       conversationId: conversation.sId,
     });
 
-    await destroyMessageRelatedResources(messageIds);
+    await destroyMessageRelatedResources(messageIds, softDeleteAndEmptyContent);
   }
 
   await destroyConversationDataSource(auth, { conversation });

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -158,6 +158,10 @@ async function destroyConversationDataSource(
 
 // This belongs to the ConversationResource. The authenticator is expected to have access to the
 // groups involved in the conversation.
+//
+// softDeleteAndEmptyContent is used in the data retention policy to keep the conversation and messages in the DB
+// but empty the content of the messages (and the title of the conversation). We still delete all other
+// resources associated with the conversation.
 export async function destroyConversation(
   auth: Authenticator,
   {

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -80,7 +80,11 @@ export async function purgeConversationsBatchActivity({
 
     await concurrentExecutor(
       conversations,
-      async (c) => destroyConversation(auth, { conversationId: c.sId }),
+      async (c) =>
+        destroyConversation(auth, {
+          conversationId: c.sId,
+          softDeleteAndEmptyContent: true,
+        }),
       {
         concurrency: 4,
       }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/2632

The data retention policy keeps the conversation and messages but empty their content and title, and set them as visibility deleted. We still delete all the actions and conversation data sources. Goal is to have valid metrics for messages but no content on DB when data retention is activated. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 