### PR TITLE
Production check: add logging around problematic check

### DIFF
--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -7,6 +7,7 @@ import { getTemporalConnectorsNamespaceConnection } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { getNotionWorkflowId } from "@app/types";
 import { withRetries } from "@app/types";
+import pino, { LoggerOptions } from "pino";
 
 interface NotionConnector {
   id: number;
@@ -31,10 +32,18 @@ async function listAllNotionConnectors() {
 async function getDescriptionsAndHistories({
   client,
   notionConnector,
+  logger,
 }: {
   client: Client;
   notionConnector: NotionConnector;
+  logger: pino.Logger<LoggerOptions>;
 }) {
+  logger.info(
+    {
+      connectorId: notionConnector.id,
+    },
+    "Retrieving Notion handles"
+  );
   const incrementalSyncHandle = client.workflow.getHandle(
     getNotionWorkflowId(notionConnector.id, false)
   );
@@ -42,15 +51,34 @@ async function getDescriptionsAndHistories({
     getNotionWorkflowId(notionConnector.id, true)
   );
 
+  logger.info(
+    {
+      connectorId: notionConnector.id,
+    },
+    "Retrieved Notion handles"
+  );
+
   const descriptions = await Promise.all([
     incrementalSyncHandle.describe(),
     garbageCollectorHandle.describe(),
   ]);
+  logger.info(
+    {
+      connectorId: notionConnector.id,
+    },
+    "Retrieved descriptions"
+  );
 
   const histories = await Promise.all([
     incrementalSyncHandle.fetchHistory(),
     garbageCollectorHandle.fetchHistory(),
   ]);
+  logger.info(
+    {
+      connectorId: notionConnector.id,
+    },
+    "Retrieved histories"
+  );
 
   return {
     descriptions,
@@ -60,7 +88,8 @@ async function getDescriptionsAndHistories({
 
 async function areTemporalWorkflowsRunning(
   client: Client,
-  notionConnector: NotionConnector
+  notionConnector: NotionConnector,
+  logger: pino.Logger<LoggerOptions>
 ) {
   try {
     const { descriptions, histories } = await withRetries(
@@ -70,7 +99,15 @@ async function areTemporalWorkflowsRunning(
     )({
       client,
       notionConnector,
+      logger,
     });
+
+    logger.info(
+      {
+        connectorId: notionConnector.id,
+      },
+      "getDescriptionsAndHistories completed"
+    );
 
     const latests: (Date | null)[] = histories.map((h) => {
       let latest: Date | null = null;
@@ -138,7 +175,7 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
     heartbeat();
 
     const { isRunning, isNotStalled, details } =
-      await areTemporalWorkflowsRunning(client, notionConnector);
+      await areTemporalWorkflowsRunning(client, notionConnector, logger);
 
     if (!isRunning) {
       missingActiveWorkflows.push({


### PR DESCRIPTION
## Description

Production checks stuck on `check_notion_active_workflows` (timeout due to heartbeat not happening within 5mn)

Adding logs to understand where it's getting stuck.

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `front`