### PR TITLE
Handle disabled app in salesforce connector

### DIFF
--- a/connectors/src/connectors/salesforce/lib/oauth.ts
+++ b/connectors/src/connectors/salesforce/lib/oauth.ts
@@ -45,6 +45,7 @@ function isSalesforceSignInError(err: unknown): err is Error {
     err.message.startsWith(
       "Error retrieving access token from salesforce: code=provider_access_token_refresh_error"
     ) &&
-    err.message.includes("invalid_grant")
+    (err.message.includes("invalid_grant") ||
+      err.message.includes("oauth_flow_disabled"))
   );
 }


### PR DESCRIPTION
## Description

Auto-pause salesforce connector when the app has been disabled (handle [this](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId%2C%40error_stack&event=AwAAAZbSNs0o4ha-EQAAABhBWmJTTnR0a0FBRDVPOUhXMkhkcUFRQWIAAAAkMDE5NmQyMzctMDFkOS00YTZmLTliODEtOWIxOTA3OWFiYjM4AAAE0A&fromUser=true&link_source=monitor_notif&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40workflowId%3Asalesforce-sync-19080%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22workflowId%22%2C%22value%22%3A%22salesforce-sync-19080%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1747282663800%2C%22to%22%3A1747283563800%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=100&top_o=top&viz=toplist&x_missing=true&from_ts=1747233402905&to_ts=1747234302905&live=true))

## Tests

None but just append a case similar to the previous one.

## Risk

Low

## Deploy Plan

Deploy `connectors`