### PR TITLE
MCP: add DD metric for mcp_actions

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -54,6 +54,7 @@ import { FileModel } from "@app/lib/resources/storage/models/files";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
 import type {
   AgentConfigurationType,
   AgentMessageType,
@@ -74,7 +75,6 @@ import {
   Ok,
   removeNulls,
 } from "@app/types";
-import { statsDClient } from "@app/logger/statsDClient";
 
 const MAX_BLOB_SIZE_BYTES = 1024 * 1024 * 10; // 10MB
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/2864

- Adds DD `increments` for `mcp_actions_timeout`, `mcp_actions_denied`, `mcp_actions_error` and `mcp_actions_success`
- Tweaks existing logs to include workspace and action name information.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`