### PR TITLE
fix(MCP): webtools v2 prompt to prohibit Unicode characters

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -36,18 +36,24 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
 
   server.tool(
     "websearch",
-    "A google search tool",
+    "A tool that performs a Google web search based on a string query. " +
+      "The input string query does not support Unicode characters.",
     {
       query: z
         .string()
         .describe(
-          "The query used to perform the google search. If requested by the user, use the google syntax `site:` to restrict the the search to a particular website or domain."
+          "The query used to perform the google search. If requested by the " +
+            "user, use the google syntax `site:` to restrict the the search " +
+            "to a particular website or domain. " +
+            "Unicode characters are not supported."
         ),
       page: z
         .number()
         .optional()
         .describe(
-          "A 1-indexed page number used to paginate through the search results. Should only be provided if page is stricly greater than 1 in order to go deeper into the search results for a specific query."
+          "A 1-indexed page number used to paginate through the search results." +
+            " Should only be provided if page is stricly greater than 1 in order" +
+            " to go deeper into the search results for a specific query."
         ),
     },
     async ({ query, page }) => {


### PR DESCRIPTION
## Description

- Context here: https://dust4ai.slack.com/archives/C050SM8NSPK/p1745910226172159
- The create on the `agent_mcp_actions` is failing due to some invalid characters in the `inputs` column.
- This PR fixes that.
- Run example [here](https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/0e9889c787/runs/278bb2edf50cbca9f40c9668b7a0eb3d4cc819e773651f6a8224f6a9f8f0cffd). Issue seems to be the model generated arguments to call the tool, that have unicode.

Test sample with the new prompt.

<img width="764" alt="Screenshot 2025-04-29 at 11 10 38 AM" src="https://github.com/user-attachments/assets/3bbf61cc-16a7-4719-8dda-97c61e51d44f" />

## Tests

- Tested with the problematic input.

## Risk

- Low.

## Deploy Plan

- Deploy front.