### PR TITLE
[connectors] feat: Use firecrawl for webcrawler

### DIFF
--- a/connectors/migrations/db/migration_67.sql
+++ b/connectors/migrations/db/migration_67.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 24, 2025
+ALTER TABLE "public"."webcrawler_configurations" ADD COLUMN "customCrawler" VARCHAR(128) DEFAULT NULL;

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dust-tt/client": "file:../sdks/js",
         "@google-cloud/bigquery": "^7.9.2",
+        "@mendable/firecrawl-js": "^1.24.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.40.0",
         "@notionhq/client": "^2.2.15",
@@ -3081,6 +3082,20 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/@mendable/firecrawl-js": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-1.24.0.tgz",
+      "integrity": "sha512-UWcyeZm23OmfskRamaT0MERn6jAmVjFsDh9/FIuj4YmG8VCZw9FvLGEioXKhTAITZ8uCeGTGarcybF86txIpkA==",
+      "dependencies": {
+        "axios": "^1.6.8",
+        "typescript-event-target": "^1.1.1",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@microsoft/microsoft-graph-client": {
@@ -16036,6 +16051,11 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-event-target": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
+      "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg=="
+    },
     "node_modules/uhyphen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
@@ -17067,6 +17087,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/zwitch": {

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@dust-tt/client": "file:../sdks/js",
     "@google-cloud/bigquery": "^7.9.2",
+    "@mendable/firecrawl-js": "^1.24.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@microsoft/microsoft-graph-types": "^2.40.0",
     "@notionhq/client": "^2.2.15",

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -71,6 +71,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       crawlFrequency: configuration.crawlFrequency,
       lastCrawledAt: null,
       headers: configuration.headers,
