### PR TITLE
Update to CODING_RULES

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -286,7 +286,7 @@ export function useFolders({ owner, spaceId } : { owner: LightWorkspaceType, spa
 ```
 
 Data posting should be done in hooks colocated with the SWR hooks. Do not fetch directly in
-componenets. Success and failure notifications should be sent from the hook.
+components. Success and failure notifications should be sent from the hook.
 
 ```
 export function useCreateFolder({

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -79,6 +79,22 @@ Example:
 No sensitive data should be sent to our servers through URL or query string parameters. HTTP body or
 headers only are acceptable for sensitive data.
 
+### [SEC2] No ModelId exposure in URLs or API endpoints
+
+Never expose or accept ModelId in URLs, API endpoints or POST/PATCH payloads. Use string identifiers
+(sId) instead. This applies to all routes, including GET, POST, PATCH, and DELETE methods. ModelIds
+should be strictly internal and never exposed to the client.
+
+Example:
+
+```
+// BAD
+/api/w/[wId]/resource/[modelId]
+
+// GOOD
+/api/w/[wId]/resource/[sId]
+```
+
 ## ERROR
 
 ### [ERR1] Do not rely on throw + catch
@@ -247,9 +263,11 @@ export function Component({ name }: MyComponentProps) { }
 
 Data fetching should rely on useSWR hooks and be abstracted in a `lib/swr/*` file.
 
-When using a disabled param and returning a loading flag, ensure `loading` is `false` if `disabled` is `true`.
+When using a disabled param and returning a loading flag, ensure `loading` is `false` if `disabled`
+is `true`.
 
-When a hook is expected to return an array of objects, return an empty array (from `emptyArray()`) while loading/error/disabled instead of `undefined`.
+When a hook is expected to return an array of objects, return an empty array (from `emptyArray()`)
+while loading/error/disabled instead of `undefined`.
 
 Example:
 
@@ -267,7 +285,8 @@ export function useFolders({ owner, spaceId } : { owner: LightWorkspaceType, spa
 }
 ```
 
-Data posting should be done in hooks colocated with the SWR hooks. Do not fetch directly in componenets.
+Data posting should be done in hooks colocated with the SWR hooks. Do not fetch directly in
+componenets. Success and failure notifications should be sent from the hook.
 
 ```
 export function useCreateFolder({


### PR DESCRIPTION
## Description

Adds coding rules for the use of sId vs ModelId in API endpoints. Tweak rule on SWR hooks to mention that we standardize on success/failure notifications to be handled by the hook itself.

## Tests

N/A

## Risk

None

## Deploy Plan

N/A