### PR TITLE
Fix: performance issues when super admin

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect } from "vitest";
+
+import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
+import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WhitelistableFeature } from "@app/types";
+
+describe("MCPServerViewResource", () => {
+  describe("listByWorkspace", () => {
+    itInTransaction(
+      "should only return views for the current workspace",
+      async (t) => {
+        // Create two workspaces
+        const workspace1 = await WorkspaceFactory.basic();
+        const workspace2 = await WorkspaceFactory.basic();
+
+        // Create spaces for each workspace
+        const systemSpace1 = await SpaceFactory.system(workspace1, t);
+        const systemSpace2 = await SpaceFactory.system(workspace2, t);
+        const space1 = await SpaceFactory.regular(workspace1, t);
+        const space2 = await SpaceFactory.regular(workspace2, t);
+
+        // Create internals servers for each workspace
+
+        await FeatureFlagFactory.basic(
+          INTERNAL_MCP_SERVERS["think"].flag as WhitelistableFeature,
+          workspace1
+        );
+
+        await FeatureFlagFactory.basic(
+          INTERNAL_MCP_SERVERS["think"].flag as WhitelistableFeature,
+          workspace2
+        );
+
+        expect(INTERNAL_MCP_SERVERS["think"].isDefault).toBe(true);
+
+        // Get auth for workspace1
+        const auth1 = await Authenticator.internalAdminForWorkspace(
+          workspace1.sId
+        );
+
+        // Get auth for workspace2
+        const auth2 = await Authenticator.internalAdminForWorkspace(
+          workspace2.sId
+        );
+
+        // Internal server in the right workspace
+        const internalServer1 = await InternalMCPServerInMemoryResource.makeNew(
+          auth1,
+          "think",
+          t
+        );
+
+        const internalServer2 = await InternalMCPServerInMemoryResource.makeNew(
+          auth2,
+          "think",
+          t
+        );
+
+        // Create MCP server views for both workspaces
+        await MCPServerViewFactory.create(
+          workspace1,
+          internalServer1.id,
+          space1
+        );
+        await MCPServerViewFactory.create(
+          workspace2,
+          internalServer2.id,
+          space2
+        );
+
+        // Create a real user for workspace1
+        const { globalGroup, systemGroup } =
+          await GroupFactory.defaults(workspace1);
+        const user1 = await UserFactory.superUser();
+        await MembershipFactory.associate(workspace1, user1, "user");
+        await GroupSpaceFactory.associate(systemSpace1, systemGroup);
+        await GroupSpaceFactory.associate(space1, globalGroup);
+
+        const auth = await Authenticator.fromUserIdAndWorkspaceId(
+          user1.sId,
+          workspace1.sId
+        );
+
+        // List views for workspace1
+        const views1 = await MCPServerViewResource.listByWorkspace(auth);
+
+        // Verify we only get views for workspace1
+        expect(views1).toHaveLength(2);
+        expect(views1[0].workspaceId).toBe(workspace1.id);
+        expect(views1[1].workspaceId).toBe(workspace1.id);
+        expect(views1[0].vaultId).toBe(systemSpace1.id);
+        expect(views1[1].vaultId).toBe(space1.id);
+
+        // List views for workspace2
+        const views2 = await MCPServerViewResource.listByWorkspace(auth2);
+
+        // Verify we only get views for workspace2
+        expect(views2).toHaveLength(2);
+        expect(views2[0].workspaceId).toBe(workspace2.id);
+        expect(views2[1].workspaceId).toBe(workspace2.id);
+        expect(views2[0].vaultId).toBe(systemSpace2.id);
+        expect(views2[1].vaultId).toBe(space2.id);
+      }
+    );
+  });
+});

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -195,7 +195,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     { where }: ResourceFindOptions<MCPServerViewModel> = {}
   ) {
     const views = await this.baseFetchWithAuthorization(auth, {
-      where,
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
       includes: [
         {
           model: UserModel,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect } from "vitest";
+
+import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
+import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WhitelistableFeature } from "@app/types";
+
+import handler from "./available";
+
+describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
+  itInTransaction("returns available servers for regular user", async (t) => {
+    // Create mock request
+    const { req, res, workspace, globalGroup } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+    // Create workspace and space
+    const space = await SpaceFactory.regular(workspace, t);
+    await GroupSpaceFactory.associate(space, globalGroup);
+    await SpaceFactory.system(workspace, t);
+
+    // Get auth
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    // Create some servers
+    await FeatureFlagFactory.basic(
+      INTERNAL_MCP_SERVERS["authentication_debugger"]
+        .flag as WhitelistableFeature,
+      workspace
+    );
+
+    // Internal server in the right workspace
+    const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+      auth,
+      "authentication_debugger",
+      t
+    );
+
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+    // Create some server views in global and current space
+    await MCPServerViewFactory.create(workspace, remoteServer.sId, space);
+
+    // Create another server in another workspace
+    const workspace2 = await WorkspaceFactory.basic();
+    await SpaceFactory.system(workspace2, t);
+    await RemoteMCPServerFactory.create(workspace2);
+
+    // Add query params
+    req.query = {
+      ...req.query,
+      spaceId: space.sId,
+    };
+
+    // Call handler
+    await handler(req, res);
+
+    // Check response
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.success).toBe(true);
+    expect(response.servers).toHaveLength(1); // Only one available server as the other is assigned to the system space
+    expect(response.servers[0].id).toBe(internalServer.id);
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
@@ -29,21 +29,22 @@ async function handler(
     // - not in global (so can be restricted but not yet assign to spaces)
     // - not in the current space
     case "GET": {
-      const internalInstalledServers =
-        await InternalMCPServerInMemoryResource.listByWorkspace(auth);
-      const remoteInstalledServers =
-        await RemoteMCPServerResource.listByWorkspace(auth);
-
-      const workspaceServerViews =
-        await MCPServerViewResource.listByWorkspace(auth);
+      const [
+        internalInstalledServers,
+        remoteInstalledServers,
+        workspaceServerViews,
+      ] = await Promise.all([
+        InternalMCPServerInMemoryResource.listByWorkspace(auth),
+        RemoteMCPServerResource.listByWorkspace(auth),
+        MCPServerViewResource.listByWorkspace(auth),
+      ]);
 
       const globalServersId = workspaceServerViews
         .filter((s) => s.space.kind === "global")
         .map((s) => s.toJSON().server.id);
 
-      const spaceServerViews = await MCPServerViewResource.listBySpace(
-        auth,
-        space
+      const spaceServerViews = workspaceServerViews.filter(
+        (s) => s.space.id === space.id
       );
       const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.id);
 


### PR DESCRIPTION
## Description

Fix the performance issue of listing available servers.
The problem was due to not filtering correctly early in listByWorkspace when one was a super user.

## Tests

Added

## Risk

Low

## Deploy Plan

Deploy `front`