### PR TITLE
Poké: Upgrade to Free plan lets you set an end date for the subscription

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -80,6 +80,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
         workspaceId: w.sId,
         planCode: FREE_UPGRADED_PLAN_CODE,
+        endDate: null,
       });
       await workspace("show", args);
       return;

--- a/front/admin/init_dust_apps.ts
+++ b/front/admin/init_dust_apps.ts
@@ -35,6 +35,7 @@ async function main() {
     await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
       workspaceId: w.sId,
       planCode: "FREE_UPGRADED_PLAN",
+      endDate: null,
     });
   }
   const lightWorkspace = renderLightWorkspaceType({ workspace: w });

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -15,7 +15,11 @@ import { Plan } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
-import { isEntreprisePlan, isProPlan } from "@app/lib/plans/plan_codes";
+import {
+  isEntreprisePlan,
+  isFreePlan,
+  isProPlan,
+} from "@app/lib/plans/plan_codes";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { PRO_PLAN_SEAT_39_CODE } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
@@ -229,10 +233,12 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     workspaceId,
     planCode,
     stripeSubscriptionId,
+    endDate,
   }: {
     workspaceId: string;
     planCode: string;
     stripeSubscriptionId?: string;
+    endDate: Date | null;
   }): Promise<SubscriptionResource> {
     const workspace = await this.findWorkspaceOrThrow(workspaceId);
     const newPlan = await this.findPlanOrThrow(planCode);
@@ -284,6 +290,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
           status: "active",
           startDate: now,
           stripeSubscriptionId: stripeSubscriptionId ?? null,
+          endDate: endDate,
         },
         { transaction: t }
       );
@@ -321,22 +328,27 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     }
 
     const plan = await this.findPlanOrThrow(enterpriseDetails.planCode);
-
     // End the current subscription if any.
     await this.internalSubscribeWorkspaceToFreePlan({
       workspaceId: owner.sId,
       planCode: plan.code,
       stripeSubscriptionId: enterpriseDetails.stripeSubscriptionId,
+      endDate: null,
     });
   }
 
   /**
    * Internal function to create a PlanInvitation for the workspace.
    */
-  static async pokeUpgradeWorkspaceToPlan(
-    auth: Authenticator,
-    planCode: string
-  ) {
+  static async pokeUpgradeWorkspaceToPlan({
+    auth,
+    planCode,
+    endDate,
+  }: {
+    auth: Authenticator;
+    planCode: string;
+    endDate: Date | null;
+  }) {
     const owner = auth.getNonNullableWorkspace();
 
     if (!auth.isDustSuperUser()) {
@@ -348,6 +360,16 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     // We search for an active subscription for this workspace
     const activeSubscription = auth.subscriptionResource();
     if (activeSubscription && activeSubscription.plan.code === newPlan.code) {
+      // If you are already on this free plan and you want to change the end date, we let you do it.
+      if (isFreePlan(newPlan.code) && activeSubscription.endDate !== endDate) {
+        await Subscription.update(
+          { endDate },
+          {
+            where: { sId: activeSubscription.sId },
+          }
+        );
+        return;
+      }
       throw new Error(
         `Cannot subscribe to plan ${planCode}: already subscribed.`
       );
@@ -396,6 +418,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     await this.internalSubscribeWorkspaceToFreePlan({
       workspaceId: owner.sId,
       planCode: newPlan.code,
+      endDate,
     });
   }
 

--- a/front/migrations/20240314_backfill_free_plan_subscriptions.ts
+++ b/front/migrations/20240314_backfill_free_plan_subscriptions.ts
@@ -46,6 +46,7 @@ makeScript({}, async ({ execute }) => {
             await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
               workspaceId: w.sId,
               planCode: FREE_TEST_PLAN_CODE,
+              endDate: null,
             });
           }
         })();

--- a/front/scripts/dev/create_test_workspaces.ts
+++ b/front/scripts/dev/create_test_workspaces.ts
@@ -76,10 +76,11 @@ async function createTestWorkspaces(
       workspace.sId
     );
 
-    await SubscriptionResource.pokeUpgradeWorkspaceToPlan(
-      authenticator,
-      FREE_UPGRADED_PLAN_CODE
-    );
+    await SubscriptionResource.pokeUpgradeWorkspaceToPlan({
+      auth: authenticator,
+      planCode: FREE_UPGRADED_PLAN_CODE,
+      endDate: null,
+    });
   }
 }
 

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -121,6 +121,22 @@ export type EnterpriseUpgradeFormType = t.TypeOf<
   typeof EnterpriseUpgradeFormSchema
 >;
 
+export const FreePlanUpgradeFormSchema = t.type({
+  planCode: NonEmptyString,
+  endDate: t.union([
+    t.refinement(
+      t.string,
+      (s) => /^\d{4}-\d{2}-\d{2}$/.test(s),
+      "YYYY-MM-DD date string"
+    ),
+    t.undefined,
+  ]),
+});
+
+export type FreePlanUpgradeFormType = t.TypeOf<
+  typeof FreePlanUpgradeFormSchema
+>;
+
 export type CheckoutUrlResult = {
   checkoutUrl: string;
   plan: PlanType;


### PR DESCRIPTION
## Description

Instead of listing the free plan on the upgrade side modal in poké, we display a single button "Upgrade to a Free Plan" that opens a modal letting you pick the plan + to pre-set an end date for the plan. This will simplifies GTM team process when they need to set a workspace on a free pilot for a given number of days (they currently set up reminders for this). 

Review with hidden whitespaces recommended!

<kbd>
<img width="765" alt="Screenshot 2025-04-23 at 14 12 17" src="https://github.com/user-attachments/assets/aea2150f-d30b-422b-8b2b-edd60f7901c5" />
</kbd>
<kbd>
<img width="705" alt="Screenshot 2025-04-23 at 14 11 29" src="https://github.com/user-attachments/assets/e57c955c-bcb0-40a7-945d-e875334758ae" />
</kbd>

## Tests

Tested locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
