### PR TITLE
[front] fix preview layout in AB

### DIFF
--- a/front/components/assistant_builder/BuilderLayout.tsx
+++ b/front/components/assistant_builder/BuilderLayout.tsx
@@ -12,12 +12,16 @@ interface BuilderLayoutProps {
 export function BuilderLayout({ leftPanel, rightPanel }: BuilderLayoutProps) {
   return (
     <div className="flex h-full w-full">
-      <ResizablePanelGroup direction="horizontal" className="h-full w-full">
-        <ResizablePanel defaultSize={50} minSize={30}>
+      <ResizablePanelGroup
+        autoSaveId="assistant-builder-layout"
+        direction="horizontal"
+        className="h-full w-full"
+      >
+        <ResizablePanel defaultSize={70} minSize={30}>
           <div className="h-full w-full overflow-y-auto px-6">{leftPanel}</div>
         </ResizablePanel>
         <ResizableHandle />
-        <ResizablePanel defaultSize={50} minSize={20}>
+        <ResizablePanel defaultSize={30} minSize={20}>
           <div className="h-full w-full overflow-y-auto px-6">{rightPanel}</div>
         </ResizablePanel>
       </ResizablePanelGroup>


### PR DESCRIPTION
## Description
This PR is to adjust the default size of preview from 50% to 30%. Also add `autoSaveId` prop so that the value will be automatically saved in localStorage and be persisted. 
before:
<img width="1506" alt="Screenshot 2025-05-16 at 16 20 45" src="https://github.com/user-attachments/assets/4d76ad89-5234-450d-b0ca-bfa4ff20bec5" />


after:
<img width="1502" alt="Screenshot 2025-05-16 at 17 30 10" src="https://github.com/user-attachments/assets/196b21e4-e823-45fe-82f7-b68151914243" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
