### PR TITLE
[Discovery] Backfill editor groups for all agents

### DIFF
--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -23,6 +23,7 @@ export type DustErrorCode =
   | "user_already_member"
   | "user_not_found"
   | "user_not_member"
+  | "group_not_found"
   // MCP Server errors
   | "remote_server_not_found"
   | "internal_server_not_found"

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -135,7 +135,10 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     if (groupAgents.length === 0) {
       return new Err(
-        new Error("Editor group association not found for agent.")
+        new DustError(
+          "group_not_found",
+          "Editor group association not found for agent."
+        )
       );
     }
 

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -1,0 +1,118 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { LightAgentConfigurationType, LightWorkspaceType } from "@app/types";
+import { Logger } from "pino";
+
+const migrateWorkspaceEditorsGroups = async (
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+) => {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const agents = await getAgentConfigurations({
+    auth,
+    agentsGetView: "admin_internal",
+    variant: "light",
+  });
+
+  if (agents.length === 0) {
+    return;
+  }
+
+  logger.info(
+    `Found ${agents.length} agents to migrate on workspace ${workspace.sId}`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  await concurrentExecutor(
+    agents,
+    (agent) => backfillAgentEditorsGroup(auth, agent),
+    { concurrency: 4 }
+  );
+
+  logger.info(
+    `Agent editors group backfill completed for workspace ${workspace.sId}`
+  );
+};
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info("Starting agent editors group backfill");
+
+  runOnAllWorkspaces(
+    async (workspace) => {
+      await migrateWorkspaceEditorsGroups(execute, logger, workspace);
+    },
+    { concurrency: 4 }
+  );
+
+  logger.info("Agent editors group backfill completed");
+});
+
+async function backfillAgentEditorsGroup(
+  auth: Authenticator,
+  agent: LightAgentConfigurationType
+): Promise<void> {
+  // find all editors of this agent
+  const agentConfigs = await AgentConfiguration.findAll({
+    where: {
+      sId: agent.sId,
+    },
+  });
+
+  const editorIds = agentConfigs.map((agentConfig) => agentConfig.authorId);
+
+  // get or create the editor group for this agent
+  const activeConfig = agentConfigs.find(
+    (agentConfig) => agentConfig.status === "active"
+  );
+
+  if (!activeConfig) {
+    throw new Error("No active agent configuration found");
+  }
+
+  const editorGroupResult = await GroupResource.findEditorGroupForAgent(
+    auth,
+    agent
+  );
+
+  let editorGroup: GroupResource | null = null;
+
+  if (editorGroupResult.isErr()) {
+    if (
+      editorGroupResult.error instanceof DustError &&
+      editorGroupResult.error.code === "group_not_found"
+    ) {
+      // create the editor group
+      editorGroup = await GroupResource.makeNewAgentEditorsGroup(
+        auth,
+        activeConfig
+      );
+    } else {
+      throw editorGroupResult.error;
+    }
+  } else {
+    editorGroup = editorGroupResult.value;
+  }
+
+  // set all the editors of the agent to the editor group
+  const users = await UserResource.fetchByModelIds(editorIds);
+  const result = await editorGroup.setMembers(
+    auth,
+    users.map((user) => user.toJSON())
+  );
+
+  if (result.isErr()) {
+    throw result.error;
+  }
+}

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -2,14 +2,99 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { GroupAgentModel } from "@app/lib/models/assistant/group_agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { UserModel } from "@app/lib/resources/storage/models/user";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { LightAgentConfigurationType, LightWorkspaceType } from "@app/types";
+import assert from "assert";
 import { Logger } from "pino";
