### PR TITLE
Add: heartbeat in syncNonThread slack connector

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -523,6 +523,8 @@ export async function syncNonThreaded(
       );
     }
 
+    await heartbeat();
+
     for (const message of c.messages) {
       if (message.ts) {
         latestTsSec = parseInt(message.ts);


### PR DESCRIPTION
## Description

Add heartbeat in slack activity to avoid "Activity execution exceeded startToClose timeout" (probably due to slack api rate limit).

## Risk

Low

## Deploy Plan

Deploy `connectors`