### PR TITLE
Click on a mention allows to see infos or start a new conversation

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -42,7 +42,7 @@ import {
 } from "@app/components/markdown/CiteBlock";
 import type { MarkdownCitation } from "@app/components/markdown/MarkdownCitation";
 import {
-  MentionBlock,
+  getMentionPlugin,
   mentionDirective,
 } from "@app/components/markdown/MentionBlock";
 import {
@@ -452,7 +452,7 @@ export function AgentMessage({
         message.sId
       ),
       sup: CiteBlock,
-      mention: MentionBlock,
+      mention: getMentionPlugin(owner),
     }),
     [owner, conversationId, message.sId, agentConfiguration.sId]
   );

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -39,7 +39,7 @@ export function UserMessage({
       mention: getMentionPlugin(owner),
       content_node_mention: ContentNodeMentionBlock,
     }),
-    []
+    [owner]
   );
 
   const additionalMarkdownPlugins: PluggableList = useMemo(

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -13,7 +13,7 @@ import {
   contentNodeMentionDirective,
 } from "@app/components/markdown/ContentNodeMentionBlock";
 import {
-  MentionBlock,
+  getMentionPlugin,
   mentionDirective,
 } from "@app/components/markdown/MentionBlock";
 import type { UserMessageType, WorkspaceType } from "@app/types";
@@ -36,7 +36,7 @@ export function UserMessage({
   const additionalMarkdownComponents: Components = useMemo(
     () => ({
       sup: CiteBlock,
-      mention: MentionBlock,
+      mention: getMentionPlugin(owner),
       content_node_mention: ContentNodeMentionBlock,
     }),
     []

--- a/front/components/markdown/MentionBlock.tsx
+++ b/front/components/markdown/MentionBlock.tsx
@@ -1,26 +1,61 @@
-import { useContext } from "react";
+import {
+  ChatBubbleBottomCenterTextIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EyeIcon,
+} from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
 import { visit } from "unist-util-visit";
 
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useURLSheet } from "@app/hooks/useURLSheet";
+import { setQueryParam } from "@app/lib/utils/router";
+import type { WorkspaceType } from "@app/types";
 
-export function MentionBlock({
+// Not exported, the one exported is getMentionPlugin since we need to pass the owner.
+function MentionBlock({
+  owner,
   agentName,
   agentSId,
 }: {
+  owner: WorkspaceType;
   agentName: string;
   agentSId: string;
 }) {
-  const { setAnimate, setSelectedAssistant } = useContext(InputBarContext);
+  const router = useRouter();
+  const { onOpenChange: onOpenChangeAssistantModal } =
+    useURLSheet("assistantDetails");
+
+  const handleStartConversation = async () => {
+    await router.push(`/w/${owner.sId}/assistant/new?assistant=${agentSId}`);
+  };
+
+  const handleSeeDetails = () => {
+    onOpenChangeAssistantModal(true);
+    setQueryParam(router, "assistantDetails", agentSId);
+  };
+
   return (
-    <span
-      className="inline-block cursor-pointer font-medium text-highlight-500"
-      onClick={() => {
-        setSelectedAssistant({ configurationId: agentSId });
-        setAnimate(true);
-      }}
-    >
-      @{agentName}
-    </span>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <span className="inline-block cursor-pointer font-medium text-highlight-500">
+          @{agentName}
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          onClick={handleStartConversation}
+          icon={() => <ChatBubbleBottomCenterTextIcon />}
+          label={`New conversation with ${agentName}`}
+        />
+        <DropdownMenuItem
+          onClick={handleSeeDetails}
+          icon={() => <EyeIcon />}
+          label={`About ${agentName}`}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -37,4 +72,20 @@ export function mentionDirective() {
       }
     });
   };
+}
+
+export function getMentionPlugin(owner: WorkspaceType) {
+  const MentionPlugin = ({
+    agentName,
+    agentSId,
+  }: {
+    agentName: string;
+    agentSId: string;
+  }) => {
+    return (
+      <MentionBlock owner={owner} agentName={agentName} agentSId={agentSId} />
+    );
+  };
+
+  return MentionPlugin;
 }

--- a/front/components/markdown/MentionBlock.tsx
+++ b/front/components/markdown/MentionBlock.tsx
@@ -47,12 +47,12 @@ function MentionBlock({
         <DropdownMenuItem
           onClick={handleStartConversation}
           icon={() => <ChatBubbleBottomCenterTextIcon />}
-          label={`New conversation with ${agentName}`}
+          label={`New conversation with @${agentName}`}
         />
         <DropdownMenuItem
           onClick={handleSeeDetails}
           icon={() => <EyeIcon />}
-          label={`About ${agentName}`}
+          label={`About @${agentName}`}
         />
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Description

Clicking on a a mention in a user or agent message opens a dropdown with 2 buttons, allowing to see the detail of the agent (opens the modal) or start a new conversation with it. 

<kbd>
<img width="535" alt="Screenshot 2025-05-12 at 14 56 11" src="https://github.com/user-attachments/assets/433aa30a-84df-42e2-9bd9-e1e4986ee33f" />
</kbd>

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
