### PR TITLE
Hubpost cleanup code + ability to filter with multiple properties and all operators

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/hupspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hupspot_utils.ts
@@ -1,0 +1,46 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import logger from "@app/logger/logger";
+
+export const logAndReturnError = ({
+  error,
+  params,
+  message,
+}: {
+  error: any;
+  params: Record<string, any>;
+  message: string;
+}): CallToolResult => {
+  logger.error(
+    {
+      error,
+      ...params,
+    },
+    `[Hubspot MCP Server] ${message}`
+  );
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: error.response?.body?.message ?? error.message ?? message,
+      },
+    ],
+  };
+};
+
+export const returnSuccess = ({
+  message,
+  result,
+}: {
+  message: string;
+  result: any;
+}): CallToolResult => {
+  return {
+    isError: false,
+    content: [
+      { type: "text", text: message },
+      { type: "text", text: JSON.stringify(result, null, 2) },
+    ],
+  };
+};

--- a/front/lib/actions/mcp_internal_actions/servers/hupspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hupspot_utils.ts
@@ -1,6 +1,43 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
+import { getAccessTokenForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+
+export const ERROR_MESSAGES = {
+  NO_ACCESS_TOKEN: "No access token found",
+  OBJECT_NOT_FOUND: "Object not found",
+  NO_OBJECTS_FOUND: "No objects found",
+} as const;
+
+export const withAuth = async (
+  auth: Authenticator,
+  mcpServerId: string,
+  action: (accessToken: string) => Promise<any>,
+  params?: any
+) => {
+  const accessToken = await getAccessTokenForInternalMCPServer(auth, {
+    mcpServerId,
+  });
+  if (!accessToken) {
+    return {
+      isError: true,
+      content: [{ type: "text", text: ERROR_MESSAGES.NO_ACCESS_TOKEN }],
+    };
+  }
+  try {
+    const result = await action(accessToken);
+    if (result?.isError) {
+      return result;
+    }
+    return returnSuccess({
+      message: "Operation completed successfully",
+      result,
+    });
+  } catch (error: any) {
+    return logAndReturnError({ error, params, message: "Operation failed" });
+  }
+};
 
 export const logAndReturnError = ({
   error,


### PR DESCRIPTION
## Description

Cleanup: 
- introduce utils  `useAuth`, `returnSuccess` and `logAndReturnError` to simplify code. 
- cleanup types: "contacts", "companies", "deals" as Hubspot simple objects, Owner is a special type. 
- remove tools that can be replaced by the tools to filter properties. 
- add tool to filter with multiple properties and supporting all operators. 

I have 3 files for hubspot: server, utils, and api_helper. I will move them all in a hubspot folder. Not doing it here to preserve the diff. 

## Tests

Locally. 

## Risk

Under a feature flag. 

## Deploy Plan

Deploy front. 