### PR TITLE
feat: static pages

### DIFF
--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: |
             ~/.npm
-            ${{ github.workspace }}/.next/cache
+            ${{ github.workspace }}/front/.next/cache
           # Generate a new cache whenever packages or source files change.
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.

--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -25,6 +25,17 @@ jobs:
             ./front/package-lock.json
             ./types/package-lock.json
             ./sdks/js/package-lock.json
+      - uses: actions/cache@v4
+        id: npm-cache-front
+        with:
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/.next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Build SDK/JS
         working-directory: sdks/js
         run: npm install && npm run build

--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -25,17 +25,6 @@ jobs:
             ./front/package-lock.json
             ./types/package-lock.json
             ./sdks/js/package-lock.json
-      - uses: actions/cache@v4
-        id: npm-cache-front
-        with:
-          path: |
-            ~/.npm
-            ${{ github.workspace }}/front/.next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Build SDK/JS
         working-directory: sdks/js
         run: npm install && npm run build

--- a/front/pages/home/about.tsx
+++ b/front/pages/home/about.tsx
@@ -27,7 +27,7 @@ import {
 } from "@app/components/home/Particles";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.icosahedron),

--- a/front/pages/home/contact.tsx
+++ b/front/pages/home/contact.tsx
@@ -10,7 +10,7 @@ import {
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.bigSphere),

--- a/front/pages/home/index.tsx
+++ b/front/pages/home/index.tsx
@@ -11,7 +11,7 @@ import { CloudConnectorsSection } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: 0,

--- a/front/pages/home/pricing.tsx
+++ b/front/pages/home/pricing.tsx
@@ -12,7 +12,7 @@ import {
 } from "@app/components/home/Particles";
 import { PricePlans } from "@app/components/plans/PlansTables";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.bigSphere),

--- a/front/pages/home/product.tsx
+++ b/front/pages/home/product.tsx
@@ -15,7 +15,7 @@ import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: 0,

--- a/front/pages/home/security.tsx
+++ b/front/pages/home/security.tsx
@@ -17,7 +17,7 @@ import {
 } from "@app/components/home/Particles";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.icosahedron),

--- a/front/pages/home/solutions/customer-support.tsx
+++ b/front/pages/home/solutions/customer-support.tsx
@@ -31,7 +31,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/data-analytics.tsx
+++ b/front/pages/home/solutions/data-analytics.tsx
@@ -25,7 +25,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/dust-platform.tsx
+++ b/front/pages/home/solutions/dust-platform.tsx
@@ -16,7 +16,7 @@ import {
 } from "@app/components/home/Particles";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.galaxy),

--- a/front/pages/home/solutions/engineering.tsx
+++ b/front/pages/home/solutions/engineering.tsx
@@ -31,7 +31,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/it.tsx
+++ b/front/pages/home/solutions/it.tsx
@@ -29,7 +29,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/knowledge.tsx
+++ b/front/pages/home/solutions/knowledge.tsx
@@ -31,7 +31,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/legal.tsx
+++ b/front/pages/home/solutions/legal.tsx
@@ -31,7 +31,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/marketing.tsx
+++ b/front/pages/home/solutions/marketing.tsx
@@ -31,7 +31,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/productivity.tsx
+++ b/front/pages/home/solutions/productivity.tsx
@@ -31,7 +31,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/recruiting-people.tsx
+++ b/front/pages/home/solutions/recruiting-people.tsx
@@ -31,7 +31,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/solutions/sales.tsx
+++ b/front/pages/home/solutions/sales.tsx
@@ -31,7 +31,7 @@ import {
 import TrustedBy from "@app/components/home/TrustedBy";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.octahedron),

--- a/front/pages/home/vulnerability.tsx
+++ b/front/pages/home/vulnerability.tsx
@@ -11,7 +11,7 @@ import {
 } from "@app/components/home/Particles";
 import { classNames } from "@app/lib/utils";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   return {
     props: {
       shape: getParticleShapeIndexByName(shapeNames.icosahedron),


### PR DESCRIPTION
## Description
Use `getStaticProps` instead of `getServerSideProps` for all `/home/*` route.
The server side rendering is not needed as the methods just return static props. Even the gtm tracking id is setup at build time.
This improve loading speed, and should reduce cpu usage for those route (but that's not probably a significant improvement as I'm not sure they're that popular)

## Tests
- Not tested locally as there is no difference between getStaticProps and getServerSideProps in dev.
- Tested on front edge
- Ran lighthouse before and after, i.e [https://dust.tt/home/security](https://dust.tt/home/security)
  -  before: 
     - perf: 96
     - FCP: 0.5s
     - LCP: 1.3s
  - after:
    - perf: 99
    - FCP: 0.6s
    - LCP: 0.9s

## Risk
Low, easy to revert and only on the public website part

## Deploy Plan
- Deploy front
