### PR TITLE
[front] feat(usage): Add total user of a workspace request

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -58,7 +58,7 @@ type UserUsageQueryResult = {
   activeDaysCount: number;
 };
 
-type InactiveUserUsageQueryResult = {
+type TotalUserUsageQueryResult = {
   userId: number;
   userName: string;
   userEmail: string;
@@ -346,7 +346,7 @@ export async function getTotalUserUsageData(
     includeUser: true,
   });
 
-  const userUsage: InactiveUserUsageQueryResult[] = memberships.reduce(
+  const userUsage: TotalUserUsageQueryResult[] = memberships.reduce(
     (acc, membership) => {
       if (
         membership.user != null &&
@@ -361,7 +361,7 @@ export async function getTotalUserUsageData(
 
       return acc;
     },
-    [] as InactiveUserUsageQueryResult[]
+    [] as TotalUserUsageQueryResult[]
   );
 
   if (!userUsage.length) {
@@ -577,7 +577,7 @@ function generateCsvFromQueryResult(
   rows:
     | WorkspaceUsageQueryResult[]
     | UserUsageQueryResult[]
-    | InactiveUserUsageQueryResult[]
+    | TotalUserUsageQueryResult[]
     | AgentUsageQueryResult[]
     | MessageUsageQueryResult[]
     | BuilderUsageQueryResult[]

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/models/assistant/conversation";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type {
@@ -18,8 +19,6 @@ import type {
   ModelId,
   WorkspaceType,
 } from "@app/types";
-
-import { MembershipResource } from "./resources/membership_resource";
 
 export interface WorkspaceUsageQueryResult {
   createdAt: string;

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -16,6 +16,7 @@ import {
   getAssistantsUsageData,
   getBuildersUsageData,
   getFeedbacksUsageData,
+  getInactiveUserUsageData,
   getMessageUsageData,
   getUserUsageData,
 } from "@app/lib/workspace_usage";
@@ -260,6 +261,10 @@ async function fetchUsageData({
   switch (table) {
     case "users":
       return { users: await getUserUsageData(start, end, workspace) };
+    case "inactive_users":
+      return {
+        inactive_users: await getInactiveUserUsageData(start, end, workspace),
+      };
     case "assistant_messages":
       return {
         assistant_messages: await getMessageUsageData(start, end, workspace),
@@ -275,15 +280,29 @@ async function fetchUsageData({
         feedbacks: await getFeedbacksUsageData(start, end, workspace),
       };
     case "all":
-      const [users, assistant_messages, builders, assistants, feedbacks] =
-        await Promise.all([
-          getUserUsageData(start, end, workspace),
-          getMessageUsageData(start, end, workspace),
-          getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace),
-          getFeedbacksUsageData(start, end, workspace),
-        ]);
-      return { users, assistant_messages, builders, assistants, feedbacks };
+      const [
+        users,
+        inactive_users,
+        assistant_messages,
+        builders,
+        assistants,
+        feedbacks,
+      ] = await Promise.all([
+        getUserUsageData(start, end, workspace),
+        getInactiveUserUsageData(start, end, workspace),
+        getMessageUsageData(start, end, workspace),
+        getBuildersUsageData(start, end, workspace),
+        getAssistantsUsageData(start, end, workspace),
+        getFeedbacksUsageData(start, end, workspace),
+      ]);
+      return {
+        users,
+        inactive_users,
+        assistant_messages,
+        builders,
+        assistants,
+        feedbacks,
+      };
     default:
       return {};
   }

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -16,8 +16,8 @@ import {
   getAssistantsUsageData,
   getBuildersUsageData,
   getFeedbacksUsageData,
-  getInactiveUserUsageData,
   getMessageUsageData,
+  getTotalUserUsageData,
   getUserUsageData,
 } from "@app/lib/workspace_usage";
 import { apiError } from "@app/logger/withlogging";
@@ -73,7 +73,7 @@ import { assertNever } from "@app/types";
  *         description: |
  *           The name of the usage table to retrieve:
  *           - "users": The list of users categorized by their activity level.
- *           - "inactive_users": The of users that didn't sent any messages
+ *           - "total_users": The total users in the workspace at the given period
  *           - "assistant_messages": The list of messages sent by users including the mentioned agents.
  *           - "builders": The list of builders categorized by their activity level.
  *           - "assistants": The list of workspace agents and their corresponding usage.
@@ -81,7 +81,7 @@ import { assertNever } from "@app/types";
  *           - "all": A concatenation of all the above tables.
  *         schema:
  *           type: string
- *           enum: [users, inactive_users, assistant_messages, builders, assistants, feedbacks, all]
+ *           enum: [users, total_users, assistant_messages, builders, assistants, feedbacks, all]
  *     responses:
  *       200:
  *         description: The usage data in CSV or JSON format, or a ZIP of multiple CSVs if table is equal to "all"
@@ -261,9 +261,9 @@ async function fetchUsageData({
   switch (table) {
     case "users":
       return { users: await getUserUsageData(start, end, workspace) };
-    case "inactive_users":
+    case "total_users":
       return {
-        inactive_users: await getInactiveUserUsageData(start, end, workspace),
+        total_users: await getTotalUserUsageData(start, end, workspace),
       };
     case "assistant_messages":
       return {
@@ -282,14 +282,14 @@ async function fetchUsageData({
     case "all":
       const [
         users,
-        inactive_users,
+        total_users,
         assistant_messages,
         builders,
         assistants,
         feedbacks,
       ] = await Promise.all([
         getUserUsageData(start, end, workspace),
-        getInactiveUserUsageData(start, end, workspace),
+        getTotalUserUsageData(start, end, workspace),
         getMessageUsageData(start, end, workspace),
         getBuildersUsageData(start, end, workspace),
         getAssistantsUsageData(start, end, workspace),
@@ -297,7 +297,7 @@ async function fetchUsageData({
       ]);
       return {
         users,
-        inactive_users,
+        total_users,
         assistant_messages,
         builders,
         assistants,

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -11,6 +11,7 @@ import {
   getAssistantsUsageData,
   getBuildersUsageData,
   getFeedbacksUsageData,
+  getInactiveUserUsageData,
   getMessageUsageData,
   getUserUsageData,
 } from "@app/lib/workspace_usage";
@@ -26,6 +27,7 @@ const MonthSchema = t.refinement(
 
 const usageTables = [
   "users",
+  "inactive_users",
   "assistant_messages",
   "builders",
   "assistants",
@@ -184,6 +186,10 @@ async function fetchUsageData({
   switch (table) {
     case "users":
       return { users: await getUserUsageData(start, end, workspace) };
+    case "inactive_users":
+      return {
+        inactive_users: await getInactiveUserUsageData(start, end, workspace),
+      };
     case "assistant_messages":
       return { mentions: await getMessageUsageData(start, end, workspace) };
     case "builders":
@@ -197,15 +203,29 @@ async function fetchUsageData({
         assistants: await getAssistantsUsageData(start, end, workspace),
       };
     case "all":
-      const [users, assistant_messages, builders, assistants, feedbacks] =
-        await Promise.all([
-          getUserUsageData(start, end, workspace),
-          getMessageUsageData(start, end, workspace),
-          getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace),
-          getFeedbacksUsageData(start, end, workspace),
-        ]);
-      return { users, assistant_messages, builders, assistants, feedbacks };
+      const [
+        users,
+        inactive_users,
+        assistant_messages,
+        builders,
+        assistants,
+        feedbacks,
+      ] = await Promise.all([
+        getUserUsageData(start, end, workspace),
+        getInactiveUserUsageData(start, end, workspace),
+        getMessageUsageData(start, end, workspace),
+        getBuildersUsageData(start, end, workspace),
+        getAssistantsUsageData(start, end, workspace),
+        getFeedbacksUsageData(start, end, workspace),
+      ]);
+      return {
+        users,
+        inactive_users,
+        assistant_messages,
+        builders,
+        assistants,
+        feedbacks,
+      };
     default:
       return {};
   }

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -11,8 +11,8 @@ import {
   getAssistantsUsageData,
   getBuildersUsageData,
   getFeedbacksUsageData,
-  getInactiveUserUsageData,
   getMessageUsageData,
+  getTotalUserUsageData,
   getUserUsageData,
 } from "@app/lib/workspace_usage";
 import { apiError } from "@app/logger/withlogging";
@@ -27,7 +27,7 @@ const MonthSchema = t.refinement(
 
 const usageTables = [
   "users",
-  "inactive_users",
+  "total_users",
   "assistant_messages",
   "builders",
   "assistants",
@@ -186,9 +186,9 @@ async function fetchUsageData({
   switch (table) {
     case "users":
       return { users: await getUserUsageData(start, end, workspace) };
-    case "inactive_users":
+    case "total_users":
       return {
-        inactive_users: await getInactiveUserUsageData(start, end, workspace),
+        total_users: await getTotalUserUsageData(start, end, workspace),
       };
     case "assistant_messages":
       return { mentions: await getMessageUsageData(start, end, workspace) };
@@ -205,14 +205,14 @@ async function fetchUsageData({
     case "all":
       const [
         users,
-        inactive_users,
+        total_users,
         assistant_messages,
         builders,
         assistants,
         feedbacks,
       ] = await Promise.all([
         getUserUsageData(start, end, workspace),
-        getInactiveUserUsageData(start, end, workspace),
+        getTotalUserUsageData(start, end, workspace),
         getMessageUsageData(start, end, workspace),
         getBuildersUsageData(start, end, workspace),
         getAssistantsUsageData(start, end, workspace),
@@ -220,7 +220,7 @@ async function fetchUsageData({
       ]);
       return {
         users,
-        inactive_users,
+        total_users,
         assistant_messages,
         builders,
         assistants,

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -3800,12 +3800,12 @@
             "in": "query",
             "name": "table",
             "required": true,
-            "description": "The name of the usage table to retrieve:\n- \"users\": The list of users categorized by their activity level.\n- \"inactive_users\": The of users that didn't sent any messages\n- \"assistant_messages\": The list of messages sent by users including the mentioned agents.\n- \"builders\": The list of builders categorized by their activity level.\n- \"assistants\": The list of workspace agents and their corresponding usage.\n- \"feedbacks\": The list of feedbacks given by users on the agent messages.\n- \"all\": A concatenation of all the above tables.\n",
+            "description": "The name of the usage table to retrieve:\n- \"users\": The list of users categorized by their activity level.\n- \"total_users\": The total users in the workspace at the given period\n- \"assistant_messages\": The list of messages sent by users including the mentioned agents.\n- \"builders\": The list of builders categorized by their activity level.\n- \"assistants\": The list of workspace agents and their corresponding usage.\n- \"feedbacks\": The list of feedbacks given by users on the agent messages.\n- \"all\": A concatenation of all the above tables.\n",
             "schema": {
               "type": "string",
               "enum": [
                 "users",
-                "inactive_users",
+                "total_users",
                 "assistant_messages",
                 "builders",
                 "assistants",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2463,6 +2463,7 @@ export type UpsertTableResponseType = z.infer<typeof UpsertTableResponseSchema>;
 
 const SupportedUsageTablesSchema = FlexibleEnumSchema<
   | "users"
+  | "inactive_users"
   | "assistant_messages"
   | "builders"
   | "assistants"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2463,7 +2463,7 @@ export type UpsertTableResponseType = z.infer<typeof UpsertTableResponseSchema>;
 
 const SupportedUsageTablesSchema = FlexibleEnumSchema<
   | "users"
-  | "inactive_users"
+  | "total_users"
   | "assistant_messages"
   | "builders"
   | "assistants"


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2774
- Add `total_users` csv in workspace usage export
- Use memberships by the workspace to fetch the users

## Tests
- Download current production list of active users for Dust workspace, and matched against the metabase result
- Locally tested (without multiple workspace)
- Tested on front-edge

## Risk
- Do a customer data cross-access again

## Deploy Plan
- Deploy on front, do the same test again
  - [ ] ZIP download via UI
  - [ ] API `table=all`
  - [ ] API `table=inactive_users`
- Releasing new version of SDK
