### PR TITLE
add missing workspace id filter and composite index

### DIFF
--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -654,6 +654,7 @@ export async function getDataSourceUsage({
         ],
       ],
       where: {
+        workspaceId: owner.id,
         dataSourceId: dataSource.id,
       },
       include: [
@@ -691,6 +692,7 @@ export async function getDataSourceUsage({
         ],
       ],
       where: {
+        workspaceId: owner.id,
         dataSourceId: dataSource.id,
       },
       include: [
@@ -804,6 +806,7 @@ export async function getDataSourceViewUsage({
         ],
       ],
       where: {
+        workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,
       },
       include: [
@@ -841,6 +844,7 @@ export async function getDataSourceViewUsage({
         ],
       ],
       where: {
+        workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,
       },
       include: [
@@ -878,6 +882,7 @@ export async function getDataSourceViewUsage({
         ],
       ],
       where: {
+        workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,
       },
       include: [

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -92,8 +92,20 @@ AgentDataSourceConfiguration.init(
         concurrently: true,
       },
       { fields: ["mcpServerConfigurationId"] },
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-14): Remove index
       { fields: ["dataSourceId"] },
+      {
+        fields: ["workspaceId", "dataSourceId"],
+        concurrently: true,
+      },
+
+      // TODO(WORKSPACE_ID_ISOLATION 2025-05-14): Remove index
       { fields: ["dataSourceViewId"] },
+      {
+        fields: ["workspaceId", "dataSourceViewId"],
+        concurrently: true,
+        name: "agent_data_source_config_workspace_id_data_source_view_id",
+      },
       {
         fields: ["workspaceId"],
         concurrently: true,

--- a/front/migrations/db/migration_263.sql
+++ b/front/migrations/db/migration_263.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 14, 2025
+CREATE INDEX CONCURRENTLY "agent_data_source_configurations_workspace_id_data_source_id" ON "agent_data_source_configurations" ("workspaceId", "dataSourceId");
+CREATE INDEX CONCURRENTLY "agent_data_source_config_workspace_id_data_source_view_id" ON "agent_data_source_configurations" ("workspaceId", "dataSourceViewId");


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add missing `workspaceId` filter on some calls of AgentDataSourceConfiguration
- Add related composite index

## Tests

## Risk

## Deploy Plan
- [ ] Run migration
- [ ] Deploy front
