### PR TITLE
[front] mcp(remote): include auth only if it is defined

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -142,13 +142,15 @@ export const connectToMCPServer = async (
           const url = new URL(remoteMCPServer.url);
 
           try {
-            const sseTransport = new SSEClientTransport(url, {
+            const req = {
               requestInit: {
                 headers: {
-                  Authorization: `Bearer ${accessToken}`,
+                  ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
                 },
               },
-            });
+            };
+
+            const sseTransport = new SSEClientTransport(url, req);
             await mcpClient.connect(sseTransport);
           } catch (e: unknown) {
             return new Err(

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -145,7 +145,9 @@ export const connectToMCPServer = async (
             const req = {
               requestInit: {
                 headers: {
-                  ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+                  ...(accessToken
+                    ? { Authorization: `Bearer ${accessToken}` }
+                    : {}),
                 },
               },
             };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Some MCP providers check the Authorization field if it's set. We currently send a `null` Bearer to the servers. This leads to crashed requests and restrain users from using certain providers?

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Behind ff, safe to rollback

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front