### PR TITLE
[front] mcp(remote): fix view creation error

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -24,7 +24,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
 import { destroyMCPServerViewDependencies } from "@app/lib/models/assistant/actions/mcp_server_view_helper";
-import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
@@ -68,7 +67,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   private async init(auth: Authenticator): Promise<Result<void, DustError>> {
     if (this.remoteMCPServerId) {
-      const remoteServer = await RemoteMCPServerResource.findByPk(auth, this.remoteMCPServerId);
+      const remoteServer = await RemoteMCPServerResource.findByPk(
+        auth,
+        this.remoteMCPServerId
+      );
       if (!remoteServer) {
         return new Err(
           new DustError(
@@ -591,9 +593,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           : this.getInternalMCPServerResource().toJSON(),
       editedByUser: this.makeEditedBy(
         this.editedByUser,
-        this.remoteMCPServer
-          ? this.remoteMCPServer.updatedAt
-          : this.updatedAt
+        this.remoteMCPServer ? this.remoteMCPServer.updatedAt : this.updatedAt
       ),
     };
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

A bug was introduced in https://github.com/dust-tt/dust/pull/12101, leading to having an error when creating an MCP Server. The MCP servers are not automatically added to the global space / you have to reload the page to update the server list state.

This is rolling back the changes about remote servers from the above PR.
A better fix will come when found.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, no error when creating a server.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
