### PR TITLE
[connectors] Skip folder if can't be found

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -383,13 +383,27 @@ export async function syncFiles({
     throw new Error(`Connector ${connectorId} not found`);
   }
 
+  const logger = getActivityLogger(connector);
+
   const parent = await MicrosoftNodeResource.fetchByInternalId(
     connectorId,
     parentInternalId
   );
 
   if (!parent) {
-    throw new Error(`Unexpected: parent node not found: ${parentInternalId}`);
+    logger.error(
+      {
+        connectorId,
+        parentInternalId,
+      },
+      `[SyncFiles] Node not found, skipping`
+    );
+
+    return {
+      count: 0,
+      childNodes: [],
+      nextLink: undefined,
+    };
   }
 
   if (parent.nodeType !== "folder" && parent.nodeType !== "drive") {
@@ -406,7 +420,6 @@ export async function syncFiles({
   }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const logger = getActivityLogger(connector);
 
   logger.info(
     {


### PR DESCRIPTION
## Description

Calling syncNodes on non-existing folder currently throw an error - this can happen if the folder has been removed between the activity enqueu and the execution, and won't resolve by itself. Just return instead of throwing an error


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy connectors
