### PR TITLE
[front] mcp(remote): enable shared secret for remote servers

### DIFF
--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -2,17 +2,23 @@ import {
   ActionBookOpenIcon,
   ActionIcons,
   Button,
+  ClipboardCheckIcon,
+  ClipboardIcon,
   CloudArrowLeftRightIcon,
   ContentMessage,
   ExclamationCircleIcon,
+  ExternalLinkIcon,
+  EyeIcon,
+  EyeSlashIcon,
   IconPicker,
   Input,
   Label,
+  LinkWrapper,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
   Separator,
-  // useCopyToClipboard,
+  useCopyToClipboard,
   useSendNotification,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -29,6 +35,7 @@ import {
 } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types";
 import { asDisplayName } from "@app/types";
+import { formatSecret } from "@app/lib/utils";
 
 interface RemoteMCPFormProps {
   owner: LightWorkspaceType;
@@ -50,8 +57,8 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
   const [syncError, setSyncError] = useState<string | null>(null);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  // const [isSecretVisible, setIsSecretVisible] = useState(false);
-  // const [isCopied, copy] = useCopyToClipboard();
+  const [isSecretVisible, setIsSecretVisible] = useState(false);
+  const [isCopied, copy] = useCopyToClipboard();
 
   const form = useForm<MCPFormType>({
     resolver: zodResolver(MCPFormSchema),
@@ -62,8 +69,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
     },
   });
 
-  const { url } = mcpServer;
-  // const { url, sharedSecret } = mcpServer;
+  const { url, sharedSecret } = mcpServer;
 
   const { mutateMCPServers } = useMCPServers({
     owner,
@@ -147,20 +153,20 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
     }
   }, [url, syncServer, mutateMCPServers, sendNotification]);
 
-  // const toggleSecretVisibility = () => {
-  //   setIsSecretVisible(!isSecretVisible);
-  // };
+  const toggleSecretVisibility = () => {
+    setIsSecretVisible(!isSecretVisible);
+  };
 
-  // const copyToClipboard = async () => {
-  //   if (sharedSecret) {
-  //     await copy(sharedSecret);
-  //     sendNotification({
-  //       title: "Copied to clipboard",
-  //       type: "success",
-  //       description: "The shared secret has been copied to your clipboard.",
-  //     });
-  //   }
-  // };
+  const copyToClipboard = async () => {
+    if (sharedSecret) {
+      await copy(sharedSecret);
+      sendNotification({
+        title: "Copied to clipboard",
+        type: "success",
+        description: "The shared secret has been copied to your clipboard.",
+      });
+    }
+  };
 
   const closePopover = () => {
     setIsPopoverOpen(false);
@@ -318,12 +324,18 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
 
       <Separator />
 
-      {/**
-       * TODO(mcp): Show shared secret in the UI.
-       * Shared secret will be added back in the future.
-       * As they are not used right now, they are confusing in the UI.
-       * Will be moved to an "Advanced" section.
-      
+      <div className="heading-lg">Advanced</div>
+      <p>
+          For more details on the advanced settings, please refer to the Dust{" "}
+          <LinkWrapper href="https://docs.dust.tt/docs/remote-mcp-server"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            documentation <ExternalLinkIcon className="inline" />
+          </LinkWrapper>
+          .
+        </p>
+      <div className="space-y-2">
        {sharedSecret && (
         <>
           <div className="space-y-2">
@@ -357,7 +369,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
           <Separator />
         </>
       )}
-      */}
+      </div>
     </div>
   );
 }

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -33,9 +33,9 @@ import {
   useSyncRemoteMCPServer,
   useUpdateRemoteMCPServer,
 } from "@app/lib/swr/mcp_servers";
+import { formatSecret } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types";
 import { asDisplayName } from "@app/types";
