### PR TITLE
[front] feat(poke/wecrawler): Add plugin to change custom crawler

### DIFF
--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -53,6 +53,10 @@ const whitelistedCommands = [
     majorCommand: "zendesk",
     command: "fetch-ticket",
   },
+  {
+    majorCommand: "webcrawler",
+    command: "update-crawler",
+  },
 ];
 
 const _adminAPIHandler = async (

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -163,12 +163,5 @@ export async function updateCrawlerType(
     return new Err(new Error(`CrawlerConfig not found for ${connector.id}`));
   }
 
-  const customCrawler = newCrawler === "default" ? null : newCrawler;
-
-  try {
-    await webcrawlerConfig.update({ customCrawler });
-    return new Ok(undefined);
-  } catch (err) {
-    return new Err(err as Error);
-  }
+  return webcrawlerConfig.updateCustomCrawlerString(newCrawler);
 }

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -16,6 +16,7 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
 import type { ModelId } from "@connectors/types";
+import { WebcrawlerCustomCrawler } from "@connectors/types";
 
 import { WebCrawlerQueueNames } from "./config";
 import {
@@ -163,5 +164,18 @@ export async function updateCrawlerType(
     return new Err(new Error(`CrawlerConfig not found for ${connector.id}`));
   }
 
-  return webcrawlerConfig.updateCustomCrawlerString(newCrawler);
+  let customCrawler: WebcrawlerCustomCrawler | null = null;
+  // If not default, then we try to match
+  if (newCrawler !== "default") {
+    customCrawler =
+      Object.values(WebcrawlerCustomCrawler).find(
+        (value) => value === newCrawler
+      ) ?? null;
+    if (customCrawler === null) {
+      return new Err(new Error(`"${newCrawler}" is not a valid crawler`));
+    }
+  }
+
+  await webcrawlerConfig.updateCustomCrawler(customCrawler);
+  return new Ok(undefined);
 }

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -146,3 +146,29 @@ export async function launchCrawlWebsiteScheduler() {
     },
   });
 }
