### PR TITLE
[front] feat(AgentTablesQueryConfiguration): Add workspaceId filter

### DIFF
--- a/front/lib/actions/configuration/table_query.ts
+++ b/front/lib/actions/configuration/table_query.ts
@@ -41,6 +41,7 @@ export async function fetchTableQueryActionConfigurations(
   const agentTablesQueryConfigurationTables =
     await AgentTablesQueryConfigurationTable.findAll({
       where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
         tablesQueryConfigurationId: {
           [Op.in]: tableQueryConfigurations.map((r) => r.id),
         },

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -112,6 +112,7 @@ export async function fetchAgentTableConfigurations(
     await AgentTablesQueryConfigurationTable.findAll({
       where: {
         id: { [Op.in]: configurationIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -251,6 +251,9 @@ export async function getDataSourceViewsUsageByCategory({
     AgentTablesQueryConfigurationTable.findAll({
       raw: true,
       group: ["dataSourceView.id"],
+      where: {
+        workspaceId: owner.id,
+      },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
         [
@@ -508,6 +511,9 @@ export async function getDataSourcesUsageByCategory({
     AgentTablesQueryConfigurationTable.findAll({
       raw: true,
       group: ["dataSource.id"],
+      where: {
+        workspaceId: owner.id,
+      },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
         [
@@ -722,6 +728,7 @@ export async function getDataSourceUsage({
         ],
       ],
       where: {
+        workspaceId: owner.id,
         dataSourceId: dataSource.id,
       },
       include: [
@@ -908,6 +915,7 @@ export async function getDataSourceViewUsage({
         ],
       ],
       where: {
+        workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,
       },
       include: [

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -121,6 +121,11 @@ AgentTablesQueryConfigurationTable.init(
         fields: ["dataSourceViewId", "tableId", "tablesQueryConfigurationId"],
         name: "agent_tables_query_configuration_table_unique_dsv",
       },
+      {
+        fields: ["workspaceId", "tablesQueryConfigurationId"],
+        concurrently: true,
+        name: "agent_tables_query_config_table_w_id_tables_query_config_id",
+      },
       // TODO(WORKSPACE_ID_ISOLATION 2025-05-14): Remove index
       { fields: ["dataSourceId"] },
       {

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -121,8 +121,20 @@ AgentTablesQueryConfigurationTable.init(
         fields: ["dataSourceViewId", "tableId", "tablesQueryConfigurationId"],
         name: "agent_tables_query_configuration_table_unique_dsv",
       },
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-14): Remove index
       { fields: ["dataSourceId"] },
+      {
+        fields: ["workspaceId", "dataSourceId"],
+        concurrently: true,
+        name: "agent_tables_query_config_table_workspace_id_data_source_id",
+      },
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-14): Remove index
       { fields: ["dataSourceViewId"] },
+      {
+        fields: ["workspaceId", "dataSourceViewId"],
+        concurrently: true,
+        name: "agent_tables_query_config_table_w_id_data_source_view_id",
+      },
     ],
     sequelize: frontSequelize,
   }

--- a/front/migrations/db/migration_258.sql
+++ b/front/migrations/db/migration_258.sql
@@ -1,3 +1,4 @@
 -- Migration created on May 14, 2025
 CREATE INDEX CONCURRENTLY "agent_tables_query_config_table_workspace_id_data_source_id" ON "agent_tables_query_configuration_tables" ("workspaceId", "dataSourceId");
 CREATE INDEX CONCURRENTLY "agent_tables_query_config_table_w_id_data_source_view_id" ON "agent_tables_query_configuration_tables" ("workspaceId", "dataSourceViewId");
+CREATE INDEX CONCURRENTLY "agent_tables_query_config_table_w_id_tables_query_config_id" ON "agent_tables_query_configuration_tables" ("workspaceId", "tablesQueryConfigurationId");

--- a/front/migrations/db/migration_258.sql
+++ b/front/migrations/db/migration_258.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 14, 2025
+CREATE INDEX CONCURRENTLY "agent_tables_query_config_table_workspace_id_data_source_id" ON "agent_tables_query_configuration_tables" ("workspaceId", "dataSourceId");
+CREATE INDEX CONCURRENTLY "agent_tables_query_config_table_w_id_data_source_view_id" ON "agent_tables_query_configuration_tables" ("workspaceId", "dataSourceViewId");


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add `workspaceId` filter to AgentTablesQueryConfiguration
- Add migration for new indexes

## Tests
- Locally could add Tables Query to an agent, and fetch associated CSV files from a conversation

## Risk
- Mid, touching AgentTablesQueryConfiguration, but should be easy to revert

## Deploy Plan
- [x] Run migration
- [x] Deploy front
