### PR TITLE
fix `front` build

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -61,7 +61,6 @@ import {
   AppLayoutSimpleCloseTitle,
   AppLayoutSimpleSaveCancelTitle,
 } from "@app/components/sparkle/AppLayoutTitle";
-import { isLegacyAllowed } from "@app/lib/api/assistant/configuration";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
@@ -71,6 +70,7 @@ import type {
   AgentConfigurationScope,
   AssistantBuilderRightPanelStatus,
   AssistantBuilderRightPanelTab,
+  WorkspaceType,
 } from "@app/types";
 import {
   assertNever,
@@ -78,11 +78,29 @@ import {
   GPT_4_1_MINI_MODEL_CONFIG,
   isAdmin,
   isBuilder,
+  isUser,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
 
 function isValidTab(tab: string): tab is BuilderScreen {
   return BUILDER_SCREENS.includes(tab as BuilderScreen);
+}
+
+/**
+ * TODO(agent discovery, 2025-04-30): Delete this function when removing scopes
+ * "workspace" and "published"
+ */
+function isLegacyAllowed(
+  owner: WorkspaceType,
+  agentConfigurationScope: AgentConfigurationScope
+): boolean {
+  if (agentConfigurationScope === "workspace" && isBuilder(owner)) {
+    return true;
+  }
+  if (agentConfigurationScope === "published" && isUser(owner)) {
+    return true;
+  }
+  return false;
 }
 
 export default function AssistantBuilder({

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1796,7 +1796,7 @@ export async function getAgentPermissions(
  * TODO(agent discovery, 2025-04-30): Delete this function when removing scopes
  * "workspace" and "published"
  */
-export function isLegacyAllowed(
+function isLegacyAllowed(
   owner: WorkspaceType,
   agentConfigurationScope: AgentConfigurationScope
 ): boolean {


### PR DESCRIPTION
## Description

- Duplicate `isLegacyAllowed` to prevent importing from `app/lib/api` in the front-end.
- All the context is [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1746018973543199).

## Tests

- `npm run build` locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.