-import { formatSecret } from "@app/lib/utils";
 
 interface RemoteMCPFormProps {
   owner: LightWorkspaceType;
@@ -326,49 +326,50 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
 
       <div className="heading-lg">Advanced</div>
       <p>
-          For more details on the advanced settings, please refer to the Dust{" "}
-          <LinkWrapper href="https://docs.dust.tt/docs/remote-mcp-server"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            documentation <ExternalLinkIcon className="inline" />
-          </LinkWrapper>
-          .
-        </p>
+        For more details on the advanced settings, please refer to the Dust{" "}
+        <LinkWrapper
+          href="https://docs.dust.tt/docs/remote-mcp-server"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          documentation <ExternalLinkIcon className="inline" />
+        </LinkWrapper>
+        .
+      </p>
       <div className="space-y-2">
-       {sharedSecret && (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor="sharedSecret">Shared Secret</Label>
-            <div className="flex items-center justify-between">
-              <p className="overflow-hidden text-ellipsis whitespace-nowrap">
-                {isSecretVisible ? sharedSecret : formatSecret(sharedSecret)}
-              </p>
-              <div className="flex items-center gap-2">
-                <Button
-                  icon={isSecretVisible ? EyeSlashIcon : EyeIcon}
-                  variant="outline"
-                  size="sm"
-                  onClick={toggleSecretVisibility}
-                  tooltip={isSecretVisible ? "Hide secret" : "Show secret"}
-                />
-                <Button
-                  icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
-                  variant="outline"
-                  size="sm"
-                  onClick={copyToClipboard}
-                  tooltip={isCopied ? "Copied!" : "Copy to clipboard"}
-                />
+        {sharedSecret && (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="sharedSecret">Shared Secret</Label>
+              <div className="flex items-center justify-between">
+                <p className="overflow-hidden text-ellipsis whitespace-nowrap">
+                  {isSecretVisible ? sharedSecret : formatSecret(sharedSecret)}
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    icon={isSecretVisible ? EyeSlashIcon : EyeIcon}
+                    variant="outline"
+                    size="sm"
+                    onClick={toggleSecretVisibility}
+                    tooltip={isSecretVisible ? "Hide secret" : "Show secret"}
+                  />
+                  <Button
+                    icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+                    variant="outline"
+                    size="sm"
+                    onClick={copyToClipboard}
+                    tooltip={isCopied ? "Copied!" : "Copy to clipboard"}
+                  />
+                </div>
               </div>
+              <p className="text-xs text-gray-500">
+                This is the secret key used to authenticate your MCP server with
+                Dust. Keep it secure.
+              </p>
             </div>
-            <p className="text-xs text-gray-500">
-              This is the secret key used to authenticate your MCP server with
-              Dust. Keep it secure.
-            </p>
-          </div>
-          <Separator />
-        </>
-      )}
+            <Separator />
+          </>
+        )}
       </div>
     </div>
   );

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -148,6 +148,9 @@ export const connectToMCPServer = async (
                   ...(accessToken
                     ? { Authorization: `Bearer ${accessToken}` }
                     : {}),
+                  ...(remoteMCPServer.sharedSecret
+                    ? { "X-Dust-Secret": remoteMCPServer.sharedSecret }
+                    : {}),
                 },
               },
             };

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -28,6 +28,8 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types";
 import { Ok, redactString, removeNulls } from "@app/types";
 
+const SECRET_REDACTION_COOLDOWN_IN_MINUTES = 10;
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
 export interface RemoteMCPServerResource
@@ -284,7 +286,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     );
     const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
     const secret =
-      differenceInMinutes > 10
+      differenceInMinutes > SECRET_REDACTION_COOLDOWN_IN_MINUTES
         ? redactString(this.sharedSecret, 4)
         : this.sharedSecret;
 

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -26,7 +26,7 @@ import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types";
-import { Ok, removeNulls } from "@app/types";
+import { Ok, redactString, removeNulls } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -277,6 +277,17 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     lastSyncAt: number | null;
     sharedSecret: string;
   } {
+    const currentTime = new Date();
+    const createdAt = new Date(this.createdAt);
+    const timeDifference = Math.abs(
+      currentTime.getTime() - createdAt.getTime()
+    );
+    const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
+    const secret =
+      differenceInMinutes > 10
+        ? redactString(this.sharedSecret, 4)
+        : this.sharedSecret;
+
     return {
       id: this.sId,
 
@@ -295,7 +306,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       // Remote MCP Server specifics
       url: this.url,
       lastSyncAt: this.lastSyncAt?.getTime() ?? null,
-      sharedSecret: this.sharedSecret,
+      sharedSecret: secret,
     };
   }
 }

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -296,22 +296,6 @@ export function isArrayEqual2DUnordered(
   return isEqual(sort2D(first), sort2D(second));
 }
 
-/**
- * Format a secret by replacing the middle characters with dots.
- * @param key The secret to format.
- * @param visibleChars The number of characters to keep at the end.
- * @param dotCount The number of dots to replace the middle characters with.
- * @returns The formatted secret.
- */
-export function formatSecret(key?: string, visibleChars = 4, dotCount = 30) {
-  if (!key) {
-    return "";
-  }
-  const dots = "•".repeat(dotCount);
-  const end = key.slice(-visibleChars);
-  return `${dots}${end}`;
-}
-
 // from http://detectmobilebrowsers.com/
 export const isMobile = (navigator: Navigator) =>
   /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(

--- a/front/pages/w/[wId]/developers/providers.tsx
+++ b/front/pages/w/[wId]/developers/providers.tsx
@@ -23,8 +23,8 @@ import {
   serviceProviders,
 } from "@app/lib/providers";
 import { useProviders } from "@app/lib/swr/apps";
-import { formatSecret } from "@app/lib/utils";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
+import { redactString } from "@app/types";
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -205,7 +205,7 @@ function ProviderListItem({
           {apiKey && (
             <div className="flex items-center gap-1 font-mono text-xs text-muted-foreground dark:text-muted-foreground-night">
               <span className="shrink-0">API Key:</span>
-              <div className="max-w-72 truncate">{formatSecret(apiKey)}</div>
+              <div className="max-w-72 truncate">{redactString(apiKey, 4)}</div>
             </div>
           )}
         </div>

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -81,6 +81,10 @@ export function redactString(str: string, n: number) {
   return redacted;
 }
 
+export function isRedacted(str: string) {
+  return str.includes("•");
+}
+
 export function truncate(text: string, length: number, omission = "...") {
   return text.length > length
     ? `${text.substring(0, length - omission.length)}${omission}`


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR enables the shared secret feature for the remote MCP servers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, header is included.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks, behind ff.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front. Documentation is here https://docs.dust.tt/docs/remote-mcp-server#identify-dust-calls-on-your-remote-servers-shared-secret