### PR TITLE
fix(Poke): Handle dark mode for `SlackAutoReadPatternsTable`

### DIFF
--- a/front/components/poke/data_sources/slack/table.tsx
+++ b/front/components/poke/data_sources/slack/table.tsx
@@ -76,8 +76,8 @@ export function SlackAutoReadPatternsTable({
   spaces,
 }: SlackAutoReadPatternsTableProps) {
   return (
-    <div className="border-material-200 my-4 flex min-h-48 flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="border-material-200 my-4 flex min-h-48 flex-col rounded-lg border bg-muted-background dark:bg-muted-background-night">
+      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4 dark:bg-primary-300-night">
         <h2 className="text-md font-bold">Slack Auto Read Patterns :</h2>
       </div>
       <div className="flex flex-grow flex-col justify-center p-4">


### PR DESCRIPTION
## Description

- This table can be found on a Slack data source.

Before:
<img width="2229" alt="Screenshot 2025-04-29 at 4 45 45 PM" src="https://github.com/user-attachments/assets/0ef18bbf-adf3-4e99-bffe-f9bfcfbd135e" />

After:
<img width="2229" alt="Screenshot 2025-04-29 at 4 45 28 PM" src="https://github.com/user-attachments/assets/aa08969d-3950-41a1-9db6-3decdaa12474" />


## Tests

- Checked locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
