### PR TITLE
Escape user provided email body

### DIFF
--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -192,9 +192,8 @@ interface sendEmailWithTemplateParams {
   body: string;
 }
 
-// This function sends an email using a predefined template.
-// Note: The salutation and footer are automatically included by the template,
-// so do not add them manually to the email body.
+// This function sends an email using a predefined template. Note: The salutation and footer are
+// automatically included by the template, so do not add them manually to the email body.
 export async function sendEmailWithTemplate({
   to,
   from,

--- a/front/pages/api/w/[wId]/data_sources/request_access.ts
+++ b/front/pages/api/w/[wId]/data_sources/request_access.ts
@@ -1,4 +1,5 @@
 import { isLeft } from "fp-ts/Either";
+import { escape } from "html-escaper";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -104,12 +105,16 @@ async function handler(
       status_code: 429,
       api_error: {
         type: "rate_limit_error",
-        message: `You have reached the limit of ${MAX_ACCESS_REQUESTS_PER_DAY} access requests per day. Please try again tomorrow.`,
+        message:
+          `You have reached the limit of ${MAX_ACCESS_REQUESTS_PER_DAY} access ` +
+          "requests per day. Please try again tomorrow.",
       },
     });
   }
 
-  const body = `${emailRequester} has sent you a request regarding your connection ${dataSource.name}: ${emailMessage}`;
+  const body =
+    `${emailRequester} has sent you a request regarding your connection ` +
+    `${dataSource.name}: ${escape(emailMessage)}`;
 
   const result = await sendEmailWithTemplate({
     to: dataSource.editedByUser.email,

--- a/front/pages/api/w/[wId]/labs/request_access.ts
+++ b/front/pages/api/w/[wId]/labs/request_access.ts
@@ -1,4 +1,5 @@
 import { isLeft } from "fp-ts/Either";
+import { escape } from "html-escaper";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -79,15 +80,19 @@ async function handler(
       status_code: 429,
       api_error: {
         type: "rate_limit_error",
-        message: `You have reached the limit of ${MAX_ACCESS_REQUESTS_PER_DAY} access requests per day. Please try again tomorrow.`,
+        message:
+          `You have reached the limit of ${MAX_ACCESS_REQUESTS_PER_DAY} access ` +
+          "requests per day. Please try again tomorrow.",
       },
     });
   }
 
-  const body = `${emailRequester} requests access to the ${featureName} labs feature for workspace <em>${auth.getNonNullableWorkspace().sId}</em>:
+  const body =
+    `${emailRequester} requests access to the ${featureName} labs feature for ` +
+    `workspace <em>${auth.getNonNullableWorkspace().sId}</em>:
   <br />
   <br />
-  ${emailMessage}`;
+  ${escape(emailMessage)}`;
 
   const result = await sendEmailWithTemplate({
     to: "support@dust.tt",

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -1,4 +1,5 @@
 import { isLeft } from "fp-ts/lib/Either";
+import { escape } from "html-escaper";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -66,12 +67,12 @@ async function handler(
   const emailRequester = user.email;
   const { emailMessage, mcpServerViewId } = bodyValidation.right;
 
-  const mcpServerViewRes = await MCPServerViewResource.fetchById(
+  const mcpServerView = await MCPServerViewResource.fetchById(
     auth,
     mcpServerViewId
   );
 
-  if (mcpServerViewRes.isErr()) {
+  if (!mcpServerView) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -80,8 +81,6 @@ async function handler(
       },
     });
   }
-
-  const mcpServerView = mcpServerViewRes.value;
 
   if (!mcpServerView.editedByUser?.sId) {
     return apiError(req, res, {
@@ -115,7 +114,7 @@ async function handler(
 
   const body =
     `${emailRequester} has sent you a request regarding access to actions: ` +
-    emailMessage;
+    escape(emailMessage);
 
   const result = await sendEmailWithTemplate({
     to: mcpServerView.editedByUser.email,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/12340

Escaping of user provided parts of email sent (to avoid taking over the whole email body with CSS and such)

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`