### PR TITLE
Fix space soft deletion to include apps

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,8 @@
   "rust-analyzer.inlayHints.parameterHints.enable": false,
   "rust-analyzer.inlayHints.typeHints.enable": false,
   "rust-analyzer.lens.implementations.enable": false,
-  "git.ignoreLimitWarning": true
+  "git.ignoreLimitWarning": true,
+  "[sql]": {
+    "editor.defaultFormatter": "inferrinizzard.prettier-sql-vscode"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,8 +21,5 @@
   "rust-analyzer.inlayHints.parameterHints.enable": false,
   "rust-analyzer.inlayHints.typeHints.enable": false,
   "rust-analyzer.lens.implementations.enable": false,
-  "git.ignoreLimitWarning": true,
-  "[sql]": {
-    "editor.defaultFormatter": "inferrinizzard.prettier-sql-vscode"
-  }
+  "git.ignoreLimitWarning": true
 }

--- a/front/lib/api/apps.ts
+++ b/front/lib/api/apps.ts
@@ -10,6 +10,19 @@ export async function softDeleteApp(
   auth: Authenticator,
   app: AppResource
 ): Promise<Result<void, Error>> {
+  const usage = await app.getUsagesByAgents(auth);
+  if (usage.isErr()) {
+    return usage;
+  } else if (usage.value.count > 0) {
+    const { agentNames } = usage.value;
+    return new Err(
+      new Error(
+        "Cannot delete app in use by " +
+          `agent${agentNames.length > 1 ? "s" : ""}: ${agentNames.join(", ")}.`
+      )
+    );
+  }
+
   const res = await app.delete(auth, { hardDelete: false });
   if (res.isErr()) {
     return res;

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -74,7 +74,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
     const agentNames = uniq(usages.map((u) => u.agentNames).flat());
     return new Err(
       new Error(
-        `Cannot delete space with data source in use by agent(s): ${agentNames.join(", ")}.`
+        `Cannot delete space with data source or app in use by agent(s): ${agentNames.join(", ")}.`
       )
     );
   }

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -61,6 +61,14 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
   }
 
   const apps = await AppResource.listBySpace(auth, space);
+  for (const app of apps) {
+    const usage = await app.getUsagesByAgents(auth);
+    if (usage.isErr()) {
+      throw usage.error;
+    } else if (usage.value.count > 0) {
+      usages.push(usage.value);
+    }
+  }
 
   if (usages.length > 0) {
     const agentNames = uniq(usages.map((u) => u.agentNames).flat());

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -3,6 +3,8 @@ import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
+import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { DatasetResource } from "@app/lib/resources/dataset_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { RunResource } from "@app/lib/resources/run_resource";
@@ -101,6 +103,34 @@ export class AppResource extends ResourceWithSpace<AppModel> {
       },
       includeDeleted,
     });
+  }
+
+  async getUsagesByAgents(auth: Authenticator) {
+    const owner = auth.getNonNullableWorkspace();
+
+    const dustAppRunConfigurations = await AgentDustAppRunConfiguration.findAll(
+      {
+        where: {
+          appId: this.id,
+          workspaceId: owner.id,
+        },
+      }
+    );
+    const agentConfigurations = await AgentConfiguration.findAll({
+      where: {
+        workspaceId: owner.id,
+        status: "active",
+        sId: {
+          [Op.in]: dustAppRunConfigurations.map((c) => c.agentConfigurationId),
+        },
+      },
+    });
+
+    const agentNames = [
+      ...new Set(agentConfigurations.map((a) => a.name)),
+    ].sort();
+
+    return new Ok({ count: agentNames.length, agentNames });
   }
 
   // Clone.


### PR DESCRIPTION
## Description

- We've observed a few "Unreachable: space not found" when listing apps for a workspace, due to a `group_vaults` relation missing.
- An issue seems to stem from the fact that the soft deletion of spaces does not seem to include the apps in it (the `hardDelete` does).

## Tests

## Risk


## Deploy Plan

- Deploy front.
