### PR TITLE
[front] feat(analytics): Add inactive users csv

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -11,10 +11,7 @@ import {
 } from "@app/lib/models/assistant/conversation";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import {
-  frontSequelize,
-  getFrontReplicaDbConnection,
-} from "@app/lib/resources/storage";
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type {
   LightAgentConfigurationType,
@@ -328,7 +325,8 @@ export const getInactiveUserUsageData = async (
   /* Fetch users that were created after the startDate
    * and don't have any user_messages in the given period
    */
-  const users = await frontSequelize.query(
+  const readReplica = getFrontReplicaDbConnection();
+  const users = await readReplica.query(
     `
 SELECT DISTINCT u.*
 FROM "users" u

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -328,10 +328,10 @@ export const getInactiveUserUsageData = async (
   const readReplica = getFrontReplicaDbConnection();
   const users = await readReplica.query(
     `
-SELECT DISTINCT u.*
+SELECT DISTINCT u.id, u.name, u.name
 FROM "users" u
 LEFT JOIN "user_messages" um ON u.id = um."userId"
-WHERE u."createdAt" >= $startDate
+WHERE u."createdAt" <= $endDate
 AND NOT EXISTS (
   SELECT 1 
   WHERE um."userId" = u.id

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -13,11 +13,12 @@ import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import {
+  getActiveUserUsageData,
   getAssistantsUsageData,
   getBuildersUsageData,
   getFeedbacksUsageData,
+  getInactiveUserUsageData,
   getMessageUsageData,
-  getUserUsageData,
 } from "@app/lib/workspace_usage";
 import { apiError } from "@app/logger/withlogging";
 import type { WorkspaceType } from "@app/types";
@@ -258,7 +259,11 @@ async function fetchUsageData({
 }): Promise<Partial<Record<UsageTableType, string>>> {
   switch (table) {
     case "users":
-      return { users: await getUserUsageData(start, end, workspace) };
+      return { users: await getActiveUserUsageData(start, end, workspace) };
+    case "inactive_users":
+      return {
+        inactive_users: await getInactiveUserUsageData(start, end, workspace),
+      };
     case "assistant_messages":
       return {
         assistant_messages: await getMessageUsageData(start, end, workspace),
@@ -274,15 +279,29 @@ async function fetchUsageData({
         feedbacks: await getFeedbacksUsageData(start, end, workspace),
       };
     case "all":
-      const [users, assistant_messages, builders, assistants, feedbacks] =
-        await Promise.all([
-          getUserUsageData(start, end, workspace),
-          getMessageUsageData(start, end, workspace),
-          getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace),
-          getFeedbacksUsageData(start, end, workspace),
-        ]);
-      return { users, assistant_messages, builders, assistants, feedbacks };
+      const [
+        users,
+        inactive_users,
+        assistant_messages,
+        builders,
+        assistants,
+        feedbacks,
+      ] = await Promise.all([
+        getActiveUserUsageData(start, end, workspace),
+        getInactiveUserUsageData(start, end, workspace),
+        getMessageUsageData(start, end, workspace),
+        getBuildersUsageData(start, end, workspace),
+        getAssistantsUsageData(start, end, workspace),
+        getFeedbacksUsageData(start, end, workspace),
+      ]);
+      return {
+        users,
+        inactive_users,
+        assistant_messages,
+        builders,
+        assistants,
+        feedbacks,
+      };
     default:
       return {};
   }

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -8,11 +8,12 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {
+  getActiveUserUsageData,
   getAssistantsUsageData,
   getBuildersUsageData,
   getFeedbacksUsageData,
+  getInactiveUserUsageData,
   getMessageUsageData,
-  getUserUsageData,
 } from "@app/lib/workspace_usage";
 import { apiError } from "@app/logger/withlogging";
 import type { WorkspaceType } from "@app/types";
@@ -26,6 +27,7 @@ const MonthSchema = t.refinement(
 
 const usageTables = [
   "users",
+  "inactive_users",
   "assistant_messages",
   "builders",
   "assistants",
@@ -183,7 +185,11 @@ async function fetchUsageData({
 }): Promise<Partial<Record<usageTableType, string>>> {
   switch (table) {
     case "users":
-      return { users: await getUserUsageData(start, end, workspace) };
+      return { users: await getActiveUserUsageData(start, end, workspace) };
+    case "inactive_users":
+      return {
+        inactive_users: await getInactiveUserUsageData(start, end, workspace),
+      };
     case "assistant_messages":
       return { mentions: await getMessageUsageData(start, end, workspace) };
     case "builders":
@@ -197,15 +203,29 @@ async function fetchUsageData({
         assistants: await getAssistantsUsageData(start, end, workspace),
       };
     case "all":
-      const [users, assistant_messages, builders, assistants, feedbacks] =
-        await Promise.all([
-          getUserUsageData(start, end, workspace),
-          getMessageUsageData(start, end, workspace),
-          getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace),
-          getFeedbacksUsageData(start, end, workspace),
-        ]);
-      return { users, assistant_messages, builders, assistants, feedbacks };
+      const [
+        users,
+        inactive_users,
+        assistant_messages,
+        builders,
+        assistants,
+        feedbacks,
+      ] = await Promise.all([
+        getActiveUserUsageData(start, end, workspace),
+        getInactiveUserUsageData(start, end, workspace),
+        getMessageUsageData(start, end, workspace),
+        getBuildersUsageData(start, end, workspace),
+        getAssistantsUsageData(start, end, workspace),
+        getFeedbacksUsageData(start, end, workspace),
+      ]);
+      return {
+        users,
+        inactive_users,
+        assistant_messages,
+        builders,
+        assistants,
+        feedbacks,
+      };
     default:
       return {};
   }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2418,6 +2418,7 @@ export type UpsertTableResponseType = z.infer<typeof UpsertTableResponseSchema>;
 
 const SupportedUsageTablesSchema = FlexibleEnumSchema<
   | "users"
+  | "inactive_users"
   | "assistant_messages"
   | "builders"
   | "assistants"


### PR DESCRIPTION
## Description
- Context: https://github.com/dust-tt/tasks/issues/2774
- Added a new csv in the analytics export with users that didn't sent any messages in a given period.
Added a new csv instead of changing the existing one to avoid breaking any potentials flows of our users if they rely on those to do any data stuff.

## Tests
- Locally tested

## Risk
- Low

## Deploy Plan
- Deploy front
