### PR TITLE
[front] - chore(AB): open preview drawer by default

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -136,7 +136,9 @@ export default function AssistantBuilder({
     "selectedTab",
     "instructions"
   );
-  const [screen, setScreen] = useState<BuilderScreen>("instructions");
+  const [screen, setScreen] = useState<BuilderScreen>(
+    currentTab && isValidTab(currentTab) ? currentTab : "instructions"
+  );
   const [edited, setEdited] = useState(defaultIsEdited ?? false);
   const [isSavingOrDeleting, setIsSavingOrDeleting] = useState(false);
   const [disableUnsavedChangesPrompt, setDisableUnsavedChangesPrompt] =
@@ -225,8 +227,13 @@ export default function AssistantBuilder({
 
   const [rightPanelStatus, setRightPanelStatus] =
     useState<AssistantBuilderRightPanelStatus>({
-      tab: template != null ? "Template" : null,
-      openedAt: template != null ? Date.now() : null,
+      tab:
+        template != null
+          ? "Template"
+          : screen == "instructions"
+            ? "Preview"
+            : null,
+      openedAt: screen == "instructions" ? Date.now() : null,
     });
 
   // We deactivate the Preview button if the BuilderState is empty (= no instructions, no tools)

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -17,19 +17,19 @@ import {
   TabsTrigger,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import { Label } from "@dust-tt/sparkle";
 import { Separator } from "@radix-ui/react-select";
 import { useContext, useEffect } from "react";
 
 import { ActionValidationProvider } from "@app/components/assistant/conversation/ActionValidationProvider";
-import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
+import {
+  ConversationsNavigationProvider,
+} from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
-import {
-  usePreviewAssistant,
-  useTryAssistantCore,
-} from "@app/components/assistant_builder/TryAssistant";
+import { usePreviewAssistant, useTryAssistantCore } from "@app/components/assistant_builder/TryAssistant";
 import type {
   AssistantBuilderSetActionType,
   AssistantBuilderState,
@@ -191,7 +191,8 @@ export default function AssistantBuilderRightPanel({
                   </ActionValidationProvider>
                 </ConversationsNavigationProvider>
               ) : (
-                <div className="flex h-full w-full items-center justify-center">
+                <div className="flex h-full w-full flex-col items-center gap-2 justify-center">
+                  <Label>Try out your assistant...</Label>
                   <Spinner />
                 </div>
               )}
@@ -201,7 +202,7 @@ export default function AssistantBuilderRightPanel({
           template &&
           screen === "instructions" && (
             <div className="mb-72 flex flex-col gap-4">
-              <div className="flex items-end justify-end justify-between pt-2">
+              <div className="flex items-end justify-end pt-2">
                 <TemplateDropDownMenu
                   screen={screen}
                   removeTemplate={removeTemplate}
@@ -219,7 +220,7 @@ export default function AssistantBuilderRightPanel({
           template &&
           screen === "actions" && (
             <div className="mb-72 flex flex-col gap-4">
-              <div className="flex items-end justify-end justify-between pt-2">
+              <div className="flex items-end justify-end pt-2">
                 <TemplateDropDownMenu
                   screen={screen}
                   removeTemplate={removeTemplate}

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -22,14 +22,15 @@ import { Separator } from "@radix-ui/react-select";
 import { useContext, useEffect } from "react";
 
 import { ActionValidationProvider } from "@app/components/assistant/conversation/ActionValidationProvider";
-import {
-  ConversationsNavigationProvider,
-} from "@app/components/assistant/conversation/ConversationsNavigationProvider";
+import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
-import { usePreviewAssistant, useTryAssistantCore } from "@app/components/assistant_builder/TryAssistant";
+import {
+  usePreviewAssistant,
+  useTryAssistantCore,
+} from "@app/components/assistant_builder/TryAssistant";
 import type {
   AssistantBuilderSetActionType,
   AssistantBuilderState,
@@ -191,7 +192,7 @@ export default function AssistantBuilderRightPanel({
                   </ActionValidationProvider>
                 </ConversationsNavigationProvider>
               ) : (
-                <div className="flex h-full w-full flex-col items-center gap-2 justify-center">
+                <div className="flex h-full w-full flex-col items-center justify-center gap-2">
                   <Label>Try out your assistant...</Label>
                   <Spinner />
                 </div>


### PR DESCRIPTION
## Description

This PR aims at having the preview drawer open by default when landing on the agent builder with the instructions tab.

This is done in order to increase discoverability of that feature, which from the feedbacks we collected is an actual problem.

## Risk

Low

## Deploy Plan

- Deploy front