### PR TITLE
feat: support loading more nodes when adding to dsview/space

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -53,6 +53,9 @@ export type UseResourcesHook = (parentId: string | null) => {
   isResourcesError: boolean;
   isResourcesTruncated?: boolean;
   resourcesError?: APIError | null;
+  nextPageCursor?: string | null;
+  loadMore?: () => void;
+  isLoadingMore?: boolean;
 };
 
 export type ContentNodeTreeItemStatus<T extends ContentNode = ContentNode> = {
@@ -138,17 +141,15 @@ function ContentNodeTreeChildren({
     isResourcesLoading,
     isResourcesError,
     resourcesError,
-    isResourcesTruncated,
     totalResourceCount,
+    nextPageCursor,
+    loadMore,
+    isLoadingMore,
   } = useResourcesHook(parentId);
 
   const filteredNodes = resources.filter(
     (n) => filter.trim().length === 0 || n.title.includes(filter)
   );
-  // The count below does not take into account the search, it's: total number of nodes - number of nodes displayed.
-  const hiddenNodesCount = totalResourceCount
-    ? Math.max(0, totalResourceCount - filteredNodes.length)
-    : 0;
 
   const getCheckedState = useCallback(
     (node: ContentNode) => {
@@ -311,11 +312,6 @@ function ContentNodeTreeChildren({
           />
         );
       })}
-      {hiddenNodesCount > 0 && (
-        <Tree.Empty
-          label={`${filteredNodes.length > 0 ? "and " : ""}${hiddenNodesCount}${isResourcesTruncated ? "+" : ""} item${hiddenNodesCount > 1 ? "s" : ""}`}
-        />
-      )}
     </Tree>
   );
 
@@ -363,7 +359,27 @@ function ContentNodeTreeChildren({
           </div>
         </>
       )}
-      <div className="overflow-y-auto p-1">{tree}</div>
+      <div className="overflow-y-auto p-1">
+        {tree}
+        {nextPageCursor && (
+          <div className="mt-2 flex flex-col items-center py-2">
+            <div className="mb-2 text-center text-xs text-gray-500">
+              {`Showing ${filteredNodes.length} of ${totalResourceCount ?? filteredNodes.length} items`}
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              label={isLoadingMore ? "Loading..." : "Load More"}
+              disabled={isResourcesLoading || isLoadingMore}
+              onClick={() => {
+                if (loadMore) {
+                  loadMore();
+                }
+              }}
+            />
+          </div>
+        )}
+      </div>
     </>
   );
 }

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -39,6 +39,7 @@ import {
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useSpaceSearch } from "@app/lib/swr/spaces";
 import type {
+  ContentNode,
   ContentNodesViewType,
   DataSourceViewContentNode,
   DataSourceViewSelectionConfiguration,
@@ -56,6 +57,7 @@ import {
 } from "@app/types";
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
+const ITEMS_PER_PAGE = 50;
 
 const getUseResourceHook =
   (
@@ -65,24 +67,76 @@ const getUseResourceHook =
     useContentNodes: typeof useDataSourceViewContentNodes
   ) =>
   (parentId: string | null) => {
+    // State for accumulating nodes for "load more".
+    const [currentCursor, setCurrentCursor] = useState<string | null>(null);
+    const [accumulatedNodes, setAccumulatedNodes] = useState<ContentNode[]>([]);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+
     const {
-      nodes,
-      isNodesLoading,
+      nodes: fetchedNodes,
+      isNodesLoading: isInitialNodesLoading,
       isNodesError,
       totalNodesCountIsAccurate,
       totalNodesCount,
+      nextPageCursor,
     } = useContentNodes({
       owner,
       dataSourceView,
       parentId: parentId ?? undefined,
       viewType,
+      pagination: { cursor: currentCursor, limit: ITEMS_PER_PAGE },
     });
+
+    useEffect(() => {
+      // Skip if no nodes were fetched yet
+      if (!fetchedNodes || fetchedNodes.length === 0) {
+        return;
+      }
+
+      if (currentCursor === null) {
+        // Initial load - just set the nodes directly
+        setAccumulatedNodes(fetchedNodes);
+        return;
+      }
+
+      if (isLoadingMore) {
+        // Load more case - append new nodes to existing ones
+        setAccumulatedNodes((prev) => {
+          // Dedup new nodes.
+          const existingIds = new Set(prev.map((node) => node.internalId));
+          const newNodes = fetchedNodes.filter(
+            (node) => !existingIds.has(node.internalId)
+          );
+          if (newNodes.length === 0) {
+            // Avoid re-rendering if no new nodes are added.
+            return prev;
+          }
+
+          return [...prev, ...newNodes];
+        });
+
+        setIsLoadingMore(false);
+      }
+    }, [fetchedNodes, currentCursor, isLoadingMore]);
+
+    // Function to load more items
+    const loadMore = useCallback(() => {
+      if (nextPageCursor && !isLoadingMore) {
+        setIsLoadingMore(true);
+        setCurrentCursor(nextPageCursor);
+      }
+    }, [nextPageCursor, isLoadingMore]);
+
     return {
-      resources: nodes,
+      resources: accumulatedNodes,
       totalResourceCount: totalNodesCount,
-      isResourcesLoading: isNodesLoading,
+      isResourcesLoading:
+        isInitialNodesLoading || (isLoadingMore && currentCursor === null),
       isResourcesError: isNodesError,
       isResourcesTruncated: !totalNodesCountIsAccurate,
+      nextPageCursor,
+      loadMore,
+      isLoadingMore,
     };
   };
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/2635

adds a "load more" button in the content nodes list when adding to a data source view, to support cases where a flat directory has more items than we show

<img width="520" alt="Screenshot 2025-04-23 at 15 15 30" src="https://github.com/user-attachments/assets/e2946b4a-1563-407d-adbe-2648e39ec7b6" />


## Tests

local

## Risk

Blast radius fairly contained, shouldn't affect any situation that we're not trying to solve for.

## Deploy Plan

Deploy front