### PR TITLE
feat: log userid

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -39,9 +39,9 @@ export function withSessionAuthentication<T>(
     async (
       req: NextApiRequest,
       res: NextApiResponse<WithAPIErrorResponse<T>>,
-      { session }
+      context
     ) => {
-      if (!session) {
+      if (!context.session) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {
@@ -52,7 +52,7 @@ export function withSessionAuthentication<T>(
         });
       }
 
-      return handler(req, res, session);
+      return handler(req, res, context.session);
     },
     isStreaming
   );

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -47,32 +47,24 @@ export function withSessionAuthentication<T>(
   handler: WithSessionAuthenticationForWorkspaceHandler<T>,
   { isStreaming = false }: { isStreaming?: boolean } = {}
 ) {
-  return withLogging(
-    async (
+  return withLogging<T>(async (req, res, context, updateContext) => {
+    if (!context.session) {
+      return apiError(req, res, {
+        status_code: 401,
+        api_error: {
+          type: "not_authenticated",
+          message:
+            "The user does not have an active session or is not authenticated.",
+        },
+      });
+    }
+    return handler(
       req,
-      res: NextApiResponse<WithAPIErrorResponse<T>>,
-      context,
+      res,
+      context as SessionAuthenticationContext,
       updateContext
-    ) => {
-      if (!context.session) {
-        return apiError(req, res, {
-          status_code: 401,
-          api_error: {
-            type: "not_authenticated",
-            message:
-              "The user does not have an active session or is not authenticated.",
-          },
-        });
-      }
-      return handler(
-        req,
-        res,
-        context as SessionAuthenticationContext,
-        updateContext
-      );
-    },
-    isStreaming
-  );
+    );
+  }, isStreaming);
 }
 
 /**

--- a/front/lib/iam/provider.ts
+++ b/front/lib/iam/provider.ts
@@ -2,6 +2,7 @@ import type { Session } from "@auth0/nextjs-auth0";
 
 // This maps to the Auth0 user.
 export interface ExternalUser {
+  sid: string;
   email: string;
   email_verified: boolean;
   name: string;

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -38,7 +38,7 @@ function loggingContextInfo(
   };
 
   if (context.auth !== null && context.auth.user() !== null) {
-    metadata.userId = context.auth.getNonNullableWorkspace().sId;
+    metadata.userId = context.auth.getNonNullableUser().sId;
   }
 
   if (context.token !== null) {

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -101,7 +101,7 @@ export function withLogging<T>(
     };
 
     try {
-      // Make a clone to make sure we don't change it deeply by mistake
+      // Make a clone to make sure we don't change it deeply by mistake.
       await handler(req, res, cloneDeep(context), (key, value) => {
         context[key] = value;
       });

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -48,13 +48,15 @@ function loggingContextInfo(
   return metadata;
 }
 
+export type WithContextHandler<C, T> = (
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<T>>,
+  context: C,
+  updateContext: UpdateLoggingContextCallback
+) => Promise<void> | void;
+
 export function withLogging<T>(
-  handler: (
-    req: NextApiRequest,
-    res: NextApiResponse<WithAPIErrorResponse<T>>,
-    context: LoggingContext,
-    updateContext: UpdateLoggingContextCallback
-  ) => Promise<void>,
+  handler: WithContextHandler<LoggingContext, T>,
   streaming = false
 ) {
   return async (
@@ -99,7 +101,7 @@ export function withLogging<T>(
     };
 
     try {
-      // make a clone to make sure we don't change it deeply by mistake
+      // Make a clone to make sure we don't change it deeply by mistake
       await handler(req, res, cloneDeep(context), (key, value) => {
         context[key] = value;
       });

--- a/front/pages/api/app-status.ts
+++ b/front/pages/api/app-status.ts
@@ -5,7 +5,6 @@ import {
   getDustStatusMemoized,
   getProviderStatusMemoized,
 } from "@app/lib/api/status";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -24,9 +23,7 @@ export interface GetAppStatusResponseBody {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetAppStatusResponseBody>>,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- session is passed by the auth wrapper
-  session: SessionWithUser
+  res: NextApiResponse<WithAPIErrorResponse<GetAppStatusResponseBody>>
 ): Promise<void> {
   if (req.method !== "GET") {
     return apiError(req, res, {

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { createWorkspace } from "@app/lib/iam/workspaces";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -12,7 +12,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<{ sId: string }>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   if (req.method !== "POST") {
     return apiError(req, res, {

--- a/front/pages/api/poke/admin.ts
+++ b/front/pages/api/poke/admin.ts
@@ -2,10 +2,10 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { AdminResponseType, WithAPIErrorResponse } from "@app/types";
@@ -14,7 +14,7 @@ import { AdminCommandSchema, ConnectorsAPI } from "@app/types";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<AdminResponseType>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/poke/kill.ts
+++ b/front/pages/api/poke/kill.ts
@@ -3,9 +3,9 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import type { KillSwitchType } from "@app/lib/poke/types";
 import { isKillSwitchType } from "@app/lib/poke/types";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
@@ -26,7 +26,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<GetKillSwitchesResponseBody | { success: true }>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -3,9 +3,9 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { apiError } from "@app/logger/withlogging";
@@ -66,7 +66,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<GetPokePlansResponseBody | UpsertPokePlanResponseBody>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/poke/plugins/[pluginId]/manifest.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/manifest.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type {
   PluginArgs,
@@ -19,7 +19,7 @@ export interface PokeGetPluginDetailsResponseBody {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeGetPluginDetailsResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
   if (!auth.isDustSuperUser()) {

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -4,12 +4,12 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import type { PluginResponse } from "@app/lib/api/poke/types";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -48,7 +48,7 @@ export interface PokeRunPluginResponseBody {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeRunPluginResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   let auth = await Authenticator.fromSuperUserSession(session, null);
   if (!auth.isDustSuperUser()) {

--- a/front/pages/api/poke/plugins/index.ts
+++ b/front/pages/api/poke/plugins/index.ts
@@ -1,11 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import type { PluginListItem } from "@app/lib/api/poke/types";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isSupportedResourceType } from "@app/types";
@@ -19,7 +19,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<PokeListPluginsForScopeResponseBody>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   let auth = await Authenticator.fromSuperUserSession(session, null);
   if (!auth.isDustSuperUser()) {

--- a/front/pages/api/poke/region.ts
+++ b/front/pages/api/poke/region.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -14,7 +14,7 @@ export type GetRegionResponseType = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetRegionResponseType>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ) {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/poke/search.ts
+++ b/front/pages/api/poke/search.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { searchPokeResources } from "@app/lib/poke/search";
 import { apiError } from "@app/logger/withlogging";
 import type { PokeItemBase } from "@app/types";
@@ -15,7 +15,7 @@ export type GetPokeSearchItemsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetPokeSearchItemsResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -3,9 +3,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -26,7 +26,7 @@ async function handler(
       PokeCreateTemplateResponseBody | PokeFetchAssistantTemplateResponse
     >
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -3,9 +3,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { AssistantTemplateListType } from "@app/pages/api/templates";
@@ -27,7 +27,7 @@ async function handler(
       CreateTemplateResponseBody | PokeFetchAssistantTemplatesResponse
     >
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -19,7 +19,7 @@ export type PullTemplatesResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PullTemplatesResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -2,9 +2,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type {
   LightAgentConfigurationType,
@@ -35,7 +35,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<ExportAgentConfigurationResponseBody>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -4,9 +4,9 @@ import {
   archiveAgentConfiguration,
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -19,7 +19,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<DeleteAgentConfigurationResponseBody>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -4,9 +4,9 @@ import {
   getAgentConfiguration,
   restoreAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -19,7 +19,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<RestoreAgentConfigurationResponseBody>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/import.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/import.ts
@@ -2,9 +2,9 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentConfigurationType, WithAPIErrorResponse } from "@app/types";
@@ -19,7 +19,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<{ assistant: AgentConfigurationType }>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ) {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -4,9 +4,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -20,7 +20,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<GetAgentConfigurationsResponseBody | void>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -1,10 +1,10 @@
 import _ from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getDatasetHash, getDatasets } from "@app/lib/api/datasets";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { AppType, DatasetType, WithAPIErrorResponse } from "@app/types";
@@ -20,7 +20,7 @@ export type ExportAppResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<ExportAppResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -1,9 +1,9 @@
 import { isLeft } from "fp-ts/lib/Either";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { PostStateResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/state";
@@ -13,7 +13,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PostStateResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId } = req.query;
   if (typeof wId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/apps/import.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/import.ts
@@ -2,9 +2,9 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { importApp } from "@app/lib/utils/apps";
 import { apiError } from "@app/logger/withlogging";
@@ -62,7 +62,7 @@ export const ImportAppBody = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<{ app: AppType }>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ) {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/apps/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/index.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { AppType, WithAPIErrorResponse } from "@app/types";
@@ -14,7 +14,7 @@ export type PokeListApps = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeListApps>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId } = req.query;
   if (typeof wId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getPokeConversation } from "@app/lib/poke/conversations";
 import { apiError } from "@app/logger/withlogging";
 import type { PokeConversationType, WithAPIErrorResponse } from "@app/types";
@@ -15,7 +15,7 @@ export type GetConversationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetConversationResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { DataSourceViewType, WithAPIErrorResponse } from "@app/types";
@@ -14,7 +14,7 @@ export type PokeListDataSourceViews = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeListDataSourceViews>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId } = req.query;
   if (typeof wId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -18,7 +18,7 @@ export type SetConfigResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<SetConfigResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -18,7 +18,7 @@ export type GetDocumentsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { softDeleteDataSourceAndLaunchScrubWorkflow } from "@app/lib/api/data_sources";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -16,7 +16,7 @@ export type DeleteDataSourceResponseBody = DataSourceType;
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<DeleteDataSourceResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
@@ -14,7 +14,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<GetDataSourcePermissionsResponseBody>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -3,10 +3,10 @@ import { DataSourceSearchQuerySchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceSearch } from "@app/lib/api/data_sources";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -15,7 +15,7 @@ import { assertNever } from "@app/types";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<DataSourceSearchResponseType>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -18,7 +18,7 @@ export type GetTablesResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetTablesResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/index.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { DataSourceType, WithAPIErrorResponse } from "@app/types";
@@ -14,7 +14,7 @@ export type PokeListDataSources = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeListDataSources>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId } = req.query;
   if (typeof wId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
@@ -16,7 +16,7 @@ export type DowngradeWorkspaceResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<DowngradeWorkspaceResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { apiError } from "@app/logger/withlogging";
 import type { WhitelistableFeature, WithAPIErrorResponse } from "@app/types";
@@ -23,7 +23,7 @@ async function handler(
       CreateOrDeleteFeatureFlagResponseBody | GetPokeFeaturesResponseBody
     >
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -3,10 +3,10 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { setInternalWorkspaceSegmentation } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { LightWorkspaceType, WithAPIErrorResponse } from "@app/types";
 
@@ -29,7 +29,7 @@ async function handler(
       SegmentWorkspaceResponseBody | DeleteWorkspaceResponseBody
     >
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -3,13 +3,13 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import {
   getPendingInvitations,
   updateInvitationStatusAndRole,
 } from "@app/lib/api/invitation";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -26,7 +26,7 @@ type PokePostInvitationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokePostInvitationResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -15,7 +15,7 @@ export type PokeListMCPServerViews = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeListMCPServerViews>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId } = req.query;
   if (typeof wId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { revokeAndTrackMembership } from "@app/lib/api/membership";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { assertNever } from "@app/types";
@@ -16,7 +16,7 @@ export type RevokeUserResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<RevokeUserResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -3,10 +3,10 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
@@ -25,7 +25,7 @@ const PostRoleUserRequestBody = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PostRoleUserResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -3,11 +3,11 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -36,7 +36,7 @@ export type PokeGetDataSourceViewContentNodes = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeGetDataSourceViewContentNodes>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId } = req.query;
   if (typeof wId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/spaces/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/index.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { SpaceType, WithAPIErrorResponse } from "@app/types";
@@ -14,7 +14,7 @@ export type PokeListSpaces = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeListSpaces>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId } = req.query;
   if (typeof wId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/trackers/[tId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/trackers/[tId].ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -17,7 +17,7 @@ export type PokeFetchTrackerResponse = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeFetchTrackerResponse>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId, tId } = req.query;
   if (typeof wId !== "string" || typeof tId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/trackers/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/trackers/index.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -17,7 +17,7 @@ export type PokeListTrackers = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PokeListTrackers>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const { wId } = req.query;
   if (typeof wId !== "string") {

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -2,9 +2,9 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
@@ -18,7 +18,7 @@ export type UpgradeWorkspaceResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<UpgradeWorkspaceResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -2,9 +2,9 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import {
   assertStripeSubscriptionIsValid,
   getStripeSubscription,
@@ -24,7 +24,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<UpgradeEnterpriseSuccessResponseBody>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(
     session,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -2,10 +2,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import type { FindOptions, Order, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/models/workspace_has_domain";
@@ -73,7 +73,7 @@ const getPlanPriority = (planCode: string) => {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetPokeWorkspacesResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const auth = await Authenticator.fromSuperUserSession(session, null);
 

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -3,9 +3,9 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -19,7 +19,7 @@ type PostStripePortalResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PostStripePortalResponseBody>>,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const bodyValidation = PostStripePortalRequestBody.decode(req.body);
   if (isLeft(bodyValidation)) {

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -3,8 +3,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
@@ -31,7 +31,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<PostUserMetadataResponseBody | GetUserResponseBody>
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   // This functions retrieves the full user including all workspaces.
   const user = await getUserFromSession(session);

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
+import type { SessionAuthenticationContext } from "@app/lib/api/auth_wrappers";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -22,7 +22,7 @@ async function handler(
       PostUserMetadataResponseBody | GetUserMetadataResponseBody
     >
   >,
-  session: SessionWithUser
+  { session }: SessionAuthenticationContext
 ): Promise<void> {
   const user = await getUserFromSession(session);
 

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -58,6 +58,7 @@ export const createPrivateApiMockRequest = async ({
   vi.mocked(getSession).mockReturnValue(
     Promise.resolve({
       user: {
+        sid: user.sId,
         sub: user.auth0Sub!,
         email: user.email!,
         email_verified: true,


### PR DESCRIPTION
## Description
- Add `userId` to processed request log
- Create context and way of updating context from below in the callstack
- Update all `session` coming from `withSessionAuthentication` with the new context. Goal is for that to be more flexible for futur usage, with less to rewrite if we want to add more info in context.
- Added a `updateContext` to force flow of update, we could remove `cloneDeep(context)` and just update the context itself down the callstack, but I'm afraid it would make update hidden and hard to track.

## Tests
- Locally
- Front-edge

## Risk
Mid:
- a lot of code, but highly typed
- Just a simple destructuration of an object.

## Deploy Plan
- Deploy front
