### PR TITLE
[front] - revert(AB): open preview drawer by default

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -227,13 +227,8 @@ export default function AssistantBuilder({
 
   const [rightPanelStatus, setRightPanelStatus] =
     useState<AssistantBuilderRightPanelStatus>({
-      tab:
-        template != null
-          ? "Template"
-          : screen == "instructions"
-            ? "Preview"
-            : null,
-      openedAt: screen == "instructions" ? Date.now() : null,
+      tab: template != null ? "Template" : null,
+      openedAt: template != null ? Date.now() : null,
     });
 
   // We deactivate the Preview button if the BuilderState is empty (= no instructions, no tools)


### PR DESCRIPTION
## Description

This PR reverts the behaviour introduced by https://github.com/dust-tt/dust/pull/12600, which consists in having the preview drawer open when landing on the AB instruction tab.

## Risk

Low

## Deploy Plan

Deploy front