### PR TITLE
[front] Add `setupSuffix` to data source display name

### DIFF
--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -21,7 +21,7 @@ function getSetupSuffixForDataSource(
   dataSource: DataSourceType
 ): string | null {
   const match = dataSource.name.match(
-    `/managed-${dataSource.connectorProvider}+-(.*)/`
+    new RegExp(`managed\\-${dataSource.connectorProvider}\\-(.*)`)
   );
   if (!match || match.length < 2) {
     return null;

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -17,10 +17,28 @@ export function getDisplayNameForDocument(document: CoreAPIDocument): string {
   return titleTag.substring(titleTagPrefix.length);
 }
 
+function getSetupSuffixForDataSource(
+  dataSource: DataSourceType
+): string | null {
+  const match = dataSource.name.match(
+    `/managed-${dataSource.connectorProvider}+-(.*)/`
+  );
+  if (!match || match.length < 2) {
+    return null;
+  }
+  return match[1];
+}
+
 export function getDisplayNameForDataSource(ds: DataSourceType) {
   if (ds.connectorProvider) {
     if (ds.connectorProvider === "webcrawler") {
       return ds.name;
+    }
+    // Not very satisfying to retro-engineer getDefaultDataSourceName but we don't store the suffix by itself.
+    // This is a technical debt to have this function.
+    const suffix = getSetupSuffixForDataSource(ds);
+    if (suffix) {
+      return `${CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name} (${suffix})`;
     }
     return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
   } else {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2802.
- This PR adds the suffix used in the `setupWithSuffix` procedure to the display name of a data source, which is visible at various locations in the product, namely in Connection Admin.

## Tests

- Tested locally.

## Risk

- Will change it at various locations.

## Deploy Plan

- Deploy front.
