### PR TITLE
`skipToolsValidation`

### DIFF
--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -227,6 +227,7 @@ export async function createConversationWithMessage({
   messageData,
   visibility = "unlisted",
   title,
+  skipToolsValidation = false,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -238,6 +239,7 @@ export async function createConversationWithMessage({
   };
   visibility?: ConversationVisibility;
   title?: string;
+  skipToolsValidation?: boolean;
 }): Promise<Result<ConversationType, SubmitMessageError>> {
   const { input, mentions, contentFragments, clientSideMCPServerIds } =
     messageData;
@@ -285,6 +287,7 @@ export async function createConversationWithMessage({
         };
       }),
     ],
+    skipToolsValidation: skipToolsValidation ?? false,
   };
 
   // Create new conversation and post the initial message at the same time.

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -287,7 +287,6 @@ export async function createConversationWithMessage({
         };
       }),
     ],
-    skipToolsValidation: skipToolsValidation ?? false,
   };
 
   // Create new conversation and post the initial message at the same time.

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -227,7 +227,6 @@ export async function createConversationWithMessage({
   messageData,
   visibility = "unlisted",
   title,
-  skipToolsValidation = false,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -239,7 +238,6 @@ export async function createConversationWithMessage({
   };
   visibility?: ConversationVisibility;
   title?: string;
-  skipToolsValidation?: boolean;
 }): Promise<Result<ConversationType, SubmitMessageError>> {
   const { input, mentions, contentFragments, clientSideMCPServerIds } =
     messageData;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -456,7 +456,8 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
 
     const { status: s } = await getExecutionStatusFromConfig(
       auth,
-      actionConfiguration
+      actionConfiguration,
+      agentMessage
     );
     let status:
       | "allowed_implicitly"

--- a/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ask_agent.ts
@@ -90,6 +90,8 @@ function createServer(auth: Authenticator): McpServer {
           },
         },
         contentFragment: undefined,
+        // TODO(spolu): pull from the current agent message
+        skipToolsValidation: false,
       });
 
       if (convRes.isErr()) {

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -315,6 +315,13 @@ export async function getExecutionStatusFromConfig(
     return { status: "pending" };
   }
 
+  // If the agent message is marked as "skipToolsValidation" we skip all tools validation
+  // irrespective of the `actionConfiguration.permission`. This is set when the agent message was
+  // created by an API call where the caller explicitly set `skipToolsValidation` to true.
+  if (agentMessage.skipToolsValidation) {
+    return { status: "allowed_implicitly" };
+  }
+
   /**
    * Permissions:
    * - "never_ask": Automatically approved

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -29,7 +29,7 @@ import {
 import type { WebsearchConfigurationType } from "@app/lib/actions/websearch";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentConfigurationType } from "@app/types";
+import type { AgentConfigurationType, AgentMessageType } from "@app/types";
 import { assertNever } from "@app/types";
 
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
@@ -304,7 +304,8 @@ export function getMCPApprovalKey({
 
 export async function getExecutionStatusFromConfig(
   auth: Authenticator,
-  actionConfiguration: MCPToolConfigurationType
+  actionConfiguration: MCPToolConfigurationType,
+  agentMessage: AgentMessageType
 ): Promise<{
   stake?: MCPToolStakeLevelType;
   status: "allowed_implicitly" | "pending";

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -661,11 +661,13 @@ export async function* postUserMessage(
     content,
     mentions,
     context,
+    skipToolsValidation,
   }: {
     conversation: ConversationType;
     content: string;
     mentions: MentionType[];
     context: UserMessageContext;
+    skipToolsValidation: boolean;
   }
 ): AsyncGenerator<
   | UserMessageErrorEvent
@@ -896,6 +898,7 @@ export async function* postUserMessage(
                   agentConfigurationId: configuration.sId,
                   agentConfigurationVersion: configuration.version,
                   workspaceId: owner.id,
+                  skipToolsValidation,
                 },
                 { transaction: t }
               );
@@ -932,6 +935,7 @@ export async function* postUserMessage(
                   error: null,
                   configuration,
                   rank: messageRow.rank,
+                  skipToolsValidation: agentMessageRow.skipToolsValidation,
                 } satisfies AgentMessageWithRankType,
               };
             })();
@@ -1113,10 +1117,8 @@ function canAccessAgent(
   }
 }
 
-/** This method creates a new user message version, and if there are new agent
- *  mentions, run them
- *  TODO: support editing with new agent mentions for any
- *  message (rather than just the last)
+/**
+ * This method creates a new user message version, and if there are new agent mentions, run them.
  */
 export async function* editUserMessage(
   auth: Authenticator,
@@ -1125,11 +1127,13 @@ export async function* editUserMessage(
     message,
     content,
     mentions,
+    skipToolsValidation,
   }: {
     conversation: ConversationType;
     message: UserMessageType;
     content: string;
     mentions: MentionType[];
+    skipToolsValidation: boolean;
   }
 ): AsyncGenerator<
   | UserMessageNewEvent
@@ -1407,6 +1411,7 @@ export async function* editUserMessage(
                 agentConfigurationId: configuration.sId,
                 agentConfigurationVersion: configuration.version,
                 workspaceId: owner.id,
+                skipToolsValidation: false,
               },
               { transaction: t }
             );
