### PR TITLE
[front] chore(AgentReasoningConfig): Add workspaceId filter

### DIFF
--- a/front/lib/actions/configuration/reasoning.ts
+++ b/front/lib/actions/configuration/reasoning.ts
@@ -2,22 +2,29 @@ import { Op } from "sequelize";
 
 import { DEFAULT_REASONING_ACTION_NAME } from "@app/lib/actions/constants";
 import type { ReasoningConfigurationType } from "@app/lib/actions/reasoning";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
 import type { AgentFetchVariant, ModelId } from "@app/types";
 
-export async function fetchReasoningActionConfigurations({
-  configurationIds,
-  variant,
-}: {
-  configurationIds: ModelId[];
-  variant: AgentFetchVariant;
-}): Promise<Map<ModelId, ReasoningConfigurationType[]>> {
+export async function fetchReasoningActionConfigurations(
+  auth: Authenticator,
+  {
+    configurationIds,
+    variant,
+  }: {
+    configurationIds: ModelId[];
+    variant: AgentFetchVariant;
+  }
+): Promise<Map<ModelId, ReasoningConfigurationType[]>> {
   if (variant !== "full") {
     return new Map();
   }
 
   const reasoningConfigurations = await AgentReasoningConfiguration.findAll({
-    where: { agentConfigurationId: { [Op.in]: configurationIds } },
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      agentConfigurationId: { [Op.in]: configurationIds },
+    },
   });
 
   if (reasoningConfigurations.length === 0) {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -530,7 +530,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     fetchTableQueryActionConfigurations(auth, { configurationIds, variant }),
     fetchWebsearchActionConfigurations(auth, { configurationIds, variant }),
     fetchBrowseActionConfigurations(auth, { configurationIds, variant }),
-    fetchReasoningActionConfigurations({ configurationIds, variant }),
+    fetchReasoningActionConfigurations(auth, { configurationIds, variant }),
     fetchMCPServerActionConfigurations(auth, { configurationIds, variant }),
     user && variant !== "extra_light"
       ? getFavoriteStates(auth, { configurationIds: configurationSIds })

--- a/front/lib/models/assistant/actions/reasoning.ts
+++ b/front/lib/models/assistant/actions/reasoning.ts
@@ -86,6 +86,7 @@ AgentReasoningConfiguration.init(
       {
         fields: ["workspaceId", "agentConfigurationId"],
         concurrently: true,
+        name: "agent_reasoning_config_workspace_id_agent_config_id",
       },
     ],
     sequelize: frontSequelize,

--- a/front/lib/models/assistant/actions/reasoning.ts
+++ b/front/lib/models/assistant/actions/reasoning.ts
@@ -83,6 +83,10 @@ AgentReasoningConfiguration.init(
         fields: ["agentConfigurationId"],
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "agentConfigurationId"],
+        concurrently: true,
+      },
     ],
     sequelize: frontSequelize,
   }

--- a/front/lib/models/assistant/actions/reasoning.ts
+++ b/front/lib/models/assistant/actions/reasoning.ts
@@ -79,6 +79,7 @@ AgentReasoningConfiguration.init(
         unique: true,
         fields: ["sId"],
       },
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-13): Remove index
       {
         fields: ["agentConfigurationId"],
         concurrently: true,

--- a/front/migrations/db/migration_256.sql
+++ b/front/migrations/db/migration_256.sql
@@ -1,0 +1,2 @@
+-- Migration created May 13, 2025
+CREATE INDEX CONCURRENTLY "agent_mcp_server_config_w_id_agent_config_id" ON "agent_mcp_server_configurations" ("workspaceId", "agentConfigurationId")

--- a/front/migrations/db/migration_256.sql
+++ b/front/migrations/db/migration_256.sql
@@ -1,2 +1,2 @@
 -- Migration created May 13, 2025
-CREATE INDEX CONCURRENTLY "agent_mcp_server_config_w_id_agent_config_id" ON "agent_mcp_server_configurations" ("workspaceId", "agentConfigurationId")
+CREATE INDEX CONCURRENTLY "agent_reasoning_config_workspace_id_agent_config_id" ON "agent_reasoning_configurations" ("workspaceId", "agentConfigurationId")


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add `workspaceId` filter to `AgentReasoningConfiguration`
- Add migration with new composite index

## Tests

## Risk

## Deploy Plan
- [ ] Run migration
- [ ] Deploy front
