### PR TITLE
Fix: sparkle citations grid numbers

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.484",
+  "version": "0.2.485",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/PaginatedCitationsGrid.tsx
+++ b/sparkle/src/components/PaginatedCitationsGrid.tsx
@@ -50,7 +50,7 @@ export function PaginatedCitationsGrid({
           return (
             <Citation href={d.href} variant="primary">
               <CitationIcons>
-                <CitationIndex>{idx}</CitationIndex>
+                <CitationIndex>{startIndex + idx + 1}</CitationIndex>
                 {d.icon}
               </CitationIcons>
               <CitationTitle>{d.title}</CitationTitle>


### PR DESCRIPTION
## Description

Fix PaginatedCitationsGrid to show the correct number (starts at 1 and show the right number on page > 1)

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `sparkle`