### PR TITLE
[MCP Extract] Refactor: extract JsonSchemaConfigurationSection component

### DIFF
--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -11,6 +11,7 @@ import React, { useEffect, useState } from "react";
 
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/actions/configuration/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/actions/configuration/DataSourceSelectionSection";
+import { JsonSchemaConfigurationSection } from "@app/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection";
 import { TimeUnitDropdown } from "@app/components/assistant_builder/actions/TimeDropdown";
 import type {
   AssistantBuilderActionConfiguration,
@@ -18,14 +19,9 @@ import type {
   AssistantBuilderTimeFrame,
 } from "@app/components/assistant_builder/types";
 import { isValidJsonSchema } from "@app/lib/utils/json_schemas";
-import {
-  Err,
-  Ok,
-  Result,
-  type SpaceType,
-  type WorkspaceType,
-} from "@app/types";
-import { JsonSchemaConfigurationSection } from "@app/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection";
+import type { Result } from "@app/types";
+import type { SpaceType, WorkspaceType } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 export function hasErrorActionProcess(
   action: AssistantBuilderActionConfiguration

--- a/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
@@ -1,6 +1,3 @@
-import { AssistantBuilderProcessConfiguration } from "@app/components/assistant_builder/types";
-import { isValidJsonSchema } from "@app/lib/utils/json_schemas";
-import { Result } from "@app/types";
 import {
   Button,
   SparklesIcon,
@@ -8,6 +5,10 @@ import {
   useSendNotification,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
+
+import type { AssistantBuilderProcessConfiguration } from "@app/components/assistant_builder/types";
+import { isValidJsonSchema } from "@app/lib/utils/json_schemas";
+import type { Result } from "@app/types";
 
 interface JsonSchemaConfigurationSectionProps {
   instructions: string;

--- a/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
@@ -1,0 +1,141 @@
+import { AssistantBuilderProcessConfiguration } from "@app/components/assistant_builder/types";
+import { isValidJsonSchema } from "@app/lib/utils/json_schemas";
+import { Result } from "@app/types";
+import {
+  Button,
+  SparklesIcon,
+  TextArea,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface JsonSchemaConfigurationSectionProps {
+  instructions: string;
+  description: string;
+  schemaConfigurationDescription: string;
+  schemaEdit: string | null;
+  setSchemaEdit: (schemaEdit: string | null) => void;
+  setEdited: (edited: boolean) => void;
+  updateAction: (
+    setNewActionConfig: (
+      previousAction: AssistantBuilderProcessConfiguration
+    ) => AssistantBuilderProcessConfiguration
+  ) => void;
+  generateSchema: (
+    instructions: string
+  ) => Promise<Result<Record<string, unknown>, Error>>;
+}
+
+export function JsonSchemaConfigurationSection({
+  instructions,
+  description,
+  schemaConfigurationDescription,
+  schemaEdit,
+  setSchemaEdit,
+  setEdited,
+  updateAction,
+  generateSchema,
+}: JsonSchemaConfigurationSectionProps) {
+  const [isGeneratingSchema, setIsGeneratingSchema] = useState(false);
+  const sendNotification = useSendNotification();
+
+  const generateSchemaFromInstructions = async () => {
+    setEdited(true);
+    let fullInstructions = `${instructions}`;
+    if (description) {
+      fullInstructions += `\n\nTool description:\n${description}`;
+    }
+    if (instructions !== null) {
+      setIsGeneratingSchema(true);
+      try {
+        const res = await generateSchema(fullInstructions);
+
+        if (res.isOk()) {
+          const schemaObject = res.value;
+          const schemaString = schemaObject
+            ? JSON.stringify(schemaObject, null, 2)
+            : null;
+
+          setSchemaEdit(schemaString);
+          setEdited(true);
+          updateAction((previousAction) => ({
+            ...previousAction,
+            jsonSchema: schemaObject,
+            _jsonSchemaString: schemaString,
+          }));
+        } else {
+          sendNotification({
+            title: "Failed to generate schema.",
+            type: "error",
+            description: `An error occurred while generating the schema: ${res.error.message}`,
+          });
+        }
+      } catch (e) {
+        sendNotification({
+          title: "Failed to generate schema.",
+          type: "error",
+          description: `An error occurred while generating the schema. Please contact us if the error persists.`,
+        });
+      } finally {
+        setIsGeneratingSchema(false);
+      }
+    } else {
+      setSchemaEdit(null);
+      setEdited(true);
+      updateAction((previousAction) => ({
+        ...previousAction,
+        jsonSchema: null,
+        _jsonSchemaString: null,
+      }));
+    }
+  };
+
+  return (
+    <>
+      <div className="font-semibold text-muted-foreground dark:text-muted-foreground-night">
+        Schema
+      </div>
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {schemaConfigurationDescription}
+      </div>
+      <Button
+        tooltip="Automatically re-generate the extraction schema based on Instructions"
+        label="Re-generate from Instructions"
+        variant="primary"
+        icon={SparklesIcon}
+        size="sm"
+        disabled={isGeneratingSchema || !instructions}
+        onClick={generateSchemaFromInstructions}
+      />
+      <TextArea
+        error={schemaEdit ? isValidJsonSchema(schemaEdit).error : undefined}
+        showErrorLabel={true}
+        placeholder={
+          '{\n  "type": "object",\n  "properties": {\n    "name": { "type": "string" },\n    ...\n  }\n}'
+        }
+        value={schemaEdit ?? ""}
+        disabled={isGeneratingSchema}
+        onChange={(e) => {
+          const newSchemaString = e.target.value;
+          setSchemaEdit(newSchemaString);
+          setEdited(true);
+
+          const parsedSchema = isValidJsonSchema(newSchemaString);
+          if (parsedSchema.isValid) {
+            updateAction((previousAction) => ({
+              ...previousAction,
+              jsonSchema: newSchemaString ? JSON.parse(newSchemaString) : null,
+              _jsonSchemaString: newSchemaString,
+            }));
+          } else {
+            // If parsing fails, still update the string version but don't update the schema
+            updateAction((previousAction) => ({
+              ...previousAction,
+              _jsonSchemaString: newSchemaString,
+            }));
+          }
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Preparatory for https://github.com/dust-tt/tasks/issues/2640

Description
---
Extract the JSON schema configuration part of 'Extract' action configuration in builder as a single component, to be reused by Extract MCP action and any future internal action requiring a JSON schema configuration.
FTR, this concerns the "Schema" section below
![image](https://github.com/user-attachments/assets/174f9f24-c32d-404c-961b-38d427291a19)

Risk
---
standard

Deploy
---
front
