### PR TITLE
[front] chore(subscription): Bypass workspaceId check when we're fecthing by stripe ID

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -180,9 +180,12 @@ export class SubscriptionResource extends BaseResource<Subscription> {
   static async fetchByStripeId(
     stripeSubscriptionId: string
   ): Promise<SubscriptionResource | null> {
-    const res = await Subscription.findOne({
+    const res = await this.model.findOne({
       where: { stripeSubscriptionId },
       include: [Plan],
+
+      // WORKSPACE_ISOLATION_BYPASS: Used to check if a subscription is not attached to a workspace
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
     if (!res) {


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Bypassing `workspaceId` check when fetching `fetchByStripeId`, ok because it's to check if a subscription exists on stripe but doesn't have a workspaceId

## Tests

## Risk
None

## Deploy Plan
Deploy front
