### PR TITLE
[front] feat(agents): Add TagsManager

### DIFF
--- a/front/components/assistant/DeleteTagDialog.tsx
+++ b/front/components/assistant/DeleteTagDialog.tsx
@@ -1,0 +1,55 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+
+import { useDeleteTag } from "@app/lib/swr/tags";
+import type { WorkspaceType } from "@app/types";
+import type { TagType } from "@app/types/tag";
+
+export const DeleteTagDialog = ({
+  owner,
+  tag,
+  open,
+  setOpen,
+}: {
+  owner: WorkspaceType;
+  tag: TagType;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}) => {
+  const { deleteTag } = useDeleteTag({ owner });
+  const onDeleteTag = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await deleteTag(tag.sId);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Are you absolutely sure?</DialogTitle>
+        </DialogHeader>
+
+        <DialogContainer>
+          This action cannot be undone.
+          <br />
+          This will delete the tag "{tag.name}" permanently.
+        </DialogContainer>
+
+        <DialogFooter
+          leftButtonProps={{ label: "Cancel", variant: "outline" }}
+          rightButtonProps={{
+            label: "Delete tag",
+            variant: "warning",
+            onClick: onDeleteTag,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/front/components/assistant/TagsFilterMenu.tsx
+++ b/front/components/assistant/TagsFilterMenu.tsx
@@ -10,19 +10,26 @@ import {
 import { useState } from "react";
 
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
+import type { WorkspaceType } from "@app/types";
 import type { TagType } from "@app/types/tag";
+
+import { TagsManager } from "./TagsManager";
 
 type TagsFilterMenuProps = {
   tags: TagType[];
   selectedTags: string[];
   setSelectedTags: (tags: string[]) => void;
+  owner: WorkspaceType;
 };
 
 export const TagsFilterMenu = ({
   tags,
   selectedTags,
   setSelectedTags,
+  owner,
 }: TagsFilterMenuProps) => {
+  const [isTagManagerOpen, setTagManagerOpen] = useState(false);
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
   const [tagSearch, setTagSearch] = useState<string>("");
 
   const filteredTags = tags
@@ -38,43 +45,59 @@ export const TagsFilterMenu = ({
     });
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="primary"
-          icon={TagIcon}
-          label={
-            selectedTags.length > 0 ? `Tags (${selectedTags.length})` : "Tags"
-          }
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        dropdownHeaders={
-          <DropdownMenuSearchbar
-            name="tagSearch"
-            placeholder="Search tags"
-            value={tagSearch}
-            onChange={setTagSearch}
-            button={<Button disabled variant="primary" label="Manage tags" />}
+    <>
+      <TagsManager
+        open={isTagManagerOpen}
+        setOpen={setTagManagerOpen}
+        owner={owner}
+      />
+      <DropdownMenu open={isDropdownOpen} onOpenChange={setDropdownOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="primary"
+            icon={TagIcon}
+            label={
+              selectedTags.length > 0 ? `Tags (${selectedTags.length})` : "Tags"
+            }
           />
-        }
-      >
-        {filteredTags.map((tag) => (
-          <DropdownMenuCheckboxItem
-            key={tag.sId}
-            checked={selectedTags.includes(tag.sId)}
-            onCheckedChange={(checked) => {
-              if (checked) {
-                setSelectedTags([...selectedTags, tag.sId]);
-              } else {
-                setSelectedTags(selectedTags.filter((t) => t !== tag.sId));
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          dropdownHeaders={
+            <DropdownMenuSearchbar
+              name="tagSearch"
+              placeholder="Search tags"
+              value={tagSearch}
+              onChange={setTagSearch}
+              button={
+                <Button
+                  variant="primary"
+                  label="Manage tags"
+                  onClick={() => {
+                    setDropdownOpen(false);
+                    setTagManagerOpen(true);
+                  }}
+                />
               }
-            }}
-          >
-            {tag.name}
-          </DropdownMenuCheckboxItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            />
+          }
+        >
+          {filteredTags.map((tag) => (
+            <DropdownMenuCheckboxItem
+              key={tag.sId}
+              checked={selectedTags.includes(tag.sId)}
+              onCheckedChange={(checked) => {
+                if (checked) {
+                  setSelectedTags([...selectedTags, tag.sId]);
+                } else {
+                  setSelectedTags(selectedTags.filter((t) => t !== tag.sId));
+                }
+              }}
+            >
+              {tag.name}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
   );
 };

--- a/front/components/assistant/TagsManager.tsx
+++ b/front/components/assistant/TagsManager.tsx
@@ -19,10 +19,8 @@ import { useTagsUsage } from "@app/lib/swr/tags";
 import type { WorkspaceType } from "@app/types";
 import type { TagTypeWithUsage } from "@app/types/tag";
 
-import {
-  EditTagDialog,
-  TagCreationDialog,
-} from "../assistant_builder/TagCreationDialog";
+import { TagCreationDialog } from "../assistant_builder/TagCreationDialog";
+import { EditTagDialog } from "../assistant_builder/TagUpdateDialog";
 import { DeleteTagDialog } from "./DeleteTagDialog";
 
 const columns = [

--- a/front/components/assistant/TagsManager.tsx
+++ b/front/components/assistant/TagsManager.tsx
@@ -1,0 +1,148 @@
+import {
+  Button,
+  DataTable,
+  PencilSquareIcon,
+  PlusIcon,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  Spinner,
+  useSendNotification,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import type { CellContext } from "@tanstack/react-table";
+import { useState } from "react";
+
+import { useTagsUsage } from "@app/lib/swr/tags";
+import type { WorkspaceType } from "@app/types";
+import type { TagTypeWithUsage } from "@app/types/tag";
+
+import {
+  EditTagDialog,
+  TagCreationDialog,
+} from "../assistant_builder/TagCreationDialog";
+import { DeleteTagDialog } from "./DeleteTagDialog";
+
+const columns = [
+  {
+    accessorKey: "name",
+    header: "Tag label",
+  },
+  {
+    accessorKey: "usage",
+    header: "Tag usage",
+  },
+  {
+    accessorKey: "action",
+    header: "",
+    cell: (info: CellContext<any, number>) => (
+      <DataTable.MoreButton menuItems={info.row.original.moreMenuItems} />
+    ),
+    meta: { className: "w-14" },
+  },
+];
+
+const NewTagButton = ({ owner }: { owner: WorkspaceType }) => {
+  const sendNotification = useSendNotification();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button label="New tag" icon={PlusIcon} onClick={() => setOpen(true)} />
+      <TagCreationDialog
+        owner={owner}
+        isOpen={open}
+        onTagCreated={() => {
+          sendNotification({
+            type: "success",
+            title: "Tag created",
+          });
+        }}
+        setIsOpen={setOpen}
+      />
+    </>
+  );
+};
+
+export type TagsManagerProps = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  owner: WorkspaceType;
+};
+
+export function TagsManager({ open, setOpen, owner }: TagsManagerProps) {
+  const { isTagsLoading, tags } = useTagsUsage({ owner });
+  const [tagActionModal, setTagActionModal] = useState<{
+    type: "delete" | "edit";
+    tag: TagTypeWithUsage;
+  } | null>(null);
+
+  const rows = tags.map((tag) => ({
+    ...tag,
+    moreMenuItems: [
+      {
+        icon: PencilSquareIcon,
+        label: "Edit tag label",
+        onClick: (e: React.MouseEvent) => {
+          e.stopPropagation();
+          setTagActionModal({ type: "edit", tag });
+        },
+        kind: "item",
+      },
+      {
+        icon: XMarkIcon,
+        label: "Delete tag",
+        onClick: (e: React.MouseEvent) => {
+          e.stopPropagation();
+          setTagActionModal({ type: "delete", tag });
+        },
+        variant: "warning",
+        kind: "item",
+      },
+    ],
+  }));
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent size="lg">
+          <SheetHeader>
+            <SheetTitle>Managing tags</SheetTitle>
+          </SheetHeader>
+
+          <SheetContainer>
+            <div className="flex w-full flex-row justify-end">
+              <NewTagButton owner={owner} />
+            </div>
+
+            {isTagsLoading && (
+              <div className="flex flex-row items-center">
+                <Spinner />
+              </div>
+            )}
+            <DataTable data={rows} columns={columns} />
+          </SheetContainer>
+        </SheetContent>
+      </Sheet>
+
+      {tagActionModal != null && tagActionModal.type === "delete" && (
+        <DeleteTagDialog
+          owner={owner}
+          open
+          setOpen={() => setTagActionModal(null)}
+          tag={tagActionModal.tag}
+        />
+      )}
+      {tagActionModal !== null && tagActionModal.type === "edit" && (
+        <EditTagDialog
+          owner={owner}
+          tag={tagActionModal.tag}
+          isOpen
+          setIsOpen={() => setTagActionModal(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/front/components/assistant_builder/TagCreationDialog.tsx
+++ b/front/components/assistant_builder/TagCreationDialog.tsx
@@ -1,0 +1,164 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+import { useCreateTag, useUpdateTag } from "@app/lib/swr/tags";
+import type { WorkspaceType } from "@app/types";
+import type { TagType } from "@app/types/tag";
+
+const MAX_TAG_LENGTH = 100;
+
+export const TagCreationDialog = ({
+  owner,
+  isOpen,
+  setIsOpen,
+  onTagCreated,
+}: {
+  owner: WorkspaceType;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  onTagCreated: (tag: TagType) => void;
+}) => {
+  const [name, setName] = useState("");
+  const { createTag } = useCreateTag({ owner });
+
+  useEffect(() => {
+    if (isOpen) {
+      setName("");
+    }
+  }, [isOpen]);
+
+  const handleCreateTag = async () => {
+    const tag = await createTag(name);
+    if (tag) {
+      onTagCreated(tag);
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>Add tag</DialogTitle>
+          <DialogDescription>
+            Create a new tag for your assistant
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <div className="flex space-x-2">
+              <div className="flex-grow">
+                <Input
+                  maxLength={MAX_TAG_LENGTH}
+                  id="name"
+                  placeholder="Tag name"
+                  value={name}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && name.length > 0) {
+                      void handleCreateTag();
+                    }
+                  }}
+                  autoFocus
+                />
+              </div>
+            </div>
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "ghost",
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "primary",
+            onClick: handleCreateTag,
+            disabled: name.length === 0,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export const EditTagDialog = ({
+  owner,
+  tag,
+  isOpen,
+  setIsOpen,
+}: {
+  owner: WorkspaceType;
+  tag: TagType;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+}) => {
+  const [name, setName] = useState(() => tag.name);
+  const { updateTag } = useUpdateTag({ owner, tagId: tag.sId });
+
+  const handleCreateTag = async () => {
+    await updateTag({ name });
+    if (tag) {
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>Edit tag</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <div className="flex space-x-2">
+              <div className="flex-grow">
+                <Input
+                  maxLength={MAX_TAG_LENGTH}
+                  id="name"
+                  placeholder="Tag name"
+                  value={name}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && name.length > 0) {
+                      void handleCreateTag();
+                    }
+                  }}
+                  autoFocus
+                />
+              </div>
+            </div>
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "ghost",
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "primary",
+            onClick: handleCreateTag,
+            disabled: name.length === 0,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/front/components/assistant_builder/TagUpdateDialog.tsx
+++ b/front/components/assistant_builder/TagUpdateDialog.tsx
@@ -2,45 +2,37 @@ import {
   Dialog,
   DialogContainer,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
   Input,
   Label,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
-import { useCreateTag } from "@app/lib/swr/tags";
+import { useUpdateTag } from "@app/lib/swr/tags";
 import type { WorkspaceType } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
-export const MAX_TAG_LENGTH = 100;
+import { MAX_TAG_LENGTH } from "./TagCreationDialog";
 
-export const TagCreationDialog = ({
+export const EditTagDialog = ({
   owner,
+  tag,
   isOpen,
   setIsOpen,
-  onTagCreated,
 }: {
   owner: WorkspaceType;
+  tag: TagType;
   isOpen: boolean;
-  setIsOpen: (isOpen: boolean) => void;
-  onTagCreated: (tag: TagType) => void;
+  setIsOpen: (open: boolean) => void;
 }) => {
-  const [name, setName] = useState("");
-  const { createTag } = useCreateTag({ owner });
-
-  useEffect(() => {
-    if (isOpen) {
-      setName("");
-    }
-  }, [isOpen]);
+  const [name, setName] = useState(() => tag.name);
+  const { updateTag } = useUpdateTag({ owner, tagId: tag.sId });
 
   const handleCreateTag = async () => {
-    const tag = await createTag(name);
+    await updateTag({ name });
     if (tag) {
-      onTagCreated(tag);
       setIsOpen(false);
     }
   };
@@ -49,10 +41,7 @@ export const TagCreationDialog = ({
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>Add tag</DialogTitle>
-          <DialogDescription>
-            Create a new tag for your assistant
-          </DialogDescription>
+          <DialogTitle>Edit tag</DialogTitle>
         </DialogHeader>
         <DialogContainer>
           <div className="space-y-2">

--- a/front/components/assistant_builder/TagsSelector.tsx
+++ b/front/components/assistant_builder/TagsSelector.tsx
@@ -1,13 +1,6 @@
 import {
   Button,
   Chip,
-  Dialog,
-  DialogContainer,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -15,108 +8,18 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Icon,
-  Input,
-  Label,
   MagnifyingGlassIcon,
   PlusIcon,
 } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
-import { useCreateTag, useTags } from "@app/lib/swr/tags";
+import { useTags } from "@app/lib/swr/tags";
 import type { WorkspaceType } from "@app/types";
 import { isAdmin } from "@app/types";
+import type { TagType } from "@app/types/tag";
 
-const MAX_TAG_LENGTH = 100;
-
-const TagCreationDialog = ({
-  owner,
-  isOpen,
-  setIsOpen,
-  setBuilderState,
-  setEdited,
-}: {
-  owner: WorkspaceType;
-  isOpen: boolean;
-  setIsOpen: (isOpen: boolean) => void;
-  builderState: AssistantBuilderState;
-  setBuilderState: (
-    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
-  ) => void;
-  setEdited: (edited: boolean) => void;
-}) => {
-  const [name, setName] = useState("");
-  const { createTag } = useCreateTag({ owner });
-
-  // const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (isOpen) {
-      setName("");
-    }
-  }, [isOpen]);
-
-  const handleCreateTag = async () => {
-    const tag = await createTag(name);
-    if (tag) {
-      setBuilderState((state) => ({
-        ...state,
-        tags: [...state.tags, tag],
-      }));
-      setEdited(true);
-      setIsOpen(false);
-    }
-  };
-
-  return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogContent size="lg">
-        <DialogHeader>
-          <DialogTitle>Add tag</DialogTitle>
-          <DialogDescription>
-            Create a new tag for your assistant
-          </DialogDescription>
-        </DialogHeader>
-        <DialogContainer>
-          <div className="space-y-2">
-            <Label htmlFor="name">Name</Label>
-            <div className="flex space-x-2">
-              <div className="flex-grow">
-                <Input
-                  maxLength={MAX_TAG_LENGTH}
-                  id="name"
-                  placeholder="Tag name"
-                  value={name}
-                  onChange={(e) => {
-                    setName(e.target.value);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && name.length > 0) {
-                      void handleCreateTag();
-                    }
-                  }}
-                  autoFocus
-                />
-              </div>
-            </div>
-          </div>
-        </DialogContainer>
-        <DialogFooter
-          leftButtonProps={{
-            label: "Cancel",
-            variant: "ghost",
-          }}
-          rightButtonProps={{
-            label: "Save",
-            variant: "primary",
-            onClick: handleCreateTag,
-            disabled: name.length === 0,
-          }}
-        />
-      </DialogContent>
-    </Dialog>
-  );
-};
+import { TagCreationDialog } from "./TagCreationDialog";
 
 export const TagsSelector = ({
   owner,
@@ -158,15 +61,23 @@ export const TagsSelector = ({
   const assistantTags = [...(builderState.tags || [])].sort((a, b) =>
     a.name.localeCompare(b.name)
   );
+
+  const onTagCreated = (tag: TagType) => {
+    setBuilderState((state) => ({
+      ...state,
+      tags: [...state.tags, tag],
+    }));
+    setEdited(true);
+    setEdited(true);
+  };
+
   return (
     <>
       <TagCreationDialog
         owner={owner}
         isOpen={isDialogOpen}
         setIsOpen={setIsDialogOpen}
-        builderState={builderState}
-        setBuilderState={setBuilderState}
-        setEdited={setEdited}
+        onTagCreated={onTagCreated}
       />
       <div className="mb-2 flex flex-wrap gap-2">
         {assistantTags.map((tag) => (

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -113,7 +113,7 @@ export function useDeleteTag({ owner }: { owner: LightWorkspaceType }) {
       sendNotification({
         type: "error",
         title: "Failed to delete tag",
-        description: json.error.message || "Failed to create tag",
+        description: json.error.message || "Failed to delete tag",
       });
     }
 

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -4,6 +4,7 @@ import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";
+import type { GetTagsUsageResponseBody } from "@app/pages/api/w/[wId]/tags/usage";
 import type { LightWorkspaceType } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
@@ -32,9 +33,35 @@ export function useTags({
   };
 }
 
+export function useTagsUsage({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const tagsFetcher: Fetcher<GetTagsUsageResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/tags/usage`,
+    tagsFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    tags: useMemo(() => (data ? data.tags : []), [data]),
+    isTagsLoading: !error && !data && !disabled,
+    isTagsError: !!error,
+    mutateTagsUsage: mutate,
+  };
+}
+
 export function useCreateTag({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
   const { mutateTags } = useTags({ owner, disabled: true });
+  const { mutateTagsUsage } = useTagsUsage({ owner, disabled: true });
 
   const createTag = async (name: string): Promise<TagType | null> => {
     const res = await fetch(`/api/w/${owner.sId}/tags`, {
@@ -57,11 +84,91 @@ export function useCreateTag({ owner }: { owner: LightWorkspaceType }) {
     }
 
     void mutateTags();
+    void mutateTagsUsage();
     const json = await res.json();
     return json.tag;
   };
 
   return {
     createTag,
+  };
+}
+
+export function useDeleteTag({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+  const { mutateTags } = useTags({ owner, disabled: true });
+  const { mutateTagsUsage } = useTagsUsage({ owner, disabled: true });
+
+  const deleteTag = async (tagId: string) => {
+    const res = await fetch(`/api/w/${owner.sId}/tags/${tagId}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      const json = await res.json();
+
+      sendNotification({
+        type: "error",
+        title: "Failed to delete tag",
+        description: json.error.message || "Failed to create tag",
+      });
+    }
+
+    sendNotification({
+      type: "success",
+      title: "tag deleted",
+    });
+
+    void mutateTags();
+    void mutateTagsUsage();
+  };
+
+  return {
+    deleteTag,
+  };
+}
+
+export function useUpdateTag({
+  owner,
+  tagId,
+}: {
+  owner: LightWorkspaceType;
+  tagId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateTags } = useTags({ owner, disabled: true });
+  const { mutateTagsUsage } = useTagsUsage({ owner, disabled: true });
+
+  const updateTag = async ({ name }: { name: string }) => {
+    const res = await fetch(`/api/w/${owner.sId}/tags/${tagId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name,
+      }),
+    });
+
+    if (!res.ok) {
+      const json = await res.json();
+
+      sendNotification({
+        type: "error",
+        title: "Failed to delete tag",
+        description: json.error.message || "Failed to create tag",
+      });
+      return;
+    }
+
+    void mutateTags();
+    void mutateTagsUsage();
+  };
+
+  return {
+    updateTag,
   };
 }

--- a/front/pages/api/w/[wId]/tags/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/tags/[tId]/index.ts
@@ -1,3 +1,5 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -5,10 +7,21 @@ import type { Authenticator } from "@app/lib/auth";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import type { TagType } from "@app/types/tag";
+
+export type UpdateTagResponseBody = {
+  tag: TagType;
+};
+
+const PatchBodySchema = t.type({
+  name: t.string,
+});
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<Record<string, never>>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<Record<string, never> | UpdateTagResponseBody>
+  >,
   auth: Authenticator
 ): Promise<void> {
   const {
@@ -65,12 +78,56 @@ async function handler(
       res.status(204).end();
       return;
     }
+    case "PUT": {
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Only workspace administrators can delete tags",
+          },
+        });
+      }
+
+      const tag = await TagResource.fetchById(auth, tId);
+
+      if (!tag) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Tag not found",
+          },
+        });
+      }
+
+      const r = PatchBodySchema.decode(req.body);
+
+      if (isLeft(r)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid request body",
+          },
+        });
+      }
+      const body = r.right;
+      const { name } = body;
+
+      await tag.updateName(name);
+
+      return res.status(200).json({
+        tag: tag.toJSON(),
+      });
+    }
     default: {
       return apiError(req, res, {
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, DELETE is expected.",
+          message:
+            "The method passed is not supported, DELETE or PATCH is expected.",
         },
       });
     }

--- a/front/pages/api/w/[wId]/tags/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/tags/[tId]/index.ts
@@ -7,11 +7,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import type { TagType } from "@app/types/tag";
-
-export type UpdateTagResponseBody = {
-  tag: TagType;
-};
 
 const PatchBodySchema = t.type({
   name: t.string,
@@ -19,9 +14,7 @@ const PatchBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<Record<string, never> | UpdateTagResponseBody>
-  >,
+  res: NextApiResponse<WithAPIErrorResponse<Record<string, never>>>,
   auth: Authenticator
 ): Promise<void> {
   const {
@@ -117,9 +110,8 @@ async function handler(
 
       await tag.updateName(name);
 
-      return res.status(200).json({
-        tag: tag.toJSON(),
-      });
+      res.status(200).end();
+      return;
     }
     default: {
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/tags/usage/index.ts
+++ b/front/pages/api/w/[wId]/tags/usage/index.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { TagResource } from "@app/lib/resources/tags_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import type { TagTypeWithUsage } from "@app/types/tag";
+
+export type GetTagsUsageResponseBody = {
+  tags: TagTypeWithUsage[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetTagsUsageResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { method } = req;
+
+  switch (method) {
+    case "GET": {
+      const tagsWithUsage = await TagResource.findAllWithUsage(auth);
+
+      return res.status(200).json({
+        tags: tagsWithUsage,
+      });
+    }
+    default: {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -360,6 +360,7 @@ export default function WorkspaceAssistants({
                     tags={uniqueTags}
                     selectedTags={selectedTags}
                     setSelectedTags={setSelectedTags}
+                    owner={owner}
                   />
                 )}
                 <Link

--- a/front/types/tag.ts
+++ b/front/types/tag.ts
@@ -3,8 +3,6 @@ export type TagType = {
   name: string;
 };
 
-export type TagTypeWithUsage = {
-  sId: string;
-  name: string;
+export type TagTypeWithUsage = TagType & {
   usage: number;
 };

--- a/front/types/tag.ts
+++ b/front/types/tag.ts
@@ -2,3 +2,9 @@ export type TagType = {
   sId: string;
   name: string;
 };
+
+export type TagTypeWithUsage = {
+  sId: string;
+  name: string;
+  usage: number;
+};


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2747
- Add tags manager to add/edit/delete tags
- Add method to fetch Tag with a computed usage
- Add route to fetch Tag with those usage
- Add route to update Tag
- Update `TagCreationDialog` to be used in AssistantBuilder and in TagsManager
![screencapture-localhost-3000-w-qCUK4zlmpW-builder-assistants-2025-04-25-18_53_29](https://github.com/user-attachments/assets/0e13e116-1f9d-46e9-9831-51df7fa99768)
![screencapture-localhost-3000-w-qCUK4zlmpW-builder-assistants-2025-04-25-18_54_25](https://github.com/user-attachments/assets/43fd8aab-2421-4d6c-b616-fe55490d21d3)

## Tests
- Locally test

## Risk
Low, behind FF

## Deploy Plan
Deploy front
