### PR TITLE
Fix information about accessibility

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -95,6 +95,12 @@ import {
   getDefaultMCPServerActionConfiguration,
   isDefaultActionName,
 } from "@app/components/assistant_builder/types";
+import {
+  isReservedName,
+  isUsableAsCapability,
+  isUsableInKnowledge,
+  useBuilderActionInfo,
+} from "@app/components/assistant_builder/useBuilderActionInfo";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
@@ -124,43 +130,6 @@ const ADVANCED_ACTION_CATEGORIES = [
   "DUST_APP_RUN",
   "MCP",
 ] as const satisfies Array<AssistantBuilderActionConfiguration["type"]>;
-
-// Actions in this list are not configurable via the "add tool" menu.
-// Instead, they should be handled in the `Capabilities` component.
-// Note: not all capabilities are actions (eg: visualization)
-const CAPABILITIES_ACTION_CATEGORIES = [
-  "WEB_NAVIGATION",
-  "REASONING",
-] as const satisfies Array<AssistantBuilderActionConfiguration["type"]>;
-
-const isUsableAsCapability = (
-  id: string,
-  mcpServerViews: MCPServerViewType[]
-) => {
-  const view = mcpServerViews.find((v) => v.id === id);
-  if (!view) {
-    return false;
-  }
-  return view.server.isDefault && getMCPServerRequirements(view).noRequirement;
-};
-
-const isUsableInKnowledge = (
-  id: string,
-  mcpServerViews: MCPServerViewType[]
-) => {
-  const view = mcpServerViews.find((v) => v.id === id);
-  if (!view) {
-    return false;
-  }
-  return view.server.isDefault && !isUsableAsCapability(id, mcpServerViews);
-};
-
-// We reserve the name we use for capability actions, as these aren't
-// configurable via the "add tool" menu.
-const isReservedName = (name: string) =>
-  CAPABILITIES_ACTION_CATEGORIES.some(
-    (c) => getDefaultActionConfiguration(c)?.name === name
-  );
 
 function ActionModeSection({
   children,
@@ -253,107 +222,18 @@ export default function ActionsScreen({
   enableReasoningTool,
   reasoningModels,
 }: ActionScreenProps) {
-  const { spaces, mcpServerViews } = useContext(AssistantBuilderContext);
+  const { mcpServerViews } = useContext(AssistantBuilderContext);
   const { hasFeature } = useFeatureFlags({
     workspaceId: owner.sId,
   });
 
-  const isCapabilityAction = useCallback(
-    (action: AssistantBuilderActionConfiguration) => {
-      if (action.type === "MCP") {
-        return isUsableAsCapability(
-          action.configuration.mcpServerViewId,
-          mcpServerViews
-        );
-      }
-
-      return (CAPABILITIES_ACTION_CATEGORIES as string[]).includes(action.type);
-    },
-    [mcpServerViews]
-  );
-
-  const configurableActions = builderState.actions.filter(
-    (a) => !isCapabilityAction(a)
-  );
-
   const isLegacyConfig = isLegacyAssistantBuilderConfiguration(builderState);
 
-  const spaceIdToActions = useMemo(() => {
-    return configurableActions.reduce<
-      Record<string, AssistantBuilderActionConfigurationWithId[]>
-    >((acc, action) => {
-      const addActionToSpace = (spaceId?: string) => {
-        if (spaceId) {
-          acc[spaceId] = (acc[spaceId] || []).concat(action);
-        }
-      };
-
-      const actionType = action.type;
-
-      switch (actionType) {
-        case "TABLES_QUERY":
-          Object.values(action.configuration).forEach((config) => {
-            addActionToSpace(config.dataSourceView.spaceId);
-          });
-          break;
-
-        case "RETRIEVAL_SEARCH":
-        case "RETRIEVAL_EXHAUSTIVE":
-        case "PROCESS":
-          Object.values(action.configuration.dataSourceConfigurations).forEach(
-            (config) => {
-              addActionToSpace(config.dataSourceView.spaceId);
-            }
-          );
-          break;
-
-        case "DUST_APP_RUN":
-          addActionToSpace(action.configuration.app?.space.sId);
-          break;
-
-        case "MCP":
-          if (action.configuration.dataSourceConfigurations) {
-            Object.values(
-              action.configuration.dataSourceConfigurations
-            ).forEach((config) => {
-              addActionToSpace(config.dataSourceView.spaceId);
-            });
-          }
-
-          if (action.configuration.tablesConfigurations) {
-            Object.values(action.configuration.tablesConfigurations).forEach(
-              (config) => {
-                addActionToSpace(config.dataSourceView.spaceId);
-              }
-            );
-          }
-
-          if (action.configuration.mcpServerViewId) {
-            const mcpServerView = mcpServerViews.find(
-              (v) => v.id === action.configuration.mcpServerViewId
-            );
-            // Default MCP server themselves are not accounted for in the space restriction.
-            if (mcpServerView && !mcpServerView.server.isDefault) {
-              addActionToSpace(mcpServerView.spaceId);
-            }
-          }
-          break;
-
-        case "WEB_NAVIGATION":
-        case "REASONING":
-          break;
-
-        default:
-          assertNever(actionType);
-      }
-      return acc;
-    }, {});
-  }, [configurableActions, mcpServerViews]);
-
-  const nonGlobalSpacessUsedInActions = useMemo(() => {
-    const nonGlobalSpaces = spaces.filter((s) => s.kind !== "global");
-    return nonGlobalSpaces.filter((v) => spaceIdToActions[v.sId]?.length > 0);
-  }, [spaceIdToActions, spaces]);
+  const {
+    configurableActions,
+    nonGlobalSpacessUsedInActions,
+    spaceIdToActions,
+  } = useBuilderActionInfo(builderState);
 
   const updateAction = useCallback(
     function _updateAction({

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -17,13 +17,7 @@ import {
 import assert from "assert";
 import { uniqueId } from "lodash";
 import { useRouter } from "next/router";
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 
 import ActionsScreen, {
   hasActionError,
@@ -367,12 +361,10 @@ export default function AssistantBuilder({
     }
   }, [edited, formValidation]);
 
-  const viewTab = useMemo(() => {
+  useEffect(() => {
     if (currentTab && isValidTab(currentTab)) {
       setScreen(currentTab);
-      return currentTab;
     }
-    return "instructions";
   }, [currentTab]);
 
   const setAction = useCallback(
@@ -406,11 +398,11 @@ export default function AssistantBuilder({
   const onAssistantSave = async () => {
     // Redirect to the right screen if there are errors.
     if (instructionsError) {
-      setScreen("instructions");
+      setCurrentTab("instructions");
     } else if (hasAnyActionsError) {
-      setScreen("actions");
+      setCurrentTab("actions");
     } else if (assistantHandleError || descriptionError) {
-      setScreen("settings");
+      setCurrentTab("settings");
     } else {
       setDisableUnsavedChangesPrompt(true);
       setIsSavingOrDeleting(true);
@@ -500,9 +492,8 @@ export default function AssistantBuilder({
                   className="w-full"
                   onValueChange={(t) => {
                     setCurrentTab(t);
-                    setScreen(t as BuilderScreen);
                   }}
-                  value={viewTab}
+                  value={screen}
                 >
                   <TabsList>
                     {Object.values(BUILDER_SCREENS_INFOS).map((tab) => (
@@ -599,11 +590,7 @@ export default function AssistantBuilder({
                     assertNever(screen);
                 }
               })()}
-              <PrevNextButtons
-                screen={screen}
-                setScreen={setScreen}
-                setCurrentTab={setCurrentTab}
-              />
+              <PrevNextButtons screen={screen} setCurrentTab={setCurrentTab} />
             </div>
           }
           buttonsRightPanel={

--- a/front/components/assistant_builder/PrevNextButtons.tsx
+++ b/front/components/assistant_builder/PrevNextButtons.tsx
@@ -5,13 +5,11 @@ import type { BuilderScreen } from "@app/components/assistant_builder/types";
 
 interface PrevNextButtonsProps {
   screen: BuilderScreen;
-  setScreen: (screen: BuilderScreen) => void;
   setCurrentTab: (tab: string) => void;
 }
 
 export function PrevNextButtons({
   screen,
-  setScreen,
   setCurrentTab,
 }: PrevNextButtonsProps) {
   return (
@@ -25,7 +23,6 @@ export function PrevNextButtons({
           data-gtm-location="assistantBuilder"
           onClick={() => {
             const newScreen = screen === "actions" ? "instructions" : "actions";
-            setScreen(newScreen);
             setCurrentTab(newScreen);
           }}
         />
@@ -41,7 +38,6 @@ export function PrevNextButtons({
           onClick={() => {
             const newScreen =
               screen === "instructions" ? "actions" : "settings";
-            setScreen(newScreen);
             setCurrentTab(newScreen);
           }}
         />

--- a/front/components/assistant_builder/SettingsScreen.tsx
+++ b/front/components/assistant_builder/SettingsScreen.tsx
@@ -586,7 +586,7 @@ export default function SettingsScreen({
                           <>Visible & usable by editors only.</>
                         )}
                         {builderState.scope === "private" && (
-                          <>Visible and usable by the current user only</>
+                          <>Visible and usable by the current user only.</>
                         )}
                       </span>
                     </div>

--- a/front/components/assistant_builder/useBuilderActionInfo.ts
+++ b/front/components/assistant_builder/useBuilderActionInfo.ts
@@ -1,0 +1,154 @@
+import { useCallback, useContext, useMemo } from "react";
+
+import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
+import type {
+  AssistantBuilderActionConfiguration,
+  AssistantBuilderActionConfigurationWithId,
+  AssistantBuilderState,
+} from "@app/components/assistant_builder/types";
+import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { assertNever } from "@app/types";
+
+// Actions in this list are not configurable via the "add tool" menu.
+// Instead, they should be handled in the `Capabilities` component.
+// Note: not all capabilities are actions (eg: visualization)
+const CAPABILITIES_ACTION_CATEGORIES = [
+  "WEB_NAVIGATION",
+  "REASONING",
+] as const satisfies Array<AssistantBuilderActionConfiguration["type"]>;
+
+// We reserve the name we use for capability actions, as these aren't
+// configurable via the "add tool" menu.
+export const isReservedName = (name: string) =>
+  CAPABILITIES_ACTION_CATEGORIES.some(
+    (c) => getDefaultActionConfiguration(c)?.name === name
+  );
+
+export const isUsableAsCapability = (
+  id: string,
+  mcpServerViews: MCPServerViewType[]
+) => {
+  const view = mcpServerViews.find((v) => v.id === id);
+  if (!view) {
+    return false;
+  }
+  return view.server.isDefault && getMCPServerRequirements(view).noRequirement;
+};
+
+export const isUsableInKnowledge = (
+  id: string,
+  mcpServerViews: MCPServerViewType[]
+) => {
+  const view = mcpServerViews.find((v) => v.id === id);
+  if (!view) {
+    return false;
+  }
+  return view.server.isDefault && !isUsableAsCapability(id, mcpServerViews);
+};
+
+export const useBuilderActionInfo = (builderState: AssistantBuilderState) => {
+  const { spaces, mcpServerViews } = useContext(AssistantBuilderContext);
+
+  const isCapabilityAction = useCallback(
+    (action: AssistantBuilderActionConfiguration) => {
+      if (action.type === "MCP") {
+        return isUsableAsCapability(
+          action.configuration.mcpServerViewId,
+          mcpServerViews
+        );
+      }
+
+      return (CAPABILITIES_ACTION_CATEGORIES as string[]).includes(action.type);
+    },
+    [mcpServerViews]
+  );
+
+  const configurableActions = builderState.actions.filter(
+    (a) => !isCapabilityAction(a)
+  );
+
+  const spaceIdToActions = useMemo(() => {
+    return configurableActions.reduce<
+      Record<string, AssistantBuilderActionConfigurationWithId[]>
+    >((acc, action) => {
+      const addActionToSpace = (spaceId?: string) => {
+        if (spaceId) {
+          acc[spaceId] = (acc[spaceId] || []).concat(action);
+        }
+      };
+
+      const actionType = action.type;
+
+      switch (actionType) {
+        case "TABLES_QUERY":
+          Object.values(action.configuration).forEach((config) => {
+            addActionToSpace(config.dataSourceView.spaceId);
+          });
+          break;
+
+        case "RETRIEVAL_SEARCH":
+        case "RETRIEVAL_EXHAUSTIVE":
+        case "PROCESS":
+          Object.values(action.configuration.dataSourceConfigurations).forEach(
+            (config) => {
+              addActionToSpace(config.dataSourceView.spaceId);
+            }
+          );
+          break;
+
+        case "DUST_APP_RUN":
+          addActionToSpace(action.configuration.app?.space.sId);
+          break;
+
+        case "MCP":
+          if (action.configuration.dataSourceConfigurations) {
+            Object.values(
+              action.configuration.dataSourceConfigurations
+            ).forEach((config) => {
+              addActionToSpace(config.dataSourceView.spaceId);
+            });
+          }
+
+          if (action.configuration.tablesConfigurations) {
+            Object.values(action.configuration.tablesConfigurations).forEach(
+              (config) => {
+                addActionToSpace(config.dataSourceView.spaceId);
+              }
+            );
+          }
+
+          if (action.configuration.mcpServerViewId) {
+            const mcpServerView = mcpServerViews.find(
+              (v) => v.id === action.configuration.mcpServerViewId
+            );
+            // Default MCP server themselves are not accounted for in the space restriction.
+            if (mcpServerView && !mcpServerView.server.isDefault) {
+              addActionToSpace(mcpServerView.spaceId);
+            }
+          }
+          break;
+
+        case "WEB_NAVIGATION":
+        case "REASONING":
+          break;
+
+        default:
+          assertNever(actionType);
+      }
+      return acc;
+    }, {});
+  }, [configurableActions, mcpServerViews]);
+
+  const nonGlobalSpacessUsedInActions = useMemo(() => {
+    const nonGlobalSpaces = spaces.filter((s) => s.kind !== "global");
+    return nonGlobalSpaces.filter((v) => spaceIdToActions[v.sId]?.length > 0);
+  }, [spaceIdToActions, spaces]);
+
+  return {
+    configurableActions,
+    nonGlobalSpacessUsedInActions,
+    spaceIdToActions,
+  };
+};


### PR DESCRIPTION
## Description

This moves some code from ActionsScreen to a hook that is reused in SettingsScreen, giving information about the actions and the space restriction the agent may have. With this info (`nonGlobalSpacessUsedInActions`) we can show a more accurate message on who can use the agent.

-------------------------

<img width="503" alt="Screenshot 2025-05-07 at 15 04 04" src="https://github.com/user-attachments/assets/8cff3db8-65df-4b73-8759-155eb7fc11e9" />

-------------------------

<img width="432" alt="Screenshot 2025-05-07 at 15 04 10" src="https://github.com/user-attachments/assets/5d37b773-c60c-47b9-9ef1-69d3e1236dda" />

-------------------------

<img width="638" alt="Screenshot 2025-05-07 at 15 05 00" src="https://github.com/user-attachments/assets/15edf4f1-eff3-4e4c-964b-a9dd46653d65" />

-------------------------

Also fixed the tab navigation in AssistantBuilder which is using the same information in 2 different places (react state + hash)

## Tests

locally

## Risk

minimal

## Deploy Plan

deploy front

