### PR TITLE
Poke: slack allow whitelisting for indexation

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -59,6 +59,7 @@ import {
   isSlackAutoReadPatterns,
   safeParseJSON,
 } from "@app/types";
+import { white } from "tailwindcss/colors";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 
@@ -1221,6 +1222,8 @@ function SlackWhitelistBot({
 }) {
   const [botName, setBotName] = useState("");
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
+  const [whitelistType, setWhitelistType] =
+    useState<SlackbotWhitelistType>("summon_agent");
 
   const selectedGroupName = groups.find(
     (group) => group.sId === selectedGroup
@@ -1238,6 +1241,29 @@ function SlackWhitelistBot({
             onChange={(e) => setBotName(e.target.value)}
             value={botName}
           />
+        </div>
+        <div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" label={whitelistType} />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="min-w-72">
+              <DropdownMenuRadioGroup
+                value={whitelistType ?? undefined}
+                onValueChange={(value) => {
+                  setWhitelistType(value as SlackbotWhitelistType);
+                }}
+              >
+                {["summon_agent", "index_messages"].map((whitelistType) => (
+                  <DropdownMenuRadioItem
+                    value={whitelistType}
+                    key={whitelistType}
+                    label={whitelistType}
+                  />
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
         <div>
           <DropdownMenu>
@@ -1264,7 +1290,7 @@ function SlackWhitelistBot({
           </DropdownMenu>
         </div>
         <Button
-          variant="outline"
+          variant="primary"
           label="Whitelist"
           onClick={async () => {
             if (!botName) {
@@ -1279,7 +1305,7 @@ function SlackWhitelistBot({
               botName,
               wId: owner.sId,
               groupId: selectedGroup,
-              whitelistType: "summon_agent",
+              whitelistType,
             });
             setBotName("");
           }}

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -59,7 +59,6 @@ import {
   isSlackAutoReadPatterns,
   safeParseJSON,
 } from "@app/types";
-import { white } from "tailwindcss/colors";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 


### PR DESCRIPTION
## Description

Add support for whitelistType in the Slack panel for whitelisting bot in poke

Fixes: https://github.com/dust-tt/tasks/issues/2758

We still ask for a group which is not really used but that's fine Company Data can be used.

## Tests

Tested locally

## Risk

N/A

## Deploy Plan

- deploy `connectors`