### PR TITLE
[front] fix: Block mentioning agent whom you don't have access to

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1098,7 +1098,7 @@ function canAccessAgent(
   return (
     agentConfiguration.canRead &&
     (agentConfiguration.status === "active" ||
-      agentConfiguration.status !== "draft")
+      agentConfiguration.status === "draft")
   );
 }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1095,7 +1095,7 @@ async function canAccessAgent(
   auth: Authenticator,
   agentConfiguration: LightAgentConfigurationType
 ): Promise<boolean> {
-  if (auth.isAdmin()) {
+  if (auth.isAdmin() || agentConfiguration.status === "draft") {
     return true;
   }
 
@@ -1105,17 +1105,17 @@ async function canAccessAgent(
   }
 
   if (agentConfiguration.scope === "private") {
-    const group = await GroupResource.fetchByAgentConfiguration(
-      auth,
-      agentConfiguration
-    );
-    return group.isMember(auth);
+    if (agentConfiguration.status === "active") {
+      const group = await GroupResource.fetchByAgentConfiguration(
+        auth,
+        agentConfiguration
+      );
+      return group.isMember(auth);
+    }
+    return false;
   }
 
-  return (
-    agentConfiguration.status === "active" ||
-    agentConfiguration.status === "draft"
-  );
+  return agentConfiguration.status === "active";
 }
 
 /** This method creates a new user message version, and if there are new agent

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1104,7 +1104,7 @@ async function canAccessAgent(
     return agentConfiguration.status === "active";
   }
 
-  if (agentConfiguration.scope === "private") {
+  if (agentConfiguration.scope === "hidden") {
     if (agentConfiguration.status === "active") {
       const group = await GroupResource.fetchByAgentConfiguration(
         auth,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1095,11 +1095,18 @@ export async function* postUserMessage(
 function canAccessAgent(
   agentConfiguration: LightAgentConfigurationType
 ): boolean {
-  return (
-    agentConfiguration.canRead &&
-    (agentConfiguration.status === "active" ||
-      agentConfiguration.status === "draft")
-  );
+  switch (agentConfiguration.status) {
+    case "active":
+    case "draft":
+      return agentConfiguration.canRead;
+    case "disabled_free_workspace":
+    case "disabled_missing_datasource":
+    case "disabled_by_admin":
+    case "archived":
+      return false;
+    default:
+      assertNever(agentConfiguration.status);
+  }
 }
 
 /** This method creates a new user message version, and if there are new agent

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -757,6 +757,7 @@ export async function* postUserMessage(
             "This agent is either disabled or you don't have access to it.",
         },
       };
+      return;
     }
 
     if (!isProviderWhitelisted(owner, agentConfig.model.providerId)) {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -422,10 +422,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async fetchByAgentConfiguration(
     auth: Authenticator,
-    agentConfiguration:
-      | AgentConfiguration
-      | AgentConfigurationType
-      | LightAgentConfigurationType
+    agentConfiguration: AgentConfiguration | AgentConfigurationType
   ): Promise<GroupResource> {
     const workspace = auth.getNonNullableWorkspace();
     const groupAgents = await GroupAgentModel.findAll({

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -422,7 +422,10 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async fetchByAgentConfiguration(
     auth: Authenticator,
-    agentConfiguration: AgentConfiguration | AgentConfigurationType
+    agentConfiguration:
+      | AgentConfiguration
+      | AgentConfigurationType
+      | LightAgentConfigurationType
   ): Promise<GroupResource> {
     const workspace = auth.getNonNullableWorkspace();
     const groupAgents = await GroupAgentModel.findAll({


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/dust/issues/12285
- Check if current user can mention the agent, won't be able to if agent is:
  - global disabled
  - hidden and you're not an editors
- If agent config is a draft or you're an admin you can still mention them.
In a shared conversation where an agent is hidden but you can still its message, it still won't allow mentioning it to be on part with what the agent-autocomplete show.

## Tests
Locally test:
- via API to mention a disabled global agent by editing first message, block ✅
- via API to mention a hidden agent that I don't own, by editing first message, block ✅
- via API to mention a hidden agent that I own, by editing first message, pass ✅
- Have a visible agent, share a conversation to a lower permission user, then hide the agent.
  - mentioning agent via UI is block ✅
  - mentioning agent via API is block ✅
- Duplicating a hidden agent via manual sId copy, duplicated agent is not blocked ✅

## Risk
- Block too much message, or unforseen edge case. Easy to rollback though.
- Not sure about if you can duplicate an agent you don't have access to and then chatting with it in draft mode?

## Deploy Plan
- Deploy front
- Re-test on prod on our workspace
