### PR TITLE
[front] Don't load actions when using non full variant

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -234,13 +234,19 @@ async function fetchGlobalAgentConfigurationForView(
   {
     agentPrefix,
     agentsGetView,
+    variant,
   }: {
     agentPrefix?: string;
     agentsGetView: AgentsGetViewType;
+    variant: AgentFetchVariant;
   }
 ) {
   const globalAgentIdsToFetch = determineGlobalAgentIdsToFetch(agentsGetView);
-  const allGlobalAgents = await getGlobalAgents(auth, globalAgentIdsToFetch);
+  const allGlobalAgents = await getGlobalAgents(
+    auth,
+    globalAgentIdsToFetch,
+    variant
+  );
   const matchingGlobalAgents = allGlobalAgents.filter(
     (a) =>
       !agentPrefix || a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())
@@ -697,6 +703,7 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>({
     const allGlobalAgents = await fetchGlobalAgentConfigurationForView(auth, {
       agentPrefix,
       agentsGetView,
+      variant,
     });
 
     return applySortAndLimit(allGlobalAgents);
@@ -706,6 +713,7 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>({
     fetchGlobalAgentConfigurationForView(auth, {
       agentPrefix,
       agentsGetView,
+      variant,
     }),
     fetchWorkspaceAgentConfigurationsForView(auth, owner, {
       agentPrefix,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -22,6 +22,7 @@ import logger from "@app/logger/logger";
 import type {
   AgentConfigurationStatus,
   AgentConfigurationType,
+  AgentFetchVariant,
   AgentModelConfigurationType,
   ConnectorProvider,
   DataSourceViewType,
@@ -996,7 +997,7 @@ function _getManagedDataSourceAgent(
     description: string;
     instructions: string | null;
     pictureUrl: string;
-    preFetchedDataSources: PrefetchedDataSourcesType;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
@@ -1013,67 +1014,7 @@ function _getManagedDataSourceAgent(
       }
     : dummyModelConfiguration;
 
-  // Check if deactivated by an admin
-  if (
-    (settings && settings.status === "disabled_by_admin") ||
-    !modelConfiguration
-  ) {
-    return {
-      id: -1,
-      sId: agentId,
-      version: 0,
-      versionCreatedAt: null,
-      versionAuthorId: null,
-      name: name,
-      description,
-      instructions: null,
-      pictureUrl,
-      status: "disabled_by_admin",
-      scope: "global",
-      userFavorite: false,
-      model,
-      actions: [],
-      maxStepsPerRun: 0,
-      visualizationEnabled: false,
-      templateId: null,
-      requestedGroupIds: [],
-      tags: [],
-      canRead: true,
-      canEdit: false,
-    };
-  }
-
-  // Check if there's a data source view for this agent
-  const filteredDataSourceViews = preFetchedDataSources.dataSourceViews.filter(
-    (dsView) => dsView.dataSource.connectorProvider === connectorProvider
-  );
-  if (filteredDataSourceViews.length === 0) {
-    return {
-      id: -1,
-      sId: agentId,
-      version: 0,
-      versionCreatedAt: null,
-      versionAuthorId: null,
-      name: name,
-      description,
-      instructions: null,
-      pictureUrl,
-      status: "disabled_missing_datasource",
-      scope: "global",
-      userFavorite: false,
-      model,
-      actions: [],
-      maxStepsPerRun: 0,
-      visualizationEnabled: false,
-      templateId: null,
-      requestedGroupIds: [],
-      tags: [],
-      canRead: true,
-      canEdit: false,
-    };
-  }
-
-  return {
+  const agent = {
     id: -1,
     sId: agentId,
     version: 0,
@@ -1083,10 +1024,56 @@ function _getManagedDataSourceAgent(
     description,
     instructions,
     pictureUrl,
-    status: "active",
-    scope: "global",
+    scope: "global" as const,
     userFavorite: false,
     model,
+    visualizationEnabled: false,
+    templateId: null,
+    requestedGroupIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+
+  // Check if deactivated by an admin
+  if (
+    (settings && settings.status === "disabled_by_admin") ||
+    !modelConfiguration
+  ) {
+    return {
+      ...agent,
+      status: "disabled_by_admin",
+      maxStepsPerRun: 0,
+      actions: [],
+    };
+  }
+
+  if (!preFetchedDataSources) {
+    return {
+      ...agent,
+      status: "active",
+      actions: [],
+      maxStepsPerRun: 1,
+    };
+  }
+
+  // Check if there's a data source view for this agent
+  const filteredDataSourceViews = preFetchedDataSources.dataSourceViews.filter(
+    (dsView) => dsView.dataSource.connectorProvider === connectorProvider
+  );
+
+  if (filteredDataSourceViews.length === 0) {
+    return {
+      ...agent,
+      status: "disabled_missing_datasource",
+      actions: [],
+      maxStepsPerRun: 0,
+    };
+  }
+
+  return {
+    ...agent,
+    status: "active",
     actions: [
       {
         id: -1,
@@ -1106,12 +1093,6 @@ function _getManagedDataSourceAgent(
       },
     ],
     maxStepsPerRun: 1,
-    visualizationEnabled: false,
-    templateId: null,
-    requestedGroupIds: [],
-    tags: [],
-    canRead: true,
-    canEdit: false,
   };
 }
 
@@ -1122,7 +1103,7 @@ function _getGoogleDriveGlobalAgent(
     preFetchedDataSources,
   }: {
     settings: GlobalAgentSettings | null;
-    preFetchedDataSources: PrefetchedDataSourcesType;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
   }
 ): AgentConfigurationType | null {
   return _getManagedDataSourceAgent(auth, {
@@ -1146,7 +1127,7 @@ function _getSlackGlobalAgent(
     preFetchedDataSources,
   }: {
     settings: GlobalAgentSettings | null;
-    preFetchedDataSources: PrefetchedDataSourcesType;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
   }
 ) {
   return _getManagedDataSourceAgent(auth, {
@@ -1170,7 +1151,7 @@ function _getGithubGlobalAgent(
     preFetchedDataSources,
   }: {
     settings: GlobalAgentSettings | null;
-    preFetchedDataSources: PrefetchedDataSourcesType;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
   }
 ) {
   return _getManagedDataSourceAgent(auth, {
@@ -1194,7 +1175,7 @@ function _getNotionGlobalAgent(
     preFetchedDataSources,
   }: {
     settings: GlobalAgentSettings | null;
-    preFetchedDataSources: PrefetchedDataSourcesType;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
   }
 ) {
   return _getManagedDataSourceAgent(auth, {
@@ -1218,7 +1199,7 @@ function _getIntercomGlobalAgent(
     preFetchedDataSources,
   }: {
     settings: GlobalAgentSettings | null;
-    preFetchedDataSources: PrefetchedDataSourcesType;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
   }
 ) {
   return _getManagedDataSourceAgent(auth, {
@@ -1242,7 +1223,7 @@ function _getDustGlobalAgent(
     preFetchedDataSources,
   }: {
     settings: GlobalAgentSettings | null;
-    preFetchedDataSources: PrefetchedDataSourcesType;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
@@ -1263,36 +1244,57 @@ function _getDustGlobalAgent(
       }
     : dummyModelConfiguration;
 
+  const instructions = `The agent answers with precision and brevity. It produces short and straight to the point answers. The agent should not provide additional information or content that the user did not ask for. When possible, the agent should answer using a single sentence.
+    # When the user asks a questions to the agent, the agent should analyze the situation as follows.
+    1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the agent's own knowledge), the agent should search in the company's internal data sources to answer the question. Searching in all datasources is the default behavior unless the user has specified the location in which case it is better to search only on the specific data source. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
+    2. If the users's question requires information that is recent and likely to be found on the public internet, the agent should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
+    3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the agent should both search the internal company data sources and the public internet before answering the user's question.
+    4. If the user's query require neither internal company data or recent public knowledge, the agent is allowed to answer without using any tool.
+    The agent always respects the mardown format and generates spaces to nest content.`;
+
+  const dustAgent = {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.DUST,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name,
+    description,
+    instructions,
+    pictureUrl,
+    scope: "global" as const,
+    userFavorite: false,
+    model,
+    visualizationEnabled: true,
+    templateId: null,
+    requestedGroupIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+
   if (
     (settings && settings.status === "disabled_by_admin") ||
     !modelConfiguration
   ) {
     return {
-      id: -1,
-      sId: GLOBAL_AGENTS_SID.DUST,
-      version: 0,
-      versionCreatedAt: null,
-      versionAuthorId: null,
-      name,
-      description,
-      instructions: null,
-      pictureUrl,
+      ...dustAgent,
       status: "disabled_by_admin",
-      scope: "global",
-      userFavorite: false,
-      model,
       actions: [
         ..._getDefaultWebActionsForGlobalAgent({
           agentSid: GLOBAL_AGENTS_SID.DUST,
         }),
       ],
       maxStepsPerRun: 0,
-      visualizationEnabled: true,
-      templateId: null,
-      requestedGroupIds: [],
-      tags: [],
-      canRead: true,
-      canEdit: false,
+    };
+  }
+
+  if (!preFetchedDataSources) {
+    return {
+      ...dustAgent,
+      status: "active",
+      actions: [],
+      maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     };
   }
 
@@ -1302,37 +1304,12 @@ function _getDustGlobalAgent(
 
   if (dataSourceViews.length === 0) {
     return {
-      id: -1,
-      sId: GLOBAL_AGENTS_SID.DUST,
-      version: 0,
-      versionCreatedAt: null,
-      versionAuthorId: null,
-      name,
-      description,
-      instructions: null,
-      pictureUrl,
+      ...dustAgent,
       status: "disabled_missing_datasource",
-      scope: "global",
-      userFavorite: false,
-      model,
       actions: [],
       maxStepsPerRun: 0,
-      visualizationEnabled: true,
-      templateId: null,
-      requestedGroupIds: [],
-      tags: [],
-      canRead: true,
-      canEdit: false,
     };
   }
-
-  const instructions = `The agent answers with precision and brevity. It produces short and straight to the point answers. The agent should not provide additional information or content that the user did not ask for. When possible, the agent should answer using a single sentence.
-    # When the user asks a questions to the agent, the agent should analyze the situation as follows.
-    1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the agent's own knowledge), the agent should search in the company's internal data sources to answer the question. Searching in all datasources is the default behavior unless the user has specified the location in which case it is better to search only on the specific data source. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-    2. If the users's question requires information that is recent and likely to be found on the public internet, the agent should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
-    3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the agent should both search the internal company data sources and the public internet before answering the user's question.
-    4. If the user's query require neither internal company data or recent public knowledge, the agent is allowed to answer without using any tool.
-    The agent always respects the mardown format and generates spaces to nest content.`;
 
   // We push one action with all data sources
   const actions: AgentActionConfigurationType[] = [
@@ -1410,34 +1387,17 @@ function _getDustGlobalAgent(
   });
 
   return {
-    id: -1,
-    sId: GLOBAL_AGENTS_SID.DUST,
-    version: 0,
-    versionCreatedAt: null,
-    versionAuthorId: null,
-    name,
-    description,
-    instructions,
-    pictureUrl,
+    ...dustAgent,
     status: "active",
-    scope: "global",
-    userFavorite: false,
-    model,
     actions,
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
-    visualizationEnabled: true,
-    templateId: null,
-    requestedGroupIds: [],
-    tags: [],
-    canRead: true,
-    canEdit: false,
   };
 }
 
 function getGlobalAgent(
   auth: Authenticator,
   sId: string | number,
-  preFetchedDataSources: PrefetchedDataSourcesType,
+  preFetchedDataSources: PrefetchedDataSourcesType | null,
   helperPromptInstance: HelperAssistantPrompt,
   globaAgentSettings: GlobalAgentSettings[]
 ): AgentConfigurationType | null {
@@ -1590,7 +1550,8 @@ const RETIRED_GLOABL_AGENTS_SID = [
 
 export async function getGlobalAgents(
   auth: Authenticator,
-  agentIds?: string[]
+  agentIds?: string[],
+  variant: AgentFetchVariant = "full"
 ): Promise<AgentConfigurationType[]> {
   if (agentIds !== undefined && agentIds.some((sId) => !isGlobalAgentId(sId))) {
     throw new Error("Invalid agentIds.");
@@ -1609,7 +1570,9 @@ export async function getGlobalAgents(
 
   const [preFetchedDataSources, globaAgentSettings, helperPromptInstance] =
     await Promise.all([
-      getDataSourcesAndWorkspaceIdForGlobalAgents(auth),
+      variant === "full"
+        ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
+        : null,
       GlobalAgentSettings.findAll({
         where: { workspaceId: owner.id },
       }),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -106,10 +106,13 @@ describe("GET /api/w/[wId]/assistant/agent_configurations", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
-      const data = JSON.parse(res._getData());
+      const data: { agentConfigurations: LightAgentConfigurationType[] } =
+        JSON.parse(res._getData());
       expect(data.agentConfigurations).toBeDefined();
       expect(Array.isArray(data.agentConfigurations)).toBe(true);
-      expect(data.agentConfigurations.length).toBe(testAgents.length + 1);
+      expect(
+        data.agentConfigurations.filter((a) => a.scope !== "global").length
+      ).toBe(testAgents.length);
     }
   );
 
@@ -125,10 +128,17 @@ describe("GET /api/w/[wId]/assistant/agent_configurations", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
-      const data = JSON.parse(res._getData());
+      const data: { agentConfigurations: LightAgentConfigurationType[] } =
+        JSON.parse(res._getData());
       expect(data.agentConfigurations).toBeDefined();
       expect(Array.isArray(data.agentConfigurations)).toBe(true);
-      expect(data.agentConfigurations.length).toBe(testAgents.length + 1 - 2);
+      expect(
+        data.agentConfigurations.filter((a) => a.scope !== "global").length
+      ).toBe(
+        testAgents.filter((a) =>
+          ["workspace", "published", "visible"].includes(a.scope)
+        ).length
+      );
     }
   );
 

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -61,7 +61,7 @@ function DustAgentDataSourceVisual({
 }: {
   dataSourceView: DataSourceViewType;
 }) {
-  const { isDark } = { isDark: false };
+  const { isDark } = useTheme();
 
   return (
     <ContextItem.Visual

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -61,7 +61,7 @@ function DustAgentDataSourceVisual({
 }: {
   dataSourceView: DataSourceViewType;
 }) {
-  const { isDark } = useTheme();
+  const { isDark } = { isDark: false };
 
   return (
     <ContextItem.Visual


### PR DESCRIPTION
## Description

Actions are already skipped for custom agents, but still loaded for global agents. This requires loading spaces / ds / dsviews (7 sql selects) for nothing

## Tests

check behaviour of global agents

## Risk

minimal

## Deploy Plan

deploy front