### PR TITLE
Reduce query size in Google Drive GC production check

### DIFF
--- a/front/lib/production_checks/managed_ds.ts
+++ b/front/lib/production_checks/managed_ds.ts
@@ -12,7 +12,7 @@ export type CoreDSDocument = {
   document_id: string;
 };
 
-const CORE_DOCUMENT_BATCH_SIZE = 5000;
+const CORE_DOCUMENT_BATCH_SIZE = 1000;
 
 export async function getCoreDocuments(
   frontDataSourceId: number


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/12378.
- We still get `canceling statement due to conflict with recovery` errors in the production check for Google Drive GC.
- This PR lowers the batch size of the select from 5k to 1k.
- Note: the `max_standby_streaming_delay` seems to be set to 20 minutes.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.