### PR TITLE
Improve application/octet-stream file upload

### DIFF
--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -13,6 +13,7 @@ import type {
   SupportedFileContentType,
 } from "@app/types";
 import {
+  DEFAULT_FILE_CONTENT_TYPE,
   Err,
   getFileFormatCategory,
   isAPIErrorResponse,
@@ -130,33 +131,45 @@ export function useFileUploaderService({
   const processSelectedFiles = (
     selectedFiles: File[]
   ): Result<FileBlob, FileBlobUploadError>[] => {
-    return selectedFiles.reduce(
-      (acc, file) => {
-        while (fileBlobs.some((f) => f.id === file.name)) {
-          const [base, ext] = file.name.split(/\.(?=[^.]+$)/);
-          const name = findAvailableTitle(base, ext, [
-            ...fileBlobs.map((f) => f.filename),
-          ]);
-          file = new File([file], name, { type: file.type });
+    const getRenamedFile = (file: File, fileType: string): File => {
+      let currentFile = file;
+      while (fileBlobs.some((f) => f.id === currentFile.name)) {
+        const [base, ext] = currentFile.name.split(/\.(?=[^.]+$)/);
+        const name = findAvailableTitle(base, ext, [
+          ...fileBlobs.map((f) => f.filename),
+        ]);
+        if (name !== currentFile.name) {
+          currentFile = new File([currentFile], name, { type: fileType });
         }
+      }
+      return currentFile;
+    };
 
-        if (!isSupportedFileContentType(file.type)) {
+    return selectedFiles.reduce<Result<FileBlob, FileBlobUploadError>[]>(
+      (acc, file) => {
+        const fileType = file.type || DEFAULT_FILE_CONTENT_TYPE;
+
+        // File objects are immutable - we can't modify their properties directly.
+        // When we need to change the name or type, we must create a new File object.
+        const renamedFile = getRenamedFile(file, fileType);
+
+        if (!isSupportedFileContentType(fileType)) {
           acc.push(
             new Err(
               new FileBlobUploadError(
                 "file_type_not_supported",
-                file,
-                `File "${file.name}" is not supported (${file.type}).`
+                renamedFile,
+                `File "${renamedFile.name}" is not supported (${fileType}).`
               )
             )
           );
           return acc;
         }
 
-        acc.push(new Ok(createFileBlob(file, file.type)));
+        acc.push(new Ok(createFileBlob(renamedFile, fileType)));
         return acc;
       },
-      [] as (Ok<FileBlob> | Err<FileBlobUploadError>)[]
+      []
     );
   };
 

--- a/front/lib/swr/file.ts
+++ b/front/lib/swr/file.ts
@@ -29,13 +29,20 @@ export function useFileProcessedContent(
     mutate,
   } = useSWRWithDefaults(
     isDisabled ? null : getFileProcessedUrl(owner, fileId),
-    // Stream fetcher -> don't try to parse the stream
-    // Wait for initial response to trigger swr error handling
+    // Stream fetcher -> don't try to parse the stream.
+    // Wait for initial response to trigger swr error handling.
     async (...args) => {
-      const response = await fetch(...args);
+      const response = await fetch(...args, { redirect: "manual" });
+
+      // File is not safe to display -> opaque redirect response. Return null.
+      if (response.type === "opaqueredirect") {
+        return null;
+      }
+
       if (!response.ok) {
         throw new Error(`Error reading the file content: ${response.status}`);
       }
+
       return response;
     },
     config

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -325,6 +325,9 @@ export type SupportedNonImageContentType = {
 // All the ones listed above
 export const supportedUploadableContentType = Object.keys(FILE_FORMATS);
 
+export const DEFAULT_FILE_CONTENT_TYPE: SupportedFileContentType =
+  "application/octet-stream";
+
 export function isSupportedFileContentType(
   contentType: string
 ): contentType is SupportedFileContentType {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/2840.

Since we release https://github.com/dust-tt/dust/pull/12353 to tighten our security posture around file upload it downgraded the experience of file upload in both the chat interface and when uploading content in a folder. This impacts some well know but pretty badly supported mime types (including markdown).

It addresses two things:
1. Default to `application/octet-stream` if type is an empty string (e.g: markdown) or undefined (e.g: unknown file type)
2. Since we don't let you view file's content if the file is not safe, which is the case for `application/octet-stream`, instead we fallback to the local file content. This remains safe as this content is only rendered in a `textarea` component which be default prevents rendering any Javascript.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
