### PR TITLE
[front] Remove useMemo and use static empty array

### DIFF
--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -11,10 +10,20 @@ import type { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/spaces/[spa
 import type { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status";
 import type {
   AppType,
+  DustAppSecretType,
+  KeyType,
   LightWorkspaceType,
+  ProviderType,
   RunRunType,
+  RunType,
   SpaceType,
 } from "@app/types";
+
+const EMPTY_APPS_ARRAY: AppType[] = [];
+const EMPTY_SECRETS_ARRAY: DustAppSecretType[] = [];
+const EMPTY_RUNS_ARRAY: RunType[] = [];
+const EMPTY_PROVIDERS_ARRAY: ProviderType[] = [];
+const EMPTY_KEYS_ARRAY: KeyType[] = [];
 
 export function useApps({
   disabled,
@@ -36,7 +45,7 @@ export function useApps({
   );
 
   return {
-    apps: useMemo(() => (data ? data.apps : []), [data]),
+    apps: data?.apps ?? EMPTY_APPS_ARRAY,
     isAppsLoading: !error && !data,
     isAppsError: !!error,
     mutateApps: mutate,
@@ -96,7 +105,7 @@ export function useDustAppSecrets(owner: LightWorkspaceType) {
   );
 
   return {
-    secrets: useMemo(() => (data ? data.secrets : []), [data]),
+    secrets: data?.secrets ?? EMPTY_SECRETS_ARRAY,
     isSecretsLoading: !error && !data,
     isSecretsError: error,
   };
@@ -118,7 +127,7 @@ export function useRuns(
   const { data, error } = useSWRWithDefaults(url, runsFetcher);
 
   return {
-    runs: useMemo(() => (data ? data.runs : []), [data]),
+    runs: data?.runs ?? EMPTY_RUNS_ARRAY,
     total: data ? data.total : 0,
     isRunsLoading: !error && !data,
     isRunsError: error,
@@ -143,7 +152,7 @@ export function useProviders({
   );
 
   return {
-    providers: useMemo(() => (data ? data.providers : []), [data]),
+    providers: data?.providers ?? EMPTY_PROVIDERS_ARRAY,
     isProvidersLoading: !error && !data,
     isProvidersError: error,
   };
@@ -159,6 +168,6 @@ export function useKeys(owner: LightWorkspaceType) {
     isKeysError: error,
     isKeysLoading: !error && !data,
     isValidating,
-    keys: useMemo(() => (data ? data.keys : []), [data]),
+    keys: data?.keys ?? EMPTY_KEYS_ARRAY,
   };
 }

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
@@ -10,20 +10,10 @@ import type { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/spaces/[spa
 import type { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status";
 import type {
   AppType,
-  DustAppSecretType,
-  KeyType,
   LightWorkspaceType,
-  ProviderType,
   RunRunType,
-  RunType,
   SpaceType,
 } from "@app/types";
-
-const EMPTY_APPS_ARRAY: AppType[] = [];
-const EMPTY_SECRETS_ARRAY: DustAppSecretType[] = [];
-const EMPTY_RUNS_ARRAY: RunType[] = [];
-const EMPTY_PROVIDERS_ARRAY: ProviderType[] = [];
-const EMPTY_KEYS_ARRAY: KeyType[] = [];
 
 export function useApps({
   disabled,
@@ -45,7 +35,7 @@ export function useApps({
   );
 
   return {
-    apps: data?.apps ?? EMPTY_APPS_ARRAY,
+    apps: data?.apps ?? getEmptyArray(),
     isAppsLoading: !error && !data,
     isAppsError: !!error,
     mutateApps: mutate,
@@ -105,7 +95,7 @@ export function useDustAppSecrets(owner: LightWorkspaceType) {
   );
 
   return {
-    secrets: data?.secrets ?? EMPTY_SECRETS_ARRAY,
+    secrets: data?.secrets ?? getEmptyArray(),
     isSecretsLoading: !error && !data,
     isSecretsError: error,
   };
@@ -127,7 +117,7 @@ export function useRuns(
   const { data, error } = useSWRWithDefaults(url, runsFetcher);
 
   return {
-    runs: data?.runs ?? EMPTY_RUNS_ARRAY,
+    runs: data?.runs ?? getEmptyArray(),
     total: data ? data.total : 0,
     isRunsLoading: !error && !data,
     isRunsError: error,
@@ -152,11 +142,12 @@ export function useProviders({
   );
 
   return {
-    providers: data?.providers ?? EMPTY_PROVIDERS_ARRAY,
+    providers: data?.providers ?? getEmptyArray(),
     isProvidersLoading: !error && !data,
     isProvidersError: error,
   };
 }
+
 export function useKeys(owner: LightWorkspaceType) {
   const keysFetcher: Fetcher<GetKeysResponseBody> = fetcher;
   const { data, error, isValidating } = useSWRWithDefaults(
@@ -168,6 +159,6 @@ export function useKeys(owner: LightWorkspaceType) {
     isKeysError: error,
     isKeysLoading: !error && !data,
     isValidating,
-    keys: data?.keys ?? EMPTY_KEYS_ARRAY,
+    keys: data?.keys ?? getEmptyArray(),
   };
 }

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
@@ -35,7 +35,7 @@ export function useApps({
   );
 
   return {
-    apps: data?.apps ?? getEmptyArray(),
+    apps: data?.apps ?? emptyArray(),
     isAppsLoading: !error && !data,
     isAppsError: !!error,
     mutateApps: mutate,
@@ -95,7 +95,7 @@ export function useDustAppSecrets(owner: LightWorkspaceType) {
   );
 
   return {
-    secrets: data?.secrets ?? getEmptyArray(),
+    secrets: data?.secrets ?? emptyArray(),
     isSecretsLoading: !error && !data,
     isSecretsError: error,
   };
@@ -117,7 +117,7 @@ export function useRuns(
   const { data, error } = useSWRWithDefaults(url, runsFetcher);
 
   return {
-    runs: data?.runs ?? getEmptyArray(),
+    runs: data?.runs ?? emptyArray(),
     total: data ? data.total : 0,
     isRunsLoading: !error && !data,
     isRunsError: error,
@@ -142,7 +142,7 @@ export function useProviders({
   );
 
   return {
-    providers: data?.providers ?? getEmptyArray(),
+    providers: data?.providers ?? emptyArray(),
     isProvidersLoading: !error && !data,
     isProvidersError: error,
   };
@@ -159,6 +159,6 @@ export function useKeys(owner: LightWorkspaceType) {
     isKeysError: error,
     isKeysLoading: !error && !data,
     isValidating,
-    keys: data?.keys ?? getEmptyArray(),
+    keys: data?.keys ?? emptyArray(),
   };
 }

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -9,7 +9,7 @@ import type {
 } from "@app/lib/api/assistant/feedback";
 import {
   fetcher,
-  getEmptyArray,
+  emptyArray,
   getErrorFromResponse,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
@@ -41,7 +41,7 @@ export function useAssistantTemplates() {
   );
 
   return {
-    assistantTemplates: data?.templates ?? getEmptyArray(),
+    assistantTemplates: data?.templates ?? emptyArray(),
     isAssistantTemplatesLoading: !error && !data,
     isAssistantTemplatesError: error,
     mutateAssistantTemplates: mutate,
@@ -135,7 +135,7 @@ export function useAgentConfigurations({
   return {
     agentConfigurations: data
       ? data.agentConfigurations
-      : getEmptyArray<LightAgentConfigurationType>(),
+      : emptyArray<LightAgentConfigurationType>(),
     isAgentConfigurationsLoading: !error && !data,
     isAgentConfigurationsError: error,
     mutate,
@@ -426,7 +426,7 @@ export function useSlackChannelsLinkedWithAgent({
   );
 
   return {
-    slackChannels: data?.slackChannels ?? getEmptyArray(),
+    slackChannels: data?.slackChannels ?? emptyArray(),
     slackDataSource: data?.slackDataSource,
     isSlackChannelsLoading: !error && !data,
     isSlackChannelsError: error,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import { useSWRConfig } from "swr";
 
+import type { SlackChannel } from "@app/components/assistant_builder/SlackIntegration";
 import type {
   AgentMessageFeedbackType,
   AgentMessageFeedbackWithMetadataType,
@@ -30,6 +31,12 @@ import type {
   UserType,
 } from "@app/types";
 
+const EMPTY_TEMPLATES_ARRAY: FetchAssistantTemplateResponse[] = [];
+const EMPTY_AGENT_CONFIGURATIONS_ARRAY: LightAgentConfigurationType[] = [];
+const EMPTY_SLACK_CHANNELS_ARRAY: (SlackChannel & {
+  agentConfigurationId: string;
+})[] = [];
+
 export function useAssistantTemplates() {
   const assistantTemplatesFetcher: Fetcher<FetchAssistantTemplatesResponse> =
     fetcher;
@@ -40,7 +47,7 @@ export function useAssistantTemplates() {
   );
 
   return {
-    assistantTemplates: useMemo(() => (data ? data.templates : []), [data]),
+    assistantTemplates: data?.templates ?? EMPTY_TEMPLATES_ARRAY,
     isAssistantTemplatesLoading: !error && !data,
     isAssistantTemplatesError: error,
     mutateAssistantTemplates: mutate,
@@ -132,10 +139,9 @@ export function useAgentConfigurations({
     });
 
   return {
-    agentConfigurations: useMemo(
-      () => (data ? data.agentConfigurations : []),
-      [data]
-    ),
+    agentConfigurations: data
+      ? data.agentConfigurations
+      : EMPTY_AGENT_CONFIGURATIONS_ARRAY,
     isAgentConfigurationsLoading: !error && !data,
     isAgentConfigurationsError: error,
     mutate,
@@ -426,7 +432,7 @@ export function useSlackChannelsLinkedWithAgent({
   );
 
   return {
-    slackChannels: useMemo(() => (data ? data.slackChannels : []), [data]),
+    slackChannels: data?.slackChannels ?? EMPTY_SLACK_CHANNELS_ARRAY,
     slackDataSource: data?.slackDataSource,
     isSlackChannelsLoading: !error && !data,
     isSlackChannelsError: error,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -3,13 +3,13 @@ import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import { useSWRConfig } from "swr";
 
-import type { SlackChannel } from "@app/components/assistant_builder/SlackIntegration";
 import type {
   AgentMessageFeedbackType,
   AgentMessageFeedbackWithMetadataType,
 } from "@app/lib/api/assistant/feedback";
 import {
   fetcher,
+  getEmptyArray,
   getErrorFromResponse,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
@@ -31,12 +31,6 @@ import type {
   UserType,
 } from "@app/types";
 
-const EMPTY_TEMPLATES_ARRAY: FetchAssistantTemplateResponse[] = [];
-const EMPTY_AGENT_CONFIGURATIONS_ARRAY: LightAgentConfigurationType[] = [];
-const EMPTY_SLACK_CHANNELS_ARRAY: (SlackChannel & {
-  agentConfigurationId: string;
-})[] = [];
-
 export function useAssistantTemplates() {
   const assistantTemplatesFetcher: Fetcher<FetchAssistantTemplatesResponse> =
     fetcher;
@@ -47,7 +41,7 @@ export function useAssistantTemplates() {
   );
 
   return {
-    assistantTemplates: data?.templates ?? EMPTY_TEMPLATES_ARRAY,
+    assistantTemplates: data?.templates ?? getEmptyArray(),
     isAssistantTemplatesLoading: !error && !data,
     isAssistantTemplatesError: error,
     mutateAssistantTemplates: mutate,
@@ -141,7 +135,7 @@ export function useAgentConfigurations({
   return {
     agentConfigurations: data
       ? data.agentConfigurations
-      : EMPTY_AGENT_CONFIGURATIONS_ARRAY,
+      : getEmptyArray<LightAgentConfigurationType>(),
     isAgentConfigurationsLoading: !error && !data,
     isAgentConfigurationsError: error,
     mutate,
@@ -432,7 +426,7 @@ export function useSlackChannelsLinkedWithAgent({
   );
 
   return {
-    slackChannels: data?.slackChannels ?? EMPTY_SLACK_CHANNELS_ARRAY,
+    slackChannels: data?.slackChannels ?? getEmptyArray(),
     slackDataSource: data?.slackDataSource,
     isSlackChannelsLoading: !error && !data,
     isSlackChannelsError: error,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -8,8 +8,8 @@ import type {
   AgentMessageFeedbackWithMetadataType,
 } from "@app/lib/api/assistant/feedback";
 import {
-  fetcher,
   emptyArray,
+  fetcher,
   getErrorFromResponse,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,

--- a/front/lib/swr/bigquery.ts
+++ b/front/lib/swr/bigquery.ts
@@ -4,6 +4,8 @@ import { fetcherWithBody, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PostCheckBigQueryLocationsResponseBody } from "@app/pages/api/w/[wId]/credentials/check_bigquery_locations";
 import type { CheckBigQueryCredentials, LightWorkspaceType } from "@app/types";
 
+const EMPTY_OBJECT: Record<string, string[]> = Object.freeze({});
+
 export function useBigQueryLocations({
   owner,
   credentials,
@@ -35,7 +37,7 @@ export function useBigQueryLocations({
   );
 
   return {
-    locations: useMemo(() => (data ? data.locations : []), [data]),
+    locations: data?.locations ?? EMPTY_OBJECT,
     isLocationsLoading: !error && !data,
     isLocationsError: !!error,
     mutateLocations: mutate,

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -8,7 +8,7 @@ import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/m
 import { getVisualizationRetryMessage } from "@app/lib/client/visualization";
 import {
   fetcher,
-  getEmptyArray,
+  emptyArray,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -70,7 +70,7 @@ export function useConversations({
   );
 
   return {
-    conversations: data?.conversations ?? getEmptyArray(),
+    conversations: data?.conversations ?? emptyArray(),
     isConversationsLoading: !error && !data,
     isConversationsError: error,
     mutateConversations: mutate,
@@ -94,7 +94,7 @@ export function useConversationFeedbacks({
   );
 
   return {
-    feedbacks: data?.feedbacks ?? getEmptyArray(),
+    feedbacks: data?.feedbacks ?? emptyArray(),
     isFeedbacksLoading: !error && !data,
     isFeedbacksError: error,
     mutateReactions: mutate,

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -7,8 +7,8 @@ import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import { getVisualizationRetryMessage } from "@app/lib/client/visualization";
 import {
-  fetcher,
   emptyArray,
+  fetcher,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -8,6 +8,7 @@ import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/m
 import { getVisualizationRetryMessage } from "@app/lib/client/visualization";
 import {
   fetcher,
+  getEmptyArray,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -19,9 +20,6 @@ import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
 } from "@app/types";
-
-const EMPTY_CONVERSATIONS_ARRAY: ConversationType[] = [];
-const EMPTY_FEEDBACKS_ARRAY: AgentMessageFeedbackType[] = [];
 
 export function useConversation({
   conversationId,
@@ -72,7 +70,7 @@ export function useConversations({
   );
 
   return {
-    conversations: data?.conversations ?? EMPTY_CONVERSATIONS_ARRAY,
+    conversations: data?.conversations ?? getEmptyArray(),
     isConversationsLoading: !error && !data,
     isConversationsError: error,
     mutateConversations: mutate,
@@ -96,7 +94,7 @@ export function useConversationFeedbacks({
   );
 
   return {
-    feedbacks: data?.feedbacks ?? EMPTY_FEEDBACKS_ARRAY,
+    feedbacks: data?.feedbacks ?? getEmptyArray(),
     isFeedbacksLoading: !error && !data,
     isFeedbacksError: error,
     mutateReactions: mutate,

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -20,6 +20,9 @@ import type {
   LightWorkspaceType,
 } from "@app/types";
 
+const EMPTY_CONVERSATIONS_ARRAY: ConversationType[] = [];
+const EMPTY_FEEDBACKS_ARRAY: AgentMessageFeedbackType[] = [];
+
 export function useConversation({
   conversationId,
   workspaceId,
@@ -69,7 +72,7 @@ export function useConversations({
   );
 
   return {
-    conversations: useMemo(() => (data ? data.conversations : []), [data]),
+    conversations: data?.conversations ?? EMPTY_CONVERSATIONS_ARRAY,
     isConversationsLoading: !error && !data,
     isConversationsError: error,
     mutateConversations: mutate,
@@ -93,7 +96,7 @@ export function useConversationFeedbacks({
   );
 
   return {
-    feedbacks: useMemo(() => (data ? data.feedbacks : []), [data]),
+    feedbacks: data?.feedbacks ?? EMPTY_FEEDBACKS_ARRAY,
     isFeedbacksLoading: !error && !data,
     isFeedbacksError: error,
     mutateReactions: mutate,

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -1,5 +1,4 @@
 import { useSendNotification } from "@dust-tt/sparkle";
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
@@ -13,10 +12,12 @@ import type { GetDataSourceViewTableResponseBody } from "@app/pages/api/w/[wId]/
 import type { SearchTablesResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search";
 import type { PatchTableResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]";
 import type {
+  DataSourceViewContentNode,
   DataSourceViewType,
   LightWorkspaceType,
   PatchDataSourceTableRequestBody,
 } from "@app/types";
+const EMPTY_TABLES_ARRAY: DataSourceViewContentNode[] = [];
 
 export function useDataSourceViewTable({
   dataSourceView,
@@ -95,7 +96,7 @@ export function useDataSourceViewTables({
   );
 
   return {
-    tables: useMemo(() => (data ? data.tables : []), [data]),
+    tables: data?.tables ?? EMPTY_TABLES_ARRAY,
     nextPageCursor: data?.nextPageCursor || null,
     isTablesLoading: !isDisabled && !error && !data,
     isTablesError: error,

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -3,8 +3,8 @@ import type { Fetcher } from "swr";
 
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
-  fetcher,
   emptyArray,
+  fetcher,
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -4,6 +4,7 @@ import type { Fetcher } from "swr";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,
+  getEmptyArray,
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -12,12 +13,10 @@ import type { GetDataSourceViewTableResponseBody } from "@app/pages/api/w/[wId]/
 import type { SearchTablesResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search";
 import type { PatchTableResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]";
 import type {
-  DataSourceViewContentNode,
   DataSourceViewType,
   LightWorkspaceType,
   PatchDataSourceTableRequestBody,
 } from "@app/types";
-const EMPTY_TABLES_ARRAY: DataSourceViewContentNode[] = [];
 
 export function useDataSourceViewTable({
   dataSourceView,
@@ -96,7 +95,7 @@ export function useDataSourceViewTables({
   );
 
   return {
-    tables: data?.tables ?? EMPTY_TABLES_ARRAY,
+    tables: data?.tables ?? getEmptyArray(),
     nextPageCursor: data?.nextPageCursor || null,
     isTablesLoading: !isDisabled && !error && !data,
     isTablesError: error,

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -4,7 +4,7 @@ import type { Fetcher } from "swr";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,
-  getEmptyArray,
+  emptyArray,
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -95,7 +95,7 @@ export function useDataSourceViewTables({
   );
 
   return {
-    tables: data?.tables ?? getEmptyArray(),
+    tables: data?.tables ?? emptyArray(),
     nextPageCursor: data?.nextPageCursor || null,
     isTablesLoading: !isDisabled && !error && !data,
     isTablesError: error,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -6,7 +6,7 @@ import {
   fetcher,
   fetcherMultiple,
   fetcherWithBody,
-  getEmptyArray,
+  emptyArray,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/data_source_views";
@@ -43,7 +43,7 @@ export function useDataSourceViews(
   );
 
   return {
-    dataSourceViews: data?.dataSourceViews ?? getEmptyArray(),
+    dataSourceViews: data?.dataSourceViews ?? emptyArray(),
     isDataSourceViewsLoading: disabled ? false : !error && !data,
     isDataSourceViewsError: disabled ? false : error,
     mutateDataSourceViews: mutate,
@@ -176,7 +176,7 @@ export function useDataSourceViewContentNodes({
     isNodesValidating: isValidating,
     mutate,
     mutateRegardlessOfQueryParams,
-    nodes: data?.nodes ?? getEmptyArray(),
+    nodes: data?.nodes ?? emptyArray(),
     totalNodesCount: data ? data.total : 0,
     totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -3,10 +3,10 @@ import type { Fetcher, KeyedMutator, SWRConfiguration } from "swr";
 
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import {
+  emptyArray,
   fetcher,
   fetcherMultiple,
   fetcherWithBody,
-  emptyArray,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/data_source_views";

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -6,6 +6,7 @@ import {
   fetcher,
   fetcherMultiple,
   fetcherWithBody,
+  getEmptyArray,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/data_source_views";
@@ -27,7 +28,6 @@ type DataSourceViewsAndNodes = {
   dataSourceView: DataSourceViewType;
   nodes: GetDataSourceViewContentNodes["nodes"];
 };
-const EMPTY_DATA_SOURCE_VIEWS_ARRAY: DataSourceViewType[] = [];
 
 export function useDataSourceViews(
   owner: LightWorkspaceType,
@@ -43,7 +43,7 @@ export function useDataSourceViews(
   );
 
   return {
-    dataSourceViews: data?.dataSourceViews ?? EMPTY_DATA_SOURCE_VIEWS_ARRAY,
+    dataSourceViews: data?.dataSourceViews ?? getEmptyArray(),
     isDataSourceViewsLoading: disabled ? false : !error && !data,
     isDataSourceViewsError: disabled ? false : error,
     mutateDataSourceViews: mutate,
@@ -176,7 +176,7 @@ export function useDataSourceViewContentNodes({
     isNodesValidating: isValidating,
     mutate,
     mutateRegardlessOfQueryParams,
-    nodes: data?.nodes ?? EMPTY_DATA_SOURCE_VIEWS_ARRAY,
+    nodes: data?.nodes ?? getEmptyArray(),
     totalNodesCount: data ? data.total : 0,
     totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -27,6 +27,7 @@ type DataSourceViewsAndNodes = {
   dataSourceView: DataSourceViewType;
   nodes: GetDataSourceViewContentNodes["nodes"];
 };
+const EMPTY_DATA_SOURCE_VIEWS_ARRAY: DataSourceViewType[] = [];
 
 export function useDataSourceViews(
   owner: LightWorkspaceType,
@@ -42,7 +43,7 @@ export function useDataSourceViews(
   );
 
   return {
-    dataSourceViews: useMemo(() => (data ? data.dataSourceViews : []), [data]),
+    dataSourceViews: data?.dataSourceViews ?? EMPTY_DATA_SOURCE_VIEWS_ARRAY,
     isDataSourceViewsLoading: disabled ? false : !error && !data,
     isDataSourceViewsError: disabled ? false : error,
     mutateDataSourceViews: mutate,
@@ -175,7 +176,7 @@ export function useDataSourceViewContentNodes({
     isNodesValidating: isValidating,
     mutate,
     mutateRegardlessOfQueryParams,
-    nodes: useMemo(() => (data ? data.nodes : []), [data]),
+    nodes: data?.nodes ?? EMPTY_DATA_SOURCE_VIEWS_ARRAY,
     totalNodesCount: data ? data.total : 0,
     totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,

--- a/front/lib/swr/datasets.ts
+++ b/front/lib/swr/datasets.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets";
 import type { GetDatasetResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]";
 import type { AppType, LightWorkspaceType } from "@app/types";

--- a/front/lib/swr/datasets.ts
+++ b/front/lib/swr/datasets.ts
@@ -1,11 +1,9 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets";
 import type { GetDatasetResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]";
-import type { AppType, DatasetType, LightWorkspaceType } from "@app/types";
-
-const EMPTY_DATASETS_ARRAY: DatasetType[] = [];
+import type { AppType, LightWorkspaceType } from "@app/types";
 
 export function useDatasets({
   owner,
@@ -27,7 +25,7 @@ export function useDatasets({
   );
 
   return {
-    datasets: data?.datasets ?? EMPTY_DATASETS_ARRAY,
+    datasets: data?.datasets ?? getEmptyArray(),
     isDatasetsLoading: !error && !data,
     isDatasetsError: !!error,
   };

--- a/front/lib/swr/datasets.ts
+++ b/front/lib/swr/datasets.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets";
 import type { GetDatasetResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]";
 import type { AppType, LightWorkspaceType } from "@app/types";
@@ -25,7 +25,7 @@ export function useDatasets({
   );
 
   return {
-    datasets: data?.datasets ?? getEmptyArray(),
+    datasets: data?.datasets ?? emptyArray(),
     isDatasetsLoading: !error && !data,
     isDatasetsError: !!error,
   };

--- a/front/lib/swr/datasets.ts
+++ b/front/lib/swr/datasets.ts
@@ -1,10 +1,11 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets";
 import type { GetDatasetResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]";
-import type { AppType, LightWorkspaceType } from "@app/types";
+import type { AppType, DatasetType, LightWorkspaceType } from "@app/types";
+
+const EMPTY_DATASETS_ARRAY: DatasetType[] = [];
 
 export function useDatasets({
   owner,
@@ -26,7 +27,7 @@ export function useDatasets({
   );
 
   return {
-    datasets: useMemo(() => (data ? data.datasets : []), [data]),
+    datasets: data?.datasets ?? EMPTY_DATASETS_ARRAY,
     isDatasetsLoading: !error && !data,
     isDatasetsError: !!error,
   };

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -5,7 +5,7 @@ import type { Fetcher } from "swr";
 
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { LabsConnectionsConfigurationResource } from "@app/lib/resources/labs_connections_resource";
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { getPKCEConfig } from "@app/lib/utils/pkce";
 import type { GetLabsConnectionsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/connections";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
@@ -141,7 +141,7 @@ export function useLabsSalesforceDataSourcesWithPersonalConnection({
   );
 
   return {
-    dataSources: data?.dataSources ?? getEmptyArray(),
+    dataSources: data?.dataSources ?? emptyArray(),
     isLoading,
     isError: error,
     mutate,

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -5,7 +5,7 @@ import type { Fetcher } from "swr";
 
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { LabsConnectionsConfigurationResource } from "@app/lib/resources/labs_connections_resource";
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { getPKCEConfig } from "@app/lib/utils/pkce";
 import type { GetLabsConnectionsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/connections";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -5,7 +5,7 @@ import type { Fetcher } from "swr";
 
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { LabsConnectionsConfigurationResource } from "@app/lib/resources/labs_connections_resource";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { getPKCEConfig } from "@app/lib/utils/pkce";
 import type { GetLabsConnectionsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/connections";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
@@ -23,8 +23,6 @@ import {
   isOAuthProvider,
   setupOAuthConnection,
 } from "@app/types";
-const EMPTY_SALESFORCE_DATA_SOURCES_ARRAY: SalesforceDataSourceWithPersonalConnection[] =
-  [];
 
 // Transcripts
 export function useLabsTranscriptsConfiguration({
@@ -143,7 +141,7 @@ export function useLabsSalesforceDataSourcesWithPersonalConnection({
   );
 
   return {
-    dataSources: data?.dataSources ?? EMPTY_SALESFORCE_DATA_SOURCES_ARRAY,
+    dataSources: data?.dataSources ?? getEmptyArray(),
     isLoading,
     isError: error,
     mutate,

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -1,7 +1,6 @@
 // LABS - CAN BE REMOVED ANYTIME
 
 import { useSendNotification } from "@dust-tt/sparkle";
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -24,6 +23,8 @@ import {
   isOAuthProvider,
   setupOAuthConnection,
 } from "@app/types";
+const EMPTY_SALESFORCE_DATA_SOURCES_ARRAY: SalesforceDataSourceWithPersonalConnection[] =
+  [];
 
 // Transcripts
 export function useLabsTranscriptsConfiguration({
@@ -142,7 +143,7 @@ export function useLabsSalesforceDataSourcesWithPersonalConnection({
   );
 
   return {
-    dataSources: useMemo(() => (data ? data.dataSources : []), [data]),
+    dataSources: data?.dataSources ?? EMPTY_SALESFORCE_DATA_SOURCES_ARRAY,
     isLoading,
     isError: error,
     mutate,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -5,8 +5,7 @@ import type { Fetcher } from "swr";
 import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
-import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   CreateMCPServerResponseBody,
   GetMCPServersResponseBody,
@@ -24,9 +23,6 @@ import type {
   PostConnectionResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/connections";
 import type { LightWorkspaceType, OAuthProvider, SpaceType } from "@app/types";
-
-const EMPTY_MPCSERVERS_ARRAY: MCPServerTypeWithViews[] = [];
-const EMPTY_CONNECTIONS_ARRAY: MCPServerConnectionType[] = [];
 
 /**
  * Hook to fetch a specific remote MCP server by ID
@@ -86,7 +82,7 @@ export function useAvailableMCPServers({
         ? data.servers.sort((a, b) =>
             mcpServersSortingFn({ mcpServer: a }, { mcpServer: b })
           )
-        : EMPTY_MPCSERVERS_ARRAY,
+        : getEmptyArray<MCPServerTypeWithViews>(),
     [data]
   );
 
@@ -117,7 +113,7 @@ export function useMCPServers({
     }
   );
 
-  const mcpServers = data?.servers ?? EMPTY_MPCSERVERS_ARRAY;
+  const mcpServers = data?.servers ?? getEmptyArray();
 
   return {
     mcpServers,
@@ -331,7 +327,7 @@ export function useMCPServerConnections({
   );
 
   return {
-    connections: data?.connections ?? EMPTY_CONNECTIONS_ARRAY,
+    connections: data?.connections ?? getEmptyArray(),
     isConnectionsLoading: !error && !data && !disabled,
     isConnectionsError: error,
     mutateConnections: mutate,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -5,7 +5,7 @@ import type { Fetcher } from "swr";
 import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   CreateMCPServerResponseBody,
   GetMCPServersResponseBody,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -5,7 +5,7 @@ import type { Fetcher } from "swr";
 import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   CreateMCPServerResponseBody,
   GetMCPServersResponseBody,
@@ -82,7 +82,7 @@ export function useAvailableMCPServers({
         ? data.servers.sort((a, b) =>
             mcpServersSortingFn({ mcpServer: a }, { mcpServer: b })
           )
-        : getEmptyArray<MCPServerTypeWithViews>(),
+        : emptyArray<MCPServerTypeWithViews>(),
     [data]
   );
 
@@ -113,7 +113,7 @@ export function useMCPServers({
     }
   );
 
-  const mcpServers = data?.servers ?? getEmptyArray();
+  const mcpServers = data?.servers ?? emptyArray();
 
   return {
     mcpServers,
@@ -327,7 +327,7 @@ export function useMCPServerConnections({
   );
 
   return {
-    connections: data?.connections ?? getEmptyArray(),
+    connections: data?.connections ?? emptyArray(),
     isConnectionsLoading: !error && !data && !disabled,
     isConnectionsError: error,
     mutateConnections: mutate,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -4,7 +4,8 @@ import type { Fetcher } from "swr";
 
 import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
+import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   CreateMCPServerResponseBody,
@@ -23,6 +24,10 @@ import type {
   PostConnectionResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/connections";
 import type { LightWorkspaceType, OAuthProvider, SpaceType } from "@app/types";
+
+const EMPTY_MPCSERVERS_ARRAY: MCPServerTypeWithViews[] = [];
+const EMPTY_CONNECTIONS_ARRAY: MCPServerConnectionType[] = [];
+
 /**
  * Hook to fetch a specific remote MCP server by ID
  */
@@ -81,7 +86,7 @@ export function useAvailableMCPServers({
         ? data.servers.sort((a, b) =>
             mcpServersSortingFn({ mcpServer: a }, { mcpServer: b })
           )
-        : [],
+        : EMPTY_MPCSERVERS_ARRAY,
     [data]
   );
 
@@ -112,7 +117,7 @@ export function useMCPServers({
     }
   );
 
-  const mcpServers = useMemo(() => (data ? data.servers : []), [data]);
+  const mcpServers = data?.servers ?? EMPTY_MPCSERVERS_ARRAY;
 
   return {
     mcpServers,
@@ -326,7 +331,7 @@ export function useMCPServerConnections({
   );
 
   return {
-    connections: useMemo(() => (data ? data.connections : []), [data]),
+    connections: data?.connections ?? EMPTY_CONNECTIONS_ARRAY,
     isConnectionsLoading: !error && !data && !disabled,
     isConnectionsError: error,
     mutateConnections: mutate,

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -6,7 +6,11 @@ import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
-import type { LightWorkspaceType } from "@app/types";
+import type {
+  LightWorkspaceType,
+  MembershipInvitationType,
+  UserTypeWithWorkspaces,
+} from "@app/types";
 
 type PaginationParams = {
   orderColumn: "createdAt";
@@ -14,6 +18,8 @@ type PaginationParams = {
   limit: number;
   // lastValue is directly set when using the nextPageUrl
 };
+const EMPTY_MEMBERS_ARRAY: UserTypeWithWorkspaces[] = [];
+const EMPTY_INVITATIONS_ARRAY: MembershipInvitationType[] = [];
 
 const appendPaginationParams = (
   params: URLSearchParams,
@@ -52,7 +58,7 @@ export function useMembers({
     });
 
   return {
-    members: useMemo(() => (data ? data.members : []), [data]),
+    members: data?.members ?? EMPTY_MEMBERS_ARRAY,
     isMembersLoading: !error && !data,
     isMembersError: error,
     hasNextPage: !!data?.nextPageUrl,
@@ -90,7 +96,7 @@ export function useAdmins(
   );
 
   return {
-    admins: useMemo(() => (data ? data.members : []), [data]),
+    admins: data?.members ?? EMPTY_MEMBERS_ARRAY,
     isAdminsLoading: !error && !data,
     iAdminsError: error,
     mutateMembers: mutate,
@@ -106,7 +112,7 @@ export function useWorkspaceInvitations(owner: LightWorkspaceType) {
   );
 
   return {
-    invitations: useMemo(() => (data ? data.invitations : []), [data]),
+    invitations: data?.invitations ?? EMPTY_INVITATIONS_ARRAY,
     isInvitationsLoading: !error && !data,
     isInvitationsError: error,
     mutateInvitations: mutate,
@@ -138,7 +144,7 @@ export function useMembersByEmails({
     );
 
   return {
-    members: useMemo(() => (data ? data.members : []), [data]),
+    members: data?.members ?? EMPTY_MEMBERS_ARRAY,
     isMembersLoading: !error && !data && !disabled,
     isMembersError: error,
     mutate,
@@ -191,7 +197,7 @@ export function useSearchMembers({
     );
 
   return {
-    members: useMemo(() => (data ? data.members : []), [data]),
+    members: data?.members ?? EMPTY_MEMBERS_ARRAY,
     totalMembersCount: data?.total ?? 0,
     isLoading: !error && !data,
     isError: !!error,

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
@@ -52,7 +52,7 @@ export function useMembers({
     });
 
   return {
-    members: data?.members ?? getEmptyArray(),
+    members: data?.members ?? emptyArray(),
     isMembersLoading: !error && !data,
     isMembersError: error,
     hasNextPage: !!data?.nextPageUrl,
@@ -90,7 +90,7 @@ export function useAdmins(
   );
 
   return {
-    admins: data?.members ?? getEmptyArray(),
+    admins: data?.members ?? emptyArray(),
     isAdminsLoading: !error && !data,
     iAdminsError: error,
     mutateMembers: mutate,
@@ -106,7 +106,7 @@ export function useWorkspaceInvitations(owner: LightWorkspaceType) {
   );
 
   return {
-    invitations: data?.invitations ?? getEmptyArray(),
+    invitations: data?.invitations ?? emptyArray(),
     isInvitationsLoading: !error && !data,
     isInvitationsError: error,
     mutateInvitations: mutate,
@@ -138,7 +138,7 @@ export function useMembersByEmails({
     );
 
   return {
-    members: data?.members ?? getEmptyArray(),
+    members: data?.members ?? emptyArray(),
     isMembersLoading: !error && !data && !disabled,
     isMembersError: error,
     mutate,
@@ -191,7 +191,7 @@ export function useSearchMembers({
     );
 
   return {
-    members: data?.members ?? getEmptyArray(),
+    members: data?.members ?? emptyArray(),
     totalMembersCount: data?.total ?? 0,
     isLoading: !error && !data,
     isError: !!error,

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,16 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
-import type {
-  LightWorkspaceType,
-  MembershipInvitationType,
-  UserTypeWithWorkspaces,
-} from "@app/types";
+import type { LightWorkspaceType } from "@app/types";
 
 type PaginationParams = {
   orderColumn: "createdAt";
@@ -18,8 +14,6 @@ type PaginationParams = {
   limit: number;
   // lastValue is directly set when using the nextPageUrl
 };
-const EMPTY_MEMBERS_ARRAY: UserTypeWithWorkspaces[] = [];
-const EMPTY_INVITATIONS_ARRAY: MembershipInvitationType[] = [];
 
 const appendPaginationParams = (
   params: URLSearchParams,
@@ -58,7 +52,7 @@ export function useMembers({
     });
 
   return {
-    members: data?.members ?? EMPTY_MEMBERS_ARRAY,
+    members: data?.members ?? getEmptyArray(),
     isMembersLoading: !error && !data,
     isMembersError: error,
     hasNextPage: !!data?.nextPageUrl,
@@ -96,7 +90,7 @@ export function useAdmins(
   );
 
   return {
-    admins: data?.members ?? EMPTY_MEMBERS_ARRAY,
+    admins: data?.members ?? getEmptyArray(),
     isAdminsLoading: !error && !data,
     iAdminsError: error,
     mutateMembers: mutate,
@@ -112,7 +106,7 @@ export function useWorkspaceInvitations(owner: LightWorkspaceType) {
   );
 
   return {
-    invitations: data?.invitations ?? EMPTY_INVITATIONS_ARRAY,
+    invitations: data?.invitations ?? getEmptyArray(),
     isInvitationsLoading: !error && !data,
     isInvitationsError: error,
     mutateInvitations: mutate,
@@ -144,7 +138,7 @@ export function useMembersByEmails({
     );
 
   return {
-    members: data?.members ?? EMPTY_MEMBERS_ARRAY,
+    members: data?.members ?? getEmptyArray(),
     isMembersLoading: !error && !data && !disabled,
     isMembersError: error,
     mutate,
@@ -197,7 +191,7 @@ export function useSearchMembers({
     );
 
   return {
-    members: data?.members ?? EMPTY_MEMBERS_ARRAY,
+    members: data?.members ?? getEmptyArray(),
     totalMembersCount: data?.total ?? 0,
     isLoading: !error && !data,
     isError: !!error,

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -2,7 +2,9 @@ import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAvailableModelsResponseType } from "@app/pages/api/w/[wId]/models";
-import type { LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType, ModelConfigurationType } from "@app/types";
+
+const EMPTY_MODELS_ARRAY: ModelConfigurationType[] = [];
 
 export function useModels({ owner }: { owner: LightWorkspaceType }) {
   const modelsFetcher: Fetcher<GetAvailableModelsResponseType> = fetcher;
@@ -13,8 +15,8 @@ export function useModels({ owner }: { owner: LightWorkspaceType }) {
   );
 
   return {
-    models: data ? data.models : [],
-    reasoningModels: data ? data.reasoningModels : [],
+    models: data ? data.models : EMPTY_MODELS_ARRAY,
+    reasoningModels: data ? data.reasoningModels : EMPTY_MODELS_ARRAY,
     isModelsLoading: !error && !data,
     isModelsError: !!error,
   };

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAvailableModelsResponseType } from "@app/pages/api/w/[wId]/models";
 import type { LightWorkspaceType } from "@app/types";
 

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAvailableModelsResponseType } from "@app/pages/api/w/[wId]/models";
 import type { LightWorkspaceType } from "@app/types";
 
@@ -13,8 +13,8 @@ export function useModels({ owner }: { owner: LightWorkspaceType }) {
   );
 
   return {
-    models: data?.models ?? getEmptyArray(),
-    reasoningModels: data?.reasoningModels ?? getEmptyArray(),
+    models: data?.models ?? emptyArray(),
+    reasoningModels: data?.reasoningModels ?? emptyArray(),
     isModelsLoading: !error && !data,
     isModelsError: !!error,
   };

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -15,8 +15,8 @@ export function useModels({ owner }: { owner: LightWorkspaceType }) {
   );
 
   return {
-    models: data ? data.models : EMPTY_MODELS_ARRAY,
-    reasoningModels: data ? data.reasoningModels : EMPTY_MODELS_ARRAY,
+    models: data?.models ?? EMPTY_MODELS_ARRAY,
+    reasoningModels: data?.reasoningModels ?? EMPTY_MODELS_ARRAY,
     isModelsLoading: !error && !data,
     isModelsError: !!error,
   };

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -1,10 +1,8 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAvailableModelsResponseType } from "@app/pages/api/w/[wId]/models";
-import type { LightWorkspaceType, ModelConfigurationType } from "@app/types";
-
-const EMPTY_MODELS_ARRAY: ModelConfigurationType[] = [];
+import type { LightWorkspaceType } from "@app/types";
 
 export function useModels({ owner }: { owner: LightWorkspaceType }) {
   const modelsFetcher: Fetcher<GetAvailableModelsResponseType> = fetcher;
@@ -15,8 +13,8 @@ export function useModels({ owner }: { owner: LightWorkspaceType }) {
   );
 
   return {
-    models: data?.models ?? EMPTY_MODELS_ARRAY,
-    reasoningModels: data?.reasoningModels ?? EMPTY_MODELS_ARRAY,
+    models: data?.models ?? getEmptyArray(),
+    reasoningModels: data?.reasoningModels ?? getEmptyArray(),
     isModelsLoading: !error && !data,
     isModelsError: !!error,
   };

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import type { RegionType } from "@app/lib/api/regions/config";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetRegionResponseType } from "@app/pages/api/poke/region";
 import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
@@ -13,10 +13,6 @@ import type {
   DataSourceType,
   LightWorkspaceType,
 } from "@app/types";
-const EMPTY_RESOURCES_ARRAY: any[] = [];
-const EMPTY_PLANS_ARRAY: any[] = [];
-const EMPTY_WORKSPACES_ARRAY: any[] = [];
-const EMPTY_FEATURES_ARRAY: any[] = [];
 
 export function usePokeRegion() {
   const regionFetcher: Fetcher<GetRegionResponseType> = fetcher;
@@ -62,7 +58,7 @@ export function usePokeConnectorPermissions({
   });
 
   return {
-    resources: data?.resources ?? EMPTY_RESOURCES_ARRAY,
+    resources: data?.resources ?? getEmptyArray(),
     isResourcesLoading: !error && !data,
     isResourcesError: error,
   };
@@ -101,7 +97,7 @@ export function usePokeWorkspaces({
   );
 
   return {
-    workspaces: data?.workspaces ?? EMPTY_WORKSPACES_ARRAY,
+    workspaces: data?.workspaces ?? getEmptyArray(),
     isWorkspacesLoading: !error && !data,
     isWorkspacesError: error,
   };
@@ -113,7 +109,7 @@ export function usePokePlans() {
   const { data, error } = useSWRWithDefaults("/api/poke/plans", plansFetcher);
 
   return {
-    plans: data?.plans ?? EMPTY_PLANS_ARRAY,
+    plans: data?.plans ?? getEmptyArray(),
     isPlansLoading: !error && !data,
     isPlansError: error,
   };
@@ -128,7 +124,7 @@ export function usePokeFeatureFlags({ workspaceId }: { workspaceId: string }) {
   );
 
   return {
-    featureFlags: data?.features ?? EMPTY_FEATURES_ARRAY,
+    featureFlags: data?.features ?? getEmptyArray(),
     isFeatureFlagsLoading: !error && !data,
     isFeatureFlagsError: error,
   };

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import type { RegionType } from "@app/lib/api/regions/config";
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetRegionResponseType } from "@app/pages/api/poke/region";
 import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -13,6 +13,10 @@ import type {
   DataSourceType,
   LightWorkspaceType,
 } from "@app/types";
+const EMPTY_RESOURCES_ARRAY: any[] = [];
+const EMPTY_PLANS_ARRAY: any[] = [];
+const EMPTY_WORKSPACES_ARRAY: any[] = [];
+const EMPTY_FEATURES_ARRAY: any[] = [];
 
 export function usePokeRegion() {
   const regionFetcher: Fetcher<GetRegionResponseType> = fetcher;
@@ -58,7 +62,7 @@ export function usePokeConnectorPermissions({
   });
 
   return {
-    resources: useMemo(() => (data ? data.resources : []), [data]),
+    resources: data?.resources ?? EMPTY_RESOURCES_ARRAY,
     isResourcesLoading: !error && !data,
     isResourcesError: error,
   };
@@ -97,7 +101,7 @@ export function usePokeWorkspaces({
   );
 
   return {
-    workspaces: useMemo(() => (data ? data.workspaces : []), [data]),
+    workspaces: data?.workspaces ?? EMPTY_WORKSPACES_ARRAY,
     isWorkspacesLoading: !error && !data,
     isWorkspacesError: error,
   };
@@ -109,7 +113,7 @@ export function usePokePlans() {
   const { data, error } = useSWRWithDefaults("/api/poke/plans", plansFetcher);
 
   return {
-    plans: useMemo(() => (data ? data.plans : []), [data]),
+    plans: data?.plans ?? EMPTY_PLANS_ARRAY,
     isPlansLoading: !error && !data,
     isPlansError: error,
   };
@@ -124,7 +128,7 @@ export function usePokeFeatureFlags({ workspaceId }: { workspaceId: string }) {
   );
 
   return {
-    featureFlags: useMemo(() => (data ? data.features : []), [data]),
+    featureFlags: data?.features ?? EMPTY_FEATURES_ARRAY,
     isFeatureFlagsLoading: !error && !data,
     isFeatureFlagsError: error,
   };

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import type { RegionType } from "@app/lib/api/regions/config";
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetRegionResponseType } from "@app/pages/api/poke/region";
 import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
@@ -58,7 +58,7 @@ export function usePokeConnectorPermissions({
   });
 
   return {
-    resources: data?.resources ?? getEmptyArray(),
+    resources: data?.resources ?? emptyArray(),
     isResourcesLoading: !error && !data,
     isResourcesError: error,
   };
@@ -97,7 +97,7 @@ export function usePokeWorkspaces({
   );
 
   return {
-    workspaces: data?.workspaces ?? getEmptyArray(),
+    workspaces: data?.workspaces ?? emptyArray(),
     isWorkspacesLoading: !error && !data,
     isWorkspacesError: error,
   };
@@ -109,7 +109,7 @@ export function usePokePlans() {
   const { data, error } = useSWRWithDefaults("/api/poke/plans", plansFetcher);
 
   return {
-    plans: data?.plans ?? getEmptyArray(),
+    plans: data?.plans ?? emptyArray(),
     isPlansLoading: !error && !data,
     isPlansError: error,
   };
@@ -124,7 +124,7 @@ export function usePokeFeatureFlags({ workspaceId }: { workspaceId: string }) {
   );
 
   return {
-    featureFlags: data?.features ?? getEmptyArray(),
+    featureFlags: data?.features ?? emptyArray(),
     isFeatureFlagsLoading: !error && !data,
     isFeatureFlagsError: error,
   };

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -8,7 +8,7 @@ import { getSpaceName } from "@app/lib/spaces";
 import {
   fetcher,
   fetcherWithBody,
-  getEmptyArray,
+  emptyArray,
   getErrorFromResponse,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
@@ -59,7 +59,7 @@ export function useSpaces({
   );
 
   return {
-    spaces: data?.spaces ?? getEmptyArray(),
+    spaces: data?.spaces ?? emptyArray(),
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
     mutate,
@@ -82,7 +82,7 @@ export function useSpacesAsAdmin({
   );
 
   return {
-    spaces: data?.spaces ?? getEmptyArray(),
+    spaces: data?.spaces ?? emptyArray(),
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
     mutate,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -8,6 +8,7 @@ import { getSpaceName } from "@app/lib/spaces";
 import {
   fetcher,
   fetcherWithBody,
+  getEmptyArray,
   getErrorFromResponse,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
@@ -41,7 +42,6 @@ import type {
   SpaceType,
 } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
-const EMPTY_SPACES_ARRAY: SpaceType[] = [];
 
 export function useSpaces({
   workspaceId,
@@ -59,7 +59,7 @@ export function useSpaces({
   );
 
   return {
-    spaces: data?.spaces ?? EMPTY_SPACES_ARRAY,
+    spaces: data?.spaces ?? getEmptyArray(),
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
     mutate,
@@ -82,7 +82,7 @@ export function useSpacesAsAdmin({
   );
 
   return {
-    spaces: data?.spaces ?? EMPTY_SPACES_ARRAY,
+    spaces: data?.spaces ?? getEmptyArray(),
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
     mutate,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -41,6 +41,7 @@ import type {
   SpaceType,
 } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
+const EMPTY_SPACES_ARRAY: SpaceType[] = [];
 
 export function useSpaces({
   workspaceId,
@@ -58,7 +59,7 @@ export function useSpaces({
   );
 
   return {
-    spaces: useMemo(() => (data ? data.spaces : []), [data]),
+    spaces: data?.spaces ?? EMPTY_SPACES_ARRAY,
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
     mutate,
@@ -81,7 +82,7 @@ export function useSpacesAsAdmin({
   );
 
   return {
-    spaces: useMemo(() => (data ? data.spaces : []), [data]),
+    spaces: data?.spaces ?? EMPTY_SPACES_ARRAY,
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
     mutate,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -6,9 +6,9 @@ import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { getSpaceName } from "@app/lib/spaces";
 import {
+  emptyArray,
   fetcher,
   fetcherWithBody,
-  emptyArray,
   getErrorFromResponse,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -13,7 +13,7 @@ import { isAPIErrorResponse, safeParseJSON } from "@app/types";
 
 const EMPTY_ARRAY = Object.freeze([]);
 
-export function getEmptyArray<T>(): T[] {
+export function emptyArray<T>(): T[] {
   return EMPTY_ARRAY as unknown as T[];
 }
 

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -11,6 +11,12 @@ import useSWRInfinite from "swr/infinite";
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 import { isAPIErrorResponse, safeParseJSON } from "@app/types";
 
+const EMPTY_ARRAY = Object.freeze([]);
+
+export function getEmptyArray<T>(): T[] {
+  return EMPTY_ARRAY as unknown as T[];
+}
+
 const DEFAULT_SWR_CONFIG: SWRConfiguration = {
   errorRetryCount: 16,
 };

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -1,12 +1,13 @@
 import { useSendNotification } from "@dust-tt/sparkle";
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";
 import type { GetTagsUsageResponseBody } from "@app/pages/api/w/[wId]/tags/usage";
 import type { LightWorkspaceType } from "@app/types";
-import type { TagType } from "@app/types/tag";
+import type { TagType, TagTypeWithUsage } from "@app/types/tag";
+const EMPTY_TAGS_ARRAY: TagType[] = [];
+const EMPTY_TAGS_WITH_USAGES_ARRAY: TagTypeWithUsage[] = [];
 
 export function useTags({
   owner,
@@ -26,7 +27,7 @@ export function useTags({
   );
 
   return {
-    tags: useMemo(() => (data ? data.tags : []), [data]),
+    tags: data?.tags ?? EMPTY_TAGS_ARRAY,
     isTagsLoading: !error && !data && !disabled,
     isTagsError: !!error,
     mutateTags: mutate,
@@ -51,7 +52,7 @@ export function useTagsUsage({
   );
 
   return {
-    tags: useMemo(() => (data ? data.tags : []), [data]),
+    tags: data?.tags ?? EMPTY_TAGS_WITH_USAGES_ARRAY,
     isTagsLoading: !error && !data && !disabled,
     isTagsError: !!error,
     mutateTagsUsage: mutate,

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -1,7 +1,7 @@
 import { useSendNotification } from "@dust-tt/sparkle";
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";
 import type { GetTagsUsageResponseBody } from "@app/pages/api/w/[wId]/tags/usage";
 import type { LightWorkspaceType } from "@app/types";

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -1,7 +1,7 @@
 import { useSendNotification } from "@dust-tt/sparkle";
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";
 import type { GetTagsUsageResponseBody } from "@app/pages/api/w/[wId]/tags/usage";
 import type { LightWorkspaceType } from "@app/types";
@@ -25,7 +25,7 @@ export function useTags({
   );
 
   return {
-    tags: data?.tags ?? getEmptyArray(),
+    tags: data?.tags ?? emptyArray(),
     isTagsLoading: !error && !data && !disabled,
     isTagsError: !!error,
     mutateTags: mutate,
@@ -50,7 +50,7 @@ export function useTagsUsage({
   );
 
   return {
-    tags: data?.tags ?? getEmptyArray(),
+    tags: data?.tags ?? emptyArray(),
     isTagsLoading: !error && !data && !disabled,
     isTagsError: !!error,
     mutateTagsUsage: mutate,

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -1,13 +1,11 @@
 import { useSendNotification } from "@dust-tt/sparkle";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";
 import type { GetTagsUsageResponseBody } from "@app/pages/api/w/[wId]/tags/usage";
 import type { LightWorkspaceType } from "@app/types";
-import type { TagType, TagTypeWithUsage } from "@app/types/tag";
-const EMPTY_TAGS_ARRAY: TagType[] = [];
-const EMPTY_TAGS_WITH_USAGES_ARRAY: TagTypeWithUsage[] = [];
+import type { TagType } from "@app/types/tag";
 
 export function useTags({
   owner,
@@ -27,7 +25,7 @@ export function useTags({
   );
 
   return {
-    tags: data?.tags ?? EMPTY_TAGS_ARRAY,
+    tags: data?.tags ?? getEmptyArray(),
     isTagsLoading: !error && !data && !disabled,
     isTagsError: !!error,
     mutateTags: mutate,
@@ -52,7 +50,7 @@ export function useTagsUsage({
   );
 
   return {
-    tags: data?.tags ?? EMPTY_TAGS_WITH_USAGES_ARRAY,
+    tags: data?.tags ?? getEmptyArray(),
     isTagsLoading: !error && !data && !disabled,
     isTagsError: !!error,
     mutateTagsUsage: mutate,

--- a/front/lib/swr/trackers.ts
+++ b/front/lib/swr/trackers.ts
@@ -1,13 +1,8 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTrackersResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/trackers";
-import type {
-  LightWorkspaceType,
-  SpaceType,
-  TrackerConfigurationType,
-} from "@app/types";
-const EMPTY_TRACKERS_ARRAY: TrackerConfigurationType[] = [];
+import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 export function useTrackers({
   disabled,
@@ -29,7 +24,7 @@ export function useTrackers({
   );
 
   return {
-    trackers: data?.trackers ?? EMPTY_TRACKERS_ARRAY,
+    trackers: data?.trackers ?? getEmptyArray(),
     isTrackersLoading: !error && !data,
     isTrackersError: !!error,
     mutateTrackers: mutate,

--- a/front/lib/swr/trackers.ts
+++ b/front/lib/swr/trackers.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTrackersResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/trackers";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 

--- a/front/lib/swr/trackers.ts
+++ b/front/lib/swr/trackers.ts
@@ -1,9 +1,13 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTrackersResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/trackers";
-import type { LightWorkspaceType, SpaceType } from "@app/types";
+import type {
+  LightWorkspaceType,
+  SpaceType,
+  TrackerConfigurationType,
+} from "@app/types";
+const EMPTY_TRACKERS_ARRAY: TrackerConfigurationType[] = [];
 
 export function useTrackers({
   disabled,
@@ -25,7 +29,7 @@ export function useTrackers({
   );
 
   return {
-    trackers: useMemo(() => (data ? data.trackers : []), [data]),
+    trackers: data?.trackers ?? EMPTY_TRACKERS_ARRAY,
     isTrackersLoading: !error && !data,
     isTrackersError: !!error,
     mutateTrackers: mutate,

--- a/front/lib/swr/trackers.ts
+++ b/front/lib/swr/trackers.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTrackersResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/trackers";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
@@ -24,7 +24,7 @@ export function useTrackers({
   );
 
   return {
-    trackers: data?.trackers ?? getEmptyArray(),
+    trackers: data?.trackers ?? emptyArray(),
     isTrackersLoading: !error && !data,
     isTrackersError: !!error,
     mutateTrackers: mutate,

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1,17 +1,15 @@
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetWorkspaceFeatureFlagsResponseType } from "@app/pages/api/w/[wId]/feature-flags";
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
 import type {
-  SubscriptionType,
   WhitelistableFeature,
   WorkspaceEnterpriseConnection,
 } from "@app/types";
-const EMPTY_SUBSCRIPTIONS_ARRAY: SubscriptionType[] = [];
-const EMPTY_FEATURE_FLAGS_ARRAY: WhitelistableFeature[] = [];
+
 export function useWorkspaceSubscriptions({
   workspaceId,
 }: {
@@ -26,7 +24,7 @@ export function useWorkspaceSubscriptions({
   );
 
   return {
-    subscriptions: data?.subscriptions ?? EMPTY_SUBSCRIPTIONS_ARRAY,
+    subscriptions: data?.subscriptions ?? getEmptyArray(),
     isSubscriptionsLoading: !error && !data,
     isSubscriptionsError: error,
   };
@@ -147,7 +145,7 @@ export function useFeatureFlags({
   );
 
   return {
-    featureFlags: data?.feature_flags ?? EMPTY_FEATURE_FLAGS_ARRAY,
+    featureFlags: data?.feature_flags ?? getEmptyArray(),
     isFeatureFlagsLoading: !error && !data,
     isFeatureFlagsError: error,
     hasFeature,

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetWorkspaceFeatureFlagsResponseType } from "@app/pages/api/w/[wId]/feature-flags";
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
@@ -24,7 +24,7 @@ export function useWorkspaceSubscriptions({
   );
 
   return {
-    subscriptions: data?.subscriptions ?? getEmptyArray(),
+    subscriptions: data?.subscriptions ?? emptyArray(),
     isSubscriptionsLoading: !error && !data,
     isSubscriptionsError: error,
   };
@@ -145,7 +145,7 @@ export function useFeatureFlags({
   );
 
   return {
-    featureFlags: data?.feature_flags ?? getEmptyArray(),
+    featureFlags: data?.feature_flags ?? emptyArray(),
     isFeatureFlagsLoading: !error && !data,
     isFeatureFlagsError: error,
     hasFeature,

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetWorkspaceFeatureFlagsResponseType } from "@app/pages/api/w/[wId]/feature-flags";
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -6,10 +6,12 @@ import type { GetWorkspaceFeatureFlagsResponseType } from "@app/pages/api/w/[wId
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
 import type {
+  SubscriptionType,
   WhitelistableFeature,
   WorkspaceEnterpriseConnection,
 } from "@app/types";
-
+const EMPTY_SUBSCRIPTIONS_ARRAY: SubscriptionType[] = [];
+const EMPTY_FEATURE_FLAGS_ARRAY: WhitelistableFeature[] = [];
 export function useWorkspaceSubscriptions({
   workspaceId,
 }: {
@@ -24,7 +26,7 @@ export function useWorkspaceSubscriptions({
   );
 
   return {
-    subscriptions: useMemo(() => (data ? data.subscriptions : []), [data]),
+    subscriptions: data?.subscriptions ?? EMPTY_SUBSCRIPTIONS_ARRAY,
     isSubscriptionsLoading: !error && !data,
     isSubscriptionsError: error,
   };
@@ -145,7 +147,7 @@ export function useFeatureFlags({
   );
 
   return {
-    featureFlags: data ? data.feature_flags : [],
+    featureFlags: data?.feature_flags ?? EMPTY_FEATURE_FLAGS_ARRAY,
     isFeatureFlagsLoading: !error && !data,
     isFeatureFlagsError: error,
     hasFeature,

--- a/front/poke/swr/agent_configurations.ts
+++ b/front/poke/swr/agent_configurations.ts
@@ -1,16 +1,12 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
-import { LightAgentConfigurationType } from "@app/types";
 
 type PokeAgentConfigurationsProps = PokeConditionalFetchProps & {
   agentsGetView?: "admin_internal" | "archived";
 };
-
-const EMPTY_ARRAY: LightAgentConfigurationType[] = [];
 
 /*
  * Agent configurations for poke. Currently only supports archived agent.
@@ -31,7 +27,7 @@ export function usePokeAgentConfigurations({
   );
 
   return {
-    data: data?.agentConfigurations ?? EMPTY_ARRAY,
+    data: data?.agentConfigurations ?? getEmptyArray(),
     isLoading: !error && !data,
     isError: error,
     mutate,

--- a/front/poke/swr/agent_configurations.ts
+++ b/front/poke/swr/agent_configurations.ts
@@ -4,10 +4,13 @@ import type { Fetcher } from "swr";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import { LightAgentConfigurationType } from "@app/types";
 
 type PokeAgentConfigurationsProps = PokeConditionalFetchProps & {
   agentsGetView?: "admin_internal" | "archived";
 };
+
+const EMPTY_ARRAY: LightAgentConfigurationType[] = [];
 
 /*
  * Agent configurations for poke. Currently only supports archived agent.
@@ -28,7 +31,7 @@ export function usePokeAgentConfigurations({
   );
 
   return {
-    data: useMemo(() => (data ? data.agentConfigurations : []), [data]),
+    data: data?.agentConfigurations ?? EMPTY_ARRAY,
     isLoading: !error && !data,
     isError: error,
     mutate,

--- a/front/poke/swr/agent_configurations.ts
+++ b/front/poke/swr/agent_configurations.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
@@ -27,7 +27,7 @@ export function usePokeAgentConfigurations({
   );
 
   return {
-    data: data?.agentConfigurations ?? getEmptyArray(),
+    data: data?.agentConfigurations ?? emptyArray(),
     isLoading: !error && !data,
     isError: error,
     mutate,

--- a/front/poke/swr/apps.ts
+++ b/front/poke/swr/apps.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListApps } from "@app/pages/api/poke/workspaces/[wId]/apps";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
@@ -13,7 +13,7 @@ export function usePokeApps({ disabled, owner }: PokeConditionalFetchProps) {
   );
 
   return {
-    data: data?.apps ?? getEmptyArray(),
+    data: data?.apps ?? emptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,

--- a/front/poke/swr/apps.ts
+++ b/front/poke/swr/apps.ts
@@ -1,12 +1,8 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListApps } from "@app/pages/api/poke/workspaces/[wId]/apps";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
-import { AppType } from "@app/types";
-
-const EMPTY_ARRAY: AppType[] = [];
 
 export function usePokeApps({ disabled, owner }: PokeConditionalFetchProps) {
   const dataSourceViewsFetcher: Fetcher<PokeListApps> = fetcher;
@@ -17,7 +13,7 @@ export function usePokeApps({ disabled, owner }: PokeConditionalFetchProps) {
   );
 
   return {
-    data: data?.apps ?? EMPTY_ARRAY,
+    data: data?.apps ?? getEmptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,

--- a/front/poke/swr/apps.ts
+++ b/front/poke/swr/apps.ts
@@ -4,6 +4,9 @@ import type { Fetcher } from "swr";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListApps } from "@app/pages/api/poke/workspaces/[wId]/apps";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import { AppType } from "@app/types";
+
+const EMPTY_ARRAY: AppType[] = [];
 
 export function usePokeApps({ disabled, owner }: PokeConditionalFetchProps) {
   const dataSourceViewsFetcher: Fetcher<PokeListApps> = fetcher;
@@ -14,7 +17,7 @@ export function usePokeApps({ disabled, owner }: PokeConditionalFetchProps) {
   );
 
   return {
-    data: useMemo(() => (data ? data.apps : []), [data]),
+    data: data?.apps ?? EMPTY_ARRAY,
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -12,6 +12,9 @@ import type {
   LightWorkspaceType,
 } from "@app/types";
 
+const EMPTY_DATA_SOURCES_ARRAY: DataSourceViewType[] = [];
+const EMPTY_ARRAY: any[] = [];
+
 export function usePokeDataSourceViews({
   disabled,
   owner,
@@ -24,7 +27,7 @@ export function usePokeDataSourceViews({
   );
 
   return {
-    data: useMemo(() => (data ? data.data_source_views : []), [data]),
+    data: data?.data_source_views ?? EMPTY_DATA_SOURCES_ARRAY,
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,
@@ -111,7 +114,7 @@ export function usePokeDataSourceViewContentNodes({
     isNodesValidating: isValidating,
     mutate,
     mutateRegardlessOfQueryParams,
-    nodes: useMemo(() => (data ? data.nodes : []), [data]),
+    nodes: data?.nodes || EMPTY_ARRAY,
     totalNodesCount: data ? data.total : 0,
     totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -5,7 +5,7 @@ import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import {
   fetcher,
   fetcherWithBody,
-  getEmptyArray,
+  emptyArray,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { PokeListDataSourceViews } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
@@ -29,7 +29,7 @@ export function usePokeDataSourceViews({
   );
 
   return {
-    data: data?.data_source_views ?? getEmptyArray(),
+    data: data?.data_source_views ?? emptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,
@@ -116,7 +116,7 @@ export function usePokeDataSourceViewContentNodes({
     isNodesValidating: isValidating,
     mutate,
     mutateRegardlessOfQueryParams,
-    nodes: data?.nodes ?? getEmptyArray(),
+    nodes: data?.nodes ?? emptyArray(),
     totalNodesCount: data ? data.total : 0,
     totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -114,7 +114,7 @@ export function usePokeDataSourceViewContentNodes({
     isNodesValidating: isValidating,
     mutate,
     mutateRegardlessOfQueryParams,
-    nodes: data?.nodes || EMPTY_ARRAY,
+    nodes: data?.nodes ?? EMPTY_ARRAY,
     totalNodesCount: data ? data.total : 0,
     totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -2,7 +2,12 @@ import { useMemo } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
-import { fetcher, fetcherWithBody, useSWRWithDefaults } from "@app/lib/swr/swr";
+import {
+  fetcher,
+  fetcherWithBody,
+  getEmptyArray,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
 import type { PokeListDataSourceViews } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
 import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
@@ -11,9 +16,6 @@ import type {
   DataSourceViewType,
   LightWorkspaceType,
 } from "@app/types";
-
-const EMPTY_DATA_SOURCES_ARRAY: DataSourceViewType[] = [];
-const EMPTY_ARRAY: any[] = [];
 
 export function usePokeDataSourceViews({
   disabled,
@@ -27,7 +29,7 @@ export function usePokeDataSourceViews({
   );
 
   return {
-    data: data?.data_source_views ?? EMPTY_DATA_SOURCES_ARRAY,
+    data: data?.data_source_views ?? getEmptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,
@@ -114,7 +116,7 @@ export function usePokeDataSourceViewContentNodes({
     isNodesValidating: isValidating,
     mutate,
     mutateRegardlessOfQueryParams,
-    nodes: data?.nodes ?? EMPTY_ARRAY,
+    nodes: data?.nodes ?? getEmptyArray(),
     totalNodesCount: data ? data.total : 0,
     totalNodesCountIsAccurate: data ? data.totalIsAccurate : true,
     nextPageCursor: data?.nextPageCursor || null,

--- a/front/poke/swr/data_sources.ts
+++ b/front/poke/swr/data_sources.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListDataSources } from "@app/pages/api/poke/workspaces/[wId]/data_sources";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
@@ -16,7 +16,7 @@ export function usePokeDataSources({
   );
 
   return {
-    data: data?.data_sources ?? getEmptyArray(),
+    data: data?.data_sources ?? emptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,

--- a/front/poke/swr/data_sources.ts
+++ b/front/poke/swr/data_sources.ts
@@ -1,12 +1,8 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListDataSources } from "@app/pages/api/poke/workspaces/[wId]/data_sources";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
-import { DataSourceType } from "@app/types";
-
-export const EMPTY_ARRAY: DataSourceType[] = [];
 
 export function usePokeDataSources({
   disabled,
@@ -20,7 +16,7 @@ export function usePokeDataSources({
   );
 
   return {
-    data: data?.data_sources ?? EMPTY_ARRAY,
+    data: data?.data_sources ?? getEmptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,

--- a/front/poke/swr/data_sources.ts
+++ b/front/poke/swr/data_sources.ts
@@ -4,6 +4,9 @@ import type { Fetcher } from "swr";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListDataSources } from "@app/pages/api/poke/workspaces/[wId]/data_sources";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import { DataSourceType } from "@app/types";
+
+export const EMPTY_ARRAY: DataSourceType[] = [];
 
 export function usePokeDataSources({
   disabled,
@@ -17,7 +20,7 @@ export function usePokeDataSources({
   );
 
   return {
-    data: useMemo(() => (data ? data.data_sources : []), [data]),
+    data: data?.data_sources ?? EMPTY_ARRAY,
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 
-import { fetcher, getEmptyArray } from "@app/lib/swr/swr";
+import { fetcher, emptyArray } from "@app/lib/swr/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
 import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pull";
 import type { GetDocumentsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents";
@@ -58,7 +58,7 @@ export function usePokeAssistantTemplates() {
   );
 
   return {
-    assistantTemplates: data?.templates ?? getEmptyArray(),
+    assistantTemplates: data?.templates ?? emptyArray(),
     isAssistantTemplatesLoading: !error && !data,
     isAssistantTemplatesError: error,
     mutateAssistantTemplates: mutate,
@@ -124,7 +124,7 @@ export function usePokeDocuments(
   );
 
   return {
-    documents: data?.documents ?? getEmptyArray(),
+    documents: data?.documents ?? emptyArray(),
     total: data ? data.total : 0,
     isDocumentsLoading: !error && !data,
     isDocumentsError: error,
@@ -145,7 +145,7 @@ export function usePokeTables(
   );
 
   return {
-    tables: data?.tables ?? getEmptyArray(),
+    tables: data?.tables ?? emptyArray(),
     total: data ? data.total : 0,
     isTablesLoading: !error && !data,
     isTablesError: error,

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 
-import { fetcher } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray } from "@app/lib/swr/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
 import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pull";
 import type { GetDocumentsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents";
@@ -16,10 +16,6 @@ import type {
   LightWorkspaceType,
 } from "@app/types";
 import { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
-
-const EMPTY_TEMPLATES_ARRAY: FetchAssistantTemplateResponse[] = [];
-const EMPTY_DOCUMENTS_ARRAY: CoreAPIDocument[] = [];
-const EMPTY_TABLES_ARRAY: CoreAPITable[] = [];
 
 export function usePokePullTemplates() {
   const { mutateAssistantTemplates } = usePokeAssistantTemplates();
@@ -62,7 +58,7 @@ export function usePokeAssistantTemplates() {
   );
 
   return {
-    assistantTemplates: data?.templates ?? EMPTY_TEMPLATES_ARRAY,
+    assistantTemplates: data?.templates ?? getEmptyArray(),
     isAssistantTemplatesLoading: !error && !data,
     isAssistantTemplatesError: error,
     mutateAssistantTemplates: mutate,
@@ -128,7 +124,7 @@ export function usePokeDocuments(
   );
 
   return {
-    documents: data?.documents ?? EMPTY_DOCUMENTS_ARRAY,
+    documents: data?.documents ?? getEmptyArray(),
     total: data ? data.total : 0,
     isDocumentsLoading: !error && !data,
     isDocumentsError: error,
@@ -149,7 +145,7 @@ export function usePokeTables(
   );
 
   return {
-    tables: data?.tables ?? EMPTY_TABLES_ARRAY,
+    tables: data?.tables ?? getEmptyArray(),
     total: data ? data.total : 0,
     isTablesLoading: !error && !data,
     isTablesError: error,

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -10,9 +10,16 @@ import type { GetTablesResponseBody } from "@app/pages/api/poke/workspaces/[wId]
 import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type {
   ConversationType,
+  CoreAPIDocument,
+  CoreAPITable,
   DataSourceType,
   LightWorkspaceType,
 } from "@app/types";
+import { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
+
+const EMPTY_TEMPLATES_ARRAY: FetchAssistantTemplateResponse[] = [];
+const EMPTY_DOCUMENTS_ARRAY: CoreAPIDocument[] = [];
+const EMPTY_TABLES_ARRAY: CoreAPITable[] = [];
 
 export function usePokePullTemplates() {
   const { mutateAssistantTemplates } = usePokeAssistantTemplates();
@@ -55,7 +62,7 @@ export function usePokeAssistantTemplates() {
   );
 
   return {
-    assistantTemplates: useMemo(() => (data ? data.templates : []), [data]),
+    assistantTemplates: data?.templates ?? EMPTY_TEMPLATES_ARRAY,
     isAssistantTemplatesLoading: !error && !data,
     isAssistantTemplatesError: error,
     mutateAssistantTemplates: mutate,
@@ -121,7 +128,7 @@ export function usePokeDocuments(
   );
 
   return {
-    documents: useMemo(() => (data ? data.documents : []), [data]),
+    documents: data?.documents ?? EMPTY_DOCUMENTS_ARRAY,
     total: data ? data.total : 0,
     isDocumentsLoading: !error && !data,
     isDocumentsError: error,
@@ -142,7 +149,7 @@ export function usePokeTables(
   );
 
   return {
-    tables: useMemo(() => (data ? data.tables : []), [data]),
+    tables: data?.tables ?? EMPTY_TABLES_ARRAY,
     total: data ? data.total : 0,
     isTablesLoading: !error && !data,
     isTablesError: error,

--- a/front/poke/swr/kill.ts
+++ b/front/poke/swr/kill.ts
@@ -1,7 +1,7 @@
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 
-import { fetcher, getEmptyArray } from "@app/lib/swr/swr";
+import { fetcher, emptyArray } from "@app/lib/swr/swr";
 import type { GetKillSwitchesResponseBody } from "@app/pages/api/poke/kill";
 
 const EMPTY_ARRAY: GetKillSwitchesResponseBody["killSwitches"] = [];
@@ -12,7 +12,7 @@ export function usePokeKillSwitches() {
   const { data, error, mutate } = useSWR("/api/poke/kill", killSwitchesFetcher);
 
   return {
-    killSwitches: data?.killSwitches ?? getEmptyArray(),
+    killSwitches: data?.killSwitches ?? emptyArray(),
     isKillSwitchesLoading: !error && !data,
     isKillSwitchesError: error,
     mutateKillSwitches: mutate,

--- a/front/poke/swr/kill.ts
+++ b/front/poke/swr/kill.ts
@@ -5,13 +5,15 @@ import useSWR from "swr";
 import { fetcher } from "@app/lib/swr/swr";
 import type { GetKillSwitchesResponseBody } from "@app/pages/api/poke/kill";
 
+const EMPTY_ARRAY: GetKillSwitchesResponseBody["killSwitches"] = [];
+
 export function usePokeKillSwitches() {
   const killSwitchesFetcher: Fetcher<GetKillSwitchesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWR("/api/poke/kill", killSwitchesFetcher);
 
   return {
-    killSwitches: useMemo(() => (data ? data.killSwitches : []), [data]),
+    killSwitches: data?.killSwitches ?? EMPTY_ARRAY,
     isKillSwitchesLoading: !error && !data,
     isKillSwitchesError: error,
     mutateKillSwitches: mutate,

--- a/front/poke/swr/kill.ts
+++ b/front/poke/swr/kill.ts
@@ -1,8 +1,7 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 
-import { fetcher } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray } from "@app/lib/swr/swr";
 import type { GetKillSwitchesResponseBody } from "@app/pages/api/poke/kill";
 
 const EMPTY_ARRAY: GetKillSwitchesResponseBody["killSwitches"] = [];
@@ -13,7 +12,7 @@ export function usePokeKillSwitches() {
   const { data, error, mutate } = useSWR("/api/poke/kill", killSwitchesFetcher);
 
   return {
-    killSwitches: data?.killSwitches ?? EMPTY_ARRAY,
+    killSwitches: data?.killSwitches ?? getEmptyArray(),
     isKillSwitchesLoading: !error && !data,
     isKillSwitchesError: error,
     mutateKillSwitches: mutate,

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -3,7 +3,7 @@ import type { Fetcher } from "swr";
 import { PluginListItem } from "@app/lib/api/poke/types";
 import {
   fetcher,
-  getEmptyArray,
+  emptyArray,
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -43,7 +43,7 @@ export function usePokeListPluginForResourceType({
   );
 
   return {
-    plugins: data?.plugins ?? getEmptyArray(),
+    plugins: data?.plugins ?? emptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
   };

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
+import { PluginListItem } from "@app/lib/api/poke/types";
 import {
   fetcher,
+  getEmptyArray,
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -11,7 +12,6 @@ import type { PokeGetPluginDetailsResponseBody } from "@app/pages/api/poke/plugi
 import type { PokeRunPluginResponseBody } from "@app/pages/api/poke/plugins/[pluginId]/run";
 import type { PluginResourceTarget, Result } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { PluginListItem } from "@app/lib/api/poke/types";
 
 const EMPTY_ARRAY: PluginListItem[] = [];
 
@@ -43,7 +43,7 @@ export function usePokeListPluginForResourceType({
   );
 
   return {
-    plugins: data?.plugins ?? EMPTY_ARRAY,
+    plugins: data?.plugins ?? getEmptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
   };

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -11,6 +11,9 @@ import type { PokeGetPluginDetailsResponseBody } from "@app/pages/api/poke/plugi
 import type { PokeRunPluginResponseBody } from "@app/pages/api/poke/plugins/[pluginId]/run";
 import type { PluginResourceTarget, Result } from "@app/types";
 import { Err, Ok } from "@app/types";
+import { PluginListItem } from "@app/lib/api/poke/types";
+
+const EMPTY_ARRAY: PluginListItem[] = [];
 
 export function usePokeListPluginForResourceType({
   disabled,
@@ -40,7 +43,7 @@ export function usePokeListPluginForResourceType({
   );
 
   return {
-    plugins: useMemo(() => (data ? data.plugins : []), [data]),
+    plugins: data?.plugins ?? EMPTY_ARRAY,
     isLoading: !error && !data && !disabled,
     isError: error,
   };

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -3,6 +3,9 @@ import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokeSearchItemsResponseBody } from "@app/pages/api/poke/search";
+import { PokeItemBase } from "@app/types";
+
+const EMPTY_ARRAY: PokeItemBase[] = [];
 
 export function usePokeSearch({
   disabled,
@@ -26,7 +29,7 @@ export function usePokeSearch({
   );
 
   return {
-    results: useMemo(() => (data ? data.results : []), [data]),
+    results: data?.results ?? EMPTY_ARRAY,
     isLoading: !error && !data && !disabled,
     isError: error,
   };

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokeSearchItemsResponseBody } from "@app/pages/api/poke/search";
 import { PokeItemBase } from "@app/types";
 
@@ -28,7 +28,7 @@ export function usePokeSearch({
   );
 
   return {
-    results: data?.results ?? getEmptyArray(),
+    results: data?.results ?? emptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
   };

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -1,7 +1,6 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokeSearchItemsResponseBody } from "@app/pages/api/poke/search";
 import { PokeItemBase } from "@app/types";
 
@@ -29,7 +28,7 @@ export function usePokeSearch({
   );
 
   return {
-    results: data?.results ?? EMPTY_ARRAY,
+    results: data?.results ?? getEmptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
   };

--- a/front/poke/swr/spaces.ts
+++ b/front/poke/swr/spaces.ts
@@ -1,7 +1,6 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListSpaces } from "@app/pages/api/poke/workspaces/[wId]/spaces";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import { SpaceType } from "@dust-tt/client";
@@ -17,7 +16,7 @@ export function usePokeSpaces({ disabled, owner }: PokeConditionalFetchProps) {
   );
 
   return {
-    data: data?.spaces ?? EMPTY_ARRAY,
+    data: data?.spaces ?? getEmptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,

--- a/front/poke/swr/spaces.ts
+++ b/front/poke/swr/spaces.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, getEmptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListSpaces } from "@app/pages/api/poke/workspaces/[wId]/spaces";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import { SpaceType } from "@dust-tt/client";
@@ -16,7 +16,7 @@ export function usePokeSpaces({ disabled, owner }: PokeConditionalFetchProps) {
   );
 
   return {
-    data: data?.spaces ?? getEmptyArray(),
+    data: data?.spaces ?? emptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,

--- a/front/poke/swr/spaces.ts
+++ b/front/poke/swr/spaces.ts
@@ -4,6 +4,9 @@ import type { Fetcher } from "swr";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListSpaces } from "@app/pages/api/poke/workspaces/[wId]/spaces";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import { SpaceType } from "@dust-tt/client";
+
+const EMPTY_ARRAY: SpaceType[] = [];
 
 export function usePokeSpaces({ disabled, owner }: PokeConditionalFetchProps) {
   const spacesFetcher: Fetcher<PokeListSpaces> = fetcher;
@@ -14,7 +17,7 @@ export function usePokeSpaces({ disabled, owner }: PokeConditionalFetchProps) {
   );
 
   return {
-    data: useMemo(() => (data ? data.spaces : []), [data]),
+    data: data?.spaces ?? EMPTY_ARRAY,
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,


### PR DESCRIPTION
## Description

Use static empty array and remove useMemo when possible.
I had to declare one empty array per type to please typescript, I was not able to reuse the same everywhere
Also found a few places where useMemo was not used (models, feature_flags)

It's still quite difficult to enforce with an eslint rule, useMemo is still needed if output data is transformed somehow.

## Tests

locally, 

## Risk

low, can be rolled back

## Deploy Plan

deploy front
