### PR TITLE
startToCloseTimeout for notion database upsert

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2502,6 +2502,8 @@ export async function upsertDatabaseStructuredDataFromCache({
     databaseId,
   });
 
+  localLogger.info("Start upserting Notion Database.");
+
   const dbModel = await NotionDatabase.findOne({
     where: {
       connectorId,
@@ -2686,6 +2688,8 @@ export async function upsertDatabaseStructuredDataFromCache({
       );
     }
   }
+
+  localLogger.info("Done upserting Notion Database.");
 
   await dbModel.update({ structuredDataUpsertedTs: upsertAt });
 }

--- a/connectors/src/connectors/notion/temporal/workflows/upserts.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/upserts.ts
@@ -17,9 +17,14 @@ import type { ModelId } from "@connectors/types";
 const {
   garbageCollectorMarkAsSeenAndReturnNewEntities,
   fetchDatabaseChildPages,
-  upsertDatabaseStructuredDataFromCache,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "15 minutes",
+});
+
+const { upsertDatabaseStructuredDataFromCache } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "30 minutes",
 });
 
 export async function upsertDatabase({


### PR DESCRIPTION
## Description

State here: https://dust4ai.slack.com/archives/C05F84CFP0E/p1745584959828739

Looks like the whole process can take more than 15mn based on logs (adding a start/end log to confirm). Bumping the startToclose accordingly.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`