### PR TITLE
[MCP Extract] Refactor JSONSchemaConfigurationSection

### DIFF
--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -96,12 +96,6 @@ export function ActionProcess({
       unit: "day",
     });
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
-  const [schemaEdit, setSchemaEdit] = useState(
-    actionConfiguration?._jsonSchemaString ??
-      (actionConfiguration?.jsonSchema
-        ? JSON.stringify(actionConfiguration.jsonSchema, null, 2)
-        : null)
-  );
   const toggleAdvancedSettings = () => {
     setShowAdvancedSettings((prev) => !prev);
   };
@@ -278,12 +272,22 @@ export function ActionProcess({
           </div>
           <JsonSchemaConfigurationSection
             instructions={instructions ?? ""}
-            schemaEdit={schemaEdit ?? ""}
-            setSchemaEdit={setSchemaEdit}
-            setEdited={setEdited}
-            updateAction={updateAction}
             description={description ?? ""}
-            schemaConfigurationDescription="Optionally, provide a schema for the data to be extracted. If you do not specify a schema, the tool will determine the schema based on the conversation context."
+            initialSchema={
+              actionConfiguration?._jsonSchemaString ??
+              (actionConfiguration?.jsonSchema
+                ? JSON.stringify(actionConfiguration.jsonSchema, null, 2)
+                : null)
+            }
+            sectionConfigurationDescription="Optionally, provide a schema for the data to be extracted. If you do not specify a schema, the tool will determine the schema based on the conversation context."
+            setEdited={setEdited}
+            onConfigUpdate={({ _jsonSchemaString, jsonSchema }) =>
+              updateAction((previousAction) => ({
+                ...previousAction,
+                _jsonSchemaString,
+                jsonSchema: jsonSchema ?? previousAction.jsonSchema,
+              }))
+            }
             generateSchema={(instructions: string) =>
               generateSchema({ owner, instructions })
             }
@@ -294,7 +298,7 @@ export function ActionProcess({
   );
 }
 
-async function generateSchema({
+export async function generateSchema({
   owner,
   instructions,
 }: {

--- a/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
@@ -4,24 +4,29 @@ import {
   TextArea,
   useSendNotification,
 } from "@dust-tt/sparkle";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { useState } from "react";
 
-import type { AssistantBuilderProcessConfiguration } from "@app/components/assistant_builder/types";
 import { isValidJsonSchema } from "@app/lib/utils/json_schemas";
 import type { Result } from "@app/types";
 
 interface JsonSchemaConfigurationSectionProps {
+  // The agent's instructions and tool description, needed to generate the
+  // schema automatically if requested by the user.
   instructions: string;
   description: string;
-  schemaConfigurationDescription: string;
-  schemaEdit: string | null;
-  setSchemaEdit: (schemaEdit: string | null) => void;
+  // A string that explains this schema configuration section, displayed to the
+  // user.
+  sectionConfigurationDescription: string;
+  initialSchema: string | null;
   setEdited: (edited: boolean) => void;
-  updateAction: (
-    setNewActionConfig: (
-      previousAction: AssistantBuilderProcessConfiguration
-    ) => AssistantBuilderProcessConfiguration
-  ) => void;
+  onConfigUpdate: ({
+    _jsonSchemaString,
+    jsonSchema,
+  }: {
+    _jsonSchemaString: string | null;
+    jsonSchema?: JSONSchema | null;
+  }) => void;
   generateSchema: (
     instructions: string
   ) => Promise<Result<Record<string, unknown>, Error>>;
@@ -30,15 +35,15 @@ interface JsonSchemaConfigurationSectionProps {
 export function JsonSchemaConfigurationSection({
   instructions,
   description,
-  schemaConfigurationDescription,
-  schemaEdit,
-  setSchemaEdit,
+  sectionConfigurationDescription,
+  initialSchema,
   setEdited,
-  updateAction,
+  onConfigUpdate,
   generateSchema,
 }: JsonSchemaConfigurationSectionProps) {
   const [isGeneratingSchema, setIsGeneratingSchema] = useState(false);
   const sendNotification = useSendNotification();
+  const [extractSchema, setExtractSchema] = useState(initialSchema);
 
   const generateSchemaFromInstructions = async () => {
     setEdited(true);
@@ -57,13 +62,12 @@ export function JsonSchemaConfigurationSection({
             ? JSON.stringify(schemaObject, null, 2)
             : null;
 
-          setSchemaEdit(schemaString);
+          setExtractSchema(schemaString);
           setEdited(true);
-          updateAction((previousAction) => ({
-            ...previousAction,
+          onConfigUpdate({
             jsonSchema: schemaObject,
             _jsonSchemaString: schemaString,
-          }));
+          });
         } else {
           sendNotification({
             title: "Failed to generate schema.",
@@ -81,13 +85,12 @@ export function JsonSchemaConfigurationSection({
         setIsGeneratingSchema(false);
       }
     } else {
-      setSchemaEdit(null);
+      setExtractSchema(null);
       setEdited(true);
-      updateAction((previousAction) => ({
-        ...previousAction,
+      onConfigUpdate({
         jsonSchema: null,
         _jsonSchemaString: null,
-      }));
+      });
     }
   };
 
@@ -97,7 +100,7 @@ export function JsonSchemaConfigurationSection({
         Schema
       </div>
       <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        {schemaConfigurationDescription}
+        {sectionConfigurationDescription}
       </div>
       <Button
         tooltip="Automatically re-generate the extraction schema based on Instructions"
@@ -109,31 +112,31 @@ export function JsonSchemaConfigurationSection({
         onClick={generateSchemaFromInstructions}
       />
       <TextArea
-        error={schemaEdit ? isValidJsonSchema(schemaEdit).error : undefined}
+        error={
+          extractSchema ? isValidJsonSchema(extractSchema).error : undefined
+        }
         showErrorLabel={true}
         placeholder={
           '{\n  "type": "object",\n  "properties": {\n    "name": { "type": "string" },\n    ...\n  }\n}'
         }
-        value={schemaEdit ?? ""}
+        value={extractSchema ?? ""}
         disabled={isGeneratingSchema}
         onChange={(e) => {
           const newSchemaString = e.target.value;
-          setSchemaEdit(newSchemaString);
+          setExtractSchema(newSchemaString);
           setEdited(true);
 
           const parsedSchema = isValidJsonSchema(newSchemaString);
           if (parsedSchema.isValid) {
-            updateAction((previousAction) => ({
-              ...previousAction,
+            onConfigUpdate({
               jsonSchema: newSchemaString ? JSON.parse(newSchemaString) : null,
               _jsonSchemaString: newSchemaString,
-            }));
+            });
           } else {
             // If parsing fails, still update the string version but don't update the schema
-            updateAction((previousAction) => ({
-              ...previousAction,
+            onConfigUpdate({
               _jsonSchemaString: newSchemaString,
-            }));
+            });
           }
         }}
       />


### PR DESCRIPTION
Preparatory work for #12698  and task https://github.com/dust-tt/tasks/issues/2640
## Description

This PR refactors the JSON schema configuration for the "Process" action in the Assistant Builder. It's required by upcoming PR #12698

The key changes include:

*   **Centralized Schema State:** The `schemaEdit` state and its update logic (`setSchemaEdit`, `updateAction` calls related to schema) have been removed from `ProcessAction.tsx`.
*   **New Prop for `JsonSchemaConfigurationSection`:** The `JsonSchemaConfigurationSection` now accepts an `initialSchema` prop to set its initial state and an `onConfigUpdate` callback to propagate schema changes (both the string and parsed JSON object) upwards. This makes the component more reusable and decouples it from the specific state management of `ProcessAction`.
*   **Simplified `ProcessAction`:** The `ProcessAction` component now passes the initial schema string and a handler for `onConfigUpdate` to `JsonSchemaConfigurationSection`. The `generateSchema` function is now exported from `ProcessAction.tsx` to be passed as a prop.
*   **Internal State in `JsonSchemaConfigurationSection`:** The `JsonSchemaConfigurationSection` now manages its own internal `extractSchema` state for the text area value.

These changes improve the component structure by making `JsonSchemaConfigurationSection` more self-contained and responsible for its own state related to schema editing and generation. `ProcessAction` now acts more as a coordinator, passing necessary data and callbacks.

## Risks

*   Minor risk of regression in the schema editing or generation functionality if the new prop-based communication between `ProcessAction` and `JsonSchemaConfigurationSection` is not correctly implemented.

## Tests

*   Manual testing of the "Process" action's schema configuration:
    *   Verify that an existing schema is correctly displayed.
    *   Verify that manually editing the schema updates the action configuration.
    *   Verify that auto-generating a schema from instructions works and updates the action configuration.
    *   Verify that an invalid schema shows an error.
    *   Verify that clearing the schema updates the action configuration.

## Deploy Plan

*   Deploy `front` service.
