### PR TITLE
let the input set duration as a number

### DIFF
--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -216,13 +216,14 @@ export function ActionRetrievalExhaustive({
           messageStatus={timeFrameError ? "error" : "default"}
           value={timeFrame.value?.toString() || ""}
           onChange={(e) => {
-            const value = parseInt(e.target.value, 10);
-            if (!isNaN(value) || !e.target.value) {
+            const duration = parseInt(e.target.value, 10);
+            if (!isNaN(duration) || !e.target.value) {
+              setTimeFrameError(null);
               setEdited(true);
               updateAction((previousAction) => ({
                 ...previousAction,
                 timeFrame: {
-                  value: e.target.value,
+                  value: duration || 1,
                   unit: timeFrame.unit,
                 },
               }));


### PR DESCRIPTION
Fix for https://github.com/dust-tt/tasks/issues/2852

Setting any value other than the default results in an error

{
"error": {
"type": "invalid_request_error",
"message": "Invalid request body: Expecting one of:\n { type: "retrieval_configuration", query: ("auto" | "none"), relativeTimeFrame: ("auto" | "none" | { duration: number, unit: f1ebc76b-e824-48f7-8e92-c31dffbf...\n { type: "retrieval_configuration", query: ("auto" | "none"), relativeTimeFrame: ("auto" | "none" | { duration: number, unit: f1ebc76b-e824-48f7-8e92-c31dffbf...\n { type: "retrieval_configuration", query: ("auto" | "none"), relativeTimeFrame: ("auto" | "none" | { duration: number, unit: f1ebc76b-e824-48f7-8e92-c31dffbf...\nat assistant.actions.0.0 but instead got: {"type":"retrieval_configuration","name":"include_data_sources","description":"fde","query":"none","relativeTimeFrame":{"duration":"3","unit":"day"},"topK":"auto","dataSources":[{"dataSourceViewId":"dsv_Q8Ac4uf35L","workspaceId":"smGFqoN2EV","filter":{"parents":null,"tags":null}}]}"
}
}

This is because the timeframe.duration field is sent as a string, and it should be a number.