### PR TITLE
Fix link to MCP server view in Poke data table

### DIFF
--- a/front/components/poke/mcp_server_views/table.tsx
+++ b/front/components/poke/mcp_server_views/table.tsx
@@ -21,7 +21,7 @@ function prepareMCPServerViewsForDisplay(
       const result = {
         ...sv,
         // For display purposes
-        mcpServerViewLink: `/poke/${owner.sId}/spaces/${sv.spaceId}/mcp_server_views/${sv.id}`,
+        mcpServerViewLink: `/poke/${owner.sId}/spaces/${sv.spaceId}/mcp_server_views/${sv.sId}`,
         spaceLink: `/poke/${owner.sId}/spaces/${sv.spaceId}`,
         editedAt: sv.editedByUser?.editedAt ?? undefined,
         editedBy: sv.editedByUser?.fullName ?? undefined,


### PR DESCRIPTION
## Description

- This PR fixes the link on the column `sId` of the Poke MCP server view data table.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
