### PR TITLE
[front] Send 403 if not allowed, fixed permission check for legacy

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1809,5 +1809,8 @@ function isLegacyAllowed(
   if (agentConfigurationScope === "published" && isUser(owner)) {
     return true;
   }
+  if (agentConfigurationScope === "private" && isUser(owner)) {
+    return true;
+  }
   return false;
 }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -67,9 +67,9 @@ async function handler(
 
       if (!agent.canEdit && !auth.isAdmin()) {
         return apiError(req, res, {
-          status_code: 404,
+          status_code: 403,
           api_error: {
-            type: "agent_configuration_not_found",
+            type: "invalid_request_error",
             message: "Only editors can modify agents.",
           },
         });
@@ -91,6 +91,16 @@ async function handler(
             },
           });
         }
+      }
+
+      if (bodyValidation.right.scope === "workspace" && !auth.isBuilder()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Only builders can upgrade agents to workspace scope.",
+          },
+        });
       }
 
       // This won't stay long since Agent Discovery initiative removes the scope


### PR DESCRIPTION
## Description

- Add a check in endpoint when upgragind agents to workspace scope
- Allow user to update to personal agent

## Tests

locally 

## Risk

low

## Deploy Plan

deploy front
