### PR TITLE
[front] restore separate query without join

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -251,11 +251,6 @@ export async function getConversation(
         required: false,
       },
       {
-        model: Mention,
-        as: "mentions",
-        required: false,
-      },
-      {
         model: AgentMessage,
         as: "agentMessage",
         required: false,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -388,7 +388,6 @@ export class Message extends WorkspaceAwareModel<Message> {
   declare agentMessage?: NonAttribute<AgentMessage>;
   declare contentFragment?: NonAttribute<ContentFragmentModel>;
   declare reactions?: NonAttribute<MessageReaction[]>;
-  declare mentions?: NonAttribute<Mention[]>;
 
   declare conversation?: NonAttribute<ConversationModel>;
 }


### PR DESCRIPTION
## Description

Restore separate query without join - load mentions separately
(note that mentions are only used for last user message very specific edge cases - we might consider removing them)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