+      customCrawler: configuration.customCrawler,
     };
 
     const connector = await ConnectorResource.makeNew(

--- a/connectors/src/connectors/webcrawler/lib/http.ts
+++ b/connectors/src/connectors/webcrawler/lib/http.ts
@@ -1,6 +1,4 @@
 import { GotScrapingHttpClient } from "@crawlee/core";
-import type { Result } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
 import type {
   HttpRequest,
   HttpResponse,
@@ -8,33 +6,8 @@ import type {
   ResponseTypes,
   StreamingHttpResponse,
 } from "crawlee";
-import { NonRetryableError } from "crawlee";
 
-import {
-  getIpAddressForUrl,
-  isPrivateIp,
-} from "@connectors/connectors/webcrawler/lib/utils";
-
-const MAX_REDIRECTS = 20;
-const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-
-export type WebCrawlerErrorName =
-  | "PRIVATE_IP"
-  | "NOT_IP_V4"
-  | "MAX_REDIRECTS"
-  | "REDIRECT_MISSING_LOCATION"
-  | "CIRCULAR_REDIRECT"
-  | "PROTOCOL_DOWNGRADE";
-
-export class WebCrawlerError extends NonRetryableError {
-  constructor(
-    message: string,
-    readonly type: WebCrawlerErrorName,
-    readonly originalError?: Error
-  ) {
-    super(message);
-  }
-}
+import { verifyRedirect } from "@connectors/connectors/webcrawler/lib/utils";
 
 export class DustHttpClient extends GotScrapingHttpClient {
   /**
@@ -43,7 +16,7 @@ export class DustHttpClient extends GotScrapingHttpClient {
   async sendRequest<TResponseType extends keyof ResponseTypes>(
     request: HttpRequest<TResponseType>
   ): Promise<HttpResponse<TResponseType>> {
-    const res = await this.verifyRedirect(request.url);
+    const res = await verifyRedirect(request.url);
 
     if (res.isErr()) {
       throw res.error;
@@ -63,7 +36,7 @@ export class DustHttpClient extends GotScrapingHttpClient {
     request: HttpRequest,
     handleRedirect?: RedirectHandler
   ): Promise<StreamingHttpResponse> {
-    const res = await this.verifyRedirect(request.url);
+    const res = await verifyRedirect(request.url);
 
     if (res.isErr()) {
       throw res.error;
@@ -77,133 +50,5 @@ export class DustHttpClient extends GotScrapingHttpClient {
       },
       handleRedirect
     );
-  }
-
-  /**
-   * Loop if needed on redirect location,
-   * throw a Result Err that would warrant
-   * a NonRetryableError. Otherwise return the last
-   * url that is not a redirect
-   */
-  async verifyRedirect(
-    initUrl: string | URL
-  ): Promise<Result<string | URL, WebCrawlerError>> {
-    let url = initUrl;
-    let foundEndOfRedirect = false;
-    let redirectCount = 0;
-    const visitedUrls = new Set<string>();
-
-    do {
-      // Fail fast if it get into a loop
-      if (visitedUrls.has(url.toString())) {
-        return new Err(
-          new WebCrawlerError(
-            "Invalid redirect: Circular redirect detected",
-            "CIRCULAR_REDIRECT"
-          )
-        );
-      }
-      visitedUrls.add(url.toString());
-
-      // Prevent infinite loops
-      if (redirectCount++ >= MAX_REDIRECTS) {
-        return new Err(
-          new WebCrawlerError(
-            "Maximum redirect count exceeded",
-            "MAX_REDIRECTS"
-          )
-        );
-      }
-
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 5000);
-
-      try {
-        const response = await fetch(url, {
-          method: "GET",
-          redirect: "manual",
-          signal: controller.signal,
-        });
-
-        clearTimeout(timeoutId);
-
-        if (REDIRECT_STATUSES.has(response.status)) {
-          const redirectUrl = response.headers
-            .get("location")
-            ?.trim()
-            .replace(/[\r\n\t]/g, ""); // Sanitize location, avoid header injection
-          if (!redirectUrl) {
-            // Server returned a redirect status without Location header
-            return new Err(
-              new WebCrawlerError(
-                `Invalid redirect: Missing Location header for status ${response.status}`,
-                "REDIRECT_MISSING_LOCATION"
-              )
-            );
-          }
-
-          let resolvedUrl: URL;
-          // relative redirect
-          if (redirectUrl.startsWith("/")) {
-            resolvedUrl = new URL(redirectUrl, url);
-          } else {
-            resolvedUrl = new URL(redirectUrl);
-          }
-
-          if (
-            new URL(initUrl).protocol === "https:" &&
-            resolvedUrl.protocol !== "https:"
-          ) {
-            return new Err(
-              new WebCrawlerError(
-                "Invalid redirect: going from https to http",
-                "PROTOCOL_DOWNGRADE"
-              )
-            );
-          }
-
-          const checkIpRes = await this.checkIp(resolvedUrl);
-          if (checkIpRes.isErr()) {
-            return checkIpRes;
-          }
-
-          url = resolvedUrl;
-        } else {
-          foundEndOfRedirect = true;
-        }
-      } catch (err) {
-        // try catch only to make sure we clear the timeout in case fetch failed
-        clearTimeout(timeoutId);
-        throw err;
-      }
-    } while (!foundEndOfRedirect);
-
-    return new Ok(url);
-  }
-
-  /**
-   * Check if IP behind url is ipv4 and is not a private ip
-   */
-  async checkIp(url: URL): Promise<Result<void, WebCrawlerError>> {
-    const { address, family } = await getIpAddressForUrl(url.toString());
-    if (family !== 4) {
-      return new Err(
-        new WebCrawlerError(`IP address is not IPv4: ${address}`, "NOT_IP_V4")
-      );
-    }
-
-    if (url.hostname === "localhost") {
-      return new Err(
-        new WebCrawlerError("No localhost authorized", "PRIVATE_IP")
-      );
-    }
-
-    if (isPrivateIp(address)) {
-      return new Err(
-        new WebCrawlerError("Private IP adress detected", "PRIVATE_IP")
-      );
-    }
-
-    return new Ok(undefined);
   }
 }

--- a/connectors/src/connectors/webcrawler/lib/utils.test.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "vitest";
+
+import { shouldCrawlLink } from "./utils";
+
+describe("shouldCrawlLink", () => {
+  // Base configuration for tests
+  const baseConfig = {
+    url: "https://example.com/blog",
+    depth: 3,
+    crawlMode: "website",
+  };
+
+  describe("Domain and path validation", () => {
+    test("should return true for links on the same domain", () => {
+      const link = "https://example.com/about";
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(true);
+    });
+
+    test("should return true for child paths of config URL", () => {
+      const link = "https://example.com/blog/post-1";
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(true);
+    });
+
+    test("should return false for different domains", () => {
+      const link = "https://different-domain.com/blog";
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(false);
+    });
+
+    test("should handle relative URLs correctly", () => {
+      // This would be resolved relative to baseConfig.url in the actual function
+      const link = "https://example.com/blog/category/post";
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("Depth limitations", () => {
+    test("should return true when current depth + 1 is less than config depth", () => {
+      const link = "https://example.com/blog/post";
+      const result = shouldCrawlLink(link, baseConfig, 1); // 1 + 1 < 3
+      expect(result).toBe(true);
+    });
+
+    test("should return false when current depth + 1 equals config depth", () => {
+      const link = "https://example.com/blog/post";
+      const result = shouldCrawlLink(link, baseConfig, 2); // 2 + 1 = 3
+      expect(result).toBe(false);
+    });
+
+    test("should return false when current depth + 1 exceeds config depth", () => {
+      const link = "https://example.com/blog/post";
+      const result = shouldCrawlLink(link, baseConfig, 3); // 3 + 1 > 3
+      expect(result).toBe(false);
+    });
+
+    test("should return false when current depth + 1 equals WEBCRAWLER_MAX_DEPTH", () => {
+      const link = "https://example.com/blog/post";
+      const deepConfig = { ...baseConfig, depth: 10 }; // Higher than WEBCRAWLER_MAX_DEPTH
+      const result = shouldCrawlLink(link, deepConfig, 4); // 4 + 1 = 5 (WEBCRAWLER_MAX_DEPTH)
+      expect(result).toBe(false);
+    });
+
+    test("should return false when current depth + 1 exceeds WEBCRAWLER_MAX_DEPTH", () => {
+      const link = "https://example.com/blog/post";
+      const deepConfig = { ...baseConfig, depth: 10 };
+      const result = shouldCrawlLink(link, deepConfig, 5); // 5 + 1 > 5
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("Crawl mode restrictions", () => {
+    test('should return true for child paths when crawlMode is "child"', () => {
+      const childConfig = { ...baseConfig, crawlMode: "child" };
+      const link = "https://example.com/blog/post";
+      const result = shouldCrawlLink(link, childConfig, 0);
+      expect(result).toBe(true);
+    });
+
+    test('should return false for non-child paths when crawlMode is "child"', () => {
+      const childConfig = { ...baseConfig, crawlMode: "child" };
+      const link = "https://example.com/about"; // Not a child of /blog
+      const result = shouldCrawlLink(link, childConfig, 0);
+      expect(result).toBe(false);
+    });
+
+    test('should return true for same domain paths when crawlMode is not "child"', () => {
+      const allConfig = { ...baseConfig, crawlMode: "website" };
+      const link = "https://example.com/about"; // Not a child but same domain
+      const result = shouldCrawlLink(link, allConfig, 0);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("Edge cases and combinations", () => {
+    test("should return false when domain matches but depth exceeds limits", () => {
+      const link = "https://example.com/blog/post";
+      const result = shouldCrawlLink(link, baseConfig, 3); // Depth exceeds
+      expect(result).toBe(false);
+    });
+
+    test("should return false when path is child but domain is different", () => {
+      const link = "https://different.com/blog/post"; // Child path but wrong domain
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(false);
+    });
+
+    test("should return false when all conditions fail", () => {
+      const childConfig = { ...baseConfig, crawlMode: "child" };
+      const link = "https://different.com/about"; // Wrong domain, not child, wrong mode
+      const result = shouldCrawlLink(link, childConfig, 4); // Depth also exceeds
+      expect(result).toBe(false);
+    });
+
+    test("should return true when all conditions pass", () => {
+      const childConfig = { ...baseConfig, crawlMode: "child" };
+      const link = "https://example.com/blog/post"; // Right domain, is child
+      const result = shouldCrawlLink(link, childConfig, 0); // Depth is fine
+      expect(result).toBe(true);
+    });
+
+    test("should handle URLs with query parameters correctly", () => {
+      const link = "https://example.com/blog/post?id=123&sort=asc";
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(true);
+    });
+
+    test("should handle URLs with hash fragments correctly", () => {
+      const link = "https://example.com/blog/post#section1";
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("Subdomain handling", () => {
+    test("should return false for different subdomains", () => {
+      const link = "https://subdomain.example.com/blog";
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("URL path normalization", () => {
+    test("should handle trailing slashes correctly", () => {
+      const configWithTrailingSlash = {
+        ...baseConfig,
+        url: "https://example.com/blog/",
+      };
+
+      const link = "https://example.com/blog/post";
+      const result = shouldCrawlLink(link, configWithTrailingSlash, 0);
+      expect(result).toBe(true);
+    });
+
+    test("should handle double slashes in paths correctly", () => {
+      const link = "https://example.com/blog//post";
+      const result = shouldCrawlLink(link, baseConfig, 0);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -52,12 +52,6 @@ import {
   WEBCRAWLER_MAX_PAGES,
 } from "@connectors/types";
 
-const { FIRECRAWL_API_KEY } = process.env;
-
-if (!FIRECRAWL_API_KEY) {
-  throw new Error("Missing FIRECRAWL_API_KEY");
-}
-
 const CONCURRENCY = 1;
 
 export async function markAsCrawled(connectorId: ModelId) {

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,6 +1,7 @@
 import { Context } from "@temporalio/activity";
 import { isCancellation } from "@temporalio/workflow";
 import { BasicCrawler, CheerioCrawler, Configuration, LogLevel } from "crawlee";
+import { randomUUID } from "crypto";
 import { Op } from "sequelize";
 import turndown from "turndown";
 
@@ -253,7 +254,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
           const extracted = crawlerResponse.markdown ?? "[NO CONTENT]";
 
           totalExtracted += extracted.length;
-          const pageTitle = crawlerResponse.metadata?.title ?? "[NO TITLE]";
+          const pageTitle = crawlerResponse.metadata?.title ?? randomUUID();
 
           // note that parentFolderUrls.length === parentFolderIds.length -1
           // since parentFolderIds includes the page as first element

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,7 +1,8 @@
 import { Context } from "@temporalio/activity";
 import { isCancellation } from "@temporalio/workflow";
-import { BasicCrawler, Configuration, LogLevel } from "crawlee";
+import { BasicCrawler, CheerioCrawler, Configuration, LogLevel } from "crawlee";
 import { Op } from "sequelize";
+import turndown from "turndown";
 
 import {
   getAllFoldersForUrl,
@@ -12,6 +13,7 @@ import {
   shouldCrawlLink,
   stableIdForUrl,
   verifyRedirect,
+  WebCrawlerError,
 } from "@connectors/connectors/webcrawler/lib/utils";
 import {
   MAX_BLOCKED_RATIO,
@@ -44,13 +46,16 @@ import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
-import type { ModelId } from "@connectors/types";
+import type { ModelId, WebcrawlerCustomCrawler } from "@connectors/types";
 import {
   INTERNAL_MIME_TYPES,
   stripNullBytes,
   validateUrl,
+  WEBCRAWLER_MAX_DEPTH,
   WEBCRAWLER_MAX_PAGES,
 } from "@connectors/types";
+
+import { DustHttpClient } from "../lib/http";
 
 const CONCURRENCY = 1;
 
@@ -123,290 +128,627 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
   const maxRequestsPerCrawl =
     webCrawlerConfig.maxPageToCrawl || WEBCRAWLER_MAX_PAGES;
 
-  const crawler = new BasicCrawler(
-    {
-      maxRequestsPerCrawl,
-      maxConcurrency: CONCURRENCY,
-      maxRequestsPerMinute: 20, // 1 request every 3 seconds average, to avoid overloading the target website
-      requestHandlerTimeoutSecs: REQUEST_HANDLING_TIMEOUT,
-      async requestHandler({ request, enqueueLinks }) {
-        Context.current().heartbeat({
-          type: "http_request",
-        });
+  // temporay solution to have both crawler while we test them
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let crawler: BasicCrawler<any>;
 
-        const checkUrl = await verifyRedirect(request.url);
-        if (checkUrl.isErr()) {
-          childLogger.error(
-            {
-              type: checkUrl.error.type,
-              configId: webCrawlerConfig.id,
-              sourceUrl: request.url,
-            },
-            checkUrl.error.message
-          );
-          return;
-        }
+  if (
+    webCrawlerConfig.customCrawler ===
+    ("firecrawl" satisfies WebcrawlerCustomCrawler)
+  ) {
+    crawler = new BasicCrawler(
+      {
+        maxRequestsPerCrawl,
+        maxConcurrency: CONCURRENCY,
+        maxRequestsPerMinute: 20, // 1 request every 3 seconds average, to avoid overloading the target website
+        requestHandlerTimeoutSecs: REQUEST_HANDLING_TIMEOUT,
+        async requestHandler({ request, enqueueLinks }) {
+          Context.current().heartbeat({
+            type: "http_request",
+          });
 
-        const currentRequestDepth = request.userData.depth || 0;
-
-        if (
-          checkUrl.value !== request.url &&
-          !shouldCrawlLink(
-            checkUrl.value.toString(),
-            webCrawlerConfig,
-            currentRequestDepth
-          )
-        ) {
-          childLogger.warn(
-            { sourceUrl: request.url, url: checkUrl.value },
-            "Should not crawl"
-          );
-          return;
-        }
-
-        const crawlerResponse = await firecrawlApp.scrapeUrl(request.url, {
-          onlyMainContent: true,
-          formats: ["markdown", "links"],
-          headers: customHeaders,
-        });
-
-        if (!crawlerResponse.success) {
-          crawlingError++;
-          childLogger.error(
-            { url: request.url, configId: webCrawlerConfig.id },
-            `Error scraping: ${crawlerResponse.error}`
-          );
-          return;
-        }
-
-        childLogger.debug(
-          {
-            url: request.url,
-            configId: webCrawlerConfig.id,
-            links: crawlerResponse.links,
-          },
-          "Receive response"
-        );
-
-        // try-catch allowing activity cancellation by temporal (various timeouts, or signal)
-        try {
-          await Context.current().sleep(1);
-        } catch (e) {
-          if (isCancellation(e)) {
+          const checkUrl = await verifyRedirect(request.url);
+          if (checkUrl.isErr()) {
             childLogger.error(
-              { error: e },
-              "The activity was canceled. Aborting crawl."
+              {
+                type: checkUrl.error.type,
+                configId: webCrawlerConfig.id,
+                sourceUrl: request.url,
+              },
+              checkUrl.error.message
             );
-
-            // raise a panic flag if the activity is aborted because it exceeded the maximum time to crawl
-            const isTooLongToCrawl =
-              Date.now() - startCrawlingTime >
-              1000 * 60 * (MAX_TIME_TO_CRAWL_MINUTES - 1);
-
-            if (isTooLongToCrawl) {
-              childLogger.error(
-                {
-                  url: rootUrl,
-                  configId: webCrawlerConfig.id,
-                  panic: true,
-                  crawls_per_minute: Math.round(
-                    pageCount.valid / MAX_TIME_TO_CRAWL_MINUTES
-                  ),
-                },
-                `Website takes too long to crawl`
-              );
-            }
-
-            // abort crawling
-            await crawler.autoscaledPool?.abort();
-            await crawler.teardown();
-            // leave without rethrowing, to avoid retries by the crawler
-            // (the cancellation already throws at the activity & workflow level)
             return;
           }
-          throw e;
-        }
 
-        await enqueueLinks({
-          urls:
-            crawlerResponse.links?.filter((link) =>
-              shouldCrawlLink(link, webCrawlerConfig, currentRequestDepth)
-            ) ?? [],
-          userData: {
-            depth: currentRequestDepth + 1,
-          },
-        });
+          const currentRequestDepth = request.userData.depth || 0;
 
-        const extracted = crawlerResponse.markdown ?? "[NO CONTENT]";
-
-        totalExtracted += extracted.length;
-        const pageTitle = crawlerResponse.metadata?.title ?? "[NO TITLE]";
-
-        // note that parentFolderUrls.length === parentFolderIds.length -1
-        // since parentFolderIds includes the page as first element
-        // and parentFolderUrls does not
-        const parentFolderUrls = getAllFoldersForUrl(request.url);
-        const parentFolderIds = getParentsForPage(request.url, false);
-
-        for (const [index, folder] of parentFolderUrls.entries()) {
-          if (createdFolders.has(folder)) {
-            continue;
+          if (
+            checkUrl.value !== request.url &&
+            !shouldCrawlLink(
+              checkUrl.value.toString(),
+              webCrawlerConfig,
+              currentRequestDepth
+            )
+          ) {
+            childLogger.warn(
+              { sourceUrl: request.url, url: checkUrl.value },
+              "Should not crawl"
+            );
+            return;
           }
 
-          const logicalParent = isTopFolder(request.url)
-            ? null
-            : getFolderForUrl(folder);
-          const [webCrawlerFolder] = await WebCrawlerFolder.upsert({
-            url: folder,
-            parentUrl: logicalParent,
+          const crawlerResponse = await firecrawlApp.scrapeUrl(request.url, {
+            onlyMainContent: true,
+            formats: ["markdown", "links"],
+            headers: customHeaders,
+          });
+
+          if (!crawlerResponse.success) {
+            crawlingError++;
+            childLogger.error(
+              { url: request.url, configId: webCrawlerConfig.id },
+              `Error scraping: ${crawlerResponse.error}`
+            );
+            return;
+          }
+
+          childLogger.debug(
+            {
+              url: request.url,
+              configId: webCrawlerConfig.id,
+              links: crawlerResponse.links,
+            },
+            "Receive response"
+          );
+
+          // try-catch allowing activity cancellation by temporal (various timeouts, or signal)
+          try {
+            await Context.current().sleep(1);
+          } catch (e) {
+            if (isCancellation(e)) {
+              childLogger.error(
+                { error: e },
+                "The activity was canceled. Aborting crawl."
+              );
+
+              // raise a panic flag if the activity is aborted because it exceeded the maximum time to crawl
+              const isTooLongToCrawl =
+                Date.now() - startCrawlingTime >
+                1000 * 60 * (MAX_TIME_TO_CRAWL_MINUTES - 1);
+
+              if (isTooLongToCrawl) {
+                childLogger.error(
+                  {
+                    url: rootUrl,
+                    configId: webCrawlerConfig.id,
+                    panic: true,
+                    crawls_per_minute: Math.round(
+                      pageCount.valid / MAX_TIME_TO_CRAWL_MINUTES
+                    ),
+                  },
+                  `Website takes too long to crawl`
+                );
+              }
+
+              // abort crawling
+              await crawler.autoscaledPool?.abort();
+              await crawler.teardown();
+              // leave without rethrowing, to avoid retries by the crawler
+              // (the cancellation already throws at the activity & workflow level)
+              return;
+            }
+            throw e;
+          }
+
+          await enqueueLinks({
+            urls:
+              crawlerResponse.links?.filter((link) =>
+                shouldCrawlLink(link, webCrawlerConfig, currentRequestDepth)
+              ) ?? [],
+            userData: {
+              depth: currentRequestDepth + 1,
+            },
+          });
+
+          const extracted = crawlerResponse.markdown ?? "[NO CONTENT]";
+
+          totalExtracted += extracted.length;
+          const pageTitle = crawlerResponse.metadata?.title ?? "[NO TITLE]";
+
+          // note that parentFolderUrls.length === parentFolderIds.length -1
+          // since parentFolderIds includes the page as first element
+          // and parentFolderUrls does not
+          const parentFolderUrls = getAllFoldersForUrl(request.url);
+          const parentFolderIds = getParentsForPage(request.url, false);
+
+          for (const [index, folder] of parentFolderUrls.entries()) {
+            if (createdFolders.has(folder)) {
+              continue;
+            }
+
+            const logicalParent = isTopFolder(request.url)
+              ? null
+              : getFolderForUrl(folder);
+            const [webCrawlerFolder] = await WebCrawlerFolder.upsert({
+              url: folder,
+              parentUrl: logicalParent,
+              connectorId: connector.id,
+              webcrawlerConfigurationId: webCrawlerConfig.id,
+              internalId: stableIdForUrl({
+                url: folder,
+                ressourceType: "folder",
+              }),
+              lastSeenAt: new Date(),
+            });
+
+            // parent folder ids of the page are in hierarchy order from the
+            // page to the root so for the current folder, its parents start at
+            // index+1 (including itself as first parent) and end at the root
+            const parents = parentFolderIds.slice(index + 1);
+            await upsertDataSourceFolder({
+              dataSourceConfig,
+              folderId: webCrawlerFolder.internalId,
+              timestampMs: webCrawlerFolder.updatedAt.getTime(),
+              parents,
+              parentId: parents[1] || null,
+              title: getDisplayNameForFolder(webCrawlerFolder),
+              mimeType: INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
+              sourceUrl: webCrawlerFolder.url,
+            });
+
+            createdFolders.add(folder);
+          }
+          const documentId = stableIdForUrl({
+            url: request.url,
+            ressourceType: "document",
+          });
+
+          await WebCrawlerPage.upsert({
+            url: request.url,
+            parentUrl: isTopFolder(request.url)
+              ? null
+              : getFolderForUrl(request.url),
             connectorId: connector.id,
             webcrawlerConfigurationId: webCrawlerConfig.id,
-            internalId: stableIdForUrl({
-              url: folder,
-              ressourceType: "folder",
-            }),
+            documentId: documentId,
+            title: pageTitle,
+            depth: currentRequestDepth,
             lastSeenAt: new Date(),
           });
 
-          // parent folder ids of the page are in hierarchy order from the
-          // page to the root so for the current folder, its parents start at
-          // index+1 (including itself as first parent) and end at the root
-          const parents = parentFolderIds.slice(index + 1);
-          await upsertDataSourceFolder({
-            dataSourceConfig,
-            folderId: webCrawlerFolder.internalId,
-            timestampMs: webCrawlerFolder.updatedAt.getTime(),
-            parents,
-            parentId: parents[1] || null,
-            title: getDisplayNameForFolder(webCrawlerFolder),
-            mimeType: INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
-            sourceUrl: webCrawlerFolder.url,
+          childLogger.info(
+            {
+              documentId,
+              configId: webCrawlerConfig.id,
+              documentLen: extracted.length,
+              url: request.url,
+            },
+            "Successfully crawled page"
+          );
+
+          statsDClient.increment("connectors_webcrawler_crawls.count", 1);
+          statsDClient.increment(
+            "connectors_webcrawler_crawls_bytes.count",
+            extracted.length
+          );
+
+          Context.current().heartbeat({
+            type: "upserting",
           });
 
-          createdFolders.add(folder);
-        }
-        const documentId = stableIdForUrl({
-          url: request.url,
-          ressourceType: "document",
-        });
+          try {
+            if (extracted.length > MAX_SMALL_DOCUMENT_TXT_LEN) {
+              pageCount.tooLarge++;
+            }
+            if (
+              extracted.length > 0 &&
+              extracted.length <= MAX_SMALL_DOCUMENT_TXT_LEN
+            ) {
+              const validatedUrl = validateUrl(request.url);
+              if (!validatedUrl.valid || !validatedUrl.standardized) {
+                childLogger.info(
+                  {
+                    documentId,
+                    configId: webCrawlerConfig.id,
+                    url: request.url,
+                  },
+                  `Invalid document or URL. Skipping`
+                );
+                return;
+              }
 
-        await WebCrawlerPage.upsert({
-          url: request.url,
-          parentUrl: isTopFolder(request.url)
-            ? null
-            : getFolderForUrl(request.url),
-          connectorId: connector.id,
-          webcrawlerConfigurationId: webCrawlerConfig.id,
-          documentId: documentId,
-          title: pageTitle,
-          depth: currentRequestDepth,
-          lastSeenAt: new Date(),
-        });
+              const formattedDocumentContent = formatDocumentContent({
+                title: pageTitle,
+                content: extracted,
+                url: validatedUrl.standardized,
+              });
 
-        childLogger.info(
-          {
-            documentId,
-            configId: webCrawlerConfig.id,
-            documentLen: extracted.length,
-            url: request.url,
-          },
-          "Successfully crawled page"
-        );
-
-        statsDClient.increment("connectors_webcrawler_crawls.count", 1);
-        statsDClient.increment(
-          "connectors_webcrawler_crawls_bytes.count",
-          extracted.length
-        );
-
-        Context.current().heartbeat({
-          type: "upserting",
-        });
-
-        try {
-          if (extracted.length > MAX_SMALL_DOCUMENT_TXT_LEN) {
-            pageCount.tooLarge++;
-          }
-          if (
-            extracted.length > 0 &&
-            extracted.length <= MAX_SMALL_DOCUMENT_TXT_LEN
-          ) {
-            const validatedUrl = validateUrl(request.url);
-            if (!validatedUrl.valid || !validatedUrl.standardized) {
+              await upsertDataSourceDocument({
+                dataSourceConfig,
+                documentId: documentId,
+                documentContent: formattedDocumentContent,
+                documentUrl: validatedUrl.standardized,
+                timestampMs: new Date().getTime(),
+                tags: [`title:${stripNullBytes(pageTitle)}`],
+                parents: parentFolderIds,
+                parentId: parentFolderIds[1] || null,
+                upsertContext: {
+                  sync_type: "batch",
+                },
+                title: stripNullBytes(pageTitle),
+                mimeType: "text/html",
+                async: true,
+              });
+            } else {
               childLogger.info(
-                { documentId, configId: webCrawlerConfig.id, url: request.url },
-                `Invalid document or URL. Skipping`
+                {
+                  documentId,
+                  configId: webCrawlerConfig.id,
+                  documentLen: extracted.length,
+                  title: pageTitle,
+                  url: request.url,
+                },
+                `Document is empty or too big to be upserted. Skipping`
               );
               return;
             }
-
-            const formattedDocumentContent = formatDocumentContent({
-              title: pageTitle,
-              content: extracted,
-              url: validatedUrl.standardized,
-            });
-
-            await upsertDataSourceDocument({
-              dataSourceConfig,
-              documentId: documentId,
-              documentContent: formattedDocumentContent,
-              documentUrl: validatedUrl.standardized,
-              timestampMs: new Date().getTime(),
-              tags: [`title:${stripNullBytes(pageTitle)}`],
-              parents: parentFolderIds,
-              parentId: parentFolderIds[1] || null,
-              upsertContext: {
-                sync_type: "batch",
-              },
-              title: stripNullBytes(pageTitle),
-              mimeType: "text/html",
-              async: true,
-            });
-          } else {
-            childLogger.info(
+          } catch (e) {
+            upsertingError++;
+            childLogger.error(
               {
-                documentId,
+                error: e,
                 configId: webCrawlerConfig.id,
-                documentLen: extracted.length,
-                title: pageTitle,
-                url: request.url,
+                url: rootUrl,
               },
-              `Document is empty or too big to be upserted. Skipping`
+              "Webcrawler error while upserting document"
+            );
+          }
+
+          pageCount.valid++;
+          await reportInitialSyncProgress(
+            connector.id,
+            `${pageCount.valid} pages`
+          );
+        },
+        errorHandler: () => {
+          // Errors are already logged by the crawler, so we are not re-logging them here.
+          Context.current().heartbeat({
+            type: "error_handler",
+          });
+        },
+      },
+      new Configuration({
+        purgeOnStart: true,
+        persistStorage: false,
+        logLevel: LogLevel.OFF,
+        availableMemoryRatio: 0.1,
+      })
+    );
+  } else {
+    crawler = new CheerioCrawler(
+      {
+        httpClient: new DustHttpClient(),
+        navigationTimeoutSecs: 10,
+        preNavigationHooks: [
+          async (crawlingContext) => {
+            Context.current().heartbeat({
+              type: "pre_navigation",
+            });
+
+            if (!crawlingContext.request.headers) {
+              crawlingContext.request.headers = {};
+            }
+            for (const [header, value] of Object.entries(customHeaders)) {
+              crawlingContext.request.headers[header] = value;
+            }
+          },
+        ],
+        maxRequestsPerCrawl,
+        maxConcurrency: CONCURRENCY,
+        maxRequestsPerMinute: 20, // 1 request every 3 seconds average, to avoid overloading the target website
+        requestHandlerTimeoutSecs: REQUEST_HANDLING_TIMEOUT,
+        async requestHandler({ $, request, enqueueLinks }) {
+          if (request.skipNavigation) {
+            childLogger.info({ url: request.url }, "Skipping page");
+            return;
+          }
+
+          Context.current().heartbeat({
+            type: "http_request",
+          });
+          const currentRequestDepth = request.userData.depth || 0;
+
+          // try-catch allowing activity cancellation by temporal (various timeouts, or signal)
+          try {
+            await Context.current().sleep(1);
+          } catch (e) {
+            if (isCancellation(e)) {
+              childLogger.error(
+                { error: e },
+                "The activity was canceled. Aborting crawl."
+              );
+
+              // raise a panic flag if the activity is aborted because it exceeded the maximum time to crawl
+              const isTooLongToCrawl =
+                Date.now() - startCrawlingTime >
+                1000 * 60 * (MAX_TIME_TO_CRAWL_MINUTES - 1);
+
+              if (isTooLongToCrawl) {
+                childLogger.error(
+                  {
+                    url: rootUrl,
+                    configId: webCrawlerConfig.id,
+                    panic: true,
+                    crawls_per_minute: Math.round(
+                      pageCount.valid / MAX_TIME_TO_CRAWL_MINUTES
+                    ),
+                  },
+                  `Website takes too long to crawl`
+                );
+              }
+
+              // abort crawling
+              await crawler.autoscaledPool?.abort();
+              await crawler.teardown();
+              // leave without rethrowing, to avoid retries by the crawler
+              // (the cancellation already throws at the activity & workflow level)
+              return;
+            }
+            throw e;
+          }
+
+          await enqueueLinks({
+            userData: {
+              depth: currentRequestDepth + 1,
+            },
+            transformRequestFunction: (req) => {
+              try {
+                if (
+                  new URL(req.url).protocol !== "http:" &&
+                  new URL(req.url).protocol !== "https:"
+                ) {
+                  return false;
+                }
+              } catch (e) {
+                return false;
+              }
+              if (webCrawlerConfig.crawlMode === "child") {
+                // We only want to crawl children of the original url
+                if (
+                  !new URL(req.url).pathname.startsWith(
+                    new URL(webCrawlerConfig.url).pathname
+                  )
+                ) {
+                  // path is not a child of the original url
+                  return false;
+                }
+              }
+              if (
+                req.userData?.depth >= WEBCRAWLER_MAX_DEPTH ||
+                req.userData?.depth >= webCrawlerConfig.depth
+              ) {
+                return false;
+              }
+              return req;
+            },
+          });
+          const extracted = new turndown()
+            .remove([
+              "style",
+              "script",
+              "iframe",
+              "noscript",
+              "nav",
+              "footer",
+              "header",
+              "form",
+              "meta",
+              "img",
+            ])
+            .turndown($.html());
+
+          totalExtracted += extracted.length;
+          const pageTitle = $("title").text();
+
+          // note that parentFolderUrls.length === parentFolderIds.length -1
+          // since parentFolderIds includes the page as first element
+          // and parentFolderUrls does not
+          const parentFolderUrls = getAllFoldersForUrl(request.url);
+          const parentFolderIds = getParentsForPage(request.url, false);
+
+          for (const [index, folder] of parentFolderUrls.entries()) {
+            if (createdFolders.has(folder)) {
+              continue;
+            }
+
+            const logicalParent = isTopFolder(request.url)
+              ? null
+              : getFolderForUrl(folder);
+            const [webCrawlerFolder] = await WebCrawlerFolder.upsert({
+              url: folder,
+              parentUrl: logicalParent,
+              connectorId: connector.id,
+              webcrawlerConfigurationId: webCrawlerConfig.id,
+              internalId: stableIdForUrl({
+                url: folder,
+                ressourceType: "folder",
+              }),
+              lastSeenAt: new Date(),
+            });
+
+            // parent folder ids of the page are in hierarchy order from the
+            // page to the root so for the current folder, its parents start at
+            // index+1 (including itself as first parent) and end at the root
+            const parents = parentFolderIds.slice(index + 1);
+            await upsertDataSourceFolder({
+              dataSourceConfig,
+              folderId: webCrawlerFolder.internalId,
+              timestampMs: webCrawlerFolder.updatedAt.getTime(),
+              parents,
+              parentId: parents[1] || null,
+              title: getDisplayNameForFolder(webCrawlerFolder),
+              mimeType: INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
+              sourceUrl: webCrawlerFolder.url,
+            });
+
+            createdFolders.add(folder);
+          }
+          const documentId = stableIdForUrl({
+            url: request.url,
+            ressourceType: "document",
+          });
+
+          await WebCrawlerPage.upsert({
+            url: request.url,
+            parentUrl: isTopFolder(request.url)
+              ? null
+              : getFolderForUrl(request.url),
+            connectorId: connector.id,
+            webcrawlerConfigurationId: webCrawlerConfig.id,
+            documentId: documentId,
+            title: pageTitle,
+            depth: currentRequestDepth,
+            lastSeenAt: new Date(),
+          });
+
+          childLogger.info(
+            {
+              documentId,
+              configId: webCrawlerConfig.id,
+              documentLen: extracted.length,
+              url: request.url,
+            },
+            "Successfully crawled page"
+          );
+
+          statsDClient.increment("connectors_webcrawler_crawls.count", 1);
+          statsDClient.increment(
+            "connectors_webcrawler_crawls_bytes.count",
+            extracted.length
+          );
+
+          Context.current().heartbeat({
+            type: "upserting",
+          });
+
+          try {
+            if (extracted.length > MAX_SMALL_DOCUMENT_TXT_LEN) {
+              pageCount.tooLarge++;
+            }
+            if (
+              extracted.length > 0 &&
+              extracted.length <= MAX_SMALL_DOCUMENT_TXT_LEN
+            ) {
+              const validatedUrl = validateUrl(request.url);
+              if (!validatedUrl.valid || !validatedUrl.standardized) {
+                childLogger.info(
+                  {
+                    documentId,
+                    configId: webCrawlerConfig.id,
+                    url: request.url,
+                  },
+                  `Invalid document or URL. Skipping`
+                );
+                return;
+              }
+
+              const formattedDocumentContent = formatDocumentContent({
+                title: pageTitle,
+                content: extracted,
+                url: validatedUrl.standardized,
+              });
+
+              await upsertDataSourceDocument({
+                dataSourceConfig,
+                documentId: documentId,
+                documentContent: formattedDocumentContent,
+                documentUrl: validatedUrl.standardized,
+                timestampMs: new Date().getTime(),
+                tags: [`title:${stripNullBytes(pageTitle)}`],
+                parents: parentFolderIds,
+                parentId: parentFolderIds[1] || null,
+                upsertContext: {
+                  sync_type: "batch",
+                },
+                title: stripNullBytes(pageTitle),
+                mimeType: "text/html",
+                async: true,
+              });
+            } else {
+              childLogger.info(
+                {
+                  documentId,
+                  configId: webCrawlerConfig.id,
+                  documentLen: extracted.length,
+                  title: pageTitle,
+                  url: request.url,
+                },
+                `Document is empty or too big to be upserted. Skipping`
+              );
+              return;
+            }
+          } catch (e) {
+            upsertingError++;
+            childLogger.error(
+              {
+                error: e,
+                configId: webCrawlerConfig.id,
+                url: rootUrl,
+              },
+              "Webcrawler error while upserting document"
+            );
+          }
+
+          pageCount.valid++;
+          await reportInitialSyncProgress(
+            connector.id,
+            `${pageCount.valid} pages`
+          );
+        },
+        failedRequestHandler: async (context, error) => {
+          Context.current().heartbeat({
+            type: "failed_request",
+          });
+
+          if (error instanceof WebCrawlerError) {
+            childLogger.error(
+              { url: context.request.url, type: error.type },
+              error.message
             );
             return;
           }
-        } catch (e) {
-          upsertingError++;
+
           childLogger.error(
             {
-              error: e,
-              configId: webCrawlerConfig.id,
-              url: rootUrl,
+              url: context.request.url,
+              error,
             },
-            "Webcrawler error while upserting document"
+            "webcrawler failedRequestHandler"
           );
-        }
-
-        pageCount.valid++;
-        await reportInitialSyncProgress(
-          connector.id,
-          `${pageCount.valid} pages`
-        );
+          if (
+            !context.response ||
+            context.response.statusCode === 403 ||
+            context.response.statusCode === 429
+          ) {
+            pageCount.blocked++;
+          }
+          crawlingError++;
+        },
+        errorHandler: () => {
+          // Errors are already logged by the crawler, so we are not re-logging them here.
+          Context.current().heartbeat({
+            type: "error_handler",
+          });
+        },
       },
-      errorHandler: () => {
-        // Errors are already logged by the crawler, so we are not re-logging them here.
-        Context.current().heartbeat({
-          type: "error_handler",
-        });
-      },
-    },
-    new Configuration({
-      purgeOnStart: true,
-      persistStorage: false,
-      logLevel: LogLevel.OFF,
-      availableMemoryRatio: 0.1,
-    })
-  );
+      new Configuration({
+        purgeOnStart: true,
+        persistStorage: false,
+        logLevel: LogLevel.OFF,
+        availableMemoryRatio: 0.1,
+      })
+    );
+  }
 
   let rootUrl = webCrawlerConfig.url.trim();
   if (!rootUrl.startsWith("http://") && !rootUrl.startsWith("https://")) {

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -19,4 +19,9 @@ export const apiConfig = {
   getTextExtractionUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");
   },
+  getFirecrawlAPIConfig: (): { apiKey: string } => {
+    return {
+      apiKey: EnvironmentConfig.getEnvVariable("FIRECRAWL_API_KEY"),
+    };
+  },
 };

--- a/connectors/src/lib/firecrawl.ts
+++ b/connectors/src/lib/firecrawl.ts
@@ -1,9 +1,7 @@
 import FirecrawlApp from "@mendable/firecrawl-js";
 
-const { FIRECRAWL_API_KEY } = process.env;
+import { apiConfig } from "./api/config";
 
-if (!FIRECRAWL_API_KEY) {
-  throw new Error("Missing FIRECRAWL_API_KEY");
-}
-
-export const firecrawlApp = new FirecrawlApp({ apiKey: FIRECRAWL_API_KEY });
+export const firecrawlApp = new FirecrawlApp({
+  apiKey: apiConfig.getFirecrawlAPIConfig().apiKey,
+});

--- a/connectors/src/lib/firecrawl.ts
+++ b/connectors/src/lib/firecrawl.ts
@@ -1,0 +1,9 @@
+import FirecrawlApp from "@mendable/firecrawl-js";
+
+const { FIRECRAWL_API_KEY } = process.env;
+
+if (!FIRECRAWL_API_KEY) {
+  throw new Error("Missing FIRECRAWL_API_KEY");
+}
+
+export const firecrawlApp = new FirecrawlApp({ apiKey: FIRECRAWL_API_KEY });

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -14,6 +14,7 @@ export class WebCrawlerConfigurationModel extends ConnectorBaseModel<WebCrawlerC
   declare depth: DepthOption;
   declare crawlFrequency: CrawlingFrequency;
   declare lastCrawledAt: Date | null;
+  declare customCrawler: string | null;
 }
 
 WebCrawlerConfigurationModel.init(
@@ -53,6 +54,11 @@ WebCrawlerConfigurationModel.init(
     lastCrawledAt: {
       type: DataTypes.DATE,
       allowNull: true,
+    },
+    customCrawler: {
+      type: DataTypes.STRING(128),
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -24,6 +24,7 @@ import type { WebCrawlerConfigurationType } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
 import {
   CrawlingFrequencies,
+  WebcrawlerCustomCrawler,
   WebCrawlerHeaderRedactedValue,
 } from "@connectors/types";
 
@@ -286,6 +287,10 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
       depth: this.depth,
       crawlFrequency: this.crawlFrequency,
       headers: redactedHeaders,
+      customCrawler:
+        Object.values(WebcrawlerCustomCrawler).find(
+          (value) => value === this.customCrawler
+        ) ?? null,
     };
   }
 }

--- a/connectors/src/types/webcrawler.ts
+++ b/connectors/src/types/webcrawler.ts
@@ -24,6 +24,9 @@ export function isDepthOption(value: unknown): value is DepthOption {
   return DepthOptions.includes(value as DepthOption);
 }
 
+export const WebcrawlerCustomCrawler = "firecrawl";
+export type WebcrawlerCustomCrawler = (typeof WebcrawlerCustomCrawler)[number];
+
 export const WebCrawlerConfigurationTypeSchema = t.type({
   url: t.string,
   depth: t.union([
@@ -43,6 +46,7 @@ export const WebCrawlerConfigurationTypeSchema = t.type({
     t.literal("monthly"),
   ]),
   headers: t.record(t.string, t.string),
+  customCrawler: t.union([t.null, t.literal("firecrawl")]),
 });
 
 export type WebCrawlerConfiguration = t.TypeOf<
@@ -58,4 +62,5 @@ export const WEBCRAWLER_DEFAULT_CONFIGURATION: WebCrawlerConfigurationType = {
   crawlMode: "website",
   crawlFrequency: "monthly",
   headers: {},
+  customCrawler: null,
 };

--- a/connectors/src/types/webcrawler.ts
+++ b/connectors/src/types/webcrawler.ts
@@ -24,7 +24,7 @@ export function isDepthOption(value: unknown): value is DepthOption {
   return DepthOptions.includes(value as DepthOption);
 }
 
-export const WebcrawlerCustomCrawler = "firecrawl";
+export const WebcrawlerCustomCrawler = ["firecrawl"] as const;
 export type WebcrawlerCustomCrawler = (typeof WebcrawlerCustomCrawler)[number];
 
 export const WebCrawlerConfigurationTypeSchema = t.type({

--- a/front/components/spaces/websites/AdvancedSettingsSection.tsx
+++ b/front/components/spaces/websites/AdvancedSettingsSection.tsx
@@ -1,24 +1,42 @@
 import {
   Button,
   CollapsibleComponent,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
   Input,
   Label,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 
-import { WebCrawlerHeaderRedactedValue } from "@app/types";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { LightWorkspaceType } from "@app/types";
+import {
+  WebcrawlerCustomCrawler,
+  WebCrawlerHeaderRedactedValue,
+} from "@app/types";
 
 type Header = { key: string; value: string };
 
 type AdvancedSettingsProps = {
   headers: Header[];
+  crawler: WebcrawlerCustomCrawler | null;
   onHeadersChange: (headers: Header[]) => void;
+  onCrawlerChange: (crawler: WebcrawlerCustomCrawler | null) => void;
+  owner: LightWorkspaceType;
 };
 
 export function AdvancedSettingsSection({
   headers,
+  crawler,
   onHeadersChange,
+  onCrawlerChange,
+  owner,
 }: AdvancedSettingsProps) {
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+
   const updateHeaderField = (
     index: number,
     field: keyof Header,
@@ -42,43 +60,90 @@ export function AdvancedSettingsSection({
       rootProps={{ defaultOpen: false }}
       triggerProps={{ label: "Advanced settings", variant: "secondary" }}
       contentChildren={
-        <div className="flex w-full flex-col gap-3">
-          <Label>Custom Headers</Label>
-          <p>Add custom request headers for the web crawler.</p>
-          <div className="flex flex-col gap-4">
-            {headers.map((header, index) => (
-              <div key={index} className="flex gap-2">
-                <div className="flex grow flex-col gap-1 px-1">
-                  <Input
-                    placeholder="Header Name"
-                    value={header.key}
-                    name="headerName"
-                    onChange={(e) =>
-                      updateHeaderField(index, "key", e.target.value)
-                    }
-                    disabled={header.value === WebCrawlerHeaderRedactedValue}
-                    className="grow"
-                  />
-                  <Input
-                    name="headerValue"
-                    placeholder="Header Value"
-                    value={header.value}
-                    onChange={(e) =>
-                      updateHeaderField(index, "value", e.target.value)
-                    }
-                    disabled={header.value === WebCrawlerHeaderRedactedValue}
-                    className="flex-1"
+        <div className="flex w-full flex-col gap-6">
+          <div className="flex w-full flex-col gap-3">
+            <Label>Custom Headers</Label>
+            <p>Add custom request headers for the web crawler.</p>
+            <div className="flex flex-col gap-4">
+              {headers.map((header, index) => (
+                <div key={index} className="flex gap-2">
+                  <div className="flex grow flex-col gap-1 px-1">
+                    <Input
+                      placeholder="Header Name"
+                      value={header.key}
+                      name="headerName"
+                      onChange={(e) =>
+                        updateHeaderField(index, "key", e.target.value)
+                      }
+                      disabled={header.value === WebCrawlerHeaderRedactedValue}
+                      className="grow"
+                    />
+                    <Input
+                      name="headerValue"
+                      placeholder="Header Value"
+                      value={header.value}
+                      onChange={(e) =>
+                        updateHeaderField(index, "value", e.target.value)
+                      }
+                      disabled={header.value === WebCrawlerHeaderRedactedValue}
+                      className="flex-1"
+                    />
+                  </div>
+                  <Button
+                    variant="outline"
+                    icon={XMarkIcon}
+                    onClick={() => removeHeader(index)}
                   />
                 </div>
-                <Button
-                  variant="outline"
-                  icon={XMarkIcon}
-                  onClick={() => removeHeader(index)}
-                />
-              </div>
-            ))}
+              ))}
+            </div>
+            <Button variant="outline" label="Add Header" onClick={addHeader} />
           </div>
-          <Button variant="outline" label="Add Header" onClick={addHeader} />
+
+          {hasFeature("custom_webcrawler") && (
+            <div className="flex w-full flex-col gap-3">
+              <div>
+                <Label>Custom crawler</Label>
+                <p>Select a custom crawler to use</p>
+              </div>
+
+              <div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      label={crawler ?? "default"}
+                      variant="outline"
+                      size="sm"
+                      isSelect
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuRadioGroup
+                      value={crawler ?? "default"}
+                      onValueChange={(value) => {
+                        if (value === "default") {
+                          onCrawlerChange(null);
+                        } else {
+                          onCrawlerChange(
+                            Object.values(WebcrawlerCustomCrawler).find(
+                              (v) => v === value
+                            ) ?? null
+                          );
+                        }
+                      }}
+                    >
+                      <DropdownMenuRadioItem value="default">
+                        default
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="firecrawl">
+                        firecrawl
+                      </DropdownMenuRadioItem>
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+          )}
         </div>
       }
     />

--- a/front/components/spaces/websites/SpaceWebsiteForm.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteForm.tsx
@@ -19,7 +19,9 @@ import { useCallback } from "react";
 
 import { AdvancedSettingsSection } from "@app/components/spaces/websites/AdvancedSettingsSection";
 import type {
+  LightWorkspaceType,
   WebCrawlerConfigurationType,
+  WebcrawlerCustomCrawler,
   WebsiteFormAction,
   WebsiteFormState,
 } from "@app/types";
@@ -36,6 +38,7 @@ type SpaceWebsiteFormProps = {
   dispatch: React.Dispatch<WebsiteFormAction>;
   isConfigurationLoading: boolean;
   webCrawlerConfiguration: WebCrawlerConfigurationType | null;
+  owner: LightWorkspaceType;
 };
 
 export function SpaceWebsiteForm({
@@ -43,6 +46,7 @@ export function SpaceWebsiteForm({
   dispatch,
   isConfigurationLoading,
   webCrawlerConfiguration,
+  owner,
 }: SpaceWebsiteFormProps) {
   const handleHeadersChange = useCallback(
     (newHeaders: WebsiteFormState["headers"]) => {
@@ -50,6 +54,17 @@ export function SpaceWebsiteForm({
         type: "SET_FIELD",
         field: "headers",
         value: newHeaders,
+      });
+    },
+    [dispatch]
+  );
+
+  const handleCrawlerChange = useCallback(
+    (crawler: WebcrawlerCustomCrawler | null) => {
+      dispatch({
+        type: "SET_FIELD",
+        field: "customCrawler",
+        value: crawler,
       });
     },
     [dispatch]
@@ -245,7 +260,10 @@ export function SpaceWebsiteForm({
       </Page.Layout>
       <AdvancedSettingsSection
         headers={state.headers}
+        crawler={state.customCrawler}
         onHeadersChange={handleHeadersChange}
+        onCrawlerChange={handleCrawlerChange}
+        owner={owner}
       />
     </Page.Layout>
   );

--- a/front/components/spaces/websites/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteModal.tsx
@@ -49,6 +49,7 @@ function getInitialFormState(
     crawlMode: config?.crawlMode ?? WEBCRAWLER_DEFAULT_CONFIGURATION.crawlMode,
     crawlFrequency:
       config?.crawlFrequency ?? WEBCRAWLER_DEFAULT_CONFIGURATION.crawlFrequency,
+    customCrawler: config?.customCrawler ?? null,
     headers: config?.headers
       ? Object.entries(config.headers).map(([k, v]) => ({ key: k, value: v }))
       : [],
@@ -106,6 +107,7 @@ function buildWebCrawlerConfig(
     depth: state.depth,
     crawlMode: state.crawlMode,
     crawlFrequency: state.crawlFrequency,
+    customCrawler: state.customCrawler,
     headers: state.headers.reduce(
       (acc, { key, value }) => {
         if (key && value) {
@@ -314,6 +316,7 @@ export default function SpaceWebsiteModal({
             dispatch={dispatch}
             isConfigurationLoading={isConfigurationLoading}
             webCrawlerConfiguration={webCrawlerConfiguration}
+            owner={owner}
           />
           {webCrawlerConfiguration && dataSourceView && (
             <DeleteSection

--- a/front/types/connectors/webcrawler.ts
+++ b/front/types/connectors/webcrawler.ts
@@ -24,6 +24,9 @@ export function isDepthOption(value: unknown): value is DepthOption {
   return DepthOptions.includes(value as DepthOption);
 }
 
+export const WebcrawlerCustomCrawler = ["firecrawl"] as const;
+export type WebcrawlerCustomCrawler = (typeof WebcrawlerCustomCrawler)[number];
+
 export const WebCrawlerConfigurationTypeSchema = t.type({
   url: t.string,
   depth: t.union([
@@ -43,6 +46,7 @@ export const WebCrawlerConfigurationTypeSchema = t.type({
     t.literal("monthly"),
   ]),
   headers: t.record(t.string, t.string),
+  customCrawler: t.union([t.null, t.literal("firecrawl")]),
 });
 
 export type WebCrawlerConfiguration = t.TypeOf<
@@ -57,5 +61,6 @@ export const WEBCRAWLER_DEFAULT_CONFIGURATION: WebCrawlerConfigurationType = {
   maxPageToCrawl: 50,
   crawlMode: "website",
   crawlFrequency: "monthly",
+  customCrawler: null,
   headers: {},
 };

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -26,6 +26,7 @@ export const WHITELISTABLE_FEATURES = [
   "salesforce_feature",
   "show_debug_tools",
   "usage_data_api",
+  "custom_webcrawler",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/front/types/website.ts
+++ b/front/types/website.ts
@@ -2,6 +2,7 @@ import type {
   CrawlingFrequency,
   DepthOption,
   WebCrawlerConfigurationType,
+  WebcrawlerCustomCrawler,
 } from "./connectors/webcrawler";
 
 export type WebsiteFormState = {
@@ -12,6 +13,7 @@ export type WebsiteFormState = {
   crawlMode: "child" | "website";
   crawlFrequency: CrawlingFrequency;
   headers: { key: string; value: string }[];
+  customCrawler: WebcrawlerCustomCrawler | null;
   errors?: {
     url?: string;
     name?: string;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -748,7 +748,10 @@ export type RetrievalActionPublicType = z.infer<
   typeof RetrievalActionTypeSchema
 >;
 
-const ProcessSchemaPropertySchema = z.union([z.custom<JSONSchema7>(), z.null()]);
+const ProcessSchemaPropertySchema = z.union([
+  z.custom<JSONSchema7>(),
+  z.null(),
+]);
 
 const ProcessActionOutputsSchema = z.object({
   data: z.array(z.unknown()),
@@ -817,6 +820,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "show_debug_tools"
   | "snowflake_connector_feature"
   | "usage_data_api"
+  | "custom_webcrawler"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description
- Add a BasicCrawler that uses Firecrawl to scrape page
- Add webcrawler config option behind FF `custom_crawler` to select which crawler you want to use (cf screenshot)
- Prefered having a dumb temporary if/else that switch between crawler instead of trying to share code inside them.
---
- Didn't use the `/crawl` feature from Firecrawl as it's not working nicely (half scraping, bad JS render or no scraping)
- Easier to insert into current flow
- Give webcrawler JS rendering capability
- Get markdown formatted directly from Firecrawl
- Firecrawl is returning a list of links found in the scrapped page, so needed to write the method to know which ones can be added to queue

<img width="763" alt="Capture d’écran 2025-04-24 à 12 27 45" src="https://github.com/user-attachments/assets/32694380-c58a-49d2-bfe3-fab21b62e17d" />

## Tests
- Locally tested with `https://dust.tt`and `https://support.ankorstore.com/collections/Je-suis-une-marque-producteur-Y3KKk55E`
- Added unit test to know which page to scrape

## Risk
As new crawler is behind a FF, risk is low. Easy to remove

## Deploy Plan
- Run `migration_67.sql` on connectors (no backfill needed)
- Deploy connectors

## Notes
Firecrawl markdown seems better than current turndown. ie:
- [solutions/sales](https://gist.github.com/johnoppenheimer/0ce5de59a5fd770f370f2c7b17b66f03) with current crawler
- [solutions/sales](https://gist.github.com/johnoppenheimer/3a1eb0da6ba0824db7f1e78023c16477) with firecrawl crawler (nicer structure, full page image url)
