### PR TITLE
[front] feat(reasoning): Add workspaceId filtering to AgentReasoningAction

### DIFF
--- a/front/lib/actions/reasoning.ts
+++ b/front/lib/actions/reasoning.ts
@@ -538,11 +538,13 @@ export async function* runReasoning(
 }
 
 export async function reasoningActionTypesFromAgentMessageIds(
-  agentMessageIds: ModelId[]
+  auth: Authenticator,
+  { agentMessageIds }: { agentMessageIds: ModelId[] }
 ): Promise<ReasoningActionType[]> {
   const models = await AgentReasoningAction.findAll({
     where: {
       agentMessageId: agentMessageIds,
+      workspaceId: auth.getNonNullableWorkspace().id,
     },
   });
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -170,7 +170,8 @@ async function batchRenderAgentMessages(
       browseActionTypesFromAgentMessageIds(auth, { agentMessageIds }))(),
     (async () =>
       conversationIncludeFileTypesFromAgentMessageIds(agentMessageIds))(),
-    (async () => reasoningActionTypesFromAgentMessageIds(agentMessageIds))(),
+    (async () =>
+      reasoningActionTypesFromAgentMessageIds(auth, { agentMessageIds }))(),
     (async () =>
       searchLabelsActionTypesFromAgentMessageIds(auth, { agentMessageIds }))(),
     (async () =>

--- a/front/lib/models/assistant/actions/reasoning.ts
+++ b/front/lib/models/assistant/actions/reasoning.ts
@@ -174,8 +174,13 @@ AgentReasoningAction.init(
     modelName: "agent_reasoning_action",
     sequelize: frontSequelize,
     indexes: [
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-12): Remove index
       {
         fields: ["agentMessageId"],
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId", "agentMessageId"],
         concurrently: true,
       },
     ],

--- a/front/migrations/db/migration_234.sql
+++ b/front/migrations/db/migration_234.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 12, 2025
+CREATE INDEX CONCURRENTLY "agent_reasoning_actions_workspace_id_agent_message_id" ON "agent_reasoning_actions" ("workspaceId", "agentMessageId");


### PR DESCRIPTION
## Description
- Add `workspaceId` filtering to AgentReasoningAction
- Add migration to add new index

## Tests
- Locally display conversation with reasoning message

## Risk
- Mid, could not show reasoning message

## Deploy Plan
- [x] Run migration
- [x] Deploy front
