### PR TITLE
feat(MCP): add `ask_agent` MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -21,6 +21,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "web_search_&_browse_v2",
   "tables_query",
   "think",
+  "ask_agent",
   "reasoning_v2",
 ] as const;
 
@@ -117,6 +118,11 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 1007,
     isDefault: true,
     flag: "dev_mcp_actions",
+  },
+  ask_agent: {
+    id: 1008,
+    isDefault: false,
+    flag: "experimental_mcp_actions",
   },
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
@@ -1,0 +1,135 @@
+import {
+  CHILD_AGENT_CONFIGURATION_URI_PATTERN,
+  INTERNAL_MIME_TYPES,
+} from "@dust-tt/client";
+import { DustAPI } from "@dust-tt/client";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import apiConfig from "@app/lib/api/config";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, getHeaderFromGroupIds, normalizeError, Ok } from "@app/types";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "ask_agent",
+  version: "1.0.0",
+  description: "Offload a query to another agent.",
+  icon: "ActionRobotIcon",
+  authorization: null,
+};
+
+function parseAgentConfigurationUri(uri: string): Result<string, Error> {
+  const match = uri.match(CHILD_AGENT_CONFIGURATION_URI_PATTERN);
+  if (!match) {
+    return new Err(
+      new Error(`Invalid URI for a child agent configuration: ${uri}`)
+    );
+  }
+  // Safe to do this because the inputs are already checked against the zod schema here.
+  return new Ok(match[2]);
+}
+
+function createServer(auth: Authenticator): McpServer {
+  const server = new McpServer(serverInfo);
+
+  server.tool(
+    "ask_agent",
+    // TODO(mcp): we probably want to make this description configurable to guide the model on when to use this sub-agent.
+    "Query another agent.",
+    {
+      query: z.string(),
+      childAgent:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT
+        ],
+    },
+    async ({ query, childAgent: { uri } }) => {
+      const childAgentIdRes = parseAgentConfigurationUri(uri);
+      if (childAgentIdRes.isErr()) {
+        return makeMCPToolTextError(childAgentIdRes.error.message);
+      }
+      const childAgentId = childAgentIdRes.value;
+
+      const owner = auth.getNonNullableWorkspace();
+      const prodCredentials = await prodAPICredentialsForOwner(owner);
+      const requestedGroupIds = auth.groups().map((g) => g.sId);
+      const api = new DustAPI(
+        apiConfig.getDustAPIConfig(),
+        {
+          ...prodCredentials,
+          extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+        },
+        logger
+      );
+
+      const user = auth.getNonNullableUser();
+      const convRes = await api.createConversation({
+        title: `MCP ask_agent - ${new Date().toISOString()}`,
+        visibility: "unlisted",
+        message: {
+          content: query,
+          mentions: [{ configurationId: childAgentId }],
+          context: {
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            username: user.username ?? "unknown",
+            fullName: user.fullName(),
+            email: user.email,
+            profilePictureUrl: user.imageUrl,
+            origin: "mcp",
+          },
+        },
+        contentFragment: undefined,
+      });
+
+      if (convRes.isErr()) {
+        const errorMessage = `Failed to create conversation: ${convRes.error.message}`;
+        return makeMCPToolTextError(errorMessage);
+      }
+
+      const { conversation, message: createdUserMessage } = convRes.value;
+      const streamRes = await api.streamAgentAnswerEvents({
+        conversation: conversation,
+        userMessageId: createdUserMessage.sId,
+      });
+
+      if (streamRes.isErr()) {
+        const errorMessage = `Failed to stream agent answer: ${streamRes.error.message}`;
+        return makeMCPToolTextError(errorMessage);
+      }
+
+      let finalContent = "";
+      try {
+        for await (const event of streamRes.value.eventStream) {
+          if (event.type === "generation_tokens") {
+            finalContent += event.text;
+          } else if (event.type === "agent_error") {
+            const errorMessage = `Agent error: ${event.error.message}`;
+            return makeMCPToolTextError(errorMessage);
+          } else if (event.type === "user_message_error") {
+            const errorMessage = `User message error: ${event.error.message}`;
+            return makeMCPToolTextError(errorMessage);
+          } else if (event.type === "agent_message_success") {
+            break;
+          }
+        }
+      } catch (streamError) {
+        const errorMessage = `Error processing agent stream: ${
+          normalizeError(streamError).message
+        }`;
+        return makeMCPToolTextError(errorMessage);
+      }
+
+      return { content: [{ type: "text", text: finalContent.trim() }] };
+    }
+  );
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
@@ -43,7 +43,12 @@ function createServer(auth: Authenticator): McpServer {
     // TODO(mcp): we probably want to make this description configurable to guide the model on when to use this sub-agent.
     "Query another agent.",
     {
-      query: z.string(),
+      query: z.string().describe(
+        `The text prompt to send to the child agent.
+          This is the question or instruction that will be processed by the selected agent,
+          which will respond with its own capabilities and knowledge.
+          Be specific and clear to get the most relevant response.`
+      ),
       childAgent:
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { default as askAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/ask_agent";
 import { default as authDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/authentication_debugger";
 import { default as childAgentDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/child_agent_debugger";
 import { default as dataSourceDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_debugger";
@@ -57,6 +58,8 @@ export function getInternalMCPServer(
       return webtoolsServer();
     case "search":
       return searchServer(auth, agentLoopContext);
+    case "ask_agent":
+      return askAgentServer(auth);
     case "reasoning_v2":
       return reasoningServer(auth);
     default:

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -13,7 +13,6 @@ import type {
   ModelId,
   Result,
   SupportedFileContentType,
-  UserMessageType,
 } from "@app/types";
 
 export type ActionGeneratedFileType = {

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -13,6 +13,7 @@ import type {
   ModelId,
   Result,
   SupportedFileContentType,
+  UserMessageType,
 } from "@app/types";
 
 export type ActionGeneratedFileType = {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -66,19 +66,19 @@ export type MessageWithRankType = WithRank<MessageType>;
  */
 
 export type UserMessageOrigin =
-  | "slack"
-  | "web"
   | "api"
   | "email"
-  | "gsheet"
-  | "zapier"
-  | "n8n"
-  | "make"
-  | "zendesk"
-  | "raycast"
-  | "github-copilot-chat"
   | "extension"
-  | "email";
+  | "github-copilot-chat"
+  | "gsheet"
+  | "make"
+  | "mcp"
+  | "n8n"
+  | "raycast"
+  | "slack"
+  | "web"
+  | "zapier"
+  | "zendesk";
 
 export type UserMessageContext = {
   username: string;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1,6 +1,6 @@
+import type { JSONSchema7 } from "json-schema";
 import moment from "moment-timezone";
 import { z } from "zod";
-import type { JSONSchema7 } from "json-schema";
 
 import { INTERNAL_MIME_TYPES_VALUES } from "./internal_mime_types";
 
@@ -242,18 +242,19 @@ export function isSupportedImageContentType(
 }
 
 const UserMessageOriginSchema = FlexibleEnumSchema<
+  | "api"
+  | "email"
+  | "extension"
+  | "github-copilot-chat"
+  | "gsheet"
+  | "make"
+  | "mcp"
+  | "n8n"
+  | "raycast"
   | "slack"
   | "web"
-  | "api"
-  | "gsheet"
   | "zapier"
-  | "n8n"
-  | "make"
   | "zendesk"
-  | "raycast"
-  | "github-copilot-chat"
-  | "extension"
-  | "email"
 >()
   .or(z.null())
   .or(z.undefined());


### PR DESCRIPTION
## Description

- This PR adds an `ask_agent` MCP server, which can be configured with a child agent and that has one tool that calls this agent without the context of the conversation.
- It relies on `api/v1` for simplicity and to avoid having too many things to move around.
- A follow up PR will allow describing this agent when configuring it to inject this description in the description of the tool.

## Tests

## Risk

## Deploy Plan

- Deploy front.