### PR TITLE
Agent router uses mention in agent message, and mention is clickable

### DIFF
--- a/front/components/markdown/MentionBlock.tsx
+++ b/front/components/markdown/MentionBlock.tsx
@@ -1,8 +1,24 @@
+import { useContext } from "react";
 import { visit } from "unist-util-visit";
 
-export function MentionBlock({ agentName }: { agentName: string }) {
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+
+export function MentionBlock({
+  agentName,
+  agentSId,
+}: {
+  agentName: string;
+  agentSId: string;
+}) {
+  const { setAnimate, setSelectedAssistant } = useContext(InputBarContext);
   return (
-    <span className="inline-block cursor-default font-medium text-highlight-500">
+    <span
+      className="inline-block cursor-pointer font-medium text-highlight-500"
+      onClick={() => {
+        setSelectedAssistant({ configurationId: agentSId });
+        setAnimate(true);
+      }}
+    >
       @{agentName}
     </span>
   );

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -21,7 +21,7 @@ const createServer = (auth: Authenticator): McpServer => {
 
   server.tool(
     "list_agents",
-    "List all active published agents in the workspace, to know which ones are the best suited for the current conversation.",
+    "List all active published agents in the workspace, to know which ones are the best suited for the current conversation. the mention directive allows the user to click on the agent name to select it.",
     {},
     async () => {
       const owner = auth.getNonNullableWorkspace();
@@ -55,8 +55,8 @@ const createServer = (auth: Authenticator): McpServer => {
       const agents = res.value;
       const formattedAgents = agents.map((agent) => {
         return {
-          sId: agent.sId,
           name: agent.name,
+          mention: `:mention[${agent.name}]{sId: ${agent.sId}}`,
           description: agent.description,
         };
       });

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -56,7 +56,7 @@ const createServer = (auth: Authenticator): McpServer => {
       const formattedAgents = agents.map((agent) => {
         return {
           name: agent.name,
-          mention: `:mention[${agent.name}]{sId: ${agent.sId}}`,
+          mention: `:mention[${agent.name}]{sId=${agent.sId}}`,
           description: agent.description,
         };
       });


### PR DESCRIPTION
## Description

Updating agent router output to let it know it can use mentions, and properly handle the mentions markdown component so that it's clickable and it fills the input bar. 

<kbd>
<img width="1004" alt="Screenshot 2025-05-07 at 22 06 54" src="https://github.com/user-attachments/assets/a8b88072-3018-4c97-81c9-6648a0f948a1" />
</kbd>

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 