### PR TITLE
refactor(MCP): simplify `MCPAction` component

### DIFF
--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -208,7 +208,9 @@ export function MCPAction({
           isOpen={showDataSourcesModal}
           setOpen={setShowDataSourcesModal}
           owner={owner}
-          onSave={handleDataSourceConfigUpdate}
+          onSave={(dataSourceConfigurations) => {
+            handleConfigUpdate((old) => ({ ...old, dataSourceConfigurations }));
+          }}
           initialDataSourceConfigurations={
             actionConfiguration.dataSourceConfigurations ?? {}
           }
@@ -223,7 +225,9 @@ export function MCPAction({
             setShowTablesModal(isOpen);
           }}
           owner={owner}
-          onSave={handleTableConfigUpdate}
+          onSave={(tablesConfigurations) => {
+            handleConfigUpdate((old) => ({ ...old, tablesConfigurations }));
+          }}
           initialDataSourceConfigurations={
             actionConfiguration.tablesConfigurations ?? {}
           }
@@ -274,7 +278,9 @@ export function MCPAction({
             actionConfiguration.dataSourceConfigurations ?? {}
           }
           openDataSourceModal={() => setShowDataSourcesModal(true)}
-          onSave={handleDataSourceConfigUpdate}
+          onSave={(dataSourceConfigurations) => {
+            handleConfigUpdate((old) => ({ ...old, dataSourceConfigurations }));
+          }}
           viewType="document"
         />
       )}
@@ -285,13 +291,17 @@ export function MCPAction({
             actionConfiguration.tablesConfigurations ?? {}
           }
           openDataSourceModal={() => setShowTablesModal(true)}
-          onSave={handleTableConfigUpdate}
+          onSave={(tablesConfigurations) => {
+            handleConfigUpdate((old) => ({ ...old, tablesConfigurations }));
+          }}
           viewType="table"
         />
       )}
       {requirements.requiresChildAgentConfiguration && (
         <ChildAgentConfigurationSection
-          onAgentSelect={handleChildAgentConfigUpdate}
+          onAgentSelect={(childAgentId) => {
+            handleConfigUpdate((old) => ({ ...old, childAgentId }));
+          }}
           selectedAgentId={actionConfiguration.childAgentId}
           owner={owner}
         />
@@ -306,7 +316,15 @@ export function MCPAction({
       <AdditionalConfigurationSection
         {...requirements}
         additionalConfiguration={actionConfiguration.additionalConfiguration}
-        onConfigUpdate={handleAdditionalConfigUpdate}
+        onConfigUpdate={(key, value) => {
+          handleConfigUpdate((old) => ({
+            ...old,
+            additionalConfiguration: {
+              ...old.additionalConfiguration,
+              [key]: value,
+            },
+          }));
+        }}
       />
     </>
   );

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -1,5 +1,5 @@
 import { ContentMessage, InformationCircleIcon } from "@dust-tt/sparkle";
-import React, { useCallback, useContext, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 import { AdditionalConfigurationSection } from "@app/components/assistant_builder/actions/configuration/AdditionalConfigurationSection";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/actions/configuration/AssistantBuilderDataSourceModal";
@@ -140,51 +140,42 @@ export function MCPAction({
     [setEdited, updateAction]
   );
 
-  const handleDataSourceConfigUpdate = useCallback(
-    (dsConfigs: DataSourceViewSelectionConfigurations) => {
+  const handleConfigUpdate = useCallback(
+    (
+      getNewConfig: (
+        old: AssistantBuilderMCPServerConfiguration
+      ) => AssistantBuilderMCPServerConfiguration
+    ) => {
       setEdited(true);
       updateAction({
         actionName: action.name,
         actionDescription: action.description,
-        getNewActionConfig: (old) => ({
-          ...(old as AssistantBuilderMCPServerConfiguration),
-          dataSourceConfigurations: dsConfigs,
-        }),
+        getNewActionConfig: (old) =>
+          getNewConfig(old as AssistantBuilderMCPServerConfiguration),
       });
     },
     [action.description, action.name, setEdited, updateAction]
+  );
+
+  const handleDataSourceConfigUpdate = useCallback(
+    (dataSourceConfigurations: DataSourceViewSelectionConfigurations) => {
+      handleConfigUpdate((old) => ({ ...old, dataSourceConfigurations }));
+    },
+    [handleConfigUpdate]
   );
 
   const handleTableConfigUpdate = useCallback(
-    (tableConfigs: DataSourceViewSelectionConfigurations) => {
-      setEdited(true);
-
-      updateAction({
-        actionName: action.name,
-        actionDescription: action.description,
-        getNewActionConfig: (old) => ({
-          ...(old as AssistantBuilderMCPServerConfiguration),
-          tablesConfigurations: tableConfigs,
-        }),
-      });
+    (tablesConfigurations: DataSourceViewSelectionConfigurations) => {
+      handleConfigUpdate((old) => ({ ...old, tablesConfigurations }));
     },
-    [action.description, action.name, setEdited, updateAction]
+    [handleConfigUpdate]
   );
 
   const handleChildAgentConfigUpdate = useCallback(
-    (newChildAgentId: string) => {
-      setEdited(true);
-
-      updateAction({
-        actionName: action.name,
-        actionDescription: action.description,
-        getNewActionConfig: (old) => ({
-          ...(old as AssistantBuilderMCPServerConfiguration),
-          childAgentId: newChildAgentId,
-        }),
-      });
+    (childAgentId: string) => {
+      handleConfigUpdate((old) => ({ ...old, childAgentId }));
     },
-    [action.description, action.name, setEdited, updateAction]
+    [handleConfigUpdate]
   );
 
   const handleReasoningModelConfigUpdate = useCallback(
@@ -205,27 +196,15 @@ export function MCPAction({
 
   const handleAdditionalConfigUpdate = useCallback(
     (key: string, value: string | number | boolean) => {
-      if (!selectedMCPServerView) {
-        return;
-      }
-      setEdited(true);
-      updateAction({
-        actionName: slugify(selectedMCPServerView?.server.name ?? ""),
-        actionDescription: selectedMCPServerView?.server.description ?? "",
-        getNewActionConfig: (prev) => {
-          const prevConfig = prev as AssistantBuilderMCPServerConfiguration;
-          return {
-            ...prevConfig,
-            mcpServerViewId: selectedMCPServerView.id,
-            additionalConfiguration: {
-              ...prevConfig.additionalConfiguration,
-              [key]: value,
-            },
-          };
+      handleConfigUpdate((old) => ({
+        ...old,
+        additionalConfiguration: {
+          ...old.additionalConfiguration,
+          [key]: value,
         },
-      });
+      }));
     },
-    [selectedMCPServerView, setEdited, updateAction]
+    [handleConfigUpdate]
   );
 
   if (action.type !== "MCP") {

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -157,55 +157,38 @@ export function MCPAction({
     [action.description, action.name, setEdited, updateAction]
   );
 
-  const handleDataSourceConfigUpdate = useCallback(
-    (dataSourceConfigurations: DataSourceViewSelectionConfigurations) => {
-      handleConfigUpdate((old) => ({ ...old, dataSourceConfigurations }));
-    },
-    [handleConfigUpdate]
+  const handleDataSourceConfigUpdate = (
+    dataSourceConfigurations: DataSourceViewSelectionConfigurations
+  ) => {
+    handleConfigUpdate((old) => ({ ...old, dataSourceConfigurations }));
+  };
+
+  const handleTableConfigUpdate = (
+    tablesConfigurations: DataSourceViewSelectionConfigurations
+  ) => {
+    handleConfigUpdate((old) => ({ ...old, tablesConfigurations }));
+  };
+
+  const handleChildAgentConfigUpdate = (childAgentId: string) => {
+    handleConfigUpdate((old) => ({ ...old, childAgentId }));
+  };
+
+  const handleReasoningModelConfigUpdate = handleConfigUpdate(
+    (reasoningModel: ModelConfigurationType) => ({ ...old, reasoningModel })
   );
 
-  const handleTableConfigUpdate = useCallback(
-    (tablesConfigurations: DataSourceViewSelectionConfigurations) => {
-      handleConfigUpdate((old) => ({ ...old, tablesConfigurations }));
-    },
-    [handleConfigUpdate]
-  );
-
-  const handleChildAgentConfigUpdate = useCallback(
-    (childAgentId: string) => {
-      handleConfigUpdate((old) => ({ ...old, childAgentId }));
-    },
-    [handleConfigUpdate]
-  );
-
-  const handleReasoningModelConfigUpdate = useCallback(
-    (reasoningModelConfig: ModelConfigurationType) => {
-      setEdited(true);
-
-      updateAction({
-        actionName: action.name,
-        actionDescription: action.description,
-        getNewActionConfig: (old) => ({
-          ...(old as AssistantBuilderMCPServerConfiguration),
-          reasoningModel: reasoningModelConfig,
-        }),
-      });
-    },
-    [action.description, action.name, setEdited, updateAction]
-  );
-
-  const handleAdditionalConfigUpdate = useCallback(
-    (key: string, value: string | number | boolean) => {
-      handleConfigUpdate((old) => ({
-        ...old,
-        additionalConfiguration: {
-          ...old.additionalConfiguration,
-          [key]: value,
-        },
-      }));
-    },
-    [handleConfigUpdate]
-  );
+  const handleAdditionalConfigUpdate = (
+    key: string,
+    value: string | number | boolean
+  ) => {
+    handleConfigUpdate((old) => ({
+      ...old,
+      additionalConfiguration: {
+        ...old.additionalConfiguration,
+        [key]: value,
+      },
+    }));
+  };
 
   if (action.type !== "MCP") {
     return null;

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -16,7 +16,6 @@ import type {
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type {
-  DataSourceViewSelectionConfigurations,
   LightWorkspaceType,
   ModelConfigurationType,
   SpaceType,
@@ -157,39 +156,6 @@ export function MCPAction({
     [action.description, action.name, setEdited, updateAction]
   );
 
-  const handleDataSourceConfigUpdate = (
-    dataSourceConfigurations: DataSourceViewSelectionConfigurations
-  ) => {
-    handleConfigUpdate((old) => ({ ...old, dataSourceConfigurations }));
-  };
-
-  const handleTableConfigUpdate = (
-    tablesConfigurations: DataSourceViewSelectionConfigurations
-  ) => {
-    handleConfigUpdate((old) => ({ ...old, tablesConfigurations }));
-  };
-
-  const handleChildAgentConfigUpdate = (childAgentId: string) => {
-    handleConfigUpdate((old) => ({ ...old, childAgentId }));
-  };
-
-  const handleReasoningModelConfigUpdate = handleConfigUpdate(
-    (reasoningModel: ModelConfigurationType) => ({ ...old, reasoningModel })
-  );
-
-  const handleAdditionalConfigUpdate = (
-    key: string,
-    value: string | number | boolean
-  ) => {
-    handleConfigUpdate((old) => ({
-      ...old,
-      additionalConfiguration: {
-        ...old.additionalConfiguration,
-        [key]: value,
-      },
-    }));
-  };
-
   if (action.type !== "MCP") {
     return null;
   }
@@ -308,7 +274,9 @@ export function MCPAction({
       )}
       {requirements.requiresReasoningConfiguration && (
         <ReasoningModelConfigurationSection
-          onModelSelect={handleReasoningModelConfigUpdate}
+          onModelSelect={(reasoningModel: ModelConfigurationType) => {
+            handleConfigUpdate((old) => ({ ...old, reasoningModel }));
+          }}
           selectedReasoningModel={actionConfiguration.reasoningModel}
           owner={owner}
         />


### PR DESCRIPTION
## Description

- This PR aims at simplifying the configuration updates in the `MCPAction` component.
- A lot of code is repeated, notably the callbacks to update configuration, which is addressed in this PR.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
