### PR TITLE
enh(cli): use Static component for conv history (+other bug fixes and improvements)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/dust-cli",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@dust-tt/client": "^1.0.47",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -134,15 +134,21 @@ const StaticConversationItem: FC<{
       );
     case "agent_message_cot_line":
       return (
-        <Text dimColor italic>
-          {item.text}
-        </Text>
+        <Box marginLeft={2}>
+          <Text dimColor italic>
+            {item.text}
+          </Text>
+        </Box>
       );
     case "agent_message_content_line":
-      return <Text>{item.text}</Text>;
+      return (
+        <Box marginLeft={2}>
+          <Text>{item.text}</Text>
+        </Box>
+      );
     case "agent_message_cancelled":
       return (
-        <Box marginBottom={1}>
+        <Box marginBottom={1} marginTop={1}>
           <Text color="red">[Cancelled]</Text>
         </Box>
       );
@@ -369,10 +375,11 @@ const CliChat: FC<CliChatProps> = ({ sId: requestedSId }) => {
               .filter((item) => !prevIds.has(item.key))
               .slice(0, isStreaming ? -1 : undefined);
 
-            const hasContentLines =
-              prev[prev.length - 1].type === "agent_message_content_line";
-
             const newItems = [...prev];
+
+            const hasContentLines =
+              newItems[newItems.length - 1].type ===
+              "agent_message_content_line";
 
             // If we already inserted some content lines for the agent message, we don't insert more cot lines, even if
             // the agent generated some additional ones.
@@ -396,7 +403,7 @@ const CliChat: FC<CliChatProps> = ({ sId: requestedSId }) => {
             }
 
             const hasCotLines =
-              prev[prev.length - 1].type === "agent_message_cot_line";
+              newItems[newItems.length - 1].type === "agent_message_cot_line";
 
             if (!hasContentLines && hasCotLines && contentLines.length > 0) {
               // This is the first content line, and we have some previous cot lines.
@@ -697,7 +704,7 @@ const CliChat: FC<CliChatProps> = ({ sId: requestedSId }) => {
       {isProcessingQuestion && (
         <Box marginTop={1}>
           <Text color="green">
-            <Spinner type="dots" /> Thinking...
+            Thinking <Spinner type="simpleDots" />
           </Text>
         </Box>
       )}


### PR DESCRIPTION
## Description

The main improvement in this PR is the use of `<Static>` for conversation history. This allows to avoid flickery terminal and scrolling issues (`ink` does not rewrite static content that was already written, so conv history becomes append only)

## Tests

Manual

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish CLI