### PR TITLE
Hubspot: Add tool to count object with filters

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -82,6 +82,7 @@ export const INTERNAL_MCP_SERVERS: Record<
       get_objects_by_properties: "low",
       get_object_by_email: "low",
       get_object_by_id: "low",
+      count_objects_by_properties: "low",
       create_object: "high",
       update_object: "high",
     },

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -6,6 +6,8 @@ import type { PublicOwner } from "@hubspot/api-client/lib/codegen/crm/owners/mod
 import type { Property } from "@hubspot/api-client/lib/codegen/crm/properties/models/Property";
 
 const MAX_ENUM_OPTIONS_DISPLAYED = 50;
+const MAX_LIMIT = 200; // Hubspot API limit.
+export const MAX_COUNT_LIMIT = 10000; // Hubspot API limit.
 export const SIMPLE_OBJECTS = ["contacts", "companies", "deals"] as const;
 type SimpleObjectType = (typeof SIMPLE_OBJECTS)[number];
 
@@ -196,6 +198,7 @@ export const getObjectByEmail = async (
       },
     ],
     properties: propertyNames,
+    limit: MAX_LIMIT,
   });
 
   if (objects.results.length === 0) {
@@ -243,7 +246,44 @@ export const getObjectsByProperties = async (
       },
     ],
     properties: propertyNames,
+    limit: MAX_LIMIT,
   });
 
   return objects.results;
+};
+
+export const countObjectsByProperties = async (
+  accessToken: string,
+  objectType: SimpleObjectType,
+  filters: Array<{
+    propertyName: string;
+    operator: FilterOperatorEnum;
+    value?: string;
+  }>
+): Promise<number> => {
+  const hubspotClient = new Client({ accessToken });
+
+  const objects = await hubspotClient.crm[objectType].searchApi.doSearch({
+    filterGroups: [
+      {
+        filters: filters.map(({ propertyName, operator, value }) => {
+          const filter: any = {
+            propertyName,
+            operator,
+          };
+          // Only include value if it's not a HAS_PROPERTY or NOT_HAS_PROPERTY operator
+          if (
+            operator !== FilterOperatorEnum.HasProperty &&
+            operator !== FilterOperatorEnum.NotHasProperty
+          ) {
+            filter.value = value;
+          }
+          return filter;
+        }),
+      },
+    ],
+    limit: 1, // We only need to know if there are any objects matching the filters.
+  });
+
+  return objects.total;
 };

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -6,8 +6,9 @@ import type { PublicOwner } from "@hubspot/api-client/lib/codegen/crm/owners/mod
 import type { Property } from "@hubspot/api-client/lib/codegen/crm/properties/models/Property";
 
 const MAX_ENUM_OPTIONS_DISPLAYED = 50;
-const MAX_LIMIT = 200; // Hubspot API limit.
+export const MAX_LIMIT = 200; // Hubspot API limit.
 export const MAX_COUNT_LIMIT = 10000; // Hubspot API limit.
+
 export const SIMPLE_OBJECTS = ["contacts", "companies", "deals"] as const;
 type SimpleObjectType = (typeof SIMPLE_OBJECTS)[number];
 

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import { getAccessTokenForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 
@@ -13,27 +14,17 @@ export const ERROR_MESSAGES = {
 export const withAuth = async (
   auth: Authenticator,
   mcpServerId: string,
-  action: (accessToken: string) => Promise<any>,
+  action: (accessToken: string) => Promise<CallToolResult>,
   params?: any
 ): Promise<CallToolResult> => {
   const accessToken = await getAccessTokenForInternalMCPServer(auth, {
     mcpServerId,
   });
   if (!accessToken) {
-    return {
-      isError: true,
-      content: [{ type: "text", text: ERROR_MESSAGES.NO_ACCESS_TOKEN }],
-    };
+    return makeMCPToolTextError(ERROR_MESSAGES.NO_ACCESS_TOKEN);
   }
   try {
-    const result = await action(accessToken);
-    if (result?.isError) {
-      return result;
-    }
-    return returnSuccess({
-      message: "Operation completed successfully",
-      result,
-    });
+    return await action(accessToken);
   } catch (error: any) {
     return logAndReturnError({ error, params, message: "Operation failed" });
   }
@@ -55,15 +46,9 @@ export const logAndReturnError = ({
     },
     `[Hubspot MCP Server] ${message}`
   );
-  return {
-    isError: true,
-    content: [
-      {
-        type: "text",
-        text: error.response?.body?.message ?? error.message ?? message,
-      },
-    ],
-  };
+  return makeMCPToolTextError(
+    error.response?.body?.message ?? error.message ?? message
+  );
 };
 
 export const returnSuccess = ({

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
@@ -15,7 +15,7 @@ export const withAuth = async (
   mcpServerId: string,
   action: (accessToken: string) => Promise<any>,
   params?: any
-) => {
+): Promise<CallToolResult> => {
   const accessToken = await getAccessTokenForInternalMCPServer(auth, {
     mcpServerId,
   });

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -11,6 +11,7 @@ import {
   getObjectProperties,
   getObjectsByProperties,
   MAX_COUNT_LIMIT,
+  MAX_LIMIT,
   SIMPLE_OBJECTS,
   updateObject,
 } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper";
@@ -133,7 +134,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
 
   server.tool(
     "get_objects_by_properties",
-    `Searches for objects in Hubspot matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is 200 objects retrieved.`,
+    `Searches for objects in Hubspot matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is ${MAX_LIMIT} objects retrieved.`,
     {
       objectType: z.enum(SIMPLE_OBJECTS),
       filters: z
@@ -170,7 +171,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
 
   server.tool(
     "count_objects_by_properties",
-    `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is 10000 objects.`,
+    `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is ${MAX_COUNT_LIMIT} objects.`,
     {
       objectType: z.enum(SIMPLE_OBJECTS),
       filters: z


### PR DESCRIPTION
## Description

Adds a hubspot-count-tool to count a number of objects matching a criteria. 

## Tests

Locally. 

## Risk

Under a feature flag. 

## Deploy Plan

Deploy front. 