### PR TITLE
Run Front QA Deploy Twice A Day

### DIFF
--- a/.github/workflows/deploy-front-qa.yml
+++ b/.github/workflows/deploy-front-qa.yml
@@ -1,12 +1,9 @@
 name: Deploy Front QA
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
+  schedule:
+    # Runs at 07:00 PT (14:00 UTC) and 14:00 PT (21:00 UTC) during PDT.
+    - cron: "0 14,21 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR modifies the execution frequency of the `front-qa` deployment tests. Currently, these tests are queued and triggered with every deployment, which provides limited value due to their slow execution time.

Instead of running after each deploy, we're implementing a more efficient schedule that balances test coverage with resource utilization, reducing unnecessary test runs while maintaining quality assurance.

See thread [here](https://dust4ai.slack.com/archives/C07C9PNNA74/p1745432789206929).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
