### PR TITLE
OAuth: do not 404 when DB is down

### DIFF
--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -137,12 +137,18 @@ async fn connections_finalize(
         .await
     {
         Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to retrieve connection",
+            Some(e),
+        ),
+        Ok(None) => error_response(
             StatusCode::NOT_FOUND,
             "connection_not_found",
             "Requested connection was not found",
-            Some(e),
+            None,
         ),
-        Ok(mut c) => match c
+        Ok(Some(mut c)) => match c
             .finalize(
                 state.clone().store.clone(),
                 &payload.code,
@@ -218,12 +224,18 @@ async fn connections_access_token(
 ) -> (StatusCode, Json<APIResponse>) {
     match state.store.retrieve_connection(&connection_id).await {
         Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to retrieve connection",
+            Some(e),
+        ),
+        Ok(None) => error_response(
             StatusCode::NOT_FOUND,
             "connection_not_found",
             "Requested connection was not found",
-            Some(e),
+            None,
         ),
-        Ok(mut c) => match c.access_token(state.clone().store.clone()).await {
+        Ok(Some(mut c)) => match c.access_token(state.clone().store.clone()).await {
             Err(e) => error_response(
                 match e.code {
                     connection::ConnectionErrorCode::TokenRevokedError => StatusCode::UNAUTHORIZED,
@@ -304,12 +316,18 @@ async fn credentials_retrieve(
 ) -> (StatusCode, Json<APIResponse>) {
     match state.store.retrieve_credential(&credential_id).await {
         Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to retrieve credentials",
+            Some(e),
+        ),
+        Ok(None) => error_response(
             StatusCode::NOT_FOUND,
             "credential_not_found",
             "Requested credential was not found",
-            Some(e),
+            None,
         ),
-        Ok(c) => match c.unseal_encrypted_content() {
+        Ok(Some(c)) => match c.unseal_encrypted_content() {
             Err(e) => error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_server_error",

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -506,8 +506,7 @@ impl Connection {
             self.related_credential_id = connection.related_credential_id;
         } else {
             return Err(anyhow::anyhow!(
-                "Connection not found in store: {}",
-                self.connection_id
+                "Connection not found in store while reloading",
             ));
         }
         Ok(())

--- a/core/src/oauth/store.rs
+++ b/core/src/oauth/store.rs
@@ -202,14 +202,15 @@ impl OAuthStore for PostgresOAuthStore {
         connection_id: &str,
     ) -> Result<Option<Connection>> {
         let c = self.retrieve_connection(connection_id).await?;
+
         if let Some(ref c) = c {
             if c.provider() == provider {
-                return Ok(Some(c.clone()));
+                Ok(Some(c.clone()))
             } else {
                 Err(anyhow::anyhow!("Connection provider mismatch"))
             }
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 


### PR DESCRIPTION
## Description

If we have an unexpected error (eg timeout talking to Postgres), we don't want to return 404 for connections and credentials as it is understood by callers as the token is not valid anymore (stopping connectors etc...)

Real world example: https://app.datadoghq.eu/logs?query=%22ExternalOAuthTokenError%3A%20Requested%20connection%20was%20not%20found%20%28error%3A%20Timed%20out%20in%20bb8%29%22&agg_m=count&agg_m_source=base&agg_q=%40workflowId%2Cregion&agg_q_source=base%2Cbase&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&spanID=2719826250770212737&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1743235407746&to_ts=1745827407746&live=true

## Tests

Covered by existing tests

## Risk

High

## Deploy Plan

- deploy `oauth`