### PR TITLE
enh(Poke): add support for dark mode in `poke/plans`

### DIFF
--- a/connectors/migrations/20250429_autojoin_slack_channels.ts
+++ b/connectors/migrations/20250429_autojoin_slack_channels.ts
@@ -83,7 +83,7 @@ makeScript(
     // Get all channels from Slack
     const remoteChannels = await getChannels(parseInt(connectorId, 10), false);
     const matchingChannels = remoteChannels.filter(
-      (c) => c.name && new RegExp(pattern).test(c.name)
+      (c) => c.name && c.name.startsWith(pattern)
     );
 
     logger.info(

--- a/connectors/migrations/20250429_autojoin_slack_channels.ts
+++ b/connectors/migrations/20250429_autojoin_slack_channels.ts
@@ -83,7 +83,7 @@ makeScript(
     // Get all channels from Slack
     const remoteChannels = await getChannels(parseInt(connectorId, 10), false);
     const matchingChannels = remoteChannels.filter(
-      (c) => c.name && c.name.startsWith(pattern)
+      (c) => c.name && new RegExp(pattern).test(c.name)
     );
 
     logger.info(

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -127,7 +127,7 @@ const PlansPage = () => {
           <div className="h-full py-8 text-2xl font-bold">Plans</div>
           <div className="h-full w-full overflow-x-auto pb-52 pt-12">
             <table className="mx-auto h-full table-auto overflow-visible rounded-lg">
-              <thead className="bg-gray-50">
+              <thead className="bg-muted dark:bg-muted-night">
                 <tr>
                   {Object.keys(PLAN_FIELDS).map((fieldName) => {
                     const field =
@@ -147,7 +147,7 @@ const PlansPage = () => {
                   <th className="px-4 py-2">Edit</th>
                 </tr>
               </thead>
-              <tbody className="h-full bg-white pb-48 text-gray-700">
+              <tbody className="h-full bg-background pb-48 text-primary-light dark:bg-background-night dark:text-primary-light-night">
                 {plansToRender?.map((plan) => {
                   const planId = plan.isNewPlan ? "newPlan" : plan.code;
 

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -168,7 +168,7 @@ const PlansPage = () => {
                           />
                         </React.Fragment>
                       ))}
-                      <td className="w-12 min-w-[4rem] flex-none border px-4 py-2">
+                      <td className="w-12 min-w-16 flex-none border px-4 py-2">
                         {plan.code === editingPlan?.code || plan.isNewPlan ? (
                           <div className="flex flex-row justify-center">
                             <IconButton


### PR DESCRIPTION
## Description

- I can't read the header row of the plans in dark mode.
- This PR adds support for dark mode in poke plans.
- Small drawback: we can't see the GitHub logo anymore.

Before:

<img width="1232" alt="Screenshot 2025-04-30 at 11 33 55 AM" src="https://github.com/user-attachments/assets/358a59f5-909d-4659-a415-327cde214c81" />

After:
<img width="1232" alt="Screenshot 2025-04-30 at 11 32 46 AM" src="https://github.com/user-attachments/assets/ebf8ef8b-2c2d-4c3e-904c-96dd85c2fce3" />

## Tests

- Checked locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.