### PR TITLE
[front chore: Add workspace id filter to 

### DIFF
--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -185,8 +185,13 @@ TrackerDataSourceConfigurationModel.init(
         using: "gin",
         name: "tracker_data_source_configuration_parent_ids_gin_idx",
       },
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-13): Remove index
       { fields: ["dataSourceId"] },
       { fields: ["dataSourceViewId"] },
+      {
+        fields: ["workspaceId", "dataSourceId"],
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -564,6 +564,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
 
     let dsConfigs = await TrackerDataSourceConfigurationModel.findAll({
       where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
         dataSourceId: dataSourceModelId,
         scope: "watched",
         // TODO(DOC_TRACKER): GIN index.

--- a/front/migrations/db/migration_254.sql
+++ b/front/migrations/db/migration_254.sql
@@ -1,0 +1,2 @@
+-- Migration created May 13, 2025
+CREATE INDEX CONCURRENTLY "tracker_data_source_configurations_workspace_id_data_source_id" ON "tracker_data_source_configurations" ("workspaceId", "dataSourceId");


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add `workspaceId` filter to `TrackerDataSourceConfigurationModel`
- Add migration for composite index

## Tests

## Risk
- There is `//TODO` left saying to add `workspaceId` column and backfill, but I haven't found the backfill. But the column seems to be filled according to metabase. Would love some details on that.

## Deploy Plan
- [ ] Run migration
- [ ] Deploy front
