### PR TITLE
[front] chore(eslint): Setup eslint-plugin-dust

### DIFF
--- a/eslint-plugin-dust/index.js
+++ b/eslint-plugin-dust/index.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const noRawSqlRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "enfore no use of raw sql",
+    },
+    schema: [],
+  },
+
+  create: function (context) {
+    // Keep track of variables that are Sequelize instances
+    const sequelizeInstances = new Set();
+
+    return {
+      // Track variables assigned Sequelize instances
+      VariableDeclarator(node) {
+        if (node.init?.type === "CallExpression") {
+          const functionName = node.init.callee.name;
+          // Add known functions that return Sequelize instances
+          if (functionName === "getFrontReplicaDbConnection") {
+            sequelizeInstances.add(node.id.name);
+          }
+        }
+      },
+
+      // Check for query method calls
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.name === "query"
+        ) {
+          const obj = node.callee.object;
+
+          // Check if the object is a known Sequelize instance
+          if (
+            obj.type === "Identifier" &&
+            // Known variable names
+            (obj.name === "frontSequelize" ||
+              // Variables we tracked that were assigned Sequelize instances
+              sequelizeInstances.has(obj.name) ||
+              // Pattern matching for *sequelize* names
+              /sequelize/i.test(obj.name))
+          ) {
+            context.report({
+              node,
+              message:
+                "Raw SQL queries are not allowed. Use Sequelize models and methods instead.",
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+module.exports = {
+  meta: {
+    name: "eslint-plugin-dust",
+    version: "0.0.0",
+  },
+  rules: {
+    "no-raw-sql": noRawSqlRule,
+  },
+};

--- a/eslint-plugin-dust/index.js
+++ b/eslint-plugin-dust/index.js
@@ -1,59 +1,6 @@
 "use strict";
 
-const noRawSqlRule = {
-  meta: {
-    type: "problem",
-    docs: {
-      description: "enfore no use of raw sql",
-    },
-    schema: [],
-  },
-
-  create: function (context) {
-    // Keep track of variables that are Sequelize instances
-    const sequelizeInstances = new Set();
-
-    return {
-      // Track variables assigned Sequelize instances
-      VariableDeclarator(node) {
-        if (node.init?.type === "CallExpression") {
-          const functionName = node.init.callee.name;
-          // Add known functions that return Sequelize instances
-          if (functionName === "getFrontReplicaDbConnection") {
-            sequelizeInstances.add(node.id.name);
-          }
-        }
-      },
-
-      // Check for query method calls
-      CallExpression(node) {
-        if (
-          node.callee.type === "MemberExpression" &&
-          node.callee.property.name === "query"
-        ) {
-          const obj = node.callee.object;
-
-          // Check if the object is a known Sequelize instance
-          if (
-            obj.type === "Identifier" &&
-            // Known variable names
-            (obj.name === "frontSequelize" ||
-              // Variables we tracked that were assigned Sequelize instances
-              sequelizeInstances.has(obj.name) ||
-              // Pattern matching for *sequelize* names
-              /sequelize/i.test(obj.name))
-          ) {
-            context.report({
-              node,
-              message:
-                "Raw SQL queries are not allowed. Use Sequelize models and methods instead.",
-            });
-          }
-        }
-      },
-    };
-  },
-};
+const noRawSqlRule = require("./rules/no-raw-sql");
 
 module.exports = {
   meta: {

--- a/eslint-plugin-dust/package.json
+++ b/eslint-plugin-dust/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "eslint-plugin-dust",
+  "version": "0.0.0",
+  "license": "MIT",
+  "files": [
+    "eslint-plugin-dust.js"
+  ]
+}

--- a/eslint-plugin-dust/rules/no-raw-sql.js
+++ b/eslint-plugin-dust/rules/no-raw-sql.js
@@ -1,0 +1,56 @@
+"use strict";
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "enfore no use of raw sql",
+    },
+    schema: [],
+  },
+
+  create: function (context) {
+    // Keep track of variables that are Sequelize instances
+    const sequelizeInstances = new Set();
+
+    return {
+      // Track variables assigned Sequelize instances
+      VariableDeclarator(node) {
+        if (node.init?.type === "CallExpression") {
+          const functionName = node.init.callee.name;
+          // Add known functions that return Sequelize instances
+          if (functionName === "getFrontReplicaDbConnection") {
+            sequelizeInstances.add(node.id.name);
+          }
+        }
+      },
+
+      // Check for query method calls
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.name === "query"
+        ) {
+          const obj = node.callee.object;
+
+          // Check if the object is a known Sequelize instance
+          if (
+            obj.type === "Identifier" &&
+            // Known variable names
+            (obj.name === "frontSequelize" ||
+              // Variables we tracked that were assigned Sequelize instances
+              sequelizeInstances.has(obj.name) ||
+              // Pattern matching for *sequelize* names
+              /sequelize/i.test(obj.name))
+          ) {
+            context.report({
+              node,
+              message:
+                "Raw SQL queries are not allowed. Use Sequelize models and methods instead.",
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
   ],
-  plugins: ["import", "simple-import-sort"],
+  plugins: ["import", "simple-import-sort", "dust"],
   rules: {
     "import/no-cycle": "error",
     curly: ["error", "all"],
@@ -56,6 +56,7 @@ module.exports = {
     ],
     "simple-import-sort/exports": "error",
     "@typescript-eslint/return-await": ["error", "in-try-catch"],
+    "dust/no-raw-sql": "warn",
   },
   overrides: [
     {

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = {
     ],
     "simple-import-sort/exports": "error",
     "@typescript-eslint/return-await": ["error", "in-try-catch"],
-    "dust/no-raw-sql": "warn",
+    "dust/no-raw-sql": "error",
   },
   overrides: [
     {

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -145,6 +145,8 @@ export async function agentMentionsCount(
     throw new Error("Invalid ranking usage days");
   }
 
+  // TODO(workspace_filtering): Review needed
+  // eslint-disable-next-line dust/no-raw-sql
   const mentions = await readReplica.query(
     `
     WITH message_counts AS (

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -145,8 +145,7 @@ export async function agentMentionsCount(
     throw new Error("Invalid ranking usage days");
   }
 
-  // TODO(workspace_filtering): Review needed
-  // eslint-disable-next-line dust/no-raw-sql
+  // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const mentions = await readReplica.query(
     `
     WITH message_counts AS (

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -610,6 +610,8 @@ async function getConversationRankVersionLock(
   // Get a lock using the unique lock key (number withing postgresql BigInt range).
   const hash = md5(`conversation_message_rank_version_${conversation.id}`);
   const lockKey = parseInt(hash, 16) % 9999999999;
+  // OK because we need to setup a lock
+  // eslint-disable-next-line dust/no-raw-sql
   await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
     transaction: t,
     replacements: { key: lockKey },

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -658,6 +658,8 @@ export async function getWorkspaceAdministrationVersionLock(
 
   const hash = md5(`workspace_administration_${workspace.id}`);
   const lockKey = parseInt(hash, 16) % 9999999999;
+  // OK because we need to setup a lock
+  // eslint-disable-next-line dust/no-raw-sql
   await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
     transaction: t,
     replacements: { key: lockKey },

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -17,8 +17,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   const connectorsReplica = getConnectorsReplicaDbConnection();
   const frontReplica = getFrontReplicaDbConnection();
   const GdriveDataSources: { id: number; connectorId: string }[] =
-    // TODO(workspace_filtering): Review needed
-    // eslint-disable-next-line dust/no-raw-sql
+    // eslint-disable-next-line dust/no-raw-sql -- Leggit
     await frontReplica.query(
       `SELECT id, "connectorId" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
       { type: QueryTypes.SELECT }

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -17,6 +17,8 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   const connectorsReplica = getConnectorsReplicaDbConnection();
   const frontReplica = getFrontReplicaDbConnection();
   const GdriveDataSources: { id: number; connectorId: string }[] =
+    // TODO(workspace_filtering): Review needed
+    // eslint-disable-next-line dust/no-raw-sql
     await frontReplica.query(
       `SELECT id, "connectorId" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
       { type: QueryTypes.SELECT }

--- a/front/lib/production_checks/managed_ds.ts
+++ b/front/lib/production_checks/managed_ds.ts
@@ -20,6 +20,8 @@ export async function getCoreDocuments(
   const coreReplica = getCoreReplicaDbConnection();
   const frontReplica = getFrontReplicaDbConnection();
 
+  // TODO(workspace_filtering): Review needed
+  // eslint-disable-next-line dust/no-raw-sql
   const managedDsData = await frontReplica.query(
     'SELECT id, "connectorId", "connectorProvider", "dustAPIProjectId" \
          FROM data_sources WHERE id = :frontDataSourceId',

--- a/front/lib/production_checks/managed_ds.ts
+++ b/front/lib/production_checks/managed_ds.ts
@@ -20,8 +20,7 @@ export async function getCoreDocuments(
   const coreReplica = getCoreReplicaDbConnection();
   const frontReplica = getFrontReplicaDbConnection();
 
-  // TODO(workspace_filtering): Review needed
-  // eslint-disable-next-line dust/no-raw-sql
+  // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const managedDsData = await frontReplica.query(
     'SELECT id, "connectorId", "connectorProvider", "dustAPIProjectId" \
          FROM data_sources WHERE id = :frontDataSourceId',

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -94,6 +94,7 @@ export async function unsafeGetUsageData(
 ): Promise<string> {
   const wId = workspace.sId;
   const readReplica = getFrontReplicaDbConnection();
+  // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const results = await readReplica.query<WorkspaceUsageQueryResult>(
     `
       SELECT
@@ -172,6 +173,7 @@ export async function getMessageUsageData(
 ): Promise<string> {
   const wId = workspace.id;
   const readReplica = getFrontReplicaDbConnection();
+  // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const results = await readReplica.query<MessageUsageQueryResult>(
     `
       SELECT
@@ -395,6 +397,7 @@ export async function getAssistantUsageData(
 ): Promise<number> {
   const wId = workspace.id;
   const readReplica = getFrontReplicaDbConnection();
+  // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const mentions = await readReplica.query<{ messages: number }>(
     `
     SELECT COUNT(a."id") AS "messages"
@@ -430,6 +433,7 @@ export async function getAssistantsUsageData(
 ): Promise<string> {
   const wId = workspace.id;
   const readReplica = getFrontReplicaDbConnection();
+  // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const mentions = await readReplica.query<AgentUsageQueryResult>(
     `
     SELECT

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -155,6 +155,7 @@
         "eslint": "^8.56.0",
         "eslint-config-next": "^14.2.3",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-dust": "file:../eslint-plugin-dust",
         "eslint-plugin-jsdoc": "^48.4.0",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "eslint-plugin-unused-imports": "^3.2.0",
@@ -175,6 +176,11 @@
       "peerDependencies": {
         "typescript": "5.4.5"
       }
+    },
+    "../eslint-plugin-dust": {
+      "version": "0.0.0",
+      "dev": true,
+      "license": "MIT"
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
@@ -13763,6 +13769,10 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint-plugin-dust": {
+      "resolved": "../eslint-plugin-dust",
+      "link": true
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.29.1",

--- a/front/package.json
+++ b/front/package.json
@@ -170,6 +170,7 @@
     "eslint": "^8.56.0",
     "eslint-config-next": "^14.2.3",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-dust": "file:../eslint-plugin-dust",
     "eslint-plugin-jsdoc": "^48.4.0",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "eslint-plugin-unused-imports": "^3.2.0",

--- a/front/pages/api/w/[wId]/workspace-analytics.ts
+++ b/front/pages/api/w/[wId]/workspace-analytics.ts
@@ -41,7 +41,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const analytics = await getAnalytics(req.query.wId as string);
+      const analytics = await getAnalytics(auth);
       res.status(200).json(analytics);
       return;
 
@@ -59,12 +59,11 @@ async function handler(
 export default withSessionAuthenticationForWorkspace(handler);
 
 async function getAnalytics(
-  wId: string
+  auth: Authenticator
 ): Promise<GetWorkspaceAnalyticsResponse> {
   const replicaDb = getFrontReplicaDbConnection();
 
-  // TODO(workspace_filtering):  Review needed
-  // eslint-disable-next-line dust/no-raw-sql
+  // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const results = await replicaDb.query<{
     member_count: number;
     weekly_active: number;
@@ -75,13 +74,10 @@ async function getAnalytics(
     prev_avg_daily_active: number;
   }>(
     `
-    WITH workspace_id AS (
-      SELECT id FROM workspaces WHERE "sId" = :wId
-    ),
-    member_counts AS (
+    WITH member_counts AS (
       SELECT COUNT(DISTINCT "userId") AS member_count
       FROM memberships
-      WHERE "workspaceId" = (SELECT id FROM workspace_id)
+      WHERE "workspaceId" = :workspace_id
         AND "startAt" <= NOW() 
         AND ("endAt" IS NULL OR "endAt" >= NOW())
     ),
@@ -90,7 +86,7 @@ async function getAnalytics(
         "userId",
         "createdAt"
       FROM user_messages
-      WHERE "workspaceId" = (SELECT id FROM workspace_id)
+      WHERE "workspaceId" = :workspace_id
         AND "createdAt" >= CURRENT_DATE - INTERVAL '60 days'
     ),
     daily_activity AS (
@@ -128,7 +124,7 @@ async function getAnalytics(
     FROM member_counts m, activity_metrics a, daily_averages d
     `,
     {
-      replacements: { wId },
+      replacements: { workspace_id: auth.getNonNullableWorkspace().id },
       type: QueryTypes.SELECT,
     }
   );

--- a/front/pages/api/w/[wId]/workspace-analytics.ts
+++ b/front/pages/api/w/[wId]/workspace-analytics.ts
@@ -63,6 +63,8 @@ async function getAnalytics(
 ): Promise<GetWorkspaceAnalyticsResponse> {
   const replicaDb = getFrontReplicaDbConnection();
 
+  // TODO(workspace_filtering):  Review needed
+  // eslint-disable-next-line dust/no-raw-sql
   const results = await replicaDb.query<{
     member_count: number;
     weekly_active: number;


### PR DESCRIPTION
## Description
Goal was to add a rule to warn/error when a raw sql is written using sequelize. For now it's pretty tight with how we calls our Sequelize instances (front and replica), check `frontSequelize` or var names when we call `getFrontReplicaDbConnection`. But I feels that's ok.
To do so:
- Create a new package `eslint-plugin-dust`. 
  - Had to be done this way as custom rule without a plugin doesn't seems possible _(or not without another plugin to explicitly do a custom rule, and I didn't want to introduce another third party plugin)_
  - That package does not need build step, it's raw vanilla js so no need for dev local setup update.
- add it in the `.eslintrc.js` of Front.
- Setup it in warn for now to show which ones are done (plan to put it in Error after review)
- I disabled 2 raw sql calls to show that the disabled worked, and they're legit as it's for lock purposes.
- Updated the `getAnalytics` method to pass a auth instead of workspacesId

## Tests
- Locally, see the CI for [4 warnings](https://github.com/dust-tt/dust/actions/runs/14926236970/job/41931628914#step:7:65)

## Risk
- Medium, updated the `getAnalytics`, not data returned but numbers could be off

## Deploy Plan
- Deploy on front-edge, check the returned analytics ✅
- Deploy on front, do the same ✅
