### PR TITLE
[front] chore(tracker-config): Add missing workspaceId and index

### DIFF
--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -201,6 +201,10 @@ TrackerDataSourceConfigurationModel.init(
         fields: ["workspaceId", "dataSourceId"],
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "trackerConfigurationId", "scope"],
+        name: "tracker_data_source_config_workspace_id_tracker_config_id_scope",
+      },
     ],
   }
 );

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -348,6 +348,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
         where: {
           trackerConfigurationId: this.id,
           scope: "maintained",
+          workspaceId: this.workspaceId,
         },
       });
 

--- a/front/migrations/db/migration_267.sql
+++ b/front/migrations/db/migration_267.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 16, 2025
+CREATE INDEX "tracker_data_source_config_workspace_id_tracker_config_id_scope" ON "tracker_data_source_configurations" ("workspaceId", "trackerConfigurationId", "scope");


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add missing `workspaceId` filter
- Add new composite index

## Tests

## Risk
- Low, filter was already done right after

## Deploy Plan
- [x] Run migration
- [ ] Deploy front
