### PR TITLE
Increase backoff on Confluence activity retries

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -47,8 +47,8 @@ const {
   startToCloseTimeout: "30 minutes",
   retry: {
     initialInterval: "60 seconds",
-    backoffCoefficient: 2,
-    maximumInterval: "3600 seconds",
+    backoffCoefficient: 4,
+    maximumInterval: "5400 seconds",
   },
 });
 


### PR DESCRIPTION
## Description

- This PR increases the backoff ratio from 2 to 4 and the maximum interval.
- The rationale here is that when we get rate limited there is no need to retry the activity quickly, there is often a large waiting time. Keeping the initial value but backing off quickly allows to target rate-limited activities and normally retry other ones.
- The maximum interval is increased: the idea here is that we usually get a retry-after of 1 hour so we're aiming at waiting a bit more than that here.

## Tests

## Risk

- Low, will be monitored to see the behavior.

## Deploy Plan

- Deploy connectors.
