### PR TITLE
Lower load on DB in Google Drive GC production check

### DIFF
--- a/front/lib/production_checks/managed_ds.ts
+++ b/front/lib/production_checks/managed_ds.ts
@@ -55,7 +55,7 @@ export async function getCoreDocuments(
   }
 
   let lastDocumentId = "";
-  const batchSize = 10000;
+  const batchSize = 5000;
   const coreDocuments: CoreDSDocument[] = [];
   let batchDocuments: CoreDSDocument[] = [];
 

--- a/front/lib/production_checks/managed_ds.ts
+++ b/front/lib/production_checks/managed_ds.ts
@@ -12,6 +12,8 @@ export type CoreDSDocument = {
   document_id: string;
 };
 
+const CORE_DOCUMENT_BATCH_SIZE = 5000;
+
 export async function getCoreDocuments(
   frontDataSourceId: number
 ): Promise<Result<CoreDSDocument[], Error>> {
@@ -55,7 +57,6 @@ export async function getCoreDocuments(
   }
 
   let lastDocumentId = "";
-  const batchSize = 5000;
   const coreDocuments: CoreDSDocument[] = [];
   let batchDocuments: CoreDSDocument[] = [];
 
@@ -72,7 +73,7 @@ export async function getCoreDocuments(
         replacements: {
           coreDsId: coreDs[0].id,
           lastDocumentId,
-          limit: batchSize,
+          limit: CORE_DOCUMENT_BATCH_SIZE,
         },
         type: QueryTypes.SELECT,
       }
@@ -85,7 +86,7 @@ export async function getCoreDocuments(
 
     coreDocuments.push(...batchDocuments);
     lastDocumentId = batchDocuments[batchDocuments.length - 1].document_id;
-  } while (batchDocuments.length === batchSize);
+  } while (batchDocuments.length === CORE_DOCUMENT_BATCH_SIZE);
 
   return new Ok(coreDocuments);
 }


### PR DESCRIPTION
## Description

- We are seeing a lot of `DatabaseError: canceling statement due to conflict with recovery` during the production check on Google Drive GC check.
- The failing query is the select on core documents (operated on the replica).
- This PR lowers the batch size for the select. 

## Tests

- N/A.

## Risk

- Low, easily rollbackable.

## Deploy Plan

- Deploy front.