### PR TITLE
chore(MCP): remove the `think` tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/think.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/think.ts
@@ -14,34 +14,6 @@ const serverInfo: InternalMCPServerDefinitionType = {
 const createServer = (): McpServer => {
   const server = new McpServer(serverInfo);
 
-  const thinkToolPrompt = `Use the tool to think about something. It will not obtain new information or make any changes to the repository, but just log the thought. Use it when complex reasoning or brainstorming is needed.
-
-Common use cases:
-1. When planning a complex refactoring, use this tool to outline different approaches and their tradeoffs
-2. When designing a new feature, use this tool to think through architecture decisions and implementation details
-3. When debugging a complex issue, use this tool to organize your thoughts and hypotheses
-
-The tool simply logs your thought process for better transparency and does not execute any code or make changes.`;
-
-  server.tool(
-    "think",
-    thinkToolPrompt,
-    {
-      thought: z.string().describe("A thought to think about."),
-    },
-    async () => {
-      return {
-        isError: false,
-        content: [
-          {
-            type: "text",
-            text: "Successfully thought about it.",
-          },
-        ],
-      };
-    }
-  );
-
   const describePlanToolPrompt = `Use this tool when you need to outline a detailed plan for solving a complex problem. It will not obtain new information or make any changes to the repository, but will log your plan for reference throughout the conversation.
 
 Common use cases:


### PR DESCRIPTION
## Description

This PR removes the `think` tool.
There are cases where I still want to use the `describePlan` tool so instead of removing the MCP server from my agents I need to remove the `think` tool.

Current observations:
- This tool ended up not living up to the expectations, it clashes and overlaps in purpose with the system prompt.
- When it ended up being used, most often it was used all the time with visibly little added value.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
