### PR TITLE
Improve handling of invalid Unicode characters in tool inputs

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -406,7 +406,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
           messageId: agentMessage.sId,
           error: {
             code: "tool_error",
-            message: `Invalid Unicode character in inputs, please retry.`,
+            message: "Invalid Unicode character in inputs, please retry.",
           },
         };
         return;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -69,6 +69,7 @@ import type {
 import {
   assertNever,
   extensionsForContentType,
+  hasNullUnicodeCharacter,
   isSupportedFileContentType,
   Ok,
   removeNulls,
@@ -395,6 +396,22 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       params: rawInputs,
       step,
     };
+
+    for (const value of Object.values(rawInputs)) {
+      if (typeof value === "string" && hasNullUnicodeCharacter(value)) {
+        yield {
+          type: "tool_error",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: "tool_error",
+            message: `Invalid Unicode character in inputs, please retry.`,
+          },
+        };
+        return;
+      }
+    }
 
     // Create the action object in the database and yield an event for
     // the generation of the params. We store the action here as the params have been generated, if

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -109,6 +109,11 @@ export function stripNullBytes(text: string): string {
   return text.replace(/\0/g, "");
 }
 
+// Checks for an escped null Unicode character.
+export function hasNullUnicodeCharacter(text: string): boolean {
+  return text.includes("\u0000");
+}
+
 export function asDisplayName(name?: string | null) {
   if (!name) {
     return "";


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2793.
- We've observed an issue with o4-mini and the MCP version of websearch where the model would include invalid Unicode characters in the tool inputs, which would make the `AgentMCPAction.create` crash.
- We cannot recreate the original string even when re-encoding with Buffer.from and Buffer.to given that the input contains extra invalid characters.
- We cannot surface a success to the agent, prompting it to retry because we cannot save the action in db.
- This PR improves the error handling by returning a more readable error.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
