### PR TITLE
Replacing Pop-Up component by dialog

### DIFF
--- a/front/components/assistant/AssistantsTable.tsx
+++ b/front/components/assistant/AssistantsTable.tsx
@@ -4,8 +4,13 @@ import {
   ClipboardIcon,
   Cog6ToothIcon,
   DataTable,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   PencilSquareIcon,
-  Popup,
   SliderToggle,
   Tooltip,
   TrashIcon,
@@ -231,19 +236,37 @@ function GlobalAgentAction({
         disabled={agent.status === "disabled_missing_datasource"}
       />
       <div className="whitespace-normal" onClick={(e) => e.stopPropagation()}>
-        <Popup
-          show={showDisabledFreeWorkspacePopup === agent.sId}
-          className="absolute bottom-8 right-0"
-          chipLabel={`Free plan`}
-          description={`@${agent.name} is only available on our paid plans.`}
-          buttonLabel="Check Dust plans"
-          buttonClick={() => {
-            void router.push(`/w/${owner.sId}/subscription`);
+        <Dialog
+          open={showDisabledFreeWorkspacePopup === agent.sId}
+          onOpenChange={(open) => {
+            if (!open) {
+              setShowDisabledFreeWorkspacePopup(null);
+            }
           }}
-          onClose={() => {
-            setShowDisabledFreeWorkspacePopup(null);
-          }}
-        />
+        >
+          <DialogContent size="md">
+            <DialogHeader hideButton={false}>
+              <DialogTitle>Free plan</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
+              {`@${agent.name} is only available on our paid plans.`}
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: () => setShowDisabledFreeWorkspacePopup(null),
+              }}
+              rightButtonProps={{
+                label: "Check Dust plans",
+                variant: "primary",
+                onClick: () => {
+                  void router.push(`/w/${owner.sId}/subscription`);
+                },
+              }}
+            />
+          </DialogContent>
+        </Dialog>
       </div>
     </>
   );

--- a/front/components/data_source/DocumentLimitPopup.tsx
+++ b/front/components/data_source/DocumentLimitPopup.tsx
@@ -1,4 +1,11 @@
-import { Popup } from "@dust-tt/sparkle";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 
 import type { LightWorkspaceType, PlanType } from "@app/types";
@@ -18,16 +25,31 @@ export const DocumentLimitPopup = ({
 }: DocumentLimitPopupProps) => {
   const router = useRouter();
   return (
-    <Popup
-      show={isOpen}
-      chipLabel={`${plan.name} plan`}
-      description={`You have reached the limit of documents per data source (${plan.limits.dataSources.documents.count} documents). Upgrade your plan for unlimited documents and data sources.`}
-      buttonLabel="Check Dust plans"
-      buttonClick={() => {
-        void router.push(`/w/${owner.sId}/subscription`);
-      }}
-      onClose={onClose}
-      className="absolute bottom-8 right-8 z-60"
-    />
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md">
+        <DialogHeader hideButton={false}>
+          <DialogTitle>{`${plan.name} plan`}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          You have reached the limit of documents per data source (
+          {plan.limits.dataSources.documents.count} documents). Upgrade your
+          plan for unlimited documents and data sources.
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Check Dust plans",
+            variant: "primary",
+            onClick: () => {
+              void router.push(`/w/${owner.sId}/subscription`);
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/front/components/data_source/SlackBotEnableView.tsx
+++ b/front/components/data_source/SlackBotEnableView.tsx
@@ -1,4 +1,14 @@
-import { ContextItem, Popup, SlackLogo, SliderToggle } from "@dust-tt/sparkle";
+import {
+  ContextItem,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  SlackLogo,
+  SliderToggle,
+} from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import * as React from "react";
@@ -65,19 +75,33 @@ export function SlackBotEnableView({
               selected={botEnabled}
               disabled={readOnly || !isAdmin || loading}
             />
-            <Popup
-              show={showNoSlackBotPopup}
-              className="absolute bottom-8 right-0"
-              chipLabel={`${plan.name} plan`}
-              description="Your plan does not allow for the Slack bot to be enabled. Upgrade your plan to chat with Dust agents on Slack."
-              buttonLabel="Check Dust plans"
-              buttonClick={() => {
-                void router.push(`/w/${owner.sId}/subscription`);
-              }}
-              onClose={() => {
-                setShowNoSlackBotPopup(false);
-              }}
-            />
+            <Dialog open={showNoSlackBotPopup}>
+              <DialogContent size="md">
+                <DialogHeader hideButton={true}>
+                  <DialogTitle>{`${plan.name} plan`}</DialogTitle>
+                </DialogHeader>
+                <DialogContainer>
+                  <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    Your plan does not allow for the Slack bot to be enabled.
+                    Upgrade your plan to chat with Dust agents on Slack.
+                  </p>
+                </DialogContainer>
+                <DialogFooter
+                  leftButtonProps={{
+                    label: "Cancel",
+                    variant: "outline",
+                    onClick: () => setShowNoSlackBotPopup(false),
+                  }}
+                  rightButtonProps={{
+                    label: "Check Dust plans",
+                    variant: "primary",
+                    onClick: () => {
+                      void router.push(`/w/${owner.sId}/subscription`);
+                    },
+                  }}
+                />
+              </DialogContent>
+            </Dialog>
           </div>
         }
       >

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -12,7 +12,6 @@ import {
   Input,
   LockIcon,
   Page,
-  Popup,
   RadioGroup,
   RadioGroupItem,
   Sheet,
@@ -184,29 +183,61 @@ export function EnterpriseConnectionDetails({
             }}
           />
         )}
-        <Popup
-          show={showNoInviteLinkPopup}
-          chipLabel="Free plan"
-          description="You cannot enable auto-join with the free plan. Upgrade your plan to invite other members."
-          buttonLabel="Check Dust plans"
-          buttonClick={() => {
-            void router.push(`/w/${owner.sId}/subscription`);
+        <Dialog open={showNoInviteLinkPopup}>
+          <DialogContent>
+            <DialogHeader>Free plan</DialogHeader>
+            You cannot enable auto-join with the free plan. Upgrade your plan to
+            invite other members.
+            <DialogFooter>
+              <Button
+                variant="secondary"
+                onClick={() => setShowNoInviteLinkPopup(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={() => {
+                  void router.push(`/w/${owner.sId}/subscription`);
+                }}
+              >
+                Check Dust plans
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+        <Dialog
+          open={showNoVerifiedDomainPopup}
+          onOpenChange={(open) => {
+            if (!open) {
+              setShowNoVerifiedDomainPopup(false);
+            }
           }}
-          className="absolute bottom-8 right-8"
-          onClose={() => setShowNoInviteLinkPopup(false)}
-        />
-        <Popup
-          show={showNoVerifiedDomainPopup}
-          chipLabel="Domain Verification Required"
-          description="Single Sign-On (SSO) is not available because your domain isn't verified yet. Contact us at support@dust.tt for assistance."
-          buttonLabel="Get Help"
-          buttonClick={() => {
-            window.location.href =
-              "mailto:support@dust.tt?subject=Help with Domain Verification for SSO";
-          }}
-          className="absolute bottom-8 right-8"
-          onClose={() => setShowNoVerifiedDomainPopup(false)}
-        />
+        >
+          <DialogContent size="md">
+            <DialogHeader hideButton={false}>
+              <DialogTitle>Domain Verification Required</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
+              Single Sign-On (SSO) is not available because your domain isn't
+              verified yet. Contact us at support@dust.tt for assistance.
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: () => setShowNoVerifiedDomainPopup(false),
+              }}
+              rightButtonProps={{
+                label: "Get Help",
+                variant: "primary",
+                onClick: () => {
+                  window.location.href =
+                    "mailto:support@dust.tt?subject=Help with Domain Verification for SSO";
+                },
+              }}
+            />
+          </DialogContent>
+        </Dialog>
       </div>
     </Page.Vertical>
   );

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -7,7 +7,6 @@ import {
   DialogHeader,
   DialogTitle,
   Page,
-  Popup,
   SearchInput,
   useSendNotification,
 } from "@dust-tt/sparkle";
@@ -212,17 +211,32 @@ export default function WorkspaceAdmin({
                   }}
                 />
               )}
-              <Popup
-                show={showNoInviteLinkPopup}
-                chipLabel="Free plan"
-                description="You cannot enable auto-join with the free plan. Upgrade your plan to invite other members."
-                buttonLabel="Check Dust plans"
-                buttonClick={() => {
-                  void router.push(`/w/${owner.sId}/subscription`);
-                }}
-                className="absolute bottom-8 right-0"
-                onClose={() => setShowNoInviteLinkPopup(false)}
-              />
+              <Dialog open={showNoInviteLinkPopup}>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Free plan</DialogTitle>
+                  </DialogHeader>
+                  <p className="text-sm text-gray-500">
+                    You cannot enable auto-join with the free plan. Upgrade your
+                    plan to invite other members.
+                  </p>
+                  <DialogFooter>
+                    <Button
+                      variant="secondary"
+                      onClick={() => setShowNoInviteLinkPopup(false)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        void router.push(`/w/${owner.sId}/subscription`);
+                      }}
+                    >
+                      Check Dust plans
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
             </div>
           </Page.Vertical>
         )}


### PR DESCRIPTION
## Description

We want to deprecate the Pop-Up component and replace it with the Dialog Alert component.

I targeted all instances in the codebase and replaced them accordingly.

For information: I will delete the Pop-Up component in Sparkle later (if we need to revert)

## Tests

I rendered it in custom pages I created in the codebase since I wasn't able to test it directly in the product (locally).

## Risk

Low - Dialog not being triggered

## Deploy Plan
1. Merge
2. Deploy