### PR TITLE
fix(labs): prevent 404 when Managing trackers as non-admin

### DIFF
--- a/front/components/labs/FeatureAccessButton.tsx
+++ b/front/components/labs/FeatureAccessButton.tsx
@@ -2,7 +2,12 @@ import { Button, Cog6ToothIcon, LockIcon } from "@dust-tt/sparkle";
 
 import { ConfigureLabsConnectionModal } from "@app/components/labs/modals/ConfigureLabsConnectionModal";
 import type { LabsConnectionsConfigurationResource } from "@app/lib/resources/labs_connections_resource";
-import type { LabsConnectionItemType, LightWorkspaceType } from "@app/types";
+import type {
+  DataSourceViewType,
+  LabsConnectionItemType,
+  LightWorkspaceType,
+  SpaceType,
+} from "@app/types";
 
 import { RequestFeatureAccessModal } from "./modals/RequestFeatureAccessModal";
 
@@ -14,8 +19,8 @@ interface FeatureAccessButtonProps {
   canRequestAccess: boolean;
   canManage: boolean;
   connection?: LabsConnectionItemType;
-  dataSourcesViews?: any[];
-  spaces?: any[];
+  dataSourcesViews?: DataSourceViewType[];
+  spaces?: SpaceType[];
   isSpacesLoading?: boolean;
   existingConfigurations?: LabsConnectionsConfigurationResource[];
 }

--- a/front/components/labs/FeatureAccessButton.tsx
+++ b/front/components/labs/FeatureAccessButton.tsx
@@ -71,6 +71,7 @@ export function FeatureAccessButton({
         disabled={true}
         icon={LockIcon}
         label="Manage"
+        tooltip="Only admins can manage this feature."
         variant="outline"
       />
     );

--- a/front/components/labs/FeatureAccessButton.tsx
+++ b/front/components/labs/FeatureAccessButton.tsx
@@ -68,20 +68,20 @@ export function FeatureAccessButton({
   if (!canManage) {
     return (
       <Button
-        disabled={true}
-        icon={LockIcon}
         label="Manage"
         tooltip="Only admins can manage this feature."
+        icon={LockIcon}
         variant="outline"
+        disabled={true}
       />
     );
   }
   return (
     <Button
-      href={managePath}
-      icon={Cog6ToothIcon}
       label="Manage"
+      icon={Cog6ToothIcon}
       variant="outline"
+      href={managePath}
     />
   );
 }

--- a/front/components/labs/FeatureAccessButton.tsx
+++ b/front/components/labs/FeatureAccessButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Cog6ToothIcon } from "@dust-tt/sparkle";
+import { Button, Cog6ToothIcon, LockIcon } from "@dust-tt/sparkle";
 
 import { ConfigureLabsConnectionModal } from "@app/components/labs/modals/ConfigureLabsConnectionModal";
 import type { LabsConnectionsConfigurationResource } from "@app/lib/resources/labs_connections_resource";
@@ -12,6 +12,7 @@ interface FeatureAccessButtonProps {
   managePath?: string;
   owner: LightWorkspaceType;
   canRequestAccess: boolean;
+  canManage: boolean;
   connection?: LabsConnectionItemType;
   dataSourcesViews?: any[];
   spaces?: any[];
@@ -25,6 +26,7 @@ export function FeatureAccessButton({
   managePath,
   owner,
   canRequestAccess,
+  canManage,
   connection,
   dataSourcesViews = [],
   spaces = [],
@@ -58,12 +60,22 @@ export function FeatureAccessButton({
     );
   }
 
+  if (!canManage) {
+    return (
+      <Button
+        disabled={true}
+        icon={LockIcon}
+        label="Manage"
+        variant="outline"
+      />
+    );
+  }
   return (
     <Button
-      label="Manage"
-      icon={Cog6ToothIcon}
-      variant="outline"
       href={managePath}
+      icon={Cog6ToothIcon}
+      label="Manage"
+      variant="outline"
     />
   );
 }

--- a/front/pages/w/[wId]/labs/index.tsx
+++ b/front/pages/w/[wId]/labs/index.tsx
@@ -172,6 +172,7 @@ export default function LabsTranscriptsIndex({
                       managePath={`/w/${owner.sId}/labs/${item.id}`}
                       owner={owner}
                       canRequestAccess={isAdmin}
+                      canManage={isAdmin}
                     />
                   }
                   visual={<Icon visual={item.icon} />}
@@ -231,6 +232,7 @@ export default function LabsTranscriptsIndex({
                                 featureName={`${item.label} connection`}
                                 owner={owner}
                                 canRequestAccess={isAdmin}
+                                canManage={isAdmin}
                                 connection={item}
                                 dataSourcesViews={dataSourceViews}
                                 spaces={spaces}

--- a/front/pages/w/[wId]/labs/index.tsx
+++ b/front/pages/w/[wId]/labs/index.tsx
@@ -49,6 +49,7 @@ const LABS_FEATURES: LabsFeatureItemType[] = [
     icon: BookOpenIcon,
     description:
       "Document monitoring made simple - receive alerts when documents are out of date.",
+    onlyAdminCanManage: true,
   },
   {
     id: "salesforce_personal_connections",
@@ -172,7 +173,7 @@ export default function LabsTranscriptsIndex({
                       managePath={`/w/${owner.sId}/labs/${item.id}`}
                       owner={owner}
                       canRequestAccess={isAdmin}
-                      canManage={isAdmin}
+                      canManage={!item.onlyAdminCanManage || isAdmin}
                     />
                   }
                   visual={<Icon visual={item.icon} />}
@@ -232,7 +233,7 @@ export default function LabsTranscriptsIndex({
                                 featureName={`${item.label} connection`}
                                 owner={owner}
                                 canRequestAccess={isAdmin}
-                                canManage={isAdmin}
+                                canManage={true}
                                 connection={item}
                                 dataSourcesViews={dataSourceViews}
                                 spaces={spaces}

--- a/front/types/labs.ts
+++ b/front/types/labs.ts
@@ -53,6 +53,7 @@ export type LabsFeatureItemType = {
   icon: React.ComponentType;
   label: string;
   description: string;
+  onlyAdminCanManage?: boolean;
 };
 
 export enum SyncStatus {


### PR DESCRIPTION
## Description

- Currently builders and users can see the labs tracker feature and click on the "Manage" button, which leads to a 404 because only admins are allowed on the manage pages.
- This PR fixes that by adding a prop that disables the "Manage" button. 

## Tests

- Checked locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.