### PR TITLE
fix(`ActionDetailsWrapper`): fix invisible icon in dark mode

### DIFF
--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -25,7 +25,10 @@ export function ActionDetailsWrapper({
             "flex flex-row items-center gap-x-2"
           )}
         >
-          <Avatar size="sm" visual={<Icon visual={visual} />} />
+          <Avatar
+            size="sm"
+            visual={<Icon visual={visual} className="text-foreground" />}
+          />
           <span className="heading-base">{actionName}</span>
         </div>
       }

--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -27,7 +27,8 @@ export function ActionDetailsWrapper({
         >
           <Avatar
             size="sm"
-            visual={<Icon visual={visual} className="text-foreground" />}
+            visual={<Icon visual={visual} />}
+            backgroundColor="bg-muted-background dark:bg-muted-background-night"
           />
           <span className="heading-base">{actionName}</span>
         </div>


### PR DESCRIPTION
## Description

The icons in the `ActionDetailsWrapper` ("Tools inspection" drawer) are not visible in dark mode anymore following https://github.com/dust-tt/dust/pull/12252.

<img width="609" alt="Screenshot 2025-04-25 at 12 14 26 PM" src="https://github.com/user-attachments/assets/fc25ab85-9efb-4ce1-bc03-cee9dd0c648b" />

This PR fixes that by overriding the color of the background.

<img width="609" alt="Screenshot 2025-04-25 at 3 24 49 PM" src="https://github.com/user-attachments/assets/db1d04e7-1eef-4c8a-872a-675c42223ae5" />

This case is treated as a one-off rather than changing the `Avatar` component since in many cases we want to keep the white background.

## Tests

- Checked locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.