### PR TITLE
[front] fix: Add workspaceId on baseFetchWithAuthorization

### DIFF
--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -72,7 +72,10 @@ export abstract class ResourceWithSpace<
   ): Promise<T[]> {
     const blobs = await this.model.findAll({
       attributes,
-      where: where as WhereOptions<M>,
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      } as WhereOptions<M>,
       include: includes,
       limit,
       order,


### PR DESCRIPTION
## Description
- Add a `workspaceId` filter in the `where` inside `baseFetchWithAuthorization`
- Added it after `...where` to avoid mistakenly overriding it _(But eager to know if there is use case allowing override?)_
- [ ] Need to create more index to account for new filter

## Tests
- Locally tested
- Deployed on front-edge
  - tested navigating in pages
  - tested in poke, navigating to few workspaces, no issue accessing, editing feature flag or gettings DataSources (which was what prompt me to write that PR)

## Risk
- High blast radius, adding a new filter at the base level could at worst return less informations. But as its a new filter, I'd say there is no risk of returning extra information.
- As this method was only checking ownership of workspace via `canFetch`, is there a reason for that? Does something somewhere (Poke?) need cross workspace access as a dust superuser?

## Deploy Plan
- Deploy front
