### PR TITLE
feat(MCP): migrate reasoning to an MCP tool

### DIFF
--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -155,6 +155,7 @@ export async function fetchMCPServerActionConfigurations(
             ? {
                 providerId: reasoningConfigurations[0].providerId,
                 modelId: reasoningConfigurations[0].modelId,
+                temperature: reasoningConfigurations[0].temperature,
                 reasoningEffort: reasoningConfigurations[0].reasoningEffort,
               }
             : null,

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -67,6 +67,8 @@ export const ConfigurableToolInputSchemas = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL]: z.object({
     modelId: z.string(),
     providerId: z.string(),
+    temperature: z.number().nullable(),
+    reasoningEffort: z.string().nullable(),
     mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL),
   }),
   // All mime types do not necessarily have a fixed schema,
@@ -154,8 +156,9 @@ export function generateConfiguredInput({
         // Unreachable, when fetching agent configurations using getAgentConfigurations, we always fill the reasoning model.
         throw new Error("Unreachable: missing reasoning model configuration.");
       }
-      const { modelId, providerId } = reasoningModel;
-      return { modelId, providerId, mimeType };
+      const { modelId, providerId, temperature, reasoningEffort } =
+        reasoningModel;
+      return { modelId, providerId, temperature, reasoningEffort, mimeType };
     }
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.STRING: {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -58,7 +58,7 @@ export function getInternalMCPServer(
     case "search":
       return searchServer(auth, agentLoopContext);
     case "reasoning_v2":
-      return reasoningServer(auth);
+      return reasoningServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -1,9 +1,15 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
 import { REASONING_MODEL_CONFIGS } from "@app/components/providers/types";
+import {
+  DEFAULT_REASONING_ACTION_DESCRIPTION,
+  DEFAULT_REASONING_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { canUseModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,21 +24,26 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: null,
 };
 
-function createServer(auth: Authenticator): McpServer {
+function createServer(auth: Authenticator, agentLoopContext?: AgentLoopContextType): McpServer {
   const server = new McpServer(serverInfo);
 
   const owner = auth.getNonNullableWorkspace();
 
   server.tool(
-    "get_model_name",
-    "Get the name of the reasoning model to use",
+    DEFAULT_REASONING_ACTION_NAME,
+    DEFAULT_REASONING_ACTION_DESCRIPTION,
     {
       model:
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL
         ],
+      text: z.string().describe("The text to reason about"),
     },
-    async ({ model: { modelId, providerId } }) => {
+    async ({ model: { modelId, providerId }, text }) => {
+      if (!agentLoopContext) {
+        throw new Error("Unreachable: missing agentLoopContext.");
+      }
+
       const featureFlags = await getFeatureFlags(owner);
       const supportedModel = REASONING_MODEL_CONFIGS.find(
         (m) => m.modelId === modelId && m.providerId === providerId
@@ -53,10 +64,54 @@ function createServer(auth: Authenticator): McpServer {
         content: [
           {
             type: "text",
-            text: `Found the following model: ${supportedModel.displayName}.`,
+            text: `This is a placeholder for the reasoning functionality. In a real implementation, we would use the shared reasoning function with the model ${supportedModel.displayName} to reason about: "${text}"`,
           },
         ],
       };
+
+      // Note: The full implementation would look something like this:
+      /*
+      // Use the shared reasoning function
+      let content = "";
+      let error = null;
+
+      // We would need to have access to the conversation, agentConfiguration, and agentMessage
+      // which would need to be passed from the agent context
+
+      // Consume the generator to get the final result
+      for await (const event of runReasoning(auth, {
+        supportedModel,
+        conversation,
+        agentConfiguration,
+        agentMessage,
+        actionConfig: {
+          modelId: supportedModel.modelId,
+          providerId: supportedModel.providerId,
+          reasoningEffort: null,
+          temperature: null,
+        },
+      })) {
+        if (event.type === "error") {
+          error = event.message;
+        } else if (event.type === "success") {
+          content = event.content;
+        }
+      }
+
+      if (error) {
+        return makeMCPToolTextError(error);
+      }
+
+      return {
+        isError: false,
+        content: [
+          {
+            type: "text",
+            text: content,
+          },
+        ],
+      };
+      */
     }
   );
 

--- a/front/lib/actions/reasoning.ts
+++ b/front/lib/actions/reasoning.ts
@@ -239,8 +239,10 @@ export class ReasoningConfigurationServerRunner extends BaseActionConfigurationS
     };
     let dustRunId: Promise<string> | undefined;
 
+    const { modelId, providerId, temperature, reasoningEffort } = actionConfig;
+
     for await (const event of runReasoning(auth, {
-      reasoningModel: { ...actionConfig },
+      reasoningModel: { modelId, providerId, temperature, reasoningEffort },
       conversation,
       agentConfiguration,
       agentMessage,

--- a/front/lib/actions/reasoning.ts
+++ b/front/lib/actions/reasoning.ts
@@ -220,7 +220,7 @@ export class ReasoningConfigurationServerRunner extends BaseActionConfigurationS
         type: "reasoning_action",
         generatedFiles: [],
       }),
-    };
+    } satisfies ReasoningStartedEvent;
 
     const actionConfig = agentConfiguration.actions.find(
       (action) =>
@@ -258,7 +258,7 @@ export class ReasoningConfigurationServerRunner extends BaseActionConfigurationS
               code: "reasoning_error",
               message: event.message,
             },
-          };
+          } satisfies ReasoningErrorEvent;
           return;
         }
         case "token": {
@@ -319,7 +319,7 @@ export class ReasoningConfigurationServerRunner extends BaseActionConfigurationS
         type: "reasoning_action",
         generatedFiles: [],
       }),
