### PR TITLE
Handle token failure in salesforce connector

### DIFF
--- a/connectors/src/connectors/salesforce/lib/oauth.ts
+++ b/connectors/src/connectors/salesforce/lib/oauth.ts
@@ -1,6 +1,7 @@
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 import { isValidSalesforceDomain } from "@connectors/types";
@@ -13,18 +14,37 @@ export type SalesforceAPICredentials = {
 export async function getSalesforceCredentials(
   connectionId: string
 ): Promise<Result<SalesforceAPICredentials, Error>> {
-  const creds = await getOAuthConnectionAccessTokenWithThrow({
-    logger,
-    provider: "salesforce",
-    connectionId,
-  });
+  try {
+    const creds = await getOAuthConnectionAccessTokenWithThrow({
+      logger,
+      provider: "salesforce",
+      connectionId,
+    });
 
-  const accessToken = creds.access_token;
-  const instanceUrl = creds.connection.metadata.instance_url;
+    const accessToken = creds.access_token;
+    const instanceUrl = creds.connection.metadata.instance_url;
 
-  if (!accessToken || !instanceUrl || !isValidSalesforceDomain(instanceUrl)) {
-    return new Err(new Error("Invalid credentials"));
+    if (!accessToken || !instanceUrl || !isValidSalesforceDomain(instanceUrl)) {
+      return new Err(new Error("Invalid credentials"));
+    }
+
+    return new Ok({ accessToken, instanceUrl });
+  } catch (e: unknown) {
+    // So that will be catched upstream by ActivityInboundLogInterceptor and stop the workflow.
+    if (isSalesforceSignInError(e)) {
+      throw new ExternalOAuthTokenError(e);
+    }
+
+    throw e;
   }
+}
 
-  return new Ok({ accessToken, instanceUrl });
+function isSalesforceSignInError(err: unknown): err is Error {
+  return (
+    err instanceof Error &&
+    err.message.startsWith(
+      "Error retrieving access token from salesforce: code=provider_access_token_refresh_error"
+    ) &&
+    err.message.includes("invalid_grant")
+  );
 }


### PR DESCRIPTION
## Description

Did the same thing as microsoft but wondering if:
- We should throw the same error for the lines just above ? (instead of new Err("invalid grant")) ?
- Should we handle directly in getOAuthConnectionAccessTokenWithThrow() ?

[Stuck workflow](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId%2C%40error_stack&event=AwAAAZbNnbN2opQURQAAABhBWmJObmNIQUFBQ0N5di1faFFlckNBQWcAAAAkMDE5NmNkOWUtOWJmZC00ZDA5LWE3ODAtMmRjOGYyMDJkMTZlAAATbQ&link_source=monitor_notif&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40workflowId%3Asalesforce-sync-22923%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22workflowId%22%2C%22value%22%3A%22salesforce-sync-22923%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1747205902800%2C%22to%22%3A1747206802800%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1747205902776&to_ts=1747206802776&live=true)
 
## Tests

Hard to do locally but fairly confident it's harmless.

## Risk

Low

## Deploy Plan

Deploy `connectors`