### PR TITLE
Hubspot: add tool to get latest objects

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -308,7 +308,7 @@ export const getLatestObjects = async (
     filterGroups: [],
     properties: propertyNames,
     sorts: ["createdate:desc"],
-    limit,
+    limit: Math.min(limit, MAX_LIMIT),
   });
 
   return objects.results;

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
@@ -51,7 +51,7 @@ export const logAndReturnError = ({
   );
 };
 
-export const returnSuccess = ({
+export const returnJSONStringifiedSuccess = ({
   message,
   result,
 }: {

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -6,6 +6,7 @@ import {
   ALL_OBJECTS,
   countObjectsByProperties,
   createObject,
+  getLatestObjects,
   getObjectByEmail,
   getObjectById,
   getObjectProperties,
@@ -17,7 +18,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper";
 import {
   ERROR_MESSAGES,
-  returnSuccess,
+  returnJSONStringifiedSuccess,
   withAuth,
 } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -52,7 +53,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           objectType,
           creatableOnly,
         });
-        return returnSuccess({
+        return returnJSONStringifiedSuccess({
           message: "Operation completed successfully",
           result,
         });
@@ -76,7 +77,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           objectType,
           objectProperties: { properties, associations: [] },
         });
-        return returnSuccess({
+        return returnJSONStringifiedSuccess({
           message: "Operation completed successfully",
           result,
         });
@@ -100,7 +101,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           objectId,
           objectProperties: { properties, associations: [] },
         });
-        return returnSuccess({
+        return returnJSONStringifiedSuccess({
           message: "Operation completed successfully",
           result,
         });
@@ -121,7 +122,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         if (!object) {
           return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
         }
-        return returnSuccess({
+        return returnJSONStringifiedSuccess({
           message: "Operation completed successfully",
           result: object,
         });
@@ -142,7 +143,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         if (!object) {
           return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
         }
-        return returnSuccess({
+        return returnJSONStringifiedSuccess({
           message: "Operation completed successfully",
           result: object,
         });
@@ -179,7 +180,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         if (!objects.length) {
           return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
         }
-        return returnSuccess({
+        return returnJSONStringifiedSuccess({
           message: "Operation completed successfully",
           result: objects,
         });
@@ -221,9 +222,30 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
             `Can't retrieve the exact number of objects matching the filters (hit Hubspot API limit of max ${MAX_COUNT_LIMIT} total objects).`
           );
         }
-        return returnSuccess({
+        return returnJSONStringifiedSuccess({
           message: "Operation completed successfully",
           result: count,
+        });
+      });
+    }
+  );
+
+  server.tool(
+    "get_latest_objects",
+    `Retrieves the latest objects from Hubspot. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is ${MAX_LIMIT} objects.`,
+    {
+      objectType: z.enum(SIMPLE_OBJECTS),
+      limit: z.number().optional(),
+    },
+    async ({ objectType, limit = 5 }) => {
+      return withAuth(auth, mcpServerId, async (accessToken) => {
+        const objects = await getLatestObjects(accessToken, objectType, limit);
+        if (!objects.length) {
+          return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
+        }
+        return returnJSONStringifiedSuccess({
+          message: "Operation completed successfully",
+          result: objects,
         });
       });
     }

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -18,10 +18,13 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper";
 import {
   ERROR_MESSAGES,
-  returnJSONStringifiedSuccess,
   withAuth,
 } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils";
-import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  makeMCPToolJSONSuccess,
+  makeMCPToolTextError,
+  makeMCPToolTextSuccess,
+} from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -53,7 +56,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           objectType,
           creatableOnly,
         });
-        return returnJSONStringifiedSuccess({
+        return makeMCPToolJSONSuccess({
           message: "Operation completed successfully",
           result,
         });
@@ -77,7 +80,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           objectType,
           objectProperties: { properties, associations: [] },
         });
-        return returnJSONStringifiedSuccess({
+        return makeMCPToolJSONSuccess({
           message: "Operation completed successfully",
           result,
         });
@@ -101,7 +104,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           objectId,
           objectProperties: { properties, associations: [] },
         });
-        return returnJSONStringifiedSuccess({
+        return makeMCPToolJSONSuccess({
           message: "Operation completed successfully",
           result,
         });
@@ -122,7 +125,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         if (!object) {
           return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
         }
-        return returnJSONStringifiedSuccess({
+        return makeMCPToolJSONSuccess({
           message: "Operation completed successfully",
           result: object,
         });
@@ -143,7 +146,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         if (!object) {
           return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
         }
-        return returnJSONStringifiedSuccess({
+        return makeMCPToolJSONSuccess({
           message: "Operation completed successfully",
           result: object,
         });
@@ -180,7 +183,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         if (!objects.length) {
           return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
         }
-        return returnJSONStringifiedSuccess({
+        return makeMCPToolJSONSuccess({
           message: "Operation completed successfully",
           result: objects,
         });
@@ -222,9 +225,9 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
             `Can't retrieve the exact number of objects matching the filters (hit Hubspot API limit of max ${MAX_COUNT_LIMIT} total objects).`
           );
         }
-        return returnJSONStringifiedSuccess({
+        return makeMCPToolTextSuccess({
           message: "Operation completed successfully",
-          result: count,
+          result: count.toString(),
         });
       });
     }
@@ -243,7 +246,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         if (!objects.length) {
           return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
         }
-        return returnJSONStringifiedSuccess({
+        return makeMCPToolJSONSuccess({
           message: "Operation completed successfully",
           result: objects,
         });

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -1,3 +1,5 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
 import type { MCPToolResult } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function makeMCPToolTextError(text: string): MCPToolResult {
@@ -11,3 +13,35 @@ export function makeMCPToolTextError(text: string): MCPToolResult {
     ],
   };
 }
+
+export const makeMCPToolTextSuccess = ({
+  message,
+  result,
+}: {
+  message: string;
+  result: string;
+}): CallToolResult => {
+  return {
+    isError: false,
+    content: [
+      { type: "text", text: message },
+      { type: "text", text: result },
+    ],
+  };
+};
+
+export const makeMCPToolJSONSuccess = ({
+  message,
+  result,
+}: {
+  message: string;
+  result: any;
+}): CallToolResult => {
+  return {
+    isError: false,
+    content: [
+      { type: "text", text: message },
+      { type: "text", text: JSON.stringify(result, null, 2) },
+    ],
+  };
+};


### PR DESCRIPTION
## Description

- Add a new tool to retrieve latest objects. 
- Put 50 objects max retrieved cause I think we're exploding the context size. 
- Rename `returnJSONStringifiedSuccess`

## Tests

Locally.

## Risk

Under a feature flag. 
Can be rolled back. 

## Deploy Plan

Deploy front. 