### PR TITLE
feat: log userid (2nd variation)

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -16,6 +16,7 @@ import {
 } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import logger from "@app/logger/logger";
+import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { UserTypeWithWorkspaces, WithAPIErrorResponse } from "@app/types";
 import { getGroupIdsFromHeaders, getUserEmailFromHeaders } from "@app/types";
@@ -29,7 +30,7 @@ import { getGroupIdsFromHeaders, getUserEmailFromHeaders } from "@app/types";
  */
 export function withSessionAuthentication<T>(
   handler: (
-    req: NextApiRequest,
+    req: NextApiRequestWithContext,
     res: NextApiResponse<WithAPIErrorResponse<T>>,
     session: SessionWithUser
   ) => Promise<void> | void,
@@ -37,7 +38,7 @@ export function withSessionAuthentication<T>(
 ) {
   return withLogging(
     async (
-      req: NextApiRequest,
+      req: NextApiRequestWithContext,
       res: NextApiResponse<WithAPIErrorResponse<T>>,
       { session }
     ) => {
@@ -84,7 +85,7 @@ export function withSessionAuthenticationForWorkspace<T>(
 ) {
   return withSessionAuthentication(
     async (
-      req: NextApiRequest,
+      req: NextApiRequestWithContext,
       res: NextApiResponse<WithAPIErrorResponse<T>>,
       session: SessionWithUser
     ) => {
@@ -100,6 +101,9 @@ export function withSessionAuthenticationForWorkspace<T>(
       }
 
       const auth = await Authenticator.fromSession(session, wId);
+      req.addLogToContext?.({
+        userId: auth.getNonNullableUser().sId,
+      });
 
       const owner = auth.workspace();
       const plan = auth.plan();

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -101,9 +101,7 @@ export function withSessionAuthenticationForWorkspace<T>(
       }
 
       const auth = await Authenticator.fromSession(session, wId);
-      req.addLogToContext?.({
-        userId: auth.getNonNullableUser().sId,
-      });
+      req.addResourceToLog?.(auth.getNonNullableUser());
 
       const owner = auth.workspace();
       const plan = auth.plan();
@@ -186,7 +184,7 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
 
   return withLogging(
     async (
-      req: NextApiRequest,
+      req: NextApiRequestWithContext,
       res: NextApiResponse<WithAPIErrorResponse<T>>
     ) => {
       const wId = typeof req.query.wId === "string" ? req.query.wId : undefined;
@@ -279,6 +277,8 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
             },
           });
         }
+
+        req.addResourceToLog?.(auth.getNonNullableUser());
 
         const maintenance = auth.workspace()?.metadata?.maintenance;
         if (maintenance) {
@@ -404,7 +404,7 @@ export function withAuth0TokenAuthentication<T>(
 ) {
   return withLogging(
     async (
-      req: NextApiRequest,
+      req: NextApiRequestWithContext,
       res: NextApiResponse<WithAPIErrorResponse<T>>
     ) => {
       const bearerTokenRes = await getBearerToken(req);
@@ -469,6 +469,8 @@ export function withAuth0TokenAuthentication<T>(
           },
         });
       }
+
+      req.addResourceToLog?.(user);
 
       const isFromExtension = req.headers["x-request-origin"] === "extension";
       const userWithWorkspaces = await getUserWithWorkspaces(

--- a/front/lib/iam/provider.ts
+++ b/front/lib/iam/provider.ts
@@ -2,6 +2,7 @@ import type { Session } from "@auth0/nextjs-auth0";
 
 // This maps to the Auth0 user.
 export interface ExternalUser {
+  sid: string;
   email: string;
   email_verified: boolean;
   name: string;

--- a/front/lib/resources/base_resource.ts
+++ b/front/lib/resources/base_resource.ts
@@ -99,13 +99,15 @@ export abstract class BaseResource<M extends Model & ResourceWithId> {
   /**
    * Remove 'Resource' suffix and convert to snake_case
    * i.e: UserResource -> user
+   * KillSwitchResource -> kill_switch
+   * MCPServerViewResource -> mcp_server_view
    */
   className(): string {
     return this.constructor.name
       .replace(/Resource$/, "") // Remove 'Resource' suffix
-      .replace(/[A-Z]/g, (letter, index) =>
-        index === 0 ? letter.toLowerCase() : "_" + letter.toLowerCase()
-      );
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2") // handle UPPERCASE followed by Titlecase
+      .replace(/([a-z])([A-Z])/g, "$1_$2") // handle normal camelCase
+      .toLowerCase();
   }
 
   /**

--- a/front/lib/resources/base_resource.ts
+++ b/front/lib/resources/base_resource.ts
@@ -21,11 +21,8 @@ export interface ResourceWithId {
   id: ModelId;
 }
 
-export type LogContextValue = string | number | null;
-export type ResourceLogContext = {
-  key: string;
-  logContext: Record<string, LogContextValue>;
-};
+export type ResourceLogValue = string | number | null;
+export type ResourceLogJSON = Record<string, ResourceLogValue>;
 
 /**
  * BaseResource serves as a foundational class for resource management.
@@ -100,10 +97,22 @@ export abstract class BaseResource<M extends Model & ResourceWithId> {
   ): Promise<Result<undefined | number, Error>>;
 
   /**
-   * Method called if the resource is added to the log context using `req.addResourceToLog`.
-   * The key in the returned value is used as kind of a namespace to avoid key overlap in the `logContext`.
+   * Remove 'Resource' suffix and convert to snake_case
+   * i.e: UserResource -> user
    */
-  toContextLog(): ResourceLogContext {
+  className(): string {
+    return this.constructor.name
+      .replace(/Resource$/, "") // Remove 'Resource' suffix
+      .replace(/[A-Z]/g, (letter, index) =>
+        index === 0 ? letter.toLowerCase() : "_" + letter.toLowerCase()
+      );
+  }
+
+  /**
+   * Method called if the resource is added to the log context using `req.addResourceToLog`.
+   * The className() of the Resource will be used as kind of a namespace to avoid key overlap in the `logContext`.
+   */
+  toLogJSON(): ResourceLogJSON {
     throw new Error("`toContextLog` not implemented");
   }
 }

--- a/front/lib/resources/base_resource.ts
+++ b/front/lib/resources/base_resource.ts
@@ -21,6 +21,12 @@ export interface ResourceWithId {
   id: ModelId;
 }
 
+export type LogContextValue = string | number | null;
+export type ResourceLogContext = {
+  key: string;
+  logContext: Record<string, LogContextValue>;
+};
+
 /**
  * BaseResource serves as a foundational class for resource management.
  * It encapsulates common CRUD operations for Sequelize models, ensuring a uniform interface
@@ -92,4 +98,12 @@ export abstract class BaseResource<M extends Model & ResourceWithId> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }
   ): Promise<Result<undefined | number, Error>>;
+
+  /**
+   * Method called if the resource is added to the log context using `req.addResourceToLog`.
+   * The key in the returned value is used as kind of a namespace to avoid key overlap in the `logContext`.
+   */
+  toContextLog(): ResourceLogContext {
+    throw new Error("`toContextLog` not implemented");
+  }
 }

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -9,7 +9,7 @@ import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { LabsPersonalSalesforceConnection } from "@app/lib/models/labs_personal_salesforce_connection";
-import type { ResourceLogContext } from "@app/lib/resources/base_resource";
+import type { ResourceLogJSON } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import {
@@ -396,12 +396,9 @@ export class UserResource extends BaseResource<UserModel> {
     };
   }
 
-  toContextLog(): ResourceLogContext {
+  toLogJSON(): ResourceLogJSON {
     return {
-      key: "user",
-      logContext: {
-        sId: this.sId,
-      },
+      sId: this.sId,
     };
   }
 }

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -9,6 +9,7 @@ import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { LabsPersonalSalesforceConnection } from "@app/lib/models/labs_personal_salesforce_connection";
+import type { ResourceLogContext } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import {
@@ -392,6 +393,15 @@ export class UserResource extends BaseResource<UserModel> {
     return {
       users: users.map((u) => new UserResource(UserModel, u.get())),
       total: count,
+    };
+  }
+
+  toContextLog(): ResourceLogContext {
+    return {
+      key: "user",
+      logContext: {
+        sId: this.sId,
+      },
     };
   }
 }

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -12,16 +12,17 @@ import type { APIErrorWithStatusCode, WithAPIErrorResponse } from "@app/types";
 import logger from "./logger";
 import { statsDClient } from "./statsDClient";
 
-type RequestContext = {
+export type LogContextValue = string | number | null;
+export type RequestContext = {
   sessionId: string | null;
 } & {
-  [key: string]: string | number | null;
+  [key: string]: LogContextValue;
 };
 
 // Make the elements undefined temporarely avoid updating all NextApiRequest to NextApiRequestWithContext.
 export interface NextApiRequestWithContext extends NextApiRequest {
   logContext?: RequestContext;
-  addLogToContext?: (data: Record<string, string | number | null>) => void;
+  addLogToContext?: (data: Record<string, LogContextValue>) => void;
 }
 
 export function withLogging<T>(

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -44,12 +44,14 @@ export function withLogging<T>(
 
     const session = await getSession(req, res);
     const sessionId = session?.user.sid || "unknown";
-    req.logContext = { sessionId };
+
+    // Use freeze to make sure we cannot update `req.logContext` down the callstack
+    req.logContext = Object.freeze({ sessionId });
     req.addLogToContext = (data) => {
-      req.logContext = {
+      req.logContext = Object.freeze({
         ...(req.logContext ?? { sessionId: null }),
         ...data,
-      };
+      });
     };
 
     let route = req.url;

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -58,6 +58,7 @@ export const createPrivateApiMockRequest = async ({
   vi.mocked(getSession).mockReturnValue(
     Promise.resolve({
       user: {
+        sid: user.sId,
         sub: user.auth0Sub!,
         email: user.email!,
         email_verified: true,


### PR DESCRIPTION
## Description
- Other iteration of what was attempted here: https://github.com/dust-tt/dust/pull/12706
- Add a `logContext` to the req with a new `NextApiRequestWithContext`. This allow more easily to bubble up data that we want to add to the log event.
  - Only resources can be added to the `logContext` and resource you want to log need to implement `toContextLog`, otherwise it will crash.
  - Used a non-flat structure with a specific key for resources logs to avoid overlap. Could just prefix them instead of doing object.
- Added a `addToLogContext` and freeze the `logContext` to make sure we have one flow of doing thing (make sure we don't allow update of the attributes of `logContext`)
- Made the attributes of `NextApiRequestWithContext` undefined by default, just to avoid migrating everything to it now, so we can use it quickly in the needed function (i.e `withSessionAuthenticationForWorkspace`)
- Added `sid` to `SessionWithUser.user` as its logged as the `sessionId` but wasn't typed (asked here https://github.com/dust-tt/dust/pull/12706#discussion_r2092544173)

Less code changes than the first attempt, less impact also.

## Tests
- Locally tested, userId is properly logged
- Locally tested to update `req.logContext.userId`, it crashed as expected

## Risk
- Low, we just extending the nextjs req with optional info

## Deploy Plan
- Deploy front
