### PR TITLE
[Discovery] Fix: (minor) permissions discrepancy between assert and API 

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1790,7 +1790,7 @@ export async function getAgentPermissions(
     case "workspace":
       return { canRead: true, canEdit: auth.isBuilder() };
     case "published":
-      return { canRead: true, canEdit: true };
+      return { canRead: true, canEdit: auth.isUser() };
     default:
       assertNever(agentConfiguration.scope);
   }


### PR DESCRIPTION
Description
---
Note: this is minor and is not a vulnerability. We increase defense in depth so that users with role 'none' trying to edit a 'published' agent are stopped at API level (they were stopped at lib level before)

This makes the assert in lib and api checks consistent with each other. Temporary since 'published' scope will soon disappear.

Fixes [discussion](https://dust4ai.slack.com/archives/C05F84CFP0E/p1746100183740629)

Risk
---
none

Deploy
---
front