@@ -1443,6 +1448,7 @@ export async function* editUserMessage(
                 error: null,
                 configuration,
                 rank: messageRow.rank,
+                skipToolsValidation: agentMessageRow.skipToolsValidation,
               } satisfies AgentMessageWithRankType,
             };
           })();
@@ -1648,6 +1654,7 @@ export async function* retryAgentMessage(
           agentConfigurationVersion:
             messageRow.agentMessage.agentConfigurationVersion,
           workspaceId: auth.getNonNullableWorkspace().id,
+          skipToolsValidation: messageRow.agentMessage.skipToolsValidation,
         },
         { transaction: t }
       );
@@ -1689,6 +1696,7 @@ export async function* retryAgentMessage(
         error: null,
         configuration: message.configuration,
         rank: m.rank,
+        skipToolsValidation: agentMessageRow.skipToolsValidation,
       };
 
       return {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1411,7 +1411,7 @@ export async function* editUserMessage(
                 agentConfigurationId: configuration.sId,
                 agentConfigurationVersion: configuration.version,
                 workspaceId: owner.id,
-                skipToolsValidation: false,
+                skipToolsValidation,
               },
               { transaction: t }
             );

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -391,6 +391,7 @@ export async function triggerFromEmail({
         profilePictureUrl: user.imageUrl,
         origin: "email",
       },
+      skipToolsValidation: true,
     },
     { resolveAfterFullGeneration: true }
   );

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -391,6 +391,9 @@ export async function triggerFromEmail({
         profilePictureUrl: user.imageUrl,
         origin: "email",
       },
+      // When running an agent from an email we have no chance of validating tools so we skip all of
+      // them and run the tools by default. This is in tension with the admin settings and could be
+      // revisited if needed.
       skipToolsValidation: true,
     },
     { resolveAfterFullGeneration: true }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -273,6 +273,7 @@ async function batchRenderAgentMessages(
           error,
           // TODO(2024-03-21 flav) Dry the agent configuration object for rendering.
           configuration: agentConfiguration,
+          skipToolsValidation: agentMessage.skipToolsValidation,
         } satisfies AgentMessageType;
         return {
           m,

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -47,11 +47,13 @@ export async function postUserMessageWithPubSub(
     content,
     mentions,
     context,
+    skipToolsValidation,
   }: {
     conversation: ConversationType;
     content: string;
     mentions: MentionType[];
     context: UserMessageContext;
+    skipToolsValidation: boolean;
   },
   { resolveAfterFullGeneration }: { resolveAfterFullGeneration: boolean }
 ): Promise<
