### PR TITLE
[front] feat(mcp-action): add workspaceId filter to AgentMCPAction

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -898,11 +898,13 @@ const buildErrorEvent = (
 // have `sId` on actions (the `sId` is on the `Message` object linked to the `UserMessage` parent of
 // this action).
 export async function mcpActionTypesFromAgentMessageIds(
-  agentMessageIds: ModelId[]
+  auth: Authenticator,
+  { agentMessageIds }: { agentMessageIds: ModelId[] }
 ): Promise<MCPActionType[]> {
   const actions = await AgentMCPAction.findAll({
     where: {
       agentMessageId: agentMessageIds,
+      workspaceId: auth.getNonNullableWorkspace().id,
     },
     include: [
       {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -173,7 +173,8 @@ async function batchRenderAgentMessages(
     (async () => reasoningActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () =>
       searchLabelsActionTypesFromAgentMessageIds(auth, { agentMessageIds }))(),
-    (async () => mcpActionTypesFromAgentMessageIds(agentMessageIds))(),
+    (async () =>
+      mcpActionTypesFromAgentMessageIds(auth, { agentMessageIds }))(),
   ]);
 
   if (!agentConfigurations) {

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -233,8 +233,13 @@ AgentMCPAction.init(
     modelName: "agent_mcp_action",
     sequelize: frontSequelize,
     indexes: [
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-12): Remove index
       {
         fields: ["agentMessageId"],
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId", "agentMessageId"],
         concurrently: true,
       },
     ],

--- a/front/migrations/db/migration_235.sql
+++ b/front/migrations/db/migration_235.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 12, 2025
+CREATE INDEX CONCURRENTLY "agent_mcp_actions_workspace_id_agent_message_id" ON "agent_mcp_actions" ("workspaceId", "agentMessageId");


### PR DESCRIPTION
## Description
- Add `workspaceId` filter to AgentMCPAction
- Add new index and necessary migration

## Tests
- Locally display mcp agent message

## Risk
Mid, could not fetch correctly AgentMCPAction, easy to revert

## Deploy Plan
- [ ] Run migration
- [ ] Deploy front
