### PR TITLE
Workspace Metrics: Fix following new scope from Agent Discovery

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -69,7 +69,7 @@ type BuilderUsageQueryResult = {
 interface AgentUsageQueryResult {
   name: string;
   description: string;
-  settings: "shared" | "private" | "company";
+  settings: "published" | "unpublished" | "unknown";
   authorEmails: string[];
   messages: number;
   distinctUsersReached: number;
@@ -182,9 +182,9 @@ export async function getMessageUsageData(
         COALESCE(ac."sId", am."agentConfigurationId") AS "assistant_id",
         COALESCE(ac."name", am."agentConfigurationId") AS "assistant_name",
         CASE
-          WHEN ac."scope" = 'published' THEN 'shared'
-          WHEN ac."scope" = 'private' THEN 'private'
-          ELSE 'company'
+          WHEN ac."scope" = 'visible' THEN 'published'
+          WHEN ac."scope" = 'hidden' THEN 'unpublished'
+          ELSE 'unknown'
         END AS "assistant_settings",
         w."id" AS "workspace_id",
         w."name" AS "workspace_name",
@@ -441,9 +441,9 @@ export async function getAssistantsUsageData(
       ac."name",
       ac."description",
       CASE
-        WHEN ac."scope" = 'published' THEN 'shared'
-        WHEN ac."scope" = 'private' THEN 'private'
-        ELSE 'company'
+        WHEN ac."scope" = 'visible' THEN 'published'
+        WHEN ac."scope" = 'hidden' THEN 'unpublished'
+        ELSE 'unknown'
       END AS "settings",
       ARRAY_AGG(DISTINCT aut."email") AS "authorEmails",
       COUNT(a."id") AS "messages",
@@ -462,7 +462,7 @@ export async function getAssistantsUsageData(
       a."createdAt" BETWEEN :startDate AND :endDate
       AND ac."workspaceId" = :wId
       AND ac."status" = 'active'
-      AND ac."scope" != 'private'
+      AND ac."scope" != 'hidden'
     GROUP BY
       ac."name",
       ac."description",


### PR DESCRIPTION
## Description

While looking at this code for something unrelated to Agent Discovery I realized that we have not updated those queries. 

## Tests

Locally. 

## Risk

Could break some user integrations (this is available from the API), not super likely though since this is changing the values no column or file name. 

## Deploy Plan

Deploy front. 