### PR TITLE
[front] Fix adding/removing tools permissions

### DIFF
--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -100,14 +100,17 @@ export const SpaceActionsList = ({
         id: "actions",
         cell: (info: CellContext<RowData, string>) => (
           <DataTable.MoreButton
-            menuItems={[
-              {
-                label: "Remove tools from space",
-                onClick: async () => onRemoveServer(info.row.original.id),
-                kind: "item",
-                disabled: !isAdmin && space.kind === "global",
-              },
-            ]}
+            menuItems={
+              isAdmin
+                ? [
+                    {
+                      label: "Remove tools from space",
+                      onClick: async () => onRemoveServer(info.row.original.id),
+                      kind: "item",
+                    },
+                  ]
+                : []
+            }
           />
         ),
         meta: {

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -217,10 +217,13 @@ export function useRemoveMCPServerViewFromSpace(owner: LightWorkspaceType) {
                 "Your actions have been removed from the space successfully.",
             });
           } else {
+            const res = await response.json();
             sendNotification({
               type: "error",
               title: "Failed to remove action",
-              description: `Could not remove actions from the space ${space.name}. Please try again.`,
+              description:
+                res.error?.message ||
+                `Could not remove actions from the space ${space.name}. Please try again.`,
             });
           }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -21,7 +21,7 @@ async function setupTest(
   role: "builder" | "user" | "admin" = "admin",
   method: RequestMethod = "DELETE"
 ) {
-  const { req, res, workspace } = await createPrivateApiMockRequest({
+  const { req, res, workspace, user } = await createPrivateApiMockRequest({
     role,
     method,
   });
@@ -32,7 +32,7 @@ async function setupTest(
   req.query.wId = workspace.sId;
   req.query.spaceId = space.sId;
 
-  return { req, res, workspace, space };
+  return { req, res, workspace, space, user };
 }
 
 describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
@@ -76,6 +76,55 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
 
     expect(deletedServerView).toBe(null);
   });
+
+  itInTransaction(
+    "should return 403 when user is not authorized to delete a server view",
+    async (t) => {
+      const { req, res, workspace, user } = await setupTest(
+        t,
+        "builder",
+        "DELETE"
+      );
+
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const regularSpace = await SpaceFactory.regular(workspace, t);
+      await regularSpace.groups[0].addMember(auth, user.toJSON(), {
+        transaction: t,
+      });
+
+      await FeatureFlagFactory.basic(
+        INTERNAL_MCP_SERVERS["authentication_debugger"]
+          .flag as WhitelistableFeature,
+        workspace
+      );
+
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        auth,
+        "authentication_debugger",
+        t
+      );
+
+      const serverView = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        regularSpace
+      );
+      req.query.svId = serverView.sId;
+      req.query.spaceId = regularSpace.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      const responseData = res._getJSONData();
+      expect(responseData).toHaveProperty("error");
+      expect(responseData.error).toHaveProperty("type", "mcp_auth_error");
+      expect(responseData.error).toHaveProperty(
+        "message",
+        "User is not authorized to remove tools from a space."
+      );
+    }
+  );
 
   itInTransaction(
     "should return 404 when server view doesn't exist",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -78,50 +78,6 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
   });
 
   itInTransaction(
-    "should return 403 when user is not authorized to delete a server view",
-    async (t) => {
-      const { req, res, workspace } = await setupTest(t, "admin", "DELETE");
-
-      const regularSpace = await SpaceFactory.regular(workspace, t);
-
-      const auth = await Authenticator.internalBuilderForWorkspace(
-        workspace.sId
-      );
-
-      await FeatureFlagFactory.basic(
-        INTERNAL_MCP_SERVERS["authentication_debugger"]
-          .flag as WhitelistableFeature,
-        workspace
-      );
-
-      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
-        auth,
-        "authentication_debugger",
-        t
-      );
-
-      const serverView = await MCPServerViewFactory.create(
-        workspace,
-        internalServer.id,
-        regularSpace
-      );
-      req.query.svId = serverView.sId;
-      req.query.spaceId = regularSpace.sId;
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(403);
-      const responseData = res._getJSONData();
-      expect(responseData).toHaveProperty("error");
-      expect(responseData.error).toHaveProperty("type", "mcp_auth_error");
-      expect(responseData.error).toHaveProperty(
-        "message",
-        "User is not authorized to remove tools from a space."
-      );
-    }
-  );
-
-  itInTransaction(
     "should return 404 when server view doesn't exist",
     async (t) => {
       const { req, res, workspace } = await setupTest(t, "admin", "DELETE");

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -84,7 +84,9 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
 
       const regularSpace = await SpaceFactory.regular(workspace, t);
 
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      const auth = await Authenticator.internalBuilderForWorkspace(
+        workspace.sId
+      );
 
       await FeatureFlagFactory.basic(
         INTERNAL_MCP_SERVERS["authentication_debugger"]

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -80,7 +80,7 @@ async function handler(
         });
       }
 
-      if (!space.canWrite(auth) && !auth.isAdmin()) {
+      if (!auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -80,7 +80,7 @@ async function handler(
         });
       }
 
-      if (!space.canWrite(auth)) {
+      if (!space.canWrite(auth) && !auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -67,6 +67,16 @@ async function handler(
 
       const { mcpServerId } = r.right;
 
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "mcp_auth_error",
+            message: "User is not authorized to add tools to a space.",
+          },
+        });
+      }
+
       const allowedSpaceKinds: SpaceKind[] = ["regular", "global"];
       if (!allowedSpaceKinds.includes(space.kind)) {
         return apiError(req, res, {

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import type { Transaction } from "sequelize";
 
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { WorkspaceType } from "@app/types";
 
@@ -30,13 +31,23 @@ export class SpaceFactory {
   }
 
   static async regular(workspace: WorkspaceType, t: Transaction) {
+    const name = "space " + faker.string.alphanumeric(8);
+    const group = await GroupResource.makeNew(
+      {
+        name: `Group for space ${name}`,
+        workspaceId: workspace.id,
+        kind: "regular",
+      },
+      { transaction: t }
+    );
+
     return SpaceResource.makeNew(
       {
-        name: "space " + faker.string.alphanumeric(8),
+        name,
         kind: "regular",
         workspaceId: workspace.id,
       },
-      [], // TODO: Add groups
+      [group],
       t
     );
   }


### PR DESCRIPTION
## Description

- Only admin should be able to remove a tool from a space (the ui is currently failing when they try and if they are not member)
- Only admin should be able to add a tool to a space (other users can only request)
- improved error message


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
