### PR TITLE
[Assistant Builder] Fix: current editor added multiple times to group

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -266,7 +266,9 @@ export default function AssistantBuilder({
     if (!agentConfigurationId) {
       setBuilderState((state) => ({
         ...state,
-        editors: [...state.editors, user],
+        editors: state.editors.some((m) => m.sId === user.sId)
+          ? state.editors
+          : [...state.editors, user],
       }));
     }
   }, [


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2828

Description
---
see title & issue
(note: glitch was only on builder view, group was correctly saved with one single editor)

Risks
---
none

Deploy
---
front