### PR TITLE
[front] - fix(layout): remove max-width style from search input

### DIFF
--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -296,7 +296,6 @@ function BackendSearch({
         value={searchTerm}
         onChange={handleSearchChange}
         disabled={isSearchDisabled}
-        className="max-w-[860px]"
       />
 
       <div


### PR DESCRIPTION
## Description

This PR ensures that the `SearchInput` are consistently taking up the whole width.

## Risk

Low

## Deploy Plan

Deploy front