### PR TITLE
feat: add query execution to exploded TQ server

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3695,7 +3695,6 @@ async fn databases_schema_retrieve(
 struct DatabaseQueryRunPayload {
     query: String,
     tables: Vec<(i64, String, String)>,
-    view_filter: Option<SearchFilter>,
 }
 
 async fn databases_query_run(
@@ -3726,15 +3725,7 @@ async fn databases_query_run(
         ),
         Ok(tables) => {
             // Check that all tables exist.
-            match tables
-                .into_iter()
-                .filter(|table| {
-                    table
-                        .as_ref()
-                        .map_or(true, |t| t.match_filter(&payload.view_filter))
-                })
-                .collect::<Option<Vec<Table>>>()
-            {
+            match tables.into_iter().collect::<Option<Vec<Table>>>() {
                 None => error_response(
                     StatusCode::NOT_FOUND,
                     "table_not_found",

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -48,7 +48,7 @@ export async function getInternalMCPServer(
     case "query_tables":
       return tablesQueryServer(auth, agentLoopRunContext);
     case "query_tables_v2":
-      return tablesQueryServerV2(auth);
+      return tablesQueryServerV2(auth, agentLoopRunContext);
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer();
     case "think":

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -29,7 +29,7 @@ import { assertNever } from "@app/types";
 // We need a model with at least 54k tokens to run tables_query.
 const TABLES_QUERY_MIN_TOKEN = 50_000;
 const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
-const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
+export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "query_tables",
@@ -402,7 +402,7 @@ function getTablesQueryError(error: string) {
  * This prefix is used to identify the row in the section file.
  * We currently only support Salesforce since it's the only connector for which we can generate a prefix.
  */
-function getSectionColumnsPrefix(
+export function getSectionColumnsPrefix(
   provider: ConnectorProvider | null
 ): string[] | null {
   switch (provider) {

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -1,15 +1,28 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
+import {
+  generateCSVFileAndSnippet,
+  generateSectionFile,
+  uploadFileToConversationDataSource,
+} from "@app/lib/actions/action_file_helpers";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { MCPToolResultContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   getDatabaseExampleRowsContent,
   getQueryWritingInstructionsContent,
   getSchemaContent,
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/schema";
+import {
+  getSectionColumnsPrefix,
+  TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH,
+} from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { fetchAgentTableConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
+import type { CSVRecord } from "@app/lib/api/csv";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -25,12 +38,15 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: null,
 };
 
-function createServer(auth: Authenticator): McpServer {
+function createServer(
+  auth: Authenticator,
+  agentLoopRunContext?: AgentLoopRunContextType
+): McpServer {
   const server = new McpServer(serverInfo);
 
   server.tool(
     "get_database_schema",
-    "Retrieves the database schema for the specified tables. You MUST call this tool at least once before attempting to query tables to understand their structure. This tool provides essential information about table columns, types, and relationships needed to write accurate SQL queries.",
+    "Retrieves the database schema. You MUST call this tool at least once before attempting to query tables to understand their structure. This tool provides essential information about table columns, types, and relationships needed to write accurate SQL queries.",
     {
       tables:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
@@ -80,7 +96,11 @@ function createServer(auth: Authenticator): McpServer {
       // Call Core API's /database_schema endpoint
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const schemaResult = await coreAPI.getDatabaseSchema({
-        tables: configuredTables,
+        tables: configuredTables.map(([projectId, dataSourceId, tableId]) => ({
+          project_id: projectId.toString(),
+          data_source_id: dataSourceId,
+          table_id: tableId,
+        })),
       });
       if (schemaResult.isErr()) {
         return makeMCPToolTextError(
@@ -95,6 +115,186 @@ function createServer(auth: Authenticator): McpServer {
           ...getQueryWritingInstructionsContent(schemaResult.value.dialect),
           ...getDatabaseExampleRowsContent(schemaResult.value.schemas),
         ],
+      };
+    }
+  );
+
+  server.tool(
+    "execute_database_query",
+    "Executes a query on the database. You MUST call the get_database_schema tool for that database at least once before attempting to execute a query. The query must respect the guidelines and schema provided by the get_database_schema tool.",
+    {
+      tables:
+        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
+      query: z
+        .string()
+        .describe(
+          "The query to execute. Must respect the guidelines provided by the `get_database_schema` tool."
+        ),
+      fileName: z
+        .string()
+        .describe("The name of the file to save the results to."),
+    },
+    async ({ tables, query, fileName }) => {
+      // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
+      if (!agentLoopRunContext) {
+        throw new Error("Unreachable: missing agentLoopRunContext.");
+      }
+
+      // Fetch table configurations
+      const agentTableConfigurationsRes = await fetchAgentTableConfigurations(
+        auth,
+        tables
+      );
+      if (agentTableConfigurationsRes.isErr()) {
+        return makeMCPToolTextError(
+          `Error fetching table configurations: ${agentTableConfigurationsRes.error.message}`
+        );
+      }
+      const agentTableConfigurations = agentTableConfigurationsRes.value;
+      if (agentTableConfigurations.length === 0) {
+        return makeMCPToolTextError(
+          "The agent does not have access to any tables. Please edit the agent's Query Tables tool to add tables, or remove the tool."
+        );
+      }
+      const dataSourceViews = await DataSourceViewResource.fetchByModelIds(
+        auth,
+        [...new Set(agentTableConfigurations.map((t) => t.dataSourceViewId))]
+      );
+      const dataSourceViewsMap = new Map(
+        dataSourceViews.map((dsv) => [dsv.id, dsv])
+      );
+
+      // Format table identifiers for Core API call
+      const configuredTables: Array<[number, string, string]> = [];
+      for (const t of agentTableConfigurations) {
+        const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
+        if (!dataSourceView || !dataSourceView.dataSource.dustAPIDataSourceId) {
+          throw new Error(
+            `Missing data source ID for view ${t.dataSourceViewId}`
+          );
+        }
+
+        configuredTables.push([
+          parseInt(dataSourceView.dataSource.dustAPIProjectId, 10),
+          dataSourceView.dataSource.dustAPIDataSourceId,
+          t.tableId,
+        ]);
+      }
+
+      // Call Core API's /query_database endpoint
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      const queryResult = await coreAPI.queryDatabase({
+        tables: configuredTables.map(([projectId, dataSourceId, tableId]) => ({
+          project_id: projectId.toString(),
+          data_source_id: dataSourceId,
+          table_id: tableId,
+        })),
+        query,
+      });
+      if (queryResult.isErr()) {
+        return makeMCPToolTextError(
+          `Error executing database query: ${queryResult.error.message}`
+        );
+      }
+
+      const content: MCPToolResultContentType[] = [];
+
+      const results: CSVRecord[] = queryResult.value.results
+        .map((r) => r.value)
+        .filter(
+          (record) =>
+            record !== undefined &&
+            record !== null &&
+            typeof record === "object"
+        );
+
+      if (results.length > 0) {
+        const queryTitle = fileName;
+
+        //TODO(mcp): return the CSV file itself as a MCP resource and let the other side handle it
+        // Generate the CSV file.
+        const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {
+          title: queryTitle,
+          conversationId: agentLoopRunContext.conversation.sId,
+          results,
+        });
+
+        // Upload the CSV file to the conversation data source.
+        await uploadFileToConversationDataSource({
+          auth,
+          file: csvFile,
+        });
+
+        // Append the CSV file to the output of the tool as an agent-generated file.
+        content.push({
+          type: "resource",
+          resource: {
+            text: `Your query results were generated successfully.`,
+            uri: csvFile.getPublicUrl(auth),
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+            fileId: csvFile.sId,
+            title: queryTitle,
+            contentType: csvFile.contentType,
+            snippet: csvSnippet,
+          },
+        });
+
+        //TODO(mcp) probably do the same for the section file
+        // Check if we should generate a section JSON file.
+        const shouldGenerateSectionFile = results.some((result) =>
+          Object.values(result).some(
+            (value) =>
+              typeof value === "string" &&
+              value.length > TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH
+          )
+        );
+
+        if (shouldGenerateSectionFile) {
+          // First, we fetch the connector provider for the data source, cause the chunking
+          // strategy of the section file depends on it: Since all tables are from the same
+          // data source, we can just take the first table's data source view id.
+          const [dataSourceView] = await DataSourceViewResource.fetchByModelIds(
+            auth,
+            [agentTableConfigurations[0].dataSourceViewId]
+          );
+          const connectorProvider =
+            dataSourceView?.dataSource?.connectorProvider ?? null;
+          const sectionColumnsPrefix =
+            getSectionColumnsPrefix(connectorProvider);
+
+          // Generate the section file.
+          const sectionFile = await generateSectionFile(auth, {
+            title: queryTitle,
+            conversationId: agentLoopRunContext.conversation.sId,
+            results,
+            sectionColumnsPrefix,
+          });
+
+          // Upload the section file to the conversation data source.
+          await uploadFileToConversationDataSource({
+            auth,
+            file: sectionFile,
+          });
+
+          // Append the section file to the output of the tool as an agent-generated file.
+          content.push({
+            type: "resource",
+            resource: {
+              text: "Your query results were generated successfully.",
+              uri: sectionFile.getPublicUrl(auth),
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+              fileId: sectionFile.sId,
+              title: `${queryTitle} (Rich Text)`,
+              contentType: sectionFile.contentType,
+              snippet: null,
+            },
+          });
+        }
+      }
+
+      return {
+        isError: false,
+        content: [],
       };
     }
   );

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -76,32 +76,27 @@ function createServer(
         dataSourceViews.map((dsv) => [dsv.id, dsv])
       );
 
-      // Format table identifiers for Core API call
-      const configuredTables: Array<[number, string, string]> = [];
-      for (const t of agentTableConfigurations) {
-        const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
-        if (!dataSourceView || !dataSourceView.dataSource.dustAPIDataSourceId) {
-          throw new Error(
-            `Missing data source ID for view ${t.dataSourceViewId}`
-          );
-        }
-
-        configuredTables.push([
-          parseInt(dataSourceView.dataSource.dustAPIProjectId, 10),
-          dataSourceView.dataSource.dustAPIDataSourceId,
-          t.tableId,
-        ]);
-      }
-
       // Call Core API's /database_schema endpoint
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const schemaResult = await coreAPI.getDatabaseSchema({
-        tables: configuredTables.map(([projectId, dataSourceId, tableId]) => ({
-          project_id: projectId.toString(),
-          data_source_id: dataSourceId,
-          table_id: tableId,
-        })),
+        tables: agentTableConfigurations.map((t) => {
+          const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
+          if (
+            !dataSourceView ||
+            !dataSourceView.dataSource.dustAPIDataSourceId
+          ) {
+            throw new Error(
+              `Missing data source ID for view ${t.dataSourceViewId}`
+            );
+          }
+          return {
+            project_id: parseInt(dataSourceView.dataSource.dustAPIProjectId),
+            data_source_id: dataSourceView.dataSource.dustAPIDataSourceId,
+            table_id: t.tableId,
+          };
+        }),
       });
+
       if (schemaResult.isErr()) {
         return makeMCPToolTextError(
           `Error retrieving database schema: ${schemaResult.error.message}`
@@ -164,31 +159,25 @@ function createServer(
         dataSourceViews.map((dsv) => [dsv.id, dsv])
       );
 
-      // Format table identifiers for Core API call
-      const configuredTables: Array<[number, string, string]> = [];
-      for (const t of agentTableConfigurations) {
-        const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
-        if (!dataSourceView || !dataSourceView.dataSource.dustAPIDataSourceId) {
-          throw new Error(
-            `Missing data source ID for view ${t.dataSourceViewId}`
-          );
-        }
-
-        configuredTables.push([
-          parseInt(dataSourceView.dataSource.dustAPIProjectId, 10),
-          dataSourceView.dataSource.dustAPIDataSourceId,
-          t.tableId,
-        ]);
-      }
-
       // Call Core API's /query_database endpoint
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const queryResult = await coreAPI.queryDatabase({
-        tables: configuredTables.map(([projectId, dataSourceId, tableId]) => ({
-          project_id: projectId.toString(),
-          data_source_id: dataSourceId,
-          table_id: tableId,
-        })),
+        tables: agentTableConfigurations.map((t) => {
+          const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
+          if (
+            !dataSourceView ||
+            !dataSourceView.dataSource.dustAPIDataSourceId
+          ) {
+            throw new Error(
+              `Missing data source ID for view ${t.dataSourceViewId}`
+            );
+          }
+          return {
+            project_id: parseInt(dataSourceView.dataSource.dustAPIProjectId),
+            data_source_id: dataSourceView.dataSource.dustAPIDataSourceId,
+            table_id: t.tableId,
+          };
+        }),
         query,
       });
       if (queryResult.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -294,7 +294,7 @@ function createServer(
 
       return {
         isError: false,
-        content: [],
+        content,
       };
     }
   );

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -211,7 +211,6 @@ function createServer(
       if (results.length > 0) {
         const queryTitle = fileName;
 
-        //TODO(mcp): return the CSV file itself as a MCP resource and let the other side handle it
         // Generate the CSV file.
         const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {
           title: queryTitle,
@@ -239,7 +238,6 @@ function createServer(
           },
         });
 
-        //TODO(mcp) probably do the same for the section file
         // Check if we should generate a section JSON file.
         const shouldGenerateSectionFile = results.some((result) =>
           Object.values(result).some(

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -209,7 +209,9 @@ function createServer(
         );
 
       if (results.length > 0) {
-        const queryTitle = fileName;
+        // date in yyyy-mm-dd
+        const humanReadableDate = new Date().toISOString().split("T")[0];
+        const queryTitle = `${fileName} (${humanReadableDate})`;
 
         // Generate the CSV file.
         const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1886,7 +1886,7 @@ export class CoreAPI {
     query,
   }: {
     tables: Array<{
-      project_id: string;
+      project_id: number;
       data_source_id: string;
       table_id: string;
     }>;
@@ -1904,11 +1904,7 @@ export class CoreAPI {
       },
       body: JSON.stringify({
         query,
-        tables: tables.map((t) => [
-          parseInt(t.project_id),
-          t.data_source_id,
-          t.table_id,
-        ]),
+        tables: tables.map((t) => [t.project_id, t.data_source_id, t.table_id]),
       }),
     });
 
@@ -1919,7 +1915,7 @@ export class CoreAPI {
     tables,
   }: {
     tables: Array<{
-      project_id: string;
+      project_id: number;
       data_source_id: string;
       table_id: string;
     }>;
@@ -1941,7 +1937,7 @@ export class CoreAPI {
         },
         body: JSON.stringify({
           tables: tables.map((t) => [
-            parseInt(t.project_id),
+            t.project_id,
             t.data_source_id,
             t.table_id,
           ]),

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1904,7 +1904,11 @@ export class CoreAPI {
       },
       body: JSON.stringify({
         query,
-        tables,
+        tables: tables.map((t) => [
+          parseInt(t.project_id),
+          t.data_source_id,
+          t.table_id,
+        ]),
       }),
     });
 
@@ -1936,7 +1940,11 @@ export class CoreAPI {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          tables,
+          tables: tables.map((t) => [
+            parseInt(t.project_id),
+            t.data_source_id,
+            t.table_id,
+          ]),
         }),
       }
     );

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -197,7 +197,7 @@ export function isRowMatchingSchema(
 }
 
 export type CoreAPIQueryResult = {
-  value: Record<string, unknown>;
+  value: Record<string, string | number | boolean | null | undefined>;
 };
 
 export type CoreAPISearchFilter = {
@@ -1884,7 +1884,6 @@ export class CoreAPI {
   async queryDatabase({
     tables,
     query,
-    filter,
   }: {
     tables: Array<{
       project_id: string;
@@ -1892,7 +1891,6 @@ export class CoreAPI {
       table_id: string;
     }>;
     query: string;
-    filter?: CoreAPISearchFilter | null;
   }): Promise<
     CoreAPIResponse<{
       schema: CoreAPITableSchema;
@@ -1907,7 +1905,6 @@ export class CoreAPI {
       body: JSON.stringify({
         query,
         tables,
-        filter,
       }),
     });
 
@@ -1917,7 +1914,11 @@ export class CoreAPI {
   async getDatabaseSchema({
     tables,
   }: {
-    tables: Array<[number, string, string]>; // project_id, data_source_id, table_id
+    tables: Array<{
+      project_id: string;
+      data_source_id: string;
+      table_id: string;
+    }>;
   }): Promise<
     CoreAPIResponse<{
       dialect: string;


### PR DESCRIPTION
## Description

Adds support for executing queries on dust tables via the exploded tables query server.

- Endpoint was pre-existing, but tweaked the params to remove the view filter (should not have been there)
- added a tool to call that endpoint

## Tests

Manual

## Risk

N/A (unused for now + gated)

## Deploy Plan

Deploy `core` and `front`