### PR TITLE
fix: Add bypass to membership fetch and add eslint rule

### DIFF
--- a/eslint-plugin-dust/index.js
+++ b/eslint-plugin-dust/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const noRawSqlRule = require("./rules/no-raw-sql");
+const noUnverifiedWorkspaceBypass = require("./rules/no-unverified-workspace-bypass.js");
 
 module.exports = {
   meta: {
@@ -9,5 +10,6 @@ module.exports = {
   },
   rules: {
     "no-raw-sql": noRawSqlRule,
+    "no-unverified-workspace-bypass": noUnverifiedWorkspaceBypass,
   },
 };

--- a/eslint-plugin-dust/rules/no-unverified-workspace-bypass.js
+++ b/eslint-plugin-dust/rules/no-unverified-workspace-bypass.js
@@ -26,7 +26,7 @@ module.exports = {
             context.report({
               node,
               message:
-                'Usage of dangerouslyBypassWorkspaceIsolationSecurity requires a comment starting with "WORKSPACE_ISOLATION_BYPASS" explaining the security bypass',
+                'Usage of dangerouslyBypassWorkspaceIsolationSecurity requires a comment starting with "WORKSPACE_ISOLATION_BYPASS:" explaining the security bypass',
             });
           }
         }

--- a/eslint-plugin-dust/rules/no-unverified-workspace-bypass.js
+++ b/eslint-plugin-dust/rules/no-unverified-workspace-bypass.js
@@ -1,0 +1,36 @@
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce WORKSPACE_ISOLATION_BYPASS comment when using dangerouslyBypassWorkspaceIsolationSecurity",
+      recommended: true,
+    },
+    schema: [], // no options
+  },
+  create(context) {
+    return {
+      Property(node) {
+        if (
+          node.key.name === "dangerouslyBypassWorkspaceIsolationSecurity" &&
+          node.value.value === true
+        ) {
+          const sourceCode = context.getSourceCode();
+          const comments = sourceCode.getCommentsBefore(node);
+
+          const hasWorkspaceBypassComment = comments.some((comment) =>
+            comment.value.trim().startsWith("WORKSPACE_ISOLATION_BYPASS"),
+          );
+
+          if (!hasWorkspaceBypassComment) {
+            context.report({
+              node,
+              message:
+                'Usage of dangerouslyBypassWorkspaceIsolationSecurity requires a comment starting with "WORKSPACE_ISOLATION_BYPASS" explaining the security bypass',
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-dust/rules/no-unverified-workspace-bypass.js
+++ b/eslint-plugin-dust/rules/no-unverified-workspace-bypass.js
@@ -19,7 +19,7 @@ module.exports = {
           const comments = sourceCode.getCommentsBefore(node);
 
           const hasWorkspaceBypassComment = comments.some((comment) =>
-            comment.value.trim().startsWith("WORKSPACE_ISOLATION_BYPASS"),
+            comment.value.trim().startsWith("WORKSPACE_ISOLATION_BYPASS:"),
           );
 
           if (!hasWorkspaceBypassComment) {

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
     "simple-import-sort/exports": "error",
     "@typescript-eslint/return-await": ["error", "in-try-catch"],
     "dust/no-raw-sql": "error",
+    "dust/no-unverified-workspace-bypass": "error",
   },
   overrides: [
     {


### PR DESCRIPTION
## Description
- Add bypass workspace isolation for Membership
- Add eslint dust rule to make sure a comment is added above said bypass

## Tests
- Locally signout / signin

## Risk
- Low, didn't add more filter, just necessary bypass log warning

## Deploy Plan
- Deploy front
