### PR TITLE
fix(sdk): correctly extract lastEventId

### DIFF
--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "license": "ISC",
       "dependencies": {
         "@types/json-schema": "^7.0.15",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -777,9 +777,11 @@ export class DustAPI {
           if (event.type === "event") {
             if (event.data) {
               try {
-                const data = JSON.parse(event.data).data;
-                lastEventId = data.eventId;
-                pendingEvents.push(data);
+                const eventData = JSON.parse(event.data);
+                if (eventData.eventId) {
+                  lastEventId = eventData.eventId;
+                }
+                pendingEvents.push(eventData.data);
               } catch (err) {
                 logger.error(
                   { error: err },


### PR DESCRIPTION
## Description

We're not correctly extracting the `lastEventId` from the event data in SDK's `streamAgentMessageEvents`. As a result, we're re-streaming all historical events on reconnect

## Tests

Manual

## Risk

N/A

## Deploy Plan

Publish CLI, deploy connectors