### PR TITLE
fix errors in Gemini with overly long tool names 

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -65,6 +65,10 @@ const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes.
 
 const EMPTY_INPUT_SCHEMA: JSONSchema7 = { type: "object", properties: {} };
 
+const MAX_TOOL_NAME_LENGTH = 64;
+
+const TOOL_NAME_SEPARATOR = "___";
+
 function makePlatformMCPToolConfigurations(
   config: PlatformMCPServerConfigurationType,
   tools: PlatformMCPToolTypeWithStakeLevel[]
@@ -235,18 +239,19 @@ function getPrefixedToolName(
 ): string {
   const slugifiedConfigName = slugify(config.name);
   const slugifiedOriginalName = slugify(originalName);
-  const separator = "___";
-  const MAX_SIZE = 64;
 
-  const prefixedName = `${slugifiedConfigName}${separator}${slugifiedOriginalName}`;
+  const prefixedName = `${slugifiedConfigName}${TOOL_NAME_SEPARATOR}${slugifiedOriginalName}`;
 
   // If the prefixed name is too long, we try to shorten the config name
-  if (prefixedName.length >= MAX_SIZE) {
+  if (prefixedName.length >= MAX_TOOL_NAME_LENGTH) {
     const maxLength =
-      MAX_SIZE - separator.length - slugifiedOriginalName.length - 1;
+      MAX_TOOL_NAME_LENGTH -
+      TOOL_NAME_SEPARATOR.length -
+      slugifiedOriginalName.length -
+      1;
     // with a minimum of 4 characters.
     if (maxLength > 4) {
-      return `${slugifiedConfigName.slice(0, maxLength)}${separator}${slugifiedOriginalName}`;
+      return `${slugifiedConfigName.slice(0, maxLength)}${TOOL_NAME_SEPARATOR}${slugifiedOriginalName}`;
     } else {
       // Otherwise, we just use the original name.
       return slugifiedOriginalName;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -54,11 +54,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { findMatchingSubSchemas } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { assertNever, Err, normalizeError, Ok, slugify } from "@app/types";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 
 const MAX_OUTPUT_ITEMS = 128;
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -242,20 +242,9 @@ function getPrefixedToolName(
 
   const prefixedName = `${slugifiedConfigName}${TOOL_NAME_SEPARATOR}${slugifiedOriginalName}`;
 
-  // If the prefixed name is too long, we try to shorten the config name
+  // If the prefixed name is too long, we return the unprefixed original name directly.
   if (prefixedName.length >= MAX_TOOL_NAME_LENGTH) {
-    const maxLength =
-      MAX_TOOL_NAME_LENGTH -
-      TOOL_NAME_SEPARATOR.length -
-      slugifiedOriginalName.length -
-      1;
-    // with a minimum of 4 characters.
-    if (maxLength > 4) {
-      return `${slugifiedConfigName.slice(0, maxLength)}${TOOL_NAME_SEPARATOR}${slugifiedOriginalName}`;
-    } else {
-      // Otherwise, we just use the original name.
-      return slugifiedOriginalName;
-    }
+    return slugifiedOriginalName;
   }
 
   return prefixedName;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -241,9 +241,9 @@ function getPrefixedToolName(
   const prefixedName = `${slugifiedConfigName}${separator}${slugifiedOriginalName}`;
 
   // If the prefixed name is too long, we try to shorten the config name
-  if (prefixedName.length > MAX_SIZE) {
+  if (prefixedName.length >= MAX_SIZE) {
     const maxLength =
-      MAX_SIZE - separator.length - slugifiedOriginalName.length;
+      MAX_SIZE - separator.length - slugifiedOriginalName.length - 1;
     // with a minimum of 4 characters.
     if (maxLength > 4) {
       return `${slugifiedConfigName.slice(0, maxLength)}${separator}${slugifiedOriginalName}`;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -348,15 +348,18 @@ export async function tryListMCPTools(
       const tools = [];
 
       for (const toolConfig of toolConfigurations) {
-        const prefixedName = getPrefixedToolName(action, toolConfig.name);
-        if (prefixedName.isErr()) {
-          return new Err(prefixedName.error);
+        const toolName = getPrefixedToolName(action, toolConfig.name);
+        // If we fail here we fail for the entire action because the tool potentially interact
+        // so we end up with a weird state if some of them are added and some are not.
+        // It's more principled to reject the action altogether in this case.
+        if (toolName.isErr()) {
+          return new Err(toolName.error);
         }
         tools.push({
           ...toolConfig,
           originalName: toolConfig.name,
           mcpServerName: action.name,
-          name: prefixedName.value,
+          name: toolName.value,
           description: toolConfig.description + extraDescription,
         });
       }


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/2771.
- Gemini's API does not support tool names with a length longer or equal to 64 characters.
- This PR addresses this issue by checking the length appropriately.
- This PR also refactors this small part in various ways and changes the logic for names that end up being too long by returning the tool name directly instead of prefixing it with the server name + ID.
- A more advanced error handling is added to handle tool names that would be too long in a generic manner.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.