### PR TITLE
Fix: ignore missing database in notion table worker

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -3136,7 +3136,7 @@ export async function markDatabasesAsUpserted({
   connectorId: ModelId;
   databaseIds: string[];
   runTimestamp: number;
-}): Promise<{ isNewDatabase: boolean }> {
+}): Promise<{ isNewDatabase: boolean; isMissing: boolean }> {
   const db = await NotionDatabase.findOne({
     where: {
       connectorId,
@@ -3147,7 +3147,7 @@ export async function markDatabasesAsUpserted({
   });
 
   if (!db) {
-    throw new Error("Could not find database in our DB.");
+    return { isNewDatabase: false, isMissing: true };
   }
 
   await NotionDatabase.update(
@@ -3164,5 +3164,5 @@ export async function markDatabasesAsUpserted({
     }
   );
 
-  return { isNewDatabase: !db.lastUpsertedRunTs };
+  return { isNewDatabase: !db.lastUpsertedRunTs, isMissing: false };
 }

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,4 +1,4 @@
-const WORKFLOW_VERSION = 46;
+const WORKFLOW_VERSION = 47;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;
 export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${WORKFLOW_VERSION}`;
 

--- a/connectors/src/connectors/notion/temporal/workflows/upserts.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/upserts.ts
@@ -170,11 +170,16 @@ export async function upsertDatabaseInCore({
 
   // We immediately mark the database as upserted, to allow the sync process
   // to queue it again while it is being processed.
-  const { isNewDatabase } = await markDatabasesAsUpserted({
+  const { isNewDatabase, isMissing } = await markDatabasesAsUpserted({
     connectorId,
     databaseIds: [databaseId],
     runTimestamp,
   });
+
+  // The database is missing from our DB (it may have been deleted), so we don't need to process it.
+  if (isMissing) {
+    return;
+  }
 
   // If the database is new, we consider this to be a "batch sync".
   // We won't trigger individual post upsert hooks for each page.


### PR DESCRIPTION
## Description

If the db is missing, stop erroring and just ignore.

## Risk

Low (only seen the error once so far)

## Deploy Plan

Deploy `connectors`