### PR TITLE
Bump `MAX_STEPS_USE_PER_RUN_LIMIT` from 12 to 24

### DIFF
--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -185,7 +185,7 @@ export function isTemplateAgentConfiguration(
 }
 
 export const DEFAULT_MAX_STEPS_USE_PER_RUN = 8;
-export const MAX_STEPS_USE_PER_RUN_LIMIT = 12;
+export const MAX_STEPS_USE_PER_RUN_LIMIT = 24;
 
 /**
  * Agent events


### PR DESCRIPTION
## Description

- This PR bumps the max number of steps per run from 12 to 24, keeping the default value of 8.
- Downsides: longer latency, potentially worse answers (also more costly).
- Upside: lets the builders tinker.

## Tests

- N/A

## Risk

- N/A

## Deploy Plan

- Deploy front.
