### PR TITLE
[front] - refacto(MCP): stronger typing in Dust App Run

### DIFF
--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -316,6 +316,12 @@ export function hasErrorActionMCP(
     ) {
       return "Please select a reasoning model.";
     }
+    if (
+      requirements.requiredDustAppConfiguration &&
+      !action.configuration.dustAppConfiguration
+    ) {
+      return "Please select a Dust App.";
+    }
 
     const missingFields = [];
     for (const key of requirements.requiredStrings) {

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -16,11 +16,11 @@ import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/r
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { Workspace } from "@app/lib/models/workspace";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import logger from "@app/logger/logger";
 import type { AgentFetchVariant, ModelId } from "@app/types";
 import { removeNulls } from "@app/types";
+import { AppResource } from "@app/lib/resources/app_resource";
 
 export async function fetchMCPServerActionConfigurations(
   auth: Authenticator,
@@ -73,14 +73,10 @@ export async function fetchMCPServerActionConfigurations(
     },
   ];
 
-  const allDustApps = await AppModel.findAll({
-    where: {
-      workspaceId: workspace.id,
-      sId: {
-        [Op.in]: removeNulls(mcpServerConfigurations.map((r) => r.appId)),
-      },
-    },
-  });
+  const allDustApps = await AppResource.fetchByIds(
+    auth,
+    removeNulls(mcpServerConfigurations.map((r) => r.appId))
+  );
 
   // Find the associated data sources configurations.
   const allDataSourceConfigurations =

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -15,12 +15,12 @@ import {
 import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { Workspace } from "@app/lib/models/workspace";
+import { AppResource } from "@app/lib/resources/app_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import logger from "@app/logger/logger";
 import type { AgentFetchVariant, ModelId } from "@app/types";
 import { removeNulls } from "@app/types";
-import { AppResource } from "@app/lib/resources/app_resource";
 
 export async function fetchMCPServerActionConfigurations(
   auth: Authenticator,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -184,7 +184,7 @@ export async function* tryCallMCPTool(
   try {
     const r = await connectToMCPServer(auth, {
       params: connectionParamsRes.value,
-      agentLoopRunContext,
+      agentLoopContext: { agentLoopRunContext },
     });
     if (r.isErr()) {
       yield {
@@ -648,7 +648,7 @@ async function listMCPServerTools(
     const connectionParams = connectionParamsRes.value;
     const r = await connectToMCPServer(auth, {
       params: connectionParams,
-      agentLoopListToolsContext,
+      agentLoopContext: { agentLoopListToolsContext },
     });
     if (r.isErr()) {
       return r;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -366,16 +366,18 @@ function getPrefixedToolName(
   return new Ok(prefixedName);
 }
 
+type AgentLoopListToolsContextWithoutConfigurationType = Omit<
+  AgentLoopListToolsContextType,
+  "agentActionConfiguration"
+>;
+
 /**
  * List the MCP tools for the given agent actions.
  * Returns MCP tools by connecting to the specified MCP servers.
  */
 export async function tryListMCPTools(
   auth: Authenticator,
-  agentLoopListToolsContext: Omit<
-    AgentLoopListToolsContextType,
-    "agentActionConfiguration"
-  >
+  agentLoopListToolsContext: AgentLoopListToolsContextWithoutConfigurationType
 ): Promise<{ tools: MCPToolConfigurationType[]; error?: string }> {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -29,12 +29,22 @@ export const isEnabledForWorkspace = async (
   return featureFlags.includes(flag);
 };
 
+export type ContextParams =
+  | {
+      agentLoopRunContext: AgentLoopRunContextType;
+      agentLoopListToolsContext?: never;
+    }
+  | {
+      agentLoopRunContext?: never;
+      agentLoopListToolsContext: AgentLoopListToolsContextType;
+    }
+  | { agentLoopRunContext?: never; agentLoopListToolsContext?: never };
+
 export const connectToInternalMCPServer = async (
   mcpServerId: string,
   transport: InMemoryTransport,
   auth: Authenticator,
-  agentLoopRunContext?: AgentLoopRunContextType,
-  agentLoopListToolsContext?: AgentLoopListToolsContextType
+  contextParams: ContextParams
 ): Promise<McpServer> => {
   const res = getInternalMCPServerNameAndWorkspaceId(mcpServerId);
   if (res.isErr()) {
@@ -48,8 +58,8 @@ export const connectToInternalMCPServer = async (
       internalMCPServerName: res.value.name,
       mcpServerId,
     },
-    agentLoopRunContext,
-    agentLoopListToolsContext
+    contextParams.agentLoopRunContext,
+    contextParams.agentLoopListToolsContext
   );
 
   await server.connect(transport);

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -8,10 +8,7 @@ import {
   INTERNAL_MCP_SERVERS,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/servers";
-import type {
-  AgentLoopListToolsContextType,
-  AgentLoopRunContextType,
-} from "@app/lib/actions/types";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 
@@ -29,22 +26,11 @@ export const isEnabledForWorkspace = async (
   return featureFlags.includes(flag);
 };
 
-export type ContextParams =
-  | {
-      agentLoopRunContext: AgentLoopRunContextType;
-      agentLoopListToolsContext?: never;
-    }
-  | {
-      agentLoopRunContext?: never;
-      agentLoopListToolsContext: AgentLoopListToolsContextType;
-    }
-  | { agentLoopRunContext?: never; agentLoopListToolsContext?: never };
-
 export const connectToInternalMCPServer = async (
   mcpServerId: string,
   transport: InMemoryTransport,
   auth: Authenticator,
-  contextParams: ContextParams
+  agentLoopContext: AgentLoopContextType
 ): Promise<McpServer> => {
   const res = getInternalMCPServerNameAndWorkspaceId(mcpServerId);
   if (res.isErr()) {
@@ -58,8 +44,7 @@ export const connectToInternalMCPServer = async (
       internalMCPServerName: res.value.name,
       mcpServerId,
     },
-    contextParams.agentLoopRunContext,
-    contextParams.agentLoopListToolsContext
+    agentLoopContext
   );
 
   await server.connect(transport);

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -17,10 +17,7 @@ import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_acti
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server_v2";
 import { default as thinkServer } from "@app/lib/actions/mcp_internal_actions/servers/think";
 import { default as webtoolsServer } from "@app/lib/actions/mcp_internal_actions/servers/webtools";
-import type {
-  AgentLoopListToolsContextType,
-  AgentLoopRunContextType,
-} from "@app/lib/actions/types";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types";
 
@@ -33,8 +30,7 @@ export async function getInternalMCPServer(
     internalMCPServerName: InternalMCPServerNameType;
     mcpServerId: string;
   },
-  agentLoopRunContext?: AgentLoopRunContextType,
-  agentLoopListToolsContext?: AgentLoopListToolsContextType
+  agentLoopContext: AgentLoopContextType
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":
@@ -46,31 +42,27 @@ export async function getInternalMCPServer(
     case "file_generation":
       return generateFileServer(auth);
     case "query_tables":
-      return tablesQueryServer(auth, agentLoopRunContext);
+      return tablesQueryServer(auth, agentLoopContext.agentLoopRunContext);
     case "query_tables_v2":
-      return tablesQueryServerV2(auth, agentLoopRunContext);
+      return tablesQueryServerV2(auth, agentLoopContext.agentLoopRunContext);
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer();
     case "think":
       return thinkServer();
     case "web_search_&_browse":
-      return webtoolsServer(agentLoopRunContext);
+      return webtoolsServer(agentLoopContext.agentLoopRunContext);
     case "search":
-      return searchServer(auth, agentLoopRunContext);
+      return searchServer(auth, agentLoopContext.agentLoopRunContext);
     case "notion":
       return notionServer(auth, mcpServerId);
     case "include_data":
-      return includeDataServer(auth, agentLoopRunContext);
+      return includeDataServer(auth, agentLoopContext.agentLoopRunContext);
     case "ask_agent":
       return askAgentServer(auth);
     case "reasoning_v2":
-      return reasoningServer(auth, agentLoopRunContext);
+      return reasoningServer(auth, agentLoopContext.agentLoopRunContext);
     case "run_dust_app":
-      return dustAppServer(
-        auth,
-        agentLoopRunContext,
-        agentLoopListToolsContext
-      );
+      return dustAppServer(auth, agentLoopContext);
     case "agent_router":
       return agentRouterServer(auth);
     default:

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -125,10 +125,10 @@ async function prepareAppContext(
 }
 
 async function processDustFileOutput(
+  auth: Authenticator,
   sanitizedOutput: DustFileOutput,
   conversation: any,
-  appName: string,
-  auth: Authenticator
+  appName: string
 ): Promise<MCPToolResultContentType[]> {
   const content: MCPToolResultContentType[] = [];
 
@@ -415,10 +415,10 @@ export default async function createServer(
           agentLoopContext.agentLoopRunContext?.conversation
         ) {
           const fileContent = await processDustFileOutput(
+            auth,
             sanitizedOutput,
             agentLoopContext.agentLoopRunContext.conversation,
-            app.name,
-            auth
+            app.name
           );
           content.push(...fileContent);
         }

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -276,12 +276,10 @@ export default async function createServer(
   const server = new McpServer(serverInfo);
   const owner = auth.getNonNullableWorkspace();
 
-  const { agentLoopRunContext, agentLoopListToolsContext } = agentLoopContext;
-
-  if (agentLoopListToolsContext) {
+  if (agentLoopContext && agentLoopContext.agentLoopListToolsContext) {
     if (
       !isMCPConfigurationForDustAppRun(
-        agentLoopListToolsContext.agentActionConfiguration
+        agentLoopContext.agentLoopListToolsContext.agentActionConfiguration
       )
     ) {
       throw new Error("Invalid Dust app run agent configuration");
@@ -289,7 +287,7 @@ export default async function createServer(
 
     const { app, schema } = await prepareAppContext(
       auth,
-      agentLoopListToolsContext.agentActionConfiguration
+      agentLoopContext.agentLoopListToolsContext.agentActionConfiguration
     );
 
     if (!app.description) {
@@ -312,14 +310,18 @@ export default async function createServer(
         };
       }
     );
-  } else if (agentLoopRunContext) {
-    if (!isMCPInternalDustAppRun(agentLoopRunContext.actionConfiguration)) {
+  } else if (agentLoopContext && agentLoopContext.agentLoopRunContext) {
+    if (
+      !isMCPInternalDustAppRun(
+        agentLoopContext.agentLoopRunContext.actionConfiguration
+      )
+    ) {
       throw new Error("Invalid Dust app run tool configuration");
     }
 
     const { app, schema, appConfig } = await prepareAppContext(
       auth,
-      agentLoopRunContext.actionConfiguration
+      agentLoopContext.agentLoopRunContext.actionConfiguration
     );
 
     if (!app.description) {
@@ -336,7 +338,7 @@ export default async function createServer(
         params = await prepareParamsWithHistory(
           params,
           schema,
-          agentLoopRunContext,
+          agentLoopContext.agentLoopRunContext,
           auth
         );
 
@@ -426,11 +428,11 @@ export default async function createServer(
 
         if (
           containsFileOutput(sanitizedOutput) &&
-          agentLoopRunContext?.conversation
+          agentLoopContext.agentLoopRunContext?.conversation
         ) {
           const fileContent = await processDustFileOutput(
             sanitizedOutput,
-            agentLoopRunContext.conversation,
+            agentLoopContext.agentLoopRunContext.conversation,
             app.name,
             auth
           );

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -32,7 +32,7 @@ import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type { DatasetSchema } from "@app/types";
 import { getHeaderFromGroupIds, SUPPORTED_MODEL_CONFIGS } from "@app/types";
-import { SpecificationBlockType } from "@app/types";
+import type { SpecificationBlockType } from "@app/types";
 
 import { ConfigurableToolInputSchemas } from "../input_schemas";
 

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -31,8 +31,8 @@ import { AppResource } from "@app/lib/resources/app_resource";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type { DatasetSchema } from "@app/types";
-import { getHeaderFromGroupIds, SUPPORTED_MODEL_CONFIGS } from "@app/types";
 import type { SpecificationBlockType } from "@app/types";
+import { getHeaderFromGroupIds, SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 import { ConfigurableToolInputSchemas } from "../input_schemas";
 

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -16,7 +16,7 @@ import type {
 } from "@app/lib/actions/mcp";
 import type { MCPToolResultContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
-import type { AgentLoopListToolsContextType } from "@app/lib/actions/types";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isMCPConfigurationForDustAppRun } from "@app/lib/actions/types/guards";
 import { isMCPInternalDustAppRun } from "@app/lib/actions/types/guards";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
@@ -271,11 +271,12 @@ const serverInfo: InternalMCPServerDefinitionType = {
 
 export default async function createServer(
   auth: Authenticator,
-  agentLoopRunContext?: AgentLoopRunContextType,
-  agentLoopListToolsContext?: AgentLoopListToolsContextType
+  agentLoopContext: AgentLoopContextType
 ): Promise<McpServer> {
   const server = new McpServer(serverInfo);
   const owner = auth.getNonNullableWorkspace();
+
+  const { agentLoopRunContext, agentLoopListToolsContext } = agentLoopContext;
 
   if (agentLoopListToolsContext) {
     if (

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -32,15 +32,11 @@ import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type { DatasetSchema } from "@app/types";
 import { getHeaderFromGroupIds, SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import { SpecificationBlockType } from "@app/types";
 
 import { ConfigurableToolInputSchemas } from "../input_schemas";
 
 const MIN_GENERATION_TOKENS = 2048;
-
-interface DustAppBlock {
-  type: string;
-  name: string;
-}
 
 interface DustFileOutput {
   __dust_file?: {
@@ -97,10 +93,11 @@ async function prepareAppContext(
   }
 
   const parsedSpec = app.parseSavedSpecification();
-  const appSpec = parsedSpec as DustAppBlock[];
   const appConfig = extractConfig(parsedSpec);
 
-  const inputSpec = appSpec.find((b: DustAppBlock) => b.type === "input");
+  const inputSpec = parsedSpec.find(
+    (b: SpecificationBlockType) => b.type === "input"
+  );
   const inputConfig = inputSpec ? appConfig[inputSpec.name] : null;
   const datasetName = inputConfig?.dataset;
 

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -19,10 +19,7 @@ import {
   isRemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
-import type {
-  AgentLoopListToolsContextType,
-  AgentLoopRunContextType,
-} from "@app/lib/actions/types";
+import { AgentLoopContextType } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import apiConfig from "@app/lib/api/config";
 import type {
@@ -113,12 +110,10 @@ export const connectToMCPServer = async (
   auth: Authenticator,
   {
     params,
-    agentLoopRunContext,
-    agentLoopListToolsContext,
+    agentLoopContext,
   }: {
     params: MCPConnectionParams;
-    agentLoopRunContext?: AgentLoopRunContextType;
-    agentLoopListToolsContext?: AgentLoopListToolsContextType;
+    agentLoopContext: AgentLoopContextType;
   }
 ): Promise<Result<Client, Error>> => {
   // This is where we route the MCP client to the right server.
@@ -140,8 +135,7 @@ export const connectToMCPServer = async (
             params.mcpServerId,
             server,
             auth,
-            agentLoopRunContext,
-            agentLoopListToolsContext
+            agentLoopContext
           );
           await mcpClient.connect(client);
           break;
@@ -303,6 +297,7 @@ export async function fetchRemoteServerMetaDataByURL(
       type: "remoteMCPServerUrl",
       remoteMCPServerUrl: url,
     },
+    agentLoopContext: {},
   });
 
   if (r.isErr()) {

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -19,7 +19,7 @@ import {
   isRemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
-import { AgentLoopContextType } from "@app/lib/actions/types";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import apiConfig from "@app/lib/api/config";
 import type {

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -156,3 +156,14 @@ export type AgentLoopListToolsContextType = {
   conversation: ConversationType;
   agentMessage: AgentMessageType;
 };
+
+export type AgentLoopContextType =
+  | {
+      agentLoopRunContext: AgentLoopRunContextType;
+      agentLoopListToolsContext?: never;
+    }
+  | {
+      agentLoopRunContext?: never;
+      agentLoopListToolsContext: AgentLoopListToolsContextType;
+    }
+  | { agentLoopRunContext?: never; agentLoopListToolsContext?: never };

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -299,4 +299,8 @@ export class AppResource extends ResourceWithSpace<AppModel> {
       space: this.space.toJSON(),
     };
   }
+
+  parseSavedSpecification() {
+    return JSON.parse(this.savedSpecification || "[]");
+  }
 }

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -16,6 +16,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { AppType, LightWorkspaceType, Result } from "@app/types";
 import { Err, Ok } from "@app/types";
+import type { SpecificationType } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -301,6 +302,6 @@ export class AppResource extends ResourceWithSpace<AppModel> {
   }
 
   parseSavedSpecification() {
-    return JSON.parse(this.savedSpecification || "[]");
+    return JSON.parse(this.savedSpecification || "[]") as SpecificationType;
   }
 }

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -15,8 +15,8 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { AppType, LightWorkspaceType, Result } from "@app/types";
-import { Err, Ok } from "@app/types";
 import type { SpecificationType } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -67,6 +67,7 @@ export class InternalMCPServerInMemoryResource {
             type: "mcpServerId",
             mcpServerId: id,
           },
+          agentLoopContext: {},
         });
 
         if (s.isErr()) {


### PR DESCRIPTION
## Description

This PR makes sure that we have stronger types in MCP. Mostly this ensures that we can't have both `agentLoopRunContext` and `agentLoopListToolsContext` at the same time.

## Risk

Low

## Deploy Plan

Deploy front