### PR TITLE
[front] Remove conversation visibility update code path

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -77,10 +77,7 @@ export function ConversationTitle({
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({
-              title,
-              visibility: conversation?.visibility,
-            }),
+            body: JSON.stringify({ title }),
           }
         );
         await mutate(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -155,16 +155,14 @@ export async function createConversation(
   };
 }
 
-export async function updateConversation(
+export async function updateConversationTitle(
   auth: Authenticator,
-  conversationId: string,
   {
+    conversationId,
     title,
-    visibility,
   }: {
-    title: string | null;
-    // Deletion should be performed by `deleteConversation` only.
-    visibility: Exclude<ConversationVisibility, "deleted">;
+    conversationId: string;
+    title: string;
   }
 ): Promise<Result<ConversationType, ConversationError>> {
   const conversation = await ConversationResource.fetchById(
@@ -176,7 +174,7 @@ export async function updateConversation(
     throw new Error(`Conversation ${conversationId} not found`);
   }
 
-  await conversation.updateVisiblity(visibility, title);
+  await conversation.updateTitle(title);
 
   return getConversation(auth, conversationId);
 }
@@ -211,7 +209,7 @@ export async function deleteConversation(
   if (destroy) {
     await conversation.delete(auth);
   } else {
-    await conversation.updateVisiblity("deleted");
+    await conversation.markAsDeleted();
   }
   return new Ok({ success: true });
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -163,7 +163,8 @@ export async function updateConversation(
     visibility,
   }: {
     title: string | null;
-    visibility: ConversationVisibility;
+    // Deletion should be performed by `deleteConversation` only.
+    visibility: Exclude<ConversationVisibility, "deleted">;
   }
 ): Promise<Result<ConversationType, ConversationError>> {
   const conversation = await ConversationResource.fetchById(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -209,7 +209,7 @@ export async function deleteConversation(
   if (destroy) {
     await conversation.delete(auth);
   } else {
-    await conversation.markAsDeleted();
+    await conversation.updateVisibilityToDeleted();
   }
   return new Ok({ success: true });
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -171,7 +171,7 @@ export async function updateConversationTitle(
   );
 
   if (!conversation) {
-    throw new Error(`Conversation ${conversationId} not found`);
+    return new Err(new ConversationError("conversation_not_found"));
   }
 
   await conversation.updateTitle(title);

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -24,8 +24,7 @@ import type {
   LightAgentConfigurationType,
   Result,
 } from "@app/types";
-import { ConversationError, removeNulls } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { ConversationError, Err, Ok, removeNulls } from "@app/types";
 
 import { GroupResource } from "./group_resource";
 import { frontSequelize } from "./storage";
@@ -430,14 +429,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
   }
 
-  async updateVisiblity(
-    visibility: ConversationVisibility,
-    title?: string | null
-  ) {
-    return this.update({
-      title,
-      visibility,
-    });
+  async updateTitle(title: string) {
+    return this.update({ title });
+  }
+
+  async markAsDeleted() {
+    return this.update({ visibility: "deleted" });
   }
 
   async updateRequestedGroupIds(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -433,7 +433,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return this.update({ title });
   }
 
-  async markAsDeleted() {
+  async updateVisibilityToDeleted() {
     return this.update({ visibility: "deleted" });
   }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -5,7 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   deleteConversation,
-  updateConversation,
+  updateConversationTitle,
 } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -18,12 +18,7 @@ import type {
 } from "@app/types";
 
 export const PatchConversationsRequestBodySchema = t.type({
-  title: t.union([t.string, t.null]),
-  visibility: t.union([
-    t.literal("unlisted"),
-    t.literal("workspace"),
-    t.literal("test"),
-  ]),
+  title: t.string,
 });
 
 export type GetConversationsResponseBody = {
@@ -93,11 +88,11 @@ async function handler(
         });
       }
 
-      const { title, visibility } = bodyValidation.right;
+      const { title } = bodyValidation.right;
 
-      const result = await updateConversation(auth, conversation.sId, {
+      const result = await updateConversationTitle(auth, {
+        conversationId: conversation.sId,
         title,
-        visibility,
       });
 
       if (result.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -22,7 +22,6 @@ export const PatchConversationsRequestBodySchema = t.type({
   visibility: t.union([
     t.literal("unlisted"),
     t.literal("workspace"),
-    t.literal("deleted"),
     t.literal("test"),
   ]),
 });


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2779.
- This PR removes the visibility from  `PATCH` requests on `/api/w/[wId]/assistant/conversations/[cId]`.
- The only remaining code path that updates the visibility is therefore the conversation deletion.
- This PR also refines the typing on this endpoint.

## Tests

- Tested locally, goal here is to monitor whether we get errors in front, if we get some it will uncover an underlying bug.

## Risk

- Endpoint only called when updating title, quite a critical code path but an issue here would mostly cause the update to fail silently.
- Easily rollbackable.

## Deploy Plan

- Deploy front.
