### PR TITLE
[front] - fix(InstructionHistory): adjust date formatting and sorting

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -223,8 +223,8 @@ export function InstructionScreen({
 
   const dateFormatter = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
-    month: "long",
-    day: "numeric",
+    month: "2-digit",
+    day: "2-digit",
     hour: "numeric",
     minute: "numeric",
     hour12: true,
@@ -304,7 +304,7 @@ export function InstructionScreen({
           <Separator />
           {compareVersion?.versionCreatedAt && (
             <Label>
-              Comparing with{" "}
+              Comparing current version with{" "}
               {dateFormatter.format(new Date(compareVersion.versionCreatedAt))}
             </Label>
           )}

--- a/front/components/assistant_builder/instructions/InstructionsHistory.tsx
+++ b/front/components/assistant_builder/instructions/InstructionsHistory.tsx
@@ -37,9 +37,7 @@ export function InstructionHistory({
         hour12: true,
       });
       return config.versionCreatedAt
-        ? dateFormatter
-            .format(new Date(config.versionCreatedAt))
-            .replace(/\//g, "/")
+        ? dateFormatter.format(new Date(config.versionCreatedAt))
         : `v${config.version}`;
     },
     []

--- a/front/components/assistant_builder/instructions/InstructionsHistory.tsx
+++ b/front/components/assistant_builder/instructions/InstructionsHistory.tsx
@@ -30,14 +30,16 @@ export function InstructionHistory({
     (config: LightAgentConfigurationType) => {
       const dateFormatter = new Intl.DateTimeFormat("en-US", {
         year: "numeric",
-        month: "long",
-        day: "numeric",
+        month: "2-digit",
+        day: "2-digit",
         hour: "numeric",
         minute: "numeric",
         hour12: true,
       });
       return config.versionCreatedAt
-        ? dateFormatter.format(new Date(config.versionCreatedAt))
+        ? dateFormatter
+            .format(new Date(config.versionCreatedAt))
+            .replace(/\//g, "/")
         : `v${config.version}`;
     },
     []
@@ -53,9 +55,9 @@ export function InstructionHistory({
         : b.version;
 
       if (timeA !== timeB) {
-        return timeA - timeB;
+        return timeB - timeA;
       }
-      return a.version - b.version;
+      return b.version - a.version;
     });
 
     const result: Array<{


### PR DESCRIPTION
## Description

This PR orders prompt versions anti-chronologically and formats dates to follow american standars: mm/dd/yyyy (e.g. `03/03/2025, 5:42 PM`)

## Risk

Low

## Deploy Plan

Deploy front