### PR TITLE
[front] Reduce number of queries when fetching messages

### DIFF
--- a/front/lib/actions/configuration/browse.ts
+++ b/front/lib/actions/configuration/browse.ts
@@ -3,14 +3,14 @@ import { Op } from "sequelize";
 import type { BrowseConfigurationType } from "@app/lib/actions/browse";
 import { DEFAULT_BROWSE_ACTION_NAME } from "@app/lib/actions/constants";
 import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
-import type { ModelId } from "@app/types";
+import type { AgentFetchVariant, ModelId } from "@app/types";
 
 export async function fetchBrowseActionConfigurations({
   configurationIds,
   variant,
 }: {
   configurationIds: ModelId[];
-  variant: "light" | "full";
+  variant: AgentFetchVariant;
 }): Promise<Map<ModelId, BrowseConfigurationType[]>> {
   if (variant !== "full") {
     return new Map();

--- a/front/lib/actions/configuration/dust_app_run.ts
+++ b/front/lib/actions/configuration/dust_app_run.ts
@@ -5,7 +5,7 @@ import type { DustAppRunConfigurationType } from "@app/lib/actions/dust_app_run"
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AppResource } from "@app/lib/resources/app_resource";
-import type { ModelId } from "@app/types";
+import type { AgentFetchVariant, ModelId } from "@app/types";
 
 export async function fetchDustAppRunActionConfigurations(
   auth: Authenticator,
@@ -14,7 +14,7 @@ export async function fetchDustAppRunActionConfigurations(
     variant,
   }: {
     configurationIds: ModelId[];
-    variant: "light" | "full";
+    variant: AgentFetchVariant;
   }
 ): Promise<Map<ModelId, DustAppRunConfigurationType[]>> {
   if (variant !== "full") {

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -18,7 +18,7 @@ import { Workspace } from "@app/lib/models/workspace";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import logger from "@app/logger/logger";
-import type { ModelId } from "@app/types";
+import type { AgentFetchVariant, ModelId } from "@app/types";
 
 export async function fetchMCPServerActionConfigurations(
   auth: Authenticator,
@@ -27,7 +27,7 @@ export async function fetchMCPServerActionConfigurations(
     variant,
   }: {
     configurationIds: ModelId[];
-    variant: "light" | "full";
+    variant: AgentFetchVariant;
   }
 ): Promise<Map<ModelId, MCPServerConfigurationType[]>> {
   if (variant !== "full") {

--- a/front/lib/actions/configuration/process.ts
+++ b/front/lib/actions/configuration/process.ts
@@ -11,14 +11,14 @@ import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/
 import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import type { ModelId } from "@app/types";
+import type { AgentFetchVariant, ModelId } from "@app/types";
 
 export async function fetchAgentProcessActionConfigurations({
   configurationIds,
   variant,
 }: {
   configurationIds: ModelId[];
-  variant: "light" | "full";
+  variant: AgentFetchVariant;
 }): Promise<Map<ModelId, ProcessConfigurationType[]>> {
   if (variant !== "full") {
     return new Map();

--- a/front/lib/actions/configuration/reasoning.ts
+++ b/front/lib/actions/configuration/reasoning.ts
@@ -3,14 +3,14 @@ import { Op } from "sequelize";
 import { DEFAULT_REASONING_ACTION_NAME } from "@app/lib/actions/constants";
 import type { ReasoningConfigurationType } from "@app/lib/actions/reasoning";
 import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
-import type { ModelId } from "@app/types";
+import type { AgentFetchVariant, ModelId } from "@app/types";
 
 export async function fetchReasoningActionConfigurations({
   configurationIds,
   variant,
 }: {
   configurationIds: ModelId[];
-  variant: "light" | "full";
+  variant: AgentFetchVariant;
 }): Promise<Map<ModelId, ReasoningConfigurationType[]>> {
   if (variant !== "full") {
     return new Map();

--- a/front/lib/actions/configuration/retrieval.ts
+++ b/front/lib/actions/configuration/retrieval.ts
@@ -11,14 +11,14 @@ import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import type { ModelId } from "@app/types";
+import type { AgentFetchVariant, ModelId } from "@app/types";
 
 export async function fetchAgentRetrievalActionConfigurations({
   configurationIds,
   variant,
 }: {
   configurationIds: ModelId[];
-  variant: "light" | "full";
+  variant: AgentFetchVariant;
 }): Promise<Map<ModelId, RetrievalConfigurationType[]>> {
   if (variant !== "full") {
     return new Map();

--- a/front/lib/actions/configuration/table_query.ts
+++ b/front/lib/actions/configuration/table_query.ts
@@ -10,14 +10,14 @@ import {
 } from "@app/lib/models/assistant/actions/tables_query";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import type { ModelId } from "@app/types";
+import type { AgentFetchVariant, ModelId } from "@app/types";
 
 export async function fetchTableQueryActionConfigurations({
   configurationIds,
   variant,
 }: {
   configurationIds: ModelId[];
-  variant: "light" | "full";
+  variant: AgentFetchVariant;
 }): Promise<Map<ModelId, TablesQueryConfigurationType[]>> {
   if (variant !== "full") {
     return new Map();

--- a/front/lib/actions/configuration/websearch.ts
+++ b/front/lib/actions/configuration/websearch.ts
@@ -3,14 +3,14 @@ import { Op } from "sequelize";
 import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/actions/constants";
 import type { WebsearchConfigurationType } from "@app/lib/actions/websearch";
 import { AgentWebsearchConfiguration } from "@app/lib/models/assistant/actions/websearch";
-import type { ModelId } from "@app/types";
+import type { AgentFetchVariant, ModelId } from "@app/types";
 
 export async function fetchWebsearchActionConfigurations({
   configurationIds,
   variant,
 }: {
   configurationIds: ModelId[];
-  variant: "light" | "full";
+  variant: AgentFetchVariant;
 }): Promise<Map<ModelId, WebsearchConfigurationType[]>> {
   if (variant !== "full") {
     return new Map();

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -251,6 +251,11 @@ export async function getConversation(
         required: false,
       },
       {
+        model: Mention,
+        as: "mentions",
+        required: false,
+      },
+      {
         model: AgentMessage,
         as: "agentMessage",
         required: false,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -388,6 +388,7 @@ export class Message extends WorkspaceAwareModel<Message> {
   declare agentMessage?: NonAttribute<AgentMessage>;
   declare contentFragment?: NonAttribute<ContentFragmentModel>;
   declare reactions?: NonAttribute<MessageReaction[]>;
+  declare mentions?: NonAttribute<Mention[]>;
 
   declare conversation?: NonAttribute<ConversationModel>;
 }

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -99,6 +99,8 @@ export type AgentModelConfigurationType = {
   responseFormat?: string;
 };
 
+export type AgentFetchVariant = "light" | "full" | "extra_light";
+
 export type LightAgentConfigurationType = {
   id: ModelId;
 


### PR DESCRIPTION
## Description

Optimize number of queries : 
- add mentions in join to avoid separate query
- add a new "variant" used when getting agents for message listing : do not fetch tags/groups that are not needed here

Ideally I think we rather have a "load options" when getting agents, instead of light/full, speciying exactly what we require.

## Tests

locally

## Risk


## Deploy Plan

deploy front