### PR TITLE
cli: add fuzzy search for agents

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.8.0",
         "clipboardy": "^4.0.0",
         "express": "^5.1.0",
+        "fuse.js": "^7.1.0",
         "ink": "^5.2.0",
         "ink-select-input": "^6.0.0",
         "ink-spinner": "^5.0.0",
@@ -3978,6 +3979,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-east-asian-width": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,6 +31,7 @@
     "@modelcontextprotocol/sdk": "^1.8.0",
     "clipboardy": "^4.0.0",
     "express": "^5.1.0",
+    "fuse.js": "^7.1.0",
     "ink": "^5.2.0",
     "ink-select-input": "^6.0.0",
     "ink-spinner": "^5.0.0",

--- a/cli/src/ui/components/SelectWithSearch.tsx
+++ b/cli/src/ui/components/SelectWithSearch.tsx
@@ -1,6 +1,7 @@
+import Fuse from "fuse.js";
 import { Box, Text, useInput, useStdout } from "ink";
 import type { ReactNode } from "react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 export interface BaseItem {
   id: string;
@@ -62,9 +63,8 @@ export const SelectWithSearch = <T extends BaseItem>({
     Math.floor(listAvailableHeight / itemLines)
   );
 
-  const filteredItems = items.filter((item) =>
-    item.label.toLowerCase().startsWith(searchQuery.toLowerCase())
-  );
+  const fuse = useMemo(() => new Fuse(items, { keys: ["label"], }), [items]);
+  const filteredItems = fuse.search(searchQuery).map(r => r.item);
 
   const totalPages = Math.max(
     1,


### PR DESCRIPTION
## Description

In our company we currently have many agents that we name with different prefixes depending on the group they are part of. EG:

- Tech_Web
- Tech_Backend
- Sales_Email

It's currently annoying to have to write the whole initial name for selecting the right agent.

With this small change, we can easy select the Tech_Web agent by simply searching for `web`