### PR TITLE
fix(poke): user invite

### DIFF
--- a/front/components/poke/invitations/columns.tsx
+++ b/front/components/poke/invitations/columns.tsx
@@ -2,11 +2,11 @@ import { ClipboardIcon, IconButton, TrashIcon } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { MembershipInvitationType } from "@app/types";
+import type { MembershipInvitationTypeWithLink } from "@app/types";
 
 export function makeColumnsForInvitations(
   onRevokeInvitation: (email: string) => Promise<void>
-): ColumnDef<MembershipInvitationType>[] {
+): ColumnDef<MembershipInvitationTypeWithLink>[] {
   return [
     {
       accessorKey: "sId",

--- a/front/components/poke/invitations/table.tsx
+++ b/front/components/poke/invitations/table.tsx
@@ -1,13 +1,16 @@
 import { useRouter } from "next/router";
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import type { MembershipInvitationType, WorkspaceType } from "@app/types";
+import type {
+  MembershipInvitationTypeWithLink,
+  WorkspaceType,
+} from "@app/types";
 
 import { makeColumnsForInvitations } from "./columns";
 
 interface InvitationsDataTableProps {
   owner: WorkspaceType;
-  invitations: MembershipInvitationType[];
+  invitations: MembershipInvitationTypeWithLink[];
 }
 
 export function InvitationsDataTable({

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -193,8 +193,15 @@ export async function sendWorkspaceInvitationEmail(
     },
   };
 
-  sgMail.setApiKey(config.getSendgridApiKey());
-  await sgMail.send(message);
+  if (process.env.NODE_ENV !== "development") {
+    sgMail.setApiKey(config.getSendgridApiKey());
+    await sgMail.send(message);
+  } else {
+    logger.debug(
+      { message },
+      "[INVITATION] invitation not sent in development"
+    );
+  }
 }
 /**
  * Returns the pending inviations associated with the authenticator's owner workspace.
@@ -357,24 +364,27 @@ export async function handleMembershipInvitations(
     ): Promise<
       Result<HandleMembershipInvitationResult[], APIErrorWithStatusCode>
     > => {
-      await getWorkspaceAdministrationVersionLock(owner, t);
+      // Only lock and check seats available if the workspace has a limits
+      if (maxUsers !== -1) {
+        await getWorkspaceAdministrationVersionLock(owner, t);
 
-      const availableSeats =
-        maxUsers -
-        (await MembershipResource.getMembersCountForWorkspace({
-          workspace: owner,
-          activeOnly: true,
-          transaction: t,
-        }));
+        const availableSeats =
+          maxUsers -
+          (await MembershipResource.getMembersCountForWorkspace({
+            workspace: owner,
+            activeOnly: true,
+            transaction: t,
+          }));
 
-      if (maxUsers !== -1 && availableSeats < invitationRequests.length) {
-        return new Err({
-          status_code: 400,
-          api_error: {
-            type: "plan_limit_error",
-            message: `Not enough seats lefts (${availableSeats} seats remaining). Please upgrade or remove inactive members to add more.`,
-          },
-        });
+        if (availableSeats < invitationRequests.length) {
+          return new Err({
+            status_code: 400,
+            api_error: {
+              type: "plan_limit_error",
+              message: `Not enough seats lefts (${availableSeats} seats remaining). Please upgrade or remove inactive members to add more.`,
+            },
+          });
+        }
       }
 
       const invalidEmails = invitationRequests.filter(
@@ -460,11 +470,13 @@ export async function handleMembershipInvitations(
           },
         });
       }
+
       await batchUnrevokeInvitations(
         auth,
         invitationsToUnrevoke.map((i) => i.sId),
         t
       );
+
       const invitationResults = await Promise.all(
         emailsToSendInvitations.map(async ({ email, role }) => {
           if (existingMembers.find((m) => m.email === email)) {

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -193,15 +193,8 @@ export async function sendWorkspaceInvitationEmail(
     },
   };
 
-  if (process.env.NODE_ENV !== "development") {
-    sgMail.setApiKey(config.getSendgridApiKey());
-    await sgMail.send(message);
-  } else {
-    logger.debug(
-      { message },
-      "[INVITATION] invitation not sent in development"
-    );
-  }
+  sgMail.setApiKey(config.getSendgridApiKey());
+  await sgMail.send(message);
 }
 /**
  * Returns the pending inviations associated with the authenticator's owner workspace.

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -5,18 +5,21 @@ import React from "react";
 import { InvitationsDataTable } from "@app/components/poke/invitations/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
 import PokeLayout from "@app/components/poke/PokeLayout";
-import { getPendingInvitations } from "@app/lib/api/invitation";
+import {
+  getMembershipInvitationUrl,
+  getPendingInvitations,
+} from "@app/lib/api/invitation";
 import { getMembers } from "@app/lib/api/workspace";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type {
-  MembershipInvitationType,
+  MembershipInvitationTypeWithLink,
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   members: UserTypeWithWorkspaces[];
-  pendingInvitations: MembershipInvitationType[];
+  pendingInvitations: MembershipInvitationTypeWithLink[];
   owner: WorkspaceType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -36,7 +39,10 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       members,
-      pendingInvitations,
+      pendingInvitations: pendingInvitations.map((invite) => ({
+        ...invite,
+        inviteLink: getMembershipInvitationUrl(owner, invite.id),
+      })),
       owner,
     },
   };

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -14,6 +14,10 @@ export type MembershipInvitationType = {
   createdAt: number;
 };
 
+export type MembershipInvitationTypeWithLink = MembershipInvitationType & {
+  inviteLink: string;
+};
+
 // Types for the invite form in Poke.
 
 export const InviteMemberFormSchema = t.type({


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/dust/pull/12284
- By removing `inviteLink` for everywhere, it also removed it from poke's invitation table, adding it back only for Poke
- Also only setup invite lock and check for available seats for workspace that have a maxUser limit.

## Tests
- Locally tested

## Risk
- Low

## Deploy Plan
- Deploy front
