### PR TITLE
[front] add CTA to empty tool list

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -1,4 +1,12 @@
-import { Chip, classNames, DataTable, Spinner } from "@dust-tt/sparkle";
+import {
+  Button,
+  Chip,
+  classNames,
+  DataTable,
+  EmptyCTA,
+  PlusIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
 
@@ -85,6 +93,8 @@ export const AdminActionsList = ({
   });
 
   const [isLoading, setIsLoading] = useState(false);
+
+  const showLoader = isMCPServersLoading || isLoading;
 
   const { connections } = useMCPServerConnections({
     owner,
@@ -221,41 +231,56 @@ export const AdminActionsList = ({
         owner={owner}
         setMCPServer={setMcpServer}
       />
-      {portalToHeader(
-        <AddActionMenu
-          owner={owner}
-          enabledMCPServers={mcpServers.map((s) => s.id)}
-          setIsLoading={setIsLoading}
-          createRemoteMCPServer={() => {
-            setInternalMCPServerToCreate(undefined);
-            setIsCreateOpen(true);
-          }}
-          createInternalMCPServer={async (mcpServer: MCPServerType) => {
-            if (mcpServer.authorization) {
-              setInternalMCPServerToCreate(mcpServer);
+      {rows.length > 0 &&
+        portalToHeader(
+          <AddActionMenu
+            owner={owner}
+            enabledMCPServers={mcpServers.map((s) => s.id)}
+            setIsLoading={setIsLoading}
+            createRemoteMCPServer={() => {
+              setInternalMCPServerToCreate(undefined);
               setIsCreateOpen(true);
-            } else {
-              setIsLoading(true);
-              await createInternalMCPServer(mcpServer.name, true);
-              setIsLoading(false);
-            }
-          }}
-        />
-      )}
+            }}
+            createInternalMCPServer={async (mcpServer: MCPServerType) => {
+              if (mcpServer.authorization) {
+                setInternalMCPServerToCreate(mcpServer);
+                setIsCreateOpen(true);
+              } else {
+                setIsLoading(true);
+                await createInternalMCPServer(mcpServer.name, true);
+                setIsLoading(false);
+              }
+            }}
+          />
+        )}
 
-      {isMCPServersLoading || isLoading ? (
+      {showLoader && (
         <div className="mt-16 flex justify-center">
           <Spinner />
         </div>
-      ) : (
-        <DataTable
-          data={rows}
-          columns={columns}
-          className="pb-4"
-          filter={filter}
-          filterColumn="name"
-        />
       )}
+
+      {!showLoader &&
+        (rows.length === 0 ? (
+          <EmptyCTA
+            message="You don’t have any tools yet."
+            action={
+              <Button
+                icon={PlusIcon}
+                onClick={() => setIsCreateOpen(true)}
+                label="Add a tool"
+              />
+            }
+          />
+        ) : (
+          <DataTable
+            data={rows}
+            columns={columns}
+            className="pb-4"
+            filter={filter}
+            filterColumn="name"
+          />
+        ))}
     </>
   );
 };

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -268,7 +268,7 @@ export const AdminActionsList = ({
               <Button
                 icon={PlusIcon}
                 onClick={() => setIsCreateOpen(true)}
-                label="Add a tool"
+                label="Add Tools"
               />
             }
           />


### PR DESCRIPTION
## Description
This PR is to show empty CTA when there is no tool 

<img width="1498" alt="Screenshot 2025-05-14 at 15 28 47" src="https://github.com/user-attachments/assets/9e631ab1-98eb-4a32-96b8-8657851c0751" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
