### PR TITLE
Poke create workspace with plan

### DIFF
--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -98,6 +99,24 @@ export function RunPluginDialog({
                     {result.value} - Make sure to reload.
                   </PokeAlertDescription>
                 </PokeAlert>
+              )}
+              {result && result.display === "textWithLink" && (
+                <>
+                  <PokeAlert variant="success">
+                    <PokeAlertTitle>Success</PokeAlertTitle>
+                    <PokeAlertDescription>
+                      <p>{result.value} - Make sure to reload.</p>
+                      <Button
+                        onClick={() => {
+                          window.open(result.link, "_blank");
+                        }}
+                        label={result.linkText}
+                        variant="highlight"
+                        className="mt-2"
+                      />
+                    </PokeAlertDescription>
+                  </PokeAlert>
+                </>
               )}
               {result && result.display === "json" && (
                 <div className="mb-4 mt-4">

--- a/front/lib/api/poke/plugins/global/create_workspace.ts
+++ b/front/lib/api/poke/plugins/global/create_workspace.ts
@@ -102,8 +102,10 @@ export const createWorkspacePlugin = createPlugin({
     }
 
     return new Ok({
-      display: "text",
+      display: "textWithLink",
       value: `Workspace created (id: ${workspace.sId}) and invitation sent to ${result.email}.`,
+      link: `poke/${workspace.sId}`,
+      linkText: "View Workspace",
     });
   },
 });

--- a/front/lib/api/poke/plugins/global/create_workspace.ts
+++ b/front/lib/api/poke/plugins/global/create_workspace.ts
@@ -34,6 +34,18 @@ export const createWorkspacePlugin = createPlugin({
         label: "Is Business",
         description: "Is the workspace a business workspace (Pro plan 39€)",
       },
+      planCode: {
+        type: "string",
+        label: "Plan Code",
+        description: "The code of the plan to subscribe the workspace to",
+        required: false,
+      },
+      endDate: {
+        type: "string",
+        label: "End Date (YYYY-MM-DD)",
+        description: "The end date of the subscription",
+        required: false,
+      },
     },
   },
   execute: async (auth, _, args) => {
@@ -54,6 +66,8 @@ export const createWorkspacePlugin = createPlugin({
       name,
       isVerified: enableAutoJoin,
       isBusiness: args.isBusiness,
+      planCode: args.planCode,
+      endDate: args.endDate ? new Date(args.endDate) : null,
     });
 
     const newWorkspaceAuth = await Authenticator.internalAdminForWorkspace(

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -33,7 +33,8 @@ export type InferPluginArgs<T extends PluginArgs> = {
 
 export type PluginResponse =
   | { display: "text"; value: string }
-  | { display: "json"; value: Record<string, unknown> };
+  | { display: "json"; value: Record<string, unknown> }
+  | { display: "textWithLink"; value: string; link: string; linkText: string };
 
 export interface Plugin<
   T extends PluginArgs,

--- a/front/scripts/dev/create_test_workspaces.ts
+++ b/front/scripts/dev/create_test_workspaces.ts
@@ -1,9 +1,7 @@
-import { Authenticator } from "@app/lib/auth";
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
 import { Plan } from "@app/lib/models/plan";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { Logger } from "@app/logger/logger";
 import { createAndLogMembership } from "@app/pages/api/login";
@@ -61,6 +59,8 @@ async function createTestWorkspaces(
       name: name,
       isVerified: true,
       isBusiness: false,
+      planCode: FREE_UPGRADED_PLAN_CODE,
+      endDate: null,
     });
 
     logger.info(`Workspace ${name} created.`);
@@ -69,17 +69,6 @@ async function createTestWorkspaces(
       user,
       workspace,
       role: "admin",
-    });
-
-    const authenticator = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-
-    await SubscriptionResource.pokeUpgradeWorkspaceToPlan({
-      auth: authenticator,
-      planCode: FREE_UPGRADED_PLAN_CODE,
-      endDate: null,
     });
   }
 }


### PR DESCRIPTION
## Description

This PR updates the poké create workspace plugin to allow setting a plan code and an end date. 
It was not straightforward to add a field to select among plans so as a start GTM team will have to copy paste the plan code. I also added the direct link to the created workspace since GTM team told me "you create the workspace and then you have to find it). I know we displayed the sId but displaying the link will be easier. 

<img width="698" alt="Screenshot 2025-04-23 at 15 36 36" src="https://github.com/user-attachments/assets/33eb2f40-f506-4865-8ca8-198b68cbdb93" />

<img width="448" alt="Screenshot 2025-04-23 at 15 52 25" src="https://github.com/user-attachments/assets/518a6e48-e718-4e65-b752-c14126b97691" />



## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 