### PR TITLE
[front] Add endpoint to create initial tags suggestions

### DIFF
--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -304,7 +304,7 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "assistant-builder-initial-tags-suggestions": {
+  "tag-manager-initial-suggestions": {
     app: {
       appId: "Huz76iC3FJ",
       appHash:

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -304,6 +304,20 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
+  "assistant-builder-initial-tags-suggestions": {
+    app: {
+      appId: "Huz76iC3FJ",
+      appHash:
+        "bca374dd4e75c3cbfb56cecfe3a70d395e3ff1ca141a2d966a69fe11871717f6",
+    },
+    config: {
+      CREATE_SUGGESTIONS: {
+        function_call: "send_tags",
+        use_cache: false,
+        use_stream: true,
+      },
+    },
+  },
 };
 
 export type DustRegistryActionName = keyof typeof BaseDustProdActionRegistry;

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -308,7 +308,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "Huz76iC3FJ",
       appHash:
-        "bca374dd4e75c3cbfb56cecfe3a70d395e3ff1ca141a2d966a69fe11871717f6",
+        "267fde1d37400086b6933eccd73c885efb1cf61915edbd32d32d92ba59051769",
     },
     config: {
       CREATE_SUGGESTIONS: {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -308,7 +308,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "Huz76iC3FJ",
       appHash:
-        "267fde1d37400086b6933eccd73c885efb1cf61915edbd32d32d92ba59051769",
+        "4c86322b20fa685fcbd87b23c5220e9be14fd56014a3f356a6cfe07b3573ab5d",
     },
     config: {
       CREATE_SUGGESTIONS: {

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -60,7 +60,7 @@ async function handler(
       const formattedAgents = agents
         .map(
           (a) =>
-            `Identifier: ${a.sId}\nName: ${a.name}\nDescription: ${a.description}\nInstructions: ${a.instructions?.substring(0, 200).replaceAll("\n", " ")}...`
+            `Identifier: ${a.sId}\nName: ${a.name}\nDescription: ${a.description?.substring(0, 200).replaceAll("\n", " ")}\nInstructions: ${a.instructions?.substring(0, 200).replaceAll("\n", " ")}`
         )
         .join("\n\n");
 

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -10,7 +10,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdActionRegistry } from "@app/lib/registry";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { getSmallWhitelistedModel, isAdmin } from "@app/types";
+import { getLargeWhitelistedModel, isAdmin } from "@app/types";
 
 const SuggestionsResponseBodySchema = t.union([
   t.type({
@@ -57,14 +57,14 @@ async function handler(
         variant: "extra_light",
       });
 
-      const formattedAgents = agents.map((a) => ({
-        id: a.sId,
-        displayName: `@${a.name}`,
-        description: a.description,
-        instructions: a.instructions?.substring(0, 200),
-      }));
+      const formattedAgents = agents
+        .map(
+          (a) =>
+            `Identifier: ${a.sId}\nName: ${a.name}\nDescription: ${a.description}\nInstructions: ${a.instructions?.substring(0, 200).replaceAll("\n", " ")}...`
+        )
+        .join("\n\n");
 
-      const model = getSmallWhitelistedModel(owner);
+      const model = getLargeWhitelistedModel(owner);
 
       if (!model) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -1,0 +1,148 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { runAction } from "@app/lib/actions/server";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { cloneBaseConfig, getDustProdActionRegistry } from "@app/lib/registry";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { getSmallWhitelistedModel, isAdmin } from "@app/types";
+
+const SuggestionsResponseBodySchema = t.union([
+  t.type({
+    status: t.literal("ok"),
+    suggestions: t.union([
+      t.array(t.type({ name: t.string, agentIds: t.array(t.string) })),
+      t.null,
+      t.undefined,
+    ]),
+  }),
+  t.type({
+    status: t.literal("unavailable"),
+    reason: t.union([
+      t.literal("user_not_finished"), // The user has not finished inputing data for suggestions to make sense
+      t.literal("irrelevant"),
+    ]),
+  }),
+]);
+
+export type SuggestionsType = t.TypeOf<typeof SuggestionsResponseBodySchema>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<SuggestionsType>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!isAdmin(owner)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "not_authenticated",
+        message: "You are not authorized to access this resource.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const agents = await getAgentConfigurations({
+        auth,
+        agentsGetView: "list",
+        variant: "extra_light",
+      });
+
+      const formattedAgents = agents.map((a) => ({
+        id: a.sId,
+        displayName: `@${a.name}`,
+        description: a.description,
+        instructions: a.instructions,
+      }));
+
+      const model = getSmallWhitelistedModel(owner);
+
+      if (!model) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `No whitelisted models were found for the workspace.`,
+          },
+        });
+      }
+
+      const config = cloneBaseConfig(
+        getDustProdActionRegistry()[
+          "assistant-builder-initial-tags-suggestions"
+        ].config
+      );
+      config.CREATE_SUGGESTIONS.provider_id = model.providerId;
+      config.CREATE_SUGGESTIONS.model_id = model.modelId;
+
+      const suggestionsResponse = await runAction(
+        auth,
+        `assistant-builder-initial-tags-suggestions`,
+        config,
+        [
+          {
+            agents: formattedAgents,
+          },
+        ]
+      );
+
+      if (suggestionsResponse.isErr() || !suggestionsResponse.value.results) {
+        const message = suggestionsResponse.isErr()
+          ? JSON.stringify(suggestionsResponse.error)
+          : "No results available";
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message,
+          },
+        });
+      }
+
+      const responseValidation = SuggestionsResponseBodySchema.decode(
+        suggestionsResponse.value.results[0][0].value
+      );
+      if (isLeft(responseValidation)) {
+        const pathError = reporter.formatValidationErrors(
+          responseValidation.left
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Invalid response from action: ${pathError}`,
+          },
+        });
+      }
+      const suggestions = responseValidation.right as {
+        status: "ok";
+        suggestions: { name: string; agentIds: string[] }[] | null | undefined;
+      };
+
+      return res.status(200).json(suggestions);
+
+      console.log("suggest", suggestions);
+      SuggestionsResponseBodySchema;
+      return res.status(200).json(suggestions);
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -61,7 +61,7 @@ async function handler(
         id: a.sId,
         displayName: `@${a.name}`,
         description: a.description,
-        instructions: a.instructions,
+        instructions: a.instructions?.substring(0, 200),
       }));
 
       const model = getSmallWhitelistedModel(owner);
@@ -77,16 +77,14 @@ async function handler(
       }
 
       const config = cloneBaseConfig(
-        getDustProdActionRegistry()[
-          "assistant-builder-initial-tags-suggestions"
-        ].config
+        getDustProdActionRegistry()["tag-manager-initial-suggestions"].config
       );
       config.CREATE_SUGGESTIONS.provider_id = model.providerId;
       config.CREATE_SUGGESTIONS.model_id = model.modelId;
 
       const suggestionsResponse = await runAction(
         auth,
-        `assistant-builder-initial-tags-suggestions`,
+        "tag-manager-initial-suggestions",
         config,
         [
           {
@@ -123,17 +121,8 @@ async function handler(
           },
         });
       }
-      const suggestions = responseValidation.right as {
-        status: "ok";
-        suggestions: { name: string; agentIds: string[] }[] | null | undefined;
-      };
 
-      return res.status(200).json(suggestions);
-
-      console.log("suggest", suggestions);
-      SuggestionsResponseBodySchema;
-      return res.status(200).json(suggestions);
-
+      return res.status(200).json(responseValidation.right);
     default:
       return apiError(req, res, {
         status_code: 405,

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -58,6 +58,7 @@ async function handler(
       });
 
       const formattedAgents = agents
+        .filter((a) => a.scope !== "global")
         .map(
           (a) =>
             `Identifier: ${a.sId}\nName: ${a.name}\nDescription: ${a.description?.substring(0, 200).replaceAll("\n", " ")}\nInstructions: ${a.instructions?.substring(0, 200).replaceAll("\n", " ")}`


### PR DESCRIPTION
## Description

Add endpoint tags/suggest_from_agents that create a list of tags and the list of agents to associate with

Associated dust-app : [assistant-builder-initial-tags-suggestions.json](https://github.com/user-attachments/files/20062206/assistant-builder-initial-tags-suggestions.json)


## Tests

Locally

## Risk

low, new endpoint

## Deploy Plan

deploy front
