### PR TITLE
enh(cli): improve handling of term width shrink

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -19,6 +19,7 @@
         "install": "^0.13.0",
         "jwt-decode": "^4.0.0",
         "keytar": "^7.9.0",
+        "lodash": "^4.17.21",
         "meow": "^13.2.0",
         "node-fetch": "^3.3.2",
         "npm": "^11.2.0",
@@ -32,6 +33,7 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.1",
+        "@types/lodash": "^4.17.16",
         "@types/node": "^22.13.16",
         "@types/react": "^19.0.12",
         "@types/update-notifier": "^6.0.8",
@@ -1275,6 +1277,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5220,6 +5229,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,7 @@
     "install": "^0.13.0",
     "jwt-decode": "^4.0.0",
     "keytar": "^7.9.0",
+    "lodash": "^4.17.21",
     "meow": "^13.2.0",
     "node-fetch": "^3.3.2",
     "npm": "^11.2.0",
@@ -50,6 +51,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.1",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^22.13.16",
     "@types/react": "^19.0.12",
     "@types/update-notifier": "^6.0.8",

--- a/cli/src/ui/components/Conversation.tsx
+++ b/cli/src/ui/components/Conversation.tsx
@@ -44,7 +44,7 @@ export type ConversationItem = { key: string } & (
     }
 );
 
