### PR TITLE
fix(labs): remove direct ID lookup in `/api/w/[wId]/labs/transcripts/[tId]`

### DIFF
--- a/front/components/labs/transcripts/StorageConfiguration.tsx
+++ b/front/components/labs/transcripts/StorageConfiguration.tsx
@@ -79,7 +79,7 @@ export function StorageConfiguration({
     }
 
     const success = await updateTranscriptsConfiguration({
-      dataSourceViewId: dataSourceView ? dataSourceView.id : null,
+      dataSourceViewId: dataSourceView ? dataSourceView.sId : null,
     });
 
     if (success) {

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -1,6 +1,6 @@
-import type { CreationAttributes } from "sequelize";
 import type {
   Attributes,
+  CreationAttributes,
   InferAttributes,
   ModelStatic,
   Transaction,
@@ -8,8 +8,11 @@ import type {
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { LabsTranscriptsConfigurationModel } from "@app/lib/resources/storage/models/labs_transcripts";
-import { LabsTranscriptsHistoryModel } from "@app/lib/resources/storage/models/labs_transcripts";
+import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import {
+  LabsTranscriptsConfigurationModel,
+  LabsTranscriptsHistoryModel,
+} from "@app/lib/resources/storage/models/labs_transcripts";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
@@ -186,12 +189,8 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     return this.update({ isDefaultWorkspaceConfiguration: isDefault });
   }
 
-  async setDataSourceViewId(dataSourceViewId: number | null) {
-    if (dataSourceViewId === undefined) {
-      return;
-    }
-
-    return this.update({ dataSourceViewId });
+  async setDataSourceView(dataSourceView: DataSourceViewResource | null) {
+    return this.update({ dataSourceViewId: dataSourceView?.id ?? null });
   }
 
   static async fetchDefaultConfigurationForWorkspace(

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -6,6 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -23,7 +24,7 @@ export type GetLabsTranscriptsConfigurationResponseBody = {
 export const PatchLabsTranscriptsConfigurationBodySchema = t.partial({
   agentConfigurationId: t.string,
   isActive: t.boolean,
-  dataSourceViewId: t.union([t.number, t.null]),
+  dataSourceViewId: t.union([t.string, t.null]),
 });
 export type PatchTranscriptsConfiguration = t.TypeOf<
   typeof PatchLabsTranscriptsConfigurationBodySchema
@@ -129,7 +130,11 @@ async function handler(
       }
 
       if (dataSourceViewId !== undefined) {
-        await transcriptsConfiguration.setDataSourceViewId(dataSourceViewId);
+        const dataSourceView = dataSourceViewId
+          ? await DataSourceViewResource.fetchById(auth, dataSourceViewId)
+          : null;
+
+        await transcriptsConfiguration.setDataSourceView(dataSourceView);
 
         if (
           isProviderWithDefaultWorkspaceConfiguration(


### PR DESCRIPTION
## Description

- The endpoint `PATCH /api/w/[wId]/labs/transcripts/[tId]` directly looks up data source views by model ID without any check on the user having the appropriate rights for it.
- This PR fixes that to look up by `sId` and to check authorization.

## Tests

- No regression tested locally, otherwise hard to test.

## Risk

- Blast radius contained to labs.

## Deploy Plan

- Deploy front.
