### PR TITLE
connectors: move unpause logic

### DIFF
--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -145,10 +145,6 @@ export const connectors = async ({
       return { success: true };
     }
     case "unpause": {
-      // We start by clearing any errorType
-      connector.errorType = null;
-      await connector.save();
-
       await throwOnError(manager.unpause());
       return { success: true };
     }

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -214,8 +214,12 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return this.update({ pausedAt: new Date() });
   }
 
+  // Unpausing a connector necessarily means clearing the connector errorType.
   async markAsUnpaused() {
-    return this.update({ pausedAt: null });
+    return this.update({
+      errorType: null,
+      pausedAt: null,
+    });
   }
 
   get isAuthTokenRevoked() {


### PR DESCRIPTION
## Description

Due to using the raw model the write was overwritten by the manager.
Moving it to the resource.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`