### PR TITLE
Add opt-in metadata support for bigquery

### DIFF
--- a/connectors/migrations/db/migration_70.sql
+++ b/connectors/migrations/db/migration_70.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 02, 2025
+ALTER TABLE "bigquery_configurations"
+ADD COLUMN "useMetadataForDBML" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -11,6 +11,7 @@
     "start:worker": "tsx ./src/start_worker.ts",
     "test": "vitest",
     "test:ci": "vitest --reporter=junit --outputFile=junit.xml --watch=false",
+    "tsc": "tsc",
     "cli": "npx tsx src/admin/cli.ts",
     "initdb": "./admin/init_db.sh",
     "create-db-migration": "./create_db_migration_file.sh"

--- a/connectors/src/connectors/bigquery/index.ts
+++ b/connectors/src/connectors/bigquery/index.ts
@@ -82,7 +82,9 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
     }
 
     // We can create the connector.
-    const configBlob = {};
+    const configBlob = {
+      useMetadataForDBML: false,
+    };
     const connector = await ConnectorResource.makeNew(
       "bigquery",
       {

--- a/connectors/src/connectors/bigquery/index.ts
+++ b/connectors/src/connectors/bigquery/index.ts
@@ -382,12 +382,86 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
     return this.resume();
   }
 
-  async setConfigurationKey(): Promise<Result<void, Error>> {
-    throw new Error("Method setConfigurationKey not implemented.");
+  async setConfigurationKey({
+    configKey,
+    configValue,
+  }: {
+    configKey: "useMetadataForDBML";
+    configValue: string;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found (connectorId: ${this.connectorId})`)
+      );
+    }
+
+    switch (configKey) {
+      case "useMetadataForDBML": {
+        const connectorConfig = await BigQueryConfigurationModel.findOne({
+          where: {
+            connectorId: connector.id,
+          },
+        });
+        if (!connectorConfig) {
+          return new Err(
+            new Error(
+              `Connector configuration not found (connectorId: ${connector.id})`
+            )
+          );
+        }
+
+        await connectorConfig.update({
+          useMetadataForDBML: configValue === "true",
+        });
+
+        // Clean lastUpsertedAt for all remote tables to force a full sync with the appropriate tags
+        await RemoteTableModel.update(
+          {
+            lastUpsertedAt: null,
+          },
+          { where: { connectorId: connector.id } }
+        );
+
+        await launchBigQuerySyncWorkflow(connector.id);
+
+        return new Ok(void 0);
+      }
+    }
   }
 
-  async getConfigurationKey(): Promise<Result<string | null, Error>> {
-    throw new Error("Method getConfigurationKey not implemented.");
+  async getConfigurationKey({
+    configKey,
+  }: {
+    configKey: "useMetadataForDBML";
+  }): Promise<Result<string | null, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found (connectorId: ${this.connectorId})`)
+      );
+    }
+
+    switch (configKey) {
+      case "useMetadataForDBML": {
+        const connectorConfig = await BigQueryConfigurationModel.findOne({
+          where: {
+            connectorId: connector.id,
+          },
+        });
+        if (!connectorConfig) {
+          return new Err(
+            new Error(
+              `Connector configuration not found (connectorId: ${connector.id})`
+            )
+          );
+        }
+
+        return new Ok(connectorConfig.useMetadataForDBML.toString());
+      }
+      default:
+        return new Err(new Error(`Invalid config key ${configKey}`));
+    }
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/bigquery/lib/permissions.ts
+++ b/connectors/src/connectors/bigquery/lib/permissions.ts
@@ -116,6 +116,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
     const allTablesRes = await fetchTables({
       credentials,
       dataset: datasetName,
+      fetchTablesDescription: false,
     });
     if (allTablesRes.isErr()) {
       return new Err(allTablesRes.error);

--- a/connectors/src/connectors/bigquery/temporal/activities.ts
+++ b/connectors/src/connectors/bigquery/temporal/activities.ts
@@ -40,6 +40,7 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
     remoteDBTree: tree,
     mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
     connector,
+    tags: [],
   });
 
   await syncSucceeded(connectorId);

--- a/connectors/src/connectors/bigquery/temporal/activities.ts
+++ b/connectors/src/connectors/bigquery/temporal/activities.ts
@@ -13,6 +13,9 @@ import {
   isBigQueryWithLocationCredentials,
 } from "@connectors/types";
 
