### PR TITLE
[Builder - MCP] Fix nit: view tool dropdown

### DIFF
--- a/front/components/assistant_builder/MCPServerSelector.tsx
+++ b/front/components/assistant_builder/MCPServerSelector.tsx
@@ -147,7 +147,13 @@ export function MCPServerSelector({
                               className="flex max-h-96 w-96 flex-col"
                             >
                               {mcpServerView.server.tools.map((tool) => (
-                                <DropdownMenuItem key={tool.name}>
+                                <DropdownMenuItem
+                                  key={tool.name}
+                                  className="cursor-default hover:bg-transparent dark:hover:bg-transparent"
+                                  onSelect={(event) => {
+                                    event.preventDefault();
+                                  }}
+                                >
                                   <div className="flex flex-col gap-1">
                                     <p className="text-sm font-semibold text-foreground dark:text-foreground-night">
                                       {tool.name}


### PR DESCRIPTION
## Description

The `DropdownMenuItem` components used to display tool details within the `MCPServerSelector` in the assistant builder had a few undesired behaviors:
- Items were grayed out on hover.
- The mouse cursor changed to a click pointer when hovering over an item.
- Clicking on an item within the tool details dropdown caused the dropdown to close.
![Screenshot From 2025-05-13 18-24-14](https://github.com/user-attachments/assets/e89cbd57-887a-4fc5-b377-9e43d6be66cc)



This PR addresses these issues by modifying the `DropdownMenuItem` specifically within the tool details view. The changes ensure that:
- There is no hover effect (background color change) on the items.
- The cursor remains the default system cursor.
- Clicking on an item does not close the dropdown, allowing users to inspect multiple tool details without needing to reopen the menu each time.

These changes improve the user experience when exploring the available tools for an agent.

## Risks
None

## Tests

- Manual testing was performed to verify the following:
    - Hovering over a tool name in the dropdown (e.g., `create_issue` as shown in the original screenshot) no longer changes its background color.
    - The mouse cursor does not change to a pointer when hovering over these tool names.
    - Clicking a tool name (e.g., `create_issue`) does not close the dropdown menu.
- All existing automated tests should continue to pass as this change primarily affects UI interaction and styling within a specific component, not underlying logic.

## Deploy Plan

- Deploy the `front` service.