@@ -68,6 +70,7 @@ export async function postUserMessageWithPubSub(
     content,
     mentions,
     context,
+    skipToolsValidation,
   });
 
   return handleUserMessageEvents(auth, {
@@ -84,11 +87,13 @@ export async function editUserMessageWithPubSub(
     message,
     content,
     mentions,
+    skipToolsValidation,
   }: {
     conversation: ConversationType;
     message: UserMessageType;
     content: string;
     mentions: MentionType[];
+    skipToolsValidation: boolean;
   }
 ): Promise<
   Result<
@@ -104,6 +109,7 @@ export async function editUserMessageWithPubSub(
     message,
     content,
     mentions,
+    skipToolsValidation,
   });
   return handleUserMessageEvents(auth, {
     conversation,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -14,7 +14,6 @@ import type {
   ParticipantActionType,
   UserMessageOrigin,
 } from "@app/types";
-import { MCPToolStakeLevelPublicType } from "@dust-tt/client";
 
 export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -14,6 +14,7 @@ import type {
   ParticipantActionType,
   UserMessageOrigin,
 } from "@app/types";
+import { MCPToolStakeLevelPublicType } from "@dust-tt/client";
 
 export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -247,8 +248,10 @@ export class AgentMessage extends WorkspaceAwareModel<AgentMessage> {
   declare errorCode: string | null;
   declare errorMessage: string | null;
 
-  // Not a relation as global agents are not in the DB
-  // needs both sId and version to uniquely identify the agent configuration
+  declare skipToolsValidation: boolean;
+
+  // Not a relation as global agents are not in the DB + sId is stable across versions. Both sId and
+  // version are needed to uniquely identify the agent configuration.
   declare agentConfigurationId: string;
   declare agentConfigurationVersion: number;
 
@@ -285,6 +288,11 @@ AgentMessage.init(
     errorMessage: {
       type: DataTypes.TEXT,
       allowNull: true,
+    },
+    skipToolsValidation: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     agentConfigurationId: {
       type: DataTypes.STRING,

--- a/front/migrations/db/migration_262.sql
+++ b/front/migrations/db/migration_262.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."agent_messages" ADD COLUMN "skipToolsValidation" BOOLEAN NOT NULL DEFAULT false;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -146,13 +146,14 @@ async function handler(
           },
         });
       }
-      const { content, mentions } = r.data;
+      const { content, mentions, skipToolsValidation } = r.data;
 
       const editedMessageRes = await editUserMessageWithPubSub(auth, {
         conversation,
         message,
         content,
         mentions,
+        skipToolsValidation,
       });
       if (editedMessageRes.isErr()) {
         return apiError(req, res, editedMessageRes.error);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -112,7 +112,8 @@ async function handler(
         });
       }
 
-      const { content, context, mentions, blocking } = r.data;
+      const { content, context, mentions, blocking, skipToolsValidation } =
+        r.data;
 
       if (isEmptyString(context.username)) {
         return apiError(req, res, {
@@ -151,6 +152,7 @@ async function handler(
             origin: context.origin ?? "api",
             clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
           },
+          skipToolsValidation,
         },
         { resolveAfterFullGeneration: blocking === true }
       );

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -152,7 +152,7 @@ async function handler(
             origin: context.origin ?? "api",
             clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
           },
-          skipToolsValidation,
+          skipToolsValidation: skipToolsValidation ?? false,
         },
         { resolveAfterFullGeneration: blocking === true }
       );

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -84,11 +84,11 @@ import {
  *                 example: unlisted
  *               skipToolsValidation:
  *                 type: boolean
- *                 description: Whether to skip the tools validation of the agent messages triggered by this user message (optional, default: false)
+ *                 description: Whether to skip the tools validation of the agent messages triggered by this user message (optional, defaults to false)
  *                 example: false
  *               blocking:
  *                 type: boolean
- *                 description: Whether to wait for the agent to generate the initial message (if false, you will need to use streaming events to get the messages, default: false).
+ *                 description: Whether to wait for the agent to generate the initial message (if false, you will need to use streaming events to get the messages, defaults to false).
  *                 example: true
  *     responses:
  *       200:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -71,10 +71,6 @@ import {
  *                 items:
  *                   $ref: '#/components/schemas/ContentFragment'
  *                 description: The list of content fragments to attach to this conversation (optional)
- *               blocking:
- *                 type: boolean
- *                 description: Whether to wait for the agent to generate the initial message (if blocking = false, you will need to use streaming events to get the messages)
- *                 example: true
  *               title:
  *                 type: string
  *                 description: The title of the conversation
@@ -86,6 +82,14 @@ import {
  *                   - workspace
  *                   - unlisted
  *                 example: unlisted
+ *               skipToolsValidation:
+ *                 type: boolean
+ *                 description: Whether to skip the tools validation of the agent messages triggered by this user message (optional, default: false)
+ *                 example: false
+ *               blocking:
+ *                 type: boolean
+ *                 description: Whether to wait for the agent to generate the initial message (if false, you will need to use streaming events to get the messages, default: false).
+ *                 example: true
  *     responses:
  *       200:
  *         description: Conversation created successfully.
@@ -132,6 +136,7 @@ async function handler(
         message,
         contentFragment,
         contentFragments,
+        skipToolsValidation,
         blocking,
       } = r.data;
 
@@ -324,10 +329,9 @@ async function handler(
       }
 
       if (message) {
-        // If a message was provided we do await for the message to be created
-        // before returning the conversation along with the message.
-        // PostUserMessageWithPubSub returns swiftly since it only waits for the
-        // initial message creation event (or error)
+        // If a message was provided we do await for the message to be created before returning the
+        // conversation along with the message. PostUserMessageWithPubSub returns swiftly since it
+        // only waits for the initial message creation event (or error)
         const messageRes = await postUserMessageWithPubSub(
           auth,
           {
@@ -344,6 +348,7 @@ async function handler(
               clientSideMCPServerIds:
                 message.context.clientSideMCPServerIds ?? [],
             },
+            skipToolsValidation,
           },
           { resolveAfterFullGeneration: blocking === true }
         );

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -348,7 +348,7 @@ async function handler(
               clientSideMCPServerIds:
                 message.context.clientSideMCPServerIds ?? [],
             },
-            skipToolsValidation,
+            skipToolsValidation: skipToolsValidation ?? false,
           },
           { resolveAfterFullGeneration: blocking === true }
         );

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -15,7 +15,6 @@ import { isUserMessageType } from "@app/types";
 const PostEditRequestBodySchema = t.type({
   content: t.string,
   mentions: t.array(t.type({ configurationId: t.string })),
-  skipToolsValidation: t.union([t.boolean, t.undefined]),
 });
 
 async function handler(
@@ -82,14 +81,15 @@ async function handler(
           },
         });
       }
