### PR TITLE
Rename agent workspace metrics

### DIFF
--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -7,7 +7,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
-import { getAssistantUsageData } from "@app/lib/workspace_usage";
+import { getAgentUsageData } from "@app/lib/workspace_usage";
 import { launchMentionsCountWorkflow } from "@app/temporal/mentions_count_queue/client";
 import type { LightAgentConfigurationType } from "@app/types";
 
@@ -115,7 +115,7 @@ export async function getAgentUsage(
   const start = new Date();
   start.setDate(end.getDate() - rankingUsageDays);
 
-  const agentUsage = await getAssistantUsageData(
+  const agentUsage = await getAgentUsageData(
     start,
     end,
     owner,

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -13,7 +13,7 @@ import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import {
-  getAssistantsUsageData,
+  getAgentsUsageData,
   getBuildersUsageData,
   getFeedbacksUsageData,
   getMessageUsageData,
@@ -268,7 +268,7 @@ async function fetchUsageData({
       return { builders: await getBuildersUsageData(start, end, workspace) };
     case "assistants":
       return {
-        assistants: await getAssistantsUsageData(start, end, workspace),
+        assistants: await getAgentsUsageData(start, end, workspace),
       };
     case "feedbacks":
       return {
@@ -280,7 +280,7 @@ async function fetchUsageData({
           getUserUsageData(start, end, workspace),
           getMessageUsageData(start, end, workspace),
           getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace),
+          getAgentsUsageData(start, end, workspace),
           getFeedbacksUsageData(start, end, workspace),
         ]);
       return { users, assistant_messages, builders, assistants, feedbacks };

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -8,7 +8,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  getAssistantsUsageData,
+  getAgentsUsageData,
   getBuildersUsageData,
   getFeedbacksUsageData,
   getMessageUsageData,
@@ -195,7 +195,7 @@ async function fetchUsageData({
       };
     case "agents":
       return {
-        agents: await getAssistantsUsageData(start, end, workspace),
+        agents: await getAgentsUsageData(start, end, workspace),
       };
     case "all":
       const [users, agent_messages, builders, agents, feedbacks] =
@@ -203,7 +203,7 @@ async function fetchUsageData({
           getUserUsageData(start, end, workspace),
           getMessageUsageData(start, end, workspace),
           getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace),
+          getAgentsUsageData(start, end, workspace),
           getFeedbacksUsageData(start, end, workspace),
         ]);
       return { users, agent_messages, builders, agents, feedbacks };

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -24,18 +24,19 @@ const MonthSchema = t.refinement(
   "YYYY-MM"
 );
 
-const usageTables = [
+const SUPPORTED_USAGE_TABLES = [
   "users",
-  "assistant_messages",
+  "agent_messages",
   "builders",
-  "assistants",
+  "agents",
   "feedbacks",
   "all",
 ];
-type usageTableType = (typeof usageTables)[number];
+type usageTableType = (typeof SUPPORTED_USAGE_TABLES)[number];
 
+// Sorcery: Create a union type with at least two elements to satisfy t.union.
 function getSupportedUsageTablesCodec(): t.Mixed {
-  const [first, second, ...rest] = usageTables;
+  const [first, second, ...rest] = SUPPORTED_USAGE_TABLES;
   return t.union([
     t.literal(first),
     t.literal(second),
@@ -184,7 +185,7 @@ async function fetchUsageData({
   switch (table) {
     case "users":
       return { users: await getUserUsageData(start, end, workspace) };
-    case "assistant_messages":
+    case "agent_messages":
       return { mentions: await getMessageUsageData(start, end, workspace) };
     case "builders":
       return { builders: await getBuildersUsageData(start, end, workspace) };
@@ -192,12 +193,12 @@ async function fetchUsageData({
       return {
         feedbacks: await getFeedbacksUsageData(start, end, workspace),
       };
-    case "assistants":
+    case "agents":
       return {
-        assistants: await getAssistantsUsageData(start, end, workspace),
+        agents: await getAssistantsUsageData(start, end, workspace),
       };
     case "all":
-      const [users, assistant_messages, builders, assistants, feedbacks] =
+      const [users, agent_messages, builders, agents, feedbacks] =
         await Promise.all([
           getUserUsageData(start, end, workspace),
           getMessageUsageData(start, end, workspace),
@@ -205,7 +206,7 @@ async function fetchUsageData({
           getAssistantsUsageData(start, end, workspace),
           getFeedbacksUsageData(start, end, workspace),
         ]);
-      return { users, assistant_messages, builders, assistants, feedbacks };
+      return { users, agent_messages, builders, agents, feedbacks };
     default:
       return {};
   }


### PR DESCRIPTION
## Description

Update on the Workspace Metrics: 
- The query were not updated on the migration for Agent Discovery (scopes are now published/unpublished).
- The name "assistant" was still used on filenames and column names; I replaced it with agents. 

## Tests

Locally and will test on front edge also (cause on local all my agent scope ends up "unknown" I guess I have not ran all the migrations. 

## Risk

Bigger risk I think is if people automated the download of workspace metrics from the API and I'm changing the file name and columns. 

## Deploy Plan

Deploy front. 
