### PR TITLE
Mcp server availability

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -185,7 +185,7 @@ export const AdminActionsList = ({
   };
 
   const rows: RowData[] = mcpServers
-    .filter((mcpServer) => !mcpServer.isDefault)
+    .filter((mcpServer) => mcpServer.availability === "manual")
     .map((mcpServer) => {
       const mcpServerWithViews = mcpServers.find((s) => s.id === mcpServer.id);
       const mcpServerView = mcpServerWithViews?.views.find(

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -203,7 +203,7 @@ export function MCPServerDetails({
                   icon={InformationCircleIcon}
                   onClick={() => setSelectedTab("info")}
                 />
-                {!mcpServer?.isDefault && (
+                {mcpServer?.availability === "manual" && (
                   <TabsTrigger
                     value="sharing"
                     label="Sharing"
@@ -212,20 +212,21 @@ export function MCPServerDetails({
                   />
                 )}
 
-                {effectiveMCPServer && !effectiveMCPServer.isDefault && (
-                  <>
-                    <div className="grow" />
-                    <Button
-                      variant="outline"
-                      icon={TrashIcon}
-                      label={"Remove"}
-                      size="sm"
-                      onClick={() => {
-                        setMCPServerToDelete(effectiveMCPServer);
-                      }}
-                    />
-                  </>
-                )}
+                {effectiveMCPServer &&
+                  effectiveMCPServer.availability === "manual" && (
+                    <>
+                      <div className="grow" />
+                      <Button
+                        variant="outline"
+                        icon={TrashIcon}
+                        label={"Remove"}
+                        size="sm"
+                        onClick={() => {
+                          setMCPServerToDelete(effectiveMCPServer);
+                        }}
+                      />
+                    </>
+                  )}
               </TabsList>
             </Tabs>
           </SheetHeader>

--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -90,7 +90,7 @@ export function MCPServerSelector({
               <RadioGroup defaultValue={selectedMCPServerView?.id}>
                 {mcpServerViewsInSpace
                   // Default servers can be added as capabilities or in the first level of the "Add tools" list
-                  .filter((view) => !view.server.isDefault)
+                  .filter((view) => view.server.availability === "manual")
                   .map((mcpServerView, idx, arr) => (
                     <React.Fragment key={mcpServerView.id}>
                       <div className="flex w-full flex-row items-center justify-between gap-2">

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -14,6 +14,7 @@ import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
+import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { LightWorkspaceType, SpaceType, TimeFrame } from "@app/types";
@@ -99,8 +100,8 @@ export function MCPAction({
     );
 
   // MCPServerView on default MCP server will not allow switching to another one.
-  const isDefaultMCPServer = useMemo(
-    () => !!selectedMCPServerView?.server.isDefault,
+  const selectedServerAvailability: MCPServerAvailability | null = useMemo(
+    () => selectedMCPServerView?.server.availability ?? null,
     [selectedMCPServerView]
   );
 
@@ -200,12 +201,13 @@ export function MCPAction({
         />
       )}
       {/* Server selection */}
-      {!selectedMCPServerView?.server.isDefault &&
+      {(selectedServerAvailability === null ||
+        selectedServerAvailability === "manual") &&
         (isEditing ? (
           <div className="text-sm text-foreground dark:text-foreground-night">
             <div>{selectedMCPServerView?.server.description}</div>
             <br />
-            {!isDefaultMCPServer && (
+            {selectedServerAvailability === "manual" && (
               <div>
                 Available to you via{" "}
                 <b>

--- a/front/components/assistant_builder/useBuilderActionInfo.ts
+++ b/front/components/assistant_builder/useBuilderActionInfo.ts
@@ -34,7 +34,10 @@ export const isUsableAsCapability = (
   if (!view) {
     return false;
   }
-  return view.server.isDefault && getMCPServerRequirements(view).noRequirement;
+  return (
+    view.server.availability === "auto" &&
+    getMCPServerRequirements(view).noRequirement
+  );
 };
 
 export const isUsableInKnowledge = (
@@ -45,7 +48,10 @@ export const isUsableInKnowledge = (
   if (!view) {
     return false;
   }
-  return view.server.isDefault && !isUsableAsCapability(id, mcpServerViews);
+  return (
+    view.server.availability === "auto" &&
+    !isUsableAsCapability(id, mcpServerViews)
+  );
 };
 
 export const useBuilderActionInfo = (builderState: AssistantBuilderState) => {

--- a/front/components/assistant_builder/useBuilderActionInfo.ts
+++ b/front/components/assistant_builder/useBuilderActionInfo.ts
@@ -130,7 +130,10 @@ export const useBuilderActionInfo = (builderState: AssistantBuilderState) => {
               (v) => v.id === action.configuration.mcpServerViewId
             );
             // Default MCP server themselves are not accounted for in the space restriction.
-            if (mcpServerView && !mcpServerView.server.isDefault) {
+            if (
+              mcpServerView &&
+              mcpServerView.server.availability === "manual"
+            ) {
               addActionToSpace(mcpServerView.spaceId);
             }
           }

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -62,7 +62,7 @@ export const MCP_TOOL_STAKE_LEVELS = [
 ] as const;
 export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVELS)[number];
 
-export const FALLBACK_INTERNAL_DEFAULT_SERVERS_TOOL_STAKE_LEVEL =
+export const FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL =
   "never_ask" as const;
 export const FALLBACK_MCP_TOOL_STAKE_LEVEL = "high" as const;
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -9,6 +9,7 @@ import type {
 } from "@app/lib/actions/constants";
 import { FALLBACK_MCP_TOOL_STAKE_LEVEL } from "@app/lib/actions/constants";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
+import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   augmentInputsWithConfiguration,
   hideInternalConfiguration,
@@ -115,7 +116,7 @@ export type PlatformMCPToolConfigurationType = Omit<
 > & {
   type: "mcp_configuration";
   inputSchema: JSONSchema;
-  isDefault: boolean;
+  availability: MCPServerAvailability;
   permission: MCPToolStakeLevelType;
   toolServerId: string;
 };

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -153,7 +153,7 @@ export const INTERNAL_MCP_SERVERS: Record<
 export type InternalMCPServerNameType =
   (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];
 
-export const getAvailabilyOfInternalMCPServerByName = (
+export const getAvailabilityOfInternalMCPServerByName = (
   name: InternalMCPServerNameType
 ): MCPServerAvailability => {
   return INTERNAL_MCP_SERVERS[name].availability;
@@ -166,7 +166,7 @@ export const getInternalMCPServerAvailability = (
   if (r.isErr()) {
     return "manual";
   }
-  return getAvailabilyOfInternalMCPServerByName(r.value.name);
+  return getAvailabilityOfInternalMCPServerByName(r.value.name);
 };
 
 export const getInternalMCPServerNameAndWorkspaceId = (

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -26,11 +26,20 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "agent_router",
 ] as const;
 
+// Whether the server is available by default in the global space.
+// Hidden servers are available by default in the global space but are not visible in the assistant builder.
+const MCP_SERVER_AVAILABILITY = [
+  "manual",
+  "auto",
+  "auto_hidden_builder",
+] as const;
+export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
+
 export const INTERNAL_MCP_SERVERS: Record<
   InternalMCPServerNameType,
   {
     id: number;
-    isDefault: boolean;
+    availability: MCPServerAvailability;
     flag: WhitelistableFeature | null;
     tools_stakes?: Record<string, MCPToolStakeLevelType>;
   }
@@ -44,7 +53,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   // Production
   github: {
     id: 1,
-    isDefault: false,
+    availability: "manual",
     flag: "mcp_actions",
     tools_stakes: {
       get_pull_request: "never_ask",
@@ -52,32 +61,32 @@ export const INTERNAL_MCP_SERVERS: Record<
   },
   image_generation: {
     id: 2,
-    isDefault: true,
+    availability: "auto",
     flag: null,
   },
   file_generation: {
     id: 3,
-    isDefault: true,
+    availability: "auto",
     flag: "mcp_actions",
   },
   tables_query: {
     id: 4,
-    isDefault: true,
+    availability: "auto",
     flag: "dev_mcp_actions", // Putting this behind the dev flag for now to allow shipping without it.
   },
   "web_search_&_browse_v2": {
     id: 5,
-    isDefault: true,
+    availability: "auto",
     flag: "mcp_actions",
   },
   think: {
     id: 6,
-    isDefault: true,
+    availability: "auto",
     flag: "experimental_mcp_actions",
   },
   hubspot: {
     id: 7,
-    isDefault: false,
+    availability: "manual",
     flag: "experimental_mcp_actions",
     tools_stakes: {
       get_object_properties: "never_ask",
@@ -91,24 +100,24 @@ export const INTERNAL_MCP_SERVERS: Record<
   },
   agent_router: {
     id: 8,
-    isDefault: true,
+    availability: "auto_hidden_builder",
     flag: "experimental_mcp_actions",
   },
 
   // Dev
   data_sources_debugger: {
     id: 1000,
-    isDefault: false,
+    availability: "manual",
     flag: "dev_mcp_actions",
   },
   child_agent_debugger: {
     id: 1001,
-    isDefault: false,
+    availability: "manual",
     flag: "dev_mcp_actions",
   },
   authentication_debugger: {
     id: 1002,
-    isDefault: false,
+    availability: "manual",
     flag: "dev_mcp_actions",
     tools_stakes: {
       hello_world: "never_ask",
@@ -116,27 +125,27 @@ export const INTERNAL_MCP_SERVERS: Record<
   },
   tables_debugger: {
     id: 1003,
-    isDefault: false,
+    availability: "manual",
     flag: "dev_mcp_actions",
   },
   primitive_types_debugger: {
     id: 1004,
-    isDefault: false,
+    availability: "manual",
     flag: "dev_mcp_actions",
   },
   search: {
     id: 1006,
-    isDefault: true,
+    availability: "auto",
     flag: "dev_mcp_actions",
   },
   reasoning_v2: {
     id: 1007,
-    isDefault: true,
+    availability: "auto",
     flag: "dev_mcp_actions",
   },
   ask_agent: {
     id: 1008,
-    isDefault: false,
+    availability: "manual",
     flag: "experimental_mcp_actions",
   },
 };
@@ -144,18 +153,20 @@ export const INTERNAL_MCP_SERVERS: Record<
 export type InternalMCPServerNameType =
   (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];
 
-export const isDefaultInternalMCPServerByName = (
+export const getAvailabilyOfInternalMCPServerByName = (
   name: InternalMCPServerNameType
-): boolean => {
-  return INTERNAL_MCP_SERVERS[name].isDefault;
+): MCPServerAvailability => {
+  return INTERNAL_MCP_SERVERS[name].availability;
 };
 
-export const isDefaultInternalMCPServer = (sId: string): boolean => {
+export const getInternalMCPServerAvailability = (
+  sId: string
+): MCPServerAvailability => {
   const r = getInternalMCPServerNameAndWorkspaceId(sId);
   if (r.isErr()) {
-    return false;
+    return "manual";
   }
-  return isDefaultInternalMCPServerByName(r.value.name);
+  return getAvailabilyOfInternalMCPServerByName(r.value.name);
 };
 
 export const getInternalMCPServerNameAndWorkspaceId = (

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -294,7 +294,7 @@ export async function fetchRemoteServerMetaDataByURL(
     return new Ok({
       ...metadata,
       tools: serverTools,
-      isDefault: false,
+      availability: "manual",
     });
   } catch (e: unknown) {
     return new Err(

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -5,7 +5,10 @@ import type {
   InternalAllowedIconType,
   RemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type {
+  InternalMCPServerNameType,
+  MCPServerAvailability,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { EditedByUser } from "@app/types";
 
@@ -15,8 +18,8 @@ export type MCPToolType = {
   inputSchema: JSONSchema | undefined;
 };
 
-export type MCPToolWithIsDefaultType = MCPToolType & {
-  isDefault: boolean;
+export type MCPToolWithAvailabilityType = MCPToolType & {
+  availability: MCPServerAvailability;
 };
 
 export type WithStakeLevelType<T> = T & {
@@ -24,12 +27,12 @@ export type WithStakeLevelType<T> = T & {
 };
 
 export type PlatformMCPToolTypeWithStakeLevel =
-  WithStakeLevelType<MCPToolWithIsDefaultType> & {
+  WithStakeLevelType<MCPToolWithAvailabilityType> & {
     toolServerId: string;
   };
 
 export type LocalMCPToolTypeWithStakeLevel =
-  WithStakeLevelType<MCPToolWithIsDefaultType>;
+  WithStakeLevelType<MCPToolWithAvailabilityType>;
 
 export type MCPToolWithStakeLevelType =
   | PlatformMCPToolTypeWithStakeLevel
@@ -43,7 +46,7 @@ export type MCPServerType = {
   icon: RemoteAllowedIconType | InternalAllowedIconType;
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
-  isDefault: boolean;
+  availability: MCPServerAvailability;
 };
 
 export type RemoteMCPServerType = MCPServerType & {
@@ -66,7 +69,7 @@ export interface MCPServerViewType {
 
 export type MCPServerDefinitionType = Omit<
   MCPServerType,
-  "tools" | "id" | "isDefault"
+  "tools" | "id" | "availability"
 >;
 
 type InternalMCPServerType = MCPServerType & {
@@ -76,7 +79,7 @@ type InternalMCPServerType = MCPServerType & {
 
 export type InternalMCPServerDefinitionType = Omit<
   InternalMCPServerType,
-  "tools" | "id" | "isDefault"
+  "tools" | "id" | "availability"
 >;
 
 export type MCPServerTypeWithViews = MCPServerType & {

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -7,9 +7,9 @@ import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
+  getAvailabilyOfInternalMCPServerByName,
+  getInternalMCPServerAvailability,
   getInternalMCPServerNameAndWorkspaceId,
-  isDefaultInternalMCPServer,
-  isDefaultInternalMCPServerByName,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
@@ -37,7 +37,7 @@ export class InternalMCPServerInMemoryResource {
   private metadata: Omit<MCPServerType, "id"> = {
     ...extractMetadataFromServerVersion(undefined),
     tools: [],
-    isDefault: false,
+    availability: "manual",
   };
 
   constructor(id: string) {
@@ -81,9 +81,9 @@ export class InternalMCPServerInMemoryResource {
           tools: extractMetadataFromTools(
             (await mcpClient.listTools()).tools
           ) as any,
-          isDefault: isInternalMCPServerName(md.name)
-            ? isDefaultInternalMCPServerByName(md.name)
-            : false,
+          availability: isInternalMCPServerName(md.name)
+            ? getAvailabilyOfInternalMCPServerByName(md.name)
+            : "manual",
         };
 
         await mcpClient.close();
@@ -182,7 +182,8 @@ export class InternalMCPServerInMemoryResource {
 
   static async fetchById(auth: Authenticator, id: string) {
     // Fast path : Do not check for default internal MCP servers as they are always available.
-    if (!isDefaultInternalMCPServer(id)) {
+    const availability = getInternalMCPServerAvailability(id);
+    if (availability === "manual") {
       const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
 
       const server = await MCPServerViewModel.findOne({

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -7,7 +7,7 @@ import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
-  getAvailabilyOfInternalMCPServerByName,
+  getAvailabilityOfInternalMCPServerByName,
   getInternalMCPServerAvailability,
   getInternalMCPServerNameAndWorkspaceId,
   isInternalMCPServerName,
@@ -82,7 +82,7 @@ export class InternalMCPServerInMemoryResource {
             (await mcpClient.listTools()).tools
           ) as any,
           availability: isInternalMCPServerName(md.name)
-            ? getAvailabilyOfInternalMCPServerByName(md.name)
+            ? getAvailabilityOfInternalMCPServerByName(md.name)
             : "manual",
         };
 

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -42,7 +42,7 @@ describe("MCPServerViewResource", () => {
           workspace2
         );
 
-        expect(INTERNAL_MCP_SERVERS["think"].isDefault).toBe(true);
+        expect(INTERNAL_MCP_SERVERS["think"].availability).toBe("auto");
 
         // Get auth for workspace1
         const auth1 = await Authenticator.internalAdminForWorkspace(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -463,7 +463,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return getInternalMCPServerAvailability(this.internalMCPServerId);
   }
 
-  static async ensureAllAutoActionsAreCreated(auth: Authenticator) {
+  static async ensureAllAutoToolsAreCreated(auth: Authenticator) {
     const names = AVAILABLE_INTERNAL_MCP_SERVER_NAMES;
 
     const autoInternalMCPServerIds: string[] = [];

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -16,7 +16,7 @@ import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
-  getAvailabilyOfInternalMCPServerByName,
+  getAvailabilityOfInternalMCPServerByName,
   getInternalMCPServerAvailability,
   isValidInternalMCPServerId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -469,7 +469,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     const autoInternalMCPServerIds: string[] = [];
     for (const name of names) {
       const isEnabled = await isEnabledForWorkspace(auth, name);
-      const availability = getAvailabilyOfInternalMCPServerByName(name);
+      const availability = getAvailabilityOfInternalMCPServerByName(name);
 
       if (isEnabled && availability !== "manual") {
         autoInternalMCPServerIds.push(

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -303,7 +303,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       cachedDescription:
         this.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION,
       authorization: this.authorization,
-      isDefault: false, // So far we don't have defaults remote MCP servers.
+      availability: "manual", // So far we don't have auto remote MCP servers.
 
       // Remote MCP Server specifics
       url: this.url,

--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -50,7 +50,7 @@ async function handler(
       const flattenedServerViews = serverViews
         .flat()
         .filter((v): v is MCPServerViewType => v !== null)
-        .filter((v) => v.server.isDefault === false);
+        .filter((v) => v.server.availability === "manual");
 
       return res.status(200).json({
         success: true,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -58,7 +58,7 @@ async function handler(
       const apps = await AppResource.listBySpace(auth, space);
       const actions = await MCPServerViewResource.listBySpace(auth, space);
       const actionsCount = actions.filter(
-        (a) => !a.toJSON().server.isDefault
+        (a) => a.toJSON().server.availability === "manual"
       ).length;
 
       const categories: { [key: string]: SpaceCategoryInfo } = {};

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -49,7 +49,7 @@ async function handler(
         success: true,
         serverViews: mcpServerViews
           .map((mcpServerView) => mcpServerView.toJSON())
-          .filter((s) => !s.server.isDefault),
+          .filter((s) => s.server.availability === "manual"),
       });
     }
     case "POST": {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -63,7 +63,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     await Promise.all([
       getAccessibleSourcesAndApps(auth),
       getAgentConfiguration(auth, context.params?.aId as string, "full"),
-      MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth),
+      MCPServerViewResource.ensureAllAutoActionsAreCreated(auth),
     ]);
 
   if (!configuration) {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -63,7 +63,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     await Promise.all([
       getAccessibleSourcesAndApps(auth),
       getAgentConfiguration(auth, context.params?.aId as string, "full"),
-      MCPServerViewResource.ensureAllAutoActionsAreCreated(auth),
+      MCPServerViewResource.ensureAllAutoToolsAreCreated(auth),
     ]);
 
   if (!configuration) {

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -137,7 +137,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  await MCPServerViewResource.ensureAllAutoActionsAreCreated(auth);
+  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
   const user = auth.getNonNullableUser();
 
   return {

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -137,7 +137,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  await MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth);
+  await MCPServerViewResource.ensureAllAutoActionsAreCreated(auth);
   const user = auth.getNonNullableUser();
 
   return {

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/actions/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/actions/index.tsx
@@ -31,7 +31,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
 
-  await MCPServerViewResource.ensureAllDefaultActionsAreCreated(auth);
+  await MCPServerViewResource.ensureAllAutoActionsAreCreated(auth);
 
   const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
   const space = await SpaceResource.fetchById(auth, spaceId);

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/actions/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/actions/index.tsx
@@ -31,7 +31,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
 
-  await MCPServerViewResource.ensureAllAutoActionsAreCreated(auth);
+  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
   const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
   const space = await SpaceResource.fetchById(auth, spaceId);


### PR DESCRIPTION
## Description

This PR replaces the `isDefault` boolean of mcp servers by a new `availability` property that takes a string. 
This should give us more flexibility and I tend to think it is clearer as is. 

Before: 
- `isDefault = true` = the mcp is added by default to the Company data space. 
- `isDefault = false` = the mcp is to be added manually by an Admin to a space. 

Now: 
- `availability = auto` = the mcp is added by default to the Company data space. 
- `availability = manual` = the mcp is to be added manually by an Admin to a space. 
- NEW `availability = auto_hidden` = the mcp is added by default to the Company data space but is not displayed on the Knowledge > Tools section and cannot be added to an agent from the assistant builder. This is used for the new tool `agent_router` that we want to add to @\dust and @\help only. 

## Tests

Locally. 
I'll push this PR on front edge to heavily test before merging. 

## Risk

Can be rolled back but since it touches a lot of files I'd rather test it properly. 

## Deploy Plan

Merge https://github.com/dust-tt/dust/pull/12485
Merge this one. 
Deploy front. 