-      const { content, mentions, skipToolsValidation } = bodyValidation.right;
+      const { content, mentions } = bodyValidation.right;
 
       const editedMessageRes = await editUserMessageWithPubSub(auth, {
         conversation,
         message,
         content,
         mentions,
-        skipToolsValidation: skipToolsValidation ?? false,
+        // For now we never skip tools when interacting with agents from the web client.
+        skipToolsValidation: false,
       });
       if (editedMessageRes.isErr()) {
         return apiError(req, res, editedMessageRes.error);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -15,6 +15,7 @@ import { isUserMessageType } from "@app/types";
 const PostEditRequestBodySchema = t.type({
   content: t.string,
   mentions: t.array(t.type({ configurationId: t.string })),
+  skipToolsValidation: t.union([t.boolean, t.undefined]),
 });
 
 async function handler(
@@ -81,13 +82,14 @@ async function handler(
           },
         });
       }
-      const { content, mentions } = bodyValidation.right;
+      const { content, mentions, skipToolsValidation } = bodyValidation.right;
 
       const editedMessageRes = await editUserMessageWithPubSub(auth, {
         conversation,
         message,
         content,
         mentions,
+        skipToolsValidation: skipToolsValidation ?? false,
       });
       if (editedMessageRes.isErr()) {
         return apiError(req, res, editedMessageRes.error);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -92,8 +92,7 @@ async function handler(
         });
       }
 
