### PR TITLE
notion: bump client timeout for db operations

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -950,6 +950,9 @@ export async function retrieveDatabaseChildrenResultPage({
   const notionClient = new Client({
     auth: accessToken,
     logger: notionClientLogger,
+    // Default is 60_000: https://github.com/makenotion/notion-sdk-js/blob/main/src/Client.ts#L135
+    // Bumped as we observed some timeouts with the default value.
+    timeoutMs: 120_000,
   });
 
   localLogger.info("Fetching database children result page from Notion API.");


### PR DESCRIPTION
## Description

Context: https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aeurope-west1%20%40workflowId%3Aworkflow-notion-145-result-page-2-databases-0&agg_m=count&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId&event=AwAAAZaAt61r3DxcHAAAABhBWmFBdDc4RkFBQk44d28yMGxDejJ3QWwAAAAkMDE5NjgwYjctYmNkMC00NzhjLThhNTAtNjRmMmY4YTkzMmY3AAAA4g&index=%2A&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1745900945630&to_ts=1745915345630&live=true

https://dust4ai.slack.com/archives/C050SM8NSPK/p1745915436259659

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `connectors`