+
+export async function updateCrawlerType(
+  connectorId: string,
+  newCrawler: string
+) {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return new Err(new Error(`Connector ${connectorId} not found`));
+  }
+
+  const webcrawlerConfig =
+    await WebCrawlerConfigurationResource.fetchByConnectorId(connector.id);
+
+  if (!webcrawlerConfig) {
+    return new Err(new Error(`CrawlerConfig not found for ${connector.id}`));
+  }
+
+  const customCrawler = newCrawler === "default" ? null : newCrawler;
+
+  try {
+    await webcrawlerConfig.update({ customCrawler });
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(err);
+  }
+}

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -169,6 +169,6 @@ export async function updateCrawlerType(
     await webcrawlerConfig.update({ customCrawler });
     return new Ok(undefined);
   } catch (err) {
-    return new Err(err);
+    return new Err(err as Error);
   }
 }

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -150,7 +150,7 @@ export async function launchCrawlWebsiteScheduler() {
 export async function updateCrawlerType(
   connectorId: string,
   newCrawler: string
-) {
+): Promise<Result<void, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -389,6 +389,14 @@ export const webcrawler = async ({
       return { success: true };
     }
     case "update-crawler": {
+      if (!args.connectorId) {
+        throw new Error("Missing --connectorId argument");
+      }
+
+      if (!args.customCrawler) {
+        throw new Error("Missing --customCrawler argument");
+      }
+
       await throwOnError(
         updateCrawlerType(args.connectorId, args.customCrawler)
       );

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -12,7 +12,10 @@ import { microsoft } from "@connectors/connectors/microsoft/lib/cli";
 import { notion } from "@connectors/connectors/notion/lib/cli";
 import { slack } from "@connectors/connectors/slack/lib/cli";
 import { snowflake } from "@connectors/connectors/snowflake/lib/cli";
-import { launchCrawlWebsiteScheduler } from "@connectors/connectors/webcrawler/temporal/client";
+import {
+  launchCrawlWebsiteScheduler,
+  updateCrawlerType,
+} from "@connectors/connectors/webcrawler/temporal/client";
 import { zendesk } from "@connectors/connectors/zendesk/lib/cli";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
@@ -378,10 +381,17 @@ export const batch = async ({
 
 export const webcrawler = async ({
   command,
+  args,
 }: WebcrawlerCommandType): Promise<AdminSuccessResponseType> => {
   switch (command) {
     case "start-scheduler": {
       await throwOnError(launchCrawlWebsiteScheduler());
+      return { success: true };
+    }
+    case "update-crawler": {
+      await throwOnError(
+        updateCrawlerType(args.connectorId, args.customCrawler)
+      );
       return { success: true };
     }
   }

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -249,32 +249,6 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
     return this.update({ customCrawler: crawler });
   }
 
-  /**
-   * In case you don't have a WebcrawlerCustomCrawler type,
-   * you can still try to update the customCrawler of the config.
-   * You can use 'default' to remove it.
-   *
-   * @param crawler string | null =
-   */
-  async updateCustomCrawlerString(
-    crawler: string | null
-  ): Promise<Result<void, Error>> {
-    let customCrawler: WebcrawlerCustomCrawler | null = null;
-    // If not default, then we try to match
-    if (crawler !== "default") {
-      customCrawler =
-        Object.values(WebcrawlerCustomCrawler).find(
-          (value) => value === crawler
-        ) ?? null;
-      if (customCrawler === null) {
-        return new Err(new Error(`"${crawler}" is not a valid crawler`));
-      }
-    }
-
-    await this.updateCustomCrawler(customCrawler);
-    return new Ok(undefined);
-  }
-
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await WebCrawlerPage.destroy({
       where: {

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -245,6 +245,36 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
     return this.headers;
   }
 
+  async updateCustomCrawler(crawler: WebcrawlerCustomCrawler | null) {
+    return this.update({ customCrawler: crawler });
+  }
+
+  /**
+   * In case you don't have a WebcrawlerCustomCrawler type,
+   * you can still try to update the customCrawler of the config.
+   * You can use 'default' to remove it.
+   *
+   * @param crawler string | null =
+   */
+  async updateCustomCrawlerString(
+    crawler: string | null
+  ): Promise<Result<void, Error>> {
+    let customCrawler: WebcrawlerCustomCrawler | null = null;
+    // If not default, then we try to match
+    if (crawler !== "default") {
+      customCrawler =
+        Object.values(WebcrawlerCustomCrawler).find(
+          (value) => value === crawler
+        ) ?? null;
+      if (customCrawler === null) {
+        return new Err(new Error(`"${crawler}" is not a valid crawler`));
+      }
+    }
+
+    await this.updateCustomCrawler(customCrawler);
+    return new Ok(undefined);
+  }
+
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await WebCrawlerPage.destroy({
       where: {

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -176,7 +176,8 @@ export type BatchCommandType = t.TypeOf<typeof BatchCommandSchema>;
 
 export const WebcrawlerCommandSchema = t.type({
   majorCommand: t.literal("webcrawler"),
-  command: t.literal("start-scheduler"),
+  command: t.union([t.literal("start-scheduler"), t.literal("update-crawler")]),
+  args: t.record(t.string, t.string),
 });
 
 export const BatchAllResponseSchema = t.type({

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -232,6 +232,18 @@ export function ViewDataSourceTable({
                         )}
                       </PokeTableCell>
                     </PokeTableRow>
+                    {connector.configuration != null &&
+                      "customCrawler" in connector.configuration && (
+                        <PokeTableRow>
+                          <PokeTableCell>Crawler</PokeTableCell>
+                          <PokeTableCell>
+                            <span>
+                              {connector.configuration.customCrawler ??
+                                "default"}
+                            </span>
+                          </PokeTableCell>
+                        </PokeTableRow>
+                      )}
                   </>
                 )}
               </PokeTableBody>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -232,7 +232,7 @@ export function ViewDataSourceTable({
                         )}
                       </PokeTableCell>
                     </PokeTableRow>
-                    {connector.configuration != null &&
+                    {connector.configuration !== null &&
                       "customCrawler" in connector.configuration && (
                         <PokeTableRow>
                           <PokeTableCell>Crawler</PokeTableCell>

--- a/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
+++ b/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
@@ -18,7 +18,7 @@ export const customCrawlerPlugin = createPlugin({
       },
     },
   },
-  isApplicableTo: (_auth, dataSource) => {
+  isApplicableTo: (_, dataSource) => {
     if (!dataSource) {
       return false;
     }

--- a/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
+++ b/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
@@ -25,7 +25,7 @@ export const customCrawlerPlugin = createPlugin({
 
     return dataSource.connectorProvider === "webcrawler";
   },
-  execute: async (_auth, dataSource, args) => {
+  execute: async (_, dataSource, args) => {
     if (!dataSource) {
       return new Err(new Error("Data source not found"));
     }

--- a/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
+++ b/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
@@ -7,7 +7,7 @@ export const customCrawlerPlugin = createPlugin({
   manifest: {
     id: "custom-crawler",
     name: "Custom Crawler",
-    description: "Setup custom crawler to webcrawler data source",
+    description: "Set up a custom crawler for the webcrawler data source",
     resourceTypes: ["data_sources"],
     args: {
       crawler: {

--- a/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
+++ b/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
@@ -1,0 +1,61 @@
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import logger from "@app/logger/logger";
+import { ConnectorsAPI, Err, Ok } from "@app/types";
+
+export const customCrawlerPlugin = createPlugin({
+  manifest: {
+    id: "custom-crawler",
+    name: "Custom Crawler",
+    description: "Setup custom crawler to webcrawler data source",
+    resourceTypes: ["data_sources"],
+    args: {
+      crawler: {
+        type: "enum",
+        label: "Crawler",
+        description: "Select a crawler",
+        values: ["firecrawl", "default"],
+      },
+    },
+  },
+  isApplicableTo: (_auth, dataSource) => {
+    if (!dataSource) {
+      return false;
+    }
+
+    return dataSource.connectorProvider === "webcrawler";
+  },
+  execute: async (_auth, dataSource, args) => {
+    if (!dataSource) {
+      return new Err(new Error("Data source not found"));
+    }
+
+    const { connectorId } = dataSource;
+    if (!connectorId) {
+      return new Err(new Error("No connector on datasource"));
+    }
+
+    const connectorsApi = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    const res = await connectorsApi.admin({
+      majorCommand: "webcrawler",
+      command: "update-crawler",
+      args: {
+        connectorId,
+        customCrawler: args.crawler,
+      },
+    });
+
+    if (res.isErr()) {
+      return new Err(new Error(res.error.message));
+    }
+
+    return new Ok({
+      display: "text",
+      value: "webcrawler updated",
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -1,4 +1,5 @@
 export * from "./compute_statistics";
+export * from "./custom_crawler";
 export * from "./garbage_collect_google_drive_document";
 export * from "./mark_connector_as_error";
 export * from "./notion_unstuck_syncing_nodes";

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -171,7 +171,8 @@ export type BatchCommandType = t.TypeOf<typeof BatchCommandSchema>;
 
 export const WebcrawlerCommandSchema = t.type({
   majorCommand: t.literal("webcrawler"),
-  command: t.literal("start-scheduler"),
+  command: t.union([t.literal("start-scheduler"), t.literal("update-crawler")]),
+  args: t.record(t.string, t.string),
 });
 
 export const BatchAllResponseSchema = t.type({


### PR DESCRIPTION
## Description
- Add a data source plugin on Poke to allow admin to set for the webcrawler connector, which crawler to use

## Tests
- Locally test
![screencapture-localhost-3000-poke-qCUK4zlmpW-data-sources-dts-ARsg16Hzy7-2025-04-30-18_13_29](https://github.com/user-attachments/assets/64efdeef-0e34-4fa7-9cde-de02ed2620d3)

## Risk
- Low, on poke

## Deploy Plan
- Deploy front
