### PR TITLE
chore: create empty migration to avoid overlap during remediations

### DIFF
--- a/front/migrations/db/migration_261.sql
+++ b/front/migrations/db/migration_261.sql
@@ -1,0 +1,2 @@
+-- Empty migration to avoid overload during remediations
+-- see https://github.com/dust-tt/tasks/issues/2842 for details


### PR DESCRIPTION
## Description
- Create an empty migration to avoid overlap of migrations during remediations, see https://github.com/dust-tt/tasks/issues/2842 or this [sheet](https://docs.google.com/spreadsheets/d/1MJJ7vxLaBptxr__LF4obbinQFYZt61WjLrBNBjJI7oI/edit?gid=605115531#gid=605115531) for detail

## Tests

## Risk

## Deploy Plan

