### PR TITLE
Extension: Fix version comparison + cleanup screen

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -22,6 +22,7 @@
         "@tiptap/react": "^2.9.1",
         "@tiptap/starter-kit": "^2.9.1",
         "buffer": "^6.0.3",
+        "compare-versions": "^6.1.1",
         "event-source-polyfill": "^1.0.31",
         "https-browserify": "^1.0.0",
         "jwt-decode": "^4.0.0",
@@ -5170,6 +5171,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="
     },
     "node_modules/compressible": {
       "version": "2.0.18",

--- a/extension/package.json
+++ b/extension/package.json
@@ -69,6 +69,7 @@
     "@tiptap/react": "^2.9.1",
     "@tiptap/starter-kit": "^2.9.1",
     "buffer": "^6.0.3",
+    "compare-versions": "^6.1.1",
     "event-source-polyfill": "^1.0.31",
     "https-browserify": "^1.0.0",
     "jwt-decode": "^4.0.0",

--- a/extension/platforms/chrome/main.tsx
+++ b/extension/platforms/chrome/main.tsx
@@ -22,6 +22,7 @@ import {
   Notification,
   Page,
 } from "@dust-tt/sparkle";
+import { compare } from "compare-versions";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
@@ -37,7 +38,8 @@ const ChromeExtensionWrapper = () => {
     if (!pendingUpdate) {
       return null;
     }
-    if (pendingUpdate.version > chrome.runtime.getManifest().version) {
+    const currentVersion = chrome.runtime.getManifest().version;
+    if (compare(pendingUpdate.version, currentVersion, ">")) {
       setIsLatestVersion(false);
     }
   };
@@ -64,17 +66,20 @@ const ChromeExtensionWrapper = () => {
         )}
       >
         <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-center">
-          <div className="flex flex-col items-center text-center space-y-4">
-            <DustLogo className="h-6 w-24" />
-            <Page.Header title="Update required" />
+          <div className="flex flex-col items-center text-center gap-4">
+            <DustLogo className="h-12 w-48" />
+            <Page.Header title="New version ready" />
+            <Page.P>
+              Install the latest version to keep using Dust. <br />
+              Relaunch from toolbar.
+            </Page.P>
+            <Button
+              label="Update now"
+              onClick={async () => {
+                chrome.runtime.reload();
+              }}
+            />
           </div>
-          <Page.SectionHeader title="Panel closes after update. Click Dust icon in toolbar to return." />
-          <Button
-            label="Update now"
-            onClick={async () => {
-              chrome.runtime.reload();
-            }}
-          />
         </div>
       </div>
     );

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",


### PR DESCRIPTION
## Description

This PR fixes the logic to compare you have the latest version of the extension -> versions are in semver. 
I'm using this lib: https://www.npmjs.com/package/compare-versions

I also improved the design of the page (fix logo size, improve wording). 

<kbd>
<img width="402" src="https://github.com/user-attachments/assets/0d0e98d1-5272-40ef-9bb8-537b8c09365e" />
</kbd>

Before the wording was longer and the logo super small
<kbd>
<img width="402" alt="Screenshot 2025-05-14 at 09 13 13" src="https://github.com/user-attachments/assets/79f0c0ce-a7dc-4aec-9593-f46bffba8d8f" />
</kbd>

## Tests

Locally. 

## Risk

/ 

## Deploy Plan

Submit to the Chrome web store. 