### PR TITLE
Frank/transcripts sid

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -397,7 +397,7 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error("Missing --cId argument");
       }
       const transcriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchByModelId(args.cId);
+        await LabsTranscriptsConfigurationResource.fetchById(args.cId);
 
       if (!transcriptsConfiguration) {
         throw new Error(
@@ -421,7 +421,7 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error("Missing --cId argument");
       }
       const transcriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchByModelId(args.cId);
+        await LabsTranscriptsConfigurationResource.fetchById(args.cId);
 
       if (!transcriptsConfiguration) {
         throw new Error(

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -257,15 +257,26 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
   /**
    * History
    */
-  async recordHistory(
-    blob: Omit<
-      CreationAttributes<LabsTranscriptsHistoryModel>,
-      "id" | "configurationId"
-    >
-  ): Promise<InferAttributes<LabsTranscriptsHistoryModel>> {
+  async recordHistory({
+    workspace,
+    fileId,
+    fileName,
+    conversationId,
+    stored,
+  }: {
+    workspace: LightWorkspaceType;
+    fileId: string;
+    fileName: string;
+    conversationId?: string | null;
+    stored?: boolean;
+  }): Promise<InferAttributes<LabsTranscriptsHistoryModel>> {
     const history = await LabsTranscriptsHistoryModel.create({
-      ...blob,
       configurationId: this.id,
+      workspaceId: workspace.id,
+      fileId,
+      fileName,
+      conversationId: conversationId,
+      stored: stored,
     });
     return history.get();
   }
@@ -349,7 +360,8 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
 
   toJSON(): LabsTranscriptsConfigurationType {
     return {
-      id: this.sId,
+      id: this.id,
+      sId: this.sId,
       workspaceId: this.workspaceId,
       provider: this.provider,
       agentConfigurationId: this.agentConfigurationId,

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -14,11 +14,7 @@ import {
   LabsTranscriptsHistoryModel,
 } from "@app/lib/resources/storage/models/labs_transcripts";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import {
-  getResourceIdFromSId,
-  getResourceNameAndIdFromSId,
-  makeSId,
-} from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   LabsTranscriptsConfigurationType,
@@ -261,20 +257,15 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
   /**
    * History
    */
-  static async recordHistoryWithSId(
-    configurationSId: string,
+  async recordHistory(
     blob: Omit<
       CreationAttributes<LabsTranscriptsHistoryModel>,
       "id" | "configurationId"
     >
   ): Promise<InferAttributes<LabsTranscriptsHistoryModel>> {
-    const details = getResourceNameAndIdFromSId(configurationSId);
-    if (!details || details.resourceName !== "transcripts_configuration") {
-      throw new Error("Invalid configuration sId");
-    }
     const history = await LabsTranscriptsHistoryModel.create({
       ...blob,
-      configurationId: Number(details.resourceModelId),
+      configurationId: this.id,
     });
     return history.get();
   }

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -33,13 +33,14 @@ const RESOURCES_PREFIX = {
   mcp_server_view: "msv",
   remote_mcp_server: "rms",
   tag: "tag",
+  transcripts_configuration: "tsc",
 
   // Resources relative to the configuration of an MCP server.
   data_source_configuration: "dsc",
   table_configuration: "tbc",
   child_agent_configuration: "cac",
 
-  // Virtual resources (no database modelsassociated).
+  // Virtual resources (no database models associated).
   internal_mcp_server: "ims",
 };
 

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -112,7 +112,7 @@ export function useUpdateTranscriptsConfiguration({
     data: Partial<PatchTranscriptsConfiguration>
   ): Promise<Result<undefined, Error>> => {
     const response = await fetch(
-      `/api/w/${owner.sId}/labs/transcripts/${transcriptsConfiguration.id}`,
+      `/api/w/${owner.sId}/labs/transcripts/${transcriptsConfiguration.sId}`,
       {
         method: "PATCH",
         headers: {

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -63,7 +63,7 @@ async function handler(
   }
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchByModelId(
+    await LabsTranscriptsConfigurationResource.fetchById(
       transcriptsConfigurationId
     );
   // TODO(2024-04-19 flav) Consider adding auth to `fetchById` to move this permission check within the method.
@@ -121,7 +121,7 @@ async function handler(
       if (isActive !== undefined) {
         logger.info(
           {
-            configurationId: transcriptsConfiguration.id,
+            configurationId: transcriptsConfiguration.sId,
             isActive,
           },
           "Setting transcript configuration active status."
@@ -166,8 +166,8 @@ async function handler(
       }
 
       const updatedTranscriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchByModelId(
-          transcriptsConfiguration.id
+        await LabsTranscriptsConfigurationResource.fetchById(
+          transcriptsConfiguration.sId
         );
 
       if (!updatedTranscriptsConfiguration) {
@@ -187,7 +187,7 @@ async function handler(
       if (shouldStartWorkflow) {
         logger.info(
           {
-            configurationId: updatedTranscriptsConfiguration.id,
+            configurationId: updatedTranscriptsConfiguration.sId,
           },
           "Starting transcript retrieval workflow."
         );

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -78,7 +78,7 @@ async function handler(
       }
 
       return res.status(200).json({
-        configuration: transcriptsConfiguration,
+        configuration: transcriptsConfiguration.toJSON(),
       });
   }
 }

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -167,7 +167,7 @@ export default function LabsTranscriptsIndex({
           onClose={() => setIsDeleteProviderDialogOpened(false)}
           onConfirm={async () => {
             await handleDisconnectProvider(
-              transcriptsConfiguration?.id || null
+              transcriptsConfiguration?.sId || null
             );
           }}
         />

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -24,7 +24,6 @@ import { useLabsTranscriptsConfiguration } from "@app/lib/swr/labs";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type {
   DataSourceViewType,
-  ModelId,
   SubscriptionType,
   WhitelistableFeature,
   WorkspaceType,
@@ -93,7 +92,7 @@ export default function LabsTranscriptsIndex({
   const sendNotification = useSendNotification();
 
   const handleDisconnectProvider = async (
-    transcriptConfigurationId: ModelId | null
+    transcriptConfigurationId: string | null
   ) => {
     if (!transcriptConfigurationId) {
       return;

--- a/front/poke/swr/agent_configurations.ts
+++ b/front/poke/swr/agent_configurations.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -341,14 +341,11 @@ export async function processTranscriptActivity(
   }
 
   try {
-    await LabsTranscriptsConfigurationResource.recordHistoryWithSId(
-      transcriptsConfiguration.sId,
-      {
-        fileId,
-        fileName: transcriptTitle.substring(0, 255),
-        workspaceId: owner.id,
-      }
-    );
+    await transcriptsConfiguration.recordHistory({
+      fileId,
+      fileName: transcriptTitle.substring(0, 255),
+      workspaceId: owner.id,
+    });
   } catch (error) {
     if (error instanceof UniqueConstraintError) {
       localLogger.info(

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -344,7 +344,7 @@ export async function processTranscriptActivity(
     await transcriptsConfiguration.recordHistory({
       fileId,
       fileName: transcriptTitle.substring(0, 255),
-      workspaceId: owner.id,
+      workspace: owner,
     });
   } catch (error) {
     if (error instanceof UniqueConstraintError) {

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -42,14 +42,14 @@ import { Err } from "@app/types";
 import { CoreAPI } from "@app/types";
 
 export async function retrieveNewTranscriptsActivity(
-  transcriptsConfigurationId: ModelId
+  transcriptsConfigurationId: string
 ): Promise<string[]> {
   const localLogger = mainLogger.child({
-    transcriptsConfigurationId,
+    transcriptsConfigurationId: transcriptsConfigurationId,
   });
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchByModelId(
+    await LabsTranscriptsConfigurationResource.fetchById(
       transcriptsConfigurationId
     );
 
@@ -129,7 +129,7 @@ export async function retrieveNewTranscriptsActivity(
 }
 
 export async function processTranscriptActivity(
-  transcriptsConfigurationId: ModelId,
+  transcriptsConfigurationId: string,
   fileId: string
 ) {
   function convertCitationsToLinks(
@@ -187,7 +187,7 @@ export async function processTranscriptActivity(
   }
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchByModelId(
+    await LabsTranscriptsConfigurationResource.fetchById(
       transcriptsConfigurationId
     );
 
@@ -341,12 +341,14 @@ export async function processTranscriptActivity(
   }
 
   try {
-    await transcriptsConfiguration.recordHistory({
-      configurationId: transcriptsConfiguration.id,
-      fileId,
-      fileName: transcriptTitle.substring(0, 255),
-      workspaceId: owner.id,
-    });
+    await LabsTranscriptsConfigurationResource.recordHistoryWithSId(
+      transcriptsConfiguration.sId,
+      {
+        fileId,
+        fileName: transcriptTitle.substring(0, 255),
+        workspaceId: owner.id,
+      }
+    );
   } catch (error) {
     if (error instanceof UniqueConstraintError) {
       localLogger.info(

--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -18,12 +18,12 @@ export async function launchRetrieveTranscriptsWorkflow(
 
   try {
     await client.workflow.start(retrieveNewTranscriptsWorkflow, {
-      args: [transcriptsConfiguration.id],
+      args: [transcriptsConfiguration.sId],
       taskQueue: TRANSCRIPTS_QUEUE_NAME,
       workflowId: workflowId,
       cronSchedule: "*/5 * * * *",
       memo: {
-        configurationId: transcriptsConfiguration.id,
+        configurationId: transcriptsConfiguration.sId,
         IsProcessingTranscripts: transcriptsConfiguration.isActive,
         IsStoringTranscripts:
           transcriptsConfiguration.dataSourceViewId !== null,

--- a/front/temporal/labs/transcripts/config.ts
+++ b/front/temporal/labs/transcripts/config.ts
@@ -1,3 +1,3 @@
-const QUEUE_VERSION = 1;
+const QUEUE_VERSION = 2;
 
 export const TRANSCRIPTS_QUEUE_NAME = `labs-transcripts-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/labs/transcripts/utils.ts
+++ b/front/temporal/labs/transcripts/utils.ts
@@ -4,14 +4,14 @@ import type { ModelId } from "@app/types";
 export function makeRetrieveTranscriptWorkflowId(
   transcriptsConfiguration: LabsTranscriptsConfigurationResource
 ): string {
-  return `labs-transcripts-retrieve-${transcriptsConfiguration.id}`;
+  return `labs-transcripts-retrieve-${transcriptsConfiguration.sId}`;
 }
 
 export function makeProcessTranscriptWorkflowId({
   transcriptsConfigurationId,
   fileId,
 }: {
-  transcriptsConfigurationId: ModelId;
+  transcriptsConfigurationId: string;
   fileId: string;
 }): string {
   return `labs-transcripts-process-${transcriptsConfigurationId}-${fileId}`;

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -209,7 +209,7 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.id,
+          transcriptsConfigurationId: transcriptsConfiguration.sId,
         },
         "[retrieveGongTranscripts] User not found. Skipping."
       );
@@ -232,7 +232,7 @@ export async function retrieveGongTranscriptContent(
         localLogger.error(
           {
             fileId,
-            transcriptsConfigurationId: transcriptsConfiguration.id,
+            transcriptsConfigurationId: transcriptsConfiguration.sId,
             status: response.status,
           },
           "[retrieveGongTranscripts] Error fetching Gong users. Skipping."
@@ -264,7 +264,7 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.id,
+          transcriptsConfigurationId: transcriptsConfiguration.sId,
           userEmail: user.email,
         },
         "[retrieveGongTranscripts] Gong user not found. Skipping."
@@ -297,7 +297,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[retrieveGongTranscripts] Error fetching call from Gong. Skipping."
     );
@@ -317,7 +317,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[retrieveGongTranscripts] Call data not found from Gong. Skipping."
     );

--- a/front/temporal/labs/transcripts/utils/modjo.ts
+++ b/front/temporal/labs/transcripts/utils/modjo.ts
@@ -340,7 +340,7 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[processTranscriptActivity] Error fetching call from Modjo. Skipping."
     );
@@ -364,7 +364,7 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[processTranscriptActivity] Call data not found from Modjo. Skipping."
     );

--- a/front/temporal/labs/transcripts/workflows.ts
+++ b/front/temporal/labs/transcripts/workflows.ts
@@ -4,8 +4,6 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
-import type { ModelId } from "@app/types";
-
 import type * as activities from "./activities";
 import { makeProcessTranscriptWorkflowId } from "./utils";
 
@@ -15,7 +13,7 @@ const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
   });
 
 export async function retrieveNewTranscriptsWorkflow(
-  transcriptsConfigurationId: ModelId
+  transcriptsConfigurationId: string
 ) {
   const filesToProcess = await retrieveNewTranscriptsActivity(
     transcriptsConfigurationId
@@ -47,7 +45,7 @@ export async function processTranscriptWorkflow({
   transcriptsConfigurationId,
 }: {
   fileId: string;
-  transcriptsConfigurationId: ModelId;
+  transcriptsConfigurationId: string;
 }): Promise<void> {
   await processTranscriptActivity(transcriptsConfigurationId, fileId);
 }

--- a/front/types/labs.ts
+++ b/front/types/labs.ts
@@ -23,7 +23,7 @@ export type LabsConnectionType = (typeof labsConnections)[number];
 // Types
 
 export type LabsTranscriptsConfigurationType = {
-  id: ModelId;
+  id: string;
   workspaceId: ModelId;
   provider: LabsTranscriptsProviderType;
   agentConfigurationId: string | null;

--- a/front/types/labs.ts
+++ b/front/types/labs.ts
@@ -23,7 +23,8 @@ export type LabsConnectionType = (typeof labsConnections)[number];
 // Types
 
 export type LabsTranscriptsConfigurationType = {
-  id: string;
+  id: ModelId;
+  sId: string;
   workspaceId: ModelId;
   provider: LabsTranscriptsProviderType;
   agentConfigurationId: string | null;


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/dust/issues/12511
* Move LabsTranscriptResource to being operated with sId as well, NO MODEL ID should be used to point objects across network boundary ever.

## Tests

* Local testing confirming transcript processing

## Risk

* Scoped to labs transcripts

## Deploy Plan

This WILL break existing workflows, so will need to follow temporal runbook:

* Stop all transcript workflows (npx tsx migrations/20250321_startstop_relocated_transcripts_workflows.ts --workspaceIds="all" --action="stop" --execute)
* Merge / deploy
* Start all transcript workflows (npx tsx migrations/20250321_startstop_relocated_transcripts_workflows.ts --workspaceIds="all" --action="start" --execute)