### PR TITLE
[Sparkle]Change tree loading behaviour to prevent re-renders

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.503",
+  "version": "0.2.504",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.503",
+      "version": "0.2.504",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.503",
+  "version": "0.2.504",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -58,21 +58,26 @@ export function Tree({
     return child;
   });
 
-  return isLoading ? (
-    <div className={cn("s-py-2 s-pl-4", className)}>
-      <Spinner size="xs" variant="dark" />
-    </div>
-  ) : (
-    <div
-      className={cn(
-        "s-flex s-flex-col s-gap-0.5 s-overflow-hidden",
-        isBoxed &&
-          "s-rounded-xl s-border s-border-border s-bg-muted-background s-px-3 s-py-2 dark:s-border-border-night dark:s-bg-muted-background-night",
-        className
+  return (
+    <>
+      <div
+        className={cn(
+          "s-flex s-flex-col s-gap-0.5 s-overflow-hidden",
+          isBoxed &&
+            "s-rounded-xl s-border s-border-border s-bg-muted-background s-px-3 s-py-2 dark:s-border-border-night dark:s-bg-muted-background-night",
+          className
+        )}
+      >
+        {modifiedChildren}
+      </div>
+      {isLoading && (
+        // add the spinner below modifiedChildren to keep the layout
+        // thus preventing re-render in case of pagination
+        <div className={cn("s-py-2 s-pl-4", className)}>
+          <Spinner size="xs" variant="dark" />
+        </div>
       )}
-    >
-      {modifiedChildren}
-    </div>
+    </>
   );
 }
 

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -170,6 +170,23 @@ export const TreeExample = () => {
                   <Tree.Item label="Item 2" visual={DocumentIcon} />
                 </Tree>
               </Tree.Item>
+              <Tree.Item
+                label="Item 8 (loading, with existing nodes)"
+                visual={FolderIcon}
+              >
+                <Tree isLoading>
+                  <Tree.Item
+                    type="leaf"
+                    label="Item 1"
+                    checkbox={{
+                      checked: checked["Item 1"],
+                      onCheckedChange: () => {
+                        check("Item 1");
+                      },
+                    }}
+                  />
+                </Tree>
+              </Tree.Item>
             </Tree>
           </div>
         </div>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Related to https://github.com/dust-tt/tasks/issues/2635

Change behaviour of the tree component when loading

- [Before]Display spinner or children (mutually exclusive)
- [After]Display spinner below children

This change is motivated by an edge case, when already have children but still wanting to load more of them because they have been paginated.

## Tests

New example added in the storybook
<img width="544" alt="image" src="https://github.com/user-attachments/assets/7f4834aa-245e-413a-9815-ddbec489ef8f" />


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
