### PR TITLE
Preserve TTL When Updating Public API Quotas

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/get_remaining_public_api_limits.ts
+++ b/front/lib/api/poke/plugins/workspaces/get_remaining_public_api_limits.ts
@@ -54,24 +54,26 @@ export const getRemainingPublicAPILimitsPlugin = createPlugin({
       return new Ok({
         display: "json",
         value: {
+          limits,
+          expiresInSeconds: -1,
           remainingCredits: limits.monthlyLimit,
           remainingCreditsPercentage: 100,
-          expiresAt: null,
           reset: resetLabel,
         },
       });
     }
 
-    const { expiresAt, remainingCredits } = remaining;
+    const { expiresInSeconds, remainingCredits } = remaining;
     const remainingCreditsPercentage =
       (remainingCredits / limits.monthlyLimit) * 100;
 
     return new Ok({
       display: "json",
       value: {
+        limits,
+        expiresInSeconds,
         remainingCredits,
         remainingCreditsPercentage,
-        expiresAt,
         reset: resetLabel,
       },
     });

--- a/front/lib/api/poke/plugins/workspaces/set_public_api_limits.ts
+++ b/front/lib/api/poke/plugins/workspaces/set_public_api_limits.ts
@@ -50,13 +50,15 @@ async function adjustCredits(
     return;
   }
 
-  const remainingCredits = await getRemainingCredits(workspace);
+  const remaining = await getRemainingCredits(workspace);
   // If key is not set, credits will be set on the next token usage.
-  if (remainingCredits === null) {
+  if (remaining === null) {
     return;
   }
 
+  const { remainingCredits } = remaining;
   const newCredits = remainingCredits + limitDelta;
+
   await resetCredits(workspace, { newCredits });
 }
 

--- a/front/lib/api/public_api_limits.ts
+++ b/front/lib/api/public_api_limits.ts
@@ -87,7 +87,8 @@ export async function trackTokenUsageCost(
     // record of over-usage, while hasReachedPublicAPILimits will block subsequent calls when
     // detecting negative credits.
     const newCredits = parseFloat(remainingCredits) - amountWithMarkup;
-    await redis.set(key, newCredits.toString());
+    // Preserve the TTL of the key.
+    await redis.set(key, newCredits.toString(), { KEEPTTL: true });
     return newCredits;
   });
 }

--- a/front/lib/api/public_api_limits.ts
+++ b/front/lib/api/public_api_limits.ts
@@ -172,7 +172,7 @@ export async function resetCredits(
 
 export async function getRemainingCredits(
   workspace: LightWorkspaceType
-): Promise<{ expiresAt: number; remainingCredits: number } | null> {
+): Promise<{ expiresInSeconds: number; remainingCredits: number } | null> {
   return runOnRedis({ origin: REDIS_ORIGIN }, async (redis) => {
     const key = getRedisKey(workspace);
     const remainingCredits = await redis.get(key);
@@ -180,11 +180,11 @@ export async function getRemainingCredits(
       return null;
     }
 
-    const expiresAt = await redis.ttl(key);
+    const expiresInSeconds = await redis.ttl(key);
 
     return {
+      expiresInSeconds,
       remainingCredits: parseFloat(remainingCredits),
-      expiresAt,
     };
   });
 }

--- a/front/lib/api/public_api_limits.ts
+++ b/front/lib/api/public_api_limits.ts
@@ -172,7 +172,7 @@ export async function resetCredits(
 
 export async function getRemainingCredits(
   workspace: LightWorkspaceType
-): Promise<number | null> {
+): Promise<{ expiresAt: number; remainingCredits: number } | null> {
   return runOnRedis({ origin: REDIS_ORIGIN }, async (redis) => {
     const key = getRedisKey(workspace);
     const remainingCredits = await redis.get(key);
@@ -180,6 +180,11 @@ export async function getRemainingCredits(
       return null;
     }
 
-    return parseFloat(remainingCredits);
+    const expiresAt = await redis.ttl(key);
+
+    return {
+      remainingCredits: parseFloat(remainingCredits),
+      expiresAt,
+    };
   });
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
From the Redis doc:
> The timeout will only be cleared by commands that delete or overwrite the contents of the key, including [DEL](https://redis.io/docs/latest/commands/del/), [SET](https://redis.io/docs/latest/commands/set/), [GETSET](https://redis.io/docs/latest/commands/getset/) and all the *STORE commands. This means that all the operations that conceptually alter the value stored at the key without replacing it with a new one will leave the timeout untouched.

We were using `SET` operation that cleared the TTL. This PR fixes this. Will manually patch the one workspace that has API quotas.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