-type ConversationProps = {
+interface ConversationProps {
   conversationItems: ConversationItem[];
   isProcessingQuestion: boolean;
   userInput: string;
@@ -52,7 +52,7 @@ type ConversationProps = {
   mentionPrefix: string;
   conversationId: string | null;
   stdout: NodeJS.WriteStream | null;
-};
+}
 
 const _Conversation: FC<ConversationProps> = ({
   conversationItems,
@@ -101,10 +101,15 @@ const _Conversation: FC<ConversationProps> = ({
   );
 };
 
-const StaticConversationItem: FC<{
+interface StaticConversationItemProps {
   item: ConversationItem;
   stdout: NodeJS.WriteStream | null;
-}> = ({ item, stdout }) => {
+}
+
+const StaticConversationItem: FC<StaticConversationItemProps> = ({
+  item,
+  stdout,
+}) => {
   const terminalWidth = stdout?.columns || 80;
   const rightPadding = 4;
 

--- a/cli/src/ui/components/Conversation.tsx
+++ b/cli/src/ui/components/Conversation.tsx
@@ -1,0 +1,219 @@
+import { assertNever } from "@dust-tt/client";
+import { Box, Static, Text } from "ink";
+import Spinner from "ink-spinner";
+import _ from "lodash";
+import type { FC } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useTerminalSize } from "../../utils/hooks/use_terminal_size.js";
+import { clearTerminal } from "../../utils/terminal.js";
+import { InputBox } from "./InputBox.js";
+
+export type ConversationItem = { key: string } & (
+  | {
+      type: "welcome_header";
+      agentName: string;
+      agentId: string;
+    }
+  | {
+      type: "user_message";
+      firstName: string;
+      content: string;
+      index: number;
+    }
+  | {
+      type: "agent_message_header";
+      agentName: string;
+      index: number;
+    }
+  | {
+      type: "agent_message_cot_line";
+      text: string;
+      index: number;
+    }
+  | {
+      type: "agent_message_content_line";
+      text: string;
+      index: number;
+    }
+  | {
+      type: "agent_message_cancelled";
+    }
+  | {
+      type: "separator";
+    }
+);
+
+type ConversationProps = {
+  conversationItems: ConversationItem[];
+  isProcessingQuestion: boolean;
+  userInput: string;
+  cursorPosition: number;
+  mentionPrefix: string;
+  conversationId: string | null;
+  stdout: NodeJS.WriteStream | null;
+};
+
+const _Conversation: FC<ConversationProps> = ({
+  conversationItems,
+  isProcessingQuestion,
+  userInput,
+  cursorPosition,
+  mentionPrefix,
+  conversationId,
+  stdout,
+}: ConversationProps) => {
+  return (
+    <Box flexDirection="column" height="100%">
+      <Static items={conversationItems}>
+        {(item) => {
+          return (
+            <StaticConversationItem
+              item={item}
+              stdout={stdout}
+              key={item.key}
+            />
+          );
+        }}
+      </Static>
+
+      {isProcessingQuestion && (
+        <Box marginTop={1}>
+          <Text color="green">
+            Thinking <Spinner type="simpleDots" />
+          </Text>
+        </Box>
+      )}
+
+      <InputBox
+        userInput={userInput}
+        cursorPosition={cursorPosition}
+        isProcessingQuestion={isProcessingQuestion}
+        mentionPrefix={mentionPrefix}
+      />
+      <Box marginTop={0}>
+        <Text dimColor>
+          ↵ to send · \↵ for new line · ESC to clear
+          {conversationId && "· Ctrl+G to open in browser"}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+const StaticConversationItem: FC<{
+  item: ConversationItem;
+  stdout: NodeJS.WriteStream | null;
+}> = ({ item, stdout }) => {
+  const terminalWidth = stdout?.columns || 80;
+  const rightPadding = 4;
+
+  switch (item.type) {
+    case "welcome_header":
+      return (
+        <Box flexDirection="row" marginBottom={1}>
+          <Box borderStyle="round" borderColor="gray" paddingX={1} paddingY={1}>
+            <Box flexDirection="column">
+              <Box justifyContent="center">
+                <Text bold>Welcome to Dust CLI beta!</Text>
+              </Box>
+              <Box height={1}></Box>
+              <Box justifyContent="center">
+                <Text>
+                  You&apos;re currently chatting with {item.agentName} (
+                  {item.agentId})
+                </Text>
+              </Box>
+              <Box height={1}></Box>
+              <Box justifyContent="center">
+                <Text dimColor>
+                  Type your message below and press Enter to send
+                </Text>
+              </Box>
+            </Box>
+          </Box>
+          <Box></Box>
+        </Box>
+      );
+    case "user_message":
+      return (
+        <Box flexDirection="column" marginBottom={1}>
+          <Box>
+            <Text bold color="green">
+              {item.firstName ?? "You"}
+            </Text>
+          </Box>
+          <Box
+            marginLeft={2}
+            marginRight={rightPadding}
+            flexDirection="column"
+            width={terminalWidth - rightPadding - 2}
+          >
+            <Text wrap="wrap">
+              {item.content.replace(/^\n+/, "").replace(/\n+$/, "")}
+            </Text>
+          </Box>
+        </Box>
+      );
+    case "agent_message_header":
+      return (
+        <Box>
+          <Text bold color="blue">
+            {item.agentName}
+          </Text>
+        </Box>
+      );
+    case "agent_message_cot_line":
+      return (
+        <Box marginLeft={2}>
+          <Text dimColor italic>
+            {item.text}
+          </Text>
+        </Box>
+      );
+    case "agent_message_content_line":
+      return (
+        <Box marginLeft={2}>
+          <Text>{item.text}</Text>
+        </Box>
+      );
+    case "agent_message_cancelled":
+      return (
+        <Box marginBottom={1} marginTop={1}>
+          <Text color="red">[Cancelled]</Text>
+        </Box>
+      );
+    case "separator":
+      return <Box height={1}></Box>;
+    default:
+      assertNever(item);
+  }
+};
+
+/**
+ * Wraps the _Conversation component to fully rerender it when the terminal is resized.
+ * This also clears the terminal before rendering.
+ * This is needed to prevent artifacts when terminal's width shrinks.
+ */
+const Conversation: React.FC<ConversationProps> = (props) => {
+  const [renderKey, setRenderKey] = useState(0);
+  const { columns } = useTerminalSize();
+
+  const handleResize = useCallback(() => {
+    void clearTerminal().then(() => setRenderKey((k) => k + 1));
+  }, []);
+
+  const debouncedHandleResize = useMemo(
+    () => _.debounce(handleResize, 100),
+    [handleResize]
+  );
+
+  useEffect(() => {
+    debouncedHandleResize();
+    return debouncedHandleResize.cancel;
+  }, [debouncedHandleResize, columns]);
+
+  return <_Conversation {...props} key={renderKey.toString()} />;
+};
+
+export default Conversation;

--- a/cli/src/ui/components/InputBox.tsx
+++ b/cli/src/ui/components/InputBox.tsx
@@ -1,12 +1,12 @@
 import { Box, Text } from "ink";
 import React from "react";
 
-type InputBoxProps = {
+interface InputBoxProps {
   userInput: string;
   cursorPosition: number;
   isProcessingQuestion: boolean;
   mentionPrefix: string;
-};
+}
 
 export function InputBox({
   userInput,
@@ -48,7 +48,7 @@ export function InputBox({
       >
         <Box flexDirection="column">
           {
-            // Find which line and position the cursor is on
+            // Find which line and position the cursor is on.
             lines.map((line, index) => (
               <Box key={index}>
                 {index === 0 && (
@@ -69,8 +69,8 @@ export function InputBox({
                     <Text>{line.substring(cursorPosInLine + 1)}</Text>
                   </>
                 ) : (
-                  // Regular line without cursor
-                  // For empty lines, just render a space to ensure the line is visible
+                  // Regular line without cursor.
+                  // For empty lines, just render a space to ensure the line is visible.
                   <Text>{line === "" ? " " : line}</Text>
                 )}
               </Box>

--- a/cli/src/ui/components/InputBox.tsx
+++ b/cli/src/ui/components/InputBox.tsx
@@ -1,0 +1,83 @@
+import { Box, Text } from "ink";
+import React from "react";
+
+type InputBoxProps = {
+  userInput: string;
+  cursorPosition: number;
+  isProcessingQuestion: boolean;
+  mentionPrefix: string;
+};
+
+export function InputBox({
+  userInput,
+  cursorPosition,
+  isProcessingQuestion,
+  mentionPrefix,
+}: InputBoxProps) {
+  let currentPos = 0;
+  const lines = userInput.split("\n");
+  const cursorLine = lines.findIndex((line) => {
+    if (
+      cursorPosition >= currentPos &&
+      cursorPosition <= currentPos + line.length
+    ) {
+      return true;
+    }
+    currentPos += line.length + 1;
+    return false;
+  });
+
+  const cursorPosInLine =
+    cursorLine >= 0
+      ? cursorPosition -
+        (cursorLine === 0
+          ? 0
+          : lines
+              .slice(0, cursorLine)
+              .reduce((sum, line) => sum + line.length + 1, 0))
+      : 0;
+
+  return (
+    <Box flexDirection="column" marginTop={0} paddingTop={0}>
+      <Box
+        borderStyle="round"
+        borderColor="gray"
+        padding={0}
+        paddingX={1}
+        marginTop={0}
+      >
+        <Box flexDirection="column">
+          {
+            // Find which line and position the cursor is on
+            lines.map((line, index) => (
+              <Box key={index}>
+                {index === 0 && (
+                  <Text color={isProcessingQuestion ? "gray" : "cyan"} bold>
+                    {mentionPrefix}
+                  </Text>
+                )}
+
+                {index === cursorLine ? (
+                  <>
+                    <Text>{line.substring(0, cursorPosInLine)}</Text>
+                    <Text
+                      backgroundColor={isProcessingQuestion ? "gray" : "blue"}
+                      color="white"
+                    >
+                      {line.charAt(cursorPosInLine) || " "}
+                    </Text>
+                    <Text>{line.substring(cursorPosInLine + 1)}</Text>
+                  </>
+                ) : (
+                  // Regular line without cursor
+                  // For empty lines, just render a space to ensure the line is visible
+                  <Text>{line === "" ? " " : line}</Text>
+                )}
+              </Box>
+            ))
+          }
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/cli/src/utils/hooks/use_clear_terminal_on_mount.ts
+++ b/cli/src/utils/hooks/use_clear_terminal_on_mount.ts
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 
+import { clearTerminal } from "../terminal.js";
+
 export function useClearTerminalOnMount() {
   useEffect(() => {
-    process.stdout.write("\x1bc");
+    void clearTerminal();
   }, []);
 }

--- a/cli/src/utils/hooks/use_terminal_size.ts
+++ b/cli/src/utils/hooks/use_terminal_size.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+export function useTerminalSize() {
+  const [size, setSize] = useState({
+    columns: process.stdout.columns || 80,
+    rows: process.stdout.rows || 24,
+  });
+
+  useEffect(() => {
+    function updateSize() {
+      setSize({
+        columns: process.stdout.columns || 80,
+        rows: process.stdout.rows || 24,
+      });
+    }
+
+    process.stdout.on("resize", updateSize);
+    return () => {
+      process.stdout.off("resize", updateSize);
+    };
+  }, []);
+
+  return size;
+}

--- a/cli/src/utils/terminal.ts
+++ b/cli/src/utils/terminal.ts
@@ -1,0 +1,7 @@
+export function clearTerminal(): Promise<void> {
+  return new Promise((resolve) => {
+    process.stdout.write("\x1b[2J\x1b[3J\x1b[H", () => {
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## Description

Handling terminal width shrink in a TUI is tricky. OpenAI codex is quite broken when you reduce the width, and the earlier versions of Claude Code as well (they have now found a solution).

Our CLI currently looks like this on width shrink:
![before](https://github.com/user-attachments/assets/f97f8f7f-39c0-4cfd-adcd-03b313510ce9)

This PR implements a solution that listens for resize events, clears the terminal and forces the re-render of the static conversation + input bar.

It now looks like this:

![after](https://github.com/user-attachments/assets/0b67dcf9-71ab-44f7-8e3c-e79a264dec67)


Also includes a little bit of refactoring (split Chat.tsx in a few files)


## Tests

Manual

## Risk

N/A

## Deploy Plan

Nothing for now (will package other changes in the next CLI version