### PR TITLE
Fix/shorten index name

### DIFF
--- a/front/lib/models/assistant/actions/browse.ts
+++ b/front/lib/models/assistant/actions/browse.ts
@@ -59,6 +59,7 @@ AgentBrowseConfiguration.init(
       {
         fields: ["workspaceId", "agentConfigurationId"],
         concurrently: true,
+        name: "agent_browse_config_workspace_id_agent_config_id",
       },
     ],
     sequelize: frontSequelize,

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -60,6 +60,7 @@ AgentDustAppRunConfiguration.init(
       {
         fields: ["workspaceId", "agentConfigurationId"],
         concurrently: true,
+        name: "agent_dust_app_run_config_workspace_id_agent_config_id",
       },
     ],
     sequelize: frontSequelize,

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -86,6 +86,7 @@ AgentProcessConfiguration.init(
       {
         fields: ["workspaceId", "agentConfigurationId"],
         concurrently: true,
+        name: "agent_process_config_workspace_id_agent_config_id",
       },
     ],
     sequelize: frontSequelize,

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -91,6 +91,7 @@ AgentRetrievalConfiguration.init(
       {
         fields: ["workspaceId", "agentConfigurationId"],
         concurrently: true,
+        name: "agent_retrieval_config_workspace_id_agent_config_id",
       },
       {
         unique: true,

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -63,6 +63,7 @@ AgentTablesQueryConfiguration.init(
       {
         fields: ["workspaceId", "agentConfigurationId"],
         concurrently: true,
+        name: "agent_tables_query_config_workspace_id_agent_config_id",
       },
     ],
     sequelize: frontSequelize,

--- a/front/lib/models/assistant/actions/websearch.ts
+++ b/front/lib/models/assistant/actions/websearch.ts
@@ -59,6 +59,7 @@ AgentWebsearchConfiguration.init(
       {
         fields: ["workspaceId", "agentConfigurationId"],
         concurrently: true,
+        name: "agent_websearch_config_workspace_id_agent_config_id",
       },
     ],
     sequelize: frontSequelize,

--- a/front/migrations/db/migration_239.sql
+++ b/front/migrations/db/migration_239.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 13, 2025
-CREATE INDEX CONCURRENTLY "agent_retrieval_configurations_workspace_id_agent_configuration_id" ON "agent_retrieval_configurations" ("workspaceId", "agentConfigurationId");
+CREATE INDEX CONCURRENTLY "agent_retrieval_config_workspace_id_agent_config_id" ON "agent_retrieval_configurations" ("workspaceId", "agentConfigurationId");

--- a/front/migrations/db/migration_246.sql
+++ b/front/migrations/db/migration_246.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 13, 2025
-CREATE INDEX CONCURRENTLY "agent_process_configurations_workspace_id_agent_configuration_id" ON "agent_process_configurations" ("workspaceId", "agentConfigurationId");
+CREATE INDEX CONCURRENTLY "agent_process_config_workspace_id_agent_config_id" ON "agent_process_configurations" ("workspaceId", "agentConfigurationId");

--- a/front/migrations/db/migration_247.sql
+++ b/front/migrations/db/migration_247.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 13, 2025
-CREATE INDEX CONCURRENTLY "agent_tables_query_configurations_workspace_id_agent_configuration_id" ON "agent_tables_query_configurations" ("workspaceId", "agentConfigurationId");
+CREATE INDEX CONCURRENTLY "agent_tables_query_config_workspace_id_agent_config_id" ON "agent_tables_query_configurations" ("workspaceId", "agentConfigurationId");

--- a/front/migrations/db/migration_248.sql
+++ b/front/migrations/db/migration_248.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 13, 2025
-CREATE INDEX CONCURRENTLY "agent_dust_app_run_configurations_workspace_id_agent_configuration_id" ON "agent_dust_app_run_configurations" ("workspaceId", "agentConfigurationId");
+CREATE INDEX CONCURRENTLY "agent_dust_app_run_config_workspace_id_agent_config_id" ON "agent_dust_app_run_configurations" ("workspaceId", "agentConfigurationId");

--- a/front/migrations/db/migration_249.sql
+++ b/front/migrations/db/migration_249.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 13, 2025
-CREATE INDEX CONCURRENTLY "agent_browse_configurations_workspace_id_agent_configuration_id" ON "agent_browse_configurations" ("workspaceId", "agentConfigurationId");
+CREATE INDEX CONCURRENTLY "agent_browse_config_workspace_id_agent_config_id" ON "agent_browse_configurations" ("workspaceId", "agentConfigurationId");

--- a/front/migrations/db/migration_250.sql
+++ b/front/migrations/db/migration_250.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 13, 2025
-CREATE INDEX CONCURRENTLY "agent_websearch_configurations_workspace_id_agent_configuration_id" ON "agent_websearch_configurations" ("workspaceId", "agentConfigurationId");
+CREATE INDEX CONCURRENTLY "agent_websearch_config_workspace_id_agent_config_id" ON "agent_websearch_configurations" ("workspaceId", "agentConfigurationId");


### PR DESCRIPTION
## Description
- Shorten some index names (not yet migrated). Sequelize want to concatenate model name and attributes, but then postgres will truncate it

## Tests
- Locally ran migration

## Risk

## Deploy Plan
 - Run migration with their associated PR.
