### PR TITLE
[Conversation] Copy message content - properly copy citations

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -77,11 +77,6 @@ import {
   removeNulls,
 } from "@app/types";
 
-function cleanUpCitations(message: string): string {
-  const regex = / ?:cite\[[a-zA-Z0-9, ]+\]/g;
-  return message.replace(regex, "");
-}
-
 interface AgentMessageProps {
   conversationId: string;
   isLastMessage: boolean;


### PR DESCRIPTION
Description
---
This was a request from a customer met today, see [here](https://dust4ai.slack.com/archives/C0506K7ETLN/p1747139854907819) -- wanted to action quickly to show responsivity.

Example on the following message:
![image](https://github.com/user-attachments/assets/00ebc682-27ee-4f4c-8a26-632a1d8d318b)

### Copy before
```
Here are summaries for each document in the "Test drive" folder:

1. **bip**  
   - The document is titled "bip" and was created and last edited by Philippe Rolet on July 1, 2024.  
   - No detailed content is available from the search, but its label is "bip".  
   - 

2. **Test 20**  
   - The document is titled "Test 20" and was created and last edited by Philippe Rolet on January 15, 2025.  
   - It carries the label "Oh yeah".  
   - No detailed content is available from the search.  
   - 

If you would like more detailed summaries or extracts from the documents themselves, let me know!
```
### Copy after
```
Here are summaries for each document in the "Test drive" folder:

1. **bip**  
   - The document is titled "bip" and was created and last edited by Philippe Rolet on July 1, 2024.  
   - No detailed content is available from the search, but its label is "bip".  
   - [1]

2. **Test 20**  
   - The document is titled "Test 20" and was created and last edited by Philippe Rolet on January 15, 2025.  
   - It carries the label "Oh yeah".  
   - No detailed content is available from the search.  
   - [2]

If you would like more detailed summaries or extracts from the documents themselves, let me know!

References:
[1] https://drive.google.com/file/d/1iFZmnPSRdS0tplRw4M0SE87_99mK7wNT7FE2Q36rCNU/view
[2] https://drive.google.com/file/d/1rir3pqk2RfXqNyo1Ru0FzJlfBrjnepjfNxzrx4uLsR4/view
```
## Risks
citations not working well in copy; low blast radius

## Deploy
front