### PR TITLE
[Discovery] Fix: draft agents don't have an editor group

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -963,6 +963,11 @@ export async function createAgentConfiguration(
             auth,
             existingAgent
           );
+          if (!group) {
+            throw new Error(
+              "Unexpected: agent should have exactly one editor group."
+            );
+          }
           const result = await group.addGroupToAgentConfiguration({
             auth,
             agentConfiguration: agentConfigurationInstance,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -423,7 +423,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   static async fetchByAgentConfiguration(
     auth: Authenticator,
     agentConfiguration: AgentConfiguration | AgentConfigurationType
-  ): Promise<GroupResource> {
+  ): Promise<GroupResource | null> {
     const workspace = auth.getNonNullableWorkspace();
     const groupAgents = await GroupAgentModel.findAll({
       where: {
@@ -441,6 +441,15 @@ export class GroupResource extends BaseResource<GroupModel> {
         },
       ],
     });
+
+    if (agentConfiguration.status === "draft") {
+      if (groupAgents.length === 0) {
+        return null;
+      }
+      throw new Error(
+        "Unexpected: draft agent shouldn't have an editor group."
+      );
+    }
 
     if (groupAgents.length !== 1) {
       throw new Error(

--- a/front/migrations/20250505_delete_group_draft_agents.ts
+++ b/front/migrations/20250505_delete_group_draft_agents.ts
@@ -36,8 +36,11 @@ makeScript({}, async ({ execute }, logger) => {
         return;
       }
       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-      if (group && execute) {
-        await group.delete(auth);
+      if (group) {
+        logger.info({ groupName: group.name, id: group.id }, "Deleting");
+        if (execute) {
+          await group.delete(auth);
+        }
       }
     },
     {

--- a/front/migrations/20250505_delete_group_draft_agents.ts
+++ b/front/migrations/20250505_delete_group_draft_agents.ts
@@ -1,0 +1,47 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { GroupAgentModel } from "@app/lib/models/assistant/group_agent";
+import { Workspace } from "@app/lib/models/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  // get all ids of groups associated with draft agents
+  const groups = await GroupAgentModel.findAll({
+    attributes: ["groupId"],
+    include: [
+      {
+        model: AgentConfiguration,
+        where: {
+          scope: "draft",
+        },
+        required: true,
+      },
+    ],
+  });
+
+  logger.info(`Found ${groups.length} groups associated with draft agents`);
+  await concurrentExecutor(
+    groups,
+    async (groupModel) => {
+      const group = await GroupResource.fetchByModelId(groupModel.id);
+      const workspace = await Workspace.findOne({
+        where: {
+          id: group?.workspaceId,
+        },
+      });
+      if (!workspace) {
+        logger.error(`Workspace not found for group ${groupModel.id}`);
+        return;
+      }
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      if (group && execute) {
+        await group.delete(auth);
+      }
+    },
+    {
+      concurrency: 4,
+    }
+  );
+});

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -96,7 +96,11 @@ async function handler(
       // This won't stay long since Agent Discovery initiative removes the scope
       // endpoint.
       const group = await GroupResource.fetchByAgentConfiguration(auth, agent);
-
+      if (!group) {
+        throw new Error(
+          "Unexpected: agent should have exactly one editor group."
+        );
+      }
       const editors = await group.getActiveMembers(auth);
 
       // Cast the assistant to ensure TypeScript understands the correct types.

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -409,7 +409,9 @@ export async function deleteAgentsActivity({
     });
 
     const group = await GroupResource.fetchByAgentConfiguration(auth, agent);
-    await group.delete(auth);
+    if (group) {
+      await group.delete(auth);
+    }
 
     hardDeleteLogger.info({ agentId: agent.sId }, "Deleting agent");
     await agent.destroy();


### PR DESCRIPTION
Fixes https://dust4ai.slack.com/archives/C05F84CFP0E/p1746459342810589

Description
---
An assert ensures agents have exactly one editor group. But draft agents shouldn't have any.

The PR updates logic + adds migration to delete any draft agent editor group from early development

Risks
---
high on migration since deleting agents on all config:
- 2 reviewers
- will run dry first and confirm count matches what I found on metabase

Deploy
---
run migration
front

