### PR TITLE
[Discovery] Fix: Allow no editor group for agents in deletion flow

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -957,10 +957,10 @@ export async function createAgentConfiguration(
           );
           await group.setMembers(auth, editors, { transaction: t });
         } else {
-          const group = await GroupResource.fetchByAgentConfiguration(
+          const group = await GroupResource.fetchByAgentConfiguration({
             auth,
-            existingAgent
-          );
+            agentConfiguration: existingAgent,
+          });
           if (!group) {
             throw new Error(
               "Unexpected: agent should have exactly one editor group."

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -420,10 +420,15 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(groups);
   }
 
-  static async fetchByAgentConfiguration(
-    auth: Authenticator,
-    agentConfiguration: AgentConfiguration | AgentConfigurationType
-  ): Promise<GroupResource | null> {
+  static async fetchByAgentConfiguration({
+    auth,
+    agentConfiguration,
+    isDeletionFlow = false,
+  }: {
+    auth: Authenticator;
+    agentConfiguration: AgentConfiguration | AgentConfigurationType;
+    isDeletionFlow?: boolean;
+  }): Promise<GroupResource | null> {
     const workspace = auth.getNonNullableWorkspace();
     const groupAgents = await GroupAgentModel.findAll({
       where: {
@@ -451,6 +456,14 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
+    // In the case of agents deletion, it is possible that the agent has no
+    // editor group associated with it, because the group may have been deleted
+    // when deleting another version of the agent with the same sId.
+    if (isDeletionFlow && groupAgents.length === 0) {
+      return null;
+    }
+
+    // In other cases, the agent should always have exactly one editor group.
     if (groupAgents.length !== 1) {
       throw new Error(
         "Unexpected: agent should have exactly one editor group."

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -105,7 +105,10 @@ async function handler(
 
       // This won't stay long since Agent Discovery initiative removes the scope
       // endpoint.
-      const group = await GroupResource.fetchByAgentConfiguration(auth, agent);
+      const group = await GroupResource.fetchByAgentConfiguration({
+        auth,
+        agentConfiguration: agent,
+      });
       if (!group) {
         throw new Error(
           "Unexpected: agent should have exactly one editor group."

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -408,7 +408,11 @@ export async function deleteAgentsActivity({
       },
     });
 
-    const group = await GroupResource.fetchByAgentConfiguration(auth, agent);
+    const group = await GroupResource.fetchByAgentConfiguration({
+      auth,
+      agentConfiguration: agent,
+      isDeletionFlow: true,
+    });
     if (group) {
       await group.delete(auth);
     }


### PR DESCRIPTION
Description
---
Fixes issue reported in https://dust4ai.slack.com/archives/C05F84CFP0E/p1746611944971459

In-code comment explaining logic.

Risk
---
low

Deploy
---
front
