### PR TITLE
[sparkle] - fix(RadioGroup): width

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.493",
+  "version": "0.2.494",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.493",
+      "version": "0.2.494",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.493",
+  "version": "0.2.494",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -106,13 +106,13 @@ const RadioGroupItem = React.forwardRef<
     );
 
     const wrappedItem = (
-      <div className="s-flex s-items-center s-gap-2">
+      <div className="s-flex s-items-center s-gap-2 s-w-full">
         {tooltipMessage ? (
           <Tooltip trigger={item} label={tooltipMessage} />
         ) : (
           item
         )}
-        {icon ? renderIcon(icon) : <></>}
+        {icon && renderIcon(icon)}
         <Label htmlFor={id} {...labelProps}>
           {label}
         </Label>


### PR DESCRIPTION
## Description

This PR aims at fixing the `RadioGroupItem` and `RadioGroupCustomItem` component to take up the full available width.

Now:
![Screenshot 2025-05-12 at 18 03 16](https://github.com/user-attachments/assets/1f53a8ee-f8f4-4aba-9afb-4d67fa08af40)

Before:
![Screenshot 2025-05-12 at 18 03 46](https://github.com/user-attachments/assets/cbbf984d-4bdb-4bf6-b9ef-f454bbadfea2)

## Risk

Low

## Deploy Plan

- Publish sparkle
- Update front