### PR TITLE
Tables Query MCP server GA

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1204,6 +1204,11 @@ function AddKnowledgeDropdown({
         collisionPadding={10}
       >
         {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
+          // TODO(mcp): remove this when we are ready to clean up tables query entirely.
+          if (key === "TABLES_QUERY") {
+            return null;
+          }
+
           const spec = ACTION_SPECIFICATIONS[key];
           if (hideAction(key)) {
             return null;

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -74,7 +74,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   query_tables: {
     id: 4,
     availability: "auto",
-    flag: "dev_mcp_actions", // Putting this behind the dev flag for now to allow shipping without it.
+    flag: null,
   },
   "web_search_&_browse": {
     id: 5,

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -6,6 +6,7 @@ import {
   generateSectionFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
+import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPToolResultContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { fetchAgentTableConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
@@ -32,7 +33,7 @@ const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "query_tables",
+  name: DEFAULT_TABLES_QUERY_ACTION_NAME,
   version: "1.0.0",
   description: "Tables, Spreadsheets, Notion DBs (quantitative) (mcp).",
   icon: "ActionTableIcon",

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -35,7 +35,7 @@ export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 const serverInfo: InternalMCPServerDefinitionType = {
   name: DEFAULT_TABLES_QUERY_ACTION_NAME,
   version: "1.0.0",
-  description: "Tables, Spreadsheets, Notion DBs (quantitative) (mcp).",
+  description: "Tables, Spreadsheets, Notion DBs (quantitative).",
   icon: "ActionTableIcon",
   authorization: null,
 };


### PR DESCRIPTION
## Description

- This PR hides the non-MCP `TablesQuery` action from the Agent builder and unflags the MCP version.
- It does not do any cleaning up for an easier revert.
- The goal here is to deploy this, then migrate all existing tables query configuration to the MCP version.

## Tests

- Checked locally that we don't see the non-MCP version and see the MCP version.
- Checked locally that pre-existing non-MCP tables query actions can still be run and are still visible in the Agent Builder.

## Risk

- The MCP version will be opened to everyone, the non-MCP version will be closed for everyone: we have to be confident that the MCP version is ready to be used.
- Safe to rollback.

## Deploy Plan

- Deploy front.
- Run `20250516_migrate_tables_query_globally.ts`.
