### PR TITLE
[connectors] fix(webcrawler): Only init firecrawl in webcrawler activities

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,3 +1,4 @@
+import FirecrawlApp from "@mendable/firecrawl-js";
 import { Context } from "@temporalio/activity";
 import { isCancellation } from "@temporalio/workflow";
 import { BasicCrawler, CheerioCrawler, Configuration, LogLevel } from "crawlee";
@@ -23,6 +24,7 @@ import {
   MIN_EXTRACTED_TEXT_LENGTH,
   REQUEST_HANDLING_TIMEOUT,
 } from "@connectors/connectors/webcrawler/temporal/workflows";
+import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import {
@@ -32,7 +34,6 @@ import {
   upsertDataSourceDocument,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
-import { firecrawlApp } from "@connectors/lib/firecrawl";
 import {
   WebCrawlerFolder,
   WebCrawlerPage,
@@ -57,6 +58,10 @@ import {
 } from "@connectors/types";
 
 import { DustHttpClient } from "../lib/http";
+
+export const firecrawlApp = new FirecrawlApp({
+  apiKey: apiConfig.getFirecrawlAPIConfig().apiKey,
+});
 
 const CONCURRENCY = 1;
 

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -59,10 +59,6 @@ import {
 
 import { DustHttpClient } from "../lib/http";
 
-export const firecrawlApp = new FirecrawlApp({
-  apiKey: apiConfig.getFirecrawlAPIConfig().apiKey,
-});
-
 const CONCURRENCY = 1;
 
 export async function markAsCrawled(connectorId: ModelId) {
@@ -104,6 +100,11 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
   if (!webCrawlerConfig) {
     throw new Error(`Webcrawler configuration not found for connector.`);
   }
+
+  const firecrawlApp = new FirecrawlApp({
+    apiKey: apiConfig.getFirecrawlAPIConfig().apiKey,
+  });
+
   const childLogger = logger.child({
     connectorId: connector.id,
   });

--- a/connectors/src/lib/firecrawl.ts
+++ b/connectors/src/lib/firecrawl.ts
@@ -1,7 +1,0 @@
-import FirecrawlApp from "@mendable/firecrawl-js";
-
-import { apiConfig } from "./api/config";
-
-export const firecrawlApp = new FirecrawlApp({
-  apiKey: apiConfig.getFirecrawlAPIConfig().apiKey,
-});


### PR DESCRIPTION
## Description
Avoid having firecrawl be loaded in every workers, init it only in webcrawler activities

## Tests

## Risk

## Deploy Plan
- Deploy connectors
- Remove firecrawl API from other workers
