### PR TITLE
Augment bodyparser size limit for runs endpoint

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -15,6 +15,10 @@ import { CoreAPI } from "@app/types";
 export const config = {
   api: {
     responseLimit: "8mb",
+    bodyParser: {
+      // 1m context size at 4mb for text gives a good higher bound.
+      sizeLimit: "4mb",
+    },
   },
 };
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/2720

With new models having larger context sizes (up to 1m tokens) we are overflowing the body parser default limit for nextJS (1mb I believe) and getting 413 on the multi-actions app run.

https://app.datadoghq.eu/logs?query=%22Error%20running%20streamed%20app%3A%20status_code%3D413%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workspaceId%2C%40model.model_id&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7233498889846999843&storage=hot&stream_sort=desc&viz=stream&from_ts=1742845340947&to_ts=1745437340947&live=true

4mb is a sane upper bound since we don't have only plain english in there (lot of json stuff) and plain english is ~4 byte per token.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`