### PR TITLE
Workspace isolation: agent configuration (author redis cache)

### DIFF
--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -165,7 +165,6 @@ AgentConfiguration.init(
       },
       { fields: ["sId"] },
       { fields: ["sId", "version"], unique: true },
-      { fields: ["authorId"] },
       { fields: ["workspaceId", "authorId", "sId"] },
       {
         name: "agent_configuration_unique_active_name",

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -166,6 +166,7 @@ AgentConfiguration.init(
       { fields: ["sId"] },
       { fields: ["sId", "version"], unique: true },
       { fields: ["authorId"] },
+      { fields: ["workspaceId", "authorId", "sId"] },
       {
         name: "agent_configuration_unique_active_name",
         fields: ["workspaceId", "name"],

--- a/front/migrations/db/migration_253.sql
+++ b/front/migrations/db/migration_253.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 13, 2025
+CREATE INDEX CONCURRENTLY "agent_configurations_workspace_id_author_id_s_id" ON "agent_configurations" ("workspaceId", "authorId", "sId");
+


### PR DESCRIPTION
## Description

As part of adding clause on `workspaceId` to all model SQL queries ([sheet](https://docs.google.com/spreadsheets/d/1MJJ7vxLaBptxr__LF4obbinQFYZt61WjLrBNBjJI7oI/edit?gid=605115531#gid=605115531)).

This PR focuses around `AgentConfiguration`, it ensures we always query this model with proper `workspaceId` clause. The only occurence visible in logs relates to the recent_author.ts file.

An introspection of all the `AgentConfiguration.findAll` queries show that the old index on authorId should be good to drop.

## Tests

- [x] Test in dev

## Risk

Touches the data model, safe to rollback.

## Deploy Plan

- [ ] Apply SQL migration 
- [ ] deploy `front`
- [ ] Drop previous index, once new index is live: `DROP INDEX agent_configurations_author_id;`