### PR TITLE
[front] feat(messages): Add workspaceId filter to Message

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -239,6 +239,7 @@ export async function getConversation(
   const messages = await Message.findAll({
     where: {
       conversationId: conversation.id,
+      workspaceId: owner.id,
     },
     order: [
       ["rank", "ASC"],
@@ -320,6 +321,7 @@ export async function getConversationMessageType(
     where: {
       conversationId: conversation.id,
       sId: messageId,
+      workspaceId: auth.getNonNullableWorkspace().id,
     },
   });
 

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -183,7 +183,10 @@ export async function destroyConversation(
       "agentMessageId",
       "contentFragmentId",
     ],
-    where: { conversationId: conversation.id },
+    where: {
+      conversationId: conversation.id,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
   });
 
   // To preserve the DB, we delete messages in batches.

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -68,6 +68,7 @@ export async function fetchConversationParticipants(
   const messages = await Message.findAll({
     where: {
       conversationId: conversation.id,
+      workspaceId: owner.id,
     },
     attributes: [],
     include: [

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -33,7 +33,7 @@ import {
  */
 
 export async function renderConversationForModel(
-  _auth: Authenticator,
+  auth: Authenticator,
   {
     conversation,
     model,
@@ -202,7 +202,7 @@ export async function renderConversationForModel(
       });
     } else if (isContentFragmentType(m)) {
       messages.push(
-        await renderLightContentFragmentForModel(m, conversation, model, {
+        await renderLightContentFragmentForModel(auth, m, conversation, model, {
           excludeImages: Boolean(excludeImages),
         })
       );

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -32,6 +32,7 @@ export async function getMessageReactions(
 
   const messages = await Message.findAll({
     where: {
+      workspaceId: owner.id,
       conversationId: conversation.id,
     },
     attributes: ["sId"],

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -462,6 +462,9 @@ Message.init(
       {
         fields: ["workspaceId", "conversationId"],
       },
+      {
+        fields: ["workspaceId", "id"],
+      },
     ],
     hooks: {
       beforeValidate: (message) => {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -465,6 +465,9 @@ Message.init(
       {
         fields: ["workspaceId", "id"],
       },
+      {
+        fields: ["workspaceId", "conversationId", "sId"],
+      },
     ],
     hooks: {
       beforeValidate: (message) => {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -459,6 +459,9 @@ Message.init(
         fields: ["parentId"],
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "conversationId"],
+      },
     ],
     hooks: {
       beforeValidate: (message) => {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -463,9 +463,6 @@ Message.init(
         fields: ["workspaceId", "conversationId"],
       },
       {
-        fields: ["workspaceId", "id"],
-      },
-      {
         fields: ["workspaceId", "conversationId", "sId"],
       },
     ],

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -275,6 +275,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
 
     const feedbackForMessages = await Message.findAll({
       where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
         conversationId: conversation.id,
         agentMessageId: {
           [Op.ne]: null,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -155,8 +155,12 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
     );
   }
 
-  static async fromMessageId(id: ModelId) {
-    const message = await Message.findByPk(id, {
+  static async fromMessageId(auth: Authenticator, id: ModelId) {
+    const message = await Message.findOne({
+      where: {
+        id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
       include: [{ model: ContentFragmentModel, as: "contentFragment" }],
     });
     if (!message) {
@@ -596,6 +600,7 @@ export async function renderFromAttachmentId(
 // Render only a tag to specifiy that a content fragment was injected at a given position except for
 // images when the model support them.
 export async function renderLightContentFragmentForModel(
+  auth: Authenticator,
   message: ContentFragmentType,
   conversation: ConversationType,
   model: ModelConfigurationType,
@@ -608,6 +613,7 @@ export async function renderLightContentFragmentForModel(
   const { contentType, sId, title, contentFragmentVersion } = message;
 
   const contentFragment = await ContentFragmentResource.fromMessageId(
+    auth,
     message.id
   );
   if (!contentFragment) {

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -259,6 +259,7 @@ export async function getUserUsageData(
       ],
     ],
     where: {
+      workspaceId: wId,
       createdAt: {
         [Op.gt]: startDate,
         [Op.lt]: endDate,

--- a/front/migrations/db/migration_227.sql
+++ b/front/migrations/db/migration_227.sql
@@ -1,3 +1,4 @@
 -- Migration created on May 12, 2025
 CREATE INDEX "messages_workspace_id_conversation_id" ON "messages" ("workspaceId", "conversationId");
 CREATE INDEX "messages_workspace_id_id" ON "messages" ("workspaceId", "id");
+CREATE INDEX "messages_workspace_id_conversation_id_s_id" ON "messages" ("workspaceId", "conversationId", "sId");

--- a/front/migrations/db/migration_227.sql
+++ b/front/migrations/db/migration_227.sql
@@ -1,4 +1,3 @@
 -- Migration created on May 12, 2025
 CREATE INDEX "messages_workspace_id_conversation_id" ON "messages" ("workspaceId", "conversationId");
-CREATE INDEX "messages_workspace_id_id" ON "messages" ("workspaceId", "id");
 CREATE INDEX "messages_workspace_id_conversation_id_s_id" ON "messages" ("workspaceId", "conversationId", "sId");

--- a/front/migrations/db/migration_227.sql
+++ b/front/migrations/db/migration_227.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 12, 2025
+CREATE INDEX "messages_workspace_id_conversation_id" ON "messages" ("workspaceId", "conversationId");

--- a/front/migrations/db/migration_227.sql
+++ b/front/migrations/db/migration_227.sql
@@ -1,2 +1,3 @@
 -- Migration created on May 12, 2025
 CREATE INDEX "messages_workspace_id_conversation_id" ON "messages" ("workspaceId", "conversationId");
+CREATE INDEX "messages_workspace_id_id" ON "messages" ("workspaceId", "id");


### PR DESCRIPTION
## Description
- Add `workspaceId` filter for calls to `Message` model.
- Add composite index for `[workspaceId, conversationId]`

## Tests
- Locally access past conversation
- Locally can send message
- Locally can share conversation to other user
- That second user can send message in the conversation
- [x] Deploy on front-edge and test the same

## Risk
- High, touch messages, ok to be reverted.

## Deploy Plan
- Run `migration_227.sql` on prodbox (EU + US)
- Deploy front
