### PR TITLE
fix(cli): add -s as a short flag for --sId

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/dust-cli",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@dust-tt/client": "^1.0.47",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -30,6 +30,7 @@ interface AppProps {
     };
     sId: {
       type: "string";
+      shortFlag: "s";
       isMultiple: true;
     };
   }>;


### PR DESCRIPTION
## Description

We want `dust -s` to be equivalent to `dust --sId`

## Tests

Manual

## Risk

N/A

## Deploy Plan

publish CLI