### PR TITLE
Fix agent feedback display in dark mode

### DIFF
--- a/front/components/assistant_builder/FeedbacksSection.tsx
+++ b/front/components/assistant_builder/FeedbacksSection.tsx
@@ -243,8 +243,8 @@ function FeedbackCard({ owner, feedback }: FeedbackCardProps) {
               className={cn(
                 "rounded-full bg-primary-300 p-2",
                 feedback.thumbDirection === "up"
-                  ? "bg-success-200"
-                  : "bg-info-200"
+                  ? "bg-success-200 dark:bg-success-200-night"
+                  : "bg-info-200 dark:bg-info-200-night"
               )}
             >
               <Icon


### PR DESCRIPTION
## Description

We could not see the 👍🏻  / 👎🏻  in dark mode. 

<img width="416" alt="Screenshot 2025-05-15 at 17 32 15" src="https://github.com/user-attachments/assets/c4617333-e2dc-450c-820e-5ff6b74dd0d7" />


## Tests

Locally. 

## Risk

/

## Deploy Plan

Deploy front. 