### PR TITLE
Fix JSONSchema comparison in MCP tool use

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -15,7 +15,7 @@ import {
   findSchemaAtPath,
   followInternalRef,
   isJSONSchemaObject,
-  schemaIsConfigurable,
+  isSchemaConfigurable,
   setValueAtPath,
 } from "@app/lib/utils/json_schemas";
 import type { WorkspaceType } from "@app/types";
@@ -238,12 +238,12 @@ export function hideInternalConfiguration(inputSchema: JSONSchema): JSONSchema {
       if (isJSONSchemaObject(property)) {
         for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
           // Check if the property matches the schema, following references if $ref points to a schema internally.
-          let schemasMatch = schemaIsConfigurable(property, mimeType);
+          let schemasMatch = isSchemaConfigurable(property, mimeType);
 
           if (!schemasMatch && property.$ref) {
             const refSchema = followInternalRef(inputSchema, property.$ref);
             if (refSchema) {
-              schemasMatch = schemaIsConfigurable(refSchema, mimeType);
+              schemasMatch = isSchemaConfigurable(refSchema, mimeType);
             }
           }
 
@@ -349,7 +349,7 @@ export function augmentInputsWithConfiguration({
       // If we found a schema and it has a matching MIME type, inject the value
       if (propSchema) {
         for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
-          if (schemaIsConfigurable(propSchema, mimeType)) {
+          if (isSchemaConfigurable(propSchema, mimeType)) {
             const value = generateConfiguredInput({
               owner,
               actionConfiguration,

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -20,15 +20,15 @@ export function isJSONSchemaObject(
 }
 
 /**
- * Checks if a JSON schema matches should be idenfied as being configurable for a specific mime type.
+ * Checks if a JSON schema matches should be identified as being configurable for a specific mime type.
  */
-export function schemaIsConfigurable(
+export function isSchemaConfigurable(
   schema: JSONSchema,
   mimeType: InternalToolInputMimeType
 ): boolean {
   // If the mime type has a static configuration schema, we check that the schema matches it.
   if (mimeType !== INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM) {
-    return schemasAreEqual(schema, ConfigurableToolInputJSONSchemas[mimeType]);
+    return areSchemasEqual(schema, ConfigurableToolInputJSONSchemas[mimeType]);
   }
   // If the mime type does not have a static configuration schema, it supports flexible schemas.
   // We only check that the schema has a `value` property and a `mimeType` property with the correct value.
@@ -49,7 +49,7 @@ export function schemaIsConfigurable(
  * Compares two JSON schemas for equality, only checking the properties, items and required fields.
  * In particular, it ignores the $schema field.
  */
-function schemasAreEqual(schemaA: JSONSchema, schemaB: JSONSchema): boolean {
+function areSchemasEqual(schemaA: JSONSchema, schemaB: JSONSchema): boolean {
   if (schemaA.type !== schemaB.type) {
     return false;
   }
@@ -59,8 +59,16 @@ function schemasAreEqual(schemaA: JSONSchema, schemaB: JSONSchema): boolean {
   if (!isEqual(schemaA.items, schemaB.items)) {
     return false;
   }
+  if (!isEqual(schemaA.properties, schemaB.properties)) {
+    return false;
+  }
+  // We need this comparison because at least the NULLABLE_TIME_FRAME
+  // relies on the anyOf field.
+  if (!isEqual(schemaA.anyOf, schemaB.anyOf)) {
+    return false;
+  }
 
-  return isEqual(schemaA.properties, schemaB.properties);
+  return isEqual(schemaA, schemaB);
 }
 
 /**
@@ -83,7 +91,7 @@ export function findMatchingSubSchemas(
     for (const [key, propSchema] of Object.entries(inputSchema.properties)) {
       if (isJSONSchemaObject(propSchema)) {
         // Check if this property's schema matches the target
-        if (schemaIsConfigurable(propSchema, mimeType)) {
+        if (isSchemaConfigurable(propSchema, mimeType)) {
           matches[key] = propSchema;
         }
 
@@ -91,7 +99,7 @@ export function findMatchingSubSchemas(
         // zodToJsonSchema generates references if the same subSchema is repeated.
         if (propSchema.$ref) {
           const refSchema = followInternalRef(inputSchema, propSchema.$ref);
-          if (refSchema && schemaIsConfigurable(refSchema, mimeType)) {
+          if (refSchema && isSchemaConfigurable(refSchema, mimeType)) {
             matches[key] = refSchema;
           }
         }
@@ -155,7 +163,7 @@ export function findMatchingSubSchemas(
       continue;
     }
 
-    if (isJSONSchemaObject(value) && schemaIsConfigurable(value, mimeType)) {
+    if (isJSONSchemaObject(value) && isSchemaConfigurable(value, mimeType)) {
       matches[key] = value;
     } else if (isJSONSchemaObject(value)) {
       const nestedMatches = findMatchingSubSchemas(value, mimeType);

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -21,12 +21,7 @@ export function isJSONSchemaObject(
     | boolean
     | undefined
 ): value is JSONSchema {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    value.type === "object"
-  );
+  return !!value && typeof value === "object";
 }
 
 /**
@@ -64,6 +59,10 @@ function areSchemasEqual(schemaA: JSONSchema, schemaB: JSONSchema): boolean {
     return false;
   }
 
+  if (!isEqual(schemaA.required, schemaB.required)) {
+    return false;
+  }
+
   // Checking for arrays with a single schema for all items.
   if (
     schemaA.type === "array" &&
@@ -74,17 +73,11 @@ function areSchemasEqual(schemaA: JSONSchema, schemaB: JSONSchema): boolean {
     return false;
   }
 
-  // Only checking differences on selected fields.
-  const fields = ["required", "anyOf", "oneOf", "allOf", "enum"] as const;
-  if (fields.some((f) => !isEqual(schemaA[f], schemaB[f]))) {
+  if (!isEqual(schemaA.anyOf, schemaB.anyOf)) {
     return false;
   }
 
-  return (
-    schemaA.properties !== undefined &&
-    schemaB.properties !== undefined &&
-    isEqual(schemaA.properties, schemaB.properties)
-  );
+  return isEqual(schemaA.properties, schemaB.properties);
 }
 
 /**

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -53,22 +53,25 @@ function areSchemasEqual(schemaA: JSONSchema, schemaB: JSONSchema): boolean {
   if (schemaA.type !== schemaB.type) {
     return false;
   }
-  if (!isEqual(schemaA.required, schemaB.required)) {
-    return false;
-  }
-  if (!isEqual(schemaA.items, schemaB.items)) {
-    return false;
-  }
-  if (!isEqual(schemaA.properties, schemaB.properties)) {
-    return false;
-  }
-  // We need this comparison because at least the NULLABLE_TIME_FRAME
-  // relies on the anyOf field.
-  if (!isEqual(schemaA.anyOf, schemaB.anyOf)) {
+
+  // Only checking differences on selected fields.
+  const fields = [
+    "required",
+    "items",
+    "anyOf",
+    "oneOf",
+    "allOf",
+    "enum",
+  ] as const;
+  if (fields.some((f) => !isEqual(schemaA[f], schemaB[f]))) {
     return false;
   }
 
-  return isEqual(schemaA, schemaB);
+  return (
+    schemaA.properties !== undefined &&
+    schemaB.properties !== undefined &&
+    isEqual(schemaA.properties, schemaB.properties)
+  );
 }
 
 /**


### PR DESCRIPTION
## Description

- Reverts dust-tt/dust#12681.
- This PR is a fixed version of https://github.com/dust-tt/dust/pull/12673, which contained a check that was too strong.
- The current JSONSchema comparison that is used to replace and reinject pre-configured tool inputs yields incorrect matches.
- Specifically, the `replace_node` tool of the co-edition server triggers a comparison with the nullable time frame input, due to both of them having no `properties` in their resulting JSONSchemas and only `anyOf`.
- This PR strengthens the JSONSchema to catch this case, and adds a strict fallback comparison.
- Took the opportunity to rename a few functions.

## Tests

- Tested locally with the failing case.
- Tested locally with TablesQuery (was previously tested on reasoning only).

## Risk

- Blast radius high as it affects every MCP tool use but risk very low.

## Deploy Plan

- Deploy front.
