### PR TITLE
Sparkle TourGuide disable autofocus on cards

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.496",
+  "version": "0.2.497",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.496",
+      "version": "0.2.497",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.496",
+  "version": "0.2.497",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/TourGuide.tsx
+++ b/sparkle/src/components/TourGuide.tsx
@@ -164,6 +164,7 @@ export const TourGuideCard = React.forwardRef<
           "dark:s-border-border-night dark:s-bg-background-night dark:s-text-foreground-night",
           className
         )}
+        onOpenAutoFocus={(e) => e.preventDefault()}
       >
         {children}
         <TourGuideCardActions


### PR DESCRIPTION
## Description

The default autofocus was displaying by default the first tooltip on the Card component. 
This prop disable the autoFocus on open. 

## Tests

Locally on Storybook. 

## Risk

None, this component is not used yet. 

## Deploy Plan

Publish Sparkle. 
