### PR TITLE
Revert "Move LabsTranscriptResource to being operated with sId"

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -397,7 +397,7 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error("Missing --cId argument");
       }
       const transcriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchById(args.cId);
+        await LabsTranscriptsConfigurationResource.fetchByModelId(args.cId);
 
       if (!transcriptsConfiguration) {
         throw new Error(
@@ -421,7 +421,7 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error("Missing --cId argument");
       }
       const transcriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchById(args.cId);
+        await LabsTranscriptsConfigurationResource.fetchByModelId(args.cId);
 
       if (!transcriptsConfiguration) {
         throw new Error(

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -33,14 +33,13 @@ const RESOURCES_PREFIX = {
   mcp_server_view: "msv",
   remote_mcp_server: "rms",
   tag: "tag",
-  transcripts_configuration: "tsc",
 
   // Resources relative to the configuration of an MCP server.
   data_source_configuration: "dsc",
   table_configuration: "tbc",
   child_agent_configuration: "cac",
 
-  // Virtual resources (no database models associated).
+  // Virtual resources (no database modelsassociated).
   internal_mcp_server: "ims",
 };
 

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -112,7 +112,7 @@ export function useUpdateTranscriptsConfiguration({
     data: Partial<PatchTranscriptsConfiguration>
   ): Promise<Result<undefined, Error>> => {
     const response = await fetch(
-      `/api/w/${owner.sId}/labs/transcripts/${transcriptsConfiguration.sId}`,
+      `/api/w/${owner.sId}/labs/transcripts/${transcriptsConfiguration.id}`,
       {
         method: "PATCH",
         headers: {

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -63,7 +63,7 @@ async function handler(
   }
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchById(
+    await LabsTranscriptsConfigurationResource.fetchByModelId(
       transcriptsConfigurationId
     );
   // TODO(2024-04-19 flav) Consider adding auth to `fetchById` to move this permission check within the method.
@@ -121,7 +121,7 @@ async function handler(
       if (isActive !== undefined) {
         logger.info(
           {
-            configurationId: transcriptsConfiguration.sId,
+            configurationId: transcriptsConfiguration.id,
             isActive,
           },
           "Setting transcript configuration active status."
@@ -166,8 +166,8 @@ async function handler(
       }
 
       const updatedTranscriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchById(
-          transcriptsConfiguration.sId
+        await LabsTranscriptsConfigurationResource.fetchByModelId(
+          transcriptsConfiguration.id
         );
 
       if (!updatedTranscriptsConfiguration) {
@@ -187,7 +187,7 @@ async function handler(
       if (shouldStartWorkflow) {
         logger.info(
           {
-            configurationId: updatedTranscriptsConfiguration.sId,
+            configurationId: updatedTranscriptsConfiguration.id,
           },
           "Starting transcript retrieval workflow."
         );

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -78,7 +78,7 @@ async function handler(
       }
 
       return res.status(200).json({
-        configuration: transcriptsConfiguration.toJSON(),
+        configuration: transcriptsConfiguration,
       });
   }
 }

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -24,6 +24,7 @@ import { useLabsTranscriptsConfiguration } from "@app/lib/swr/labs";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type {
   DataSourceViewType,
+  ModelId,
   SubscriptionType,
   WhitelistableFeature,
   WorkspaceType,
@@ -92,7 +93,7 @@ export default function LabsTranscriptsIndex({
   const sendNotification = useSendNotification();
 
   const handleDisconnectProvider = async (
-    transcriptConfigurationId: string | null
+    transcriptConfigurationId: ModelId | null
   ) => {
     if (!transcriptConfigurationId) {
       return;
@@ -167,7 +168,7 @@ export default function LabsTranscriptsIndex({
           onClose={() => setIsDeleteProviderDialogOpened(false)}
           onConfirm={async () => {
             await handleDisconnectProvider(
-              transcriptsConfiguration?.sId || null
+              transcriptsConfiguration?.id || null
             );
           }}
         />

--- a/front/poke/swr/agent_configurations.ts
+++ b/front/poke/swr/agent_configurations.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -42,14 +42,14 @@ import { Err } from "@app/types";
 import { CoreAPI } from "@app/types";
 
 export async function retrieveNewTranscriptsActivity(
-  transcriptsConfigurationId: string
+  transcriptsConfigurationId: ModelId
 ): Promise<string[]> {
   const localLogger = mainLogger.child({
-    transcriptsConfigurationId: transcriptsConfigurationId,
+    transcriptsConfigurationId,
   });
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchById(
+    await LabsTranscriptsConfigurationResource.fetchByModelId(
       transcriptsConfigurationId
     );
 
@@ -129,7 +129,7 @@ export async function retrieveNewTranscriptsActivity(
 }
 
 export async function processTranscriptActivity(
-  transcriptsConfigurationId: string,
+  transcriptsConfigurationId: ModelId,
   fileId: string
 ) {
   function convertCitationsToLinks(
@@ -187,7 +187,7 @@ export async function processTranscriptActivity(
   }
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchById(
+    await LabsTranscriptsConfigurationResource.fetchByModelId(
       transcriptsConfigurationId
     );
 
@@ -342,9 +342,10 @@ export async function processTranscriptActivity(
 
   try {
     await transcriptsConfiguration.recordHistory({
+      configurationId: transcriptsConfiguration.id,
       fileId,
       fileName: transcriptTitle.substring(0, 255),
-      workspace: owner,
+      workspaceId: owner.id,
     });
   } catch (error) {
     if (error instanceof UniqueConstraintError) {

--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -18,12 +18,12 @@ export async function launchRetrieveTranscriptsWorkflow(
 
   try {
     await client.workflow.start(retrieveNewTranscriptsWorkflow, {
-      args: [transcriptsConfiguration.sId],
+      args: [transcriptsConfiguration.id],
       taskQueue: TRANSCRIPTS_QUEUE_NAME,
       workflowId: workflowId,
       cronSchedule: "*/5 * * * *",
       memo: {
-        configurationId: transcriptsConfiguration.sId,
+        configurationId: transcriptsConfiguration.id,
         IsProcessingTranscripts: transcriptsConfiguration.isActive,
         IsStoringTranscripts:
           transcriptsConfiguration.dataSourceViewId !== null,

--- a/front/temporal/labs/transcripts/config.ts
+++ b/front/temporal/labs/transcripts/config.ts
@@ -1,3 +1,3 @@
-const QUEUE_VERSION = 2;
+const QUEUE_VERSION = 1;
 
 export const TRANSCRIPTS_QUEUE_NAME = `labs-transcripts-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/labs/transcripts/utils.ts
+++ b/front/temporal/labs/transcripts/utils.ts
@@ -4,14 +4,14 @@ import type { ModelId } from "@app/types";
 export function makeRetrieveTranscriptWorkflowId(
   transcriptsConfiguration: LabsTranscriptsConfigurationResource
 ): string {
-  return `labs-transcripts-retrieve-${transcriptsConfiguration.sId}`;
+  return `labs-transcripts-retrieve-${transcriptsConfiguration.id}`;
 }
 
 export function makeProcessTranscriptWorkflowId({
   transcriptsConfigurationId,
   fileId,
 }: {
-  transcriptsConfigurationId: string;
+  transcriptsConfigurationId: ModelId;
   fileId: string;
 }): string {
   return `labs-transcripts-process-${transcriptsConfigurationId}-${fileId}`;

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -209,7 +209,7 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.sId,
+          transcriptsConfigurationId: transcriptsConfiguration.id,
         },
         "[retrieveGongTranscripts] User not found. Skipping."
       );
@@ -232,7 +232,7 @@ export async function retrieveGongTranscriptContent(
         localLogger.error(
           {
             fileId,
-            transcriptsConfigurationId: transcriptsConfiguration.sId,
+            transcriptsConfigurationId: transcriptsConfiguration.id,
             status: response.status,
           },
           "[retrieveGongTranscripts] Error fetching Gong users. Skipping."
@@ -264,7 +264,7 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.sId,
+          transcriptsConfigurationId: transcriptsConfiguration.id,
           userEmail: user.email,
         },
         "[retrieveGongTranscripts] Gong user not found. Skipping."
@@ -297,7 +297,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.sId,
+        transcriptsConfigurationId: transcriptsConfiguration.id,
       },
       "[retrieveGongTranscripts] Error fetching call from Gong. Skipping."
     );
@@ -317,7 +317,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.sId,
+        transcriptsConfigurationId: transcriptsConfiguration.id,
       },
       "[retrieveGongTranscripts] Call data not found from Gong. Skipping."
     );

--- a/front/temporal/labs/transcripts/utils/modjo.ts
+++ b/front/temporal/labs/transcripts/utils/modjo.ts
@@ -340,7 +340,7 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.sId,
+        transcriptsConfigurationId: transcriptsConfiguration.id,
       },
       "[processTranscriptActivity] Error fetching call from Modjo. Skipping."
     );
@@ -364,7 +364,7 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.sId,
+        transcriptsConfigurationId: transcriptsConfiguration.id,
       },
       "[processTranscriptActivity] Call data not found from Modjo. Skipping."
     );

--- a/front/temporal/labs/transcripts/workflows.ts
+++ b/front/temporal/labs/transcripts/workflows.ts
@@ -4,6 +4,8 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
+import type { ModelId } from "@app/types";
+
 import type * as activities from "./activities";
 import { makeProcessTranscriptWorkflowId } from "./utils";
 
@@ -13,7 +15,7 @@ const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
   });
 
 export async function retrieveNewTranscriptsWorkflow(
-  transcriptsConfigurationId: string
+  transcriptsConfigurationId: ModelId
 ) {
   const filesToProcess = await retrieveNewTranscriptsActivity(
     transcriptsConfigurationId
@@ -45,7 +47,7 @@ export async function processTranscriptWorkflow({
   transcriptsConfigurationId,
 }: {
   fileId: string;
-  transcriptsConfigurationId: string;
+  transcriptsConfigurationId: ModelId;
 }): Promise<void> {
   await processTranscriptActivity(transcriptsConfigurationId, fileId);
 }

--- a/front/types/labs.ts
+++ b/front/types/labs.ts
@@ -24,7 +24,6 @@ export type LabsConnectionType = (typeof labsConnections)[number];
 
 export type LabsTranscriptsConfigurationType = {
   id: ModelId;
-  sId: string;
   workspaceId: ModelId;
   provider: LabsTranscriptsProviderType;
   agentConfigurationId: string | null;


### PR DESCRIPTION
This reverts commit 32e721c65384ecc62a9157acc28f089b99bcc0a1.

* Temporarily reverting in order to avoid breaking any active customer processing while we create a script 
