### PR TITLE
[front] chore(message): Add some missing workspaceId filtering

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -467,6 +467,7 @@ export async function getSuggestedAgentsForConversation(
   // and this comes from a route so since we don't want to pass the model id in a route we use the conversation sId.
   const message = await Message.findOne({
     where: {
+      workspaceId: owner.id,
       conversationId: conversation.id,
     },
     order: [
@@ -1275,6 +1276,7 @@ export async function* editUserMessage(
         where: {
           sId: message.sId,
           conversationId: conversation.id,
+          workspaceId: owner.id,
         },
         include: [
           {
@@ -1292,6 +1294,7 @@ export async function* editUserMessage(
       }
       const newerMessage = await Message.findOne({
         where: {
+          workspaceId: owner.id,
           rank: messageRow.rank,
           conversationId: conversation.id,
           version: messageRow.version + 1,
@@ -1612,6 +1615,7 @@ export async function* retryAgentMessage(
 
       const messageRow = await Message.findOne({
         where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
           conversationId: conversation.id,
           id: message.id,
         },
@@ -1630,6 +1634,7 @@ export async function* retryAgentMessage(
       }
       const newerMessage = await Message.findOne({
         where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
           rank: messageRow.rank,
           conversationId: conversation.id,
           version: messageRow.version + 1,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -453,9 +453,15 @@ Message.init(
         unique: true,
         fields: ["sId"],
       },
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-13): Remove index
       {
         unique: true,
         fields: ["conversationId", "rank", "version"],
+      },
+      {
+        unique: true,
+        fields: ["workspaceId", "conversationId", "rank", "version"],
+        concurrently: true,
       },
       {
         fields: ["agentMessageId"],

--- a/front/migrations/db/migration_261.sql
+++ b/front/migrations/db/migration_261.sql
@@ -1,2 +1,2 @@
--- Empty migration to avoid overload during remediations
--- see https://github.com/dust-tt/tasks/issues/2842 for details
+-- Migration created on May 13, 2025
+CREATE UNIQUE INDEX CONCURRENTLY "messages_workspace_id_conversation_id_rank_version" ON "messages" ("workspaceId", "conversationId", "rank", "version");


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add some missing workspaceId filtering
- Add migration with new composite indexes

Used the migration created as starting point for migration after the workspaceId checks

## Tests
- Locally could retry a message
- Locally could send a message without mentioning any agent, then clicking to one of the suggested one, message edited correctly

## Risk
Mid, touching retry and message edition

## Deploy Plan
- [x] Run migration
- [x] Deploy front
