### PR TITLE
Fix ES alias creation for local dev setup

### DIFF
--- a/core/bin/elasticsearch/create_index.rs
+++ b/core/bin/elasticsearch/create_index.rs
@@ -157,7 +157,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }),
     };
 
-    search_store
+    let alias_creation_response = search_store
         .client
         .indices()
         .update_aliases()
@@ -165,10 +165,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
 
-    match response.status_code() {
+    match alias_creation_response.status_code() {
         StatusCode::OK => Ok(()),
         _ => {
-            let body = response.json::<serde_json::Value>().await?;
+            let body = alias_creation_response.json::<serde_json::Value>().await?;
             eprintln!("{:?}", body);
             Err(anyhow::anyhow!("Failed to create alias").into())
         }

--- a/core/bin/elasticsearch/create_index.rs
+++ b/core/bin/elasticsearch/create_index.rs
@@ -152,7 +152,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         false => serde_json::json!({
             "actions": [
                 { "add": { "index": index_fullname, "alias": index_alias, "is_write_index": true } },
-                { "add": { "index": index_previous_fullname, "alias": index_alias, "is_write_index": false } }
             ]
         }),
     };

--- a/core/bin/elasticsearch/create_index.rs
+++ b/core/bin/elasticsearch/create_index.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // create index with settings and mappings
-    let response = search_store
+    let index_creation_response = search_store
         .client
         .indices()
         .create(IndicesCreateParts::Index(index_fullname.as_str()))
@@ -132,10 +132,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
 
-    match response.status_code() {
+    match index_creation_response.status_code() {
         StatusCode::OK => println!("Index created: {}", index_fullname),
         _ => {
-            let body = response.json::<serde_json::Value>().await?;
+            let body = index_creation_response.json::<serde_json::Value>().await?;
             eprintln!("{:?}", body);
             return Err(anyhow::anyhow!("Failed to create index").into());
         }


### PR DESCRIPTION
## Description

- Multiple errors were observed when setting up a new local dev setup, all due to aliases to the ES indexes not existing.
- These errors were once hidden by the index autocreation, it has been disabled since, which helped uncover an error when because two alias creations were attempted at once (on version `n` and on version `n - 1`).
- This PR fixes this by correctly surfacing the error in the alias creation and removing the extra alias creation.

## Tests

- Tested locally.

## Risk

- N/A, only new local dev setups affected.

## Deploy Plan

- No deploy.
