### PR TITLE
[front] chore: avoid duplicate getSession call

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -13,7 +13,6 @@ import {
   getAPIKey,
   getAuthType,
   getBearerToken,
-  getSession,
 } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import logger from "@app/logger/logger";
@@ -39,10 +38,9 @@ export function withSessionAuthentication<T>(
   return withLogging(
     async (
       req: NextApiRequest,
-      res: NextApiResponse<WithAPIErrorResponse<T>>
+      res: NextApiResponse<WithAPIErrorResponse<T>>,
+      { session }
     ) => {
-      const session = await getSession(req, res);
-
       if (!session) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -2,7 +2,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
-import { getSession } from "@app/lib/auth";
 import { AuthFlowError, SSOEnforcedError } from "@app/lib/iam/errors";
 import {
   getPendingMembershipInvitationForEmailAndWorkspace,
@@ -326,9 +325,9 @@ async function handleRegularSignupFlow(
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>,
+  { session }: { session: SessionWithUser | null }
 ): Promise<void> {
-  const session = await getSession(req, res);
   if (!session) {
     res.status(401).end();
     return;


### PR DESCRIPTION
## Description
`getSession` is already called by `withLogging`, so doing the call again in `withSessionAuthentication` is redundant.
I also create a first version of a `context` that can be passed across our middleware.
Assumption is it should improve speed a bit as a remote call to Auth0 is removed for all authenticated calls.

## Tests
- Locally, check some pages, logout, signin
- Same on front-edge

## Risk
- High, as we're removing a `getSession`, if a side effect is unsight we would fail auth. But fast and easy to revert.

## Deploy Plan
- Deploy
