### PR TITLE
[front] fix(migration): Shorten index name

### DIFF
--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -130,6 +130,7 @@ AgentMCPServerConfiguration.init(
       {
         fields: ["workspaceId", "agentConfigurationId"],
         concurrently: true,
+        name: "agent_mcp_srv_config_w_id_agent_config_id",
       },
       {
         unique: true,

--- a/front/migrations/db/migration_251.sql
+++ b/front/migrations/db/migration_251.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 13, 2025
-CREATE INDEX CONCURRENTLY "agent_mcp_server_configurations_workspace_id_agent_configuration_id" ON "agent_mcp_server_configurations" ("workspaceId", "agentConfigurationId");
+CREATE INDEX CONCURRENTLY "agent_mcp_srv_config_w_id_agent_config_id" ON "agent_mcp_server_configurations" ("workspaceId", "agentConfigurationId");


### PR DESCRIPTION
## Description
Shorten the index name, due to:
- Postgres would truncate it
- That make sequelize want to try to recreate the index each time we run `create-db-migration`, and error because it already exists

## Tests
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- https://github.com/dust-tt/dust/pull/12574
