### PR TITLE
[sparkle] Fix focus trap 

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.489",
+  "version": "0.2.490",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.489",
+      "version": "0.2.490",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.489",
+  "version": "0.2.490",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -224,6 +224,7 @@ interface DropdownMenuContentProps
   mountPortal?: boolean;
   mountPortalContainer?: HTMLElement;
   dropdownHeaders?: React.ReactNode;
+  onOpenAutoFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
 }
 
 const DropdownMenuContent = React.forwardRef<

--- a/sparkle/src/components/SearchDropdownMenu.tsx
+++ b/sparkle/src/components/SearchDropdownMenu.tsx
@@ -54,9 +54,6 @@ export function SearchDropdownMenu({
           onChange={(value) => {
             setSearchInputValue(value);
             setIsOpen(value.length >= minLengthToOpen);
-            setTimeout(() => {
-              searchInputRef.current?.focus();
-            }, 0);
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
@@ -82,6 +79,9 @@ export function SearchDropdownMenu({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+        }}
         side="bottom"
         align="start"
         className="s-w-[--radix-popper-anchor-width]"


### PR DESCRIPTION
## Description

Use the onOpenAutoFocus prop from radix to prevent taking focus on open, so that we can continue typing in input

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
