### PR TITLE
feat(Confluence): add option to ignore `x-ratelimit-nearlimit` header

### DIFF
--- a/connectors/migrations/db/migration_68.sql
+++ b/connectors/migrations/db/migration_68.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 25, 2025
+ALTER TABLE "public"."confluence_configurations" ADD COLUMN "ignoreNearRateLimit" BOOLEAN DEFAULT false;

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -74,6 +74,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
 
     const confluenceConfigurationBlob = {
       cloudId,
+      ignoreNearRateLimit: false,
       url: cloudUrl,
       userAccountId,
     };

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -11,7 +11,10 @@ import {
   confluenceUpsertPagesWithFullParentsWorkflow,
   confluenceUpsertPageWithFullParentsWorkflow,
 } from "@connectors/connectors/confluence/temporal/workflows";
-import { ConfluenceSpace } from "@connectors/lib/models/confluence";
+import {
+  ConfluenceConfiguration,
+  ConfluenceSpace,
+} from "@connectors/lib/models/confluence";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -173,6 +176,48 @@ export const confluence = async ({
           null
         );
       }
+      return { success: true };
+    }
+    case "ignore-near-rate-limit": {
+      const { connectorId } = args;
+      if (!connectorId) {
+        throw new Error("Missing --connectorId argument");
+      }
+
+      const configuration = await ConfluenceConfiguration.findOne({
+        where: {
+          connectorId,
+        },
+      });
+      if (!configuration) {
+        throw new Error(
+          `Confluence configuration not found (connectorId: ${args.connectorId})`
+        );
+      }
+
+      await configuration.update({ ignoreNearRateLimit: true });
+
+      return { success: true };
+    }
+    case "unignore-near-rate-limit": {
+      const { connectorId } = args;
+      if (!connectorId) {
+        throw new Error("Missing --connectorId argument");
+      }
+
+      const configuration = await ConfluenceConfiguration.findOne({
+        where: {
+          connectorId,
+        },
+      });
+      if (!configuration) {
+        throw new Error(
+          `Confluence configuration not found (connectorId: ${args.connectorId})`
+        );
+      }
+
+      await configuration.update({ ignoreNearRateLimit: false });
+
       return { success: true };
     }
 

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -439,7 +439,7 @@ export class ConfluenceClient {
     // When approaching the rate limit, we defer the handling of the backoff to Temporal.
     // We have no accurate estimation of the time we should wait here, the goal here is more to warm up the exponential
     // backoff to slow down the queries as soon as they approach the rate limit.
-    if (checkNearRateLimit(response)) {
+    if (!bypassThrottle && checkNearRateLimit(response)) {
       statsDClient.increment("external.api.calls", 1, [
         "provider:confluence",
         "status:near_rate_limit",

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -282,19 +282,23 @@ export class ConfluenceClient {
   private readonly restApiBaseUrl: string;
   private readonly legacyRestApiBaseUrl: string;
   private readonly proxyAgent?: ProxyAgent;
+  private readonly ignoreNearRateLimit?: boolean;
 
   constructor(
     private readonly authToken: string,
     {
       cloudId,
+      ignoreNearRateLimit,
       useProxy = false,
     }: {
       cloudId?: string;
+      ignoreNearRateLimit?: boolean;
       useProxy?: boolean;
     } = {}
   ) {
     this.restApiBaseUrl = `/ex/confluence/${cloudId}/wiki/api/v2`;
     this.legacyRestApiBaseUrl = `/ex/confluence/${cloudId}/wiki/rest/api`;
+    this.ignoreNearRateLimit = ignoreNearRateLimit;
     if (useProxy) {
       this.proxyAgent = new ProxyAgent(
         `http://${EnvironmentConfig.getEnvVariable(
@@ -439,7 +443,11 @@ export class ConfluenceClient {
     // When approaching the rate limit, we defer the handling of the backoff to Temporal.
     // We have no accurate estimation of the time we should wait here, the goal here is more to warm up the exponential
     // backoff to slow down the queries as soon as they approach the rate limit.
-    if (!bypassThrottle && checkNearRateLimit(response)) {
+    if (
+      !bypassThrottle &&
+      !this.ignoreNearRateLimit &&
+      checkNearRateLimit(response)
+    ) {
       statsDClient.increment("external.api.calls", 1, [
         "provider:confluence",
         "status:near_rate_limit",

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -92,20 +92,22 @@ async function getConfluenceAccessTokenWithThrow(connectionId: string) {
 
 export async function getConfluenceClient(config: {
   cloudId?: string;
+  ignoreNearRateLimit?: boolean;
   connectorId: ModelId;
 }): Promise<ConfluenceClient>;
 export async function getConfluenceClient(
-  config: { cloudId?: string },
+  config: { cloudId?: string; ignoreNearRateLimit?: boolean },
   connector: ConnectorResource
 ): Promise<ConfluenceClient>;
 export async function getConfluenceClient(
   config: {
     cloudId?: string;
+    ignoreNearRateLimit?: boolean;
     connectorId?: ModelId;
   },
   connector?: ConnectorResource
 ) {
-  const { cloudId, connectorId } = config;
+  const { cloudId, connectorId, ignoreNearRateLimit } = config;
 
   // Ensure the connector is fetched if not directly provided.
   const effectiveConnector =
@@ -122,6 +124,7 @@ export async function getConfluenceClient(
 
   return new ConfluenceClient(accessToken, {
     cloudId,
+    ignoreNearRateLimit,
     useProxy: effectiveConnector.useProxy ?? false,
   });
 }

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -11,6 +11,7 @@ export class ConfluenceConfiguration extends ConnectorBaseModel<ConfluenceConfig
   declare cloudId: string;
   declare url: string;
   declare userAccountId: string;
+  declare ignoreNearRateLimit: boolean;
 }
 ConfluenceConfiguration.init(
   {
@@ -35,6 +36,11 @@ ConfluenceConfiguration.init(
     userAccountId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    ignoreNearRateLimit: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: false,
     },
   },
   {

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -36,6 +36,8 @@ export const ConfluenceCommandSchema = t.type({
     t.literal("upsert-page"),
     t.literal("upsert-pages"),
     t.literal("update-parents"),
+    t.literal("ignore-near-rate-limit"),
+    t.literal("unignore-near-rate-limit"),
   ]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),


### PR DESCRIPTION
## Description

- We currently have a behavior of rejecting requests that are close to the rate limit.
- The `x-ratelimit-limit`, `x-ratelimit-reamining`  and `x-ratelimit-reset` headers are only logged when hitting the rate limit.
- This PR adds an option to disable this behavior across a whole connector, which would make us able to get some intel on the actual rate limit observed, and potentially study a bit more the behavior of the `x-ratelimit-nearlimit` header compared to the other ones.
- The CLI is also extended to enable/disable this feature.
- A follow up PR will expose the rate limit headers in poke.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Run `migration_68.sql`.
- Deploy `connectors`.