### PR TITLE
Poké: fix transparent background when scrolling on a select field

### DIFF
--- a/front/components/poke/shadcn/ui/select.tsx
+++ b/front/components/poke/shadcn/ui/select.tsx
@@ -42,6 +42,7 @@ const SelectScrollUpButton = React.forwardRef<
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
+      "bg-muted-background dark:bg-muted-background-night",
       className
     )}
     {...props}
@@ -59,6 +60,7 @@ const SelectScrollDownButton = React.forwardRef<
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
+      "bg-muted-background dark:bg-muted-background-night",
       className
     )}
     {...props}


### PR DESCRIPTION
## Description


Fixes this: 
<img width="666" alt="Screenshot 2025-04-24 at 12 07 11" src="https://github.com/user-attachments/assets/be6e09fe-fd53-40da-afb3-b1cf8b81879c" />

From: https://github.com/dust-tt/tasks/issues/2737

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front