### PR TITLE
[security] hide invitation link from objects returned by the API

### DIFF
--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -1,7 +1,6 @@
 import { verify } from "jsonwebtoken";
 
 import config from "@app/lib/api/config";
-import { getMembershipInvitationUrl } from "@app/lib/api/invitation";
 import { AuthFlowError } from "@app/lib/iam/errors";
 import { MembershipInvitation } from "@app/lib/models/membership_invitation";
 import { Workspace } from "@app/lib/models/workspace";

--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -100,7 +100,6 @@ export async function getPendingMembershipInvitationWithWorkspaceForEmail(
         createdAt: pendingInvitation.createdAt.getTime(),
         id: pendingInvitation.id,
         initialRole: pendingInvitation.initialRole,
-        inviteLink: getMembershipInvitationUrl(workspace, pendingInvitation.id),
         inviteEmail: pendingInvitation.inviteEmail,
         sId: pendingInvitation.sId,
         status: pendingInvitation.status,

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,9 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  getMembershipInvitationToken,
-  getTokenFromMembershipInvitationUrl,
-} from "@app/lib/api/invitation";
+import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
 import { getSession } from "@app/lib/auth";
 import { AuthFlowError, SSOEnforcedError } from "@app/lib/iam/errors";

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -10,7 +10,6 @@ export type MembershipInvitationType = {
   id: ModelId;
   status: "pending" | "consumed" | "revoked";
   inviteEmail: string;
-  inviteLink: string;
   initialRole: ActiveRoleType;
   createdAt: number;
 };


### PR DESCRIPTION
## Description

Hides inviteLink from invitation objects returned to the API

Fixes: https://github.com/dust-tt/dust/issues/12199

## Tests

Tested invitation flow locally

## Risk

Breaking invitation flow. Didn't touch the "invitation checking flow so low security risk"

## Deploy Plan

- deploy `front`