### PR TITLE
[front] chore(AgentDataSourceConfiguration): add workspaceId filter

### DIFF
--- a/front/lib/actions/configuration/process.ts
+++ b/front/lib/actions/configuration/process.ts
@@ -44,6 +44,7 @@ export async function fetchAgentProcessActionConfigurations(
   const processDatasourceConfigurations =
     await AgentDataSourceConfiguration.findAll({
       where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
         processConfigurationId: {
           [Op.in]: processConfiguration.map((r) => r.id),
         },

--- a/front/lib/actions/configuration/retrieval.ts
+++ b/front/lib/actions/configuration/retrieval.ts
@@ -44,6 +44,7 @@ export async function fetchAgentRetrievalActionConfigurations(
   const retrievalDatasourceConfigurations =
     await AgentDataSourceConfiguration.findAll({
       where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
         retrievalConfigurationId: {
           [Op.in]: retrievalConfigurations.map((r) => r.id),
         },

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -53,21 +53,14 @@ async function fetchAgentDataSourceConfiguration(
   }
 
   const agentDataSourceConfiguration =
-    await AgentDataSourceConfiguration.findByPk(sIdParts.resourceModelId, {
+    await AgentDataSourceConfiguration.findOne({
+      where: {
+        id: sIdParts.resourceModelId,
+        workspaceId: sIdParts.workspaceModelId,
+      },
       nest: true,
       include: [{ model: DataSourceModel, as: "dataSource", required: true }],
     });
-
-  if (
-    agentDataSourceConfiguration &&
-    agentDataSourceConfiguration.workspaceId !== sIdParts.workspaceModelId
-  ) {
-    return new Err(
-      new Error(
-        `Data source configuration ${dataSourceConfigId} does not belong to workspace ${sIdParts.workspaceModelId}`
-      )
-    );
-  }
 
   if (!agentDataSourceConfiguration) {
     return new Err(

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -83,6 +83,9 @@ export async function getDataSourceViewsUsageByCategory({
     AgentDataSourceConfiguration.findAll({
       raw: true,
       group: ["dataSourceView.id"],
+      where: {
+        workspaceId: owner.id,
+      },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
         [
@@ -136,6 +139,9 @@ export async function getDataSourceViewsUsageByCategory({
     AgentDataSourceConfiguration.findAll({
       raw: true,
       group: ["dataSourceView.id"],
+      where: {
+        workspaceId: owner.id,
+      },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
         [
@@ -189,6 +195,9 @@ export async function getDataSourceViewsUsageByCategory({
     AgentDataSourceConfiguration.findAll({
       raw: true,
       group: ["dataSourceView.id"],
+      where: {
+        workspaceId: owner.id,
+      },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
         [
@@ -355,6 +364,9 @@ export async function getDataSourcesUsageByCategory({
     AgentDataSourceConfiguration.findAll({
       raw: true,
       group: ["dataSource.id"],
+      where: {
+        workspaceId: owner.id,
+      },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
         [
@@ -400,6 +412,9 @@ export async function getDataSourcesUsageByCategory({
     AgentDataSourceConfiguration.findAll({
       raw: true,
       group: ["dataSource.id"],
+      where: {
+        workspaceId: owner.id,
+      },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
         [
@@ -445,6 +460,9 @@ export async function getDataSourcesUsageByCategory({
     AgentDataSourceConfiguration.findAll({
       raw: true,
       group: ["dataSource.id"],
+      where: {
+        workspaceId: owner.id,
+      },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
         [
@@ -593,6 +611,7 @@ export async function getDataSourceUsage({
       ],
       where: {
         dataSourceId: dataSource.id,
+        workspaceId: owner.id,
       },
       include: [
         {

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -77,11 +77,27 @@ AgentDataSourceConfiguration.init(
   {
     modelName: "agent_data_source_configuration",
     indexes: [
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-13): Remove index
       { fields: ["retrievalConfigurationId"] },
+      {
+        fields: ["workspaceId", "retrievalConfigurationId"],
+        concurrently: true,
+        name: "agent_data_source_config_workspace_id_retrieval_config_id",
+      },
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-13): Remove index
       { fields: ["processConfigurationId"] },
+      {
+        fields: ["workspaceId", "processConfigurationId"],
+        name: "agent_data_source_config_workspace_id_process_config_id",
+        concurrently: true,
+      },
       { fields: ["mcpServerConfigurationId"] },
       { fields: ["dataSourceId"] },
       { fields: ["dataSourceViewId"] },
+      {
+        fields: ["workspaceId"],
+        concurrently: true,
+      },
     ],
     sequelize: frontSequelize,
     hooks: {

--- a/front/migrations/db/migration_257.sql
+++ b/front/migrations/db/migration_257.sql
@@ -1,0 +1,4 @@
+-- Migration created on May 13, 2025
+CREATE INDEX CONCURRENTLY "agent_data_source_configurations_workspace_id" ON "agent_data_source_configurations" ("workspaceId");
+CREATE INDEX CONCURRENTLY "agent_data_source_config_workspace_id_retrieval_config_id" ON "agent_data_source_configurations" ("workspaceId", "retrievalConfigurationId");
+CREATE INDEX CONCURRENTLY "agent_data_source_config_workspace_id_process_config_id" ON "agent_data_source_configurations" ("workspaceId", "processConfigurationId");


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add `workspaceId` filtering to `AgentDataSourceConfiguration.find` query
- Add migration with composite indexes

## Tests
- Locally check that usages are the same
- Front-edge check that usages are the same than before

## Risk
- Mid, touching AgentDataSourceConfiguration, if wrong could reduce data source config available to agent
- ok to revert

## Deploy Plan
- [x] Run migration
- [x] Deploy front
