### PR TITLE
Reasoning MCP server GA

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -231,7 +231,7 @@ export default function ActionsScreen({
 
   const isLegacyConfig = isLegacyAssistantBuilderConfiguration(builderState);
 
-  const { nonGlobalSpacessUsedInActions, spaceIdToActions } =
+  const { nonGlobalSpacesUsedInActions, spaceIdToActions } =
     useBuilderActionInfo(builderState);
 
   const {
@@ -461,12 +461,12 @@ export default function ActionsScreen({
             </div>
           )}
         </div>
-        {nonGlobalSpacessUsedInActions.length > 0 && (
+        {nonGlobalSpacesUsedInActions.length > 0 && (
           <div className="w-full">
             <Chip
               color="info"
               size="sm"
-              label={`Based on the sources you selected, this agent can only be used by users with access to space${nonGlobalSpacessUsedInActions.length > 1 ? "s" : ""} : ${nonGlobalSpacessUsedInActions.map((v) => v.name).join(", ")}.`}
+              label={`Based on the sources you selected, this agent can only be used by users with access to space${nonGlobalSpacesUsedInActions.length > 1 ? "s" : ""} : ${nonGlobalSpacesUsedInActions.map((v) => v.name).join(", ")}.`}
             />
           </div>
         )}

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -11,11 +11,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   InformationCircleIcon,
   Input,
@@ -82,7 +77,6 @@ import type {
   AssistantBuilderActionState,
   AssistantBuilderPendingAction,
   AssistantBuilderProcessConfiguration,
-  AssistantBuilderReasoningConfiguration,
   AssistantBuilderRetrievalConfiguration,
   AssistantBuilderSetActionType,
   AssistantBuilderState,
@@ -108,7 +102,6 @@ import {
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
-  ModelConfigurationType,
   SpaceType,
   WhitelistableFeature,
   WorkspaceType,
@@ -211,8 +204,6 @@ interface ActionScreenProps {
   setEdited: (edited: boolean) => void;
   setAction: (action: AssistantBuilderSetActionType) => void;
   pendingAction: AssistantBuilderPendingAction;
-  enableReasoningTool: boolean;
-  reasoningModels: ModelConfigurationType[];
 }
 
 export default function ActionsScreen({
@@ -222,8 +213,6 @@ export default function ActionsScreen({
   setEdited,
   setAction,
   pendingAction,
-  enableReasoningTool,
-  reasoningModels,
 }: ActionScreenProps) {
   const { hasFeature } = useFeatureFlags({
     workspaceId: owner.sId,
@@ -240,7 +229,6 @@ export default function ActionsScreen({
     selectableDefaultMCPServerViews,
     selectableNonDefaultMCPServerViews,
   } = useTools({
-    enableReasoningTool,
     actions: builderState.actions,
   });
 
@@ -430,33 +418,6 @@ export default function ActionsScreen({
                     maxStepsPerRun,
                   }));
                 }}
-                setReasoningModel={
-                  enableReasoningTool &&
-                  builderState.actions.find((a) => a.type === "REASONING")
-                    ? (model) => {
-                        setEdited(true);
-                        setBuilderState((state) => ({
-                          ...state,
-                          actions: state.actions.map((a) =>
-                            a.type === "REASONING"
-                              ? {
-                                  ...a,
-                                  configuration: {
-                                    ...a.configuration,
-                                    modelId: model.modelId,
-                                    providerId: model.providerId,
-                                    reasoningEffort:
-                                      model.reasoningEffort ?? null,
-                                  },
-                                }
-                              : a
-                          ),
-                        }));
-                      }
-                    : undefined
-                }
-                reasoningModels={reasoningModels}
-                builderState={builderState}
               />
             </div>
           )}
@@ -1136,29 +1097,10 @@ function ActionEditor({
 function AdvancedSettings({
   maxStepsPerRun,
   setMaxStepsPerRun,
-  reasoningModels,
-  setReasoningModel,
-  builderState,
 }: {
   maxStepsPerRun: number | null;
   setMaxStepsPerRun: (maxStepsPerRun: number | null) => void;
-  reasoningModels?: ModelConfigurationType[];
-  setReasoningModel: ((model: ModelConfigurationType) => void) | undefined;
-  builderState: AssistantBuilderState;
 }) {
-  const reasoningConfig = builderState.actions.find(
-    (a) => a.type === "REASONING"
-  )?.configuration as AssistantBuilderReasoningConfiguration | undefined;
-
-  const reasoningModel =
-    reasoningModels?.find(
-      (m) =>
-        m.modelId === reasoningConfig?.modelId &&
-        m.providerId === reasoningConfig?.providerId &&
-        (m.reasoningEffort ?? null) ===
-          (reasoningConfig?.reasoningEffort ?? null)
-    ) ?? reasoningModels?.[0];
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -1192,26 +1134,6 @@ function AdvancedSettings({
             }
           }}
         />
-
-        {(reasoningModels?.length ?? 0) > 1 && setReasoningModel && (
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger label="Reasoning model" className="mt-1" />
-            <DropdownMenuSubContent>
-              <DropdownMenuRadioGroup
-                value={`${reasoningModel?.modelId}-${reasoningModel?.providerId}-${reasoningModel?.reasoningEffort ?? ""}`}
-              >
-                {(reasoningModels ?? []).map((model) => (
-                  <DropdownMenuRadioItem
-                    key={`${model.modelId}-${model.providerId}-${model.reasoningEffort ?? ""}`}
-                    value={`${model.modelId}-${model.providerId}-${model.reasoningEffort ?? ""}`}
-                    label={model.displayName}
-                    onClick={() => setReasoningModel(model)}
-                  />
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1094,13 +1094,15 @@ function ActionEditor({
   );
 }
 
+interface AdvancedSettingsProps {
+  maxStepsPerRun: number | null;
+  setMaxStepsPerRun: (maxStepsPerRun: number | null) => void;
+}
+
 function AdvancedSettings({
   maxStepsPerRun,
   setMaxStepsPerRun,
-}: {
-  maxStepsPerRun: number | null;
-  setMaxStepsPerRun: (maxStepsPerRun: number | null) => void;
-}) {
+}: AdvancedSettingsProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/front/components/assistant_builder/AddToolsDropdown.tsx
+++ b/front/components/assistant_builder/AddToolsDropdown.tsx
@@ -188,7 +188,7 @@ export function AddToolsDropdown({
             ))}
             {defaultMCPServerViews.map((view) => (
               <MCPDropdownMenuItem
-                key={`${view.id}-${view.label}`} // there can be multiple views with the same id               view={view}
+                key={`${view.id}-${view.label}`} // There can be multiple views with the same id.
                 view={view}
                 onClick={onClickMCPServer}
               />

--- a/front/components/assistant_builder/AdvancedSettings.tsx
+++ b/front/components/assistant_builder/AdvancedSettings.tsx
@@ -67,17 +67,19 @@ const isInvalidJson = (value: string | null | undefined): boolean => {
   }
 };
 
-export function AdvancedSettings({
-  generationSettings,
-  setGenerationSettings,
-  models,
-}: {
+interface AdvancedSettingsProps {
   generationSettings: AssistantBuilderState["generationSettings"];
   setGenerationSettings: (
     generationSettingsSettings: AssistantBuilderState["generationSettings"]
   ) => void;
   models: ModelConfigurationType[];
-}) {
+}
+
+export function AdvancedSettings({
+  generationSettings,
+  setGenerationSettings,
+  models,
+}: AdvancedSettingsProps) {
   const { isDark } = useTheme();
   if (!models) {
     return null;

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -475,8 +475,6 @@ export default function AssistantBuilder({
                             setEdited={setEdited}
                             setAction={setAction}
                             pendingAction={pendingAction}
-                            enableReasoningTool={reasoningModels.length > 0}
-                            reasoningModels={reasoningModels}
                           />
                         );
 

--- a/front/components/assistant_builder/SettingsScreen.tsx
+++ b/front/components/assistant_builder/SettingsScreen.tsx
@@ -27,7 +27,7 @@ import React, {
 import { AvatarPicker } from "@app/components/assistant_builder/avatar_picker/AssistantBuilderAvatarPicker";
 import {
   buildSelectedEmojiType,
-  makeUrlForEmojiAndBackgroud,
+  makeUrlForEmojiAndBackground,
 } from "@app/components/assistant_builder/avatar_picker/utils";
 import {
   DROID_AVATAR_URLS,
@@ -214,7 +214,7 @@ export default function SettingsScreen({
       const suggestion = emojiSuggestions.value.suggestions[0];
       const emoji = buildSelectedEmojiType(suggestion.emoji);
       if (emoji) {
-        avatarUrl = makeUrlForEmojiAndBackgroud(
+        avatarUrl = makeUrlForEmojiAndBackground(
           {
             id: emoji.id,
             unified: emoji.unified,

--- a/front/components/assistant_builder/SettingsScreen.tsx
+++ b/front/components/assistant_builder/SettingsScreen.tsx
@@ -202,7 +202,7 @@ export default function SettingsScreen({
     }
   }, [owner, builderState.instructions, builderState.description]);
 
-  const { nonGlobalSpacessUsedInActions } = useBuilderActionInfo(builderState);
+  const { nonGlobalSpacesUsedInActions } = useBuilderActionInfo(builderState);
 
   const updateEmojiFromSuggestions = useCallback(async () => {
     let avatarUrl: string | null = null;
@@ -557,16 +557,16 @@ export default function SettingsScreen({
                       builderState.scope === "published" ||
                       builderState.scope === "workspace") && (
                       <>
-                        {nonGlobalSpacessUsedInActions.length === 0 && (
+                        {nonGlobalSpacesUsedInActions.length === 0 && (
                           <>Visible & usable by all members of the workspace.</>
                         )}
-                        {nonGlobalSpacessUsedInActions.length > 0 && (
+                        {nonGlobalSpacesUsedInActions.length > 0 && (
                           <div>
                             Visible & usable by the members of the{" "}
-                            {`space${nonGlobalSpacessUsedInActions.length > 1 ? "s" : ""}`}{" "}
+                            {`space${nonGlobalSpacesUsedInActions.length > 1 ? "s" : ""}`}{" "}
                             :{" "}
                             <b>
-                              {nonGlobalSpacessUsedInActions
+                              {nonGlobalSpacesUsedInActions
                                 .map((v) => v.name)
                                 .join(", ")}
                             </b>

--- a/front/components/assistant_builder/actions/configuration/ReasoningModelConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ReasoningModelConfigurationSection.tsx
@@ -66,7 +66,7 @@ export function ReasoningModelConfigurationSection({
         variant="warning"
         size="sm"
       >
-        There are no reasoning model available on your workspace.
+        There are no reasoning models available on your workspace.
       </ContentMessage>
     );
   }

--- a/front/components/assistant_builder/avatar_picker/AssistantBuilderEmojiPicker.tsx
+++ b/front/components/assistant_builder/avatar_picker/AssistantBuilderEmojiPicker.tsx
@@ -16,7 +16,7 @@ import type {
   AvatarPickerTabElement,
   SelectedEmojiType,
 } from "@app/components/assistant_builder/avatar_picker/types";
-import { makeUrlForEmojiAndBackgroud } from "@app/components/assistant_builder/avatar_picker/utils";
+import { makeUrlForEmojiAndBackground } from "@app/components/assistant_builder/avatar_picker/utils";
 import { generateTailwindBackgroundColors } from "@app/types";
 
 const DEFAULT_BACKGROUND_COLOR: avatarUtils.AvatarBackgroundColorType =
@@ -64,7 +64,7 @@ const AssistantBuilderEmojiPicker = React.forwardRef<
     return {
       getUrl: async () => {
         if (selectedEmoji) {
-          return makeUrlForEmojiAndBackgroud(selectedEmoji, selectedBgColor);
+          return makeUrlForEmojiAndBackground(selectedEmoji, selectedBgColor);
         }
 
         return null;

--- a/front/components/assistant_builder/avatar_picker/utils.ts
+++ b/front/components/assistant_builder/avatar_picker/utils.ts
@@ -1,11 +1,10 @@
 import type { EmojiMartData as EmojiData } from "@dust-tt/sparkle";
-import { avatarUtils } from "@dust-tt/sparkle";
-import { DataEmojiMart } from "@dust-tt/sparkle";
+import { avatarUtils, DataEmojiMart } from "@dust-tt/sparkle";
 
 import type { SelectedEmojiType } from "@app/components/assistant_builder/avatar_picker/types";
 import { EMOJI_AVATAR_BASE_URL } from "@app/components/assistant_builder/shared";
 
-export function makeUrlForEmojiAndBackgroud(
+export function makeUrlForEmojiAndBackground(
   emoji: SelectedEmojiType,
   backgroundColor: `bg-${string}`
 ) {
@@ -47,7 +46,7 @@ export function getDefaultAvatarUrlForPreview(): string | null {
   if (!emoji) {
     return null;
   }
-  return makeUrlForEmojiAndBackgroud(
+  return makeUrlForEmojiAndBackground(
     {
       id: emoji.id,
       unified: emoji.unified,

--- a/front/components/assistant_builder/useBuilderActionInfo.ts
+++ b/front/components/assistant_builder/useBuilderActionInfo.ts
@@ -151,14 +151,14 @@ export const useBuilderActionInfo = (builderState: AssistantBuilderState) => {
     }, {});
   }, [configurableActions, mcpServerViews]);
 
-  const nonGlobalSpacessUsedInActions = useMemo(() => {
+  const nonGlobalSpacesUsedInActions = useMemo(() => {
     const nonGlobalSpaces = spaces.filter((s) => s.kind !== "global");
     return nonGlobalSpaces.filter((v) => spaceIdToActions[v.sId]?.length > 0);
   }, [spaceIdToActions, spaces]);
 
   return {
     configurableActions,
-    nonGlobalSpacessUsedInActions,
+    nonGlobalSpacesUsedInActions,
     spaceIdToActions,
   };
 };

--- a/front/components/assistant_builder/useTools.ts
+++ b/front/components/assistant_builder/useTools.ts
@@ -23,7 +23,6 @@ const DEFAULT_TOOLS_WITH_CONFIGURATION = [
 ] as const satisfies Array<AssistantBuilderActionConfiguration["type"]>;
 
 const DEFAULT_TOOLS_WITHOUT_CONFIGURATION = [
-  "REASONING",
   "DATA_VISUALIZATION",
 ] as const satisfies Array<
   | AssistantBuilderActionConfiguration["type"]
@@ -46,22 +45,12 @@ function getDefaultConfigurationSpecification(
   };
 }
 
-function getAvailableNonMCPActions({
-  enableReasoningTool,
-}: {
-  enableReasoningTool: boolean;
-}) {
+function getAvailableNonMCPActions() {
   // We should not show the option if it's already selected.
   const list = [
     ...DEFAULT_TOOLS_WITHOUT_CONFIGURATION,
     ...DEFAULT_TOOLS_WITH_CONFIGURATION,
-  ].filter((tool) => {
-    if (tool === "REASONING") {
-      return enableReasoningTool;
-    }
-
-    return true;
-  });
+  ];
 
   return list.map((item) => getDefaultConfigurationSpecification(item));
 }
@@ -132,17 +121,13 @@ function getGroupedMCPServerViews({
 }
 
 interface UseToolsProps {
-  enableReasoningTool: boolean;
   actions: AssistantBuilderActionState[];
 }
 
-export const useTools = ({ enableReasoningTool, actions }: UseToolsProps) => {
+export const useTools = ({ actions }: UseToolsProps) => {
   const { mcpServerViews, spaces } = useContext(AssistantBuilderContext);
 
-  const nonDefaultMCPActions = useMemo(
-    () => getAvailableNonMCPActions({ enableReasoningTool }),
-    [enableReasoningTool]
-  );
+  const nonDefaultMCPActions = useMemo(() => getAvailableNonMCPActions(), []);
 
   const {
     mcpServerViewsWithKnowledge,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -19,7 +19,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "primitive_types_debugger",
   "query_tables",
   "query_tables_v2",
-  "reasoning_v2",
+  "reasoning",
   "run_dust_app",
   "search",
   "think",
@@ -139,7 +139,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     availability: "auto",
     flag: "dev_mcp_actions",
   },
-  reasoning_v2: {
+  reasoning: {
     id: 1007,
     availability: "auto",
     flag: "dev_mcp_actions",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -142,7 +142,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   reasoning: {
     id: 1007,
     availability: "auto",
-    flag: "dev_mcp_actions",
+    flag: null,
   },
   ask_agent: {
     id: 1008,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -59,7 +59,7 @@ export async function getInternalMCPServer(
       return includeDataServer(auth, agentLoopContext);
     case "ask_agent":
       return askAgentServer(auth);
-    case "reasoning_v2":
+    case "reasoning":
       return reasoningServer(auth, agentLoopContext.runContext);
     case "run_dust_app":
       return dustAppServer(auth, agentLoopContext);

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -18,7 +18,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   name: "reasoning",
   version: "1.0.0",
   description:
-    "Agent can decide to trigger a reasoning model for complex tasks (mcp)",
+    "Agent can decide to trigger a reasoning model for complex tasks.",
   icon: "ActionLightbulbIcon",
   authorization: null,
 };

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -15,7 +15,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { isModelId, isModelProviderId, isReasoningEffortId } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "reasoning_v2",
+  name: "reasoning",
   version: "1.0.0",
   description:
     "Agent can decide to trigger a reasoning model for complex tasks (mcp)",

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -6,7 +6,7 @@ import type {
   WhereOptions,
 } from "sequelize";
 
-import { makeUrlForEmojiAndBackgroud } from "@app/components/assistant_builder/avatar_picker/utils";
+import { makeUrlForEmojiAndBackground } from "@app/components/assistant_builder/avatar_picker/utils";
 import type { Authenticator } from "@app/lib/auth";
 import {
   CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID,
@@ -106,7 +106,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
   get pictureUrl() {
     const [id, unified] = this.emoji ? this.emoji.split("/") : [];
 
-    return makeUrlForEmojiAndBackgroud(
+    return makeUrlForEmojiAndBackground(
       {
         id,
         unified,

--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -71,7 +71,7 @@ async function migrateWorkspaceReasoningActions({
   const mcpServerView =
     await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
-      "reasoning_v2"
+      "reasoning"
     );
   if (!mcpServerView) {
     throw new Error("Reasoning MCP server view not found.");

--- a/front/migrations/20250516_migrate_reasoning_to_mcp_globally.ts
+++ b/front/migrations/20250516_migrate_reasoning_to_mcp_globally.ts
@@ -95,7 +95,7 @@ async function migrateWorkspaceReasoningActions(
   const mcpServerView =
     await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
-      "reasoning_v2"
+      "reasoning"
     );
   if (!mcpServerView) {
     throw new Error("Reasoning MCP server view not found.");

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -26,7 +26,7 @@ import type { Control } from "react-hook-form";
 import { useFieldArray, useForm } from "react-hook-form";
 import { MultiSelect } from "react-multi-select-component";
 
-import { makeUrlForEmojiAndBackgroud } from "@app/components/assistant_builder/avatar_picker/utils";
+import { makeUrlForEmojiAndBackground } from "@app/components/assistant_builder/avatar_picker/utils";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import {
   PokeForm,
@@ -412,7 +412,7 @@ function PreviewDialog({ form }: { form: any }) {
   const backgroundColor = form.getValues("backgroundColor");
   const [id, unified] = emoji ? emoji.split("/") : [];
 
-  const avatarVisual = makeUrlForEmojiAndBackgroud(
+  const avatarVisual = makeUrlForEmojiAndBackground(
     {
       id,
       unified,


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2820.
- This PR removes the feature flag on the MCP reasoning action.
- The non-MCP version is removed from the Agent Builder, including the Advanced Settings menu.

This PR can be merged before migrating existing reasoning action configuration to the MCP one.
- The immediate change for current users is that they will be able to add new MCP reasoning actions but not non-MCP ones. The existing actions are not affected and are displayed as they were before.
- One notable change is that the reasoning tool is now visible even if no reasoning model is available on the workspace, in the modal for configuring the tool there is a warning specifying that there is no reasoning model available. Discoverability is a bit better IMHO, I see this as a very minor improvement.

## Tests

- Tested locally.

## Risk

- Medium but easily rollbackable.

## Deploy Plan

- Deploy front.
- Run `20250516_migrate_reasoning_globally.ts`.
