### PR TITLE
[front] show data viz in action by default

### DIFF
--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -304,7 +304,9 @@ export type ActionSpecificationWithType = ActionSpecification & {
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
 export function getDefaultAssistantState() {
   return {
-    actions: [],
+    // Data Visualization is not an action but we show it like an action.
+    // We enable it by default so we should push it to actions list.
+    actions: [getDataVisualizationActionConfiguration()],
     handle: null,
     scope: "private",
     description: null,


### PR DESCRIPTION
## Description
This PR is to show data viz (as an action) in UI by default, so it should be always shown when you create a new agent. 


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
