### PR TITLE
[front] chore(content_fragment): Add missing workspace id filter

### DIFF
--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -175,10 +175,11 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
     return ContentFragmentResource.fromMessage(message);
   }
 
-  static async fetchManyByModelIds(ids: Array<ModelId>) {
+  static async fetchManyByModelIds(auth: Authenticator, ids: Array<ModelId>) {
     const blobs = await ContentFragmentResource.model.findAll({
       where: {
         id: ids,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add a missing `workspaceId` filter when destroy content fragment
- Pass `Authenticator` instead of simple `WorkspaceType`

## Tests
- Locally test to delete a conversation

## Risk
- Mid, touching the conversation deletion, but easy to revert

## Deploy Plan
- Deploy front
