### PR TITLE
Fix table deletion logic

### DIFF
--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -149,7 +149,7 @@ export function useCreateDataSourceViewDocument(
       sendNotification({
         type: "success",
         title: "Document processing",
-        description: "Your document will appear shortly",
+        description: "Your document is processing and will appear shortly",
       });
 
       const response: PostDocumentResponseBody = await res.json();

--- a/front/lib/swr/file.ts
+++ b/front/lib/swr/file.ts
@@ -86,8 +86,8 @@ export function useUpsertFileAsDatasourceEntry(
 
       sendNotification({
         type: "success",
-        title: "File successfully uploaded",
-        description: "The file has been successfully uploaded.",
+        title: "File processing",
+        description: "Your file is processing and will appear shortly.",
       });
 
       const response: UpsertFileToDataSourceResponseBody = await res.json();


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/2735

Table deletion was broken due to the use of now semi-deprecated viewType.

We have flows with viewType and flows without viewType. A way to make the viewType appear is to upload a document by providing a custom body (no file upload).

Will create a follow-up PR to remove the view type logic entirely as I think it does not make sense anymore post search capabilities?

## Tests

Tested locally (upload, batch upload, for table and document, deletion of document and tables)

## Risk

Low

## Deploy Plan

- deploy `front`