### PR TITLE
fix(front): uniformize handling of IDs in `MCPServerViewType`

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -8,7 +8,7 @@ import {
   PlusIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
@@ -64,11 +64,11 @@ export const AddActionMenu = ({
           </div>
         )}
         {availableMCPServers
-          .filter((mcpServer) => !enabledMCPServers.includes(mcpServer.id))
+          .filter((mcpServer) => !enabledMCPServers.includes(mcpServer.sId))
           .filter((mcpServer) => filterMCPServer(mcpServer, searchText))
           .map((mcpServer) => (
             <DropdownMenuItem
-              key={mcpServer.id}
+              key={mcpServer.sId}
               label={asDisplayName(mcpServer.name)}
               icon={() => getAvatar(mcpServer, "xs")}
               description={mcpServer.description}

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -187,7 +187,9 @@ export const AdminActionsList = ({
   const rows: RowData[] = mcpServers
     .filter((mcpServer) => mcpServer.availability === "manual")
     .map((mcpServer) => {
-      const mcpServerWithViews = mcpServers.find((s) => s.id === mcpServer.id);
+      const mcpServerWithViews = mcpServers.find(
+        (s) => s.sId === mcpServer.sId
+      );
       const mcpServerView = mcpServerWithViews?.views.find(
         (v) => v.spaceId === systemSpace?.sId
       );
@@ -199,7 +201,7 @@ export const AdminActionsList = ({
         mcpServerView,
         spaces: spaces.filter((s) => spaceIds?.includes(s.sId)),
         isConnected: !!connections.find(
-          (c) => c.internalMCPServerId === mcpServer.id
+          (c) => c.internalMCPServerId === mcpServer.sId
         ),
         onClick: () => {
           if (mcpServerView && mcpServer) {
@@ -224,7 +226,7 @@ export const AdminActionsList = ({
       {portalToHeader(
         <AddActionMenu
           owner={owner}
-          enabledMCPServers={mcpServers.map((s) => s.id)}
+          enabledMCPServers={mcpServers.map((s) => s.sId)}
           setIsLoading={setIsLoading}
           createRemoteMCPServer={() => {
             setInternalMCPServerToCreate(undefined);

--- a/front/components/actions/mcp/CreateMCPServerModal.tsx
+++ b/front/components/actions/mcp/CreateMCPServerModal.tsx
@@ -93,7 +93,7 @@ export function CreateMCPServerModal({
         if (createServerRes.success) {
           await createMCPServerConnection({
             connectionId: cRes.value.connection_id,
-            mcpServerId: createServerRes.server.id,
+            mcpServerId: createServerRes.server.sId,
             provider: authorization.provider,
           });
         } else {

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -20,7 +20,7 @@ import {
   TrashIcon,
 } from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { MCPServerDetailsInfo } from "@app/components/actions/mcp/MCPServerDetailsInfo";
 import { MCPServerDetailsSharing } from "@app/components/actions/mcp/MCPServerDetailsSharing";
@@ -52,12 +52,12 @@ export function MCPServerDetails({
   const [selectedTab, setSelectedTab] = useState<string>("info");
 
   const serverType = mcpServer
-    ? getServerTypeAndIdFromSId(mcpServer.id).serverType
+    ? getServerTypeAndIdFromSId(mcpServer.sId).serverType
     : "internal";
 
   const { server: updatedMCPServer } = useMCPServer({
     owner,
-    serverId: mcpServer?.id || "",
+    serverId: mcpServer?.sId || "",
     disabled: serverType !== "remote",
   });
 
@@ -81,7 +81,7 @@ export function MCPServerDetails({
   });
 
   const connection = connections.find(
-    (c) => c.internalMCPServerId === effectiveMCPServer?.id
+    (c) => c.internalMCPServerId === effectiveMCPServer?.sId
   );
 
   const [isLoading, setIsLoading] = useState(false);
@@ -126,7 +126,7 @@ export function MCPServerDetails({
                 if (mcpServerToDelete) {
                   setMCPServerToDelete(undefined);
                   setIsLoading(true);
-                  await deleteServer(mcpServerToDelete.id);
+                  await deleteServer(mcpServerToDelete.sId);
                   setIsLoading(false);
                   onClose();
                 }
@@ -172,7 +172,7 @@ export function MCPServerDetails({
                     onClick={() => {
                       void createAndSaveMCPServerConnection({
                         authorizationInfo: authorization,
-                        mcpServerId: effectiveMCPServer?.id,
+                        mcpServerId: effectiveMCPServer?.sId,
                       });
                     }}
                   />

--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -16,7 +16,7 @@ export function MCPServerDetailsInfo({
   mcpServer,
   owner,
 }: MCPServerDetailsInfoProps) {
-  const serverType = getServerTypeAndIdFromSId(mcpServer.id).serverType;
+  const serverType = getServerTypeAndIdFromSId(mcpServer.sId).serverType;
   return (
     <div className="flex flex-col gap-2">
       {mcpServerIsRemote(mcpServer) && (
@@ -26,7 +26,7 @@ export function MCPServerDetailsInfo({
         owner={owner}
         tools={mcpServer.tools}
         serverType={serverType}
-        serverId={mcpServer.id}
+        serverId={mcpServer.sId}
       />
     </div>
   );

--- a/front/components/actions/mcp/MCPServerDetailsSharing.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsSharing.tsx
@@ -73,7 +73,7 @@ export function MCPServerDetailsSharing({
   const { mcpServers } = useMCPServers({
     owner,
   });
-  const mcpServerWithViews = mcpServers.find((s) => s.id === mcpServer.id);
+  const mcpServerWithViews = mcpServers.find((s) => s.sId === mcpServer.sId);
   const [loading, setLoading] = useState(false);
 
   const views =

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -73,8 +73,8 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
   });
 
   // Use the serverId from state for the hooks
-  const { updateServer } = useUpdateRemoteMCPServer(owner, mcpServer.id);
-  const { syncServer } = useSyncRemoteMCPServer(owner, mcpServer.id);
+  const { updateServer } = useUpdateRemoteMCPServer(owner, mcpServer.sId);
+  const { syncServer } = useSyncRemoteMCPServer(owner, mcpServer.sId);
 
   const onSubmit = useCallback(
     async (values: MCPFormType) => {

--- a/front/components/assistant/details/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/AssistantToolsSection.tsx
@@ -7,7 +7,6 @@ import {
   ScanIcon,
 } from "@dust-tt/sparkle";
 import _ from "lodash";
-import React from "react";
 
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -157,12 +156,12 @@ function renderOtherAction(
     };
   } else if (isServerSideMCPServerConfiguration(action)) {
     const mcpServer = mcpServers.find((s) =>
-      s.views.some((v) => v.id === action.mcpServerViewId)
+      s.views.some((v) => v.sId === action.mcpServerViewId)
     );
     if (!mcpServer) {
       return null;
     }
-    const { serverType } = getServerTypeAndIdFromSId(mcpServer.id);
+    const { serverType } = getServerTypeAndIdFromSId(mcpServer.sId);
     const avatar = getAvatar(mcpServer, "xs");
     return {
       title: action.name,

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -168,7 +168,7 @@ function actionIcon(
 ) {
   if (action.type === "MCP") {
     const server = mcpServerViews.find(
-      (v) => v.id === action.configuration.mcpServerViewId
+      (v) => v.sId === action.configuration.mcpServerViewId
     )?.server;
 
     if (server) {
@@ -997,7 +997,7 @@ function ActionEditor({
       case "MCP":
         const selectedMCPServerView = mcpServerViews.find((mcpServerView) =>
           action.type === "MCP"
-            ? mcpServerView.id === action.configuration.mcpServerViewId
+            ? mcpServerView.sId === action.configuration.mcpServerViewId
             : false
         );
 

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -91,7 +91,7 @@ export function MCPAction({
   const noMCPServerView = mcpServerViews.length === 0;
 
   const selectedMCPServerView = mcpServerViews.find(
-    (mcpServerView) => mcpServerView.id === actionConfiguration.mcpServerViewId
+    (mcpServerView) => mcpServerView.sId === actionConfiguration.mcpServerViewId
   );
 
   // If there is only one tool, instead of showing the MCPToolsList, we show it
@@ -285,7 +285,7 @@ export function hasErrorActionMCP(
   if (action.type === "MCP") {
     const mcpServerView = mcpServerViews.find(
       (mcpServerView) =>
-        mcpServerView.id === action.configuration.mcpServerViewId
+        mcpServerView.sId === action.configuration.mcpServerViewId
     );
     if (!mcpServerView) {
       return "Please select a tool.";

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -438,7 +438,7 @@ export function getDefaultMCPServerActionConfiguration(
   return {
     type: "MCP",
     configuration: {
-      mcpServerViewId: mcpServerView?.id ?? "not-a-valid-sId",
+      mcpServerViewId: mcpServerView?.sId ?? "not-a-valid-sId",
       dataSourceConfigurations: null,
       tablesConfigurations: null,
       childAgentId: null,

--- a/front/components/assistant_builder/useBuilderActionInfo.ts
+++ b/front/components/assistant_builder/useBuilderActionInfo.ts
@@ -30,7 +30,7 @@ export const isUsableAsCapability = (
   id: string,
   mcpServerViews: MCPServerViewType[]
 ) => {
-  const view = mcpServerViews.find((v) => v.id === id);
+  const view = mcpServerViews.find((v) => v.sId === id);
   if (!view) {
     return false;
   }
@@ -44,7 +44,7 @@ export const isUsableInKnowledge = (
   id: string,
   mcpServerViews: MCPServerViewType[]
 ) => {
-  const view = mcpServerViews.find((v) => v.id === id);
+  const view = mcpServerViews.find((v) => v.sId === id);
   if (!view) {
     return false;
   }
@@ -127,7 +127,7 @@ export const useBuilderActionInfo = (builderState: AssistantBuilderState) => {
 
           if (action.configuration.mcpServerViewId) {
             const mcpServerView = mcpServerViews.find(
-              (v) => v.id === action.configuration.mcpServerViewId
+              (v) => v.sId === action.configuration.mcpServerViewId
             );
             // Default MCP server themselves are not accounted for in the space restriction.
             if (

--- a/front/components/assistant_builder/useTools.ts
+++ b/front/components/assistant_builder/useTools.ts
@@ -83,7 +83,7 @@ function getGroupedMCPServerViews({
 
   const mcpServerViewsWithLabel = mcpServerViews.map((view) => {
     // There can be the same tool available in different spaces, in that case we need to show the space name.
-    const displayeName = asDisplayName(view.server.name);
+    const displayName = asDisplayName(view.server.name);
 
     if (serverIdToCount[view.server.sId] > 1) {
       const spaceName = spaces.find(
@@ -93,14 +93,14 @@ function getGroupedMCPServerViews({
       if (spaceName) {
         return {
           ...view,
-          label: `${displayeName} (${spaceName})`,
+          label: `${displayName} (${spaceName})`,
         };
       }
     }
 
     return {
       ...view,
-      label: displayeName,
+      label: displayName,
     };
   });
 

--- a/front/components/assistant_builder/useTools.ts
+++ b/front/components/assistant_builder/useTools.ts
@@ -75,7 +75,7 @@ function getGroupedMCPServerViews({
 }) {
   const serverIdToCount = mcpServerViews.reduce(
     (acc, view) => {
-      acc[view.server.id] = (acc[view.server.id] || 0) + 1;
+      acc[view.server.sId] = (acc[view.server.sId] || 0) + 1;
       return acc;
     },
     {} as Record<string, number>
@@ -85,7 +85,7 @@ function getGroupedMCPServerViews({
     // There can be the same tool available in different spaces, in that case we need to show the space name.
     const displayeName = asDisplayName(view.server.name);
 
-    if (serverIdToCount[view.server.id] > 1) {
+    if (serverIdToCount[view.server.sId] > 1) {
       const spaceName = spaces.find(
         (space) => space.sId === view.spaceId
       )?.name;

--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -75,7 +75,7 @@ export function UserToolsTable({ owner }: UserToolsTableProps) {
             .includes(searchQuery.toLowerCase())
       )
       .map((serverView) => ({
-        id: serverView.id,
+        id: serverView.sId,
         name: serverView.server.name,
         description: serverView.server.description,
         visual: getAvatar(serverView.server),

--- a/front/components/poke/mcp_server_views/columns.tsx
+++ b/front/components/poke/mcp_server_views/columns.tsx
@@ -5,12 +5,12 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
 interface MCPServerView {
-  id: string;
+  sId: string;
   createdAt: number;
   updatedAt: number;
   spaceId: string;
   server: {
-    id: string;
+    sId: string;
     name: string;
     description: string;
   };
@@ -23,11 +23,11 @@ interface MCPServerView {
 export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
   return [
     {
-      accessorKey: "id",
+      accessorKey: "sId",
       cell: ({ row }) => {
-        const { mcpServerViewLink, id } = row.original;
+        const { mcpServerViewLink, sId } = row.original;
 
-        return <LinkWrapper href={mcpServerViewLink}>{id}</LinkWrapper>;
+        return <LinkWrapper href={mcpServerViewLink}>{sId}</LinkWrapper>;
       },
       header: "sId",
     },

--- a/front/components/poke/mcp_server_views/view.tsx
+++ b/front/components/poke/mcp_server_views/view.tsx
@@ -38,7 +38,7 @@ export function ViewMCPServerViewTable({
               </PokeTableRow>
               <PokeTableRow>
                 <PokeTableHead>Server ID</PokeTableHead>
-                <PokeTableCellWithCopy label={mcpServerView.server.id} />
+                <PokeTableCellWithCopy label={mcpServerView.server.sId} />
               </PokeTableRow>
               <PokeTableRow>
                 <PokeTableHead>Server Description</PokeTableHead>

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -63,8 +63,8 @@ export const SpaceActionsList = ({
     await mutateAvailableMCPServers();
   };
 
-  const onRemoveServer = async (id: string) => {
-    await removeFromSpace(serverViews.find((view) => view.id === id)!, space);
+  const onRemoveServer = async (sId: string) => {
+    await removeFromSpace(serverViews.find((view) => view.sId === sId)!, space);
     await mutateMCPServerViews();
     await mutateAvailableMCPServers();
   };
@@ -123,7 +123,7 @@ export const SpaceActionsList = ({
   const rows: RowData[] = React.useMemo(
     () =>
       serverViews.map((serverView) => ({
-        id: serverView.id,
+        id: serverView.sId,
         name: serverView.server.name,
         description: serverView.server.description,
         avatar: getAvatar(serverView.server),

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -8,7 +8,7 @@ import {
   PlusIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
@@ -68,7 +68,7 @@ export default function SpaceManagedActionsViewsModel({
           .filter((s) => filterMCPServer(s, searchText))
           .map((server) => (
             <DropdownMenuItem
-              key={server.id}
+              key={server.sId}
               label={asDisplayName(server.name)}
               icon={() => getAvatar(server, "xs")}
               description={server.description}

--- a/front/components/spaces/mcp/RequestActionsModal.tsx
+++ b/front/components/spaces/mcp/RequestActionsModal.tsx
@@ -57,7 +57,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
       try {
         await sendRequestActionsAccessEmail({
           emailMessage: message,
-          mcpServerViewId: selectedMcpServer.id,
+          mcpServerViewId: selectedMcpServer.sId,
           owner,
         });
         sendNotification({
@@ -75,7 +75,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
         logger.error(
           {
             userToId,
-            mcpServerId: selectedMcpServer.id,
+            mcpServerId: selectedMcpServer.sId,
             error: e,
           },
           "Error sending email"
@@ -138,7 +138,7 @@ export function RequestActionsModal({ owner, space }: RequestActionsModal) {
                       <DropdownMenuContent>
                         {serverViews.map((v) => (
                           <DropdownMenuItem
-                            key={v.id}
+                            key={v.sId}
                             label={asDisplayName(v.server.name)}
                             icon={() => getAvatar(v.server, "xs")}
                             onClick={() => setSelectedMcpServer(v)}

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -73,8 +73,12 @@ export const mcpServersSortingFn = (
   a: { mcpServer: MCPServerType },
   b: { mcpServer: MCPServerType }
 ) => {
-  const { serverType: aServerType } = getServerTypeAndIdFromSId(a.mcpServer.id);
-  const { serverType: bServerType } = getServerTypeAndIdFromSId(b.mcpServer.id);
+  const { serverType: aServerType } = getServerTypeAndIdFromSId(
+    a.mcpServer.sId
+  );
+  const { serverType: bServerType } = getServerTypeAndIdFromSId(
+    b.mcpServer.sId
+  );
   if (aServerType === bServerType) {
     return a.mcpServer.name.localeCompare(b.mcpServer.name);
   }
@@ -84,6 +88,6 @@ export const mcpServersSortingFn = (
 export function mcpServerIsRemote(
   server: MCPServerType
 ): server is RemoteMCPServerType {
-  const serverType = getServerTypeAndIdFromSId(server.id).serverType;
+  const serverType = getServerTypeAndIdFromSId(server.sId).serverType;
   return serverType === "remote";
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -19,8 +19,10 @@ import {
   isRemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
-import type { AgentLoopListToolsContextType } from "@app/lib/actions/types";
+import type {
+  AgentLoopListToolsContextType,
+  AgentLoopRunContextType,
+} from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import apiConfig from "@app/lib/api/config";
 import type {
@@ -55,7 +57,7 @@ async function getAccessTokenForRemoteMCPServer(
   if (metadata.authorization) {
     const connection = await MCPServerConnectionResource.findByMCPServer({
       auth,
-      mcpServerId: metadata.id,
+      mcpServerId: metadata.sId,
     });
     if (connection.isOk()) {
       const token = await getOAuthConnectionAccessToken({
@@ -295,7 +297,7 @@ export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
 export async function fetchRemoteServerMetaDataByURL(
   auth: Authenticator,
   url: string
-): Promise<Result<Omit<MCPServerType, "id">, Error>> {
+): Promise<Result<Omit<MCPServerType, "sId">, Error>> {
   const r = await connectToMCPServer(auth, {
     params: {
       type: "remoteMCPServerUrl",

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -10,7 +10,7 @@ import type {
   MCPServerAvailability,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
-import type { EditedByUser } from "@app/types";
+import type { EditedByUser, ModelId } from "@app/types";
 
 export type MCPToolType = {
   name: string;
@@ -39,7 +39,7 @@ export type MCPToolWithStakeLevelType =
   | ClientSideMCPToolTypeWithStakeLevel;
 
 export type MCPServerType = {
-  id: string;
+  sId: string;
   name: string;
   version: string;
   description: string;
@@ -59,7 +59,8 @@ export type RemoteMCPServerType = MCPServerType & {
 };
 
 export interface MCPServerViewType {
-  id: string;
+  id: ModelId;
+  sId: string;
   createdAt: number;
   updatedAt: number;
   spaceId: string;
@@ -69,7 +70,7 @@ export interface MCPServerViewType {
 
 export type MCPServerDefinitionType = Omit<
   MCPServerType,
-  "tools" | "id" | "availability"
+  "tools" | "sId" | "availability"
 >;
 
 type InternalMCPServerType = MCPServerType & {
@@ -79,7 +80,7 @@ type InternalMCPServerType = MCPServerType & {
 
 export type InternalMCPServerDefinitionType = Omit<
   InternalMCPServerType,
-  "tools" | "id" | "availability"
+  "tools" | "sId" | "availability"
 >;
 
 export type MCPServerTypeWithViews = MCPServerType & {

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -34,7 +34,7 @@ export class InternalMCPServerInMemoryResource {
   // SID of the internal MCP server, scoped to a workspace.
   readonly id: string;
 
-  private metadata: Omit<MCPServerType, "id"> = {
+  private metadata: Omit<MCPServerType, "sId"> = {
     ...extractMetadataFromServerVersion(undefined),
     tools: [],
     availability: "manual",
@@ -268,7 +268,7 @@ export class InternalMCPServerInMemoryResource {
   // Serialization.
   toJSON(): MCPServerType {
     return {
-      id: this.id,
+      sId: this.id,
       ...this.metadata,
     };
   }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -605,7 +605,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   // Serialization.
   toJSON(): MCPServerViewType {
     return {
-      id: this.sId,
+      id: this.id,
+      sId: this.sId,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.space.sId,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -291,7 +291,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         : this.sharedSecret;
 
     return {
-      id: this.sId,
+      sId: this.sId,
 
       name: this.name,
       description: this.description,

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -62,7 +62,7 @@ const getOptimisticDataForCreate = (
           views: [
             ...mcpServerWithViews.views,
             {
-              id: 0,
+              id: -1, // The ID is not known at optimistic data creation time.
               sId: "global",
               createdAt: Date.now(),
               updatedAt: Date.now(),

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -50,19 +50,20 @@ const getOptimisticDataForCreate = (
   if (!data) {
     return { servers: [], success: true };
   }
-  const mcpServerWithViews = data.servers.find((s) => s.id === server.id);
+  const mcpServerWithViews = data.servers.find((s) => s.sId === server.sId);
 
   if (mcpServerWithViews) {
     return {
       ...data,
       servers: [
-        ...data.servers.filter((v) => v.id !== server.id),
+        ...data.servers.filter((v) => v.sId !== server.sId),
         {
           ...mcpServerWithViews,
           views: [
             ...mcpServerWithViews.views,
             {
-              id: "global",
+              id: 0,
+              sId: "global",
               createdAt: Date.now(),
               updatedAt: Date.now(),
               server,
@@ -86,17 +87,19 @@ const getOptimisticDataForRemove = (
   }
 
   const mcpServerWithViews = data.servers.find(
-    (s) => s.id === serverView.server.id
+    (s) => s.sId === serverView.server.sId
   );
 
   if (mcpServerWithViews) {
     return {
       ...data,
       servers: [
-        ...data.servers.filter((v) => v.id !== serverView.server.id),
+        ...data.servers.filter((v) => v.sId !== serverView.server.sId),
         {
           ...mcpServerWithViews,
-          views: mcpServerWithViews.views.filter((v) => v.id !== serverView.id),
+          views: mcpServerWithViews.views.filter(
+            (v) => v.sId !== serverView.sId
+          ),
         },
       ],
     };
@@ -149,7 +152,7 @@ export function useAddMCPServerToSpace(owner: LightWorkspaceType) {
             {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ mcpServerId: server.id }),
+              body: JSON.stringify({ mcpServerId: server.sId }),
             }
           );
 
@@ -200,7 +203,7 @@ export function useRemoveMCPServerViewFromSpace(owner: LightWorkspaceType) {
       await mutateMCPServers(
         async (data) => {
           const response = await fetch(
-            `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views/${serverView.id}`,
+            `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views/${serverView.sId}`,
             {
               method: "DELETE",
             }

--- a/front/pages/api/w/[wId]/mcp/fetch.ts
+++ b/front/pages/api/w/[wId]/mcp/fetch.ts
@@ -11,7 +11,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 export type GetRemoteMCPServersResponseBody = {
   success: boolean;
-  server: Omit<MCPServerType, "id">;
+  server: Omit<MCPServerType, "sId">;
 };
 
 const GetQueryParamsSchema = t.type({

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -71,7 +71,7 @@ async function handler(
           async (r) => {
             const server = r.toJSON();
             const views = (
-              await MCPServerViewResource.listByMCPServer(auth, server.id)
+              await MCPServerViewResource.listByMCPServer(auth, server.sId)
             ).map((v) => v.toJSON());
             return { ...server, views };
           },
@@ -163,7 +163,7 @@ async function handler(
           success: true,
           server: {
             ...metadata,
-            id: newRemoteMCPServer.sId,
+            sId: newRemoteMCPServer.sId,
           },
         });
       } else {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -69,6 +69,6 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
     const response = res._getJSONData();
     expect(response.success).toBe(true);
     expect(response.servers).toHaveLength(1); // Only one available server as the other is assigned to the system space
-    expect(response.servers[0].id).toBe(internalServer.id);
+    expect(response.servers[0].sId).toBe(internalServer.id);
   });
 });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
@@ -41,12 +41,12 @@ async function handler(
 
       const globalServersId = workspaceServerViews
         .filter((s) => s.space.kind === "global")
-        .map((s) => s.toJSON().server.id);
+        .map((s) => s.toJSON().server.sId);
 
       const spaceServerViews = workspaceServerViews.filter(
         (s) => s.space.id === space.id
       );
-      const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.id);
+      const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.sId);
 
       const availableServer: MCPServerType[] = [];
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
@@ -71,7 +71,7 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated", () => {
     // Only the server view that is not in the global space should be return as activable.
     expect(res._getJSONData().serverViews).toHaveLength(1);
     expect(res._getJSONData().serverViews[0].server.id).toBe(
-      mcpServer2.toJSON().id
+      mcpServer2.toJSON().sId
     );
   });
 });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
@@ -70,7 +70,7 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated", () => {
 
     // Only the server view that is not in the global space should be return as activable.
     expect(res._getJSONData().serverViews).toHaveLength(1);
-    expect(res._getJSONData().serverViews[0].server.id).toBe(
+    expect(res._getJSONData().serverViews[0].server.sId).toBe(
       mcpServer2.toJSON().sId
     );
   });

--- a/front/types/data_source_view.ts
+++ b/front/types/data_source_view.ts
@@ -17,8 +17,8 @@ export interface DataSourceViewType {
   kind: DataSourceViewKind;
   parentsIn: string[] | null;
   sId: string;
-  updatedAt: number;
   spaceId: string;
+  updatedAt: number;
 }
 
 export type DataSourceViewsWithDetails = DataSourceViewType & {

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -35,9 +35,7 @@ export type PokeDataSourceViewType = DataSourceViewType &
   };
 
 export type PokeMCPServerViewType = MCPServerViewType &
-  // Consequence of small inconsistencies in typing between MCPServerViewType and
-  // DataSourceViewType, hard to fix and only affects this type for now.
-  Omit<PokeItemBase, "id"> & {
+  PokeItemBase & {
     space: PokeSpaceType;
   };
 


### PR DESCRIPTION
## Description

- Some context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1747140475439899).
- There is currently a discrepancy in how IDs are handled in `MCPServerViewType` compared to other types derived from DB models such as `DataSourceViewType` for instance.
- The field `id` in `MCPServerViewType` is actually an `sId`, and the `id` is missing.
- This PR fixes that and aligns everyone.

## Tests

- `tsc` very helpful, local tests to use MCP server views.

## Risk

- Blast radius quite high: affects MCP server view creation, update, display, fetching.

## Deploy Plan

- Deploy front.
