### PR TITLE
Add onEnd and onDismiss properties to Sparkle TourGuide component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.497",
+  "version": "0.2.498",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.497",
+      "version": "0.2.498",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.497",
+  "version": "0.2.498",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/TourGuide.tsx
+++ b/sparkle/src/components/TourGuide.tsx
@@ -183,12 +183,16 @@ export interface TourGuideProps {
   children: React.ReactNode;
   autoStart?: boolean;
   onStart?: () => void;
+  onEnd?: () => void;
+  onDismiss?: () => void;
 }
 
 export function TourGuide({
   children,
   autoStart = true,
   onStart,
+  onEnd,
+  onDismiss,
 }: TourGuideProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isActive, setIsActive] = useState(autoStart);
@@ -274,11 +278,13 @@ export function TourGuide({
       setCurrentIndex(currentIndex + 1);
     } else {
       setIsActive(false);
+      onEnd?.();
     }
   };
 
   const handleDismiss = () => {
     setIsActive(false);
+    onDismiss?.();
   };
 
   if (!isActive || cards.length === 0) {


### PR DESCRIPTION
## Description

I'm adding `onEnd` and `onDismiss` properties to Sparkle TourGuide component to be able to control what needs to be done when the tour is done from front. 

## Tests

Locally on storybook. 

## Risk

Component not used yet; 

## Deploy Plan

Publish Sparkle. 