### PR TITLE
Un-gate Image Generation Capability

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -51,7 +51,6 @@ import type {
   PlatformMCPToolTypeWithStakeLevel,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -62,7 +61,7 @@ import { assertNever, Err, normalizeError, Ok, slugify } from "@app/types";
 
 const MAX_OUTPUT_ITEMS = 128;
 
-const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 60 * 1000; // 1 minute.
+const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes.
 
 const EMPTY_INPUT_SCHEMA: JSONSchema7 = { type: "object", properties: {} };
 
@@ -273,10 +272,6 @@ export async function tryListMCPTools(
   }
 ): Promise<MCPToolConfigurationType[]> {
   const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("mcp_actions")) {
-    return [];
-  }
 
   // Filter for MCP server configurations.
   const mcpServerActions = agentActions.filter(isMCPServerConfiguration);

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -50,7 +50,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   image_generation: {
     id: 2,
     isDefault: true,
-    flag: "mcp_actions",
+    flag: null,
   },
   file_generation: {
     id: 3,

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -11,7 +11,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { dustManagedCredentials } from "@app/types";
+import { dustManagedCredentials, Err } from "@app/types";
 
 const IMAGE_GENERATION_RATE_LIMITER_KEY = "image_generation";
 const IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS = 60 * 60 * 24 * 7; // 1 week.
@@ -139,29 +139,61 @@ const createServer = (auth: Authenticator): McpServer => {
 
       const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
 
-      const files = await concurrentExecutor(
+      const fileResults = await concurrentExecutor(
         result.data,
-        async (image) =>
-          uploadBase64ImageToFileStorage(auth, {
-            base64: image.b64_json!,
-            contentType: DEFAULT_IMAGE_MIME_TYPE,
-            fileName,
-          }),
+        async (image) => {
+          try {
+            const res = await uploadBase64ImageToFileStorage(auth, {
+              base64: image.b64_json!,
+              contentType: DEFAULT_IMAGE_MIME_TYPE,
+              fileName,
+            });
+
+            return res;
+          } catch (error) {
+            logger.error(
+              {
+                action: "mcp_tool",
+                tool: "generate_image",
+                workspaceId: workspace.sId,
+                error,
+              },
+              "Failed to save the generated image."
+            );
+
+            return new Err("Failed to save the generated image.");
+          }
+        },
         { concurrency: 10 }
       );
 
-      const content: MCPToolResultContentType[] = files.map((file) => ({
-        type: "resource",
-        resource: {
-          contentType: file.contentType,
-          fileId: file.sId,
-          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-          snippet: null,
-          text: "Your image was generated successfully.",
-          title: file.fileName,
-          uri: file.getPublicUrl(auth),
-        },
-      }));
+      const errors = fileResults.filter((r) => r.isErr());
+      if (errors.length > 0) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Failed to generate image: ${errors.map((e) => e.error).join(", ")}`,
+            },
+          ],
+        };
+      }
+
+      const content: MCPToolResultContentType[] = fileResults
+        .filter((f) => f.isOk())
+        .map(({ value: file }) => ({
+          type: "resource",
+          resource: {
+            contentType: file.contentType,
+            fileId: file.sId,
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+            snippet: null,
+            text: "Your image was generated successfully.",
+            title: file.fileName,
+            uri: file.getPublicUrl(auth),
+          },
+        }));
 
       return {
         isError: false,

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -161,7 +161,7 @@ const createServer = (auth: Authenticator): McpServer => {
               "Failed to save the generated image."
             );
 
-            return new Err("Failed to save the generated image.");
+            return new Err(new Error("Failed to save the generated image."));
           }
         },
         { concurrency: 10 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/12239.

This PR un-gates the image generation capability and make error handling of the tool more robust.

I had to slightly bump the MCP timeout as occasionally image generation takes more than one minute. Will try to make it per server in a follow up PR to keep the default one minute.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
