### PR TITLE
[Agent Discovery] Editors backfill: skip broken workspaces

### DIFF
--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -113,13 +113,26 @@ const migrateWorkspaceEditorsGroups = async (
   workspace: LightWorkspaceType
 ) => {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const agents = (
-    await getAgentConfigurations({
-      auth,
-      agentsGetView: "admin_internal",
-      variant: "light",
-    })
-  ).filter((agent) => agent.scope !== "global");
+  const agents = await (async () => {
+    try {
+      return (
+        await getAgentConfigurations({
+          auth,
+          agentsGetView: "admin_internal",
+          variant: "light",
+        })
+      ).filter((agent) => agent.scope !== "global");
+    } catch (error) {
+      logger.error(
+        {
+          error,
+          workspace,
+        },
+        "Error getting agent configurations"
+      );
+      return [];
+    }
+  })();
 
   if (agents.length === 0) {
     return;


### PR DESCRIPTION
Description
---
Some workspaces don't have a global group
We'll skip them and save the log

Risks
---
low

Deploy
---
front
