### PR TITLE
Github: add list_organization_projects

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -544,12 +544,12 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         let content = "";
         projects.forEach((project) => {
           content +=
-            `project='${project.title}' id=${project.id} ` +
+            `project='${project.title}' node_id=${project.id} ` +
             `description='${project.shortDescription}'\n`;
           project.fields.nodes.forEach((field) => {
-            content += `  field='${field.name}' id=${field.id}\n`;
+            content += `  field='${field.name}' node_id=${field.id}\n`;
             field.options.forEach((o) => {
-              content += `    option='${o.name}' id=${o.id}\n`;
+              content += `    option='${o.name}' node_id=${o.id}\n`;
             });
           });
           content += "\n";
@@ -602,11 +602,11 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .object({
           fieldId: z
             .string()
-            .describe("The ID of the field to update (GraphQL ID)."),
+            .describe("The node ID of the field to update (GraphQL ID)."),
           optionId: z
             .string()
             .describe(
-              "The ID of the option to update the field to (GraphQL ID)."
+              "The node ID of the option to update the field to (GraphQL ID)."
             ),
         })
         .optional()


### PR DESCRIPTION
## Description

Example return from listing open projects on our organization:
```
project='Team Tasks' id=PVT_kwDOBusSY84AU_LA description=This is where all actives engineering tasks lives except eng runner's tasks, they have a dedicated project.
  field=Status id=PVTSSF_lADOBusSY84AU_LAzgNaPPQ
    option=Ready id=ec6eff36
    option=Blocked id=87f1e26f
    option=In Progress id=47fc9ee4
    option=Done id=98236657
    option=Archived id=cd036f4a
  field=Stream id=PVTSSF_lADOBusSY84AU_LAzgjeTQ4
    option=Olympus id=896b68a5
    option=_Content nodes -> core id=81204c2c
    option=_JIT DataSources id=1b051ec2
    option=_Builder Feedback Loop id=8883b08e
    option=_Tags as Filters id=d20c6618
    option=_Salesforce Connector id=0f656cf0
    option=_Keyword Search for Knowledge/Builder id=2771a778
    option=_Attach from datasources id=f70b1ff7
    option=Action V2 id=9bfbf579
    option=Agent discovery id=0906e0e2

project='EngRunner' id=PVT_kwDOBusSY84AUxxP description=null
  field=Status id=PVTSSF_lADOBusSY84AUxxPzgNRpNE
    option=Backlog id=f75ad846
    option=In Progress id=47fc9ee4
    option=Done id=98236657
```

Will allow giving general purpose instructions to agents to move issues in various projects without having to discover the project IDs. Was otherwise close to impossible to write a guide for GitHub + this will make issueBot much better than god :)

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`