### PR TITLE
Add notion internal MCP server

### DIFF
--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -15,8 +15,10 @@ use std::env;
 lazy_static! {
     static ref OAUTH_NOTION_CLIENT_ID: String = env::var("OAUTH_NOTION_CLIENT_ID").unwrap();
     static ref OAUTH_NOTION_CLIENT_SECRET: String = env::var("OAUTH_NOTION_CLIENT_SECRET").unwrap();
-    static ref OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_ID: String = env::var("OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_ID").unwrap();
-    static ref OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET: String = env::var("OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET").unwrap();
+    static ref OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_ID: String =
+        env::var("OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_ID").unwrap();
+    static ref OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET: String =
+        env::var("OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET").unwrap();
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -30,7 +32,10 @@ impl NotionUseCase {
         match s {
             Some("connection") | None => Ok(NotionUseCase::Connection),
             Some("platform_actions") => Ok(NotionUseCase::PlatformActions),
-            Some(other) => Err(anyhow!(format!("Notion use_case format invalid: {}", other))),
+            Some(other) => Err(anyhow!(format!(
+                "Notion use_case format invalid: {}",
+                other
+            ))),
         }
     }
 }
@@ -79,7 +84,10 @@ impl Provider for NotionConnectionProvider {
             .post("https://api.notion.com/v1/oauth/token")
             .header("Accept", "application/json")
             .header("Content-Type", "application/json")
-            .header("Authorization", format!("Basic {}", self.basic_auth(&use_case)))
+            .header(
+                "Authorization",
+                format!("Basic {}", self.basic_auth(&use_case)),
+            )
             .json(&body);
 
         let raw_json = execute_request(ConnectionProvider::Notion, req)

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -15,6 +15,24 @@ use std::env;
 lazy_static! {
     static ref OAUTH_NOTION_CLIENT_ID: String = env::var("OAUTH_NOTION_CLIENT_ID").unwrap();
     static ref OAUTH_NOTION_CLIENT_SECRET: String = env::var("OAUTH_NOTION_CLIENT_SECRET").unwrap();
+    static ref OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_ID: String = env::var("OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_ID").unwrap();
+    static ref OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET: String = env::var("OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET").unwrap();
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum NotionUseCase {
+    Connection,
+    PlatformActions,
+}
+
+impl NotionUseCase {
+    pub fn from_str(s: Option<&str>) -> Result<Self> {
+        match s {
+            Some("connection") | None => Ok(NotionUseCase::Connection),
+            Some("platform_actions") => Ok(NotionUseCase::PlatformActions),
+            Some(other) => Err(anyhow!(format!("Notion use_case format invalid: {}", other))),
+        }
+    }
 }
 
 pub struct NotionConnectionProvider {}
@@ -24,11 +42,15 @@ impl NotionConnectionProvider {
         NotionConnectionProvider {}
     }
 
-    fn basic_auth(&self) -> String {
-        general_purpose::STANDARD.encode(&format!(
-            "{}:{}",
-            *OAUTH_NOTION_CLIENT_ID, *OAUTH_NOTION_CLIENT_SECRET
-        ))
+    fn basic_auth(&self, use_case: &NotionUseCase) -> String {
+        let (client_id, client_secret) = match use_case {
+            NotionUseCase::PlatformActions => (
+                &*OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_ID,
+                &*OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET,
+            ),
+            NotionUseCase::Connection => (&*OAUTH_NOTION_CLIENT_ID, &*OAUTH_NOTION_CLIENT_SECRET),
+        };
+        general_purpose::STANDARD.encode(&format!("{}:{}", client_id, client_secret))
     }
 }
 
@@ -40,11 +62,12 @@ impl Provider for NotionConnectionProvider {
 
     async fn finalize(
         &self,
-        _connection: &Connection,
+        connection: &Connection,
         _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
+        let use_case = NotionUseCase::from_str(connection.metadata()["use_case"].as_str())?;
         let body = json!({
             "grant_type": "authorization_code",
             "code": code,
@@ -56,7 +79,7 @@ impl Provider for NotionConnectionProvider {
             .post("https://api.notion.com/v1/oauth/token")
             .header("Accept", "application/json")
             .header("Content-Type", "application/json")
-            .header("Authorization", format!("Basic {}", self.basic_auth()))
+            .header("Authorization", format!("Basic {}", self.basic_auth(&use_case)))
             .json(&body);
 
         let raw_json = execute_request(ConnectionProvider::Notion, req)

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -17,6 +17,7 @@ import {
   CommandLineIcon,
   GithubLogo,
   HubspotLogo,
+  NotionLogo,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import type { ComponentProps } from "react";
@@ -44,6 +45,7 @@ export const InternalActionIcons = {
   GithubLogo,
   HubspotLogo,
   CommandLineIcon,
+  NotionLogo,
 };
 
 export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -117,6 +117,13 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 11,
     availability: "manual",
     flag: "experimental_mcp_actions",
+    tools_stakes: {
+      retrieve_database_content: "never_ask",
+      query_database: "never_ask",
+      retrieve_page: "never_ask",
+      retrieve_database_schema: "never_ask",
+      search: "never_ask",
+    },
   },
 
   // Dev

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -23,6 +23,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "search",
   "think",
   "web_search_&_browse_v2",
+  "notion",
 ] as const;
 
 // Whether the server is available by default in the global space.
@@ -111,6 +112,11 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 10,
     availability: "auto",
     flag: "dev_mcp_actions",
+  },
+  notion: {
+    id: 11,
+    availability: "manual",
+    flag: "experimental_mcp_actions",
   },
 
   // Dev

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -8,7 +8,8 @@ import { default as generateFileServer } from "@app/lib/actions/mcp_internal_act
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
 import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/server";
 import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation";
-import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include";
+import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include_data";
+import { default as notionServer } from "@app/lib/actions/mcp_internal_actions/servers/notion";
 import { default as primitiveTypesDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/primitive_types_debugger";
 import { default as reasoningServer } from "@app/lib/actions/mcp_internal_actions/servers/reasoning";
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
@@ -56,6 +57,8 @@ export async function getInternalMCPServer(
       return webtoolsServer(agentLoopRunContext);
     case "search":
       return searchServer(auth, agentLoopRunContext);
+    case "notion":
+      return notionServer(auth, mcpServerId);
     case "include_data":
       return includeDataServer(auth, agentLoopRunContext);
     case "ask_agent":

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -8,7 +8,7 @@ import { default as generateFileServer } from "@app/lib/actions/mcp_internal_act
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
 import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/server";
 import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation";
-import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include_data";
+import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include";
 import { default as notionServer } from "@app/lib/actions/mcp_internal_actions/servers/notion";
 import { default as primitiveTypesDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/primitive_types_debugger";
 import { default as reasoningServer } from "@app/lib/actions/mcp_internal_actions/servers/reasoning";

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -1,0 +1,456 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@notionhq/client";
+import { z } from "zod";
+
+import { getAccessTokenForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "notion",
+  version: "1.0.0",
+  description: "Notion tools to manage pages and databases.",
+  authorization: {
+    provider: "notion" as const,
+    use_case: "platform_actions" as const,
+  },
+  icon: "NotionLogo",
+};
+
+const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
+  const server = new McpServer(serverInfo);
+
+  const parentPageSchema = z
+    .object({
+      type: z
+        .literal("page_id")
+        .describe("Must be 'page_id' for a page parent."),
+      page_id: z.string().describe("The ID of the parent page."),
+    })
+    .strict();
+
+  const allowedColors = [
+    "default",
+    "gray",
+    "brown",
+    "orange",
+    "yellow",
+    "green",
+    "blue",
+    "purple",
+    "pink",
+    "red",
+    "default_background",
+    "gray_background",
+    "brown_background",
+    "orange_background",
+    "yellow_background",
+    "green_background",
+    "blue_background",
+    "purple_background",
+    "pink_background",
+    "red_background",
+  ] as const;
+
+  const titleRichTextSchema = z
+    .object({
+      type: z.literal("text"),
+      text: z.object({
+        content: z.string(),
+        link: z.object({ url: z.string() }).nullable().optional(),
+      }),
+      annotations: z
+        .object({
+          bold: z.boolean().optional(),
+          italic: z.boolean().optional(),
+          strikethrough: z.boolean().optional(),
+          underline: z.boolean().optional(),
+          code: z.boolean().optional(),
+          color: z.enum(allowedColors).optional(),
+        })
+        .optional(),
+      plain_text: z.string().optional(),
+      href: z.string().nullable().optional(),
+    })
+    .strict();
+
+  const propertiesSchema = z
+    .record(z.string(), z.any())
+    .describe(
+      "Properties for the new page or database. Keys are property names, values are property value objects as per Notion API. See https://developers.notion.com/reference/page#property-value-types for details. Value should be an empty object if there are no properties to update."
+    );
+
+  const searchFilterSchema = z
+    .object({
+      property: z.literal("object"),
+      value: z.enum(["page", "database"]),
+    })
+    .describe(
+      "A set of criteria, value and property keys, that limits the results to either only pages or only databases. Only property: 'object' and value: 'page' or 'database' are allowed."
+    );
+
+  const searchSortSchema = z
+    .object({
+      direction: z.enum(["ascending", "descending"]),
+      timestamp: z.literal("last_edited_time"),
+    })
+    .describe(
+      "A set of criteria, direction and timestamp keys, that orders the results. Only timestamp: 'last_edited_time' is allowed."
+    );
+
+  const dbFilterSchema = z
+    .object({})
+    .passthrough()
+    .describe(
+      "Filter object as per Notion API. Must match the Notion API filter structure. See https://developers.notion.com/reference/post-database-query-filter"
+    );
+  const dbSortSchema = z
+    .object({
+      property: z.string(),
+      direction: z.enum(["ascending", "descending"]),
+    })
+    .strict()
+    .describe(
+      "Sort object as per Notion API. See https://developers.notion.com/reference/post-database-query-sort"
+    );
+  const dbSortsArraySchema = z
+    .array(dbSortSchema)
+    .describe("Array of sort objects as per Notion API.");
+
+  server.tool(
+    "search",
+    "Search for pages, databases, or blocks in Notion.",
+    {
+      query: z.string().optional().describe("Search query string."),
+      filter: searchFilterSchema.optional(),
+      sort: searchSortSchema.optional(),
+      start_cursor: z
+        .string()
+        .optional()
+        .describe(
+          "A cursor value returned in a previous response that limits the response to results starting after the cursor."
+        ),
+      page_size: z
+        .number()
+        .optional()
+        .describe(
+          "The number of items from the full list to include in the response. Maximum: 100."
+        ),
+    },
+    async ({ query, filter, sort, start_cursor, page_size }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.search({
+          query,
+          filter,
+          sort,
+          start_cursor,
+          page_size,
+        });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  server.tool(
+    "retrieve_page",
+    "Retrieve a Notion page by its ID.",
+    {
+      pageId: z.string().describe("The Notion page ID."),
+    },
+    async ({ pageId }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.pages.retrieve({ page_id: pageId });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  server.tool(
+    "retrieve_database_schema",
+    "Retrieve a Notion database's schema by its ID.",
+    {
+      databaseId: z.string().describe("The Notion database ID."),
+    },
+    async ({ databaseId }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.databases.retrieve({
+          database_id: databaseId,
+        });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  server.tool(
+    "retrieve_database_content",
+    "Retrieve the content (pages) of a Notion database by its ID.",
+    {
+      databaseId: z.string().describe("The Notion database ID."),
+      filter: dbFilterSchema.optional(),
+      sorts: dbSortsArraySchema.optional(),
+      start_cursor: z
+        .string()
+        .optional()
+        .describe("Start cursor for pagination."),
+      page_size: z.number().optional().describe("Page size for pagination."),
+    },
+    async ({ databaseId, filter, sorts, start_cursor, page_size }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.databases.query({
+          database_id: databaseId,
+          filter: filter as any,
+          sorts,
+          start_cursor,
+          page_size,
+        });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  server.tool(
+    "query_database",
+    "Query a Notion database (alias for retrieve_database_content).",
+    {
+      databaseId: z.string().describe("The Notion database ID."),
+      filter: dbFilterSchema.optional(),
+      sorts: dbSortsArraySchema.optional(),
+      start_cursor: z
+        .string()
+        .optional()
+        .describe("Start cursor for pagination."),
+      page_size: z.number().optional().describe("Page size for pagination."),
+    },
+    async ({ databaseId, filter, sorts, start_cursor, page_size }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.databases.query({
+          database_id: databaseId,
+          filter: filter as any,
+          sorts,
+          start_cursor,
+          page_size,
+        });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  server.tool(
+    "create_page",
+    "Create a new Notion page.",
+    {
+      parent: parentPageSchema.describe(
+        "REQUIRED. Parent object (see Notion API). Must include type: 'page_id' and a valid page_id."
+      ),
+      properties: propertiesSchema,
+      icon: z.any().optional().describe("Icon (optional)."),
+      cover: z.any().optional().describe("Cover (optional)."),
+    },
+    async ({ parent, properties, icon, cover }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.pages.create({
+          parent,
+          properties,
+          icon,
+          cover,
+        });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  server.tool(
+    "create_page_from_database",
+    "Create a new Notion page in a database (alias for create_page with parent as database).",
+    {
+      databaseId: z.string().describe("The Notion database ID."),
+      properties: propertiesSchema,
+      icon: z.any().optional().describe("Icon (optional)."),
+      cover: z.any().optional().describe("Cover (optional)."),
+    },
+    async ({ databaseId, properties, icon, cover }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.pages.create({
+          parent: { database_id: databaseId, type: "database_id" },
+          properties,
+          icon,
+          cover,
+        });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  server.tool(
+    "create_database",
+    "Create a new Notion database (table).",
+    {
+      parent: parentPageSchema.describe(
+        "REQUIRED. Parent object (see Notion API). Must include type: 'page_id' and a valid page_id."
+      ),
+      title: z
+        .array(titleRichTextSchema)
+        .describe(
+          "REQUIRED. Title for the database as an array of rich text objects (see Notion API). Each item must have type: 'text' and a text object with content."
+        ),
+      properties: propertiesSchema,
+      icon: z.any().optional().describe("Icon (optional)."),
+      cover: z.any().optional().describe("Cover (optional)."),
+    },
+    async ({ parent, title, properties, icon, cover }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.databases.create({
+          parent,
+          title,
+          properties,
+          icon,
+          cover,
+        });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  server.tool(
+    "update_page",
+    "Update a Notion page's properties.",
+    {
+      pageId: z.string().describe("The Notion page ID."),
+      properties: propertiesSchema,
+    },
+    async ({ pageId, properties }) => {
+      try {
+        const notion = await getNotionClient(auth, mcpServerId);
+        if (!notion) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "No access token found" }],
+          };
+        }
+        const result = await notion.pages.update({
+          page_id: pageId,
+          properties,
+        });
+        return {
+          isError: false,
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e: any) {
+        return { isError: true, content: [{ type: "text", text: e.message }] };
+      }
+    }
+  );
+
+  return server;
+};
+
+const getNotionClient = async (
+  auth: any,
+  mcpServerId: string
+): Promise<Client | null> => {
+  const accessToken = await getAccessTokenForInternalMCPServer(auth, {
+    mcpServerId,
+  });
+  if (!accessToken) {
+    return null;
+  }
+  return new Client({ auth: accessToken });
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -76,8 +76,9 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
 
   const propertiesSchema = z
     .record(z.string(), z.any())
+    .default({})
     .describe(
-      "Properties for the new page or database. Keys are property names, values are property value objects as per Notion API. See https://developers.notion.com/reference/page#property-value-types for details. Value should be an empty object if there are no properties to update."
+      "Properties for the new page or database. Keys are property names, values are property value objects as per Notion API. See https://developers.notion.com/reference/page#property-value-types for details."
     );
 
   const searchFilterSchema = z
@@ -258,7 +259,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
 
   server.tool(
     "query_database",
-    "Query a Notion database (alias for retrieve_database_content).",
+    "Query a Notion database.",
     {
       databaseId: z.string().describe("The Notion database ID."),
       filter: dbFilterSchema.optional(),
@@ -300,7 +301,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     "Create a new Notion page.",
     {
       parent: parentPageSchema.describe(
-        "REQUIRED. Parent object (see Notion API). Must include type: 'page_id' and a valid page_id."
+        "Parent object (see Notion API). Must include type: 'page_id' and a valid page_id."
       ),
       properties: propertiesSchema,
       icon: z.any().optional().describe("Icon (optional)."),
@@ -333,7 +334,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
 
   server.tool(
     "create_page_from_database",
-    "Create a new Notion page in a database (alias for create_page with parent as database).",
+    "Create a new Notion page in a database.",
     {
       databaseId: z.string().describe("The Notion database ID."),
       properties: propertiesSchema,
@@ -370,12 +371,12 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     "Create a new Notion database (table).",
     {
       parent: parentPageSchema.describe(
-        "REQUIRED. Parent object (see Notion API). Must include type: 'page_id' and a valid page_id."
+        "Parent object (see Notion API). Must include type: 'page_id' and a valid page_id."
       ),
       title: z
         .array(titleRichTextSchema)
         .describe(
-          "REQUIRED. Title for the database as an array of rich text objects (see Notion API). Each item must have type: 'text' and a text object with content."
+          "Title for the database as an array of rich text objects (see Notion API). Each item must have type: 'text' and a text object with content."
         ),
       properties: propertiesSchema,
       icon: z.any().optional().describe("Icon (optional)."),

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -432,13 +432,9 @@ export function getMCPServerRequirements(
       })
     ).length > 0;
 
-  const mayRequiresTimeFrameConfiguration =
-    Object.keys(
-      findPathsToConfiguration({
-        mcpServer: server,
-        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME,
-      })
-    ).length > 0;
+  const mayRequiresTimeFrameConfiguration = server.tools.some(
+    (tool) => tool.inputSchema?.properties?.timeFrame
+  );
 
   const requiredStrings = Object.keys(
     findPathsToConfiguration({

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -132,6 +132,11 @@ const config = {
   getOAuthNotionClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_NOTION_CLIENT_ID");
   },
+  getOAuthNotionPlatformActionsClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable(
+      "OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_ID"
+    );
+  },
   getOAuthConfluenceClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_CONFLUENCE_CLIENT_ID");
   },

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -149,11 +149,15 @@ const PROVIDER_STRATEGIES: Record<
     },
   },
   notion: {
-    setupUri: ({ connection }) => {
+    setupUri: ({ connection, useCase }) => {
+      const clientId =
+        useCase === "platform_actions"
+          ? config.getOAuthNotionPlatformActionsClientId()
+          : config.getOAuthNotionClientId();
       return (
         `https://api.notion.com/v1/oauth/authorize?owner=user` +
         `&response_type=code` +
-        `&client_id=${config.getOAuthNotionClientId()}` +
+        `&client_id=${clientId}` +
         `&state=${connection.connection_id}` +
         `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("notion"))}`
       );

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -15,6 +15,7 @@
         "@hubspot/api-client": "^12.0.1",
         "@mendable/firecrawl-js": "^1.24.0",
         "@modelcontextprotocol/sdk": "^1.11.1",
+        "@notionhq/client": "^2.3.0",
         "@octokit/core": "^6.1.5",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-label": "^2.0.2",
@@ -3423,6 +3424,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.3.0.tgz",
+      "integrity": "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@npmcli/fs": {

--- a/front/package.json
+++ b/front/package.json
@@ -30,6 +30,7 @@
     "@hubspot/api-client": "^12.0.1",
     "@mendable/firecrawl-js": "^1.24.0",
     "@modelcontextprotocol/sdk": "^1.11.1",
+    "@notionhq/client": "^2.3.0",
     "@octokit/core": "^6.1.5",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-label": "^2.0.2",

--- a/front/types/oauth/client/access_token.ts
+++ b/front/types/oauth/client/access_token.ts
@@ -1,4 +1,4 @@
-import type { OAuthConnectionType, OAuthProvider } from "../../oauth/lib";
+import type { OAuthConnectionType } from "../../oauth/lib";
 import type { OAuthAPIError } from "../../oauth/oauth_api";
 import { OAuthAPI } from "../../oauth/oauth_api";
 import type { LoggerInterface } from "../../shared/logger";


### PR DESCRIPTION
## Description

* Adding internal MCP server to search + edit notion
* Uses separate oauth token from Notion connection (following pattern used by our Github actions)

## Tests

* Created own page locally that searched + created new Notion pages

## Risk

* Minimal - behind feature flag

## Deploy Plan

1. Add environment variable for Notion oauth key
2. Deploy front
