### PR TITLE
feat(MCP): add support for enums when defining tool inputs

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -141,8 +141,7 @@ const isUsableAsCapability = (
   if (!view) {
     return false;
   }
-  const requirements = getMCPServerRequirements(view);
-  return view.server.isDefault && requirements.noRequirement;
+  return view.server.isDefault && getMCPServerRequirements(view).noRequirement;
 };
 
 const isUsableInKnowledge = (

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -371,6 +371,11 @@ export function hasErrorActionMCP(
         return `Please fill in all required numeric fields.`;
       }
     }
+    for (const key in requirements.requiredEnums) {
+      if (!(key in action.configuration.additionalConfiguration)) {
+        return `Please fill in all required fields.`;
+      }
+    }
 
     return null;
   }

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -127,7 +127,7 @@ export function MCPAction({
           dataSourceConfigurations: null,
           tablesConfigurations: null,
           childAgentId: null,
-          // We initialize boolean with false by default.
+          // We initialize boolean with false because leaving them unset means false.
           additionalConfiguration: Object.fromEntries(
             requirements.requiredBooleans.map((key) => [key, false])
           ),

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -127,7 +127,7 @@ export function MCPAction({
           dataSourceConfigurations: null,
           tablesConfigurations: null,
           childAgentId: null,
-          // We initialize boolean with false because leaving them unset means false.
+          // We initialize boolean with false because leaving them unset means false (toggle on the left).
           additionalConfiguration: Object.fromEntries(
             requirements.requiredBooleans.map((key) => [key, false])
           ),

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -318,10 +318,7 @@ export function MCPAction({
         />
       )}
       <AdditionalConfigurationSection
-        requiredStrings={requirements.requiredStrings}
-        requiredNumbers={requirements.requiredNumbers}
-        requiredBooleans={requirements.requiredBooleans}
-        requiredEnums={requirements.requiredEnums}
+        {...requirements}
         additionalConfiguration={actionConfiguration.additionalConfiguration}
         onConfigUpdate={handleAdditionalConfigUpdate}
       />

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -347,13 +347,13 @@ export function hasErrorActionMCP(
       requirements.requiresDataSourceConfiguration &&
       !action.configuration.dataSourceConfigurations
     ) {
-      return "Please select data source(s).";
+      return "Please select one or multiple data sources.";
     }
     if (
       requirements.requiresTableConfiguration &&
       !action.configuration.tablesConfigurations
     ) {
-      return "Please select table(s).";
+      return "Please select one or multiple tables.";
     }
     if (
       requirements.requiresChildAgentConfiguration &&
@@ -361,20 +361,24 @@ export function hasErrorActionMCP(
     ) {
       return "Please select a child agent.";
     }
-    for (const key in requirements.requiredStrings) {
+    const missingFields = [];
+    for (const key of requirements.requiredStrings) {
       if (!(key in action.configuration.additionalConfiguration)) {
-        return `Please fill in all fields.`;
+        missingFields.push(key);
       }
     }
-    for (const key in requirements.requiredNumbers) {
+    for (const key of requirements.requiredNumbers) {
       if (!(key in action.configuration.additionalConfiguration)) {
-        return `Please fill in all required numeric fields.`;
+        missingFields.push(key);
       }
     }
     for (const key in requirements.requiredEnums) {
       if (!(key in action.configuration.additionalConfiguration)) {
-        return `Please fill in all required fields.`;
+        missingFields.push(key);
       }
+    }
+    if (missingFields.length > 0) {
+      return `Some fields are missing: ${missingFields.map(asDisplayName).join(", ")}.`;
     }
 
     return null;

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -321,6 +321,7 @@ export function MCPAction({
         requiredStrings={requirements.requiredStrings}
         requiredNumbers={requirements.requiredNumbers}
         requiredBooleans={requirements.requiredBooleans}
+        requiredEnums={requirements.requiredEnums}
         additionalConfiguration={actionConfiguration.additionalConfiguration}
         onConfigUpdate={handleAdditionalConfigUpdate}
       />

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -19,7 +19,7 @@ import type {
   LightWorkspaceType,
   SpaceType,
 } from "@app/types";
-import { assertNever, slugify } from "@app/types";
+import { asDisplayName, assertNever, slugify } from "@app/types";
 
 interface NoActionAvailableProps {
   owner: LightWorkspaceType;

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -127,8 +127,10 @@ export function MCPAction({
           dataSourceConfigurations: null,
           tablesConfigurations: null,
           childAgentId: null,
-          // We initialize with the default values for required booleans since these can be left unset.
-          additionalConfiguration: requirements.requiredBooleans,
+          // We initialize boolean with false by default.
+          additionalConfiguration: Object.fromEntries(
+            requirements.requiredBooleans.map((key) => [key, false])
+          ),
         }),
       });
     },

--- a/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
@@ -285,7 +285,6 @@ export const AdditionalConfigurationSection: React.FC<
     () => groupKeysByPrefix(requiredBooleans),
     [requiredBooleans]
   );
-  // Group enums by prefix, preserving the key-value structure.
   const groupedEnumsByPrefix = useMemo(() => {
     const groups: Record<string, Record<string, string[]>> = {};
     Object.entries(requiredEnums).forEach(([key, values]) => {
@@ -305,7 +304,6 @@ export const AdditionalConfigurationSection: React.FC<
     Object.keys(groupedStrings).forEach((prefix) => prefixSet.add(prefix));
     Object.keys(groupedNumbers).forEach((prefix) => prefixSet.add(prefix));
     Object.keys(groupedBooleans).forEach((prefix) => prefixSet.add(prefix));
-    // Use prefixes from the correctly grouped enums.
     Object.keys(groupedEnumsByPrefix).forEach((prefix) =>
       prefixSet.add(prefix)
     );
@@ -317,7 +315,7 @@ export const AdditionalConfigurationSection: React.FC<
     Object.keys(requiredStrings).length > 0 ||
     Object.keys(requiredNumbers).length > 0 ||
     Object.keys(requiredBooleans).length > 0 ||
-    Object.keys(requiredEnums).length > 0; // Also consider enums
+    Object.keys(requiredEnums).length > 0;
 
   if (!hasConfiguration) {
     return null;
@@ -342,7 +340,6 @@ export const AdditionalConfigurationSection: React.FC<
           requiredStrings={groupedStrings[prefix] || []}
           requiredNumbers={groupedNumbers[prefix] || []}
           requiredBooleans={groupedBooleans[prefix] || []}
-          // Pass the correctly filtered enum group.
           requiredEnums={groupedEnumsByPrefix[prefix] || {}}
           additionalConfiguration={additionalConfiguration}
           onConfigUpdate={onConfigUpdate}

--- a/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
@@ -13,24 +13,22 @@ function getKeyPrefix(key: string): string {
   return segments.length > 1 ? segments[0] : "";
 }
 
-function groupKeysByPrefix<T extends string | number | boolean | null>(
-  keys: Record<string, T>
-): Record<string, Record<string, T>> {
-  const groups: Record<string, Record<string, T>> = {};
+function groupKeysByPrefix(keys: string[]): Record<string, string[]> {
+  const groups: Record<string, string[]> = {};
 
-  Object.entries(keys).forEach(([key, value]) => {
+  keys.forEach((key) => {
     const prefix = getKeyPrefix(key);
     if (!groups[prefix]) {
-      groups[prefix] = {};
+      groups[prefix] = [];
     }
-    groups[prefix][key] = value;
+    groups[prefix].push(key);
   });
 
   return groups;
 }
 
 interface BooleanConfigurationSectionProps {
-  requiredBooleans: Record<string, boolean>;
+  requiredBooleans: string[];
   additionalConfiguration: Record<string, string | number | boolean>;
   onConfigUpdate: (key: string, value: boolean) => void;
 }
@@ -40,12 +38,14 @@ function BooleanConfigurationSection({
   additionalConfiguration,
   onConfigUpdate,
 }: BooleanConfigurationSectionProps) {
-  if (Object.keys(requiredBooleans).length === 0) {
+  if (requiredBooleans.length === 0) {
     return null;
   }
 
-  return Object.entries(requiredBooleans).map(([key, defaultValue]) => {
-    const value = (additionalConfiguration[key] as boolean) ?? defaultValue;
+  return requiredBooleans.map((key) => {
+    // Ugly hack but the type of additionalConfiguration is highly dynamic.
+    // We make sure to save a boolean value that said.
+    const value = !!additionalConfiguration[key];
     return (
       <div key={key} className="mb-2 flex items-center gap-1">
         <Label htmlFor={`boolean-${key}`} className="w-1/5 text-sm font-medium">
@@ -64,7 +64,7 @@ function BooleanConfigurationSection({
 }
 
 interface NumberConfigurationSectionProps {
-  requiredNumbers: Record<string, number | null>;
+  requiredNumbers: string[];
   additionalConfiguration: Record<string, string | number | boolean>;
   onConfigUpdate: (key: string, value: number) => void;
 }
@@ -74,12 +74,12 @@ function NumberConfigurationSection({
   additionalConfiguration,
   onConfigUpdate,
 }: NumberConfigurationSectionProps) {
-  if (Object.keys(requiredNumbers).length === 0) {
+  if (requiredNumbers.length === 0) {
     return null;
   }
 
-  return Object.entries(requiredNumbers).map(([key, defaultValue]) => {
-    const value = additionalConfiguration[key] ?? defaultValue;
+  return requiredNumbers.map((key) => {
+    const value = additionalConfiguration[key] ?? null;
     return (
       <div key={key} className="mb-2 flex items-center gap-1">
         <Label htmlFor={`number-${key}`} className="w-1/5 text-sm font-medium">
@@ -103,7 +103,7 @@ function NumberConfigurationSection({
 }
 
 interface StringConfigurationSectionProps {
-  requiredStrings: Record<string, string>;
+  requiredStrings: string[];
   additionalConfiguration: Record<string, string | number | boolean>;
   onConfigUpdate: (key: string, value: string) => void;
 }
@@ -113,12 +113,12 @@ function StringConfigurationSection({
   additionalConfiguration,
   onConfigUpdate,
 }: StringConfigurationSectionProps) {
-  if (Object.keys(requiredStrings).length === 0) {
+  if (requiredStrings.length === 0) {
     return null;
   }
 
-  return Object.entries(requiredStrings).map(([key, defaultValue]) => {
-    const value = additionalConfiguration[key] ?? defaultValue;
+  return requiredStrings.map((key) => {
+    const value = additionalConfiguration[key] ?? "";
     return (
       <div key={key} className="mb-2 flex items-center gap-1">
         <Label htmlFor={`string-${key}`} className="w-1/5 text-sm font-medium">
@@ -138,9 +138,9 @@ function StringConfigurationSection({
 
 interface GroupedConfigurationSectionProps {
   prefix: string;
-  requiredStrings: Record<string, string>;
-  requiredNumbers: Record<string, number | null>;
-  requiredBooleans: Record<string, boolean>;
+  requiredStrings: string[];
+  requiredNumbers: string[];
+  requiredBooleans: string[];
   additionalConfiguration: Record<string, string | number | boolean>;
   onConfigUpdate: (key: string, value: string | number | boolean) => void;
 }
@@ -191,9 +191,9 @@ function GroupedConfigurationSection({
 }
 
 interface AdditionalConfigurationSectionProps {
-  requiredStrings: Record<string, string>;
-  requiredNumbers: Record<string, number | null>;
-  requiredBooleans: Record<string, boolean>;
+  requiredStrings: string[];
+  requiredNumbers: string[];
+  requiredBooleans: string[];
   additionalConfiguration: Record<string, string | number | boolean>;
   onConfigUpdate: (key: string, value: string | number | boolean) => void;
 }
@@ -257,9 +257,9 @@ export const AdditionalConfigurationSection: React.FC<
         <GroupedConfigurationSection
           key={prefix || "general"}
           prefix={prefix}
-          requiredStrings={groupedStrings[prefix] || {}}
-          requiredNumbers={groupedNumbers[prefix] || {}}
-          requiredBooleans={groupedBooleans[prefix] || {}}
+          requiredStrings={groupedStrings[prefix] || []}
+          requiredNumbers={groupedNumbers[prefix] || []}
+          requiredBooleans={groupedBooleans[prefix] || []}
           additionalConfiguration={additionalConfiguration}
           onConfigUpdate={onConfigUpdate}
         />

--- a/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
@@ -285,7 +285,7 @@ export const AdditionalConfigurationSection: React.FC<
     () => groupKeysByPrefix(requiredBooleans),
     [requiredBooleans]
   );
-  const groupedEnumsByPrefix = useMemo(() => {
+  const groupedEnums = useMemo(() => {
     const groups: Record<string, Record<string, string[]>> = {};
     Object.entries(requiredEnums).forEach(([key, values]) => {
       const prefix = getKeyPrefix(key);
@@ -304,12 +304,10 @@ export const AdditionalConfigurationSection: React.FC<
     Object.keys(groupedStrings).forEach((prefix) => prefixSet.add(prefix));
     Object.keys(groupedNumbers).forEach((prefix) => prefixSet.add(prefix));
     Object.keys(groupedBooleans).forEach((prefix) => prefixSet.add(prefix));
-    Object.keys(groupedEnumsByPrefix).forEach((prefix) =>
-      prefixSet.add(prefix)
-    );
+    Object.keys(groupedEnums).forEach((prefix) => prefixSet.add(prefix));
 
     return Array.from(prefixSet).sort();
-  }, [groupedStrings, groupedNumbers, groupedBooleans, groupedEnumsByPrefix]);
+  }, [groupedStrings, groupedNumbers, groupedBooleans, groupedEnums]);
 
   const hasConfiguration =
     Object.keys(requiredStrings).length > 0 ||
@@ -340,7 +338,7 @@ export const AdditionalConfigurationSection: React.FC<
           requiredStrings={groupedStrings[prefix] || []}
           requiredNumbers={groupedNumbers[prefix] || []}
           requiredBooleans={groupedBooleans[prefix] || []}
-          requiredEnums={groupedEnumsByPrefix[prefix] || {}}
+          requiredEnums={groupedEnums[prefix] || {}}
           additionalConfiguration={additionalConfiguration}
           onConfigUpdate={onConfigUpdate}
         />

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1,7 +1,4 @@
-import {
-  ConfigurableToolInputJSONSchemas,
-  INTERNAL_MIME_TYPES,
-} from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import assert from "assert";
 import type { JSONSchema7 } from "json-schema";
@@ -318,17 +315,13 @@ export async function tryListMCPTools(
         const hasDataSourceConfiguration =
           findMatchingSchemaKeys(
             toolConfigurations[0].inputSchema,
-            ConfigurableToolInputJSONSchemas[
-              INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-            ]
+            INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
           ).length > 0;
 
         const hasTableConfiguration =
           findMatchingSchemaKeys(
             toolConfigurations[0].inputSchema,
-            ConfigurableToolInputJSONSchemas[
-              INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
-            ]
+            INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
           ).length > 0;
 
         if (hasDataSourceConfiguration && hasTableConfiguration) {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -55,7 +55,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import { findMatchingSchemaKeys } from "@app/lib/utils/json_schemas";
+import { findMatchingSubSchemas } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { assertNever, Err, normalizeError, Ok, slugify } from "@app/types";
@@ -313,15 +313,19 @@ export async function tryListMCPTools(
       // Only do it when there is a single tool configuration as we only have one description to add.
       if (toolConfigurations.length === 1 && action.description) {
         const hasDataSourceConfiguration =
-          findMatchingSchemaKeys(
-            toolConfigurations[0].inputSchema,
-            INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+          Object.keys(
+            findMatchingSubSchemas(
+              toolConfigurations[0].inputSchema,
+              INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+            )
           ).length > 0;
 
         const hasTableConfiguration =
-          findMatchingSchemaKeys(
-            toolConfigurations[0].inputSchema,
-            INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
+          Object.keys(
+            findMatchingSubSchemas(
+              toolConfigurations[0].inputSchema,
+              INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
+            )
           ).length > 0;
 
         if (hasDataSourceConfiguration && hasTableConfiguration) {

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -23,7 +23,7 @@ import {
   findSchemaAtPath,
   followInternalRef,
   isJSONSchemaObject,
-  schemaMatchesMimeType,
+  schemaIsConfigurable,
   setValueAtPath,
 } from "@app/lib/utils/json_schemas";
 import type { WorkspaceType } from "@app/types";
@@ -222,12 +222,12 @@ export function hideInternalConfiguration(inputSchema: JSONSchema): JSONSchema {
       if (isJSONSchemaObject(property)) {
         for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
           // Check if the property matches the schema, following references if $ref points to a schema internally.
-          let schemasMatch = schemaMatchesMimeType(property, mimeType);
+          let schemasMatch = schemaIsConfigurable(property, mimeType);
 
           if (!schemasMatch && property.$ref) {
             const refSchema = followInternalRef(inputSchema, property.$ref);
             if (refSchema) {
-              schemasMatch = schemaMatchesMimeType(refSchema, mimeType);
+              schemasMatch = schemaIsConfigurable(refSchema, mimeType);
             }
           }
 
@@ -338,7 +338,7 @@ export function augmentInputsWithConfiguration({
       // If we found a schema and it has a matching MIME type, inject the value
       if (propSchema) {
         for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
-          if (schemaMatchesMimeType(propSchema, mimeType)) {
+          if (schemaIsConfigurable(propSchema, mimeType)) {
             // We found a matching mimeType, augment the inputs
             setValueAtPath(
               inputs,

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -68,7 +68,7 @@ export const ConfigurableToolInputSchemas = {
   // for instance the ENUM mime type is flexible and the exact content of the enum is dynamic.
 } as const satisfies Partial<Record<InternalToolInputMimeType, z.ZodType>>;
 
-// Type for the tool inputs that have a flexible schema, which are schemas that are fully defined by the tool.
+// Type for the tool inputs that have a flexible schema, which are schemas that can vary between tools.
 type FlexibleConfigurableToolInput = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM]: {
     value: string | number | boolean;

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -68,7 +68,7 @@ export const ConfigurableToolInputSchemas = {
   // for instance the ENUM mime type is flexible and the exact content of the enum is dynamic.
 } as const satisfies Partial<Record<InternalToolInputMimeType, z.ZodType>>;
 
-// Type for the tool inputs that have a flexible schema.
+// Type for the tool inputs that have a flexible schema, which are schemas that are fully defined by the tool.
 type FlexibleConfigurableToolInput = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM]: {
     value: string | number | boolean;

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -443,7 +443,8 @@ export function getMCPServerRequirements(
       }
       return [
         key,
-        valueProperty.enum?.filter((v) => typeof v === "string") ?? [],
+        valueProperty.enum?.filter((v): v is string => typeof v === "string") ??
+          [],
       ];
     })
   );

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -375,33 +375,39 @@ export function getMCPServerRequirements(
     };
   }
   const { server } = mcpServerView;
+
   const requiresDataSourceConfiguration =
     findPathsToConfiguration({
       mcpServer: server,
       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
     }).length > 0;
+
   const requiresTableConfiguration =
     findPathsToConfiguration({
       mcpServer: server,
       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
     }).length > 0;
+
   const requiresChildAgentConfiguration =
     findPathsToConfiguration({
       mcpServer: server,
       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT,
     }).length > 0;
+
   const requiredStrings = Object.fromEntries(
     findPathsToConfiguration({
       mcpServer: server,
       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
     }).map((path) => [path, ""])
   );
+
   const requiredNumbers = Object.fromEntries(
     findPathsToConfiguration({
       mcpServer: server,
       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
     }).map((path) => [path, null])
   );
+
   const requiredBooleans = Object.fromEntries(
     findPathsToConfiguration({
       mcpServer: server,

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -71,7 +71,7 @@ export const ConfigurableToolInputSchemas = {
 // Type for the tool inputs that have a flexible schema, which are schemas that can vary between tools.
 type FlexibleConfigurableToolInput = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM]: {
-    value: string | number | boolean;
+    value: string;
     mimeType: typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM;
   };
 };
@@ -173,6 +173,11 @@ export function generateConfiguredInput({
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM: {
       const value = actionConfiguration.additionalConfiguration[keyPath];
+      if (typeof value !== "string") {
+        throw new Error(
+          `Expected string value for key ${keyPath}, got ${typeof value}`
+        );
+      }
       return { value, mimeType };
     }
 

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -358,9 +358,9 @@ export function getMCPServerRequirements(
   requiresDataSourceConfiguration: boolean;
   requiresTableConfiguration: boolean;
   requiresChildAgentConfiguration: boolean;
-  requiredStrings: Record<string, string>;
-  requiredNumbers: Record<string, number | null>;
-  requiredBooleans: Record<string, boolean>;
+  requiredStrings: string[];
+  requiredNumbers: string[];
+  requiredBooleans: string[];
   noRequirement: boolean;
 } {
   if (!mcpServerView) {
@@ -368,9 +368,9 @@ export function getMCPServerRequirements(
       requiresDataSourceConfiguration: false,
       requiresTableConfiguration: false,
       requiresChildAgentConfiguration: false,
-      requiredStrings: {},
-      requiredNumbers: {},
-      requiredBooleans: {},
+      requiredStrings: [],
+      requiredNumbers: [],
+      requiredBooleans: [],
       noRequirement: false,
     };
   }
@@ -394,26 +394,20 @@ export function getMCPServerRequirements(
       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT,
     }).length > 0;
 
-  const requiredStrings = Object.fromEntries(
-    findPathsToConfiguration({
-      mcpServer: server,
-      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
-    }).map((path) => [path, ""])
-  );
+  const requiredStrings = findPathsToConfiguration({
+    mcpServer: server,
+    mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+  });
 
-  const requiredNumbers = Object.fromEntries(
-    findPathsToConfiguration({
-      mcpServer: server,
-      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
-    }).map((path) => [path, null])
-  );
+  const requiredNumbers = findPathsToConfiguration({
+    mcpServer: server,
+    mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
+  });
 
-  const requiredBooleans = Object.fromEntries(
-    findPathsToConfiguration({
-      mcpServer: server,
-      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
-    }).map((path) => [path, false])
-  );
+  const requiredBooleans = findPathsToConfiguration({
+    mcpServer: server,
+    mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+  });
 
   return {
     requiresDataSourceConfiguration,
@@ -427,8 +421,8 @@ export function getMCPServerRequirements(
       !requiresDataSourceConfiguration &&
       !requiresTableConfiguration &&
       !requiresChildAgentConfiguration &&
-      Object.keys(requiredStrings).length === 0 &&
-      Object.keys(requiredNumbers).length === 0 &&
-      Object.keys(requiredBooleans).length === 0,
+      requiredStrings.length === 0 &&
+      requiredNumbers.length === 0 &&
+      requiredBooleans.length === 0,
   };
 }

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -36,6 +36,10 @@ function createServer(): McpServer {
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING],
       enabled:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN],
+      category: z.object({
+        value: z.enum(["A", "B", "C"]),
+        mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM),
+      }),
     },
     async (params) => {
       return {

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -1,7 +1,4 @@
-import {
-  ConfigurableToolInputJSONSchemas,
-  INTERNAL_MIME_TYPES,
-} from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 import type { BrowseConfigurationType } from "@app/lib/actions/browse";
 import type {
@@ -140,9 +137,7 @@ export function isMCPActionWithDataSource(
     return (
       findMatchingSchemaKeys(
         arg.inputSchema,
-        ConfigurableToolInputJSONSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ]
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
       ).length > 0
     );
   }

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -25,9 +25,9 @@ import type {
   WebsearchActionType,
   WebsearchConfigurationType,
 } from "@app/lib/actions/websearch";
-import { findMatchingSchemaKeys } from "@app/lib/utils/json_schemas";
-import type { AgentActionType } from "@app/types";
+import { findMatchingSubSchemas } from "@app/lib/utils/json_schemas";
 import type {
+  AgentActionType,
   AgentConfigurationType,
   TemplateAgentConfigurationType,
 } from "@app/types";
@@ -135,9 +135,11 @@ export function isMCPActionWithDataSource(
 ): arg is MCPToolConfigurationType {
   if (isMCPActionConfiguration(arg)) {
     return (
-      findMatchingSchemaKeys(
-        arg.inputSchema,
-        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+      Object.keys(
+        findMatchingSubSchemas(
+          arg.inputSchema,
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+        )
       ).length > 0
     );
   }

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -2,7 +2,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { describe, expect, it } from "vitest";
 
-import { findMatchingSchemaKeys } from "./json_schemas";
+import { findMatchingSubSchemas } from "./json_schemas";
 
 describe("JSON Schema Utilities", () => {
   describe("findMatchingSchemaKeys", () => {
@@ -90,7 +90,7 @@ describe("JSON Schema Utilities", () => {
       };
 
       // Look for STRING configuration schema
-      const result = findMatchingSchemaKeys(
+      const result = findMatchingSubSchemas(
         mainSchema,
         INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
       );
@@ -159,7 +159,7 @@ describe("JSON Schema Utilities", () => {
       };
 
       // Look for TABLE configuration schema
-      const result = findMatchingSchemaKeys(
+      const result = findMatchingSubSchemas(
         mainSchema,
         INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
       );
@@ -211,7 +211,7 @@ describe("JSON Schema Utilities", () => {
       };
 
       // Look for CHILD_AGENT configuration schema
-      const result = findMatchingSchemaKeys(
+      const result = findMatchingSubSchemas(
         mainSchema,
         INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT
       );

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -94,7 +94,7 @@ describe("JSON Schema Utilities", () => {
         mainSchema,
         INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
       );
-      expect(result).toContain("config.userPreferences.theme");
+      expect(Object.keys(result)).toContain("config.userPreferences.theme");
     });
 
     it("should return array item keys when array items match the target schema", () => {
@@ -163,7 +163,9 @@ describe("JSON Schema Utilities", () => {
         mainSchema,
         INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
       );
-      expect(result).toContain("dataSourceConfigs.items.settings.tables");
+      expect(Object.keys(result)).toContain(
+        "dataSourceConfigs.items.settings.tables"
+      );
     });
 
     it("should handle complex nested schemas with CHILD_AGENT configuration", () => {
@@ -215,7 +217,9 @@ describe("JSON Schema Utilities", () => {
         mainSchema,
         INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT
       );
-      expect(result).toContain("workflow.steps.items.action.executor");
+      expect(Object.keys(result)).toContain(
+        "workflow.steps.items.action.executor"
+      );
     });
   });
 });

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -1,7 +1,4 @@
-import {
-  ConfigurableToolInputJSONSchemas,
-  INTERNAL_MIME_TYPES,
-} from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { describe, expect, it } from "vitest";
 
@@ -93,10 +90,10 @@ describe("JSON Schema Utilities", () => {
       };
 
       // Look for STRING configuration schema
-      const targetSchema =
-        ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING];
-
-      const result = findMatchingSchemaKeys(mainSchema, targetSchema);
+      const result = findMatchingSchemaKeys(
+        mainSchema,
+        INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
+      );
       expect(result).toContain("config.userPreferences.theme");
     });
 
@@ -162,10 +159,10 @@ describe("JSON Schema Utilities", () => {
       };
 
       // Look for TABLE configuration schema
-      const targetSchema =
-        ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE];
-
-      const result = findMatchingSchemaKeys(mainSchema, targetSchema);
+      const result = findMatchingSchemaKeys(
+        mainSchema,
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
+      );
       expect(result).toContain("dataSourceConfigs.items.settings.tables");
     });
 
@@ -214,12 +211,10 @@ describe("JSON Schema Utilities", () => {
       };
 
       // Look for CHILD_AGENT configuration schema
-      const targetSchema =
-        ConfigurableToolInputJSONSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT
-        ];
-
-      const result = findMatchingSchemaKeys(mainSchema, targetSchema);
+      const result = findMatchingSchemaKeys(
+        mainSchema,
+        INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT
+      );
       expect(result).toContain("workflow.steps.items.action.executor");
     });
   });

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -23,8 +23,10 @@ export function schemaMatchesMimeType(
   schema: JSONSchema,
   mimeType: InternalToolInputMimeType
 ): boolean {
-  if (ConfigurableToolInputJSONSchemas[mimeType]) {
-    return schemasAreEqual(schema, ConfigurableToolInputJSONSchemas[mimeType]);
+  // If the mime type is in the ConfigurableToolInputJSONSchemas, we check that the schema matches the fixed schema.
+  const fixedSchema = ConfigurableToolInputJSONSchemas[mimeType];
+  if (fixedSchema) {
+    return schemasAreEqual(schema, fixedSchema);
   }
   // If the mime type is not in the ConfigurableToolInputJSONSchemas, it is a flexible mime type.
   // We only check that the schema has a mimeType property with the correct value.

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -214,6 +214,7 @@ const TOOL_MIME_TYPES = {
       "STRING",
       "NUMBER",
       "BOOLEAN",
+      "ENUM",
     ],
   }),
   TOOL_OUTPUT: generateToolMimeTypes({

--- a/sdks/js/src/tool_input_schemas.ts
+++ b/sdks/js/src/tool_input_schemas.ts
@@ -52,7 +52,7 @@ export const ConfigurableToolInputSchemas = {
   // for instance the ENUM mime type is flexible and the exact content of the enum is dynamic.
 } as const satisfies Partial<Record<InternalToolInputMimeType, z.ZodType>>;
 
-// Type for the tool inputs that have a flexible schema.
+// Type for the tool inputs that have a flexible schema, which are schemas that are fully defined by the tool.
 type FlexibleConfigurableToolInput = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM]: {
     value: string | number | boolean;

--- a/sdks/js/src/tool_input_schemas.ts
+++ b/sdks/js/src/tool_input_schemas.ts
@@ -17,6 +17,7 @@ export const CHILD_AGENT_CONFIGURATION_URI_PATTERN =
 
 /**
  * Mapping between the mime types we used to identify a configurable resource and the Zod schema used to validate it.
+ * Not all mime types have a fixed schema, for instance the ENUM mime type is flexible.
  */
 export const ConfigurableToolInputSchemas = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE]: z.array(
@@ -47,10 +48,26 @@ export const ConfigurableToolInputSchemas = {
     value: z.boolean(),
     mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN),
   }),
-} as const satisfies Record<InternalToolInputMimeType, z.ZodType>;
+  // Partial because all mime types do not necessarily have a fixed schema,
+  // for instance the ENUM mime type is flexible and the exact content of the enum is dynamic.
+} as const satisfies Partial<Record<InternalToolInputMimeType, z.ZodType>>;
 
-export type ConfigurableToolInputType = z.infer<
-  (typeof ConfigurableToolInputSchemas)[InternalToolInputMimeType]
+// Type for the tool inputs that have a flexible schema.
+type FlexibleConfigurableToolInput = {
+  [INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM]: {
+    value: string | number | boolean;
+    mimeType: typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM;
+  };
+};
+
+export type ConfigurableToolInputType =
+  | z.infer<
+      (typeof ConfigurableToolInputSchemas)[keyof typeof ConfigurableToolInputSchemas]
+    >
+  | FlexibleConfigurableToolInput[keyof FlexibleConfigurableToolInput];
+
+export type DataSourcesToolConfigurationType = z.infer<
+  (typeof ConfigurableToolInputSchemas)[typeof INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE]
 >;
 
 /**
@@ -62,4 +79,4 @@ export const ConfigurableToolInputJSONSchemas = Object.fromEntries(
     key,
     zodToJsonSchema(schema),
   ])
-) as Record<InternalToolInputMimeType, JSONSchema>;
+) as Partial<Record<InternalToolInputMimeType, JSONSchema>>;

--- a/sdks/js/src/tool_input_schemas.ts
+++ b/sdks/js/src/tool_input_schemas.ts
@@ -52,7 +52,7 @@ export const ConfigurableToolInputSchemas = {
   // for instance the ENUM mime type is flexible and the exact content of the enum is dynamic.
 } as const satisfies Partial<Record<InternalToolInputMimeType, z.ZodType>>;
 
-// Type for the tool inputs that have a flexible schema, which are schemas that are fully defined by the tool.
+// Type for the tool inputs that have a flexible schema, which are schemas that can vary between tools.
 type FlexibleConfigurableToolInput = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM]: {
     value: string | number | boolean;


### PR DESCRIPTION
## Description

- Add support for adding an enum in the input of a tool and making it configurable.
This differs from currently configurable inputs because the zod schema depends on the tool here and cannot be defined once for all.
- Extend the features of the current JSONSchema parser to additionally extract the values of the enum from the schema.
- Improve the error messages on configuration save.

## Tests

- Tested locally.

## Risk

- Blast radius mostly contained to Assistant Builder.

## Deploy Plan

- Deploy front.