### PR TITLE
[front] feat(apps): Add workspaceId filter and new composite index

### DIFF
--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -50,10 +50,14 @@ export class AppResource extends ResourceWithSpace<AppModel> {
 
   private static async baseFetch(
     auth: Authenticator,
-    options?: ResourceFindOptions<AppModel>
+    options: ResourceFindOptions<AppModel> = {}
   ) {
     const apps = await this.baseFetchWithAuthorization(auth, {
       ...options,
+      where: {
+        ...options.where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
     });
 
     // This is what enforces the accessibility to an app.
@@ -85,9 +89,6 @@ export class AppResource extends ResourceWithSpace<AppModel> {
     options?: { includeDeleted: boolean }
   ) {
     return this.baseFetch(auth, {
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
       includeDeleted: options?.includeDeleted,
     });
   }

--- a/front/lib/resources/storage/models/apps.ts
+++ b/front/lib/resources/storage/models/apps.ts
@@ -78,6 +78,8 @@ AppModel.init(
       { unique: true, fields: ["sId"] },
       { fields: ["workspaceId", "visibility"] },
       { fields: ["workspaceId", "sId", "visibility"] },
+      { fields: ["workspaceId", "sId"] },
+      { fields: ["workspaceId", "vaultId"] },
     ],
   }
 );

--- a/front/migrations/db/migration_226.sql
+++ b/front/migrations/db/migration_226.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 12, 2025
+CREATE INDEX "apps_workspace_id_s_id" ON "apps" ("workspaceId", "sId");
+CREATE INDEX "apps_workspace_id_vault_id" ON "apps" ("workspaceId", "vaultId");


### PR DESCRIPTION
## Description
- Add `workspaceId` filter to `baseFetch` of AppResource
- Remove the filter in `listByWorkspace` as its redundant with `baseFetch`
- Add composite index because of:
  - `[workspaceId, vaultId]`  -> `listBySpace`
  - `[workspaceId, sId]` -> `fetchByIds`

## Tests
- Locally created an app, no issue calling it
- Locally created an agent, no issue getting suggestion given by public dust apps
- Same agent was given public dust-app (`reasoning`) capabilities, no issue observed we're using [prod credentials](https://github.com/dust-tt/dust/blob/b42543075033131b926467ba2cb6f7fc9526debc/front/lib/actions/server.ts#L88) to call public dust-apps
- On front-edge, tested creating an app, no issue calling suggestions
- On front-edge, tested calling agent with public dust-app capabilities (like websearch v1), no issue so far.

## Risk
- High, if wrong, public dust apps could not work, but easy to revert.

## Deploy Plan
- Deploy front-edge, test
- Run migration `migration_226.sql` on EU + US
- Deploy front, test