-      const { content, context, mentions, skipToolsValidation } =
-        bodyValidation.right;
+      const { content, context, mentions } = bodyValidation.right;
 
       if (context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(
@@ -125,8 +124,6 @@ async function handler(
 
       const conversation = conversationRes.value;
 
-      /* postUserMessageWithPubSub returns swiftly since it only waits for the
-        initial message creation event (or error) */
       const messageRes = await postUserMessageWithPubSub(
         auth,
         {
@@ -142,7 +139,8 @@ async function handler(
             origin: "web",
             clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
           },
-          skipToolsValidation: skipToolsValidation ?? false,
+          // For now we never skip tools when interacting with agents from the web client.
+          skipToolsValidation: false,
         },
         { resolveAfterFullGeneration: false }
       );

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -92,7 +92,8 @@ async function handler(
         });
       }
 
-      const { content, context, mentions } = bodyValidation.right;
+      const { content, context, mentions, skipToolsValidation } =
+        bodyValidation.right;
 
       if (context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(
@@ -141,6 +142,7 @@ async function handler(
             origin: "web",
             clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
           },
+          skipToolsValidation: skipToolsValidation ?? false,
         },
         { resolveAfterFullGeneration: false }
       );

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -71,13 +71,8 @@ async function handler(
         });
       }
 
-      const {
-        title,
-        visibility,
-        message,
-        contentFragments,
-        skipToolsValidation,
-      } = bodyValidation.right;
+      const { title, visibility, message, contentFragments } =
+        bodyValidation.right;
 
       if (message?.context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(
@@ -185,7 +180,8 @@ async function handler(
               clientSideMCPServerIds:
                 message.context.clientSideMCPServerIds ?? [],
             },
-            skipToolsValidation: skipToolsValidation ?? false,
+            // For now we never skip tools when interacting with agents from the web client.
+            skipToolsValidation: false,
           },
           { resolveAfterFullGeneration: false }
         );

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -71,8 +71,13 @@ async function handler(
         });
       }
 
-      const { title, visibility, message, contentFragments } =
-        bodyValidation.right;
+      const {
+        title,
+        visibility,
+        message,
+        contentFragments,
+        skipToolsValidation,
+      } = bodyValidation.right;
 
       if (message?.context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(
@@ -180,6 +185,7 @@ async function handler(
               clientSideMCPServerIds:
                 message.context.clientSideMCPServerIds ?? [],
             },
+            skipToolsValidation: skipToolsValidation ?? false,
           },
           { resolveAfterFullGeneration: false }
         );

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -494,6 +494,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "lastEventId",
+            "required": false,
+            "description": "ID of the last event",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -1176,11 +1185,6 @@
                     },
                     "description": "The list of content fragments to attach to this conversation (optional)"
                   },
-                  "blocking": {
-                    "type": "boolean",
-                    "description": "Whether to wait for the agent to generate the initial message (if blocking = false, you will need to use streaming events to get the messages)",
-                    "example": true
-                  },
                   "title": {
                     "type": "string",
                     "description": "The title of the conversation",
@@ -1194,6 +1198,16 @@
                       "unlisted"
                     ],
                     "example": "unlisted"
+                  },
+                  "skipToolsValidation": {
+                    "type": "boolean",
+                    "description": "Whether to skip the tools validation of the agent messages triggered by this user message (optional, defaults to false)",
+                    "example": false
+                  },
+                  "blocking": {
+                    "type": "boolean",
+                    "description": "Whether to wait for the agent to generate the initial message (if false, you will need to use streaming events to get the messages, defaults to false).",
+                    "example": true
                   }
                 }
               }

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -632,6 +632,7 @@ export async function processTranscriptActivity(
         content: `Transcript: ${transcriptTitle}`,
         mentions: [{ configurationId: agentConfigurationId }],
         context: baseContext,
+        skipToolsValidation: true,
       },
       { resolveAfterFullGeneration: true }
     );

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -632,6 +632,9 @@ export async function processTranscriptActivity(
         content: `Transcript: ${transcriptTitle}`,
         mentions: [{ configurationId: agentConfigurationId }],
         context: baseContext,
+        // When running an agent as trigger of a transcript we have no chance of validating tools so
+        // we skip all of them and run the tools by default. This is in tension with the admin
+        // settings and could be revisited if needed.
         skipToolsValidation: true,
       },
       { resolveAfterFullGeneration: true }

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -21,12 +21,7 @@ export const MessageBaseSchema = t.type({
   ]),
 });
 
