### PR TITLE
Add support for icon at root level for breadcrumbs

### DIFF
--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType } from "react";
 import React from "react";
 
-import { Button } from "@sparkle/components/Button";
+import { Button, ICON_SIZE_MAP } from "@sparkle/components/Button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -130,6 +130,19 @@ function BreadcrumbItem({
         tooltip={item.label}
         size={size}
       />
+    );
+  }
+
+  if (item.icon) {
+    return (
+      <div className="s-shrink0 s-label-sm s-inline-flex s-h-9 s-items-center s-gap-2 s-border s-border-border/0 s-px-3">
+        <Icon
+          visual={item.icon}
+          size={ICON_SIZE_MAP[size]}
+          className={cn("-s-mx-0.5")}
+        />
+        <div className={cn("", commonClassName)}>{item.label}</div>
+      </div>
     );
   }
 

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -148,7 +148,7 @@ const chevronVariantMap = {
 
 export interface MetaButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 
@@ -171,7 +171,7 @@ MetaButton.displayName = "MetaButton";
 type IconSizeType = "xs" | "sm" | "md";
 type CounterSizeType = "xs" | "sm" | "md";
 
-const ICON_SIZE_MAP: Record<ButtonSizeType, IconSizeType> = {
+export const ICON_SIZE_MAP: Record<ButtonSizeType, IconSizeType> = {
   xmini: "xs",
   mini: "sm",
   xs: "xs",

--- a/sparkle/src/stories/Breadcrumbs.stories.tsx
+++ b/sparkle/src/stories/Breadcrumbs.stories.tsx
@@ -27,6 +27,10 @@ type BreadcrumbsExampleProps = {
 };
 
 export const BreadcrumbsExample = (args: BreadcrumbsExampleProps) => {
+  const items0 = [
+    { label: "Home", icon: HomeIcon },
+  ];
+
   const items1 = [
     { label: "Home", href: "#", icon: HomeIcon },
     { label: "Spaces", onClick: () => alert("Spaces clicked!") },
@@ -80,6 +84,7 @@ export const BreadcrumbsExample = (args: BreadcrumbsExampleProps) => {
 
   return (
     <div className="s-flex s-flex-col s-gap-4 s-pb-8">
+      <Breadcrumbs items={items0} {...args} />
       <Breadcrumbs items={items1} {...args} />
       <Breadcrumbs items={items2} {...args} />
       <Breadcrumbs items={items4} {...args} />


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Preparatory work to fix https://github.com/dust-tt/tasks/issues/2847.

Expected follow up:

1. release @dust-tt/sparkle
2. bump @dust-tt/sparkle deps in front/package.json

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
A root level case has been added in the breadcrumbs page of the storybook.

Before
<img width="664" alt="image" src="https://github.com/user-attachments/assets/bbc9a173-e8b6-486c-84a9-ae31111baa6b" />

After
<img width="645" alt="image" src="https://github.com/user-attachments/assets/2537a8c0-f077-4023-adbf-bde31c64b955" />


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Knowledge screens UI

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
