### PR TITLE
Fix: normalize 2d array for agent configuration

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -69,6 +69,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { tagsSorter } from "@app/lib/utils";
+import { normalizeArrays } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationScope,
@@ -919,7 +920,7 @@ export async function createAgentConfiguration(
           workspaceId: owner.id,
           authorId: user.id,
           templateId: template?.id,
-          requestedGroupIds,
+          requestedGroupIds: normalizeArrays(requestedGroupIds),
           responseFormat: model.responseFormat,
         },
         {

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -313,17 +313,20 @@ export function isArrayEqual2DUnordered(
   return isEqual(sort2D(first), sort2D(second));
 }
 
-// Postgres requires all subarrays to be of the same length
+// Postgres requires all subarrays to be of the same length.
 // This function ensures that all subarrays are of the same length
 // by repeating the last element of each subarray until all subarrays have the same length.
 // Make sure that it's okay to use this function for your use case.
 export function normalizeArrays<T>(array2D: T[][]): T[][] {
-  const longestArray = array2D.reduce(
+  // Copy the array to avoid mutating the original array.
+  const array2DCopy = array2D.map((array) => [...array]);
+
+  const longestArray = array2DCopy.reduce(
     (max, req) => Math.max(max, req.length),
     0
   );
   // for each array, repeatedly add the last id until array is of longest array length
-  const updatedArrays = array2D.map((array) => {
+  const updatedArrays = array2DCopy.map((array) => {
     while (array.length < longestArray) {
       array.push(array[array.length - 1]);
     }

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -313,6 +313,26 @@ export function isArrayEqual2DUnordered(
   return isEqual(sort2D(first), sort2D(second));
 }
 
+// Postgres requires all subarrays to be of the same length
+// This function ensures that all subarrays are of the same length
+// by repeating the last element of each subarray until all subarrays have the same length.
+// Make sure that it's okay to use this function for your use case.
+export function normalizeArrays<T>(array2D: T[][]): T[][] {
+  const longestArray = array2D.reduce(
+    (max, req) => Math.max(max, req.length),
+    0
+  );
+  // for each array, repeatedly add the last id until array is of longest array length
+  const updatedArrays = array2D.map((array) => {
+    while (array.length < longestArray) {
+      array.push(array[array.length - 1]);
+    }
+    return array;
+  });
+
+  return updatedArrays;
+}
+
 // from http://detectmobilebrowsers.com/
 export const isMobile = (navigator: Navigator) =>
   /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -189,7 +189,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "license": "ISC",
       "dependencies": {
         "@types/json-schema": "^7.0.15",

--- a/front/temporal/permissions_queue/activities.ts
+++ b/front/temporal/permissions_queue/activities.ts
@@ -10,7 +10,7 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { Workspace } from "@app/lib/models/workspace";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { isArrayEqual2DUnordered } from "@app/lib/utils";
+import { isArrayEqual2DUnordered, normalizeArrays } from "@app/lib/utils";
 import mainLogger from "@app/logger/logger";
 
 export async function updateSpacePermissions({
@@ -106,7 +106,7 @@ export async function updateSpacePermissions({
 
     await AgentConfiguration.update(
       {
-        requestedGroupIds,
+        requestedGroupIds: normalizeArrays(requestedGroupIds),
       },
       {
         where: {


### PR DESCRIPTION
## Description

Apply the same normalization for agent configurations `requestedGroupIds` that we do for conversation.

## Tests

Local

## Risk

Low, just moved code and same exact use case.

## Deploy Plan

Deploy `front`