### PR TITLE
[sparkle]: fix height for dropdown with header 

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.494",
+  "version": "0.2.495",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.494",
+      "version": "0.2.495",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.494",
+  "version": "0.2.495",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -250,6 +250,7 @@ const DropdownMenuContent = React.forwardRef<
         className={cn(
           menuStyleClasses.container,
           "s-flex s-flex-col s-p-0 s-shadow-md",
+          dropdownHeaders && "s-h-80 xs:s-h-96", // We use dropdownHeaders for putting search bar, so we can set the height for the container
           className
         )}
         {...props}


### PR DESCRIPTION
## Description
This PR is to set the max height when there is searchHeaders in dropdown

before:
<img width="472" alt="Screenshot 2025-05-13 at 12 11 07" src="https://github.com/user-attachments/assets/5615c718-55f5-4e02-adf9-15069b802e40" />


after:
<img width="420" alt="Screenshot 2025-05-13 at 12 10 53" src="https://github.com/user-attachments/assets/e8fff178-d4f8-410e-a8b6-0bd42ab3269d" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