+
+async function backfillAgentEditorsGroup(
+  auth: Authenticator,
+  agent: LightAgentConfigurationType,
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  // find all editors of this agent
+  const agentConfigs = await AgentConfiguration.findAll({
+    where: {
+      sId: agent.sId,
+    },
+  });
+
+  const editorIds = [
+    ...new Set(agentConfigs.map((agentConfig) => agentConfig.authorId)),
+  ];
+
+  // check all groups for this sId, there should be max 1
+  const groupAgentRelationships = await GroupAgentModel.findAll({
+    where: {
+      agentConfigurationId: agentConfigs.map((config) => config.id),
+      workspaceId: workspace.id,
+    },
+    attributes: ["groupId", "agentConfigurationId"],
+  });
+
+  const groupSet = new Set(
+    groupAgentRelationships.map((relationship) => relationship.groupId)
+  );
+
+  if (groupSet.size > 1) {
+    logger.info("Multiple groups found for agent", agent);
+    throw new Error("Multiple groups found for agent");
+  }
+
+  let editorGroup: GroupResource | null = null;
+
+  if (groupSet.size === 1) {
+    editorGroup = await GroupResource.fetchByModelId(
+      groupAgentRelationships[0].groupId
+    );
+    assert(editorGroup, "Editor group not found");
+  } else {
+    // Create an editor group for the agent without author
+    editorGroup = await GroupResource.makeNew({
+      workspaceId: workspace.id,
+      name: `Group for Agent ${agent.name}`,
+      kind: "agent_editors",
+    });
+  }
+
+  // Associate the group with all agent configurations that don't yet have the
+  // association
+  await GroupAgentModel.bulkCreate(
+    agentConfigs
+      .filter(
+        (config) =>
+          !groupAgentRelationships.some(
+            (relationship) => relationship.agentConfigurationId === config.id
+          )
+      )
+      .map((config) => ({
+        groupId: editorGroup.id,
+        agentConfigurationId: config.id,
+        workspaceId: workspace.id,
+      }))
+  );
+
+  // set all the editors of the agent to the editor group
+  const users = await UserResource.fetchByModelIds(editorIds);
+  if (execute) {
+    const result = await editorGroup.setMembers(
+      auth,
+      users.map((user) => user.toJSON())
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+  }
+}
 
 const migrateWorkspaceEditorsGroups = async (
   execute: boolean,
@@ -17,11 +102,13 @@ const migrateWorkspaceEditorsGroups = async (
   workspace: LightWorkspaceType
 ) => {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const agents = await getAgentConfigurations({
-    auth,
-    agentsGetView: "admin_internal",
-    variant: "light",
-  });
+  const agents = (
+    await getAgentConfigurations({
+      auth,
+      agentsGetView: "admin_internal",
+      variant: "light",
+    })
+  ).filter((agent) => agent.scope !== "global");
 
   if (agents.length === 0) {
     return;
@@ -37,8 +124,9 @@ const migrateWorkspaceEditorsGroups = async (
 
   await concurrentExecutor(
     agents,
-    (agent) => backfillAgentEditorsGroup(auth, agent, execute),
-    { concurrency: 4 }
+    (agent) =>
+      backfillAgentEditorsGroup(auth, agent, workspace, execute, logger),
+    { concurrency: 1 }
   );
 
   logger.info(
@@ -49,76 +137,12 @@ const migrateWorkspaceEditorsGroups = async (
 makeScript({}, async ({ execute }, logger) => {
   logger.info("Starting agent editors group backfill");
 
-  runOnAllWorkspaces(
+  await runOnAllWorkspaces(
     async (workspace) => {
       await migrateWorkspaceEditorsGroups(execute, logger, workspace);
     },
-    { concurrency: 4 }
+    { concurrency: 1 }
   );
 
   logger.info("Agent editors group backfill completed");
 });
-
-async function backfillAgentEditorsGroup(
-  auth: Authenticator,
-  agent: LightAgentConfigurationType,
-  execute: boolean
-): Promise<void> {
-  // find all editors of this agent
-  const agentConfigs = await AgentConfiguration.findAll({
-    where: {
-      sId: agent.sId,
-    },
-  });
-
-  const editorIds = agentConfigs.map((agentConfig) => agentConfig.authorId);
-
-  // get or create the editor group for this agent
-  const activeConfig = agentConfigs.find(
-    (agentConfig) => agentConfig.status === "active"
-  );
-
-  if (!activeConfig) {
-    throw new Error("No active agent configuration found");
-  }
-
-  const editorGroupResult = await GroupResource.findEditorGroupForAgent(
-    auth,
-    agent
-  );
-
-  let editorGroup: GroupResource | null = null;
-
-  if (editorGroupResult.isErr()) {
-    if (
-      editorGroupResult.error instanceof DustError &&
-      editorGroupResult.error.code === "group_not_found"
-    ) {
-      if (!execute) {
-        return;
-      }
-      // create the editor group
-      editorGroup = await GroupResource.makeNewAgentEditorsGroup(
-        auth,
-        activeConfig
-      );
-    } else {
-      throw editorGroupResult.error;
-    }
-  } else {
-    editorGroup = editorGroupResult.value;
-  }
-
-  // set all the editors of the agent to the editor group
-  const users = await UserResource.fetchByModelIds(editorIds);
-  if (execute) {
-    const result = await editorGroup.setMembers(
-      auth,
-      users.map((user) => user.toJSON())
-    );
-
-    if (result.isErr()) {
-      throw result.error;
-    }
-  }
-}

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -1,10 +1,8 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { GroupAgentModel } from "@app/lib/models/assistant/group_agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -126,7 +126,7 @@ const migrateWorkspaceEditorsGroups = async (
     agents,
     (agent) =>
       backfillAgentEditorsGroup(auth, agent, workspace, execute, logger),
-    { concurrency: 1 }
+    { concurrency: 4 }
   );
 
   logger.info(
@@ -141,7 +141,7 @@ makeScript({}, async ({ execute }, logger) => {
     async (workspace) => {
       await migrateWorkspaceEditorsGroups(execute, logger, workspace);
     },
-    { concurrency: 1 }
+    { concurrency: 4 }
   );
 
   logger.info("Agent editors group backfill completed");


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2727

Description
---
- in all workspaces for all agents
- if agent editor group already exists, set members = all agent's existing authors
- if it doesn't, create it and do the same

Risks
---
standard. Editor groups not used in prod yet, even behind ff.

Deploy
---
front
run migration
