### PR TITLE
Remove unnecessary uses of `useMemo`

### DIFF
--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -62,7 +62,7 @@ export function useAssistantTemplate({
   );
 
   return {
-    assistantTemplate: useMemo(() => (data ? data : null), [data]),
+    assistantTemplate: data ? data : null,
     isAssistantTemplateLoading: !error && !data,
     isAssistantTemplateError: error,
     mutateAssistantTemplate: mutate,
@@ -169,10 +169,8 @@ export function useSuggestedAgentConfigurations({
   const dataToUse = cachedData || data;
 
   return {
-    suggestedAgentConfigurations: useMemo(
-      () => (dataToUse ? dataToUse.agentConfigurations : []),
-      [dataToUse]
-    ),
+    suggestedAgentConfigurations:
+      dataToUse?.agentConfigurations ?? emptyArray(),
     isSuggestedAgentConfigurationsLoading: !error && !dataToUse,
     isSuggestedAgentConfigurationsError: error,
     mutate,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -250,7 +250,7 @@ export function useDataSourceViewSearchTags({
   );
 
   return {
-    tags: useMemo(() => data?.tags || [], [data]),
+    tags: data?.tags ?? emptyArray(),
     isLoading,
     isError: !!error,
     mutate,

--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -23,7 +22,7 @@ export function useDataSourceUsage({
   );
 
   return {
-    usage: useMemo(() => (data ? data.usage : null), [data]),
+    usage: data?.usage ?? null,
     isUsageLoading: !error && !data,
     isUsageError: error,
     mutate,

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -1,8 +1,8 @@
 import { useSendNotification } from "@dust-tt/sparkle";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetAgentEditorsResponseBody,
   PatchAgentEditorsRequestBody,
@@ -33,7 +33,7 @@ export function useEditors({
   );
 
   return {
-    editors: useMemo(() => (data ? data.editors : []), [data]),
+    editors: data?.editors ?? emptyArray(),
     isEditorsLoading: !error && !data && !disabled,
     isEditorsError: !!error,
     mutateEditors: mutate,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1,5 +1,5 @@
 import { useSendNotification } from "@dust-tt/sparkle";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
@@ -173,13 +173,8 @@ export function useSpaceDataSourceViews({
       { disabled }
     );
 
-  const spaceDataSourceViews = useMemo(() => {
-    return (data?.dataSourceViews ??
-      []) as GetSpaceDataSourceViewsResponseBody<false>["dataSourceViews"];
-  }, [data]);
-
   return {
-    spaceDataSourceViews,
+    spaceDataSourceViews: data?.dataSourceViews ?? emptyArray(),
     mutate,
     mutateRegardlessOfQueryParams,
     isSpaceDataSourceViewsLoading: !disabled && !error && !data,
@@ -215,13 +210,8 @@ export function useSpaceDataSourceViewsWithDetails({
       { disabled }
     );
 
-  const spaceDataSourceViews = useMemo(() => {
-    return (data?.dataSourceViews ??
-      []) as GetSpaceDataSourceViewsResponseBody<true>["dataSourceViews"];
-  }, [data]);
-
   return {
-    spaceDataSourceViews,
+    spaceDataSourceViews: data?.dataSourceViews ?? emptyArray(),
     mutate,
     mutateRegardlessOfQueryParams,
     isSpaceDataSourceViewsLoading: !error && !data && !disabled,
@@ -680,7 +670,7 @@ export function useSpaceSearch({
   );
 
   return {
-    searchResultNodes: useMemo(() => data?.nodes ?? [], [data]),
+    searchResultNodes: data?.nodes ?? emptyArray(),
     total: data?.total ?? 0,
     isSearchLoading: isLoading,
     isSearchError: error,
@@ -778,7 +768,7 @@ export function useSpacesSearch({
   );
 
   return {
-    searchResultNodes: useMemo(() => data?.nodes ?? [], [data]),
+    searchResultNodes: data?.nodes ?? emptyArray(),
     isSearchLoading: isLoading,
     isSearchError: error,
     mutate,
@@ -853,10 +843,9 @@ export function useSpacesSearchWithInfiniteScroll({
     );
 
   return {
-    searchResultNodes: useMemo(
-      () => (data ? data.flatMap((d) => (d ? d.nodes : [])) : []),
-      [data]
-    ),
+    searchResultNodes: data
+      ? data.flatMap((d) => (d ? d.nodes : []))
+      : emptyArray(),
     isSearchLoading: isLoading,
     isSearchError: error,
     isSearchValidating: isValidating,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1,5 +1,5 @@
 import { useSendNotification } from "@dust-tt/sparkle";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
@@ -843,9 +843,10 @@ export function useSpacesSearchWithInfiniteScroll({
     );
 
   return {
-    searchResultNodes: data
-      ? data.flatMap((d) => (d ? d.nodes : []))
-      : emptyArray(),
+    searchResultNodes: useMemo(
+      () => (data ? data.flatMap((d) => (d ? d.nodes : [])) : []),
+      [data]
+    ),
     isSearchLoading: isLoading,
     isSearchError: error,
     isSearchValidating: isValidating,

--- a/front/lib/swr/useAppStatus.ts
+++ b/front/lib/swr/useAppStatus.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -13,7 +12,7 @@ export function useAppStatus() {
   );
 
   return {
-    appStatus: useMemo(() => (data ? data : null), [data]),
+    appStatus: data ? data : null,
     isAppStatusLoading: !error && !data,
     isAppStatusError: !!error,
   };


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/12370.
- This PR remove some `useMemo` that were used to cache an empty array.

## Tests

- Tested locally but not perfectly exhaustive.

## Risk

- Low.

## Deploy Plan

- Deploy front.
