### PR TITLE
[front] fix(data_source): Fix race conditions data_sources

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -133,15 +133,20 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
   private static async baseFetch(
     auth: Authenticator,
     fetchDataSourceOptions?: FetchDataSourceOptions,
-    options?: ResourceFindOptions<DataSourceModel>
+    options?: ResourceFindOptions<DataSourceModel>,
+    transaction?: Transaction
   ) {
     const { includeDeleted } = fetchDataSourceOptions ?? {};
 
-    return this.baseFetchWithAuthorization(auth, {
-      ...this.getOptions(fetchDataSourceOptions),
-      ...options,
-      includeDeleted,
-    });
+    return this.baseFetchWithAuthorization(
+      auth,
+      {
+        ...this.getOptions(fetchDataSourceOptions),
+        ...options,
+        includeDeleted,
+      },
+      transaction
+    );
   }
 
   static async fetchById(
@@ -338,7 +343,8 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
   static async listByWorkspace(
     auth: Authenticator,
     options?: FetchDataSourceOptions,
-    includeConversationDataSources?: boolean
+    includeConversationDataSources?: boolean,
+    transaction?: Transaction
   ): Promise<DataSourceResource[]> {
     const where: WhereOptions<DataSourceModel> = {
       workspaceId: auth.getNonNullableWorkspace().id,
@@ -348,9 +354,14 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
         [Op.is]: undefined,
       };
     }
-    return this.baseFetch(auth, options, {
-      where,
-    });
+    return this.baseFetch(
+      auth,
+      options,
+      {
+        where,
+      },
+      transaction
+    );
   }
 
   static async listByConnectorProvider(

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -67,7 +67,8 @@ export abstract class ResourceWithSpace<
       order,
       where,
       includeDeleted,
-    }: ResourceFindOptions<M> = {}
+    }: ResourceFindOptions<M> = {},
+    transaction?: Transaction
   ): Promise<T[]> {
     const blobs = await this.model.findAll({
       attributes,
@@ -76,6 +77,7 @@ export abstract class ResourceWithSpace<
       limit,
       order,
       includeDeleted,
+      transaction,
     });
 
     if (blobs.length === 0) {


### PR DESCRIPTION
## Description
Fix race conditions attempting to create multiple data_sources without provider (i.e folders) at the same time.
- https://github.com/dust-tt/dust/issues/12196
- Encapsulate listing DataSource by workspace and creation of DataSource in a transaction
- Setup the lock only if the plan has limits

## Tests
- https://gist.github.com/johnoppenheimer/d52c42f6e5ca5cece1c20b1e37241a18

## Risk
- Low, easy to rollback if needed

## Deploy Plan
- Deploy front
