### PR TITLE
Add a CLI command to delete a data source

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -39,7 +39,6 @@ import {
   removeNulls,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
-import { launchScrubDataSourceWorkflow } from "@app/poke/temporal/client";
 
 // `cli` takes an object type and a command as first two arguments and then a list of arguments.
 const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
@@ -309,7 +308,9 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
 
-      const dataSource = await DataSourceResource.fetchById(auth, args.dsId);
+      const dataSource = await DataSourceResource.fetchById(auth, args.dsId, {
+        includeDeleted: true,
+      });
       if (!dataSource) {
         throw new Error(
           `DataSource not found: wId='${args.wId}' dsId='${args.dsId}'`

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -6,7 +6,10 @@ import { getConversation } from "@app/lib/api/assistant/conversation";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
 import { getTextRepresentationFromMessages } from "@app/lib/api/assistant/utils";
 import { default as config } from "@app/lib/api/config";
-import { getDataSources } from "@app/lib/api/data_sources";
+import {
+  getDataSources,
+  softDeleteDataSourceAndLaunchScrubWorkflow,
+} from "@app/lib/api/data_sources";
 import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
 import { Authenticator } from "@app/lib/auth";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
@@ -36,6 +39,7 @@ import {
   removeNulls,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
+import { launchScrubDataSourceWorkflow } from "@app/poke/temporal/client";
 
 // `cli` takes an object type and a command as first two arguments and then a list of arguments.
 const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
@@ -295,10 +299,33 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
 
       return;
     }
+    case "delete": {
+      if (!args.wId) {
+        throw new Error("Missing --wId argument");
+      }
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
+      }
+
+      const auth = await Authenticator.internalAdminForWorkspace(args.wId);
+
+      const dataSource = await DataSourceResource.fetchById(auth, args.dsId);
+      if (!dataSource) {
+        throw new Error(
+          `DataSource not found: wId='${args.wId}' dsId='${args.dsId}'`
+        );
+      }
+
+      await softDeleteDataSourceAndLaunchScrubWorkflow(auth, dataSource);
+
+      console.log(`Data Source deleted: ${args.dsId}`);
+
+      return;
+    }
 
     default:
       console.log(`Unknown data-source command: ${command}`);
-      console.log("Possible values: `delete`, `scrub`");
+      console.log("Possible values: `delete`, `delete-document`");
   }
 };
 

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -299,6 +299,9 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
       return;
     }
     case "delete": {
+      // It's possible to delete a data source directly from Pokké UI but
+      // it's not accessible for a relocated workspace. This command is there to let us
+      // delete a data source for a relocated workspace.
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }


### PR DESCRIPTION
## Description

- This PR adds a command to delete a data source.
- This command is usually not necessary due to the presence of a button in poke that does the same, it will be used here in the context of a relocated workspace where we wish to delete one data source specifically.

## Tests

- Tested locally.

## Risk

- Destructive action that is not tracked (unlike the poke plugin), will probably rollback after it fulfilled its purpose since there is no real need for it.

## Deploy Plan

- Deploy front.
