### PR TITLE
[MCP Extract] Pass agentsList as arg to constructMAAPrompt

### DIFF
--- a/front/lib/actions/process.ts
+++ b/front/lib/actions/process.ts
@@ -362,6 +362,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
         "Process the retrieved data to extract structured information based on the provided schema.",
       model: supportedModel,
       hasAvailableActions: false,
+      agentsList: null,
     });
 
     const dataSourceViews = await DataSourceViewResource.fetchByIds(

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -26,7 +26,10 @@ import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
 } from "@app/lib/api/assistant/agent_message_content_parser";
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import {
+  getAgentConfiguration,
+  getAgentConfigurations,
+} from "@app/lib/api/assistant/configuration";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getEmulatedAndJITActions } from "@app/lib/api/assistant/jit_actions";
 import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent";
@@ -402,6 +405,16 @@ async function* runMultiActionsAgent(
     fallbackPrompt += ".";
   }
 
+  const agentsList = agentConfiguration.instructions?.includes(
+    "{ASSISTANTS_LIST}"
+  )
+    ? await getAgentConfigurations({
+        auth,
+        agentsGetView: auth.user() ? "list" : "all",
+        variant: "light",
+      })
+    : null;
+
   const prompt = await constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -409,6 +422,7 @@ async function* runMultiActionsAgent(
     model,
     hasAvailableActions: !!availableActions.length,
     errorContext: error,
+    agentsList,
   });
 
   const MIN_GENERATION_TOKENS = model.generationTokensCount;


### PR DESCRIPTION
Description
---
Preparation for creation of the MCP Extract action, replacing the legacy one.

The Extract action relies on constructPrompt. In very rare cases constructPrompt needs to list agents, which creates a circular dependency when using constructPrompt in an MCP server.

Those rare cases are 1. never seen with an extract action, see [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1747324914670829) and 2. even if, irrelevant to the action itself which does not needs the replacement.

This PR therefore allows avoiding the circular dependency

Risks
---
standard

Deploy
---
front