-    };
+    } satisfies ReasoningThinkingEvent;
 
     yield {
       type: "reasoning_success",
@@ -337,7 +337,7 @@ export class ReasoningConfigurationServerRunner extends BaseActionConfigurationS
         type: "reasoning_action",
         generatedFiles: [],
       }),
-    };
+    } satisfies ReasoningSuccessEvent;
 
     await action.update({
       output: actionOutput.content,

--- a/front/lib/actions/reasoning.ts
+++ b/front/lib/actions/reasoning.ts
@@ -429,10 +429,6 @@ export async function* runReasoning(
   }
 
   if (supportedModel.modelId === CLAUDE_3_7_SONNET_20250219_MODEL_ID) {
-    // We can't pass a temperature different from 1.0 in thinking mode
-    // ref: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
-    config.MODEL.temperature = 1.0;
-    delete config.MODEL.top_p;
     // Pass some extra field: https://docs.anthropic.com/en/docs/about-claude/models/extended-thinking-models#extended-output-capabilities-beta
     config.MODEL.anthropic_beta_thinking = {
       type: "enabled",

--- a/front/lib/actions/reasoning.ts
+++ b/front/lib/actions/reasoning.ts
@@ -297,9 +297,6 @@ export class ReasoningConfigurationServerRunner extends BaseActionConfigurationS
           } satisfies ReasoningTokensEvent;
           break;
         }
-        case "success": {
-          break;
-        }
         case "runId": {
           dustRunId = event.runId;
           break;
@@ -375,7 +372,6 @@ export async function* runReasoning(
 ): AsyncGenerator<
   | { type: "error"; message: string }
   | { type: "token"; token: GenerationTokensEvent }
-  | { type: "success" }
   | { type: "runId"; runId: Promise<string> }
 > {
   const owner = auth.getNonNullableWorkspace();
@@ -543,8 +539,6 @@ export async function* runReasoning(
   for await (const token of contentParser.flushTokens()) {
     yield { type: "token", token };
   }
-
-  yield { type: "success" };
 }
 
 export async function reasoningActionTypesFromAgentMessageIds(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -26,6 +26,11 @@ export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 export const REASONING_EFFORT_IDS = ["low", "medium", "high"] as const;
 export type ReasoningEffortIdType = (typeof REASONING_EFFORT_IDS)[number];
 
+export const isReasoningEffortId = (
+  reasoningEffortId: string
+): reasoningEffortId is ReasoningEffortIdType =>
+  REASONING_EFFORT_IDS.includes(reasoningEffortId as ReasoningEffortIdType);
+
 export const DEFAULT_EMBEDDING_PROVIDER_ID = "openai";
 export const EMBEDDING_PROVIDER_IDS = [
   DEFAULT_EMBEDDING_PROVIDER_ID,

--- a/sdks/js/src/tool_input_schemas.ts
+++ b/sdks/js/src/tool_input_schemas.ts
@@ -51,6 +51,8 @@ export const ConfigurableToolInputSchemas = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL]: z.object({
     modelId: z.string(),
     providerId: z.string(),
+    temperature: z.number().nullable(),
+    reasoningEffort: z.string().nullable(),
     mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL),
   }),
   // All mime types do not necessarily have a fixed schema,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2745.
- This PR extracts a function `runReasoning` from the `run` method of the `ReasoningConfigurationServerRunner` and reuses it to implement reasoning as an MCP tool.
- The component for the outputs was introduced as part of https://github.com/dust-tt/dust/pull/12155, it is not currently plugged accordingly, which will be tackled in a follow up PR.

## Tests

- TBC.

## Risk

- Low.

## Deploy Plan

- Deploy front.