-export const InternalPostMessagesRequestBodySchema = t.intersection([
-  MessageBaseSchema,
-  t.type({
-    skipToolsValidation: t.union([t.boolean, t.undefined]),
-  }),
-]);
+export const InternalPostMessagesRequestBodySchema = MessageBaseSchema;
 
 const ContentFragmentBaseSchema = t.intersection([
   t.type({
@@ -191,7 +186,6 @@ export const InternalPostConversationsRequestBodySchema = t.type({
   ]),
   message: t.union([MessageBaseSchema, t.null]),
   contentFragments: t.array(InternalPostContentFragmentRequestBodySchema),
-  skipToolsValidation: t.union([t.boolean, t.undefined]),
 });
 
 export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 
 import { getSupportedNonImageMimeTypes } from "../../files";
 
-export const InternalPostMessagesRequestBodySchema = t.type({
+export const MessageBaseSchema = t.type({
   content: t.refinement(
     t.string,
     (s): s is string => s.length > 0,
@@ -20,6 +20,13 @@ export const InternalPostMessagesRequestBodySchema = t.type({
     }),
   ]),
 });
+
+export const InternalPostMessagesRequestBodySchema = t.intersection([
+  MessageBaseSchema,
+  t.type({
+    skipToolsValidation: t.union([t.boolean, t.undefined]),
+  }),
+]);
 
 const ContentFragmentBaseSchema = t.intersection([
   t.type({
@@ -182,8 +189,9 @@ export const InternalPostConversationsRequestBodySchema = t.type({
     t.literal("deleted"),
     t.literal("test"),
   ]),
-  message: t.union([InternalPostMessagesRequestBodySchema, t.null]),
+  message: t.union([MessageBaseSchema, t.null]),
   contentFragments: t.array(InternalPostContentFragmentRequestBodySchema),
+  skipToolsValidation: t.union([t.boolean, t.undefined]),
 });
 
 export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -167,6 +167,7 @@ export type AgentMessageType = {
   version: number;
   parentMessageId: string | null;
   configuration: LightAgentConfigurationType;
+  skipToolsValidation: boolean;
   status: AgentMessageStatus;
   actions: AgentActionType[];
   content: string | null;

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -631,14 +631,16 @@ export class DustAPI {
   async postUserMessage({
     conversationId,
     message,
+    skipToolsValidation = false,
   }: {
     conversationId: string;
     message: PublicPostMessagesRequestBody;
+    skipToolsValidation?: boolean;
   }) {
     const res = await this.request({
       method: "POST",
       path: `assistant/conversations/${conversationId}/messages`,
-      body: { ...message },
+      body: { ...message, skipToolsValidation },
     });
 
     const r = await this._resultFromResponse(

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -609,6 +609,7 @@ export class DustAPI {
     contentFragment,
     contentFragments,
     blocking = false,
+    skipToolsValidation = false,
   }: PublicPostConversationsRequestBody) {
     const res = await this.request({
       method: "POST",
@@ -620,6 +621,7 @@ export class DustAPI {
         contentFragment,
         contentFragments,
         blocking,
+        skipToolsValidation,
       },
     });
 

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -631,16 +631,14 @@ export class DustAPI {
   async postUserMessage({
     conversationId,
     message,
-    skipToolsValidation = false,
   }: {
     conversationId: string;
     message: PublicPostMessagesRequestBody;
-    skipToolsValidation?: boolean;
   }) {
     const res = await this.request({
       method: "POST",
       path: `assistant/conversations/${conversationId}/messages`,
-      body: { ...message, skipToolsValidation },
+      body: { ...message },
     });
 
     const r = await this._resultFromResponse(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3,6 +3,7 @@ import moment from "moment-timezone";
 import { z } from "zod";
 
 import { INTERNAL_MIME_TYPES_VALUES } from "./internal_mime_types";
+import { skip } from "node:test";
 
 type StringLiteral<T> = T extends string
   ? string extends T
@@ -2089,6 +2090,7 @@ export const PublicPostConversationsRequestBodySchema = z.intersection(
         .array(),
       z.undefined(),
     ]),
+    skipToolsValidation: z.boolean().optional().default(false),
   }),
   z
     .object({
@@ -2189,7 +2191,8 @@ export const PatchDataSourceViewRequestSchema = z.union([
       parentsToAdd: z.union([z.array(z.string()), z.undefined()]),
       parentsToRemove: z.array(z.string()).optional(),
     })
-    // For the fields to be not optional, see https://stackoverflow.com/questions/71477015/specify-a-zod-schema-with-a-non-optional-but-possibly-undefined-field
+    // For the fields to be not optional, see:
+    // https://stackoverflow.com/questions/71477015/specify-a-zod-schema-with-a-non-optional-but-possibly-undefined-field
     .transform((o) => ({
       parentsToAdd: o.parentsToAdd,
       parentsToRemove: o.parentsToRemove,
@@ -2258,7 +2261,9 @@ export const PostDataSourceDocumentRequestSchema = z.object({
   upsert_context: z
     .object({
       sync_type: z.union([z.enum(["batch", "incremental"]), z.undefined()]),
-    }) // For the fields to be not optional, see https://stackoverflow.com/questions/71477015/specify-a-zod-schema-with-a-non-optional-but-possibly-undefined-field
+    })
+    // For the fields to be not optional, see:
+    // https://stackoverflow.com/questions/71477015/specify-a-zod-schema-with-a-non-optional-but-possibly-undefined-field
     .transform((o) => ({
       sync_type: o.sync_type,
     }))

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3,7 +3,6 @@ import moment from "moment-timezone";
 import { z } from "zod";
 
 import { INTERNAL_MIME_TYPES_VALUES } from "./internal_mime_types";
-import { skip } from "node:test";
 
 type StringLiteral<T> = T extends string
   ? string extends T

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1961,11 +1961,11 @@ export const PublicPostMessagesRequestBodySchema = z.intersection(
     context: UserMessageContextSchema.extend({
       clientSideMCPServerIds: z.array(z.string()).optional().nullable(),
     }),
-    skipToolsValidation: z.boolean().optional().default(false),
   }),
   z
     .object({
       blocking: z.boolean().optional(),
+      skipToolsValidation: z.boolean().optional(),
     })
     .partial()
 );
@@ -2091,11 +2091,11 @@ export const PublicPostConversationsRequestBodySchema = z.intersection(
         .array(),
       z.undefined(),
     ]),
-    skipToolsValidation: z.boolean().optional().default(false),
   }),
   z
     .object({
       blocking: z.boolean().optional(),
+      skipToolsValidation: z.boolean().optional(),
     })
     .partial()
 );

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1987,6 +1987,7 @@ export const PublicPostEditMessagesRequestBodySchema = z.object({
       configurationId: z.string(),
     })
   ),
+  skipToolsValidation: z.boolean().optional().default(false),
 });
 
 export type PublicPostEditMessagesRequestBody = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1962,6 +1962,7 @@ export const PublicPostMessagesRequestBodySchema = z.intersection(
     context: UserMessageContextSchema.extend({
       clientSideMCPServerIds: z.array(z.string()).optional().nullable(),
     }),
+    skipToolsValidation: z.boolean().optional().default(false),
   }),
   z
     .object({


### PR DESCRIPTION
## Description

Introduces `skipToolsValidation` to allow API users (and internal use-cases) to skip tools validation for selected API calls.

TBD if we want to set to true for transcripts trigger and  email triggers but that seem low surface enough to be ~Ok.

I went with a boolean but tried hard not to. But here anything else would feel really weird. I thought of `stakeLevelOverride` but that would make little sense when set to anything else than `never_ask`, and the overall construct would have been quite over complicated.

- Added skipToolsValidation to public API but fully optional (non breaking)
- Consider skipToolsValidation=false for all internal conversation API (web client)
- Added skipToolsValidation to all pubsub post/edit conversation/message

`migration-ack`: migration to be run before deploy (see deploy plan)
`sdk-ack`: non breaking change (as tested with connectors' slack bot code unchanged but type checking)
`documentation-ack`: `npm run docs` done + deploy plan updated

## Tests

- [x] in product
  - [x] create conversation with mention
  - [x] create conversation without mention + pick suggested agent
  - [x] retry agent message
  - [x] post new message with mention
  - [x] post new message without mention + pick suggested agent
- [x] API
  - [x] create conversation with and without skiptToolsValidation
  - [x] post message with and without skipToolsValidation
  - [x] edit message with and without skipToolsvalidation

## Risk

Low post testing locally for main flows

## Deploy Plan

- run migration
- deploy `front`
- deploy OpenAPI Docs