### PR TITLE
[front] - enh(builder): use DropdownMenusub

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -38,26 +38,14 @@ import assert from "assert";
 import { uniqueId } from "lodash";
 import { BarChartIcon, LightbulbIcon } from "lucide-react";
 import type { ReactNode } from "react";
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 import {
   ActionDustAppRun,
   isActionDustAppRunValid as hasErrorActionDustAppRun,
 } from "@app/components/assistant_builder/actions/DustAppRunAction";
-import {
-  hasErrorActionMCP,
-  MCPAction,
-} from "@app/components/assistant_builder/actions/MCPAction";
-import {
-  ActionProcess,
-  hasErrorActionProcess,
-} from "@app/components/assistant_builder/actions/ProcessAction";
+import { hasErrorActionMCP, MCPAction } from "@app/components/assistant_builder/actions/MCPAction";
+import { ActionProcess, hasErrorActionProcess } from "@app/components/assistant_builder/actions/ProcessAction";
 import { ActionReasoning } from "@app/components/assistant_builder/actions/ReasoningAction";
 import {
   ActionRetrievalExhaustive,
@@ -97,17 +85,8 @@ import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type {
-  ModelConfigurationType,
-  SpaceType,
-  WhitelistableFeature,
-  WorkspaceType,
-} from "@app/types";
-import {
-  asDisplayName,
-  assertNever,
-  MAX_STEPS_USE_PER_RUN_LIMIT,
-} from "@app/types";
+import type { ModelConfigurationType, SpaceType, WhitelistableFeature, WorkspaceType } from "@app/types";
+import { asDisplayName, assertNever, MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types";
 
 const DATA_SOURCES_ACTION_CATEGORIES = [
   "RETRIEVAL_SEARCH",
@@ -1549,7 +1528,7 @@ function Capabilities({
           isSelect
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent>
+      <DropdownMenuContent align="start">
         {shouldShowOldWebCapabilities && (
           <Capability
             name="Web search & browse"

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -15,7 +15,12 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   InformationCircleIcon,
   Input,
@@ -38,14 +43,26 @@ import assert from "assert";
 import { uniqueId } from "lodash";
 import { BarChartIcon, LightbulbIcon } from "lucide-react";
 import type { ReactNode } from "react";
-import React, { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import {
   ActionDustAppRun,
   isActionDustAppRunValid as hasErrorActionDustAppRun,
 } from "@app/components/assistant_builder/actions/DustAppRunAction";
-import { hasErrorActionMCP, MCPAction } from "@app/components/assistant_builder/actions/MCPAction";
-import { ActionProcess, hasErrorActionProcess } from "@app/components/assistant_builder/actions/ProcessAction";
+import {
+  hasErrorActionMCP,
+  MCPAction,
+} from "@app/components/assistant_builder/actions/MCPAction";
+import {
+  ActionProcess,
+  hasErrorActionProcess,
+} from "@app/components/assistant_builder/actions/ProcessAction";
 import { ActionReasoning } from "@app/components/assistant_builder/actions/ReasoningAction";
 import {
   ActionRetrievalExhaustive,
@@ -85,8 +102,17 @@ import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { ModelConfigurationType, SpaceType, WhitelistableFeature, WorkspaceType } from "@app/types";
-import { asDisplayName, assertNever, MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types";
+import type {
+  ModelConfigurationType,
+  SpaceType,
+  WhitelistableFeature,
+  WorkspaceType,
+} from "@app/types";
+import {
+  asDisplayName,
+  assertNever,
+  MAX_STEPS_USE_PER_RUN_LIMIT,
+} from "@app/types";
 
 const DATA_SOURCES_ACTION_CATEGORIES = [
   "RETRIEVAL_SEARCH",
@@ -1237,75 +1263,60 @@ function AdvancedSettings({
     ) ?? reasoningModels?.[0];
 
   return (
-    <Popover
-      popoverTriggerAsChild
-      trigger={
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         <Button
           label="Advanced settings"
           variant="outline"
           size="sm"
           isSelect
         />
-      }
-      content={
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-col items-start justify-start">
-              <div className="w-full grow text-sm font-bold text-muted-foreground dark:text-muted-foreground-night">
-                Max steps per run
-              </div>
-              <div className="w-full grow text-sm text-muted-foreground dark:text-muted-foreground-night">
-                up to {MAX_STEPS_USE_PER_RUN_LIMIT}
-              </div>
-            </div>
-            <Input
-              value={maxStepsPerRun?.toString() ?? ""}
-              placeholder=""
-              name="maxStepsPerRun"
-              onChange={(e) => {
-                if (!e.target.value || e.target.value === "") {
-                  setMaxStepsPerRun(null);
-                  return;
-                }
-                const value = parseInt(e.target.value);
-                if (
-                  !isNaN(value) &&
-                  value >= 0 &&
-                  value <= MAX_STEPS_USE_PER_RUN_LIMIT
-                ) {
-                  setMaxStepsPerRun(value);
-                }
-              }}
-            />
-            {(reasoningModels?.length ?? 0) > 1 && setReasoningModel && (
-              <div className="flex flex-col gap-2">
-                <div className="font-semibold text-muted-foreground dark:text-muted-foreground-night">
-                  Reasoning model
-                </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      label={reasoningModel?.displayName}
-                      isSelect
-                    />
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    {(reasoningModels ?? []).map((model) => (
-                      <DropdownMenuItem
-                        key={model.modelId + (model.reasoningEffort ?? "")}
-                        label={model.displayName}
-                        onClick={() => setReasoningModel(model)}
-                      />
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            )}
-          </div>
-        </div>
-      }
-    />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-60 p-2" align="end">
+        <DropdownMenuLabel
+          label={`Max steps per run (up to ${MAX_STEPS_USE_PER_RUN_LIMIT})`}
+        />
+        <Input
+          value={maxStepsPerRun?.toString() ?? ""}
+          placeholder=""
+          name="maxStepsPerRun"
+          onChange={(e) => {
+            if (!e.target.value || e.target.value === "") {
+              setMaxStepsPerRun(null);
+              return;
+            }
+            const value = parseInt(e.target.value);
+            if (
+              !isNaN(value) &&
+              value >= 0 &&
+              value <= MAX_STEPS_USE_PER_RUN_LIMIT
+            ) {
+              setMaxStepsPerRun(value);
+            }
+          }}
+        />
+
+        {(reasoningModels?.length ?? 0) > 1 && setReasoningModel && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger label="Reasoning model" className="mt-1" />
+            <DropdownMenuSubContent>
+              <DropdownMenuRadioGroup
+                value={`${reasoningModel?.modelId}-${reasoningModel?.providerId}-${reasoningModel?.reasoningEffort ?? ""}`}
+              >
+                {(reasoningModels ?? []).map((model) => (
+                  <DropdownMenuRadioItem
+                    key={`${model.modelId}-${model.providerId}-${model.reasoningEffort ?? ""}`}
+                    value={`${model.modelId}-${model.providerId}-${model.reasoningEffort ?? ""}`}
+                    label={model.displayName}
+                    onClick={() => setReasoningModel(model)}
+                  />
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/front/components/assistant_builder/AdvancedSettings.tsx
+++ b/front/components/assistant_builder/AdvancedSettings.tsx
@@ -5,11 +5,12 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-  Label,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
   ScrollArea,
   ScrollBar,
 } from "@dust-tt/sparkle";
@@ -117,77 +118,93 @@ export function AdvancedSettings({
   }
 
   return (
-    <PopoverRoot>
-      <PopoverTrigger asChild>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         <Button
           label="Advanced settings"
           variant="outline"
           size="sm"
           isSelect
         />
-      </PopoverTrigger>
-      <PopoverContent className="w-96 p-4" align="end">
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col items-start gap-2">
-            <Label>Model selection</Label>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  isSelect
-                  label={
-                    getSupportedModelConfig(generationSettings.modelSettings)
-                      .displayName
-                  }
-                  variant="outline"
-                  size="sm"
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuLabel label="Best performing models" />
-                <ScrollArea className="flex max-h-72 flex-col" hideScrollBar>
-                  <ModelList
-                    modelConfigs={bestPerformingModelConfigs}
-                    onClick={(modelSettings) => {
-                      setGenerationSettings({
-                        ...generationSettings,
-                        modelSettings,
-                      });
-                    }}
-                  />
-                  <DropdownMenuLabel label="Other models" />
-                  <ModelList
-                    modelConfigs={otherModelConfigs}
-                    onClick={(modelSettings) => {
-                      setGenerationSettings({
-                        ...generationSettings,
-                        modelSettings,
-                      });
-                    }}
-                  />
-                  <ScrollBar className="py-0" />
-                </ScrollArea>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-          <div className="flex flex-col items-start gap-2">
-            <Label>Creativity level</Label>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  isSelect
-                  label={
-                    getCreativityLevelFromTemperature(
-                      generationSettings?.temperature
-                    ).label
-                  }
-                  variant="outline"
-                  size="sm"
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <div className="flex flex-col gap-1 p-1">
+          {/* Model Selection */}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger label="Model selection" />
+            <DropdownMenuSubContent className="w-80">
+              <DropdownMenuLabel label="Best performing models" />
+              <ScrollArea className="flex max-h-72 flex-col" hideScrollBar>
+                <DropdownMenuRadioGroup
+                  value={`${generationSettings.modelSettings.modelId}${generationSettings.modelSettings.reasoningEffort ? `-${generationSettings.modelSettings.reasoningEffort}` : ""}`}
+                >
+                  {bestPerformingModelConfigs.map((modelConfig) => (
+                    <DropdownMenuRadioItem
+                      key={`${modelConfig.modelId}${modelConfig.reasoningEffort ? `-${modelConfig.reasoningEffort}` : ""}`}
+                      value={`${modelConfig.modelId}${modelConfig.reasoningEffort ? `-${modelConfig.reasoningEffort}` : ""}`}
+                      icon={getModelProviderLogo(
+                        modelConfig.providerId,
+                        isDark
+                      )}
+                      description={modelConfig.shortDescription}
+                      label={modelConfig.displayName}
+                      onClick={() => {
+                        setGenerationSettings({
+                          ...generationSettings,
+                          modelSettings: {
+                            modelId: modelConfig.modelId,
+                            providerId: modelConfig.providerId,
+                            reasoningEffort: modelConfig.reasoningEffort,
+                          },
+                        });
+                      }}
+                    />
+                  ))}
+                </DropdownMenuRadioGroup>
+
+                <DropdownMenuLabel label="Other models" />
+                <DropdownMenuRadioGroup
+                  value={`${generationSettings.modelSettings.modelId}${generationSettings.modelSettings.reasoningEffort ? `-${generationSettings.modelSettings.reasoningEffort}` : ""}`}
+                >
+                  {otherModelConfigs.map((modelConfig) => (
+                    <DropdownMenuRadioItem
+                      key={`${modelConfig.modelId}${modelConfig.reasoningEffort ? `-${modelConfig.reasoningEffort}` : ""}`}
+                      value={`${modelConfig.modelId}${modelConfig.reasoningEffort ? `-${modelConfig.reasoningEffort}` : ""}`}
+                      icon={getModelProviderLogo(
+                        modelConfig.providerId,
+                        isDark
+                      )}
+                      description={modelConfig.shortDescription}
+                      label={modelConfig.displayName}
+                      onClick={() => {
+                        setGenerationSettings({
+                          ...generationSettings,
+                          modelSettings: {
+                            modelId: modelConfig.modelId,
+                            providerId: modelConfig.providerId,
+                            reasoningEffort: modelConfig.reasoningEffort,
+                          },
+                        });
+                      }}
+                    />
+                  ))}
+                </DropdownMenuRadioGroup>
+                <ScrollBar className="py-0" />
+              </ScrollArea>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          {/* Creativity Level */}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger label="Creativity level" />
+            <DropdownMenuSubContent>
+              <DropdownMenuRadioGroup
+                value={generationSettings.temperature.toString()}
+              >
                 {CREATIVITY_LEVELS.map(({ label, value }) => (
-                  <DropdownMenuItem
-                    key={label}
+                  <DropdownMenuRadioItem
+                    key={value}
+                    value={value.toString()}
                     label={label}
                     onClick={() => {
                       setGenerationSettings({
@@ -197,65 +214,68 @@ export function AdvancedSettings({
                     }}
                   />
                 ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
           {supportsResponseFormat && (
-            <div className="flex flex-col gap-2">
-              <Label>Structured Response Format</Label>
-              <ScrollArea className="h-96">
-                <CodeEditor
-                  data-color-mode={isDark ? "dark" : "light"}
-                  value={generationSettings?.responseFormat ?? ""}
-                  placeholder={
-                    "Example:\n\n" +
-                    "{\n" +
-                    '  "type": "json_schema",\n' +
-                    '  "json_schema": {\n' +
-                    '    "name": "YourSchemaName",\n' +
-                    '    "strict": true,\n' +
-                    '    "schema": {\n' +
-                    '      "type": "object",\n' +
-                    '      "properties": {\n' +
-                    '        "property1":\n' +
-                    '          { "type":"string" }\n' +
-                    "      },\n" +
-                    '      "required": ["property1"],\n' +
-                    '      "additionalProperties": false\n' +
-                    "    }\n" +
-                    "  }\n" +
-                    "}"
-                  }
-                  name="responseFormat"
-                  onChange={(e) => {
-                    setGenerationSettings({
-                      ...generationSettings,
-                      responseFormat: e.target.value,
-                    });
-                  }}
-                  minHeight={380}
-                  className={cn(
-                    "rounded-lg",
-                    isInvalidJson(generationSettings?.responseFormat)
-                      ? "border-2 border-red-500 bg-slate-100 dark:bg-slate-100-night"
-                      : "bg-slate-100 dark:bg-slate-100-night"
-                  )}
-                  style={{
-                    fontSize: 13,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    overflowY: "auto",
-                    height: "400px",
-                  }}
-                  language="json"
-                />
-                <ScrollBar orientation="vertical" />
-              </ScrollArea>
-            </div>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger label="Structured Response Format" />
+              <DropdownMenuSubContent className="w-96">
+                <ScrollArea className="h-96">
+                  <CodeEditor
+                    data-color-mode={isDark ? "dark" : "light"}
+                    value={generationSettings?.responseFormat ?? ""}
+                    placeholder={
+                      "Example:\n\n" +
+                      "{\n" +
+                      '  "type": "json_schema",\n' +
+                      '  "json_schema": {\n' +
+                      '    "name": "YourSchemaName",\n' +
+                      '    "strict": true,\n' +
+                      '    "schema": {\n' +
+                      '      "type": "object",\n' +
+                      '      "properties": {\n' +
+                      '        "property1":\n' +
+                      '          { "type":"string" }\n' +
+                      "      },\n" +
+                      '      "required": ["property1"],\n' +
+                      '      "additionalProperties": false\n' +
+                      "    }\n" +
+                      "  }\n" +
+                      "}"
+                    }
+                    name="responseFormat"
+                    onChange={(e) => {
+                      setGenerationSettings({
+                        ...generationSettings,
+                        responseFormat: e.target.value,
+                      });
+                    }}
+                    minHeight={380}
+                    className={cn(
+                      "rounded-lg",
+                      isInvalidJson(generationSettings?.responseFormat)
+                        ? "border-2 border-red-500 bg-slate-100 dark:bg-slate-100-night"
+                        : "bg-slate-100 dark:bg-slate-100-night"
+                    )}
+                    style={{
+                      fontSize: 13,
+                      fontFamily:
+                        "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                      overflowY: "auto",
+                      height: "400px",
+                    }}
+                    language="json"
+                  />
+                  <ScrollBar orientation="vertical" />
+                </ScrollArea>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
           )}
         </div>
-      </PopoverContent>
-    </PopoverRoot>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/front/components/assistant_builder/AdvancedSettings.tsx
+++ b/front/components/assistant_builder/AdvancedSettings.tsx
@@ -3,7 +3,6 @@ import {
   cn,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -25,7 +24,6 @@ import type {
   AssistantCreativityLevel,
   ModelConfigurationType,
   ModelIdType,
-  SupportedModel,
 } from "@app/types";
 import {
   ASSISTANT_CREATIVITY_LEVEL_DISPLAY_NAMES,
@@ -280,35 +278,5 @@ export function AdvancedSettings({
         </div>
       </DropdownMenuContent>
     </DropdownMenu>
-  );
-}
-
-interface ModelListProps {
-  modelConfigs: ModelConfigurationType[];
-  onClick: (modelSettings: SupportedModel) => void;
-}
-
-function ModelList({ modelConfigs, onClick }: ModelListProps) {
-  const { isDark } = useTheme();
-  const handleClick = (modelConfig: ModelConfigurationType) => {
-    onClick({
-      modelId: modelConfig.modelId,
-      providerId: modelConfig.providerId,
-      reasoningEffort: modelConfig.reasoningEffort,
-    });
-  };
-
-  return (
-    <>
-      {modelConfigs.map((modelConfig) => (
-        <DropdownMenuItem
-          key={`${modelConfig.modelId}${modelConfig.reasoningEffort ? `-${modelConfig.reasoningEffort}` : ""}`}
-          icon={getModelProviderLogo(modelConfig.providerId, isDark)}
-          description={modelConfig.shortDescription}
-          label={modelConfig.displayName}
-          onClick={() => handleClick(modelConfig)}
-        />
-      ))}
-    </>
   );
 }

--- a/front/components/assistant_builder/AdvancedSettings.tsx
+++ b/front/components/assistant_builder/AdvancedSettings.tsx
@@ -199,7 +199,11 @@ export function AdvancedSettings({
             <DropdownMenuSubTrigger label="Creativity level" />
             <DropdownMenuSubContent>
               <DropdownMenuRadioGroup
-                value={generationSettings.temperature.toString()}
+                value={
+                  getCreativityLevelFromTemperature(
+                    generationSettings?.temperature
+                  ).label
+                }
               >
                 {CREATIVITY_LEVELS.map(({ label, value }) => (
                   <DropdownMenuRadioItem

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -565,6 +565,7 @@ function SearchResultsTable({
       };
     });
   }, [
+    onClearSearch,
     addToSpace,
     canReadInSpace,
     canWriteInSpace,


### PR DESCRIPTION
## Description

This PR aims at enhancing the way we display Dropdowns in the agent builder to use `DropdownMenuSub` instead of weirdly nested `Dropdowns`

![Screenshot 2025-04-23 at 11 57 07](https://github.com/user-attachments/assets/2335f1ed-7c2c-4329-9484-58d722579717)
![Screenshot 2025-04-23 at 11 57 25](https://github.com/user-attachments/assets/aefb1302-a9d1-498e-b5d0-c6daa7c5b557)

## Risk

Low

## Deploy Plan

- Deploy front