### PR TITLE
Paginate on `FileStorage.getFiles` when deleting data sources

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -67,7 +67,7 @@ import { ConversationResource } from "../resources/conversation_resource";
 import { frontSequelize } from "../resources/storage";
 
 // Number of files we pull from GCS at once for deletion.
-// We take 10_000 to make sure we don't crash the pod, if we have 10k documents of 100kB (which is a lot) we're at 1GB.
+// If we have 10k documents of 100kB each (which is a lot) we are at 1GB here.
 const FILE_BATCH_SIZE = 10_000;
 
 export async function getDataSources(

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -66,6 +66,10 @@ import {
 import { ConversationResource } from "../resources/conversation_resource";
 import { frontSequelize } from "../resources/storage";
 
+// Number of files we pull from GCS at once for deletion.
+// We take 10_000 to make sure we don't crash the pod, if we have 10k documents of 100kB (which is a lot) we're at 1GB.
+const FILE_BATCH_SIZE = 10_000;
+
 export async function getDataSources(
   auth: Authenticator,
   { includeEditedBy }: { includeEditedBy: boolean } = {
@@ -148,44 +152,49 @@ export async function hardDeleteDataSource(
   // Delete all files in the data source's bucket.
   const { dustAPIProjectId } = dataSource;
 
-  const files = await getDustDataSourcesBucket().getFiles({
-    prefix: dustAPIProjectId,
-  });
+  let files;
 
-  const chunkSize = 32;
-  const chunks = [];
-  for (let i = 0; i < files.length; i += chunkSize) {
-    chunks.push(files.slice(i, i + chunkSize));
-  }
+  do {
+    files = await getDustDataSourcesBucket().getFiles({
+      prefix: dustAPIProjectId,
+      maxResults: FILE_BATCH_SIZE,
+    });
 
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i];
-    if (!chunk) {
-      continue;
+    const chunkSize = 32;
+    const chunks = [];
+    for (let i = 0; i < files.length; i += chunkSize) {
+      chunks.push(files.slice(i, i + chunkSize));
     }
-    await Promise.all(
-      chunk.map((f) => {
-        return (async () => {
-          try {
-            await f.delete();
-          } catch (error) {
-            if (isGCSNotFoundError(error)) {
-              logger.warn(
-                {
-                  path: f.name,
-                  dataSourceId: dataSource.sId,
-                  dustAPIProjectId,
-                },
-                "File not found during deletion, skipping"
-              );
-            } else {
-              throw error;
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      if (!chunk) {
+        continue;
+      }
+      await Promise.all(
+        chunk.map((f) => {
+          return (async () => {
+            try {
+              await f.delete();
+            } catch (error) {
+              if (isGCSNotFoundError(error)) {
+                logger.warn(
+                  {
+                    path: f.name,
+                    dataSourceId: dataSource.sId,
+                    dustAPIProjectId,
+                  },
+                  "File not found during deletion, skipping"
+                );
+              } else {
+                throw error;
+              }
             }
-          }
-        })();
-      })
-    );
-  }
+          })();
+        })
+      );
+    }
+  } while (files.length === FILE_BATCH_SIZE);
 
   // Ensure all content fragments from dsviews are expired.
   // Only used temporarily to unstuck queues -- TODO(fontanierh)

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -107,8 +107,14 @@ export class FileStorage {
     return this.bucket.file(filename);
   }
 
-  async getFiles({ prefix }: { prefix?: string } = {}) {
-    const [files] = await this.bucket.getFiles({ prefix });
+  async getFiles({
+    maxResults,
+    prefix,
+  }: {
+    prefix?: string;
+    maxResults: number;
+  }) {
+    const [files] = await this.bucket.getFiles({ prefix, maxResults });
 
     return files;
   }


### PR DESCRIPTION
## Description

- We currently have an issue where the deletion of an very (extremely) large data source causes the front-worker pod to OOM. The OOM is suspected to occur when we pull the files from GCS.
- This PR adds pagination we pull files from the bucket, and paginates when we delete a data source.

## Tests

- Hard to test.

## Risk

- Blast radius relatively contained as it's an admin action.
- Risk of not properly deleting all the data.

## Deploy Plan

- Deploy front.
