### PR TITLE
Fix search when managing agents

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -230,7 +230,7 @@ export default function WorkspaceAssistants({
           (a) =>
             a.status === "active" &&
             // Filters on search query
-            subFilter(assistantSearch, a.name)
+            subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase())
         )
         .sort((a, b) => {
           return compareForFuzzySort(

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -230,7 +230,7 @@ export default function WorkspaceAssistants({
           (a) =>
             a.status === "active" &&
             // Filters on search query
-            subFilter(assistantSearch, a.name.toLowerCase())
+            subFilter(assistantSearch, a.name)
         )
         .sort((a, b) => {
           return compareForFuzzySort(


### PR DESCRIPTION

## Description

- Closes https://github.com/dust-tt/tasks/issues/2773.
- The search when managing agents (`/w/[wId]/builder/assistants`) was half case-sensitive half case-unsensitive, making it impossible to search for agent that start with a capital letter.
- This PR makes the search actually case unsensitive.

<img width="734" alt="Screenshot 2025-04-29 at 2 09 05 PM" src="https://github.com/user-attachments/assets/6d416bd8-8a8f-4f9c-80f0-47ca21883628" />

## Tests

- Checked locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.