### PR TITLE
Fix payload parsing in poke plugins

### DIFF
--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -113,7 +113,10 @@ async function handler(
 
       // Convert fields to a plain object
       const formData = Object.fromEntries([
-        ...Object.entries(fields).map(([key, value]) => [key, value?.[0]]),
+        ...Object.entries(fields).map(([key, value]) => [
+          key,
+          Array.isArray(value) ? value?.[0] : value,
+        ]),
         ...Object.entries(files).map(([key, value]) => [key, value?.[0]]),
       ]);
       const pluginCodec = createIoTsCodecFromArgs(plugin.manifest.args);


### PR DESCRIPTION
## Description

- We currently cannot run the poke plugin for maintenance on connectors.
- This is a regression introduced in https://github.com/dust-tt/dust/pull/12394/files.
- This PR fixes that.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.