### PR TITLE
Add: correct dynamic tags support for search and include

### DIFF
--- a/front/components/assistant/details/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/AssistantKnowledgeSection.tsx
@@ -22,13 +22,13 @@ import { useMemo, useState } from "react";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { DataSourceViewPermissionTree } from "@app/components/DataSourceViewPermissionTree";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import type { DataSourceConfiguration } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
 import {
   isRetrievalConfiguration,
   isServerSideMCPServerConfiguration,
   isTablesQueryConfiguration,
 } from "@app/lib/actions/types/guards";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import { getContentNodeInternalIdFromTableId } from "@app/lib/api/content_nodes";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -16,10 +16,7 @@ import type { DustAppRunConfigurationType } from "@app/lib/actions/dust_app_run"
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { ProcessConfigurationType } from "@app/lib/actions/process";
 import type { ReasoningConfigurationType } from "@app/lib/actions/reasoning";
-import type {
-  DataSourceConfiguration,
-  RetrievalConfigurationType,
-} from "@app/lib/actions/retrieval";
+import type { RetrievalConfigurationType } from "@app/lib/actions/retrieval";
 import type {
   TableDataSourceConfiguration,
   TablesQueryConfigurationType,
@@ -36,6 +33,7 @@ import {
   isTablesQueryConfiguration,
   isWebsearchConfiguration,
 } from "@app/lib/actions/types/guards";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -14,11 +14,9 @@ import {
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
-import type {
-  DataSourceConfiguration,
-  RetrievalTimeframe,
-} from "@app/lib/actions/retrieval";
+import type { RetrievalTimeframe } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type {
   AgentConfigurationType,
   DataSourceViewSelectionConfigurations,

--- a/front/lib/actions/configuration/helpers.ts
+++ b/front/lib/actions/configuration/helpers.ts
@@ -1,9 +1,7 @@
-import type {
-  DataSourceConfiguration,
-  DataSourceFilter,
-  RetrievalTimeframe,
-} from "@app/lib/actions/retrieval";
+import type { RetrievalTimeframe } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
+import type { DataSourceFilter } from "@app/lib/api/assistant/configuration";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import type { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import type { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -24,7 +24,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { getMCPEvents } from "@app/lib/actions/pubsub";
 import type { ReasoningModelConfiguration } from "@app/lib/actions/reasoning";
-import type { DataSourceConfiguration } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
 import type {
   AgentLoopRunContextType,
@@ -40,6 +39,7 @@ import type {
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   processAndStoreFromUrl,
   uploadBase64ImageToFileStorage,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -193,7 +193,7 @@ export async function* tryCallMCPTool(
   try {
     const r = await connectToMCPServer(auth, {
       params: connectionParamsRes.value,
-      agentLoopContext: { agentLoopRunContext },
+      agentLoopContext: { runContext: agentLoopRunContext },
     });
     if (r.isErr()) {
       yield {
@@ -658,7 +658,7 @@ async function listMCPServerTools(
     const connectionParams = connectionParamsRes.value;
     const r = await connectToMCPServer(auth, {
       params: connectionParams,
-      agentLoopContext: { agentLoopListToolsContext },
+      agentLoopContext: { listToolsContext: agentLoopListToolsContext },
     });
     if (r.isErr()) {
       return r;

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -13,7 +13,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   getCoreSearchArgs,
-  mustTagsBeSuppliedByLLM,
+  shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
@@ -77,8 +77,8 @@ function createServer(
       ),
   };
 
-  const tagsAreDynamic = agentLoopContext
-    ? mustTagsBeSuppliedByLLM(agentLoopContext)
+  const areTagsDynamic = agentLoopContext
+    ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
   const includeFunction = async ({
@@ -245,7 +245,7 @@ function createServer(
     };
   };
 
-  if (!tagsAreDynamic) {
+  if (!areTagsDynamic) {
     server.tool(
       "retrieve_recent_documents",
       "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -1,14 +1,21 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import assert from "assert";
+import { trim } from "lodash";
+import { z } from "zod";
 
+import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   IncludeQueryResourceType,
   IncludeResultResourceType,
+  MCPToolResult,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import {
+  getCoreSearchArgs,
+  mustTagsBeSuppliedByLLM,
+} from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -28,6 +35,8 @@ import {
   timeFrameFromNow,
 } from "@app/types";
 
+const DEFAULT_SEARCH_LABELS_LIMIT = 10;
+
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "include_data",
   version: "1.0.0",
@@ -38,83 +47,122 @@ const serverInfo: InternalMCPServerDefinitionType = {
 
 function createServer(
   auth: Authenticator,
-  agentLoopRunContext?: AgentLoopRunContextType
+  agentLoopContext?: AgentLoopContextType
 ): McpServer {
   const server = new McpServer(serverInfo);
 
-  server.tool(
-    "retrieve_recent_documents",
-    "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
-    {
-      timeFrame:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
-        ],
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-    },
-    async ({ timeFrame, dataSources }) => {
-      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-      const credentials = dustManagedCredentials();
+  const commonInputsSchema = {
+    timeFrame:
+      ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+      ],
+    dataSources:
+      ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  };
 
-      if (!agentLoopRunContext) {
-        throw new Error(
-          "agentLoopRunContext is required where the tool is called."
-        );
-      }
+  const tagsInputSchema = {
+    tagsIn: z
+      .array(z.string())
+      .describe(
+        "A list of labels (also called tags) to restrict the search based on the user request and past conversation context." +
+          "If multiple labels are provided, the search will return documents that have at least one of the labels." +
+          "You can't check that all labels are present, only that at least one is present." +
+          "If no labels are provided, the search will return all documents regardless of their labels."
+      ),
+    tagsNot: z
+      .array(z.string())
+      .describe(
+        "A list of labels (also called tags) to exclude from the search based on the user request and past conversation context." +
+          "Any document having one of these labels will be excluded from the search."
+      ),
+  };
 
-      // Compute the topK and refsOffset for the search.
-      const topK = getRetrievalTopK({
-        agentConfiguration: agentLoopRunContext.agentConfiguration,
-        stepActions: agentLoopRunContext.stepActions,
-      });
-      const refsOffset = actionRefsOffset({
-        agentConfiguration: agentLoopRunContext.agentConfiguration,
-        stepActionIndex: agentLoopRunContext.stepActionIndex,
-        stepActions: agentLoopRunContext.stepActions,
-        refsOffset: agentLoopRunContext.citationsRefsOffset,
-      });
+  const tagsAreDynamic = agentLoopContext
+    ? mustTagsBeSuppliedByLLM(agentLoopContext)
+    : false;
 
-      // Get the core search args for each data source, fail if any of them are invalid.
-      const coreSearchArgsResults = await concurrentExecutor(
-        dataSources,
-        async (dataSourceConfiguration) =>
-          getCoreSearchArgs(auth, dataSourceConfiguration),
-        { concurrency: 10 }
+  const includeFunction = async ({
+    timeFrame,
+    dataSources,
+    tagsIn,
+    tagsNot,
+  }: {
+    timeFrame: TimeFrame | null;
+    dataSources: DataSourcesToolConfigurationType;
+    tagsIn?: string[];
+    tagsNot?: string[];
+  }): Promise<MCPToolResult> => {
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    const credentials = dustManagedCredentials();
+
+    if (!agentLoopContext?.runContext) {
+      throw new Error(
+        "agentLoopRunContext is required where the tool is called."
       );
+    }
 
-      // If any of the data sources are invalid, return an error message.
-      if (coreSearchArgsResults.some((res) => res.isErr())) {
+    // Compute the topK and refsOffset for the search.
+    const topK = getRetrievalTopK({
+      agentConfiguration: agentLoopContext.runContext.agentConfiguration,
+      stepActions: agentLoopContext.runContext.stepActions,
+    });
+    const refsOffset = actionRefsOffset({
+      agentConfiguration: agentLoopContext.runContext.agentConfiguration,
+      stepActionIndex: agentLoopContext.runContext.stepActionIndex,
+      stepActions: agentLoopContext.runContext.stepActions,
+      refsOffset: agentLoopContext.runContext.citationsRefsOffset,
+    });
+
+    // Get the core search args for each data source, fail if any of them are invalid.
+    const coreSearchArgsResults = await concurrentExecutor(
+      dataSources,
+      async (dataSourceConfiguration) =>
+        getCoreSearchArgs(auth, dataSourceConfiguration),
+      { concurrency: 10 }
+    );
+
+    // If any of the data sources are invalid, return an error message.
+    if (coreSearchArgsResults.some((res) => res.isErr())) {
+      return {
+        isError: false,
+        content: removeNulls(
+          coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
+        ).map((error) => ({
+          type: "text",
+          text: error.message,
+        })),
+      };
+    }
+
+    const coreSearchArgs = removeNulls(
+      coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
+    );
+
+    const searchResults = await coreAPI.searchDataSources(
+      "",
+      topK,
+      credentials,
+      false,
+      coreSearchArgs.map((args) => {
+        // In addition to the tags provided by the user, we also add the tags that the model inferred
+        // from the conversation history.
+        const finalTagsIn = [
+          ...(args.filter.tags?.in ?? []),
+          ...(tagsIn ?? []),
+        ];
+        const finalTagsNot = [
+          ...(args.filter.tags?.not ?? []),
+          ...(tagsNot ?? []),
+        ];
+
         return {
-          isError: false,
-          content: removeNulls(
-            coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
-          ).map((error) => ({
-            type: "text",
-            text: error.message,
-          })),
-        };
-      }
-
-      const coreSearchArgs = removeNulls(
-        coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
-      );
-
-      const searchResults = await coreAPI.searchDataSources(
-        "",
-        topK,
-        credentials,
-        false,
-        coreSearchArgs.map((args) => ({
           projectId: args.projectId,
           dataSourceId: args.dataSourceId,
           filter: {
             ...args.filter,
             tags: {
-              in: args.filter.tags?.in ?? null,
-              not: args.filter.tags?.not ?? null,
+              in: finalTagsIn.length > 0 ? finalTagsIn : null,
+              not: finalTagsNot.length > 0 ? finalTagsNot : null,
             },
             timestamp: {
               gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
@@ -122,82 +170,172 @@ function createServer(
             },
           },
           view_filter: args.view_filter,
-        }))
-      );
-
-      if (searchResults.isErr()) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: searchResults.error.message,
-            },
-          ],
         };
-      }
+      })
+    );
 
-      if (refsOffset + topK > getRefs().length) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "The inclusion exhausted the total number of references available for citations",
-            },
-          ],
-        };
-      }
-
-      const refs = getRefs().slice(refsOffset, refsOffset + topK);
-
-      const results: IncludeResultResourceType[] =
-        searchResults.value.documents.map((doc) => {
-          const dataSourceView = coreSearchArgs.find(
-            (args) =>
-              args.dataSourceView.dataSource.dustAPIDataSourceId ===
-              doc.data_source_id
-          )?.dataSourceView;
-
-          assert(dataSourceView, "DataSource view not found");
-
-          return {
-            mimeType:
-              INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_INCLUDE_RESULT,
-            uri: doc.source_url ?? "",
-            text: getDisplayNameForDocument(doc),
-
-            id: doc.document_id,
-            source: {
-              provider:
-                dataSourceView.dataSource.connectorProvider ?? undefined,
-              name: getDataSourceNameFromView(dataSourceView),
-            },
-            tags: doc.tags,
-            ref: refs.shift() as string,
-            chunks: doc.chunks.map((chunk) => chunk.text),
-          };
-        });
-
+    if (searchResults.isErr()) {
       return {
-        isError: false,
+        isError: true,
         content: [
-          ...results.map((result) => ({
-            type: "resource" as const,
-            resource: result,
-          })),
           {
-            type: "resource" as const,
-            resource: makeQueryResource(
-              searchResults.value.documents,
-              topK,
-              timeFrame ?? null
-            ),
+            type: "text",
+            text: searchResults.error.message,
           },
         ],
       };
     }
-  );
+
+    if (refsOffset + topK > getRefs().length) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "The inclusion exhausted the total number of references available for citations",
+          },
+        ],
+      };
+    }
+
+    const refs = getRefs().slice(refsOffset, refsOffset + topK);
+
+    const results: IncludeResultResourceType[] =
+      searchResults.value.documents.map((doc) => {
+        const dataSourceView = coreSearchArgs.find(
+          (args) =>
+            args.dataSourceView.dataSource.dustAPIDataSourceId ===
+            doc.data_source_id
+        )?.dataSourceView;
+
+        assert(dataSourceView, "DataSource view not found");
+
+        return {
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_INCLUDE_RESULT,
+          uri: doc.source_url ?? "",
+          text: getDisplayNameForDocument(doc),
+
+          id: doc.document_id,
+          source: {
+            provider: dataSourceView.dataSource.connectorProvider ?? undefined,
+            name: getDataSourceNameFromView(dataSourceView),
+          },
+          tags: doc.tags,
+          ref: refs.shift() as string,
+          chunks: doc.chunks.map((chunk) => chunk.text),
+        };
+      });
+
+    return {
+      isError: false,
+      content: [
+        ...results.map((result) => ({
+          type: "resource" as const,
+          resource: result,
+        })),
+        {
+          type: "resource" as const,
+          resource: makeQueryResource(
+            searchResults.value.documents,
+            topK,
+            timeFrame ?? null
+          ),
+        },
+      ],
+    };
+  };
+
+  if (!tagsAreDynamic) {
+    server.tool(
+      "retrieve_recent_documents",
+      "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
+      commonInputsSchema,
+      includeFunction
+    );
+  } else {
+    server.tool(
+      "retrieve_recent_documents",
+      "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
+      {
+        ...commonInputsSchema,
+        ...tagsInputSchema,
+      },
+      includeFunction
+    );
+
+    server.tool(
+      "search_labels",
+      "Find exact matching labels (also called tags) before using them in the tool `retrieve_recent_documents`" +
+        "Restricting or excluding content succeeds only with existing labels. " +
+        "Searching without verifying labels first typically returns no results.",
+      {
+        query: z
+          .string()
+          .describe(
+            "The text to search for in existing labels (also called tags) using edge ngram matching (case-insensitive). " +
+              "Matches labels that start with any word in the search text. " +
+              "The returned labels can be used in tagsIn/tagsNot parameters to restrict or exclude content " +
+              "based on the user request and conversation context."
+          ),
+        dataSources:
+          ConfigurableToolInputSchemas[
+            INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+          ],
+      },
+      async ({ query, dataSources }) => {
+        const coreSearchArgsResults = await concurrentExecutor(
+          dataSources,
+          async (dataSourceConfiguration) =>
+            getCoreSearchArgs(auth, dataSourceConfiguration),
+          { concurrency: 10 }
+        );
+
+        if (coreSearchArgsResults.some((res) => res.isErr())) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "Invalid data sources" }],
+          };
+        }
+
+        const coreSearchArgs = removeNulls(
+          coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
+        );
+
+        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+        const result = await coreAPI.searchTags({
+          dataSourceViews: coreSearchArgs.map((arg) => arg.dataSourceView),
+          limit: DEFAULT_SEARCH_LABELS_LIMIT,
+          query,
+          queryType: "match",
+        });
+
+        if (result.isErr()) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "Error searching for labels" }],
+          };
+        }
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text:
+                "Labels found:\n\n" +
+                removeNulls(
+                  result.value.tags.map((tag) =>
+                    tag.tag && trim(tag.tag)
+                      ? `${tag.tag} (${tag.match_count} matches)`
+                      : null
+                  )
+                ).join("\n"),
+            },
+          ],
+        };
+      }
+    );
+  }
 
   return server;
 }

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -42,25 +42,25 @@ export async function getInternalMCPServer(
     case "file_generation":
       return generateFileServer(auth);
     case "query_tables":
-      return tablesQueryServer(auth, agentLoopContext.agentLoopRunContext);
+      return tablesQueryServer(auth, agentLoopContext.runContext);
     case "query_tables_v2":
-      return tablesQueryServerV2(auth, agentLoopContext.agentLoopRunContext);
+      return tablesQueryServerV2(auth, agentLoopContext.runContext);
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer();
     case "think":
       return thinkServer();
     case "web_search_&_browse":
-      return webtoolsServer(agentLoopContext.agentLoopRunContext);
+      return webtoolsServer(agentLoopContext.runContext);
     case "search":
-      return searchServer(auth, agentLoopContext.agentLoopRunContext);
+      return searchServer(auth, agentLoopContext);
     case "notion":
       return notionServer(auth, mcpServerId);
     case "include_data":
-      return includeDataServer(auth, agentLoopContext.agentLoopRunContext);
+      return includeDataServer(auth, agentLoopContext);
     case "ask_agent":
       return askAgentServer(auth);
     case "reasoning_v2":
-      return reasoningServer(auth, agentLoopContext.agentLoopRunContext);
+      return reasoningServer(auth, agentLoopContext.runContext);
     case "run_dust_app":
       return dustAppServer(auth, agentLoopContext);
     case "agent_router":

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -267,10 +267,10 @@ export default async function createServer(
   const server = new McpServer(serverInfo);
   const owner = auth.getNonNullableWorkspace();
 
-  if (agentLoopContext && agentLoopContext.agentLoopListToolsContext) {
+  if (agentLoopContext && agentLoopContext.listToolsContext) {
     if (
       !isMCPConfigurationForDustAppRun(
-        agentLoopContext.agentLoopListToolsContext.agentActionConfiguration
+        agentLoopContext.listToolsContext.agentActionConfiguration
       )
     ) {
       throw new Error("Invalid Dust app run agent configuration");
@@ -278,7 +278,7 @@ export default async function createServer(
 
     const { app, schema } = await prepareAppContext(
       auth,
-      agentLoopContext.agentLoopListToolsContext.agentActionConfiguration
+      agentLoopContext.listToolsContext.agentActionConfiguration
     );
 
     if (!app.description) {
@@ -301,18 +301,16 @@ export default async function createServer(
         };
       }
     );
-  } else if (agentLoopContext && agentLoopContext.agentLoopRunContext) {
+  } else if (agentLoopContext && agentLoopContext.runContext) {
     if (
-      !isMCPInternalDustAppRun(
-        agentLoopContext.agentLoopRunContext.actionConfiguration
-      )
+      !isMCPInternalDustAppRun(agentLoopContext.runContext.actionConfiguration)
     ) {
       throw new Error("Invalid Dust app run tool configuration");
     }
 
     const { app, schema, appConfig } = await prepareAppContext(
       auth,
-      agentLoopContext.agentLoopRunContext.actionConfiguration
+      agentLoopContext.runContext.actionConfiguration
     );
 
     if (!app.description) {
@@ -329,7 +327,7 @@ export default async function createServer(
         params = await prepareParamsWithHistory(
           params,
           schema,
-          agentLoopContext.agentLoopRunContext,
+          agentLoopContext.runContext,
           auth
         );
 
@@ -401,12 +399,12 @@ export default async function createServer(
 
         if (
           containsFileOutput(sanitizedOutput) &&
-          agentLoopContext.agentLoopRunContext?.conversation
+          agentLoopContext.runContext?.conversation
         ) {
           const fileContent = await processDustFileOutput(
             auth,
             sanitizedOutput,
-            agentLoopContext.agentLoopRunContext.conversation,
+            agentLoopContext.runContext.conversation,
             app.name
           );
           content.push(...fileContent);

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -4,13 +4,18 @@ import assert from "assert";
 import { trim } from "lodash";
 import { z } from "zod";
 
+import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
+  MCPToolResult,
   SearchQueryResourceType,
   SearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import {
+  getCoreSearchArgs,
+  mustTagsBeSuppliedByLLM,
+} from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -43,280 +48,312 @@ const serverInfo: InternalMCPServerDefinitionType = {
 
 function createServer(
   auth: Authenticator,
-  agentLoopRunContext?: AgentLoopRunContextType
+  agentLoopContext?: AgentLoopContextType
 ): McpServer {
   const server = new McpServer(serverInfo);
 
-  server.tool(
-    "search_data_sources",
-    "Search the data sources specified by the user." +
-      " The search is based on semantic similarity between the query and chunks of information" +
-      " from the data sources.",
-    {
-      query: z
-        .string()
-        .describe(
-          "The string used to retrieve relevant chunks of information using semantic similarity" +
-            " based on the user request and conversation context." +
-            " Include as much semantic signal based on the entire conversation history," +
-            " paraphrasing if necessary. longer queries are generally better."
-        ),
-      relativeTimeFrame: z
-        .string()
-        .regex(/^(all|\d+[hdwmy])$/)
-        .describe(
-          "The time frame (relative to LOCAL_TIME) to restrict the search based" +
-            " on the user request and past conversation context." +
-            " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
-            " where {k} is a number. Be strict, do not invent invalid values."
-        ),
-      tagsIn: z
-        .array(z.string())
-        .describe(
-          "An optional list of labels (also called tags) to restrict the search based on the user request and past conversation context." +
-            "If multiple labels are provided, the search will return documents that have at least one of the labels." +
-            "You can't check that all labels are present, only that at least one is present." +
-            "If no labels are provided, the search will return all documents regardless of their labels."
-        )
-        .optional(),
-      tagsNot: z
-        .array(z.string())
-        .describe(
-          "An optional list of labels (also called tags) to exclude from the search based on the user request and past conversation context." +
-            "Any document having one of these labels will be excluded from the search."
-        )
-        .optional(),
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-    },
-    async ({ query, relativeTimeFrame, dataSources, tagsIn, tagsNot }) => {
-      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-      const credentials = dustManagedCredentials();
-      const timeFrame = parseTimeFrame(relativeTimeFrame);
+  const commonInputsSchema = {
+    query: z
+      .string()
+      .describe(
+        "The string used to retrieve relevant chunks of information using semantic similarity" +
+          " based on the user request and conversation context." +
+          " Include as much semantic signal based on the entire conversation history," +
+          " paraphrasing if necessary. longer queries are generally better."
+      ),
+    relativeTimeFrame: z
+      .string()
+      .regex(/^(all|\d+[hdwmy])$/)
+      .describe(
+        "The time frame (relative to LOCAL_TIME) to restrict the search based" +
+          " on the user request and past conversation context." +
+          " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
+          " where {k} is a number. Be strict, do not invent invalid values."
+      ),
+    dataSources:
+      ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  };
 
-      if (!agentLoopRunContext) {
-        throw new Error(
-          "agentLoopRunContext is required where the tool is called."
-        );
-      }
+  const tagsInputSchema = {
+    tagsIn: z
+      .array(z.string())
+      .describe(
+        "A list of labels (also called tags) to restrict the search based on the user request and past conversation context." +
+          "If multiple labels are provided, the search will return documents that have at least one of the labels." +
+          "You can't check that all labels are present, only that at least one is present." +
+          "If no labels are provided, the search will return all documents regardless of their labels."
+      ),
+    tagsNot: z
+      .array(z.string())
+      .describe(
+        "A list of labels (also called tags) to exclude from the search based on the user request and past conversation context." +
+          "Any document having one of these labels will be excluded from the search."
+      ),
+  };
 
-      // Compute the topK and refsOffset for the search.
-      const topK = getRetrievalTopK({
-        agentConfiguration: agentLoopRunContext.agentConfiguration,
-        stepActions: agentLoopRunContext.stepActions,
-      });
-      const refsOffset = actionRefsOffset({
-        agentConfiguration: agentLoopRunContext.agentConfiguration,
-        stepActionIndex: agentLoopRunContext.stepActionIndex,
-        stepActions: agentLoopRunContext.stepActions,
-        refsOffset: agentLoopRunContext.citationsRefsOffset,
-      });
+  const tagsAreDynamic = agentLoopContext
+    ? mustTagsBeSuppliedByLLM(agentLoopContext)
+    : false;
 
-      // Get the core search args for each data source, fail if any of them are invalid.
-      const coreSearchArgsResults = await concurrentExecutor(
-        dataSources,
-        async (dataSourceConfiguration) =>
-          getCoreSearchArgs(auth, dataSourceConfiguration),
-        { concurrency: 10 }
+  const searchFunction = async ({
+    query,
+    relativeTimeFrame,
+    dataSources,
+    tagsIn,
+    tagsNot,
+  }: {
+    query: string;
+    relativeTimeFrame: string;
+    dataSources: DataSourcesToolConfigurationType;
+    tagsIn?: string[];
+    tagsNot?: string[];
+  }): Promise<MCPToolResult> => {
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    const credentials = dustManagedCredentials();
+    const timeFrame = parseTimeFrame(relativeTimeFrame);
+
+    if (!agentLoopContext?.runContext) {
+      throw new Error(
+        "agentLoopRunContext is required where the tool is called."
       );
+    }
 
-      // If any of the data sources are invalid, return an error message.
-      if (coreSearchArgsResults.some((res) => res.isErr())) {
+    // Compute the topK and refsOffset for the search.
+    const topK = getRetrievalTopK({
+      agentConfiguration: agentLoopContext.runContext.agentConfiguration,
+      stepActions: agentLoopContext.runContext.stepActions,
+    });
+    const refsOffset = actionRefsOffset({
+      agentConfiguration: agentLoopContext.runContext.agentConfiguration,
+      stepActionIndex: agentLoopContext.runContext.stepActionIndex,
+      stepActions: agentLoopContext.runContext.stepActions,
+      refsOffset: agentLoopContext.runContext.citationsRefsOffset,
+    });
+
+    // Get the core search args for each data source, fail if any of them are invalid.
+    const coreSearchArgsResults = await concurrentExecutor(
+      dataSources,
+      async (dataSourceConfiguration) =>
+        getCoreSearchArgs(auth, dataSourceConfiguration),
+      { concurrency: 10 }
+    );
+
+    // If any of the data sources are invalid, return an error message.
+    if (coreSearchArgsResults.some((res) => res.isErr())) {
+      return {
+        isError: false,
+        content: removeNulls(
+          coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
+        ).map((error) => ({
+          type: "text",
+          text: error.message,
+        })),
+      };
+    }
+
+    const coreSearchArgs = removeNulls(
+      coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
+    );
+
+    // Now we can search each data source.
+    const searchResults = await coreAPI.searchDataSources(
+      query,
+      topK,
+      credentials,
+      false,
+      coreSearchArgs.map((args) => {
+        // In addition to the tags provided by the user, we also add the tags that the model inferred
+        // from the conversation history.
+        const finalTagsIn = [
+          ...(args.filter.tags?.in ?? []),
+          ...(tagsIn ?? []),
+        ];
+        const finalTagsNot = [
+          ...(args.filter.tags?.not ?? []),
+          ...(tagsNot ?? []),
+        ];
+
         return {
-          isError: false,
-          content: removeNulls(
-            coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
-          ).map((error) => ({
+          projectId: args.projectId,
+          dataSourceId: args.dataSourceId,
+          filter: {
+            ...args.filter,
+            tags: {
+              in: finalTagsIn.length > 0 ? finalTagsIn : null,
+              not: finalTagsNot.length > 0 ? finalTagsNot : null,
+            },
+            timestamp: {
+              gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
+              lt: null,
+            },
+          },
+          view_filter: args.view_filter,
+        };
+      })
+    );
+
+    if (searchResults.isErr()) {
+      return {
+        isError: true,
+        content: [
+          {
             type: "text",
-            text: error.message,
-          })),
-        };
-      }
+            text: searchResults.error.message,
+          },
+        ],
+      };
+    }
 
-      const coreSearchArgs = removeNulls(
-        coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
-      );
+    if (refsOffset + topK > getRefs().length) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "The search exhausted the total number of references available for citations",
+          },
+        ],
+      };
+    }
 
-      // Now we can search each data source.
-      const searchResults = await coreAPI.searchDataSources(
-        query,
-        topK,
-        credentials,
-        false,
-        coreSearchArgs.map((args) => {
-          // In addition to the tags provided by the user, we also add the tags that the model inferred
-          // from the conversation history.
-          const finalTagsIn = [
-            ...(args.filter.tags?.in ?? []),
-            ...(tagsIn ?? []),
-          ];
-          const finalTagsNot = [
-            ...(args.filter.tags?.not ?? []),
-            ...(tagsNot ?? []),
-          ];
+    const refs = getRefs().slice(refsOffset, refsOffset + topK);
 
-          return {
-            projectId: args.projectId,
-            dataSourceId: args.dataSourceId,
-            filter: {
-              ...args.filter,
-              tags: {
-                in: finalTagsIn.length > 0 ? finalTagsIn : null,
-                not: finalTagsNot.length > 0 ? finalTagsNot : null,
-              },
-              timestamp: {
-                gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
-                lt: null,
-              },
-            },
-            view_filter: args.view_filter,
-          };
-        })
-      );
+    const results: SearchResultResourceType[] =
+      searchResults.value.documents.map((doc) => {
+        const dataSourceView = coreSearchArgs.find(
+          (args) =>
+            args.dataSourceView.dataSource.dustAPIDataSourceId ===
+            doc.data_source_id
+        )?.dataSourceView;
 
-      if (searchResults.isErr()) {
+        assert(dataSourceView, "DataSource view not found");
+
         return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: searchResults.error.message,
-            },
-          ],
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+          uri: doc.source_url ?? "",
+          text: getDisplayNameForDocument(doc),
+
+          id: doc.document_id,
+          source: {
+            provider: dataSourceView.dataSource.connectorProvider ?? undefined,
+            name: getDataSourceNameFromView(dataSourceView),
+          },
+          tags: doc.tags,
+          ref: refs.shift() as string,
+          chunks: doc.chunks.map((chunk) => chunk.text),
         };
-      }
+      });
 
-      if (refsOffset + topK > getRefs().length) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "The search exhausted the total number of references available for citations",
-            },
+    return {
+      isError: false,
+      content: [
+        ...results.map((result) => ({
+          type: "resource" as const,
+          resource: result,
+        })),
+        {
+          type: "resource" as const,
+          resource: makeQueryResource(query, timeFrame, tagsIn, tagsNot),
+        },
+      ],
+    };
+  };
+
+  if (!tagsAreDynamic) {
+    server.tool(
+      "search_data_sources",
+      "Search the data sources specified by the user." +
+        " The search is based on semantic similarity between the query and chunks of information" +
+        " from the data sources.",
+      commonInputsSchema,
+      searchFunction
+    );
+  } else {
+    server.tool(
+      "search_data_sources",
+      "Search the data sources specified by the user." +
+        " The search is based on semantic similarity between the query and chunks of information" +
+        " from the data sources.",
+      {
+        ...commonInputsSchema,
+        ...tagsInputSchema,
+      },
+      searchFunction
+    );
+
+    server.tool(
+      "search_labels",
+      "Find exact matching labels (also called tags) before using them in the tool `search_data_sources`" +
+        "Restricting or excluding content succeeds only with existing labels. " +
+        "Searching without verifying labels first typically returns no results.",
+      {
+        query: z
+          .string()
+          .describe(
+            "The text to search for in existing labels (also called tags) using edge ngram matching (case-insensitive). " +
+              "Matches labels that start with any word in the search text. " +
+              "The returned labels can be used in tagsIn/tagsNot parameters to restrict or exclude content " +
+              "based on the user request and conversation context."
+          ),
+        dataSources:
+          ConfigurableToolInputSchemas[
+            INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
           ],
-        };
-      }
+      },
+      async ({ query, dataSources }) => {
+        const coreSearchArgsResults = await concurrentExecutor(
+          dataSources,
+          async (dataSourceConfiguration) =>
+            getCoreSearchArgs(auth, dataSourceConfiguration),
+          { concurrency: 10 }
+        );
 
-      const refs = getRefs().slice(refsOffset, refsOffset + topK);
-
-      const results: SearchResultResourceType[] =
-        searchResults.value.documents.map((doc) => {
-          const dataSourceView = coreSearchArgs.find(
-            (args) =>
-              args.dataSourceView.dataSource.dustAPIDataSourceId ===
-              doc.data_source_id
-          )?.dataSourceView;
-
-          assert(dataSourceView, "DataSource view not found");
-
+        if (coreSearchArgsResults.some((res) => res.isErr())) {
           return {
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-            uri: doc.source_url ?? "",
-            text: getDisplayNameForDocument(doc),
-
-            id: doc.document_id,
-            source: {
-              provider:
-                dataSourceView.dataSource.connectorProvider ?? undefined,
-              name: getDataSourceNameFromView(dataSourceView),
-            },
-            tags: doc.tags,
-            ref: refs.shift() as string,
-            chunks: doc.chunks.map((chunk) => chunk.text),
+            isError: true,
+            content: [{ type: "text", text: "Invalid data sources" }],
           };
+        }
+
+        const coreSearchArgs = removeNulls(
+          coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
+        );
+
+        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+        const result = await coreAPI.searchTags({
+          dataSourceViews: coreSearchArgs.map((arg) => arg.dataSourceView),
+          limit: DEFAULT_SEARCH_LABELS_LIMIT,
+          query,
+          queryType: "match",
         });
 
-      return {
-        isError: false,
-        content: [
-          ...results.map((result) => ({
-            type: "resource" as const,
-            resource: result,
-          })),
-          {
-            type: "resource" as const,
-            resource: makeQueryResource(query, timeFrame, tagsIn, tagsNot),
-          },
-        ],
-      };
-    }
-  );
+        if (result.isErr()) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "Error searching for labels" }],
+          };
+        }
 
-  server.tool(
-    "search_labels",
-    "Find exact matching labels (also called tags) before using them in the tool `search_data_sources`" +
-      "Restricting or excluding content succeeds only with existing labels. " +
-      "Searching without verifying labels first typically returns no results.",
-    {
-      query: z
-        .string()
-        .describe(
-          "The text to search for in existing labels (also called tags) using edge ngram matching (case-insensitive). " +
-            "Matches labels that start with any word in the search text. " +
-            "The returned labels can be used in tagsIn/tagsNot parameters to restrict or exclude content " +
-            "based on the user request and conversation context."
-        ),
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-    },
-    async ({ query, dataSources }) => {
-      const coreSearchArgsResults = await concurrentExecutor(
-        dataSources,
-        async (dataSourceConfiguration) =>
-          getCoreSearchArgs(auth, dataSourceConfiguration),
-        { concurrency: 10 }
-      );
-
-      if (coreSearchArgsResults.some((res) => res.isErr())) {
         return {
-          isError: true,
-          content: [{ type: "text", text: "Invalid data sources" }],
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text:
+                "Labels found:\n\n" +
+                removeNulls(
+                  result.value.tags.map((tag) =>
+                    tag.tag && trim(tag.tag)
+                      ? `${tag.tag} (${tag.match_count} matches)`
+                      : null
+                  )
+                ).join("\n"),
+            },
+          ],
         };
       }
-
-      const coreSearchArgs = removeNulls(
-        coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
-      );
-
-      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-      const result = await coreAPI.searchTags({
-        dataSourceViews: coreSearchArgs.map((arg) => arg.dataSourceView),
-        limit: DEFAULT_SEARCH_LABELS_LIMIT,
-        query,
-        queryType: "match",
-      });
-
-      if (result.isErr()) {
-        return {
-          isError: true,
-          content: [{ type: "text", text: "Error searching for labels" }],
-        };
-      }
-
-      return {
-        isError: false,
-        content: [
-          {
-            type: "text",
-            text:
-              "Labels found:\n\n" +
-              removeNulls(
-                result.value.tags.map((tag) =>
-                  tag.tag && trim(tag.tag)
-                    ? `${tag.tag} (${tag.match_count} matches)`
-                    : null
-                )
-              ).join("\n"),
-          },
-        ],
-      };
-    }
-  );
+    );
+  }
 
   return server;
 }

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -13,7 +13,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   getCoreSearchArgs,
-  mustTagsBeSuppliedByLLM,
+  shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
@@ -91,8 +91,8 @@ function createServer(
       ),
   };
 
