### PR TITLE
Migrate existing reasoning actions to the MCP version

### DIFF
--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -35,14 +35,14 @@ async function migrateWorkspaceReasoningActions({
     order: [["id", "ASC"]],
   });
 
-  logger.info(
-    `Found ${reasoningConfigs.length} reasoning configurations to migrate`
-  );
-
   if (reasoningConfigs.length === 0) {
     logger.info("No reasoning configurations to migrate");
     return;
   }
+
+  logger.info(
+    `Found ${reasoningConfigs.length} reasoning configurations to migrate`
+  );
 
   // Create the MCP server views in system and global spaces.
   await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -1,0 +1,148 @@
+import { Op } from "sequelize";
+
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { Authenticator } from "@app/lib/auth";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
+import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+/**
+ * Migrates reasoning actions from non-MCP to MCP version for a specific workspace
+ */
+async function migrateWorkspaceReasoningActions({
+  wId,
+  execute,
+  logger,
+}: {
+  wId: string;
+  execute: boolean;
+  logger: typeof Logger;
+}): Promise<void> {
+  // Get admin auth for the workspace
+  const auth = await Authenticator.internalAdminForWorkspace(wId);
+
+  // Find all existing reasoning configurations that are linked to an agent configuration
+  // (non-MCP version) and not yet linked to an MCP server configuration
+  const reasoningConfigs = await AgentReasoningConfiguration.findAll({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      agentConfigurationId: { [Op.not]: null },
+      mcpServerConfigurationId: null,
+    },
+  });
+
+  logger.info(
+    `Found ${reasoningConfigs.length} reasoning configurations to migrate`
+  );
+
+  if (reasoningConfigs.length === 0) {
+    logger.info("No reasoning configurations to migrate");
+    return;
+  }
+
+  // Get the system space to create the MCP server view
+  const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+
+  // Get the reasoning_v2 MCP server ID
+  const reasoningMcpServerId = internalMCPServerNameToSId({
+    name: "reasoning_v2",
+    workspaceId: auth.getNonNullableWorkspace().id,
+  });
+
+  // Check if the reasoning_v2 MCP server view already exists in the system space
+  const mcpServerViews = await MCPServerViewResource.listByMCPServer(
+    auth,
+    reasoningMcpServerId
+  );
+
+  if (!execute) {
+    logger.info("Dry run - would create the following MCP configurations:");
+    for (const config of reasoningConfigs) {
+      logger.info(
+        `  - Reasoning config ${config.sId} for agent ${config.agentConfigurationId}`
+      );
+    }
+    return;
+  }
+
+  // Create the MCP server view if it doesn't exist
+  let mcpServerViewResource: MCPServerViewResource;
+  if (mcpServerViews.length === 0) {
+    logger.info("Creating reasoning MCP server view");
+    mcpServerViewResource = await MCPServerViewResource.create(auth, {
+      mcpServerId: reasoningMcpServerId,
+      space: systemSpace,
+    });
+  } else {
+    mcpServerViewResource = await MCPServerViewResource.fetchByModelPk(
+      auth,
+      mcpServerViews[0].id
+    );
+    if (!mcpServerViewResource) {
+      throw new Error("Failed to fetch MCP server view");
+    }
+  }
+
+  // For each reasoning configuration, create an MCP server configuration and link it
+  await concurrentExecutor(
+    reasoningConfigs,
+    async (reasoningConfig) => {
+      // Create a new AgentMCPServerConfiguration
+      const mcpConfig = await AgentMCPServerConfiguration.create({
+        sId: generateRandomModelSId(),
+        agentConfigurationId: reasoningConfig.agentConfigurationId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        mcpServerViewId: mcpServerViewResource.id,
+        internalMCPServerId: reasoningMcpServerId,
+        additionalConfiguration: {},
+        timeFrame: null,
+        name: reasoningConfig.name,
+        singleToolDescriptionOverride: reasoningConfig.description,
+        appId: null,
+      });
+
+      // Update the reasoning configuration to link it to the MCP server configuration
+      await reasoningConfig.update({
+        mcpServerConfigurationId: mcpConfig.id,
+        agentConfigurationId: null,
+      });
+
+      logger.info(
+        `Migrated reasoning config ${reasoningConfig.sId} to MCP server config ${mcpConfig.sId}`
+      );
+    },
+    { concurrency: 5 }
+  );
+
+  logger.info(
+    `Successfully migrated ${reasoningConfigs.length} reasoning configurations to MCP`
+  );
+}
+
+makeScript(
+  {
+    wId: {
+      type: "string",
+      description: "Workspace ID to migrate",
+      demandOption: true,
+    },
+  },
+  async ({ execute, wId }, logger) => {
+    const workspaceLogger = logger.child({ workspaceId: wId });
+    workspaceLogger.info("Starting migration of reasoning actions to MCP");
+
+    await migrateWorkspaceReasoningActions({
+      wId,
+      execute,
+      logger: workspaceLogger,
+    });
+
+    workspaceLogger.info("Migration completed");
+  }
+);

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -108,6 +108,8 @@ async function migrateWorkspaceReasoningActions({
         });
 
         revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
