### PR TITLE
[Discovery] Allow regular users to search their workspace members

### DIFF
--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -70,6 +70,7 @@ export function useMembersCount(owner: LightWorkspaceType) {
   const { total } = useMembers({
     workspaceId: owner.sId,
     pagination: { limit: 0, orderColumn: "createdAt", orderDirection: "asc" },
+    disabled: owner.role !== "admin",
   });
 
   return total;

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -70,7 +70,6 @@ export function useMembersCount(owner: LightWorkspaceType) {
   const { total } = useMembers({
     workspaceId: owner.sId,
     pagination: { limit: 0, orderColumn: "createdAt", orderDirection: "asc" },
-    disabled: owner.role !== "admin",
   });
 
   return total;

--- a/front/pages/api/w/[wId]/members/index.test.ts
+++ b/front/pages/api/w/[wId]/members/index.test.ts
@@ -2,12 +2,12 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
 import { describe, expect, vi } from "vitest";
 
-import type { UserTypeWithWorkspaces } from "@app/types";
 import { parseQueryString } from "@app/lib/utils/router";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
+import type { UserTypeWithWorkspaces } from "@app/types";
 
 import handler, { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "./index";
 

--- a/front/pages/api/w/[wId]/members/index.test.ts
+++ b/front/pages/api/w/[wId]/members/index.test.ts
@@ -7,7 +7,6 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
-import type { UserTypeWithWorkspaces } from "@app/types";
 
 import handler, { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "./index";
 

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -95,17 +95,6 @@ async function handler(
         });
       }
 
-      if (!auth.isAdmin()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "Only users that are `admins` for the current workspace can see memberships or modify it.",
-          },
-        });
-      }
-
       const { members, total, nextPageParams } = await getMembers(
         auth,
         { activeOnly: true },

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -9,22 +9,20 @@ import { itInTransaction } from "@app/tests/utils/utils";
 import handler from "./search";
 
 describe("GET /api/w/[wId]/members/search", () => {
-  itInTransaction("returns 403 for non-admin users", async () => {
-    const { req, res } = await createPrivateApiMockRequest({
+  itInTransaction("allows search for non-admin users", async () => {
+    const { req, res, user } = await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
     });
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can search memberships.",
-      },
-    });
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.total).toBe(1);
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0].id).toBe(user.id);
+    expect(data.members[0].workspaces[0].role).toBe("user");
   });
 
   itInTransaction("returns 405 for non-GET methods", async () => {

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -42,17 +42,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<SearchMembersResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can search memberships.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
       const queryRes = SearchMembersQueryCodec.decode(req.query);


### PR DESCRIPTION
Fixes issue described [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1745826541111239)

## Description

This PR updates workspace member visibility permissions to allow regular users ('user' and 'builder' roles) to view and search the list of workspace members. Previously, only 'admin' users had this permission.

This change is a requirement Agent Editor feature (part of Agent Discovery & Management), which requires users to be able to select other workspace members to add them as editors to an agent.

**Changes:**

*   Removed the admin-only authorization check from the `GET /api/w/[wId]/members` endpoint handler (`front/pages/api/w/[wId]/members/index.ts`).
*   Removed the admin-only authorization check from the `GET /api/w/[wId]/members/search` endpoint handler (`front/pages/api/w/[wId]/members/search.ts`).
*   Verified that endpoints responsible for modifying memberships (e.g., `POST /api/w/[wId]/members/[uId]`) retain their admin-only restrictions.

## Risks

*   Low risk: This change only grants *read* access (listing/searching members) to non-admin users. Permissions for *modifying* memberships remain restricted to admins.

## Tests
*   **Automated:**
    *   Existing API tests for `members/index.ts` and `members/search.ts` may need updates to expect a 200 OK response for GET requests from non-admin roles, instead of a 403.
    *   Ensure tests for modification endpoints still correctly assert that non-admins receive permission errors (e.g., 403).

## Deploy Plan

*   Deploy the `front` service.
*   No database migrations required.
