### PR TITLE
fix styling issues when using system theme in Dust App builder

### DIFF
--- a/front/components/ViewFolderAPIModal.tsx
+++ b/front/components/ViewFolderAPIModal.tsx
@@ -14,6 +14,7 @@ import {
 import dynamic from "next/dynamic";
 import { useState } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { DataSourceType, SpaceType, WorkspaceType } from "@app/types";
 import { assertNever } from "@app/types";
 
@@ -80,9 +81,7 @@ export function ViewFolderAPIModal({
     }
   };
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>

--- a/front/components/ViewFolderAPIModal.tsx
+++ b/front/components/ViewFolderAPIModal.tsx
@@ -80,7 +80,9 @@ export function ViewFolderAPIModal({
     }
   };
 
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
 
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
@@ -122,7 +124,7 @@ export function ViewFolderAPIModal({
                 <span className="italic">{dataSource.name}</span>:
               </Page.P>
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={true}
                 value={`$ ${cURLRequest("upsert")}`}
                 language="shell"
@@ -156,7 +158,7 @@ export function ViewFolderAPIModal({
                 <span className="italic">{dataSource.name}</span>:
               </Page.P>
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={true}
                 value={`$ ${cURLRequest("search")}`}
                 language="shell"

--- a/front/components/app/ViewAppAPIModal.tsx
+++ b/front/components/app/ViewAppAPIModal.tsx
@@ -16,6 +16,7 @@ import {
 import dynamic from "next/dynamic";
 import { useState } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { AppType, RunConfig, RunType, WorkspaceType } from "@app/types";
 import { assertNever } from "@app/types";
 
@@ -90,9 +91,7 @@ export function ViewAppAPIModal({
     }
   };
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Sheet>

--- a/front/components/app/ViewAppAPIModal.tsx
+++ b/front/components/app/ViewAppAPIModal.tsx
@@ -90,7 +90,9 @@ export function ViewAppAPIModal({
     }
   };
 
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
 
   return (
     <Sheet>
@@ -133,7 +135,7 @@ export function ViewAppAPIModal({
                 <span className="italic">{app.name}</span>:
               </Page.P>
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={true}
                 value={`$ ${cURLRequest("run")}`}
                 language="shell"

--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -204,7 +204,9 @@ export default function Chat({
   const [isModelSupportsResponseFormat, setIsModelSupportsResponseFormat] =
     useState(config ? supportsResponseFormat(config) : false);
 
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
 
   return (
     <Block
@@ -390,7 +392,7 @@ export default function Chat({
                     <div className="flex w-full font-normal">
                       <div className="w-full leading-5">
                         <CodeEditor
-                          data-color-mode={theme === "dark" ? "dark" : "light"}
+                          data-color-mode={isDark ? "dark" : "light"}
                           readOnly={readOnly}
                           value={responseFormatText}
                           language="json"
@@ -444,7 +446,7 @@ export default function Chat({
           <div className="flex w-full font-normal">
             <div className="w-full leading-5">
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={readOnly}
                 value={block.spec.instructions}
                 language="jinja2"
@@ -468,7 +470,7 @@ export default function Chat({
           <div className="flex w-full font-normal">
             <div className="w-full leading-4">
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={readOnly}
                 value={block.spec.messages_code}
                 language="js"
@@ -495,7 +497,7 @@ export default function Chat({
                 <div className="flex w-full font-normal">
                   <div className="w-full leading-4">
                     <CodeEditor
-                      data-color-mode={theme === "dark" ? "dark" : "light"}
+                      data-color-mode={isDark ? "dark" : "light"}
                       readOnly={readOnly}
                       value={block.spec.functions_code}
                       language="js"

--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -11,6 +11,7 @@ import dynamic from "next/dynamic";
 import { useState } from "react";
 
 import ModelPicker from "@app/components/app/ModelPicker";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { supportsResponseFormat } from "@app/lib/providers";
 import { classNames, shallowBlockClone } from "@app/lib/utils";
 import type {
@@ -204,9 +205,7 @@ export default function Chat({
   const [isModelSupportsResponseFormat, setIsModelSupportsResponseFormat] =
     useState(config ? supportsResponseFormat(config) : false);
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Block

--- a/front/components/app/blocks/Code.tsx
+++ b/front/components/app/blocks/Code.tsx
@@ -3,6 +3,7 @@ import "@uiw/react-textarea-code-editor/dist.css";
 import { Label } from "@dust-tt/sparkle";
 import dynamic from "next/dynamic";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { shallowBlockClone } from "@app/lib/utils";
 import type { WorkspaceType } from "@app/types";
 import type {
@@ -13,7 +14,6 @@ import type {
 import type { BlockType, RunType } from "@app/types";
 
 import Block from "./Block";
-
 const CodeEditor = dynamic(
   () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),
   { ssr: false }
@@ -56,9 +56,7 @@ export default function Code({
     onBlockUpdate(b);
   };
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Block

--- a/front/components/app/blocks/Code.tsx
+++ b/front/components/app/blocks/Code.tsx
@@ -56,7 +56,9 @@ export default function Code({
     onBlockUpdate(b);
   };
 
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
 
   return (
     <Block
@@ -82,7 +84,7 @@ export default function Code({
           <div className="flex w-full font-normal">
             <div className="w-full">
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={readOnly}
                 value={block.spec.code}
                 language="js"

--- a/front/components/app/blocks/Curl.tsx
+++ b/front/components/app/blocks/Curl.tsx
@@ -107,7 +107,9 @@ export default function Curl({
     }
   });
 
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
 
   return (
     <Block
@@ -185,7 +187,7 @@ export default function Curl({
           <div className="flex w-full font-normal">
             <div className="w-full">
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={readOnly}
                 value={block.spec.headers_code}
                 language="js"
@@ -207,7 +209,7 @@ export default function Curl({
           <div className="flex w-full font-normal">
             <div className="w-full">
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={readOnly}
                 value={block.spec.body_code}
                 language="js"

--- a/front/components/app/blocks/Curl.tsx
+++ b/front/components/app/blocks/Curl.tsx
@@ -12,6 +12,7 @@ import {
 import dynamic from "next/dynamic";
 import { useEffect } from "react";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { shallowBlockClone } from "@app/lib/utils";
 import type {
   AppType,
@@ -107,9 +108,7 @@ export default function Curl({
     }
   });
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Block

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -194,7 +194,9 @@ export default function DataSource({
     onBlockUpdate(b);
   };
 
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
 
   return (
     <Block
@@ -256,7 +258,7 @@ export default function DataSource({
           <div className="flex w-full font-normal">
             <div className="w-full leading-5">
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={readOnly}
                 value={block.spec.query}
                 language="jinja2"
@@ -283,7 +285,7 @@ export default function DataSource({
               <div className="flex w-full flex-col gap-2">
                 <div className="flex w-full flex-col gap-2">
                   <CodeEditor
-                    data-color-mode={theme === "dark" ? "dark" : "light"}
+                    data-color-mode={isDark ? "dark" : "light"}
                     readOnly={readOnly}
                     value={block.spec.filter_code}
                     language="js"

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -11,6 +11,7 @@ import dynamic from "next/dynamic";
 import { useState } from "react";
 
 import DataSourcePicker from "@app/components/data_source/DataSourcePicker";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { shallowBlockClone } from "@app/lib/utils";
 import type {
   AppType,
@@ -22,7 +23,6 @@ import type {
 } from "@app/types";
 
 import Block from "./Block";
-
 const CodeEditor = dynamic(
   () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),
   { ssr: false }
@@ -194,9 +194,7 @@ export default function DataSource({
     onBlockUpdate(b);
   };
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Block

--- a/front/components/app/blocks/Database.tsx
+++ b/front/components/app/blocks/Database.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import { useCallback, useEffect } from "react";
 
 import DataSourcePicker from "@app/components/data_source/DataSourcePicker";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import TablePicker from "@app/components/tables/TablePicker";
 import { classNames, shallowBlockClone } from "@app/lib/utils";
 import type { WorkspaceType } from "@app/types";
@@ -17,7 +18,6 @@ import type {
 import type { BlockType, RunType } from "@app/types";
 
 import Block from "./Block";
-
 const CodeEditor = dynamic(
   () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),
   { ssr: false }
@@ -214,9 +214,7 @@ export default function Database({
   onBlockDown: () => void;
   onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
 }>) {
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Block

--- a/front/components/app/blocks/Database.tsx
+++ b/front/components/app/blocks/Database.tsx
@@ -214,7 +214,10 @@ export default function Database({
   onBlockDown: () => void;
   onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
 }>) {
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+
   return (
     <Block
       owner={owner}
@@ -246,7 +249,7 @@ export default function Database({
           <Label>Query</Label>
           <div className="w-full font-normal">
             <CodeEditor
-              data-color-mode={theme === "dark" ? "dark" : "light"}
+              data-color-mode={isDark ? "dark" : "light"}
               readOnly={readOnly}
               value={block.spec.query}
               language="jinja2"

--- a/front/components/app/blocks/LLM.tsx
+++ b/front/components/app/blocks/LLM.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 
 import ModelPicker from "@app/components/app/ModelPicker";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { classNames, shallowBlockClone } from "@app/lib/utils";
 import type { WorkspaceType } from "@app/types";
 import type {
@@ -152,9 +153,7 @@ export default function LLM({
 
   const [newStop, setNewStop] = useState("");
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Block

--- a/front/components/app/blocks/LLM.tsx
+++ b/front/components/app/blocks/LLM.tsx
@@ -152,7 +152,9 @@ export default function LLM({
 
   const [newStop, setNewStop] = useState("");
 
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
 
   return (
     <Block
@@ -438,7 +440,7 @@ export default function LLM({
           <div className="flex w-full font-normal">
             <div className="w-full leading-5">
               <CodeEditor
-                data-color-mode={theme === "dark" ? "dark" : "light"}
+                data-color-mode={isDark ? "dark" : "light"}
                 readOnly={readOnly}
                 value={block.spec.prompt}
                 language="jinja2"

--- a/front/components/app/blocks/WhileEnd.tsx
+++ b/front/components/app/blocks/WhileEnd.tsx
@@ -59,7 +59,9 @@ export function While({
     onBlockUpdate(b);
   };
 
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const theme = localStorage.getItem("theme");
+  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
 
   return (
     <Block
@@ -111,7 +113,7 @@ export function While({
                 )}
               >
                 <CodeEditor
-                  data-color-mode={theme === "dark" ? "dark" : "light"}
+                  data-color-mode={isDark ? "dark" : "light"}
                   readOnly={readOnly}
                   value={block.spec.condition_code}
                   language="js"

--- a/front/components/app/blocks/WhileEnd.tsx
+++ b/front/components/app/blocks/WhileEnd.tsx
@@ -2,6 +2,7 @@ import "@uiw/react-textarea-code-editor/dist.css";
 
 import dynamic from "next/dynamic";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { classNames, shallowBlockClone } from "@app/lib/utils";
 import type { WorkspaceType } from "@app/types";
 import type { SpecificationBlockType, SpecificationType } from "@app/types";
@@ -59,9 +60,7 @@ export function While({
     onBlockUpdate(b);
   };
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const theme = localStorage.getItem("theme");
-  const isDark = theme === "dark" || (theme === "system" && mediaQuery.matches);
+  const { isDark } = useTheme();
 
   return (
     <Block


### PR DESCRIPTION
## Description

When a user sets its theme to "system" and yet the system theme is dark, the applied css classes were different from the ones applied when the theme is simply set to "dark".

This happens in the /app/blocks components only, because the theme value is pulled from the localstorage there instead of the useTheme hook.

Theme = System
<img width="840" alt="image" src="https://github.com/user-attachments/assets/444946c7-0270-462b-bf36-8c135374c6c6" />




Theme=Dark
<img width="832" alt="image" src="https://github.com/user-attachments/assets/08f0f918-021f-45aa-89b9-bd79a0c101d5" />



