### PR TITLE
feat: ContentNodeTree hover

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -3,6 +3,8 @@ import {
   BracesIcon,
   Button,
   ExternalLinkIcon,
+  HistoryIcon,
+  Icon,
   IconButton,
   ListCheckIcon,
   SearchInput,
@@ -267,9 +269,12 @@ function ContentNodeTreeChildren({
                     }
                     side={i === 0 ? "bottom" : "top"}
                     trigger={
-                      <span className="text-xs text-gray-600">
-                        {timeAgoFrom(n.lastUpdatedAt)} ago
-                      </span>
+                      <div className="flex flex-row gap-1 text-gray-600">
+                        <Icon visual={HistoryIcon} size="xs" />
+                        <span className="text-xs">
+                          {timeAgoFrom(n.lastUpdatedAt)} ago
+                        </span>
+                      </div>
                     }
                   />
                 ) : null}

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -251,7 +251,7 @@ function ContentNodeTreeChildren({
                 : undefined
             }
             actions={
-              <div className="mr-8 flex flex-row gap-2">
+              <div className="mr-8 flex grow flex-row gap-2">
                 {n.sourceUrl && (
                   <Button
                     href={n.sourceUrl}

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -252,6 +252,14 @@ function ContentNodeTreeChildren({
             }
             actions={
               <div className="mr-8 flex flex-row gap-2">
+                {n.sourceUrl && (
+                  <Button
+                    href={n.sourceUrl}
+                    icon={ExternalLinkIcon}
+                    size="xs"
+                    variant="outline"
+                  />
+                )}
                 {n.lastUpdatedAt ? (
                   <Tooltip
                     label={
@@ -259,26 +267,12 @@ function ContentNodeTreeChildren({
                     }
                     side={i === 0 ? "bottom" : "top"}
                     trigger={
-                      <span className="text-xs text-gray-500">
+                      <span className="text-xs text-gray-600">
                         {timeAgoFrom(n.lastUpdatedAt)} ago
                       </span>
                     }
                   />
                 ) : null}
-                <IconButton
-                  size="xs"
-                  icon={ExternalLinkIcon}
-                  onClick={() => {
-                    if (n.sourceUrl) {
-                      window.open(n.sourceUrl, "_blank");
-                    }
-                  }}
-                  className={classNames(
-                    n.sourceUrl ? "" : "pointer-events-none opacity-0"
-                  )}
-                  disabled={!n.sourceUrl}
-                  variant="outline"
-                />
                 {onDocumentViewClick && (
                   <IconButton
                     size="xs"

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -283,7 +283,6 @@ Tree.Item = React.forwardRef<
               {label}
             </div>
           )}
-          <div className="s-grow" />
           {actions && (
             <div
               className={cn(

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -287,7 +287,7 @@ Tree.Item = React.forwardRef<
           {actions && (
             <div
               className={cn(
-                "s-flex s-gap-2 s-pl-4",
+                "s-flex s-grow s-gap-2 s-pl-4",
                 areActionsFading &&
                   "s-transform s-opacity-0 s-duration-300 group-hover/tree:s-opacity-100"
               )}

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -17,6 +17,8 @@ import {
   DustIcon,
   EyeIcon,
   FolderIcon,
+  HistoryIcon,
+  Icon,
   IconButton,
   PlusCircleIcon,
   Tree,
@@ -41,7 +43,7 @@ export const TreeExample = () => {
   return (
     <div className="s-flex s-flex-col s-gap-10">
       <div className="s-flex s-gap-10">
-        <div className="s-flex s-max-w-xs s-flex-col s-gap-3">
+        <div className="s-flex s-flex-col s-gap-3">
           <div className="s-text-xl">Tree</div>
           <div>
             <Tree>
@@ -133,13 +135,14 @@ export const TreeExample = () => {
                   />
 
                   <Tree.Item
-                    label="1"
+                    label="t"
                     visual={DocumentIcon}
                     type="leaf"
                     actions={
                       <div className="s-flex s-grow s-flex-row s-items-center s-justify-between">
                         <Button size="mini" variant="outline" icon={EyeIcon} />
-                        <div className="s-text-sm s-text-muted-foreground">
+                        <div className="s-flex s-flex-row s-items-center s-gap-1 s-text-sm s-text-muted-foreground">
+                          <Icon visual={HistoryIcon} size="xs" />
                           1y
                         </div>
                       </div>

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -41,7 +41,7 @@ export const TreeExample = () => {
   return (
     <div className="s-flex s-flex-col s-gap-10">
       <div className="s-flex s-gap-10">
-        <div className="s-flex s-w-44 s-flex-col s-gap-3">
+        <div className="s-flex s-max-w-xs s-flex-col s-gap-3">
           <div className="s-text-xl">Tree</div>
           <div>
             <Tree>
@@ -129,6 +129,20 @@ export const TreeExample = () => {
                           variant="outline"
                         />
                       </>
+                    }
+                  />
+
+                  <Tree.Item
+                    label="1"
+                    visual={DocumentIcon}
+                    type="leaf"
+                    actions={
+                      <div className="s-flex s-grow s-flex-row s-items-center s-justify-between">
+                        <Button size="mini" variant="outline" icon={EyeIcon} />
+                        <div className="s-text-sm s-text-muted-foreground">
+                          1y
+                        </div>
+                      </div>
                     }
                   />
                 </Tree>


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2740
- Make Tree.Item actions grow

UI before sparkle update
<img width="667" alt="Capture d’écran 2025-04-24 à 15 20 38" src="https://github.com/user-attachments/assets/d08afcbd-a05f-4eff-a661-bf7a4e43ca87" />

## Tests
- Added case on Tree.stories.ts

## Risk
UI only, low

## Deploy Plan
- Publish new sparkle
- Update front
- Deploy front
