### PR TITLE
Fix user message layout when very big line

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -48,8 +48,8 @@ export function UserMessage({
   );
 
   return (
-    <div className="flex w-full flex-col">
-      <div className="flex flex-col items-end gap-6">
+    <div className="flex flex-grow flex-col">
+      <div className="max-w-full self-end">
         <ConversationMessage
           pictureUrl={message.user?.image || message.context.profilePictureUrl}
           name={message.context.fullName ?? undefined}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/2796
(open the convo on the card to see the broken layout). 

It was fixed by adding `max-w-full` to wrap `ConversationMessage`.

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 