### PR TITLE
Remove mcp_actions feature flag

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -97,7 +97,7 @@ const ConversationLayoutContent = ({
   });
 
   const hasCoEditionFeatureFlag = useMemo(
-    () => hasFeature("mcp_actions") && hasFeature("co_edition"),
+    () => hasFeature("co_edition"),
     [hasFeature]
   );
 

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -47,7 +47,6 @@ import type {
   DataSourceViewType,
   LightWorkspaceType,
   SpaceType,
-  WhitelistableFeature,
 } from "@app/types";
 import {
   asDisplayName,
@@ -243,7 +242,7 @@ const SYSTEM_SPACE_ITEMS = [
     label: "Tools",
     visual: BoltIcon,
     category: "actions" as DataSourceViewCategory,
-    flag: "mcp_actions" as WhitelistableFeature,
+    flag: null,
   },
 ];
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -47,14 +47,13 @@ export const INTERNAL_MCP_SERVERS: Record<
   // Notes:
   // ids should be stable, do not change them for production internal servers as it would break existing agents.
   // Let's start dev actions at 1000 to avoid conflicts with production actions.
-  // flag "mcp_actions" for actions that are part of the MCP actions feature.
   // flag "dev_mcp_actions" for actions that are only used internally for dev and testing.
 
   // Production
   github: {
     id: 1,
     availability: "manual",
-    flag: "mcp_actions",
+    flag: null,
     tools_stakes: {
       get_pull_request: "never_ask",
     },
@@ -67,7 +66,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   file_generation: {
     id: 3,
     availability: "auto",
-    flag: "mcp_actions",
+    flag: null,
   },
   query_tables: {
     id: 4,

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -96,7 +96,7 @@ export const ACTION_SPECIFICATIONS: Record<
     description: "Add additional sets of tools",
     cardIcon: BoltIcon,
     dropDownIcon: BoltIcon,
-    flag: "mcp_actions",
+    flag: null,
   },
 };
 

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -130,7 +130,6 @@ export const CATEGORY_DETAILS: {
   actions: {
     label: "Tools",
     icon: ACTION_SPECIFICATIONS["MCP"].cardIcon,
-    flag: "mcp_actions",
   },
 };
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -189,7 +189,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.47",
+      "version": "1.0.48",
       "license": "ISC",
       "dependencies": {
         "@types/json-schema": "^7.0.15",

--- a/front/pages/w/[wId]/me/index.tsx
+++ b/front/pages/w/[wId]/me/index.tsx
@@ -10,7 +10,6 @@ import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useUser } from "@app/lib/swr/user";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
@@ -38,9 +37,6 @@ export default function ProfilePage({
   owner,
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const { hasFeature } = useFeatureFlags({
-    workspaceId: owner.sId,
-  });
   const { user, isUserLoading, mutateUser } = useUser();
 
   return (
@@ -68,12 +64,8 @@ export default function ProfilePage({
 
             <Separator />
 
-            {hasFeature("mcp_actions") && (
-              <>
-                <Page.SectionHeader title="Tools Confirmation Preferences" />
-                <UserToolsTable owner={owner} />
-              </>
-            )}
+            <Page.SectionHeader title="Tools Confirmation Preferences" />
+            <UserToolsTable owner={owner} />
           </Page.Layout>
         </Page>
       </AppContentLayout>

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -15,7 +15,6 @@ export const WHITELISTABLE_FEATURES = [
   "labs_salesforce_personal_connections",
   "labs_trackers",
   "labs_transcripts",
-  "mcp_actions",
   "okta_enterprise_connection",
   "openai_o1_custom_assistants_feature",
   "openai_o1_feature",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -809,7 +809,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_salesforce_personal_connections"
   | "labs_trackers"
   | "labs_transcripts"
-  | "mcp_actions"
   | "okta_enterprise_connection"
   | "openai_o1_custom_assistants_feature"
   | "openai_o1_feature"


### PR DESCRIPTION
## Description

Make MCP tools available to all.
- Will enable file_generation tool
- Will enable github tool
- Will show "tools" in knowledge > administration
- Will show "tools" in knowledge > space X
- Will allow adding remote MCP server as tool
- Will show tools approval pref in profile.
- Will show "add more.." in agent builder (until yuka's PR, should be this morning)

## Tests

Locally

## Risk

Low, we have been running with the flag ON for many workspaces since a few weeks.

## Deploy Plan

Deploy `front`