### PR TITLE
feat: CLI to reprocess all notion orphaned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ qdrant_storage
 core-api-keys.json
 oauth-api-keys.json
 /extension/build/
+**/.claude/settings.local.json
+CLAUDE.md

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -674,6 +674,32 @@ export const notion = async ({
       return { success: true };
     }
 
+    case "update-all-orphaned-resources-parents": {
+      const connectors = await ConnectorModel.findAll({
+        where: {
+          type: "notion",
+          errorType: null,
+          pausedAt: null,
+        },
+      });
+
+      logger.info(
+        {
+          connectorsCount: connectors.length,
+        },
+        "[Admin] Starting workflows to update orphaned resources parents for all active notion connectors"
+      );
+
+      for (const connector of connectors) {
+        logger.info(
+          { connectorId: connector.id },
+          "[Admin] Starting update orphaned resources parents workflow"
+        );
+        await launchUpdateOrphanedResourcesParentsWorkflow(connector.id);
+      }
+      return { success: true };
+    }
+
     default:
       throw new Error("Unknown notion command: " + command);
   }

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -102,7 +102,6 @@ export const NotionCommandSchema = t.type({
     t.literal("update-parents-fields"),
     t.literal("clear-parents-last-updated-at"),
     t.literal("update-orphaned-resources-parents"),
-    t.literal("update-all-orphaned-resources-parents"),
   ]),
   args: t.record(
     t.string,

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -102,6 +102,7 @@ export const NotionCommandSchema = t.type({
     t.literal("update-parents-fields"),
     t.literal("clear-parents-last-updated-at"),
     t.literal("update-orphaned-resources-parents"),
+    t.literal("update-all-orphaned-resources-parents"),
   ]),
   args: t.record(
     t.string,


### PR DESCRIPTION
## Description

Adds a command to the notion connector CLI that triggers the `updateOrphanedResourcesParentsWorkflow` temporal workflow for all active Notion connectors.

The goal is to attempt to fix all the resources that have been put in orphaned at some point but no longer are and haven't been re-processed

## Tests

manual


## Risk

Hitting notion rate limits

## Deploy Plan

Deploy changes and run the command from a `connectors` pod in EU and US