-  const tagsAreDynamic = agentLoopContext
-    ? mustTagsBeSuppliedByLLM(agentLoopContext)
+  const areTagsDynamic = agentLoopContext
+    ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
   const searchFunction = async ({
@@ -259,7 +259,7 @@ function createServer(
     };
   };
 
-  if (!tagsAreDynamic) {
+  if (!areTagsDynamic) {
     server.tool(
       "search_data_sources",
       "Search the data sources specified by the user." +

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -184,7 +184,7 @@ export async function getCoreSearchArgs(
   });
 }
 
-export function mustTagsBeSuppliedByLLM(
+export function shouldAutoGenerateTags(
   agentLoopContext: AgentLoopContextType
 ): boolean {
   const hasTagAutoMode = (
@@ -196,8 +196,7 @@ export function mustTagsBeSuppliedByLLM(
     );
 
   if (
-    agentLoopContext.listToolsContext &&
-    agentLoopContext.listToolsContext.agentActionConfiguration &&
+    !!agentLoopContext.listToolsContext?.agentActionConfiguration &&
     isServerSideMCPServerConfiguration(
       agentLoopContext.listToolsContext.agentActionConfiguration
     ) &&
@@ -207,8 +206,7 @@ export function mustTagsBeSuppliedByLLM(
       agentLoopContext.listToolsContext.agentActionConfiguration.dataSources
     );
   } else if (
-    agentLoopContext.runContext &&
-    agentLoopContext.runContext.actionConfiguration &&
+    !!agentLoopContext.runContext?.actionConfiguration &&
     isServerSideMCPToolConfiguration(
       agentLoopContext.runContext.actionConfiguration
     ) &&

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -9,6 +9,12 @@ import {
   DATA_SOURCE_CONFIGURATION_URI_PATTERN,
   TABLE_CONFIGURATION_URI_PATTERN,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  isServerSideMCPServerConfiguration,
+  isServerSideMCPToolConfiguration,
+} from "@app/lib/actions/types/guards";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
@@ -176,4 +182,42 @@ export async function getCoreSearchArgs(
     view_filter: dataSourceView.toViewFilter(),
     dataSourceView: dataSourceView.toJSON(),
   });
+}
+
+export function mustTagsBeSuppliedByLLM(
+  agentLoopContext: AgentLoopContextType
+): boolean {
+  const hasTagAutoMode = (
+    dataSourceConfigurations: DataSourceConfiguration[]
+  ) =>
+    dataSourceConfigurations.some(
+      (dataSourceConfiguration) =>
+        dataSourceConfiguration.filter.tags?.mode === "auto"
+    );
+
+  if (
+    agentLoopContext.listToolsContext &&
+    agentLoopContext.listToolsContext.agentActionConfiguration &&
+    isServerSideMCPServerConfiguration(
+      agentLoopContext.listToolsContext.agentActionConfiguration
+    ) &&
+    !!agentLoopContext.listToolsContext.agentActionConfiguration.dataSources
+  ) {
+    return hasTagAutoMode(
+      agentLoopContext.listToolsContext.agentActionConfiguration.dataSources
+    );
+  } else if (
+    agentLoopContext.runContext &&
+    agentLoopContext.runContext.actionConfiguration &&
+    isServerSideMCPToolConfiguration(
+      agentLoopContext.runContext.actionConfiguration
+    ) &&
+    !!agentLoopContext.runContext.actionConfiguration.dataSources
+  ) {
+    return hasTagAutoMode(
+      agentLoopContext.runContext.actionConfiguration.dataSources
+    );
+  }
+
+  return false;
 }

--- a/front/lib/actions/process.ts
+++ b/front/lib/actions/process.ts
@@ -10,10 +10,7 @@ import {
   PROCESS_ACTION_TOP_K,
 } from "@app/lib/actions/constants";
 import { getExtractFileTitle } from "@app/lib/actions/process/utils";
-import type {
-  DataSourceConfiguration,
-  RetrievalTimeframe,
-} from "@app/lib/actions/retrieval";
+import type { RetrievalTimeframe } from "@app/lib/actions/retrieval";
 import {
   applyDataSourceFilters,
   retrievalAutoTimeFrameInputSpecification,
@@ -61,6 +58,7 @@ export const PROCESS_SCHEMA_ALLOWED_TYPES = [
 ] as const;
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import { FileResource } from "@app/lib/resources/file_resource";
 
 // Properties in the process configuration table are stored as an array of objects.

--- a/front/lib/actions/retrieval.ts
+++ b/front/lib/actions/retrieval.ts
@@ -19,6 +19,7 @@ import type {
 import { dustAppRunInputsToInputSchema } from "@app/lib/actions/types/agent";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
@@ -33,23 +34,9 @@ import type {
   FunctionMessageTypeModel,
   ModelId,
   Result,
-  TagsFilter,
   TimeFrame,
 } from "@app/types";
 import { Ok, parseTimeFrame, timeFrameFromNow } from "@app/types";
-
-export type DataSourceFilter = {
-  parents: { in: string[]; not: string[] } | null;
-  tags?: TagsFilter;
-};
-
-// TODO(mcp): move function and types relative to data sources to a dedicated file instead of retrieval.ts.
-export type DataSourceConfiguration = {
-  sId?: string; // The sId is not always available, for instance it is not in an unsaved state of the builder.
-  workspaceId: string;
-  dataSourceViewId: string;
-  filter: DataSourceFilter;
-};
 
 /**
  * Retrieval configuration

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -162,11 +162,11 @@ export type AgentLoopListToolsContextType = {
 
 export type AgentLoopContextType =
   | {
-      agentLoopRunContext: AgentLoopRunContextType;
-      agentLoopListToolsContext?: never;
+      runContext: AgentLoopRunContextType;
+      listToolsContext?: never;
     }
   | {
-      agentLoopRunContext?: never;
-      agentLoopListToolsContext: AgentLoopListToolsContextType;
+      runContext?: never;
+      listToolsContext: AgentLoopListToolsContextType;
     }
-  | { agentLoopRunContext?: never; agentLoopListToolsContext?: never };
+  | { runContext?: never; listToolsContext?: never };

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -25,7 +25,6 @@ import {
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
 import type { ReasoningModelConfiguration } from "@app/lib/actions/reasoning";
-import type { DataSourceConfiguration } from "@app/lib/actions/retrieval";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
 import type {
   AgentActionConfigurationType,
@@ -81,6 +80,7 @@ import type {
   LightAgentConfigurationType,
   ModelId,
   Result,
+  TagsFilter,
   UserType,
   WorkspaceType,
 } from "@app/types";
@@ -97,6 +97,18 @@ import {
   removeNulls,
 } from "@app/types";
 import type { TagType } from "@app/types/tag";
+
+export type DataSourceFilter = {
+  parents: { in: string[]; not: string[] } | null;
+  tags?: TagsFilter;
+};
+
+export type DataSourceConfiguration = {
+  sId?: string; // The sId is not always available, for instance it is not in an unsaved state of the builder.
+  workspaceId: string;
+  dataSourceViewId: string;
+  filter: DataSourceFilter;
+};
 
 type SortStrategyType = "alphabetical" | "priority" | "updatedAt";
 interface SortStrategy {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -21,10 +21,7 @@ import {
   makeConversationListFilesAction,
 } from "@app/lib/actions/conversation/list_files";
 import type { ProcessConfigurationType } from "@app/lib/actions/process";
-import type {
-  DataSourceConfiguration,
-  RetrievalConfigurationType,
-} from "@app/lib/actions/retrieval";
+import type { RetrievalConfigurationType } from "@app/lib/actions/retrieval";
 import type { TablesQueryConfigurationType } from "@app/lib/actions/tables_query";
 import type {
   ActionConfigurationType,
@@ -34,6 +31,7 @@ import {
   isProcessConfiguration,
   isRetrievalConfiguration,
 } from "@app/lib/actions/types/guards";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   isMultiSheetSpreadsheetContentType,
   isSearchableFolder,


### PR DESCRIPTION
## Description

To be ISO with the previous search and include actions, add support for LLM supplied tags via the datasource "tagMode" parameter (instead of optionals args).

Imho, should be revisited as the code and product surface is big and now we have support for optional args which should solve the issue.

## Tests

Locally with / without the auto mode and listing tools and params.

## Risk

Low, theses 2 tools are behind a FF.

## Deploy Plan

Deploy `front`