### PR TITLE
New agent router MCP tool to list agents for @help

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -23,6 +23,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "think",
   "ask_agent",
   "reasoning_v2",
+  "agent_router",
 ] as const;
 
 export const INTERNAL_MCP_SERVERS: Record<
@@ -87,6 +88,11 @@ export const INTERNAL_MCP_SERVERS: Record<
       create_object: "high",
       update_object: "high",
     },
+  },
+  agent_router: {
+    id: 8,
+    isDefault: true,
+    flag: "experimental_mcp_actions",
   },
 
   // Dev

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -1,0 +1,83 @@
+import { DustAPI } from "@dust-tt/client";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import apiConfig from "@app/lib/api/config";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { getHeaderFromGroupIds } from "@app/types/groups";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "agent_router",
+  version: "1.0.0",
+  description: "Tools with access to the published agents of the workspace.",
+  icon: "ActionRobotIcon",
+  authorization: null,
+};
+
+const createServer = (auth: Authenticator): McpServer => {
+  const server = new McpServer(serverInfo);
+
+  server.tool(
+    "list_agents",
+    "List all active published agents in the workspace, to know which ones are the best suited for the current conversation.",
+    {},
+    async () => {
+      const owner = auth.getNonNullableWorkspace();
+      const prodCredentials = await prodAPICredentialsForOwner(owner);
+      const requestedGroupIds = auth.groups().map((g) => g.sId);
+      const api = new DustAPI(
+        apiConfig.getDustAPIConfig(),
+        {
+          ...prodCredentials,
+          extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+        },
+        logger
+      );
+
+      // We cannot call the internal getAgentConfigurations() here because it causes a circular dependency.
+      // Instead, we call the public API endpoint.
+      // Since this endpoint is using the workspace credentials we do not have the user and as a result
+      // we cannot use the "list" view, meaning we do not have the user's unpublished agents.
+      const res = await api.getAgentConfigurations({
+        view: "all",
+      });
+      if (res.isErr()) {
+        return {
+          isError: true,
+          content: [
+            { type: "text", text: "Error fetching agent configurations" },
+          ],
+        };
+      }
+
+      const agents = res.value;
+      const formattedAgents = agents.map((agent) => {
+        return {
+          sId: agent.sId,
+          name: agent.name,
+          description: agent.description,
+        };
+      });
+
+      return {
+        isError: false,
+        content: [
+          {
+            type: "text",
+            text: "Published agents successfully fetched",
+          },
+          {
+            type: "text",
+            text: JSON.stringify(formattedAgents),
+          },
+        ],
+      };
+    }
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { default as agentRouterServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
 import { default as askAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/ask_agent";
 import { default as authDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/authentication_debugger";
 import { default as childAgentDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/child_agent_debugger";
@@ -62,6 +63,8 @@ export function getInternalMCPServer(
       return askAgentServer(auth);
     case "reasoning_v2":
       return reasoningServer(auth, agentLoopContext);
+    case "agent_router":
+      return agentRouterServer(auth);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -11,6 +11,8 @@ import {
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
+import type { PlatformMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
 import config from "@app/lib/api/config";
@@ -18,6 +20,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationStatus,
@@ -136,6 +139,32 @@ function _getDefaultWebActionsForGlobalAgent({
   ];
 }
 
+function _getAgentRouterToolsConfiguration(
+  agentId: GLOBAL_AGENTS_SID,
+  mcpServerView: MCPServerViewResource | null
+): PlatformMCPServerConfigurationType[] {
+  if (!mcpServerView) {
+    return [];
+  }
+  return [
+    {
+      id: -1,
+      sId: agentId + "-agent-router-list-action",
+      type: "mcp_server_configuration",
+      name: "list_agents",
+      description:
+        "List the published agents of the workspace. Useful to route to the best matching agent.",
+      mcpServerViewId: mcpServerView.sId,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      reasoningModel: null,
+      additionalConfiguration: {},
+      timeFrame: null,
+    },
+  ];
+}
+
 /**
  * GLOBAL AGENTS CONFIGURATION
  *
@@ -146,9 +175,11 @@ function _getDefaultWebActionsForGlobalAgent({
 function _getHelperGlobalAgent({
   auth,
   helperPromptInstance,
+  agentRouterMCPServerView,
 }: {
   auth: Authenticator;
   helperPromptInstance: HelperAssistantPrompt;
+  agentRouterMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let prompt = "";
 
@@ -177,6 +208,7 @@ function _getHelperGlobalAgent({
       }
     : dummyModelConfiguration;
   const status = modelConfiguration ? "active" : "disabled_by_admin";
+
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.HELPER,
@@ -212,6 +244,10 @@ function _getHelperGlobalAgent({
       ..._getDefaultWebActionsForGlobalAgent({
         agentSid: GLOBAL_AGENTS_SID.HELPER,
       }),
+      ..._getAgentRouterToolsConfiguration(
+        GLOBAL_AGENTS_SID.HELPER,
+        agentRouterMCPServerView
+      ),
     ],
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
     visualizationEnabled: true,
@@ -1221,9 +1257,11 @@ function _getDustGlobalAgent(
   {
     settings,
     preFetchedDataSources,
+    agentRouterMCPServerView,
   }: {
     settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
+    agentRouterMCPServerView: MCPServerViewResource | null;
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
@@ -1381,6 +1419,13 @@ function _getDustGlobalAgent(
     description: null,
   });
 
+  actions.push(
+    ..._getAgentRouterToolsConfiguration(
+      GLOBAL_AGENTS_SID.DUST,
+      agentRouterMCPServerView
+    )
+  );
+
   // Fix the action ids.
   actions.forEach((action, i) => {
     action.id = -i;
@@ -1399,7 +1444,8 @@ function getGlobalAgent(
   sId: string | number,
   preFetchedDataSources: PrefetchedDataSourcesType | null,
   helperPromptInstance: HelperAssistantPrompt,
-  globaAgentSettings: GlobalAgentSettings[]
+  globaAgentSettings: GlobalAgentSettings[],
+  agentRouterMCPServerView: MCPServerViewResource | null
 ): AgentConfigurationType | null {
   const settings =
     globaAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -1410,6 +1456,7 @@ function getGlobalAgent(
       agentConfiguration = _getHelperGlobalAgent({
         auth,
         helperPromptInstance,
+        agentRouterMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT35_TURBO:
@@ -1514,6 +1561,7 @@ function getGlobalAgent(
       agentConfiguration = _getDustGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
+        agentRouterMCPServerView,
       });
       break;
     default:
@@ -1568,16 +1616,32 @@ export async function getGlobalAgents(
     throw new Error("Unexpected `auth` without `plan`.");
   }
 
-  const [preFetchedDataSources, globaAgentSettings, helperPromptInstance] =
-    await Promise.all([
-      variant === "full"
-        ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
-        : null,
-      GlobalAgentSettings.findAll({
-        where: { workspaceId: owner.id },
-      }),
-      HelperAssistantPrompt.getInstance(),
-    ]);
+  const [
+    preFetchedDataSources,
+    globaAgentSettings,
+    helperPromptInstance,
+    agentRouterMcpServerViews,
+  ] = await Promise.all([
+    variant === "full"
+      ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
+      : null,
+    GlobalAgentSettings.findAll({
+      where: { workspaceId: owner.id },
+    }),
+    HelperAssistantPrompt.getInstance(),
+    MCPServerViewResource.listByMCPServer(
+      auth,
+      internalMCPServerNameToSId({
+        name: "agent_router",
+        workspaceId: owner.id,
+      })
+    ),
+  ]);
+
+  // We prefetch the agent router mcp server view to be able to add this tool to some global agents.
+  const agentRouterMCPServerView =
+    agentRouterMcpServerViews.find((view) => view.space.kind === "global") ??
+    null;
 
   // If agentIds have been passed we fetch those. Otherwise we fetch them all, removing the retired
   // one (which will remove these models from the list of default agents in the product + list of
@@ -1622,7 +1686,8 @@ export async function getGlobalAgents(
       sId,
       preFetchedDataSources,
       helperPromptInstance,
-      globaAgentSettings
+      globaAgentSettings,
+      agentRouterMCPServerView
     )
   );
 


### PR DESCRIPTION
## Description

This PR introduces a new internal MCP server with a tool to list agents. 
This new tool is added by default to @\help and @\dust. 

I initially tried to call the internal `getAgentConfigurations()` but this cause some circle dependencies issues because to load agents configurations we load the mcp servers, that are very hard to solve. I tried implementing some registry logic to register and fetch server but I think we want to avoid some kind of bootstrap where we have to registerAllServers() to boot the app. 

The plan B was to not call the internal code but call instead our public API endpoint to fetch agents. Two un-cool things with that: 
1/ We do not get the user agents (since auth is for the workspace). 
2/ The public api route does not fetch the tools, while presenting the list of tools could have been a great thing to show. 

On this PR the tool is shown on the Knowledge > Tools section and can be added to any agent from the builder. 
I have a next PR based on this one to handle this and make it not accessible from the builder. We will only show the tool in the list of capabilities of the global agents for which it was added. 

## Next steps: 

- PR to refactor the mcp "isDefault" to something that also holds the information of the tool being "hidden". 
- Deploy both PR on front-edge to test. 
- Deploy to prod (it's only activated on our workspace with the current flag).

Then we can: 
If working super well we can put in under the mcp feature flag. 
If not working super well, we can test updating the global agents prompts to make them smarter about how to use this tool. 

## Tests

Locally, and will deploy on front-edge to test on our workspace where the feature flag is activated plus on another workspace without mcp activated. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 