### PR TITLE
[front] chore(subscription): bypass correctly workspaceId filter

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -30,6 +30,7 @@ import { REPORT_USAGE_METADATA_KEY } from "@app/lib/plans/usage/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { getWorkspaceFirstAdmin } from "@app/lib/workspace";
 import { checkWorkspaceActivity } from "@app/lib/workspace_usage";
@@ -47,8 +48,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Ok, sendUserOperationMessage } from "@app/types";
-
-import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_models";
 
 const DEFAULT_PLAN_WHEN_NO_SUBSCRIPTION: PlanAttributes = FREE_NO_PLAN_DATA;
 const FREE_NO_PLAN_SUBSCRIPTION_ID = -1;


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Bypass the workspaceId check, it's correctly filtered, but the rule check for `number | [number]`, no more than 1 element. Here we fetch for more than 1 elements, it's used for the scrub.

## Tests

## Risk

## Deploy Plan
- Deploy front
