### PR TITLE
[Agent Discovery] Editors group view / add functionality in Builder

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -248,10 +248,10 @@ export default function AssistantBuilder({
       );
     }
     if (!agentConfigurationId) {
-      setBuilderState({
-        ...builderState,
-        editors: [...(builderState.editors ?? []), user],
-      });
+      setBuilderState((state) => ({
+        ...state,
+        editors: [...(state.editors ?? []), user],
+      }));
     }
   }, [
     isUserLoading,
@@ -259,7 +259,6 @@ export default function AssistantBuilder({
     user,
     agentConfigurationId,
     initialBuilderState,
-    builderState,
   ]);
 
   const openRightPanelTab = (tabName: AssistantBuilderRightPanelTab) => {

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -79,6 +79,7 @@ import {
   isBuilder,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
+import { useEditors } from "@app/lib/swr/editors";
 
 function isValidTab(tab: string): tab is BuilderScreen {
   return BUILDER_SCREENS.includes(tab as BuilderScreen);
@@ -171,6 +172,8 @@ export default function AssistantBuilder({
           },
         }
   );
+
+  const { mutateEditors } = useEditors({ owner, agentConfigurationId });
 
   const [pendingAction, setPendingAction] =
     useState<AssistantBuilderPendingAction>({
@@ -409,6 +412,7 @@ export default function AssistantBuilder({
           type: "error",
         });
       } else {
+        void mutateEditors();
         if (slackDataSource) {
           await mutateSlackChannels();
         }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -572,6 +572,7 @@ export default function AssistantBuilder({
                         slackChannelSelected={selectedSlackChannels || []}
                         slackDataSource={slackDataSource}
                         setSelectedSlackChannels={setSelectedSlackChannels}
+                        currentUserId={user?.sId ?? null}
                       />
                     );
                   default:

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -15,7 +15,7 @@ import {
   useSendNotification,
 } from "@dust-tt/sparkle";
 import assert from "assert";
-import { initial, uniqueId } from "lodash";
+import { uniqueId } from "lodash";
 import { useRouter } from "next/router";
 import React, {
   useCallback,

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -241,7 +241,7 @@ export default function AssistantBuilder({
     }
     if (agentConfigurationId && initialBuilderState?.editors) {
       assert(
-        user.sId in initialBuilderState.editors,
+        initialBuilderState.editors.get(user.sId),
         "Unreachable: User is not in editors"
       );
     }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -70,6 +70,7 @@ import type {
   AgentConfigurationScope,
   AssistantBuilderRightPanelStatus,
   AssistantBuilderRightPanelTab,
+  UserType,
 } from "@app/types";
 import {
   assertNever,
@@ -238,14 +239,21 @@ export default function AssistantBuilder({
     if (isUserError || isUserLoading || !user) {
       return;
     }
-    if (agentConfigurationId && initialBuilderState) {
+    if (agentConfigurationId && initialBuilderState?.editors) {
       assert(
         user.sId in initialBuilderState.editors,
         "Unreachable: User is not in editors"
       );
     }
     if (!agentConfigurationId) {
+      if (!builderState.editors) {
+        builderState.editors = new Map<string, UserType>();
+      }
       builderState.editors.set(user.sId, user);
+      setBuilderState({
+        ...builderState,
+        editors: builderState.editors,
+      });
     }
   }, [
     isUserLoading,

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -62,7 +62,6 @@ import {
   AppLayoutSimpleSaveCancelTitle,
 } from "@app/components/sparkle/AppLayoutTitle";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
-import { useEditors } from "@app/lib/swr/editors";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
 import { useUser } from "@app/lib/swr/user";
@@ -172,8 +171,6 @@ export default function AssistantBuilder({
         }
   );
 
-  const { mutateEditors } = useEditors({ owner, agentConfigurationId });
-
   const [pendingAction, setPendingAction] =
     useState<AssistantBuilderPendingAction>({
       action: null,
@@ -241,7 +238,7 @@ export default function AssistantBuilder({
     if (isUserError || isUserLoading || !user) {
       return;
     }
-    if (agentConfigurationId && initialBuilderState?.editors) {
+    if (agentConfigurationId && initialBuilderState) {
       assert(
         initialBuilderState.editors.some((m) => m.sId === user.sId),
         "Unreachable: User is not in editors"
@@ -250,7 +247,7 @@ export default function AssistantBuilder({
     if (!agentConfigurationId) {
       setBuilderState((state) => ({
         ...state,
-        editors: [...(state.editors ?? []), user],
+        editors: [...state.editors, user],
       }));
     }
   }, [
@@ -411,7 +408,6 @@ export default function AssistantBuilder({
           type: "error",
         });
       } else {
-        void mutateEditors();
         if (slackDataSource) {
           await mutateSlackChannels();
         }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -571,7 +571,7 @@ export default function AssistantBuilder({
                         slackChannelSelected={selectedSlackChannels || []}
                         slackDataSource={slackDataSource}
                         setSelectedSlackChannels={setSelectedSlackChannels}
-                        currentUserId={user?.sId ?? null}
+                        currentUser={user}
                       />
                     );
                   default:

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -62,6 +62,7 @@ import {
   AppLayoutSimpleSaveCancelTitle,
 } from "@app/components/sparkle/AppLayoutTitle";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { useEditors } from "@app/lib/swr/editors";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
 import { useUser } from "@app/lib/swr/user";
@@ -70,7 +71,6 @@ import type {
   AgentConfigurationScope,
   AssistantBuilderRightPanelStatus,
   AssistantBuilderRightPanelTab,
-  UserType,
 } from "@app/types";
 import {
   assertNever,
@@ -79,7 +79,6 @@ import {
   isBuilder,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
-import { useEditors } from "@app/lib/swr/editors";
 
 function isValidTab(tab: string): tab is BuilderScreen {
   return BUILDER_SCREENS.includes(tab as BuilderScreen);
@@ -260,6 +259,7 @@ export default function AssistantBuilder({
     user,
     agentConfigurationId,
     initialBuilderState,
+    builderState,
   ]);
 
   const openRightPanelTab = (tabName: AssistantBuilderRightPanelTab) => {

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -241,18 +241,14 @@ export default function AssistantBuilder({
     }
     if (agentConfigurationId && initialBuilderState?.editors) {
       assert(
-        initialBuilderState.editors.get(user.sId),
+        initialBuilderState.editors.some((m) => m.sId === user.sId),
         "Unreachable: User is not in editors"
       );
     }
     if (!agentConfigurationId) {
-      if (!builderState.editors) {
-        builderState.editors = new Map<string, UserType>();
-      }
-      builderState.editors.set(user.sId, user);
       setBuilderState({
         ...builderState,
-        editors: builderState.editors,
+        editors: [...(builderState.editors ?? []), user],
       });
     }
   }, [

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -14,7 +14,8 @@ import {
   useHashParam,
   useSendNotification,
 } from "@dust-tt/sparkle";
-import { uniqueId } from "lodash";
+import assert from "assert";
+import { initial, uniqueId } from "lodash";
 import { useRouter } from "next/router";
 import React, {
   useCallback,
@@ -63,6 +64,7 @@ import {
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
+import { useUser } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   AgentConfigurationScope,
@@ -94,6 +96,7 @@ export default function AssistantBuilder({
 }: AssistantBuilderProps) {
   const router = useRouter();
   const sendNotification = useSendNotification();
+  const { user, isUserLoading, isUserError } = useUser();
 
   const { killSwitches } = useKillSwitches();
   const { models, reasoningModels } = useModels({ owner });
@@ -154,6 +157,7 @@ export default function AssistantBuilder({
           visualizationEnabled: initialBuilderState.visualizationEnabled,
           templateId: initialBuilderState.templateId,
           tags: initialBuilderState.tags,
+          editors: initialBuilderState.editors,
         }
       : {
           ...getDefaultAssistantState(),
@@ -227,6 +231,29 @@ export default function AssistantBuilder({
       triggerPreviewButtonAnimation();
     }
   }, [isBuilderStateEmpty]);
+
+  // If agent is created, the user creating it should be added to the builder
+  // editors list. If not, then the user should be in this list.
+  useEffect(() => {
+    if (isUserError || isUserLoading || !user) {
+      return;
+    }
+    if (agentConfigurationId && initialBuilderState) {
+      assert(
+        user.sId in initialBuilderState.editors,
+        "Unreachable: User is not in editors"
+      );
+    }
+    if (!agentConfigurationId) {
+      builderState.editors.set(user.sId, user);
+    }
+  }, [
+    isUserLoading,
+    isUserError,
+    user,
+    agentConfigurationId,
+    initialBuilderState,
+  ]);
 
   const openRightPanelTab = (tabName: AssistantBuilderRightPanelTab) => {
     setRightPanelStatus({

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -55,7 +55,6 @@ import type {
   DataSourceType,
   Result,
   UserType,
-  UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
 import { Err, isAdmin, Ok } from "@app/types";
@@ -877,7 +876,7 @@ function EditorsMembersList({
   const members = useMemo(
     () =>
       builderState.editors?.map((m) => ({ ...m, workspaces: [owner] })) ?? [],
-    [builderState]
+    [builderState, owner]
   );
 	
   const membersData = {

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -782,63 +782,6 @@ async function fetchWithErr<T>(
 
 const DEFAULT_PAGE_SIZE = 25;
 
-// TODO: Mock data
-const membersData = {
-  members: [
-    {
-      sId: "mock1",
-      fullName: "Mock User 1",
-      email: "mock1@test.com",
-      image: "https://example.com/image.png",
-      workspaces: [
-        {
-          role: "admin" as const,
-          sId: "mock1",
-          name: "Mock Workspace 1",
-          id: 1,
-          segmentation: null,
-          whiteListedProviders: null,
-          defaultEmbeddingProvider: null,
-          metadata: null,
-        },
-      ],
-      id: 1,
-      createdAt: 0,
-      provider: null,
-      username: "mock1",
-      firstName: "Mock",
-      lastName: "User 1",
-    },
-    {
-      sId: "mock2",
-      fullName: "Mock User 2",
-      email: "mock2@test.com",
-      image: "https://example.com/image.png",
-      workspaces: [
-        {
-          role: "admin" as const,
-          sId: "mock1",
-          name: "Mock Workspace 1",
-          id: 1,
-          segmentation: null,
-          whiteListedProviders: null,
-          defaultEmbeddingProvider: null,
-          metadata: null,
-        },
-      ],
-      id: 2,
-      createdAt: 0,
-      provider: null,
-      username: "mock2",
-      firstName: "Mock",
-      lastName: "User 2",
-    },
-  ],
-  totalMembersCount: 2,
-  isLoading: false,
-  mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
-};
-
 const onRowClick = () => {};
 
 function EditorsMembersList({
@@ -864,21 +807,21 @@ function EditorsMembersList({
     setPagination({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
   }, [setPagination]);
 
-  const editorsData = useEditors({ owner, agentConfigurationId });
+  const onRemoveMember = useCallback(
+    (removed: UserType) =>
+      setBuilderState((s) => ({
+        ...s,
+        editors: s.editors ? s.editors.filter((m) => m.sId != removed.sId) : [],
+      })),
+    [setBuilderState]
+  );
 
-  const onRemoveMember = useCallback((removed) =>
-          setBuilderState((s) => ({
-            ...s,
-            editors: s.editors
-              ? s.editors.filter((m) => m.sId != removed.sId)
-              : [],
-          })), [setBuilderState]);
   const members = useMemo(
     () =>
       builderState.editors?.map((m) => ({ ...m, workspaces: [owner] })) ?? [],
     [builderState, owner]
   );
-	
+
   const membersData = {
     members,
     totalMembersCount: members.length,
@@ -910,7 +853,7 @@ function EditorsMembersList({
         currentUser={currentUser}
         membersData={membersData}
         onRowClick={onRowClick}
-        onRemoveMemberClick={onRemoveMemberClick}
+        onRemoveMemberClick={onRemoveMember}
         showColumns={["name", "email", "remove"]}
         pagination={pagination}
         setPagination={setPagination}
@@ -930,7 +873,6 @@ function AddEditorDropdown({
 }) {
   const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const itemsContainerRef = React.useRef<HTMLDivElement>(null);
 
   const { members: workspaceMembers, isLoading: isWorkspaceMembersLoading } =
     useSearchMembers({
@@ -982,7 +924,7 @@ function AddEditorDropdown({
                 onClick={async () => {
                   setSearchTerm("");
                   setIsEditorPickerOpen(false);
-                  await onAddEditor(member);
+                  onAddEditor(member);
                 }}
                 truncateText
                 disabled={editors.some((e) => e.sId === member.sId)}

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -177,6 +177,7 @@ type NamingScreenProps = {
   slackChannelSelected: SlackChannel[];
   slackDataSource: DataSourceType | undefined;
   setSelectedSlackChannels: (channels: SlackChannel[]) => void;
+  currentUserId: string | null;
 };
 
 export default function NamingScreen({
@@ -193,6 +194,7 @@ export default function NamingScreen({
   slackChannelSelected,
   slackDataSource,
   setSelectedSlackChannels,
+  currentUserId,
 }: NamingScreenProps) {
   const confirm = useContext(ConfirmContext);
   const sendNotification = useSendNotification();
@@ -652,7 +654,7 @@ export default function NamingScreen({
               </div>
             </div>
             <EditorsMembersList
-              currentUserId={"mock1"}
+              currentUserId={currentUserId}
               owner={owner}
               agentConfigurationId={agentConfigurationId}
             />
@@ -842,7 +844,7 @@ function EditorsMembersList({
   owner,
   agentConfigurationId,
 }: {
-  currentUserId: string;
+  currentUserId: string | null;
   owner: WorkspaceType;
   agentConfigurationId: string | null;
 }) {
@@ -881,7 +883,7 @@ function EditorsMembersList({
         />
       </div>
       <MembersList
-        currentUserId={currentUserId}
+        currentUserId={currentUserId ?? "current-user-not-loaded"}
         membersData={membersData}
         onRowClick={onRowClick}
         onRemoveMemberClick={onRemoveMemberClick}

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -659,6 +659,7 @@ export default function NamingScreen({
               owner={owner}
               builderState={builderState}
               setBuilderState={setBuilderState}
+              setEdited={setEdited}
             />
           </>
         )}
@@ -846,6 +847,7 @@ function EditorsMembersList({
   owner,
   builderState,
   setBuilderState,
+  setEdited,
 }: {
   currentUserId: string | null;
   owner: WorkspaceType;
@@ -853,6 +855,7 @@ function EditorsMembersList({
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
+  setEdited: (edited: boolean) => void;
 }) {
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
@@ -900,6 +903,7 @@ function EditorsMembersList({
               ...s,
               editors: [...(s.editors ?? []), added],
             }));
+            setEdited(true);
           }}
         />
       </div>

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -805,12 +805,14 @@ function EditorsMembersList({
   }, [setPagination]);
 
   const onRemoveMember = useCallback(
-    (removed: UserType) =>
+    (removed: UserType) => {
       setBuilderState((s) => ({
         ...s,
         editors: s.editors ? s.editors.filter((m) => m.sId != removed.sId) : [],
-      })),
-    [setBuilderState]
+      }));
+      setEdited(true);
+    },
+    [setBuilderState, setEdited]
   );
 
   const members = useMemo(

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -177,7 +177,7 @@ type NamingScreenProps = {
   slackChannelSelected: SlackChannel[];
   slackDataSource: DataSourceType | undefined;
   setSelectedSlackChannels: (channels: SlackChannel[]) => void;
-  currentUserId: string | null;
+  currentUser: UserType | null;
 };
 
 export default function NamingScreen({
@@ -194,7 +194,7 @@ export default function NamingScreen({
   slackChannelSelected,
   slackDataSource,
   setSelectedSlackChannels,
-  currentUserId,
+  currentUser,
 }: NamingScreenProps) {
   const confirm = useContext(ConfirmContext);
   const sendNotification = useSendNotification();
@@ -654,7 +654,7 @@ export default function NamingScreen({
               </div>
             </div>
             <EditorsMembersList
-              currentUserId={currentUserId}
+              currentUser={currentUser}
               owner={owner}
               builderState={builderState}
               setBuilderState={setBuilderState}
@@ -842,13 +842,13 @@ const membersData = {
 const onRowClick = () => {};
 
 function EditorsMembersList({
-  currentUserId,
+  currentUser,
   owner,
   builderState,
   setBuilderState,
   setEdited,
 }: {
-  currentUserId: string | null;
+  currentUser: UserType | null;
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
   setBuilderState: (
@@ -907,7 +907,7 @@ function EditorsMembersList({
         />
       </div>
       <MembersList
-        currentUserId={currentUserId ?? "current-user-not-loaded"}
+        currentUser={currentUser}
         membersData={membersData}
         onRowClick={onRowClick}
         onRemoveMemberClick={onRemoveMemberClick}

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -58,9 +58,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, isAdmin, Ok } from "@app/types";
-import { useEditors } from "@app/lib/swr/editors";
-import { LightAgentConfigurationType } from "@dust-tt/client";
-import { m } from "motion/react";
 import type { TagType } from "@app/types/tag";
 
 export function removeLeadingAt(handle: string) {

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -657,6 +657,7 @@ export default function NamingScreen({
               currentUserId={currentUserId}
               owner={owner}
               agentConfigurationId={agentConfigurationId}
+              setBuilderState={setBuilderState}
             />
           </>
         )}
@@ -838,15 +839,19 @@ const membersData = {
 };
 
 const onRowClick = () => {};
-const onRemoveMemberClick = () => {};
+
 function EditorsMembersList({
   currentUserId,
   owner,
   agentConfigurationId,
+  setBuilderState,
 }: {
   currentUserId: string | null;
   owner: WorkspaceType;
   agentConfigurationId: string | null;
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
 }) {
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
@@ -858,6 +863,11 @@ function EditorsMembersList({
 
   const editorsData = useEditors({ owner, agentConfigurationId });
 
+  const onRemoveMember = useCallback((member) =>
+          setBuilderState((s) => ({
+            ...s,
+            editors: s.editors?.delete(member.sId),
+          })), [setBuilderState]);
   const members = useMemo(() => {
     const members = editorsData.editorsMap
       ? [...editorsData.editorsMap.values()]

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -863,18 +863,16 @@ function EditorsMembersList({
 
   const editorsData = useEditors({ owner, agentConfigurationId });
 
-  const onRemoveMember = useCallback((member) =>
+  const onRemoveMember = useCallback((removed) =>
           setBuilderState((s) => ({
             ...s,
-            editors: s.editors?.delete(member.sId),
+            editors: s.editors
+              ? s.editors.filter((m) => m.sId != removed.sId)
+              : [],
           })), [setBuilderState]);
-  const members = useMemo(() => {
-    const members = editorsData.editorsMap
-      ? [...editorsData.editorsMap.values()]
-      : [];
-    return members.map((m) => ({ ...m, workspaces: [owner] }));
-  }, []);
-
+  const members =
+    editorsData.editors?.map((m) => ({ ...m, workspaces: [owner] })) ?? [];
+	
   const membersData = {
     members,
     totalMembersCount: members.length,

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -877,7 +877,7 @@ function AddEditorDropdown({
 }) {
   const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const itemsContainerRef = React.useRef<HTMLDivElement>(null);
 
   const { members: workspaceMembers, isLoading: isWorkspaceMembersLoading } =
     useSearchMembers({
@@ -906,12 +906,11 @@ function AddEditorDropdown({
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar
-              ref={searchInputRef}
               name="search"
               onChange={(value) => setSearchTerm(value)}
               placeholder="Search members"
               value={searchTerm}
-              button={<Button icon={PlusIcon} label="Create" />}
+              button={<Button icon={PlusIcon} label="Add member" />}
             />
             <DropdownMenuSeparator />
           </>

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -891,12 +891,16 @@ function EditorsMembersList({
         <div className="flex flex-grow" />
         <AddEditorDropdown
           owner={owner}
-          onAddEditor={(added) =>
+          editors={builderState.editors ?? []}
+          onAddEditor={(added) => {
+            if (builderState.editors?.some((e) => e.sId === added.sId)) {
+              return;
+            }
             setBuilderState((s) => ({
               ...s,
               editors: [...(s.editors ?? []), added],
-            }))
-          }
+            }));
+          }}
         />
       </div>
       <MembersList
@@ -914,9 +918,11 @@ function EditorsMembersList({
 
 function AddEditorDropdown({
   owner,
+  editors,
   onAddEditor,
 }: {
   owner: WorkspaceType;
+  editors: UserType[];
   onAddEditor: (member: UserType) => void;
 }) {
   const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
@@ -976,6 +982,7 @@ function AddEditorDropdown({
                   await onAddEditor(member);
                 }}
                 truncateText
+                disabled={editors.some((e) => e.sId === member.sId)}
               />
             );
           })

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -58,6 +58,9 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, isAdmin, Ok } from "@app/types";
+import { useEditors } from "@app/lib/swr/editors";
+import { LightAgentConfigurationType } from "@dust-tt/client";
+import { m } from "motion/react";
 import type { TagType } from "@app/types/tag";
 
 export function removeLeadingAt(handle: string) {
@@ -648,7 +651,11 @@ export default function NamingScreen({
                 </div>
               </div>
             </div>
-            <EditorsMembersList currentUserId={"mock1"} owner={owner} />
+            <EditorsMembersList
+              currentUserId={"mock1"}
+              owner={owner}
+              agentConfigurationId={agentConfigurationId}
+            />
           </>
         )}
       </div>
@@ -833,9 +840,11 @@ const onRemoveMemberClick = () => {};
 function EditorsMembersList({
   currentUserId,
   owner,
+  agentConfigurationId,
 }: {
   currentUserId: string;
   owner: WorkspaceType;
+  agentConfigurationId: string | null;
 }) {
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
@@ -844,6 +853,22 @@ function EditorsMembersList({
   useEffect(() => {
     setPagination({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
   }, [setPagination]);
+
+  const editorsData = useEditors({ owner, agentConfigurationId });
+
+  const members = useMemo(() => {
+    const members = editorsData.editorsMap
+      ? [...editorsData.editorsMap.values()]
+      : [];
+    return members.map((m) => ({ ...m, workspaces: [owner] }));
+  }, []);
+
+  const membersData = {
+    members,
+    totalMembersCount: members.length,
+    isLoading: editorsData.isEditorsLoading,
+    mutateRegardlessOfQueryParams: editorsData.mutateEditors,
+  };
 
   return (
     <div className="flex flex-col gap-2">

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -96,6 +96,7 @@ export function usePreviewAssistant({
         visualizationEnabled: builderState.visualizationEnabled,
         templateId: builderState.templateId,
         tags: builderState.tags,
+        editors: builderState.editors,
       },
       agentConfigurationId: null,
       slackData: {

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -19,6 +19,7 @@ import type {
   RetrievalTimeframe,
 } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
+import editors from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 import type {
   AgentConfigurationType,
   DataSourceViewSelectionConfigurations,
@@ -97,8 +98,8 @@ export async function submitAssistantBuilderForm({
   Result<LightAgentConfigurationType | AgentConfigurationType, Error>
 > {
   const { selectedSlackChannels, slackChannelsLinkedWithAgent } = slackData;
-  let { handle, description, instructions, avatarUrl } = builderState;
-  if (!handle || !description || !instructions || !avatarUrl) {
+  let { handle, description, instructions, avatarUrl, editors } = builderState;
+  if (!handle || !description || !instructions || !avatarUrl || !editors) {
     if (!isDraft) {
       // Should be unreachable, we keep this for TS
       throw new Error("Form not valid (unreachable)");
@@ -107,6 +108,7 @@ export async function submitAssistantBuilderForm({
       description = description?.trim() || "Preview";
       instructions = instructions?.trim() || "Preview";
       avatarUrl = avatarUrl ?? "";
+      editors = [];
     }
   }
 
@@ -330,6 +332,7 @@ export async function submitAssistantBuilderForm({
       visualizationEnabled: builderState.visualizationEnabled,
       templateId: builderState.templateId,
       tags: builderState.tags,
+      editors: editors.map((e) => ({ sId: e.sId })),
     },
   };
 

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -19,7 +19,6 @@ import type {
   RetrievalTimeframe,
 } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
-import editors from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 import type {
   AgentConfigurationType,
   DataSourceViewSelectionConfigurations,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -29,6 +29,7 @@ import type {
   SubscriptionType,
   SupportedModel,
   TimeframeUnit,
+  UserType,
   WorkspaceType,
 } from "@app/types";
 import {
@@ -233,6 +234,7 @@ export type AssistantBuilderState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
+  editors: Map<string, UserType>;
 };
 
 export type AssistantBuilderInitialState = {
@@ -251,6 +253,7 @@ export type AssistantBuilderInitialState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
+  editors: Map<string, UserType>;
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
@@ -273,6 +276,7 @@ export function getDefaultAssistantState() {
     visualizationEnabled: true,
     templateId: null,
     tags: [],
+    editors: new Map<string, UserType>(),
   } satisfies AssistantBuilderState;
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -234,7 +234,7 @@ export type AssistantBuilderState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors?: Map<string, UserType>;
+  editors?: UserType[];
 };
 
 export type AssistantBuilderInitialState = {
@@ -253,7 +253,7 @@ export type AssistantBuilderInitialState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors?: Map<string, UserType>;
+  editors?: UserType[];
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
@@ -276,7 +276,7 @@ export function getDefaultAssistantState() {
     visualizationEnabled: true,
     templateId: null,
     tags: [],
-    editors: new Map<string, UserType>(),
+    editors: [],
   } satisfies AssistantBuilderState;
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -234,7 +234,7 @@ export type AssistantBuilderState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors: Map<string, UserType>;
+  editors?: Map<string, UserType>;
 };
 
 export type AssistantBuilderInitialState = {
@@ -253,7 +253,7 @@ export type AssistantBuilderInitialState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors: Map<string, UserType>;
+  editors?: Map<string, UserType>;
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -234,7 +234,7 @@ export type AssistantBuilderState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors?: UserType[];
+  editors: UserType[];
 };
 
 export type AssistantBuilderInitialState = {
@@ -253,7 +253,7 @@ export type AssistantBuilderInitialState = {
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];
-  editors?: UserType[];
+  editors: UserType[];
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -14,6 +14,7 @@ import type { KeyedMutator } from "swr";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
+import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 
 type RowData = {
   icon: string;
@@ -55,7 +56,9 @@ type MembersData = {
   members: UserTypeWithWorkspaces[];
   totalMembersCount: number;
   isLoading: boolean;
-  mutateRegardlessOfQueryParams: KeyedMutator<SearchMembersResponseBody>;
+  mutateRegardlessOfQueryParams:
+    | KeyedMutator<SearchMembersResponseBody>
+    | KeyedMutator<GetAgentEditorsResponseBody>;
 };
 
 const memberColumns = [

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -103,10 +103,14 @@ const memberColumns = [
     header: "",
     cell: (info: Info) => (
       <DataTable.CellContent>
-        <IconButton
-          icon={XMarkIcon}
-          onClick={info.row.original.onRemoveMemberClick}
-        />
+        {info.row.original.isCurrentUser ? (
+          <></>
+        ) : (
+          <IconButton
+            icon={XMarkIcon}
+            onClick={info.row.original.onRemoveMemberClick}
+          />
+        )}
       </DataTable.CellContent>
     ),
     meta: {

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -13,7 +13,7 @@ import type { KeyedMutator } from "swr";
 
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
-import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
+import type { RoleType, UserType, UserTypeWithWorkspaces } from "@app/types";
 
 type RowData = {
   icon: string;
@@ -122,7 +122,7 @@ const memberColumns = [
 ];
 
 export function MembersList({
-  currentUserId,
+  currentUser,
   membersData,
   onRowClick,
   onRemoveMemberClick,
@@ -130,7 +130,7 @@ export function MembersList({
   pagination,
   setPagination,
 }: {
-  currentUserId: string;
+  currentUser: UserType | null;
   membersData: MembersData;
   onRowClick: (user: UserTypeWithWorkspaces) => void;
   onRemoveMemberClick?: (user: UserTypeWithWorkspaces) => void;
@@ -155,9 +155,9 @@ export function MembersList({
       allUsers: filteredMembers,
       onClick: onRowClick,
       onRemoveMemberClick,
-      currentUserId,
+      currentUserId: currentUser?.sId ?? "current-user-not-loaded",
     });
-  }, [members, onRowClick, onRemoveMemberClick, currentUserId]);
+  }, [members, onRowClick, onRemoveMemberClick, currentUser]);
 
   return (
     <>

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -14,7 +14,6 @@ import type { KeyedMutator } from "swr";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
-import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 
 type RowData = {
   icon: string;

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -58,7 +58,7 @@ type MembersData = {
   isLoading: boolean;
   mutateRegardlessOfQueryParams:
     | KeyedMutator<SearchMembersResponseBody>
-    | KeyedMutator<GetAgentEditorsResponseBody>;
+    | (() => void);
 };
 
 const memberColumns = [

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -940,7 +940,7 @@ export async function createAgentConfiguration(
             agentConfigurationInstance,
             { transaction: t }
           );
-          group.setMembers(auth, editors, { transaction });
+          await group.setMembers(auth, editors, { transaction });
         } else {
           const groupRes = await GroupResource.fetchByAgentConfiguration(
             auth,
@@ -962,7 +962,7 @@ export async function createAgentConfiguration(
                 `Error adding group to agent ${existingAgent.sId}: ${result.error}`
               );
             }
-            group.setMembers(auth, editors, { transaction });
+            await group.setMembers(auth, editors, { transaction });
           } else {
             logger.warn(
               {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -940,7 +940,7 @@ export async function createAgentConfiguration(
             agentConfigurationInstance,
             { transaction: t }
           );
-          await group.setMembers(auth, editors, { transaction });
+          await group.setMembers(auth, editors, { transaction: t });
         } else {
           const groupRes = await GroupResource.fetchByAgentConfiguration(
             auth,
@@ -962,7 +962,7 @@ export async function createAgentConfiguration(
                 `Error adding group to agent ${existingAgent.sId}: ${result.error}`
               );
             }
-            await group.setMembers(auth, editors, { transaction });
+            await group.setMembers(auth, editors, { transaction: t });
           } else {
             logger.warn(
               {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -25,6 +25,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
+  AgentConfigurationType,
   GroupKind,
   GroupType,
   LightAgentConfigurationType,
@@ -421,7 +422,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async fetchByAgentConfiguration(
     auth: Authenticator,
-    agentConfiguration: AgentConfiguration
+    agentConfiguration: AgentConfiguration | AgentConfigurationType
   ): Promise<Result<GroupResource, DustError>> {
     const workspace = auth.getNonNullableWorkspace();
     const groupAgent = await GroupAgentModel.findOne({

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -28,7 +28,7 @@ export function useEditors({
   );
 
   return {
-    editors: useMemo(() => (data ? data.editors : undefined), [data]),
+    editors: useMemo(() => (data ? data.editors : []), [data]),
     isEditorsLoading: !error && !data && !disabled,
     isEditorsError: !!error,
     mutateEditors: mutate,

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -3,33 +3,26 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import {
-  isTemplateAgentConfiguration,
-  UserType,
-  type LightAgentConfigurationType,
-  type LightWorkspaceType,
-  type TemplateAgentConfigurationType,
-} from "@app/types";
-import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
+import type { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
+import type { UserType } from "@app/types";
+import type { LightWorkspaceType } from "@app/types";
 
 export function useEditors({
   owner,
-  agentConfiguration,
+  agentConfigurationId,
   disabled,
 }: {
   owner: LightWorkspaceType;
-  agentConfiguration:
-    | LightAgentConfigurationType
-    | TemplateAgentConfigurationType
-    | null;
+  agentConfigurationId: string | null;
   disabled?: boolean;
 }) {
   const editorsFetcher: Fetcher<GetAgentEditorsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    !agentConfiguration || isTemplateAgentConfiguration(agentConfiguration)
-      ? null
-      : `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/editors`,
+    agentConfigurationId
+      ? `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/editors`
+      : null,
+
     editorsFetcher,
     {
       disabled,

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -3,11 +3,13 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type {
-  LightAgentConfigurationType,
-  LightWorkspaceType,
+import {
+  isTemplateAgentConfiguration,
+  UserType,
+  type LightAgentConfigurationType,
+  type LightWorkspaceType,
+  type TemplateAgentConfigurationType,
 } from "@app/types";
-import type { TagType } from "@app/types/tag";
 import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
 
 export function useEditors({
@@ -16,13 +18,18 @@ export function useEditors({
   disabled,
 }: {
   owner: LightWorkspaceType;
-  agentConfiguration: LightAgentConfigurationType;
+  agentConfiguration:
+    | LightAgentConfigurationType
+    | TemplateAgentConfigurationType
+    | null;
   disabled?: boolean;
 }) {
   const editorsFetcher: Fetcher<GetAgentEditorsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/editors`,
+    !agentConfiguration || isTemplateAgentConfiguration(agentConfiguration)
+      ? null
+      : `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/editors`,
     editorsFetcher,
     {
       disabled,
@@ -30,7 +37,16 @@ export function useEditors({
   );
 
   return {
-    editors: useMemo(() => (data ? data.editors : []), [data]),
+    editorsMap: useMemo(
+      () =>
+        data
+          ? data.editors.reduce(
+              (acc, val) => acc.set(val.sId, val),
+              new Map<string, UserType>()
+            )
+          : undefined,
+      [data]
+    ),
     isEditorsLoading: !error && !data && !disabled,
     isEditorsError: !!error,
     mutateEditors: mutate,

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -1,4 +1,3 @@
-import { useSendNotification } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -1,0 +1,38 @@
+import { useSendNotification } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  LightAgentConfigurationType,
+  LightWorkspaceType,
+} from "@app/types";
+import type { TagType } from "@app/types/tag";
+import { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
+
+export function useEditors({
+  owner,
+  agentConfiguration,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  agentConfiguration: LightAgentConfigurationType;
+  disabled?: boolean;
+}) {
+  const editorsFetcher: Fetcher<GetAgentEditorsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/editors`,
+    editorsFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    editors: useMemo(() => (data ? data.editors : []), [data]),
+    isEditorsLoading: !error && !data && !disabled,
+    isEditorsError: !!error,
+    mutateEditors: mutate,
+  };
+}

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -3,7 +3,6 @@ import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentEditorsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors";
-import type { UserType } from "@app/types";
 import type { LightWorkspaceType } from "@app/types";
 
 export function useEditors({
@@ -29,16 +28,7 @@ export function useEditors({
   );
 
   return {
-    editorsMap: useMemo(
-      () =>
-        data
-          ? data.editors.reduce(
-              (acc, val) => acc.set(val.sId, val),
-              new Map<string, UserType>()
-            )
-          : undefined,
-      [data]
-    ),
+    editors: useMemo(() => (data ? data.editors : undefined), [data]),
     isEditorsLoading: !error && !data && !disabled,
     isEditorsError: !!error,
     mutateEditors: mutate,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -19,60 +19,6 @@ vi.mock("@app/lib/api/assistant/recent_authors", () => ({
   agentConfigurationWasUpdatedBy: vi.fn(),
 }));
 
-// Helper to create a test agent configuration
-async function createTestAgent(
-  auth: Authenticator,
-  t?: Transaction,
-  overrides: Partial<{
-    name: string;
-    description: string;
-    scope: Exclude<LightAgentConfigurationType["scope"], "global">;
-    model: {
-      providerId: ModelProviderIdType;
-      modelId: ModelIdType;
-      temperature?: number;
-    };
-  }> = {}
-): Promise<LightAgentConfigurationType> {
-  const name = overrides.name ?? "Test Agent";
-  const description = overrides.description ?? "Test Agent Description";
-  const scope = overrides.scope ?? "workspace";
-  const providerId = overrides.model?.providerId ?? "openai";
-  const modelId = overrides.model?.modelId ?? "gpt-4-turbo";
-  const temperature = overrides.model?.temperature ?? 0.7;
-  const user = auth.user()?.toJSON();
-
-  const result = await createAgentConfiguration(
-    auth,
-    {
-      name,
-      description,
-      instructions: "Test Instructions",
-      maxStepsPerRun: 5,
-      visualizationEnabled: false,
-      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
-      status: "active",
-      scope,
-      model: {
-        providerId,
-        modelId,
-        temperature,
-      },
-      templateId: null,
-      requestedGroupIds: [], // Let createAgentConfiguration handle group creation
-      tags: [], // Added missing tags property
-      editors: user ? [user] : [],
-    },
-    t
-  );
-
-  if (result.isErr()) {
-    throw result.error;
-  }
-
-  return result.value;
-}
-
 async function setupTest(
   options: {
     agentOwnerRole?: "admin" | "builder" | "user";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -19,6 +19,60 @@ vi.mock("@app/lib/api/assistant/recent_authors", () => ({
   agentConfigurationWasUpdatedBy: vi.fn(),
 }));
 
+// Helper to create a test agent configuration
+async function createTestAgent(
+  auth: Authenticator,
+  t?: Transaction,
+  overrides: Partial<{
+    name: string;
+    description: string;
+    scope: Exclude<LightAgentConfigurationType["scope"], "global">;
+    model: {
+      providerId: ModelProviderIdType;
+      modelId: ModelIdType;
+      temperature?: number;
+    };
+  }> = {}
+): Promise<LightAgentConfigurationType> {
+  const name = overrides.name ?? "Test Agent";
+  const description = overrides.description ?? "Test Agent Description";
+  const scope = overrides.scope ?? "workspace";
+  const providerId = overrides.model?.providerId ?? "openai";
+  const modelId = overrides.model?.modelId ?? "gpt-4-turbo";
+  const temperature = overrides.model?.temperature ?? 0.7;
+  const user = auth.user()?.toJSON();
+
+  const result = await createAgentConfiguration(
+    auth,
+    {
+      name,
+      description,
+      instructions: "Test Instructions",
+      maxStepsPerRun: 5,
+      visualizationEnabled: false,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope,
+      model: {
+        providerId,
+        modelId,
+        temperature,
+      },
+      templateId: null,
+      requestedGroupIds: [], // Let createAgentConfiguration handle group creation
+      tags: [], // Added missing tags property
+      editors: user ? [user] : [],
+    },
+    t
+  );
+
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  return result.value;
+}
+
 async function setupTest(
   options: {
     agentOwnerRole?: "admin" | "builder" | "user";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -97,7 +97,7 @@ async function handler(
       // endpoint.
       const groupRes = await GroupResource.fetchByAgentConfiguration(
         auth,
-        assistant
+        agent
       );
 
       if (groupRes.isErr()) {
@@ -105,7 +105,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "assistant_saving_error",
-            message: `Error fetching group for agent ${assistant.sId}: ${groupRes.error}`,
+            message: `Error fetching group for agent ${agent.sId}: ${groupRes.error}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -11,10 +11,10 @@ import {
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentStatus, WithAPIErrorResponse } from "@app/types";
-import { GroupResource } from "@app/lib/resources/group_resource";
 
 export const PostAgentScopeRequestBodySchema = t.type({
   scope: t.union([

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -14,6 +14,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentStatus, WithAPIErrorResponse } from "@app/types";
+import { GroupResource } from "@app/lib/resources/group_resource";
 
 export const PostAgentScopeRequestBodySchema = t.type({
   scope: t.union([
@@ -92,6 +93,27 @@ async function handler(
         }
       }
 
+      // This won't stay long since Agent Discovery initiative removes the scope
+      // endpoint.
+      const groupRes = await GroupResource.fetchByAgentConfiguration(
+        auth,
+        assistant
+      );
+
+      if (groupRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "assistant_saving_error",
+            message: `Error fetching group for agent ${assistant.sId}: ${groupRes.error}`,
+          },
+        });
+      }
+
+      const group = groupRes.value;
+
+      const editors = await group.getActiveMembers(auth);
+
       // Cast the assistant to ensure TypeScript understands the correct types.
       const typedAssistant = {
         ...agent,
@@ -110,6 +132,7 @@ async function handler(
 
           return action;
         }),
+        editors,
       };
 
       const agentConfigurationRes = await createOrUpgradeAgentConfiguration({

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -21,6 +21,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -37,7 +38,6 @@ import {
   Ok,
   PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@app/types";
-import { UserResource } from "@app/lib/resources/user_resource";
 
 export type GetAgentConfigurationsResponseBody = {
   agentConfigurations: LightAgentConfigurationType[];

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -37,6 +37,7 @@ import {
   Ok,
   PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@app/types";
+import { UserResource } from "@app/lib/resources/user_resource";
 
 export type GetAgentConfigurationsResponseBody = {
   agentConfigurations: LightAgentConfigurationType[];
@@ -320,6 +321,10 @@ export async function createOrUpgradeAgentConfiguration({
     }
   }
 
+  const editors = (
+    await UserResource.fetchByIds(assistant.editors.map((e) => e.sId))
+  ).map((e) => e.toJSON());
+
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name: assistant.name,
     description: assistant.description,
@@ -337,6 +342,7 @@ export async function createOrUpgradeAgentConfiguration({
       actions
     ),
     tags: assistant.tags,
+    editors,
   });
 
   if (agentConfigurationRes.isErr()) {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -17,6 +17,7 @@ import config from "@app/lib/api/config";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { useEditors } from "@app/lib/swr/editors";
 import type {
   AgentConfigurationType,
   AppType,
@@ -27,7 +28,6 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
-import { useEditors } from "@app/lib/swr/editors";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   actions: AssistantBuilderInitialState["actions"];
@@ -124,7 +124,7 @@ export default function EditAssistant({
 
   const { editorsMap } = useEditors({
     owner,
-    agentConfiguration,
+    agentConfigurationId: agentConfiguration.sId,
   });
 
   if (agentConfiguration.scope === "global") {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -25,12 +25,15 @@ import type {
   PlanType,
   SpaceType,
   SubscriptionType,
+  UserType,
   WorkspaceType,
 } from "@app/types";
+import { GroupResource } from "@app/lib/resources/group_resource";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   actions: AssistantBuilderInitialState["actions"];
   agentConfiguration: AgentConfigurationType;
+  agentEditors: UserType[];
   baseUrl: string;
   dataSourceViews: DataSourceViewType[];
   dustApps: AppType[];
@@ -89,10 +92,23 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   const mcpServerViewsJSON = mcpServerViews.map((v) => v.toJSON());
 
+  const editorGroupRes = await GroupResource.findEditorGroupForAgent(
+    auth,
+    configuration
+  );
+  if (editorGroupRes.isErr()) {
+    throw new Error("Failed to find editor group for agent");
+  }
+
+  const agentEditors = (await editorGroupRes.value.getActiveMembers(auth)).map(
+    (m) => m.toJSON()
+  );
+
   return {
     props: {
       actions,
       agentConfiguration: configuration,
+      agentEditors,
       baseUrl: config.getClientFacingUrl(),
       dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
       dustApps: dustApps.map((a) => a.toJSON()),
@@ -109,6 +125,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function EditAssistant({
   actions,
   agentConfiguration,
+  agentEditors,
   baseUrl,
   spaces,
   dataSourceViews,
@@ -120,11 +137,6 @@ export default function EditAssistant({
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   throwIfInvalidAgentConfiguration(agentConfiguration);
-
-  const { editors } = useEditors({
-    owner,
-    agentConfigurationId: agentConfiguration.sId,
-  });
 
   if (agentConfiguration.scope === "global") {
     throw new Error("Cannot edit global agent");
@@ -166,7 +178,7 @@ export default function EditAssistant({
           maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           templateId: agentConfiguration.templateId,
           tags: agentConfiguration.tags,
-          editors,
+          editors: agentEditors,
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -122,7 +122,7 @@ export default function EditAssistant({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   throwIfInvalidAgentConfiguration(agentConfiguration);
 
-  const { editorsMap } = useEditors({
+  const { editors } = useEditors({
     owner,
     agentConfigurationId: agentConfiguration.sId,
   });
@@ -167,7 +167,7 @@ export default function EditAssistant({
           maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           templateId: agentConfiguration.templateId,
           tags: agentConfiguration.tags,
-          editors: editorsMap,
+          editors,
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -27,6 +27,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { useEditors } from "@app/lib/swr/editors";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   actions: AssistantBuilderInitialState["actions"];
@@ -121,6 +122,11 @@ export default function EditAssistant({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   throwIfInvalidAgentConfiguration(agentConfiguration);
 
+  const { editorsMap } = useEditors({
+    owner,
+    agentConfiguration,
+  });
+
   if (agentConfiguration.scope === "global") {
     throw new Error("Cannot edit global agent");
   }
@@ -161,7 +167,7 @@ export default function EditAssistant({
           maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           templateId: agentConfiguration.templateId,
           tags: agentConfiguration.tags,
-          editors: new Map<string, UserType>(),
+          editors: editorsMap,
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -16,8 +16,8 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import config from "@app/lib/api/config";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { useEditors } from "@app/lib/swr/editors";
 import type {
   AgentConfigurationType,
   AppType,
@@ -28,7 +28,6 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
-import { GroupResource } from "@app/lib/resources/group_resource";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   actions: AssistantBuilderInitialState["actions"];

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -25,7 +25,6 @@ import type {
   PlanType,
   SpaceType,
   SubscriptionType,
-  UserType,
   WorkspaceType,
 } from "@app/types";
 

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -24,6 +24,7 @@ import type {
   PlanType,
   SpaceType,
   SubscriptionType,
+  UserType,
   WorkspaceType,
 } from "@app/types";
 
@@ -160,6 +161,7 @@ export default function EditAssistant({
           maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           templateId: agentConfiguration.templateId,
           tags: agentConfiguration.tags,
+          editors: new Map<string, UserType>(),
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import type { ParsedUrlQuery } from "querystring";
-import { useMemo } from "react";
 
 import AssistantBuilder from "@app/components/assistant_builder/AssistantBuilder";
 import { AssistantBuilderProvider } from "@app/components/assistant_builder/AssistantBuilderContext";
@@ -23,18 +22,17 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
 import { useEditors } from "@app/lib/swr/editors";
-import {
-  isTemplateAgentConfiguration,
-  type AgentConfigurationType,
-  type AppType,
-  type DataSourceViewType,
-  type PlanType,
-  type SpaceType,
-  type SubscriptionType,
-  type TemplateAgentConfigurationType,
-  type UserType,
-  type WorkspaceType,
+import type {
+  AgentConfigurationType,
+  AppType,
+  DataSourceViewType,
+  PlanType,
+  SpaceType,
+  SubscriptionType,
+  TemplateAgentConfigurationType,
+  WorkspaceType,
 } from "@app/types";
+import { isTemplateAgentConfiguration } from "@app/types";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -28,6 +28,7 @@ import type {
   SpaceType,
   SubscriptionType,
   TemplateAgentConfigurationType,
+  UserType,
   WorkspaceType,
 } from "@app/types";
 
@@ -216,6 +217,7 @@ export default function CreateAssistant({
                 visualizationEnabled: agentConfiguration.visualizationEnabled,
                 templateId: templateId,
                 tags: agentConfiguration.tags,
+                editors: new Map<string, UserType>(),
               }
             : null
         }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -169,7 +169,7 @@ export default function CreateAssistant({
   isAgentDiscoveryEnabled,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({ templateId });
-  const { editorsMap } = useEditors({
+  const { editors } = useEditors({
     owner,
     agentConfigurationId:
       agentConfiguration && !isTemplateAgentConfiguration(agentConfiguration)
@@ -228,7 +228,7 @@ export default function CreateAssistant({
                 visualizationEnabled: agentConfiguration.visualizationEnabled,
                 templateId: templateId,
                 tags: agentConfiguration.tags,
-                editors: editorsMap,
+                editors,
               }
             : null
         }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import type { ParsedUrlQuery } from "querystring";
 

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -1,5 +1,7 @@
+import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import type { ParsedUrlQuery } from "querystring";
+import { useMemo } from "react";
 
 import AssistantBuilder from "@app/components/assistant_builder/AssistantBuilder";
 import { AssistantBuilderProvider } from "@app/components/assistant_builder/AssistantBuilderContext";
@@ -20,20 +22,19 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
-import type {
-  AgentConfigurationType,
-  AppType,
-  DataSourceViewType,
-  PlanType,
-  SpaceType,
-  SubscriptionType,
-  TemplateAgentConfigurationType,
-  UserType,
-  WorkspaceType,
-} from "@app/types";
 import { useEditors } from "@app/lib/swr/editors";
-import _ from "lodash";
-import { useMemo } from "react";
+import {
+  isTemplateAgentConfiguration,
+  type AgentConfigurationType,
+  type AppType,
+  type DataSourceViewType,
+  type PlanType,
+  type SpaceType,
+  type SubscriptionType,
+  type TemplateAgentConfigurationType,
+  type UserType,
+  type WorkspaceType,
+} from "@app/types";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;
@@ -170,7 +171,10 @@ export default function CreateAssistant({
   const { assistantTemplate } = useAssistantTemplate({ templateId });
   const { editorsMap } = useEditors({
     owner,
-    agentConfiguration,
+    agentConfigurationId:
+      agentConfiguration && !isTemplateAgentConfiguration(agentConfiguration)
+        ? agentConfiguration.sId
+        : null,
   });
 
   if (agentConfiguration) {

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -31,6 +31,9 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { useEditors } from "@app/lib/swr/editors";
+import _ from "lodash";
+import { useMemo } from "react";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;
@@ -165,6 +168,10 @@ export default function CreateAssistant({
   isAgentDiscoveryEnabled,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({ templateId });
+  const { editorsMap } = useEditors({
+    owner,
+    agentConfiguration,
+  });
 
   if (agentConfiguration) {
     throwIfInvalidAgentConfiguration(agentConfiguration);
@@ -217,7 +224,7 @@ export default function CreateAssistant({
                 visualizationEnabled: agentConfiguration.visualizationEnabled,
                 templateId: templateId,
                 tags: agentConfiguration.tags,
-                editors: new Map<string, UserType>(),
+                editors: editorsMap,
               }
             : null
         }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -20,7 +20,6 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
-import { useEditors } from "@app/lib/swr/editors";
 import type {
   AgentConfigurationType,
   AppType,
@@ -31,7 +30,6 @@ import type {
   TemplateAgentConfigurationType,
   WorkspaceType,
 } from "@app/types";
-import { isTemplateAgentConfiguration } from "@app/types";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;
@@ -166,13 +164,6 @@ export default function CreateAssistant({
   isAgentDiscoveryEnabled,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({ templateId });
-  const { editors } = useEditors({
-    owner,
-    agentConfigurationId:
-      agentConfiguration && !isTemplateAgentConfiguration(agentConfiguration)
-        ? agentConfiguration.sId
-        : null,
-  });
 
   if (agentConfiguration) {
     throwIfInvalidAgentConfiguration(agentConfiguration);
@@ -225,7 +216,8 @@ export default function CreateAssistant({
                 visualizationEnabled: agentConfiguration.visualizationEnabled,
                 templateId: templateId,
                 tags: agentConfiguration.tags,
-                editors,
+                // either new, or template, or duplicate, so initially no editors
+                editors: [],
               }
             : null
         }

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -265,7 +265,7 @@ export default function WorkspaceAdmin({
         </div>
         <InvitationsList owner={owner} searchText={searchTerm} />
         <WorkspaceMembersList
-          currentUserId={user.sId}
+          currentUser={user}
           owner={owner}
           searchTerm={searchTerm}
         />
@@ -365,11 +365,11 @@ function DomainAutoJoinModal({
 const DEFAULT_PAGE_SIZE = 25;
 
 function WorkspaceMembersList({
-  currentUserId,
+  currentUser,
   owner,
   searchTerm,
 }: {
-  currentUserId: string;
+  currentUser: UserType | null;
   owner: WorkspaceType;
   searchTerm: string;
 }) {
@@ -396,7 +396,7 @@ function WorkspaceMembersList({
     <div className="flex flex-col gap-2">
       <Page.H variant="h5">Members</Page.H>
       <MembersList
-        currentUserId={currentUserId}
+        currentUser={currentUser}
         membersData={membersData}
         onRowClick={setSelectedMember}
         showColumns={["name", "email", "role"]}

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -49,6 +49,7 @@ export class AgentConfigurationFactory {
         templateId: null,
         requestedGroupIds: [], // Let createAgentConfiguration handle group creation
         tags: [], // Added missing tags property
+        editors: [],
       },
       t
     );

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -7,6 +7,7 @@ import type {
   ModelIdType,
   ModelProviderIdType,
 } from "@app/types";
+import assert from "assert";
 
 export class AgentConfigurationFactory {
   static async createTestAgent(
@@ -30,6 +31,9 @@ export class AgentConfigurationFactory {
     const modelId = overrides.model?.modelId ?? "gpt-4-turbo";
     const temperature = overrides.model?.temperature ?? 0.7;
 
+    const user = auth.user();
+    assert(user, "User is required");
+
     const result = await createAgentConfiguration(
       auth,
       {
@@ -49,7 +53,7 @@ export class AgentConfigurationFactory {
         templateId: null,
         requestedGroupIds: [], // Let createAgentConfiguration handle group creation
         tags: [], // Added missing tags property
-        editors: [],
+        editors: [user.toJSON()],
       },
       t
     );

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -215,6 +215,10 @@ const TagSchema = t.type({
   name: t.string,
 });
 
+const EditorSchema = t.type({
+  sId: t.string,
+});
+
 export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
   assistant: t.type({
     name: t.string,
@@ -239,6 +243,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     maxStepsPerRun: t.union([t.number, t.undefined]),
     visualizationEnabled: t.boolean,
     tags: t.array(TagSchema),
+    editors: t.array(EditorSchema),
   }),
 });
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -169,6 +169,19 @@ export interface TemplateAgentConfigurationType {
   tags: TagType[];
 }
 
+export function isTemplateAgentConfiguration(
+  agentConfiguration:
+    | LightAgentConfigurationType
+    | TemplateAgentConfigurationType
+    | null
+): agentConfiguration is TemplateAgentConfigurationType {
+  return !!(
+    agentConfiguration &&
+    "isTemplate" in agentConfiguration &&
+    agentConfiguration.isTemplate === true
+  );
+}
+
 export const DEFAULT_MAX_STEPS_USE_PER_RUN = 8;
 export const MAX_STEPS_USE_PER_RUN_LIMIT = 12;
 


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2467

## Description

Reinstates https://github.com/dust-tt/dust/pull/12143 which had been reverted.
Issue was that editor groups were missing on some agents, but now groups have been backfilled.

Follows #12132 that was only UX. Makes the UX functional
- editors field added to builder state
- useEditors swr hook
- add remove button to editors
- update group appropriately when saving agent configuration

## Risk
standard. Behind ff. Tested locally

## Deploy Plan
front
