### PR TITLE
MCPServerViewResource.fetchById API change

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -207,17 +207,17 @@ async function getMCPClientConnectionParams(
     isPlatformMCPServerConfiguration(config) ||
     isPlatformMCPToolConfiguration(config)
   ) {
-    const res = await MCPServerViewResource.fetchById(
+    const mcpServerView = await MCPServerViewResource.fetchById(
       auth,
       config.mcpServerViewId
     );
-    if (res.isErr()) {
-      return res;
+    if (!mcpServerView) {
+      return new Err(new Error("MCP server view not found"));
     }
 
     return new Ok({
       type: "mcpServerId",
-      mcpServerId: res.value.mcpServerId,
+      mcpServerId: mcpServerView.mcpServerId,
     });
   }
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1312,13 +1312,13 @@ export async function createAgentActionConfiguration(
           auth,
           action.mcpServerViewId
         );
-        if (mcpServerView.isErr()) {
-          return new Err(mcpServerView.error);
+        if (!mcpServerView) {
+          return new Err(new Error("MCP server view not found"));
         }
 
         const {
           server: { name: serverName, description: serverDescription, tools },
-        } = mcpServerView.value.toJSON();
+        } = mcpServerView.toJSON();
 
         const isSingleTool = tools.length === 1;
 
@@ -1327,7 +1327,7 @@ export async function createAgentActionConfiguration(
             sId: generateRandomModelSId(),
             agentConfigurationId: agentConfiguration.id,
             workspaceId: owner.id,
-            mcpServerViewId: mcpServerView.value.id,
+            mcpServerViewId: mcpServerView.id,
             additionalConfiguration: action.additionalConfiguration,
             name: serverName !== action.name ? action.name : null,
             singleToolDescriptionOverride:

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -228,25 +228,18 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     auth: Authenticator,
     id: string,
     options?: ResourceFindOptions<MCPServerViewModel>
-  ): Promise<Result<MCPServerViewResource, DustError>> {
-    const viewRes = await this.fetchByIds(auth, [id], options);
+  ): Promise<MCPServerViewResource | null> {
+    const [mcpServerView] = await this.fetchByIds(auth, [id], options);
 
-    if (viewRes.isErr()) {
-      return viewRes;
-    }
-
-    return new Ok(viewRes.value[0]);
+    return mcpServerView ?? null;
   }
 
   static async fetchByIds(
     auth: Authenticator,
     ids: string[],
     options?: ResourceFindOptions<MCPServerViewModel>
-  ): Promise<Result<MCPServerViewResource[], DustError>> {
+  ): Promise<MCPServerViewResource[]> {
     const viewModelIds = removeNulls(ids.map((id) => getResourceIdFromSId(id)));
-    if (viewModelIds.length !== ids.length) {
-      return new Err(new DustError("invalid_id", "Invalid id"));
-    }
 
     const views = await this.baseFetch(auth, {
       ...options,
@@ -258,16 +251,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       },
     });
 
-    if (views.length !== ids.length) {
-      return new Err(
-        new DustError(
-          "resource_not_found",
-          ids.length === 1 ? "View not found" : "Some views were not found"
-        )
-      );
-    }
-
-    return new Ok(views);
+    return views ?? [];
   }
 
   static async fetchByModelPk(auth: Authenticator, id: ModelId) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -74,7 +74,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
       serverView.sId
     );
 
-    expect(deletedServerView.isErr()).toBe(true);
+    expect(deletedServerView).toBe(null);
   });
 
   itInTransaction(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -43,9 +43,12 @@ async function handler(
 
   switch (req.method) {
     case "DELETE": {
-      const r = await MCPServerViewResource.fetchById(auth, serverViewId);
+      const mcpServerView = await MCPServerViewResource.fetchById(
+        auth,
+        serverViewId
+      );
 
-      if (r.isErr()) {
+      if (!mcpServerView) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
@@ -55,7 +58,7 @@ async function handler(
         });
       }
 
-      if (r.value.space.id !== space.id) {
+      if (mcpServerView.space.id !== space.id) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
@@ -86,7 +89,7 @@ async function handler(
           },
         });
       }
-      await r.value.delete(auth, { hardDelete: true });
+      await mcpServerView.delete(auth, { hardDelete: true });
 
       return res.status(200).json({
         deleted: true,

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -126,10 +126,10 @@ export async function scrubMCPServerViewActivity({
       includeDeleted: true,
     }
   );
-  if (mcpServerView.isErr()) {
+  if (!mcpServerView) {
     throw new Error("MCPServerView not found.");
   }
-  await mcpServerView.value.delete(auth, { hardDelete: true });
+  await mcpServerView.delete(auth, { hardDelete: true });
 }
 
 export async function scrubSpaceActivity({


### PR DESCRIPTION
## Description

fetchById(s) must follow existing pattern returning `*Resource | null`. Fixing it before it propagates.

## Tests

Covered by type system + existing tests

## Risk

Low

## Deploy Plan

- deploy `front`