### PR TITLE
Block TRACE methods altogether in Next middleware

### DIFF
--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -9,6 +9,11 @@ import {
 import logger from "@app/logger/logger";
 
 export function middleware(request: NextRequest) {
+  // Block TRACE requests
+  if (request.method === "TRACE") {
+    return new NextResponse(null, { status: 405 });
+  }
+
   const url = request.nextUrl.pathname;
 
   // The CASA test attempts to at least double encode the string to bypass checks hence why we


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/12337.
- This PR updates the middleware in our Nextjs app to block the TRACE verb altogether.

## Tests

- Tested locally.

## Risk

- High blast radius.

## Deploy Plan

- Deploy front.