### PR TITLE
[front] feat(ab): Add tags suggestions

### DIFF
--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -26,6 +26,7 @@ jobs:
           MONITORED_PATHS=(
             'front/lib/models/'
             'front/lib/resources/storage/models/'
+            'front/lib/registry.ts'
             'connectors/src/lib/models/'
             'connectors/src/resources/storage/models/'
             'front/pages/api/v1/'

--- a/front/admin/check_registry_apps.ts
+++ b/front/admin/check_registry_apps.ts
@@ -40,7 +40,10 @@ async function main({
   const notDeployedApps = res.value.filter((a) => !a.deployed);
   if (notDeployedApps.length > 0) {
     throw new Error(
-      "Missing apps: " + notDeployedApps.map((a) => a.appId).join(", ")
+      "Missing apps: " +
+        notDeployedApps.map((a) => a.appId).join(", ") +
+        "\n" +
+        "Check runbook: https://www.notion.so/dust-tt/Runbook-Update-Assistant-dust-apps-18c28599d94180d78dabe92f445157a8"
     );
   }
   console.log("All apps are deployed");

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -20,6 +20,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -38,6 +39,7 @@ import type { AssistantBuilderState } from "@app/components/assistant_builder/ty
 import { ConfirmContext } from "@app/components/Confirm";
 import { MembersList } from "@app/components/members/MembersList";
 import { useSearchMembers } from "@app/lib/swr/memberships";
+import { useCreateTag, useTags } from "@app/lib/swr/tags";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { debounce } from "@app/lib/utils/debounce";
 import type {
@@ -49,6 +51,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, Ok } from "@app/types";
+import type { TagType } from "@app/types/tag";
 
 export function removeLeadingAt(handle: string) {
   return handle.startsWith("@") ? handle.slice(1) : handle;
@@ -493,6 +496,11 @@ export default function NamingScreen({
               </div>
               <div className="flex flex-[1_0_0] flex-col gap-4">
                 <Page.SectionHeader title="Tags" />
+                <TagsSuggestions
+                  owner={owner}
+                  builderState={builderState}
+                  setBuilderState={setBuilderState}
+                />
                 <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
                   <TagsSelector
                     owner={owner}
@@ -568,6 +576,34 @@ async function getDescriptionSuggestions({
     body: JSON.stringify({
       type: "description",
       inputs: { instructions, name },
+    }),
+  });
+}
+
+async function getTagsSuggestions({
+  owner,
+  instructions,
+  description,
+  tags,
+}: {
+  owner: WorkspaceType;
+  instructions: string;
+  description: string;
+  tags: string[];
+}): Promise<Result<BuilderSuggestionsType, APIError>> {
+  return fetchWithErr(`/api/w/${owner.sId}/assistant/builder/suggestions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      type: "tags",
+      inputs: {
+        instructions,
+        description,
+        tags,
+        isAdmin: owner.role === "admin",
+      },
     }),
   });
 }
@@ -751,5 +787,110 @@ function AddEditorDropdown({
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function TagsSuggestions({
+  owner,
+  builderState,
+  setBuilderState,
+}: {
+  owner: WorkspaceType;
+  builderState: AssistantBuilderState;
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
+}) {
+  const { tags, isTagsLoading } = useTags({ owner });
+
+  const { createTag } = useCreateTag({ owner });
+  const tagsDebounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
+  const [tagsSuggestions, setTagsSuggestions] =
+    useState<BuilderSuggestionsType>({
+      status: "unavailable",
+      reason: "irrelevant",
+    });
+
+  const filteredTagsSuggestions = useMemo(() => {
+    if (tagsSuggestions.status !== "ok") {
+      return [];
+    }
+
+    // As only admin can create tag, we make sure the suggestions we received exist
+    if (owner.role !== "admin") {
+      return (
+        tagsSuggestions.suggestions
+          ?.slice(0, 3)
+          .filter((tag) => tags.findIndex((t) => t.name === tag) !== -1) ?? []
+      );
+    }
+
+    return tagsSuggestions.suggestions ?? [];
+  }, [owner.role, tagsSuggestions, tags]);
+
+  const updateTagsSuggestions = useCallback(async () => {
+    const tagsSuggestions = await getTagsSuggestions({
+      owner,
+      instructions: builderState.instructions || "",
+      description: builderState.description || "",
+      tags: tags.map((t) => t.name),
+    });
+
+    if (tagsSuggestions.isOk()) {
+      setTagsSuggestions(tagsSuggestions.value);
+    }
+  }, [owner, builderState.description, builderState.instructions, tags]);
+
+  useEffect(() => {
+    if (!isTagsLoading) {
+      debounce(tagsDebounceHandle, updateTagsSuggestions);
+    }
+  }, [
+    owner,
+    builderState.description,
+    builderState.instructions,
+    updateTagsSuggestions,
+    tags,
+    isTagsLoading,
+  ]);
+
+  const addTag = async (name: string) => {
+    const isTagInAssistant =
+      builderState.tags.findIndex((t) => t.name === name) !== -1;
+    let tag: TagType | null = tags.find((t) => t.name === name) ?? null;
+
+    if (tag === null && !isTagInAssistant && owner.role === "admin") {
+      tag = await createTag(name);
+    }
+
+    if (tag != null && !isTagInAssistant) {
+      setBuilderState((state) => ({
+        ...state,
+        tags: state.tags.concat(tag),
+      }));
+    }
+  };
+
+  return (
+    <>
+      {tagsSuggestions.status === "ok" &&
+        tagsSuggestions.suggestions?.length && (
+          <div className="flex items-center gap-2">
+            <div className="text-muted-foregroup text-xs font-semibold dark:text-muted-foreground-night">
+              Suggestions:
+            </div>
+
+            {filteredTagsSuggestions.map((tag) => (
+              <Button
+                key={`tag-suggestion-${tag}`}
+                size="xs"
+                variant="outline"
+                label={tag}
+                onClick={() => addTag(tag)}
+              />
+            ))}
+          </div>
+        )}
+    </>
   );
 }

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -874,7 +874,7 @@ function TagsSuggestions({
   return (
     <>
       {tagsSuggestions.status === "ok" &&
-        tagsSuggestions.suggestions?.length && (
+        filteredTagsSuggestions.length > 0 && (
           <div className="flex items-center gap-2">
             <div className="text-muted-foregroup text-xs font-semibold dark:text-muted-foreground-night">
               Suggestions:

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -115,6 +115,14 @@ function warnDocumentationAck(documentationAckLabel: string) {
   );
 }
 
+function checkAppsRegistry() {
+  warn(
+    `File \`front/lib/registry.ts\` has been modified.
+    Please check [Runbook: Update Assistant dust-apps](https://www.notion.so/dust-tt/Runbook-Update-Assistant-dust-apps-18c28599d94180d78dabe92f445157a8)
+    `
+  );
+}
+
 function checkDiffFiles() {
   const diffFiles = danger.git.modified_files
     .concat(danger.git.created_files)
@@ -160,6 +168,15 @@ function checkDiffFiles() {
 
   if (modifiedSdksFiles.length > 0) {
     checkSDKLabel();
+  }
+
+  // dust-apps registry
+  const modifiedAppsRegistry = diffFiles.filter((path) => {
+    return path === "front/lib/registry.ts";
+  });
+
+  if (modifiedAppsRegistry.length > 0) {
+    checkAppsRegistry();
   }
 }
 

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -219,6 +219,20 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
+  "assistant-builder-tags-suggestions": {
+    app: {
+      appId: "7mjFTd4e45",
+      appHash:
+        "430bb302f09d43230f5772f700c7f9823d18be44dd264e002a9d67849ab13d02",
+    },
+    config: {
+      CREATE_SUGGESTIONS: {
+        // `provider_id` and `model_id` must be set by caller.
+        function_call: "send_suggestions",
+        use_cache: false,
+      },
+    },
+  },
   "assistant-builder-process-action-schema-generator": {
     app: {
       appId: "b36c7416bd",

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -59,6 +59,7 @@ async function handler(
         case "name":
         case "description":
         case "emoji":
+        case "tags":
           model = getSmallWhitelistedModel(owner);
           break;
         default:

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -206,6 +206,15 @@ export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([
     type: t.literal("description"),
     inputs: t.type({ instructions: t.string, name: t.string }),
   }),
+  t.type({
+    type: t.literal("tags"),
+    inputs: t.type({
+      instructions: t.string,
+      description: t.string,
+      isAdmin: t.boolean,
+      tags: t.array(t.string),
+    }),
+  }),
 ]);
 
 export type BuilderSuggestionsRequestType = t.TypeOf<


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2653
- Add tags suggestion in the Assistant Builder
- If user is admin, can show new tags (that will be created)
- If not admin, only show existing tags
- Create new [dust-app](https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/7mjFTd4e45) to make suggestion

## Tests
- Locally tested, suggestions works. When not an admin, the prompt can still sometimes suggest non existing tags, so filter them also client side.
<img width="989" alt="Capture d’écran 2025-04-28 à 16 13 58" src="https://github.com/user-attachments/assets/2a38208e-f8ce-4641-a20b-1a92f4508cfd" />

## Risk
Low, behind FF.

## Deploy Plan
Deploy front
