### PR TITLE
Restrict transcript processing based on user space write access

### DIFF
--- a/front/components/labs/transcripts/ProcessingConfiguration.tsx
+++ b/front/components/labs/transcripts/ProcessingConfiguration.tsx
@@ -39,8 +39,8 @@ export function ProcessingConfiguration({
 
   const sendNotification = useSendNotification();
   const { doUpdate } = useUpdateTranscriptsConfiguration({
-    workspaceId: owner.sId,
-    transcriptConfigurationId: transcriptsConfiguration.id,
+    owner,
+    transcriptsConfiguration,
   });
 
   const handleSelectAssistant = async (

--- a/front/components/labs/transcripts/ProcessingConfiguration.tsx
+++ b/front/components/labs/transcripts/ProcessingConfiguration.tsx
@@ -38,7 +38,7 @@ export function ProcessingConfiguration({
     );
 
   const sendNotification = useSendNotification();
-  const updateTranscriptsConfiguration = useUpdateTranscriptsConfiguration({
+  const { doUpdate } = useUpdateTranscriptsConfiguration({
     workspaceId: owner.sId,
     transcriptConfigurationId: transcriptsConfiguration.id,
   });
@@ -47,12 +47,12 @@ export function ProcessingConfiguration({
     assistant: LightAgentConfigurationType
   ) => {
     setAssistantSelected(assistant);
-    const response = await updateTranscriptsConfiguration({
+    const response = await doUpdate({
       isActive: transcriptsConfiguration.isActive,
       agentConfigurationId: assistant.sId,
     });
 
-    if (response.ok) {
+    if (response.isOk()) {
       sendNotification({
         type: "success",
         title: "Success!",
@@ -69,23 +69,10 @@ export function ProcessingConfiguration({
   };
 
   const handleSetIsActive = async (isActive: boolean) => {
-    const response = await updateTranscriptsConfiguration({ isActive });
+    const response = await doUpdate({ isActive });
 
-    if (response.ok) {
-      sendNotification({
-        type: "success",
-        title: "Success!",
-        description: isActive
-          ? "We will start summarizing your meeting transcripts."
-          : "We will no longer summarize your meeting transcripts.",
-      });
+    if (response.isOk()) {
       await mutateTranscriptsConfiguration();
-    } else {
-      sendNotification({
-        type: "error",
-        title: "Failed to update",
-        description: "Could not update the configuration. Please try again.",
-      });
     }
   };
 

--- a/front/components/labs/transcripts/ProcessingConfiguration.tsx
+++ b/front/components/labs/transcripts/ProcessingConfiguration.tsx
@@ -47,12 +47,12 @@ export function ProcessingConfiguration({
     assistant: LightAgentConfigurationType
   ) => {
     setAssistantSelected(assistant);
-    const success = await updateTranscriptsConfiguration({
+    const response = await updateTranscriptsConfiguration({
       isActive: transcriptsConfiguration.isActive,
       agentConfigurationId: assistant.sId,
     });
 
-    if (success) {
+    if (response.ok) {
       sendNotification({
         type: "success",
         title: "Success!",
@@ -69,9 +69,9 @@ export function ProcessingConfiguration({
   };
 
   const handleSetIsActive = async (isActive: boolean) => {
-    const success = await updateTranscriptsConfiguration({ isActive });
+    const response = await updateTranscriptsConfiguration({ isActive });
 
-    if (success) {
+    if (response.ok) {
       sendNotification({
         type: "success",
         title: "Success!",

--- a/front/components/labs/transcripts/StorageConfiguration.tsx
+++ b/front/components/labs/transcripts/StorageConfiguration.tsx
@@ -78,11 +78,11 @@ export function StorageConfiguration({
       return;
     }
 
-    const success = await updateTranscriptsConfiguration({
+    const response = await updateTranscriptsConfiguration({
       dataSourceViewId: dataSourceView ? dataSourceView.sId : null,
     });
 
-    if (success) {
+    if (response.ok) {
       sendNotification({
         type: "success",
         title: "Success!",
@@ -92,10 +92,11 @@ export function StorageConfiguration({
       });
       await mutateTranscriptsConfiguration();
     } else {
+      const responseBody = await response.json();
       sendNotification({
         type: "error",
         title: "Failed to update",
-        description: "Could not update the configuration. Please try again.",
+        description: responseBody.error.message,
       });
     }
   };

--- a/front/components/labs/transcripts/StorageConfiguration.tsx
+++ b/front/components/labs/transcripts/StorageConfiguration.tsx
@@ -40,7 +40,7 @@ export function StorageConfiguration({
   isSpacesLoading,
 }: StorageConfigurationProps) {
   const sendNotification = useSendNotification();
-  const updateTranscriptsConfiguration = useUpdateTranscriptsConfiguration({
+  const { doUpdate } = useUpdateTranscriptsConfiguration({
     workspaceId: owner.sId,
     transcriptConfigurationId: transcriptsConfiguration.id,
   });
@@ -78,26 +78,12 @@ export function StorageConfiguration({
       return;
     }
 
-    const response = await updateTranscriptsConfiguration({
+    const response = await doUpdate({
       dataSourceViewId: dataSourceView ? dataSourceView.sId : null,
     });
 
-    if (response.ok) {
-      sendNotification({
-        type: "success",
-        title: "Success!",
-        description: dataSourceView
-          ? "We will now store your meeting transcripts."
-          : "We will no longer store your meeting transcripts.",
-      });
+    if (response.isOk()) {
       await mutateTranscriptsConfiguration();
-    } else {
-      const responseBody = await response.json();
-      sendNotification({
-        type: "error",
-        title: "Failed to update",
-        description: responseBody.error.message,
-      });
     }
   };
 

--- a/front/components/labs/transcripts/StorageConfiguration.tsx
+++ b/front/components/labs/transcripts/StorageConfiguration.tsx
@@ -39,8 +39,8 @@ export function StorageConfiguration({
   isSpacesLoading,
 }: StorageConfigurationProps) {
   const { doUpdate } = useUpdateTranscriptsConfiguration({
-    workspaceId: owner.sId,
-    transcriptConfigurationId: transcriptsConfiguration.id,
+    owner,
+    transcriptsConfiguration,
   });
 
   const [storeInFolder, setStoreInFolder] = useState(false);
@@ -82,6 +82,8 @@ export function StorageConfiguration({
 
     if (response.isOk()) {
       await mutateTranscriptsConfiguration();
+    } else {
+      setSelectionConfigurations({});
     }
   };
 

--- a/front/components/labs/transcripts/StorageConfiguration.tsx
+++ b/front/components/labs/transcripts/StorageConfiguration.tsx
@@ -4,7 +4,6 @@ import {
   Page,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
 import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useState } from "react";
 import type { KeyedMutator } from "swr";
@@ -39,7 +38,6 @@ export function StorageConfiguration({
   spaces,
   isSpacesLoading,
 }: StorageConfigurationProps) {
-  const sendNotification = useSendNotification();
   const { doUpdate } = useUpdateTranscriptsConfiguration({
     workspaceId: owner.sId,
     transcriptConfigurationId: transcriptsConfiguration.id,

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -23,7 +23,8 @@ import {
   isOAuthProvider,
   setupOAuthConnection,
 } from "@app/types";
-import { Ok, Err, type Result } from "@app/types/shared/result";
+import type {Result} from "@app/types/shared/result";
+import { Err, Ok  } from "@app/types/shared/result";
 
 // Transcripts
 export function useLabsTranscriptsConfiguration({

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -103,7 +103,7 @@ export function useUpdateTranscriptsConfiguration({
   transcriptConfigurationId: number;
 }) {
   return async (data: Partial<PatchTranscriptsConfiguration>) => {
-    const response = await fetch(
+    return fetch(
       `/api/w/${workspaceId}/labs/transcripts/${transcriptConfigurationId}`,
       {
         method: "PATCH",
@@ -113,8 +113,6 @@ export function useUpdateTranscriptsConfiguration({
         body: JSON.stringify(data),
       }
     );
-
-    return response.ok;
   };
 }
 

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -23,8 +23,8 @@ import {
   isOAuthProvider,
   setupOAuthConnection,
 } from "@app/types";
-import type {Result} from "@app/types/shared/result";
-import { Err, Ok  } from "@app/types/shared/result";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 // Transcripts
 export function useLabsTranscriptsConfiguration({

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -134,6 +134,20 @@ async function handler(
           ? await DataSourceViewResource.fetchById(auth, dataSourceViewId)
           : null;
 
+        if (dataSourceView) {
+          const canWrite = dataSourceView.canWrite(auth);
+          if (!canWrite) {
+            return apiError(req, res, {
+              status_code: 403,
+              api_error: {
+                type: "data_source_auth_error",
+                message:
+                  "The user does not have permission to write to the datasource view.",
+              },
+            });
+          }
+        }
+
         await transcriptsConfiguration.setDataSourceView(dataSourceView);
 
         if (

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -442,6 +442,16 @@ export async function processTranscriptActivity(
       return;
     }
 
+    const canWrite = datasourceView.canWrite(auth);
+    if (!canWrite) {
+      localLogger.error(
+        {},
+        "[processTranscriptActivity] User does not have permission to write to datasource view. Stopping."
+      );
+      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
+      return;
+    }
+
     const dataSource = datasourceView.dataSource;
 
     if (!dataSource) {


### PR DESCRIPTION
## Description

* I believe that "DataSourceViewResource.fetchByModelIds" (https://github.com/dust-tt/dust/blob/main/front/temporal/labs/transcripts/activities.ts#L431-L434) will return if the user is in the correct workspace. It does not check read/write permissions for the space. I have added an additional check to only allow folder selection if the user has write access.

## Tests

* Selected a transcript folder that was restricted to my user. Confirmed that I was able to write transcripts prior to these changes. Processing stopped after these changes were made.

## Risk

* Scoped to only Dust labs

## Deploy Plan

* Deploy front