### PR TITLE
Add: script to migrate all web search and browse actions on active ag…

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -91,7 +91,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.45",
+      "version": "1.0.47",
       "license": "ISC",
       "dependencies": {
         "@types/json-schema": "^7.0.15",

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1,5 +1,4 @@
 import {
-  ActionGlobeAltIcon,
   Avatar,
   BookOpenIcon,
   Button,
@@ -102,7 +101,6 @@ import {
   useBuilderActionInfo,
 } from "@app/components/assistant_builder/useBuilderActionInfo";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/utils";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -1385,24 +1383,6 @@ function Capabilities({
     builderState.actions,
   ]);
 
-  // Users should see the old web Capabilities only if
-  // their agents has it selected in the past or
-  // if they don't have mcp_actions activated
-  const shouldShowOldWebCapabilities = useMemo(() => {
-    // this is to catch any changes in the name
-    const webtoolsV2ServerName: InternalMCPServerNameType =
-      "web_search_&_browse_v2";
-
-    const webtoolsServer = mcpServerViews.find(
-      (view) => view.server.name === webtoolsV2ServerName
-    );
-    if (webtoolsServer != null) {
-      return isWebNavigationEnabled;
-    }
-
-    return true;
-  }, [isWebNavigationEnabled, mcpServerViews]);
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -1416,31 +1396,6 @@ function Capabilities({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {shouldShowOldWebCapabilities && (
-          <Capability
-            name="Web search & browse"
-            description="Agent can search (Google) and retrieve information from specific websites."
-            icon={() => <Avatar icon={ActionGlobeAltIcon} size="sm" />}
-            enabled={isWebNavigationEnabled}
-            onEnable={() => {
-              setEdited(true);
-              const defaultWebNavigationAction =
-                getDefaultActionConfiguration("WEB_NAVIGATION");
-              assert(defaultWebNavigationAction);
-              setAction({
-                type: "insert",
-                action: defaultWebNavigationAction,
-              });
-            }}
-            onDisable={() => {
-              const defaultWebNavigationAction =
-                getDefaultActionConfiguration("WEB_NAVIGATION");
-              assert(defaultWebNavigationAction);
-              deleteAction(defaultWebNavigationAction.name);
-            }}
-          />
-        )}
-
         <Capability
           name="Data visualization"
           description="Agent can generate charts and graphs."

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -22,7 +22,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "run_dust_app",
   "search",
   "think",
-  "web_search_&_browse_v2",
+  "web_search_&_browse",
 ] as const;
 
 // Whether the server is available by default in the global space.
@@ -73,10 +73,10 @@ export const INTERNAL_MCP_SERVERS: Record<
     availability: "auto",
     flag: "dev_mcp_actions", // Putting this behind the dev flag for now to allow shipping without it.
   },
