### PR TITLE
[front] fix(tags): Fix tags usage filter and improve security

### DIFF
--- a/front/components/assistant/TagsFilterMenu.tsx
+++ b/front/components/assistant/TagsFilterMenu.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type { WorkspaceType } from "@app/types";
+import { isAdmin } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
 import { TagsManager } from "./TagsManager";
@@ -70,14 +71,16 @@ export const TagsFilterMenu = ({
               value={tagSearch}
               onChange={setTagSearch}
               button={
-                <Button
-                  variant="primary"
-                  label="Manage tags"
-                  onClick={() => {
-                    setDropdownOpen(false);
-                    setTagManagerOpen(true);
-                  }}
-                />
+                isAdmin(owner) ? (
+                  <Button
+                    variant="primary"
+                    label="Manage tags"
+                    onClick={() => {
+                      setDropdownOpen(false);
+                      setTagManagerOpen(true);
+                    }}
+                  />
+                ) : undefined
               }
             />
           }

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -136,7 +136,7 @@ export class TagResource extends BaseResource<TagModel> {
               SELECT COUNT(DISTINCT ac."sId")
               FROM tag_agents ta
               JOIN agent_configurations ac ON ac.id = ta."agentConfigurationId" 
-              WHERE ta."tagId" = tags.id
+              WHERE ta."tagId" = tags.id AND ac.status = 'active'
             )
           `),
           "usage",

--- a/front/pages/api/w/[wId]/tags/usage/index.ts
+++ b/front/pages/api/w/[wId]/tags/usage/index.ts
@@ -20,6 +20,16 @@ async function handler(
 
   switch (method) {
     case "GET": {
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Only workspace administrators can see tags usage",
+          },
+        });
+      }
+
       const tagsWithUsage = await TagResource.findAllWithUsage(auth);
 
       return res.status(200).json({


### PR DESCRIPTION
## Description
- Add missing filter by `agent_configurations.status = 'active'`, was getting usage on agent that were archived or else.
- Don't allow access to `/tags/usage` if not an admin
- Hide `Manage tags` if user is not admin

## Tests
- Locally test

## Risk
- Could include more usage that necessary (but no extra information)

## Deploy Plan
- Deploy front
- Re-test live
