### PR TITLE
delete workspace workflows: bump some activities start to close timeut

### DIFF
--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -2,26 +2,30 @@ import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/poke/temporal/activities";
 
-// Create a single proxy with all activities
-const activityProxies = proxyActivities<typeof activities>({
+// Create a single proxy with all normal and long activities
+const normalActivityProxies = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minute",
+});
+const longActivityProxies = proxyActivities<typeof activities>({
+  startToCloseTimeout: "180 minute",
 });
 
 const {
   deleteAgentsActivity,
   deleteAppsActivity,
-  deleteConversationsActivity,
   deleteMembersActivity,
   deletePluginRunsActivity,
   deleteRunOnDustAppsActivity,
   deleteSpacesActivity,
   deleteTrackersActivity,
   deleteTranscriptsActivity,
-  deleteWorkspaceActivity,
   isWorkflowDeletableActivity,
   scrubDataSourceActivity,
   scrubSpaceActivity,
-} = activityProxies;
+} = normalActivityProxies;
+
+const { deleteConversationsActivity, deleteWorkspaceActivity } =
+  longActivityProxies;
 
 export async function scrubDataSourceWorkflow({
   dataSourceId,


### PR DESCRIPTION
## Description

Motivation: https://cloud.temporal.io/namespaces/dust-front-prod.gmnlm/workflows/poke-109a6a027a-delete-workspace/01965f7d-390f-77de-8cc4-2bf6e464804d/history


We now run pretty large workspace deletion due to relocations

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`