### PR TITLE
Fix broken multiple mentions

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -452,10 +452,10 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         return AgentConfiguration.findAll({
           where: {
             workspaceId: owner.id,
-            sId: latestVersions.map((v) => v.sId),
-            version: {
-              [Op.in]: latestVersions.map((v) => v.max_version),
-            },
+            [Op.or]: latestVersions.map((v) => ({
+              sId: v.sId,
+              version: v.max_version,
+            })),
           },
           order: [["version", "DESC"]],
         });


### PR DESCRIPTION
## Description

Fixes https://dust4ai.slack.com/archives/C05B529FHV1/p1746642423966369

From: https://github.com/dust-tt/dust/issues/8900
We were fetching the latest versions of agents (couple sID, latest version) but we were not filtering keeping this matching. 

Hence multiple version of the same agents could be retrieved if the latest version of agent A was also an existing version of agent B. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 