### PR TITLE
[front] Agent permission fixes

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -290,7 +290,7 @@ export function AssistantBrowser({
               size="sm"
             />
 
-            {isBuilder(owner) && (
+            {(isBuilder(owner) || hasAgentDiscovery) && (
               <Button
                 tooltip="Manage agents"
                 href={`/w/${owner.sId}/builder/assistants/`}

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -55,7 +55,7 @@ import type {
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
-import { GLOBAL_AGENTS_SID, isBuilder, removeNulls } from "@app/types";
+import { GLOBAL_AGENTS_SID, isAdmin, removeNulls } from "@app/types";
 
 import { AddEditorDropdown } from "../members/AddEditorsDropdown";
 import { MembersList } from "../members/MembersList";
@@ -482,7 +482,7 @@ export function AssistantDetails({
                 <SheetTitle />
               </VisuallyHidden>
               <DescriptionSection />
-              {isBuilder(owner) && (
+              {(agentConfiguration?.canEdit || isAdmin(owner)) && (
                 <Tabs value={selectedTab}>
                   <TabsList border={false}>
                     <TabsTrigger

--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -20,11 +20,8 @@ import { DeleteAssistantDialog } from "@app/components/assistant/DeleteAssistant
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
-import {
-  isAdmin,
-  type LightAgentConfigurationType,
-  type WorkspaceType,
-} from "@app/types";
+import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
+import { isAdmin } from "@app/types";
 
 interface AssistantDetailsButtonBarProps {
   agentConfiguration: LightAgentConfigurationType;

--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -20,7 +20,11 @@ import { DeleteAssistantDialog } from "@app/components/assistant/DeleteAssistant
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
-import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
+import {
+  isAdmin,
+  type LightAgentConfigurationType,
+  type WorkspaceType,
+} from "@app/types";
 
 interface AssistantDetailsButtonBarProps {
   agentConfiguration: LightAgentConfigurationType;
@@ -57,7 +61,7 @@ export function AssistantDetailsButtonBar({
     return <></>;
   }
 
-  const allowDeletion = agentConfiguration.canEdit;
+  const allowDeletion = agentConfiguration.canEdit || isAdmin(owner);
 
   function AssistantDetailsDropdownMenu() {
     return (
@@ -117,7 +121,7 @@ export function AssistantDetailsButtonBar({
     );
   }
 
-  const canEditAssistant = agentConfiguration.canEdit;
+  const canEditAssistant = agentConfiguration.canEdit || isAdmin(owner);
 
   const isFavoriteDisabled =
     isAgentConfigurationValidating || isUpdatingFavorite;

--- a/front/components/assistant/AssistantsTable.tsx
+++ b/front/components/assistant/AssistantsTable.tsx
@@ -357,7 +357,7 @@ export function AssistantsTable({
                         }`
                       );
                     },
-                    kind: "item",
+                    kind: "item" as const,
                   },
                   {
                     label: "Copy agent ID",
@@ -370,7 +370,7 @@ export function AssistantsTable({
                         agentConfiguration.sId
                       );
                     },
-                    kind: "item",
+                    kind: "item" as const,
                   },
                   {
                     label: "Duplicate (New)",
@@ -383,7 +383,7 @@ export function AssistantsTable({
                         `/w/${owner.sId}/builder/assistants/new?flow=personal_assistants&duplicate=${agentConfiguration.sId}`
                       );
                     },
-                    kind: "item",
+                    kind: "item" as const,
                   },
                   {
                     label: "Delete",
@@ -391,12 +391,12 @@ export function AssistantsTable({
                     "data-gtm-location": "assistantDetails",
                     icon: TrashIcon,
                     disabled: !agentConfiguration.canEdit && !isAdmin(owner),
-                    variant: "warning",
+                    variant: "warning" as const,
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       setShowDeleteDialog({ open: true, agentConfiguration });
                     },
-                    kind: "item",
+                    kind: "item" as const,
                   },
                 ].filter((item) => !item.disabled)
               : [],

--- a/front/components/assistant/AssistantsTable.tsx
+++ b/front/components/assistant/AssistantsTable.tsx
@@ -28,7 +28,7 @@ import type {
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@app/types";
-import { isBuilder, pluralize } from "@app/types";
+import { isAdmin, isBuilder, pluralize } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
 type MoreMenuItem = {
@@ -344,6 +344,7 @@ export function AssistantsTable({
                     "data-gtm-label": "assistantEditButton",
                     "data-gtm-location": "assistantDetails",
                     icon: PencilSquareIcon,
+                    disabled: !agentConfiguration.canEdit && !isAdmin(owner),
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       void router.push(
@@ -389,6 +390,7 @@ export function AssistantsTable({
                     "data-gtm-label": "assistantDeletionButton",
                     "data-gtm-location": "assistantDetails",
                     icon: TrashIcon,
+                    disabled: !agentConfiguration.canEdit && !isAdmin(owner),
                     variant: "warning",
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
@@ -396,7 +398,7 @@ export function AssistantsTable({
                     },
                     kind: "item",
                   },
-                ]
+                ].filter((item) => !item.disabled)
               : [],
         };
       }),

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -364,21 +364,10 @@ export function SharingDropdown({
   let scopes = Object.entries(SCOPE_INFO).filter(
     ([entryScope]) =>
       entryScope !== "global" &&
+      entryScope !== "hidden" &&
+      entryScope !== "visible" &&
       (isBuilder(owner) || entryScope !== "workspace")
   );
-
-  if (!featureFlags.hasFeature("agent_discovery")) {
-    scopes = scopes.filter(
-      ([entryScope]) => entryScope !== "hidden" && entryScope !== "visible"
-    );
-  } else {
-    scopes = scopes.filter(
-      ([entryScope]) =>
-        entryScope === agentConfiguration?.scope ||
-        entryScope === "hidden" ||
-        entryScope === "visible"
-    );
-  }
 
   const usageText = assistantName
     ? assistantUsageMessage({
@@ -415,7 +404,10 @@ export function SharingDropdown({
         : SCOPE_INFO[requestNewScope].confirmationModalData;
   }
 
-  const allowedToChange = !disabled && agentConfiguration?.canEdit;
+  const allowedToChange =
+    !featureFlags.hasFeature("agent_discovery") &&
+    !disabled &&
+    (agentConfiguration?.canEdit || isAdmin(owner));
 
   return (
     <div>

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -361,7 +361,7 @@ export function SharingDropdown({
     workspaceId: owner.sId,
   });
 
-  let scopes = Object.entries(SCOPE_INFO).filter(
+  const scopes = Object.entries(SCOPE_INFO).filter(
     ([entryScope]) =>
       entryScope !== "global" &&
       entryScope !== "hidden" &&

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1770,10 +1770,6 @@ export async function getAgentPermissions(
   agentConfiguration: LightAgentConfigurationType,
   memberAgents: ModelId[]
 ) {
-  if (auth.isAdmin()) {
-    return { canRead: true, canEdit: agentConfiguration.scope !== "global" };
-  }
-
   switch (agentConfiguration.scope) {
     case "global":
       return { canRead: true, canEdit: false };

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics.ts
@@ -70,7 +70,7 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit) {
+  if (!assistant.canEdit && !auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics.ts
@@ -60,7 +60,7 @@ async function handler(
     "light"
   );
 
-  if (!assistant || !assistant.canRead) {
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -39,7 +39,7 @@ async function handler(
 
   // Check that user has access to this agent
   const assistant = await getAgentConfiguration(auth, aId, "light");
-  if (!assistant || !assistant.canRead) {
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -74,7 +74,7 @@ async function handler(
         });
       }
 
-      if (!agent.canEdit) {
+      if (!agent.canEdit && !auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -146,7 +146,7 @@ async function handler(
       });
 
     case "DELETE":
-      if (!agent.canEdit) {
+      if (!agent.canEdit && !auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -38,7 +38,7 @@ async function handler(
     req.query.aId as string,
     "full"
   );
-  if (!agent || !agent.canRead) {
+  if (!agent || (!agent.canRead && !auth.isAdmin())) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -27,7 +27,10 @@ async function handler(
         req.query.aId as string,
         "light"
       );
-      if (!agentConfiguration || !agentConfiguration.canEdit) {
+      if (
+        !agentConfiguration ||
+        (!agentConfiguration.canEdit && !auth.isAdmin())
+      ) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -41,7 +41,7 @@ async function handler(
     "full"
   );
 
-  if (!agent || !agent.canRead) {
+  if (!agent || (!agent.canRead && !auth.isAdmin())) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -65,7 +65,7 @@ async function handler(
         });
       }
 
-      if (!agent.canEdit) {
+      if (!agent.canEdit && !auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -72,7 +72,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  if (!configuration.canEdit) {
+  if (!configuration.canEdit && !auth.isAdmin()) {
     return {
       notFound: true,
     };


### PR DESCRIPTION
## Description

- Don't set "canRead"/"canEdit" for admin if not explicitly editor
- Check if admin when needed (admin can still edit/delete/restore)
- Show "Manage" agents for all users (when agent discovery is enabled)
- Remove scope switcher on details header (when agent discovery is enabled)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
