### PR TITLE
Fix: stop ms connectors when app is removed

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -6,6 +6,8 @@ import type {
 
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 
+const knownMicrosoftSignInErrors = ["AADSTS50173", "AADSTS700016"];
+
 // The SDK does not expose an error class that is rich enough for our use.
 // We'll use this function as a temporary solution for identifying an identified type of error.
 export function isMicrosoftSignInError(err: unknown): err is Error {
@@ -14,8 +16,7 @@ export function isMicrosoftSignInError(err: unknown): err is Error {
     err.message.startsWith(
       "Error retrieving access token from microsoft: code=provider_access_token_refresh_error"
     ) &&
-    err.message.includes("invalid_grant") &&
-    err.message.includes("AADSTS50173")
+    knownMicrosoftSignInErrors.some((code) => err.message.includes(code))
   );
 }
 


### PR DESCRIPTION
## Description

Stop MS connectors on know error codes (we have one in prod).

## Tests

Not easy, but will check in prod.

## Risk

Low

## Deploy Plan

Deploy `connectors`