### PR TITLE
chore(message): Add more missing workspaceId

### DIFF
--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -545,6 +545,7 @@ export async function* getConversationEvents({
 }
 
 export async function cancelMessageGenerationEvent(
+  auth: Authenticator,
   messageIds: string[]
 ): Promise<void> {
   const redis = await getRedisClient({ origin: "cancel_message_generation" });
@@ -562,7 +563,10 @@ export async function cancelMessageGenerationEvent(
 
       // Already set the status to cancel
       const dbTask = Message.findOne({
-        where: { sId: messageId },
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          sId: messageId,
+        },
       }).then(async (message) => {
         if (message && message.agentMessageId) {
           await AgentMessage.update(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -104,7 +104,7 @@ async function handler(
         });
       }
 
-      await cancelMessageGenerationEvent(r.data.messageIds);
+      await cancelMessageGenerationEvent(auth, r.data.messageIds);
       return res.status(200).json({ success: true });
 
     default:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -58,7 +58,7 @@ async function handler(
           },
         });
       }
-      await cancelMessageGenerationEvent(bodyValidation.right.messageIds);
+      await cancelMessageGenerationEvent(auth, bodyValidation.right.messageIds);
       return res.status(200).json({ success: true });
 
     default:


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add missing `workspaceId` when cancelling a message

## Tests
- Locally tested to cancel a message generation

## Risk

## Deploy Plan
- Deploy front
