### PR TITLE
Fix: do not check credentials when pausing/unpausing salesforce connector

### DIFF
--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -325,13 +325,18 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
   }
 
   async pause(): Promise<Result<undefined, Error>> {
-    const getConnectorAndCredentialsRes = await getConnectorAndCredentials(
-      this.connectorId
-    );
-    if (getConnectorAndCredentialsRes.isErr()) {
-      return new Err(getConnectorAndCredentialsRes.error);
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+
+    if (!connector) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+        },
+        "Notion connector not found."
+      );
+
+      return new Err(new Error("Connector not found"));
     }
-    const { connector } = getConnectorAndCredentialsRes.value;
 
     await connector.markAsPaused();
     const stopRes = await this.stop();
@@ -343,14 +348,18 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
-    const getConnectorAndCredentialsRes = await getConnectorAndCredentials(
-      this.connectorId
-    );
-    if (getConnectorAndCredentialsRes.isErr()) {
-      return new Err(getConnectorAndCredentialsRes.error);
-    }
-    const { connector } = getConnectorAndCredentialsRes.value;
+    const connector = await ConnectorResource.fetchById(this.connectorId);
 
+    if (!connector) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+        },
+        "Notion connector not found."
+      );
+
+      return new Err(new Error("Connector not found"));
+    }
     await connector.markAsUnpaused();
     const r = await this.resume();
     if (r.isErr()) {


### PR DESCRIPTION
## Description

Remove "side" check on credentials when getting connector to pause / unpause.

## Tests

Straightforward

## Risk

Low

## Deploy Plan

Deploy `connectors`