### PR TITLE
[sparkle] Support exotic components

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.478",
+  "version": "0.2.480",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.478",
+      "version": "0.2.480",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.479",
+  "version": "0.2.480",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -110,12 +110,20 @@ const renderIcon = (
   icon: React.ComponentType | React.ReactNode,
   size: "xs" | "sm" = "xs"
 ) => {
-  if (!icon) {
-    return null;
+  // If it's a React element (already rendered), return it as is
+  if (React.isValidElement(icon)) {
+    return icon;
   }
-  return typeof icon === "function" ? <Icon size={size} visual={icon} /> : icon;
+
+  // For any component type (including exotic components), render it with Icon
+  if (typeof icon === "function" || typeof icon === "object") {
+    return <Icon size={size} visual={icon as React.ComponentType} />;
+  }
+
+  // For primitive values, return null
+  return null;
 };
-  
+
 const ItemWithLabelIconAndDescription = <
   T extends ItemWithLabelIconAndDescriptionProps,
 >({


### PR DESCRIPTION
## Description

Support exotic components (objects returned by forwardRef, as lucide icons) - in that case pass to Icon to render it

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
