### PR TITLE
MCP Sever request: narrow and rework

### DIFF
--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -33,7 +33,7 @@ interface RequestActionsModal {
 }
 
 export function RequestActionsModal({ owner, space }: RequestActionsModal) {
-  const { serverViews, isMCPServerViewsLoading: isLoading } =
+  const { mcpServerViews, isMCPServerViewsLoading: isLoading } =
     useMCPServerViewsNotActivated({ owner, space });
   const [selectedMcpServer, setSelectedMcpServer] =
     useState<MCPServerViewType | null>(null);
@@ -56,9 +56,8 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
     } else {
       try {
         await sendRequestActionsAccessEmail({
-          userTo: userToId,
           emailMessage: message,
-          serverName: selectedMcpServer.server.name,
+          mcpServerViewId: selectedMcpServer.id,
           owner,
         });
         sendNotification({
@@ -103,7 +102,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
               <div className="flex items-center gap-2">
                 {isLoading && <Spinner size="lg" />}
 
-                {!isLoading && serverViews.length === 0 && (
+                {!isLoading && mcpServerViews.length === 0 && (
                   <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                     <p>
                       There are no extra tools set up that you can request
@@ -112,7 +111,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                   </label>
                 )}
 
-                {serverViews.length >= 1 && (
+                {mcpServerViews.length >= 1 && (
                   <>
                     <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                       <p>Which tools you want to get access to?</p>
@@ -137,7 +136,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                         )}
                       </DropdownMenuTrigger>
                       <DropdownMenuContent>
-                        {serverViews.map((v) => (
+                        {mcpServerViews.map((v) => (
                           <DropdownMenuItem
                             key={v.id}
                             label={asDisplayName(v.server.name)}

--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -33,7 +33,7 @@ interface RequestActionsModal {
 }
 
 export function RequestActionsModal({ owner, space }: RequestActionsModal) {
-  const { mcpServerViews, isMCPServerViewsLoading: isLoading } =
+  const { serverViews, isMCPServerViewsLoading: isLoading } =
     useMCPServerViewsNotActivated({ owner, space });
   const [selectedMcpServer, setSelectedMcpServer] =
     useState<MCPServerViewType | null>(null);
@@ -102,7 +102,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
               <div className="flex items-center gap-2">
                 {isLoading && <Spinner size="lg" />}
 
-                {!isLoading && mcpServerViews.length === 0 && (
+                {!isLoading && serverViews.length === 0 && (
                   <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                     <p>
                       There are no extra tools set up that you can request
@@ -111,7 +111,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                   </label>
                 )}
 
-                {mcpServerViews.length >= 1 && (
+                {serverViews.length >= 1 && (
                   <>
                     <label className="block text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                       <p>Which tools you want to get access to?</p>
@@ -136,7 +136,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                         )}
                       </DropdownMenuTrigger>
                       <DropdownMenuContent>
-                        {mcpServerViews.map((v) => (
+                        {serverViews.map((v) => (
                           <DropdownMenuItem
                             key={v.id}
                             label={asDisplayName(v.server.name)}

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -67,20 +67,17 @@ export async function sendRequestFeatureAccessEmail({
 }
 
 export async function sendRequestActionsAccessEmail({
-  userTo,
-  emailMessage,
-  serverName,
   owner,
+  emailMessage,
+  mcpServerViewId,
 }: {
-  userTo: string;
-  emailMessage: string;
-  serverName: string;
   owner: LightWorkspaceType;
+  emailMessage: string;
+  mcpServerViewId: string;
 }) {
   const emailBlob: PostRequestActionsAccessBody = {
     emailMessage,
-    serverName,
-    userTo,
+    mcpServerViewId,
   };
 
   const res = await fetch(`/api/w/${owner.sId}/mcp/request_access`, {

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -122,12 +122,12 @@ export function useMCPServerViewsNotActivated({
       disabled,
     }
   );
-  const serverViews = useMemo(
-    () => (data ? data.serverViews.sort(mcpServerViewSortingFn) : []),
+  const mcpServerViews = useMemo(
+    () => (data ? data.mcpServerViews.sort(mcpServerViewSortingFn) : []),
     [data]
   );
   return {
-    serverViews,
+    mcpServerViews,
     isMCPServerViewsLoading: !error && !data && !disabled,
     isMCPServerViewsError: error,
     mutateMCPServerViews: mutate,

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -122,12 +122,12 @@ export function useMCPServerViewsNotActivated({
       disabled,
     }
   );
-  const mcpServerViews = useMemo(
-    () => (data ? data.mcpServerViews.sort(mcpServerViewSortingFn) : []),
+  const serverViews = useMemo(
+    () => (data ? data.serverViews.sort(mcpServerViewSortingFn) : []),
     [data]
   );
   return {
-    mcpServerViews,
+    mcpServerViews: serverViews,
     isMCPServerViewsLoading: !error && !data && !disabled,
     isMCPServerViewsError: error,
     mutateMCPServerViews: mutate,

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -127,7 +127,7 @@ export function useMCPServerViewsNotActivated({
     [data]
   );
   return {
-    mcpServerViews: serverViews,
+    serverViews,
     isMCPServerViewsLoading: !error && !data && !disabled,
     isMCPServerViewsError: error,
     mutateMCPServerViews: mutate,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
@@ -1,20 +1,64 @@
 import { describe, expect } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
 
-import handler from "./index";
+import handler from "./not_activated";
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated", () => {
-  itInTransaction("returns MCP servers views", async (t) => {
-    const { req, res, workspace } = await createPrivateApiMockRequest({
-      role: "admin",
-    });
+  itInTransaction("returns activable MCP servers views", async (t) => {
+    const { req, res, workspace, globalGroup } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+      });
 
     // Create a system space
     const systemSpace = await SpaceFactory.system(workspace, t);
     req.query.spaceId = systemSpace.sId;
+
+    // Create global space
+    const globalSpace = await SpaceFactory.global(workspace, t);
+
+    // Create a regular space to test the endpoint on
+    const space = await SpaceFactory.regular(workspace, t);
+    await GroupSpaceFactory.associate(space, globalGroup);
+
+    // Create two test servers
+    const mcpServer1 = await RemoteMCPServerFactory.create(workspace, {
+      name: "Test Server 1",
+      url: "https://test-server-1.example.com",
+      tools: [
+        {
+          name: "tool-1",
+          description: "Tool 1 description",
+          inputSchema: undefined,
+        },
+      ],
+    });
+
+    const mcpServer2 = await RemoteMCPServerFactory.create(workspace, {
+      name: "Test Server 2",
+      url: "https://test-server-2.example.com",
+      tools: [
+        {
+          name: "tool-2",
+          description: "Tool 2 description",
+          inputSchema: undefined,
+        },
+      ],
+    });
+
+    await MCPServerViewFactory.create(workspace, mcpServer1.sId, globalSpace);
+
+    // Add query params
+    req.query = {
+      ...req.query,
+      spaceId: space.sId,
+    };
 
     await handler(req, res);
 
@@ -23,5 +67,11 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated", () => {
       success: true,
       serverViews: expect.any(Array),
     });
+
+    // Only the server view that is not in the global space should be return as activable.
+    expect(res._getJSONData().serverViews).toHaveLength(1);
+    expect(res._getJSONData().serverViews[0].server.id).toBe(
+      mcpServer2.toJSON().id
+    );
   });
 });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -8,13 +8,12 @@ import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
 export type GetMCPServerViewsNotActivatedResponseBody = {
   success: boolean;
-  serverViews: MCPServerViewType[];
+  mcpServerViews: MCPServerViewType[];
 };
 
 async function handler(
@@ -29,22 +28,24 @@ async function handler(
 
   switch (method) {
     case "GET": {
-      const workspaceServerViews =
-        await MCPServerViewResource.listByWorkspace(auth);
-
-      const spaceServerViews = await MCPServerViewResource.listBySpace(
+      const spaceMcpServerViews = await MCPServerViewResource.listBySpace(
         auth,
         space
       );
 
-      const nonCompanyDataServerViews = workspaceServerViews.filter(
-        (s) => s.space.kind !== "global" && s.space.kind !== "system"
+      const workspaceServerViews =
+        await MCPServerViewResource.listByWorkspace(auth);
+
+      // MCP servers that can be added to a space are the ones that have been activated by the admin
+      // (they are in the system space) but are not already in the company space. Note that this
+      // leaks system mcpServerView ids (not ideal but OK since they are enumerable).
+      const availableMcpServerViews = workspaceServerViews.filter(
+        (s) => s.space.kind !== "global" && s.space.kind === "system"
       );
 
-      // We get the actions that aren't activated in Company Data and not in the space making the request
-      const serverViewsNotActivated = _.differenceWith(
-        nonCompanyDataServerViews,
-        spaceServerViews,
+      const mcpServerViewsNotActivated = _.differenceWith(
+        availableMcpServerViews,
+        spaceMcpServerViews,
         (a, b) => {
           return (
             (a.internalMCPServerId ?? a.remoteMCPServerId) ===
@@ -53,32 +54,11 @@ async function handler(
         }
       );
 
-      // We can have duplicate because some actions can be activated in many spaces
-      const serverViews = _.uniqBy(
-        serverViewsNotActivated,
-        (s) => s.internalMCPServerId ?? s.remoteMCPServerId
-      );
-
       return res.status(200).json({
         success: true,
-        serverViews: removeNulls(
-          serverViews.map((s) => {
-            // WARN: Probably due to Intenal MCP Server view pointing to `internalMCPServerId` that doesn't exists anymore.
-            // Need to think about migration of mcp_server_view when we're updating internal mcp servers.
-            try {
-              return s.toJSON();
-            } catch (err) {
-              logger.error(
-                {
-                  serverViewId: s.sId,
-                  workspaceId: s.workspaceId,
-                  spaceId: space.sId,
-                  userId: auth.getNonNullableUser().id,
-                },
-                "couldn't toJSON() a mcp_server_view"
-              );
-              return null;
-            }
+        mcpServerViews: removeNulls(
+          mcpServerViewsNotActivated.map((s) => {
+            return s.toJSON();
           })
         ),
       });

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -111,6 +111,7 @@ const API_ERROR_TYPES = [
   "tracker_not_found",
   // MCP Server Connections:
   "mcp_server_connection_not_found",
+  "mcp_server_view_not_found",
   // Conversation:
   ...CONVERSATION_ERROR_TYPES,
   // MCP:


### PR DESCRIPTION
## Description

- rework the logic of what we offer to activate to users in non company data space by request to admin
Context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1746017433626849?thread_ts=1746014645.842589&cid=C050SM8NSPK
- manage who to send the email to server side (otherwise can use this endpoint to send an email to any user of the workspace)

## Tests

Updated and completed tests + tested locally

## Risk

Low

## Deploy Plan

- deploy `front`