### PR TITLE
Product Tour: only if no convo on page

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -116,8 +116,8 @@ const ConversationLayoutContent = ({
     useWelcomeTourGuide();
 
   const shouldDisplayWelcomeTourGuide = useMemo(() => {
-    return router.query.welcome === "true";
-  }, [router.query.welcome]);
+    return router.query.welcome === "true" && !activeConversationId;
+  }, [router.query.welcome, activeConversationId]);
 
   const onTourGuideEnd = () => {
     void router.push(router.asPath.replace("?welcome=true", ""), undefined, {


### PR DESCRIPTION
## Description

Since the anchors are only made for the convo/new page, better disabling it on a conversation page (even if technically the product tour will never show unless someone manually adds the query param in url). 

## Tests

Locally. 

## Risk

/ 

## Deploy Plan

Deploy front. 