-  "web_search_&_browse_v2": {
+  "web_search_&_browse": {
     id: 5,
     availability: "auto",
-    flag: "mcp_actions",
+    flag: null,
   },
   think: {
     id: 6,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -50,7 +50,7 @@ export async function getInternalMCPServer(
       return primitiveTypesDebuggerServer();
     case "think":
       return thinkServer();
-    case "web_search_&_browse_v2":
+    case "web_search_&_browse":
       return webtoolsServer(agentLoopRunContext);
     case "search":
       return searchServer(auth, agentLoopRunContext);

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -10,7 +10,7 @@ import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { actionRefsOffset } from "@app/lib/actions/utils";
 import { getWebsearchNumResults } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
-import type { MCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import {
   browseUrls,
   isBrowseScrapeSuccessResponse,
@@ -19,8 +19,8 @@ import { webSearch } from "@app/lib/utils/websearch";
 import type { OAuthProvider } from "@app/types";
 
 export const provider: OAuthProvider = "google_drive" as const;
-export const serverInfo: MCPServerDefinitionType = {
-  name: "web_search_&_browse_v2",
+export const serverInfo: InternalMCPServerDefinitionType = {
+  name: "web_search_&_browse",
   version: "1.0.0",
   description:
     "Agent can search (Google) and retrieve information from specific websites.",

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -155,7 +155,7 @@ export function isMCPConfigurationForInternalWebsearch(
 ): arg is ServerSideMCPServerConfigurationType {
   return (
     isServerSideMCPServerConfiguration(arg) &&
-    isInternalMCPServerOfName(arg.internalMCPServerId, "web_search_&_browse_v2")
+    isInternalMCPServerOfName(arg.internalMCPServerId, "web_search_&_browse")
   );
 }
 
@@ -204,7 +204,7 @@ export function isMCPInternalWebsearch(
 ): arg is ServerSideMCPToolConfigurationType {
   return (
     isServerSideMCPToolConfiguration(arg) &&
-    isInternalMCPServerOfName(arg.internalMCPServerId, "web_search_&_browse_v2")
+    isInternalMCPServerOfName(arg.internalMCPServerId, "web_search_&_browse")
   );
 }
 

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -236,7 +236,7 @@ export function getCitationsCount({
         isServerSideMCPToolConfiguration(action) &&
         isInternalMCPServerOfName(
           action.internalMCPServerId,
-          "web_search_&_browse_v2"
+          "web_search_&_browse"
         )
       ) {
         return getWebsearchNumResults({

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -1631,7 +1631,7 @@ export async function getGlobalAgents(
     preFetchedDataSources,
     globaAgentSettings,
     helperPromptInstance,
-    agentRouterMcpServerViews,
+    agentRouterMCPServerView,
   ] = await Promise.all([
     variant === "full"
       ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
@@ -1640,19 +1640,11 @@ export async function getGlobalAgents(
       where: { workspaceId: owner.id },
     }),
     HelperAssistantPrompt.getInstance(),
-    MCPServerViewResource.listByMCPServer(
+    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
-      internalMCPServerNameToSId({
-        name: "agent_router",
-        workspaceId: owner.id,
-      })
+      "agent_router"
     ),
   ]);
-
-  // We prefetch the agent router mcp server view to be able to add this tool to some global agents.
-  const agentRouterMCPServerView =
-    agentRouterMcpServerViews.find((view) => view.space.kind === "global") ??
-    null;
 
   // If agentIds have been passed we fetch those. Otherwise we fetch them all, removing the retired
   // one (which will remove these models from the list of default agents in the product + list of

--- a/front/lib/models/assistant/actions/browse.ts
+++ b/front/lib/models/assistant/actions/browse.ts
@@ -61,10 +61,17 @@ AgentBrowseConfiguration.init(
 );
 
 AgentConfiguration.hasMany(AgentBrowseConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  foreignKey: {
+    name: "agentConfigurationId",
+    allowNull: false,
+  },
+  as: "browseConfigurations",
 });
 AgentBrowseConfiguration.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  foreignKey: {
+    name: "agentConfigurationId",
+    allowNull: false,
+  },
 });
 
 export class AgentBrowseAction extends WorkspaceAwareModel<AgentBrowseAction> {

--- a/front/lib/models/assistant/actions/websearch.ts
+++ b/front/lib/models/assistant/actions/websearch.ts
@@ -62,6 +62,7 @@ AgentWebsearchConfiguration.init(
 
 AgentConfiguration.hasMany(AgentWebsearchConfiguration, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
+  as: "websearchConfigurations",
 });
 AgentWebsearchConfiguration.belongsTo(AgentConfiguration, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -1,6 +1,8 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import type { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
+import type { AgentWebsearchConfiguration } from "@app/lib/models/assistant/actions/websearch";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -49,6 +51,9 @@ export class AgentConfiguration extends WorkspaceAwareModel<AgentConfiguration> 
   declare requestedGroupIds: number[][];
 
   declare author: NonAttribute<UserModel>;
+
+  declare browseConfigurations: NonAttribute<AgentBrowseConfiguration[]>;
+  declare websearchConfigurations: NonAttribute<AgentWebsearchConfiguration[]>;
 }
 
 AgentConfiguration.init(

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -296,15 +296,14 @@ DataSourceModel.hasMany(TrackerGenerationModel, {
   onDelete: "RESTRICT",
 });
 TrackerGenerationModel.belongsTo(DataSourceModel, {
-  foreignKey: { allowNull: false },
+  foreignKey: { allowNull: false, name: "dataSourceId" },
   as: "dataSource",
 });
 
 DataSourceModel.hasMany(TrackerGenerationModel, {
   foreignKey: { allowNull: true },
-  as: "maintainedDocumentDataSource",
 });
 TrackerGenerationModel.belongsTo(DataSourceModel, {
-  foreignKey: { allowNull: true },
+  foreignKey: { allowNull: true, name: "maintainedDocumentDataSourceId" },
   as: "maintainedDocumentDataSource",
 });

--- a/front/migrations/20250513_migrate_browse_websearch_to_mcp.ts
+++ b/front/migrations/20250513_migrate_browse_websearch_to_mcp.ts
@@ -1,0 +1,167 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import { AgentWebsearchConfiguration } from "@app/lib/models/assistant/actions/websearch";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { Workspace } from "@app/lib/models/workspace";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import type { LoggerInterface } from "@app/types";
+
+import { makeScript } from "../scripts/helpers";
+
+const argumentSpecs = {
+  workspaceSid: {
+    type: "string" as const,
+    describe:
+      "Optional workspace SID to migrate. If not provided, will migrate all workspaces.",
+  },
+};
+
+async function migrateWorkspace(
+  workspace: Workspace,
+  logger: LoggerInterface,
+  execute: boolean
+): Promise<void> {
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      execute,
+    },
+    "Starting migration for workspace"
+  );
+
+  // Create internal authenticator
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // Ensure all auto tools are created
+  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+  // Get MCP server view for the combined tool
+  const mcpServerView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "web_search_&_browse"
+    );
+
+  if (!mcpServerView) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+      },
+      "Failed to get MCP server view for web_search_&_browse"
+    );
+    return;
+  }
+
+  // List all active agent configurations with browse or websearch
+  const agentConfigs = await AgentConfiguration.findAll({
+    where: {
+      workspaceId: workspace.id,
+      status: "active",
+    },
+    include: [
+      {
+        model: AgentBrowseConfiguration,
+        required: false,
+        as: "browseConfigurations",
+      },
+      {
+        model: AgentWebsearchConfiguration,
+        required: false,
+        as: "websearchConfigurations",
+      },
+    ],
+  });
+
+  for (const agentConfig of agentConfigs) {
+    const hasBrowse = agentConfig.browseConfigurations.length > 0;
+    const hasWebsearch = agentConfig.websearchConfigurations.length > 0;
+
+    if (!hasBrowse && !hasWebsearch) {
+      continue;
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        agentConfigurationId: agentConfig.sId,
+        hasBrowse,
+        hasWebsearch,
+        execute,
+      },
+      "Migrating agent configuration"
+    );
+
+    if (execute) {
+      // Create MCP server configuration
+      await AgentMCPServerConfiguration.create({
+        sId: generateRandomModelSId(),
+        workspaceId: workspace.id,
+        agentConfigurationId: agentConfig.id,
+        mcpServerViewId: mcpServerView.id,
+        internalMCPServerId: mcpServerView.internalMCPServerId,
+        additionalConfiguration: {},
+        timeFrame: null,
+      });
+
+      // Delete old configurations
+      for (const browseConfig of agentConfig.browseConfigurations) {
+        await browseConfig.destroy();
+      }
+
+      for (const websearchConfig of agentConfig.websearchConfigurations) {
+        await websearchConfig.destroy();
+      }
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId: agentConfig.sId,
+        },
+        "Successfully migrated agent configuration"
+      );
+    } else {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          agentConfigurationId: agentConfig.sId,
+        },
+        "Would migrate agent configuration (dry run)"
+      );
+    }
+  }
+}
+
+async function main(
+  args: { workspaceId?: string; execute: boolean },
+  logger: LoggerInterface
+) {
+  if (args.workspaceId) {
+    const workspace = await Workspace.findOne({
+      where: {
+        sId: args.workspaceId,
+      },
+    });
+
+    if (!workspace) {
+      throw new Error(`Workspace ${args.workspaceId} not found`);
+    }
+
+    await migrateWorkspace(workspace, logger, args.execute);
+  } else {
+    const workspaces = await Workspace.findAll();
+    logger.info(
+      {
+        workspaceCount: workspaces.length,
+      },
+      "Migrating all workspaces"
+    );
+
+    for (const workspace of workspaces) {
+      await migrateWorkspace(workspace, logger, args.execute);
+    }
+  }
+}
+
+makeScript(argumentSpecs, main);

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -189,7 +189,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "license": "ISC",
       "dependencies": {
         "@types/json-schema": "^7.0.15",


### PR DESCRIPTION
## Description

- Remove _v2 from websearch & browser MCP tool name
- Remove flag (so it's available to all)
- Remove useless code in action screen to show old version
- Create script that find out all existing active configuration with websearch or browse, create the MCP version then delete the old action configuration(s).

## Tests

Tested locally

## Risk

Medium as it manipulate agents configurations.

## Deploy Plan

Block deployments
Pull on prodbox and run the script
Deploy prod.