### PR TITLE
[front] chore(mcp): Move back websearch mcp to dev

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -63,10 +63,12 @@ export const INTERNAL_MCP_SERVERS: Record<
     isDefault: true,
     flag: "dev_mcp_actions", // Putting this behind the dev flag for now to allow shipping without it.
   },
+  // WARN: This action was moved back to dev
+  // keeping it here with the same ID to not break workspaces
   "web_search_&_browse_v2": {
     id: 5,
     isDefault: true,
-    flag: "mcp_actions",
+    flag: "dev_mcp_actions",
   },
   think: {
     id: 6,


### PR DESCRIPTION
## Description
- As websearch/browse v2 is not totally ready, move it back behind `dev_mcp_actions`. 
- Keep the ID the same to avoid breaking internal mcp configuration
- The web capabilites V1 show up properly when v2 is not available.

## Tests
- Locally tested, hidding the action doesn't break agent, it just doesn't show and doesn't give access to the action.

## Risk
- Currently some of our users have access to that v2 action, hiding the action would remove web capabilities for those agents. A migration of their data is needed first.

## Deploy Plan
- Migrate agent that have that v2 back to v1
