### PR TITLE
Fix client side error when opening `UserMenu` dropdown

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -181,7 +181,7 @@ export function UserMenu({
                       );
                     }
                   }}
-                  icon={BugIcon}
+                  icon={<BugIcon />}
                 />
               )}
               {!isOnlyAdmin(owner) && (

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -113,7 +113,7 @@ export function UserMenu({
         <DropdownMenuLabel label="Beta" />
         <DropdownMenuItem
           label="Exploratory features"
-          icon={TestTubeIcon}
+          icon={<TestTubeIcon />}
           href={`/w/${owner.sId}/labs`}
         />
 
@@ -167,7 +167,7 @@ export function UserMenu({
 
         {showDebugTools(featureFlags) && (
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger label="Dev Tools" icon={BugIcon} />
+            <DropdownMenuSubTrigger label="Dev Tools" icon={<BugIcon />} />
             <DropdownMenuSubContent>
               {router.route === "/w/[wId]/assistant/[cId]" && (
                 <DropdownMenuItem


### PR DESCRIPTION
## Description

- This PR fixes a client side error occurring when rendering lucide icons in a `ItemWithLabelIconAndDescription`.
- The error is due to a certain check in `renderIcon` where the lucide icon is not recognized as a function (it's an exotic component) and we attempt at rendering it directly although it's an object.

## Tests

- Local.

## Risk

- N/A.

## Deploy Plan

- Deploy `front`.