+// Must be kept in sync with the tag in core.
+const USE_METADATA_FOR_DBML_TAG = "bigquery:useMetadataForDBML";
+
 export async function syncBigQueryConnection(connectorId: ModelId) {
   const getConnectorAndCredentialsRes = await getConnectorAndCredentials({
     connectorId,
@@ -27,16 +30,6 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
 
   const { credentials, connector } = getConnectorAndCredentialsRes.value;
 
-  // BigQuery is read-only as we force the readonly scope when creating the client.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- BigQuery is read-only but leaving the call in case of copy-pasting later.
-  const readonlyConnectionCheck = isConnectionReadonly();
-
-  const treeRes = await fetchTree({ credentials });
-  if (treeRes.isErr()) {
-    throw treeRes.error;
-  }
-  const tree = treeRes.value;
-
   const connectorConfig = await BigQueryConfigurationModel.findOne({
     where: {
       connectorId: connector.id,
@@ -48,13 +41,26 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
     );
   }
 
+  // BigQuery is read-only as we force the readonly scope when creating the client.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- BigQuery is read-only but leaving the call in case of copy-pasting later.
+  const readonlyConnectionCheck = isConnectionReadonly();
+
   const useMetadataForDBML = connectorConfig.useMetadataForDBML;
+
+  const treeRes = await fetchTree({
+    credentials,
+    fetchTablesDescription: useMetadataForDBML,
+  });
+  if (treeRes.isErr()) {
+    throw treeRes.error;
+  }
+  const tree = treeRes.value;
 
   await sync({
     remoteDBTree: tree,
     mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
     connector,
-    tags: useMetadataForDBML ? ["bigquery:useMetadataForDBML"] : [],
+    tags: useMetadataForDBML ? [USE_METADATA_FOR_DBML_TAG] : [],
   });
 
   await syncSucceeded(connectorId);

--- a/connectors/src/connectors/salesforce/temporal/activities.ts
+++ b/connectors/src/connectors/salesforce/temporal/activities.ts
@@ -30,6 +30,7 @@ export async function syncSalesforceConnection(connectorId: ModelId) {
     // Only keep the table name in the remote table id.
     internalTableIdToRemoteTableId: (internalTableId: string) =>
       parseInternalId(internalTableId).tableName ?? internalTableId,
+    tags: [],
   });
 
   await syncSucceeded(connectorId);

--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -57,6 +57,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
     await sync({
       mimeTypes: INTERNAL_MIME_TYPES.SNOWFLAKE,
       connector,
+      tags: [],
     });
 
     // ... and we mark the connector as errored.
@@ -76,6 +77,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
       remoteDBTree: tree,
       mimeTypes: INTERNAL_MIME_TYPES.SNOWFLAKE,
       connector,
+      tags: [],
     });
 
     await syncSucceeded(connectorId);

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -774,6 +774,7 @@ export async function upsertDataSourceRemoteTable({
   parentId,
   title,
   mimeType,
+  tags,
 }: {
   dataSourceConfig: DataSourceConfig;
   tableId: string;
@@ -786,6 +787,7 @@ export async function upsertDataSourceRemoteTable({
   parentId: string | null;
   title: string;
   mimeType: string;
+  tags?: string[];
 }) {
   const localLogger = logger.child({ ...loggerArgs, tableId, tableName });
   const statsDTags = [
@@ -815,6 +817,7 @@ export async function upsertDataSourceRemoteTable({
     remote_database_secret_id: remoteDatabaseSecretId,
     title: safeSubstring(title, 0, MAX_TITLE_LENGTH),
     mime_type: mimeType,
+    tags: tags,
   };
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {

--- a/connectors/src/lib/models/bigquery.ts
+++ b/connectors/src/lib/models/bigquery.ts
@@ -7,6 +7,7 @@ import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model
 export class BigQueryConfigurationModel extends ConnectorBaseModel<BigQueryConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare useMetadataForDBML: boolean;
 }
 BigQueryConfigurationModel.init(
   {
@@ -19,6 +20,11 @@ BigQueryConfigurationModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    useMetadataForDBML: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/connectors/src/lib/remote_databases/activities.test.ts
+++ b/connectors/src/lib/remote_databases/activities.test.ts
@@ -80,6 +80,7 @@ describe("sync remote databases", async () => {
         remoteDBTree,
         connector: connector,
         mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+        tags: [],
       });
 
       const remoteDB = await RemoteDatabaseModel.findOne({
@@ -149,6 +150,7 @@ describe("sync remote databases", async () => {
         remoteDBTree,
         connector: connector,
         mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+        tags: [],
       });
 
       const remoteDatabase = await RemoteDatabaseModel.findOne({
@@ -251,6 +253,7 @@ describe("sync remote databases", async () => {
         connector: connector,
         mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
         internalTableIdToRemoteTableId,
+        tags: ["my-test-tag"],
       });
 
       const remoteTable = await RemoteTableModel.findOne({
@@ -277,6 +280,7 @@ describe("sync remote databases", async () => {
         parentId: "test-db.test-schema",
         title: "test-table",
         mimeType: INTERNAL_MIME_TYPES.BIGQUERY.TABLE,
+        tags: ["my-test-tag"],
       });
     }
   );
@@ -322,6 +326,7 @@ describe("sync remote databases", async () => {
         remoteDBTree,
         connector: connector,
         mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+        tags: [],
       });
 
       expect(deleteDataSourceFolder).toHaveBeenCalledWith({
@@ -364,6 +369,7 @@ describe("sync remote databases", async () => {
       remoteDBTree: undefined,
       connector: connector,
       mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+      tags: [],
     });
 
     expect(await RemoteDatabaseModel.count()).toEqual(0);
@@ -427,6 +433,7 @@ describe("sync remote databases", async () => {
         remoteDBTree,
         connector: connector,
         mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+        tags: ["my-test-tag"],
       });
 
       // Check database model
@@ -501,6 +508,7 @@ describe("sync remote databases", async () => {
         parentId: "test__DUST_DOT__db.test__DUST_DOT__schema",
         title: "test.table",
         mimeType: INTERNAL_MIME_TYPES.BIGQUERY.TABLE,
+        tags: ["my-test-tag"],
       });
     }
   );
@@ -568,6 +576,7 @@ describe("sync remote databases", async () => {
         connector: connector,
         mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
         internalTableIdToRemoteTableId,
+        tags: ["my-test-tag"],
       });
 
       expect(upsertDataSourceRemoteTable).toHaveBeenCalledWith({
@@ -585,6 +594,7 @@ describe("sync remote databases", async () => {
         parentId: "test-db.test-schema",
         title: "test-table",
         mimeType: INTERNAL_MIME_TYPES.BIGQUERY.TABLE,
+        tags: ["my-test-tag"],
       });
     }
   );

--- a/connectors/src/lib/remote_databases/activities.test.ts
+++ b/connectors/src/lib/remote_databases/activities.test.ts
@@ -56,7 +56,9 @@ describe("sync remote databases", async () => {
           dataSourceId: dataSourceConfig.dataSourceId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         },
-        {},
+        {
+          useMetadataForDBML: false,
+        },
         t
       );
 
@@ -120,7 +122,9 @@ describe("sync remote databases", async () => {
           dataSourceId: dataSourceConfig.dataSourceId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         },
-        {},
+        {
+          useMetadataForDBML: false,
+        },
         t
       );
 
@@ -199,7 +203,9 @@ describe("sync remote databases", async () => {
           dataSourceId: dataSourceConfig.dataSourceId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         },
-        {},
+        {
+          useMetadataForDBML: false,
+        },
         t
       );
 
@@ -302,7 +308,9 @@ describe("sync remote databases", async () => {
           dataSourceId: dataSourceConfig.dataSourceId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         },
-        {},
+        {
+          useMetadataForDBML: false,
+        },
         t
       );
 
@@ -361,7 +369,9 @@ describe("sync remote databases", async () => {
         dataSourceId: dataSourceConfig.dataSourceId,
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
       },
-      {},
+      {
+        useMetadataForDBML: false,
+      },
       t
     );
 
@@ -397,7 +407,9 @@ describe("sync remote databases", async () => {
           dataSourceId: dataSourceConfig.dataSourceId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         },
-        {},
+        {
+          useMetadataForDBML: false,
+        },
         t
       );
 
@@ -530,7 +542,9 @@ describe("sync remote databases", async () => {
           dataSourceId: dataSourceConfig.dataSourceId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         },
-        {},
+        {
+          useMetadataForDBML: false,
+        },
         t
       );
 

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -333,7 +333,7 @@ const createTableAndHierarchy = async ({
       tableName: tableInternalId,
       remoteDatabaseTableId: internalTableIdToRemoteTableId(tableInternalId),
       remoteDatabaseSecretId: connector.connectionId,
-      tableDescription: "",
+      tableDescription: table.description ?? "",
       parents: [tableInternalId, schemaInternalId, databaseInternalId],
       parentId: schemaInternalId,
       title: tableName,

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -240,6 +240,7 @@ const createTableAndHierarchy = async ({
   connector,
   mimeTypes,
   internalTableIdToRemoteTableId,
+  tags,
 }: {
   tableInternalId: string;
   table: RemoteDBTable;
@@ -252,6 +253,7 @@ const createTableAndHierarchy = async ({
     | typeof INTERNAL_MIME_TYPES.SNOWFLAKE
     | typeof INTERNAL_MIME_TYPES.SALESFORCE;
   internalTableIdToRemoteTableId: (internalTableId: string) => string;
+  tags: string[];
 }): Promise<{
   newDatabase: RemoteDatabaseModel | null;
   newSchema: RemoteSchemaModel | null;
@@ -336,6 +338,7 @@ const createTableAndHierarchy = async ({
       parentId: schemaInternalId,
       title: tableName,
       mimeType: mimeTypes.TABLE,
+      tags,
     });
   }
 
@@ -347,6 +350,7 @@ export async function sync({
   connector,
   mimeTypes,
   internalTableIdToRemoteTableId = (internalTableId: string) => internalTableId,
+  tags,
 }: {
   remoteDBTree?: RemoteDBTree;
   connector: ConnectorResource;
@@ -355,6 +359,7 @@ export async function sync({
     | typeof INTERNAL_MIME_TYPES.SNOWFLAKE
     | typeof INTERNAL_MIME_TYPES.SALESFORCE;
   internalTableIdToRemoteTableId?: (internalTableId: string) => string;
+  tags: string[];
 }) {
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
@@ -515,6 +520,7 @@ export async function sync({
             connector,
             mimeTypes,
             internalTableIdToRemoteTableId,
+            tags,
           });
           for (const usedInternalId of newTableUsedInternalIds) {
             usedInternalIds.add(usedInternalId);

--- a/connectors/src/lib/remote_databases/utils.ts
+++ b/connectors/src/lib/remote_databases/utils.ts
@@ -25,12 +25,16 @@ export const remoteDBSchemaCodec = t.type({
   database_name: t.string,
 });
 export type RemoteDBSchema = t.TypeOf<typeof remoteDBSchemaCodec>;
-
-export const remoteDBTableCodec = t.type({
-  name: t.string,
-  database_name: t.string,
-  schema_name: t.string,
-});
+export const remoteDBTableCodec = t.intersection([
+  t.type({
+    name: t.string,
+    database_name: t.string,
+    schema_name: t.string,
+  }),
+  t.partial({
+    description: t.string,
+  }),
+]);
 export type RemoteDBTable = t.TypeOf<typeof remoteDBTableCodec>;
 
 export type RemoteDBTree = {

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -114,9 +114,13 @@ pub async fn get_tables_schema(
                 .zip(schemas.iter())
                 .map(|(table, schema)| {
                     let table_id = table.table_id_for_dbml().replace("__DUST_DOT__", ".");
-                    schema
-                        .as_ref()
-                        .map(|s| s.render_dbml(&table_id, table.description()))
+                    schema.as_ref().map(|s| {
+                        s.render_dbml(
+                            &table_id,
+                            table.description(),
+                            remote_db.should_use_column_description(table),
+                        )
+                    })
                 })
                 .collect::<Vec<_>>();
 

--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -31,6 +31,9 @@ pub trait RemoteDatabase {
         query: &str,
     ) -> Result<(Vec<QueryResult>, TableSchema, String), QueryDatabaseError>;
     async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<Option<TableSchema>>>;
+    fn should_use_column_description(&self, _table: &Table) -> bool {
+        false
+    }
 }
 
 pub async fn get_remote_database(

--- a/core/src/databases/remote_databases/salesforce/salesforce.rs
+++ b/core/src/databases/remote_databases/salesforce/salesforce.rs
@@ -469,6 +469,7 @@ impl SalesforceRemoteDatabase {
                     value_type,
                     possible_values: possible_values.flatten(),
                     non_filterable: Some(!filterable),
+                    description: None,
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -70,6 +70,7 @@ impl TryFrom<SnowflakeSchemaColumn> for TableSchemaColumn {
             value_type: col_type,
             possible_values: None,
             non_filterable: None,
+            description: None,
         })
     }
 }

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -350,7 +350,7 @@ impl LocalTable {
 
         match self.table.schema {
             None => format!("Table {} {{\n}}", name),
-            Some(ref schema) => schema.render_dbml(name, self.table.description()),
+            Some(ref schema) => schema.render_dbml(name, self.table.description(), false),
         }
     }
 

--- a/front/components/data_source/BigQueryUseMetadataForDBMLView.tsx
+++ b/front/components/data_source/BigQueryUseMetadataForDBMLView.tsx
@@ -1,0 +1,87 @@
+import {
+  BigQueryLogo,
+  ContextItem,
+  SliderToggle,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { useConnectorConfig } from "@app/lib/swr/connectors";
+import type { APIError, DataSourceType, WorkspaceType } from "@app/types";
+
+export function BigQueryUseMetadataForDBMLView({
+  owner,
+  readOnly,
+  isAdmin,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+}) {
+  const { configValue, mutateConfig } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey: "useMetadataForDBML",
+  });
+  const useMetadataForDBML = configValue === "true";
+
+  const sendNotification = useSendNotification();
+  const [loading, setLoading] = useState(false);
+
+  const handleSetUseMetadataForDBML = async (useMetadataForDBML: boolean) => {
+    setLoading(true);
+    const res = await fetch(
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/useMetadataForDBML`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: JSON.stringify({ configValue: useMetadataForDBML.toString() }),
+      }
+    );
+    if (res.ok) {
+      await mutateConfig();
+      setLoading(false);
+    } else {
+      setLoading(false);
+      const err = (await res.json()) as { error: APIError };
+      sendNotification({
+        type: "error",
+        title: "Failed to enable BigQuery use metadata for DBML",
+        description: err.error.message,
+      });
+    }
+    return true;
+  };
+
+  return (
+    <ContextItem.List>
+      <ContextItem
+        title="Use descriptions"
+        visual={<ContextItem.Visual visual={BigQueryLogo} />}
+        action={
+          <div className="relative">
+            <SliderToggle
+              size="xs"
+              onClick={async () => {
+                await handleSetUseMetadataForDBML(!useMetadataForDBML);
+              }}
+              selected={useMetadataForDBML}
+              disabled={readOnly || !isAdmin || loading}
+            />
+          </div>
+        }
+      >
+        <ContextItem.Description>
+          <div className="text-muted-foreground dark:text-muted-foreground-night">
+            Your tables and columns description set in BigQuery will be used to
+            describe the schemas to Agents.
+          </div>
+        </ContextItem.Description>
+      </ContextItem>
+    </ContextItem.List>
+  );
+}

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -18,6 +18,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
+import { BigQueryUseMetadataForDBMLView } from "@app/components/data_source/BigQueryUseMetadataForDBMLView";
 import { GithubCodeEnableView } from "@app/components/data_source/GithubCodeEnableView";
 import { GongOptionComponent } from "@app/components/data_source/gong/GongOptionComponent";
 import { IntercomConfigView } from "@app/components/data_source/IntercomConfigView";
@@ -328,6 +329,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     getLogoComponent: () => {
       return BigQueryLogo;
     },
+    optionsComponent: BigQueryUseMetadataForDBMLView,
     isNested: true,
     guideLink: "https://docs.dust.tt/docs/bigquery",
     selectLabel: "Select tables",

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -74,13 +74,14 @@ async function handler(
     });
   }
 
-  // We only allow setting and retrieving `botEnabled` (Slack), `codeSyncEnabled` (GitHub),
+  // We only allow setting and retrieving `botEnabled` (Slack), `codeSyncEnabled` (GitHub), `useMetadataForDBML` (BigQuery),
   // `intercomConversationsNotesSyncEnabled` (Intercom), `zendeskSyncUnresolvedTicketsEnabled` and `zendeskHideCustomerDetails`.
   // This is mainly to prevent users from enabling other configs that are not released (e.g., google_drive `pdfEnabled`).
   if (
     ![
       "botEnabled",
       "codeSyncEnabled",
+      "useMetadataForDBML",
       "intercomConversationsNotesSyncEnabled",
       "zendeskSyncUnresolvedTicketsEnabled",
       "zendeskHideCustomerDetails",


### PR DESCRIPTION
## Description

Added the ability for an admin to leverage the descriptions set in bigquery in the schema that we expose to the model.
- Added UI in admin panel
- Support in connectors
- Support in core

## Tests

Updated

<img width="742" alt="image" src="https://github.com/user-attachments/assets/1437e535-8cd2-49d2-94e6-354a26e4c1e5" />
<img width="495" alt="image" src="https://github.com/user-attachments/assets/0af694e3-2716-445e-b2f6-38b39c5f1eef" />
<img width="494" alt="image" src="https://github.com/user-attachments/assets/c5a41984-7e52-4b6e-b929-b6f4b42ded30" />

## Risk

Low

## Deploy Plan

Apply migration 70 in connectors first, then deploy.