### PR TITLE
[front] chore(eslint): Add eslint rule check index name limit

### DIFF
--- a/eslint-plugin-dust/index.js
+++ b/eslint-plugin-dust/index.js
@@ -1,7 +1,8 @@
 "use strict";
 
 const noRawSqlRule = require("./rules/no-raw-sql");
-const noUnverifiedWorkspaceBypass = require("./rules/no-unverified-workspace-bypass.js");
+const noUnverifiedWorkspaceBypass = require("./rules/no-unverified-workspace-bypass");
+const tooLongIndexName = require("./rules/too-long-index-name");
 
 module.exports = {
   meta: {
@@ -11,5 +12,6 @@ module.exports = {
   rules: {
     "no-raw-sql": noRawSqlRule,
     "no-unverified-workspace-bypass": noUnverifiedWorkspaceBypass,
+    "too-long-index-name": tooLongIndexName,
   },
 };

--- a/eslint-plugin-dust/rules/too-long-index-name.js
+++ b/eslint-plugin-dust/rules/too-long-index-name.js
@@ -1,0 +1,82 @@
+"use strict";
+
+function toSnakeCase(str) {
+  return str
+    .replace(/([A-Z])/g, "_$1")
+    .toLowerCase()
+    .replace(/^_/, "");
+}
+
+const POSTGRES_INDEX_NAME_MAX_LENGTH = 63;
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "enforce index name length limit for sequelize models",
+    },
+    schema: [],
+  },
+  create: function (context) {
+    return {
+      CallExpression(node) {
+        // Check if it's a Model.init call
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.name === "init" &&
+          node.arguments.length >= 2 &&
+          node.arguments[1].type === "ObjectExpression"
+        ) {
+          const options = node.arguments[1];
+          const modelNameProp = options.properties.find(
+            (p) => p.key.name === "modelName",
+          );
+          const indexesProp = options.properties.find(
+            (p) => p.key.name === "indexes",
+          );
+
+          if (!modelNameProp || !indexesProp) return;
+
+          const modelName = modelNameProp.value.value;
+          const indexes = indexesProp.value.elements;
+
+          indexes.forEach((index) => {
+            if (index.type !== "ObjectExpression") return;
+
+            // Skip if index has a name property
+            const nameProp = index.properties.find(
+              (p) => p.key.name === "name",
+            );
+            if (nameProp) {
+              if (
+                nameProp.value.value.length > POSTGRES_INDEX_NAME_MAX_LENGTH
+              ) {
+                context.report({
+                  node: nameProp,
+                  message: `index name '${nameProp.value.value}' exceeds ${POSTGRES_INDEX_NAME_MAX_LENGTH} characters. Which is PostgreSQL index name limit.`,
+                });
+              }
+              return;
+            }
+
+            const fieldsProp = index.properties.find(
+              (p) => p.key.name === "fields",
+            );
+            if (!fieldsProp) return;
+
+            const fields = fieldsProp.value.elements;
+            const fieldsStr = fields.map((f) => toSnakeCase(f.value)).join("_");
+            const fullIndexName = `${modelName}s_${fieldsStr}`;
+
+            if (fullIndexName.length > POSTGRES_INDEX_NAME_MAX_LENGTH) {
+              context.report({
+                node: index,
+                message: `Default index name '${fullIndexName}' exceeds ${POSTGRES_INDEX_NAME_MAX_LENGTH} characters. Which is PostgreSQL index name limit.`,
+              });
+            }
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-dust/rules/too-long-index-name.js
+++ b/eslint-plugin-dust/rules/too-long-index-name.js
@@ -20,6 +20,14 @@ module.exports = {
   create: function (context) {
     return {
       CallExpression(node) {
+        // Skip super.init calls
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.type === "Super"
+        ) {
+          return;
+        }
+
         // Check if it's a Model.init call
         if (
           node.callee.type === "MemberExpression" &&

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -58,7 +58,7 @@ module.exports = {
     "@typescript-eslint/return-await": ["error", "in-try-catch"],
     "dust/no-raw-sql": "error",
     "dust/no-unverified-workspace-bypass": "error",
-    "dust/too-long-index-name": "warn",
+    "dust/too-long-index-name": "error",
   },
   overrides: [
     {

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
     "@typescript-eslint/return-await": ["error", "in-try-catch"],
     "dust/no-raw-sql": "error",
     "dust/no-unverified-workspace-bypass": "error",
+    "dust/too-long-index-name": "warn",
   },
   overrides: [
     {


### PR DESCRIPTION
## Description
- Postresql has a index name limit of [63 bytes](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS), if a longer name is provided it will be truncated.
- By default Sequelize use the format `{modelName}_{fields.join('_')}` to generate index name during migration without checking the size, which would be truncated by postgres during migration, which would create a diff between what we have in code and what's inside postgres.
- This new eslint rule errors at us if a infered (default) generated index name goes above the limit, as well as the limit of a custom index name.

## Tests
- Locally

## Risk
- Low, dev only