+        revertSql += `UPDATE "agent_reasoning_configurations" SET "agentConfigurationId" = '${reasoningConfig.agentConfigurationId}' WHERE "id" = '${reasoningConfig.id}';\n`;
+        revertSql += `UPDATE "agent_reasoning_configurations" SET "mcpServerConfigurationId" = NULL WHERE "id" = '${reasoningConfig.id}';\n`;
 
         // Untie the reasoning config from the agent configuration and move it to the MCP server configuration.
         await reasoningConfig.update({
@@ -115,8 +117,6 @@ async function migrateWorkspaceReasoningActions({
           agentConfigurationId: null,
         });
 
-        revertSql += `UPDATE "agent_reasoning_configurations" SET "agentConfigurationId" = '${reasoningConfig.agentConfigurationId}' WHERE "id" = '${reasoningConfig.id}';\n`;
-        revertSql += `UPDATE "agent_reasoning_configurations" SET "mcpServerConfigurationId" = NULL WHERE "id" = '${reasoningConfig.id}';\n`;
 
         // Log the model IDs for an easier rollback.
         logger.info(

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -3,6 +3,7 @@ import { Op } from "sequelize";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -38,6 +39,17 @@ async function migrateWorkspaceReasoningActions({
       agentConfigurationId: { [Op.not]: null },
       mcpServerConfigurationId: null,
     },
+    // Filter on active agents.
+    include: [
+      {
+        attributes: [],
+        model: AgentConfiguration,
+        required: true,
+        where: {
+          status: "active",
+        },
+      },
+    ],
     order: [["id", "ASC"]],
   });
 

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -138,9 +138,15 @@ async function migrateWorkspaceReasoningActions({
     { concurrency: 10 }
   );
 
-  logger.info(
-    `Successfully migrated ${reasoningConfigs.length} reasoning configurations to MCP.`
-  );
+  if (execute) {
+    logger.info(
+      `Successfully migrated ${reasoningConfigs.length} reasoning configurations to MCP.`
+    );
+  } else {
+    logger.info(
+      `Would have migrated ${reasoningConfigs.length} reasoning configurations to MCP.`
+    );
+  }
 
   return revertSql;
 }

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -117,7 +117,6 @@ async function migrateWorkspaceReasoningActions({
           agentConfigurationId: null,
         });
 
-
         // Log the model IDs for an easier rollback.
         logger.info(
           {

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -35,6 +35,7 @@ async function migrateWorkspaceReasoningActions({
   // (non-MCP version) and not yet linked to an MCP server configuration
   const reasoningConfigs = await AgentReasoningConfiguration.findAll({
     where: {
+      // No index here so that might be slow.
       workspaceId: auth.getNonNullableWorkspace().id,
       agentConfigurationId: { [Op.not]: null },
       mcpServerConfigurationId: null,

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -115,8 +115,8 @@ async function migrateWorkspaceReasoningActions({
           agentConfigurationId: null,
         });
 
-        revertSql += `UPDATE "agent_reasoning_configurations" SET "agent_configuration_id" = '${reasoningConfig.agentConfigurationId}' WHERE "id" = '${reasoningConfig.id}';\n`;
-        revertSql += `UPDATE "agent_reasoning_configurations" SET "mcp_server_configuration_id" = NULL WHERE "id" = '${reasoningConfig.id}';\n`;
+        revertSql += `UPDATE "agent_reasoning_configurations" SET "agentConfigurationId" = '${reasoningConfig.agentConfigurationId}' WHERE "id" = '${reasoningConfig.id}';\n`;
+        revertSql += `UPDATE "agent_reasoning_configurations" SET "mcpServerConfigurationId" = NULL WHERE "id" = '${reasoningConfig.id}';\n`;
 
         // Log the model IDs for an easier rollback.
         logger.info(

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -32,6 +32,7 @@ async function migrateWorkspaceReasoningActions({
       agentConfigurationId: { [Op.not]: null },
       mcpServerConfigurationId: null,
     },
+    order: [["id", "ASC"]],
   });
 
   logger.info(

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -107,9 +107,9 @@ async function migrateWorkspaceReasoningActions({
           appId: null,
         });
 
-        revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
         revertSql += `UPDATE "agent_reasoning_configurations" SET "agentConfigurationId" = '${reasoningConfig.agentConfigurationId}' WHERE "id" = '${reasoningConfig.id}';\n`;
         revertSql += `UPDATE "agent_reasoning_configurations" SET "mcpServerConfigurationId" = NULL WHERE "id" = '${reasoningConfig.id}';\n`;
+        revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
 
         // Untie the reasoning config from the agent configuration and move it to the MCP server configuration.
         await reasoningConfig.update({

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -42,7 +42,6 @@ async function migrateWorkspaceReasoningActions({
   });
 
   if (reasoningConfigs.length === 0) {
-    logger.info("No reasoning configurations to migrate.");
     return;
   }
 
@@ -53,7 +52,6 @@ async function migrateWorkspaceReasoningActions({
   if (execute) {
     // Create the MCP server views in system and global spaces.
     await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-    logger.info("Created MCP server views in system and global spaces.");
   }
 
   const mcpServerView =

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -74,7 +74,7 @@ async function migrateWorkspaceReasoningActions({
         // The data model is a bit ugly, this was a bit temporary.
         logger.info(
           { configModelId: reasoningConfig.id },
-          `Already an MCP reasoning config, skipping`
+          `Already an MCP reasoning config, skipping.`
         );
         return;
       }
@@ -105,11 +105,18 @@ async function migrateWorkspaceReasoningActions({
             configModelId: reasoningConfig.id,
             mcpConfigModelId: mcpConfig.id,
           },
-          `Migrated reasoning config to MCP server config`
+          `Migrated reasoning config to MCP server config.`
+        );
+      } else {
+        logger.info(
+          {
+            configModelId: reasoningConfig.id,
+          },
+          `Would create MCP server config and migrate reasoning config to it.`
         );
       }
     },
-    { concurrency: 5 }
+    { concurrency: 10 }
   );
 
   logger.info(

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -87,7 +87,7 @@ async function migrateWorkspaceReasoningActions({
         // This should never happen since we fetch where agentConfigurationId is not null.
         // The data model is a bit ugly, this was a bit temporary.
         logger.info(
-          { configModelId: reasoningConfig.id },
+          { reasoningConfigurationId: reasoningConfig.id },
           `Already an MCP reasoning config, skipping.`
         );
         return;
@@ -121,15 +121,15 @@ async function migrateWorkspaceReasoningActions({
         // Log the model IDs for an easier rollback.
         logger.info(
           {
-            configModelId: reasoningConfig.id,
-            mcpConfigModelId: mcpConfig.id,
+            reasoningConfigurationId: reasoningConfig.id,
+            mcpServerConfigurationId: mcpConfig.id,
           },
           `Migrated reasoning config to MCP server config.`
         );
       } else {
         logger.info(
           {
-            configModelId: reasoningConfig.id,
+            reasoningConfigurationId: reasoningConfig.id,
           },
           `Would create MCP server config and migrate reasoning config to it.`
         );

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -150,6 +150,7 @@ makeScript(
     wId: {
       type: "string",
       description: "Workspace ID to migrate",
+      required: true,
     },
   },
   async ({ execute, wId }, parentLogger) => {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/2820.
This PR adds a script that migrates the reasoning actions for a workspace from the non-MCP version to the MCP version.
Will do a separate PR that won't be merged right away to remove the feature flag on this action and clean up code that is superseded by it.

## Tests

- Tested locally (create agent, run migration, check, run reverse SQL), dry run to be examined closely.

## Risk

- Rollback not built in the script but doable.

## Deploy Plan

- Run the script for our workspace.
