### PR TITLE
Add toggle to block Slack agents with access to restricted space

### DIFF
--- a/connectors/migrations/db/migration_69.sql
+++ b/connectors/migrations/db/migration_69.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."slack_configurations" ADD COLUMN "restrictedSpaceAgentsEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -14,6 +14,7 @@ export class SlackConfigurationModel extends ConnectorBaseModel<SlackConfigurati
   declare updatedAt: CreationOptional<Date>;
   declare slackTeamId: string;
   declare botEnabled: boolean;
+  declare restrictedSpaceAgentsEnabled: boolean;
   // Whitelisted domains are in the format "domain:group_id".
   declare whitelistedDomains?: readonly string[];
   declare autoReadChannelPatterns: SlackAutoReadPattern[];
@@ -48,6 +49,11 @@ SlackConfigurationModel.init(
       type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: [],
+    },
+    restrictedSpaceAgentsEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
     },
   },
   {

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -64,6 +64,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
         botEnabled: otherSlackConfigurationWithBotEnabled ? false : true,
         connectorId,
         slackTeamId,
+        restrictedSpaceAgentsEnabled: true,
       },
       { transaction }
     );
@@ -337,6 +338,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
       autoReadChannelPatterns: this.autoReadChannelPatterns,
       botEnabled: this.botEnabled,
       whitelistedDomains: this.whitelistedDomains?.map((d) => d),
+      restrictedSpaceAgentsEnabled: this.restrictedSpaceAgentsEnabled,
     };
   }
 }

--- a/connectors/src/types/slack.ts
+++ b/connectors/src/types/slack.ts
@@ -22,6 +22,7 @@ export const SlackConfigurationTypeSchema = t.type({
   botEnabled: t.boolean,
   whitelistedDomains: t.union([t.array(t.string), t.undefined]),
   autoReadChannelPatterns: SlackAutoReadPatternsSchema,
+  restrictedSpaceAgentsEnabled: t.union([t.boolean, t.undefined]),
 });
 
 export type SlackConfigurationType = t.TypeOf<

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -5,3 +5,4 @@ export * from "./notion_unstuck_syncing_nodes";
 export * from "./notion_update_orphaned_resources_parents";
 export * from "./notion_url_sync";
 export * from "./operations";
+export * from "./toggle_restricted_space_agent_slack_access";

--- a/front/lib/api/poke/plugins/data_sources/toggle_restricted_space_agent_slack_access.ts
+++ b/front/lib/api/poke/plugins/data_sources/toggle_restricted_space_agent_slack_access.ts
@@ -1,0 +1,84 @@
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import logger from "@app/logger/logger";
+import { ConnectorsAPI } from "@app/types";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const restrictedSpaceAgentsPlugin = createPlugin({
+  manifest: {
+    id: "restricted-space-agents",
+    name: "Configure Restricted Space Agents",
+    description:
+      "Configure whether agents with access to data from restricted spaces can be invoked via Slack",
+    resourceTypes: ["data_sources"],
+    args: {
+      action: {
+        type: "enum",
+        label: "Action",
+        description:
+          "Select whether to enable or disable restricted space agents for Slack",
+        values: ["enable", "disable"],
+      },
+      confirm: {
+        type: "boolean",
+        label: "Confirm Action",
+        description: "Confirm you want to proceed with this action",
+      },
+    },
+  },
+  isApplicableTo: (auth, resource) => {
+    return resource?.connectorProvider === "slack";
+  },
+  execute: async (auth, dataSource, args) => {
+    if (!dataSource) {
+      return new Err(new Error("Cannot find data source."));
+    }
+
+    if (dataSource.connectorProvider !== "slack") {
+      return new Err(
+        new Error("This action is only available for Slack data sources.")
+      );
+    }
+
+    const { action, confirm } = args;
+    if (!confirm) {
+      return new Err(
+        new Error("Please confirm that you want to proceed with this action.")
+      );
+    }
+
+    if (!["enable", "disable"].includes(action)) {
+      return new Err(
+        new Error("Invalid action. Must be either 'enable' or 'disable'.")
+      );
+    }
+
+    if (!dataSource.connectorId) {
+      return new Err(
+        new Error("No Slack connector found for this data source.")
+      );
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    // Set restricted space agents enabled/disabled according to action
+    const res = await connectorsAPI.setConnectorConfig(
+      dataSource.connectorId,
+      "restrictedSpaceAgentsEnabled",
+      (action === "enable").toString()
+    );
+
+    if (res.isErr()) {
+      return new Err(new Error(res.error.message));
+    }
+
+    const actionText = action === "enable" ? "enabled" : "disabled";
+    return new Ok({
+      display: "text",
+      value: `Restricted space agents have been ${actionText} on Slack for this workspace.`,
+    });
+  },
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -297,6 +297,7 @@ const handleDataSourceWithProvider = async ({
       botEnabled: true,
       whitelistedDomains: undefined,
       autoReadChannelPatterns: [],
+      restrictedSpaceAgentsEnabled: true,
     };
   }
 

--- a/front/types/connectors/slack.ts
+++ b/front/types/connectors/slack.ts
@@ -22,6 +22,7 @@ export const SlackConfigurationTypeSchema = t.type({
   botEnabled: t.boolean,
   whitelistedDomains: t.union([t.array(t.string), t.undefined]),
   autoReadChannelPatterns: SlackAutoReadPatternsSchema,
+  restrictedSpaceAgentsEnabled: t.union([t.boolean, t.undefined]),
 });
 
 export type SlackConfigurationType = t.TypeOf<


### PR DESCRIPTION
## Description

* Adding toggle via poke to block slack agents that have access to restricted spaces. User would receive a standard error message to contact their admin.

## Tests

```
Frank
  30 minutes ago
@DevFrank
 +gpt-4o Should work

DevFrank
APP  [30 minutes ago](https://dust4ai.slack.com/archives/C08KSKG0953/p1746022506894159?thread_ts=1745958710.503449&cid=C08KSKG0953)
@gpt4
Here is the content from your latest file:
•   ​URL:​ Slack thread link
•   ​Status:​ No messages previously sent in this thread.
If you need to test with a thread that contains messages, try uploading one with some actual content!
Go to full conversation | Browse agents | Use Dust in Slack | Learn more
Only visible to you
10:15
Ask another agent

Frank
  29 minutes ago
[@DevFrank](https://dust4ai.slack.com/team/U08QAE2GK9Q)
 +VerySensitiveStuff Block me plesae

DevFrank
APP  29 minutes ago
This agent belongs to a restricted space and cannot be invoked on Slack for this workspace. Contact your workspace administrator if you need access.
```
## Risk

* Expected to be enabled by default. Can rollback if not.

## Deploy Plan

* Connector Migration
* Deploy connector
* Deploy front
