### PR TITLE
Handle pagination in script to batch add Slack channels to global space

### DIFF
--- a/front/migrations/20250502_batch_add_to_company_space.ts
+++ b/front/migrations/20250502_batch_add_to_company_space.ts
@@ -24,6 +24,7 @@ async function getParentsToAdd({
 
   let nextPageCursor;
   const allNodes = [];
+  let nodes;
 
   do {
     const searchResult = await coreApi.searchNodes({
@@ -44,7 +45,7 @@ async function getParentsToAdd({
       throw searchResult.error;
     }
 
-    const { nodes, next_page_cursor } = searchResult.value;
+    nodes = searchResult.value.nodes;
 
     if (execute) {
       logger.info(`Found ${nodes.length} parents to add.`);
@@ -56,8 +57,8 @@ async function getParentsToAdd({
     }
 
     allNodes.push(...nodes);
-    nextPageCursor = next_page_cursor;
-  } while (nextPageCursor && allNodes.length === BATCH_SIZE);
+    nextPageCursor = searchResult.value.next_page_cursor;
+  } while (nextPageCursor && nodes.length === BATCH_SIZE);
 
   return allNodes.map((node) => node.node_id);
 }


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/12424.
- In my example I have > 1000 channels to add, the `nodes/search` endpoint only supports pages up to 1000 elements.
- This PR paginates the call until we get all the nodes.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- No deploy.
