### PR TITLE
fix: race condition in `createCallbackPromise`

### DIFF
--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -7,7 +7,7 @@ import { publishEvent } from "@app/lib/api/assistant/pubsub";
 import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
-import { createCallbackPromise } from "@app/lib/utils";
+import { createCallbackReader } from "@app/lib/utils";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 
@@ -25,10 +25,10 @@ export async function* getMCPEventsForServer(
 ) {
   const channelId = getMCPServerChannelId(auth, { mcpServerId });
 
-  const callbackPromise = createCallbackPromise<EventPayload | "close">();
+  const callbackReader = createCallbackReader<EventPayload | "close">();
   const { history, unsubscribe } = await getRedisHybridManager().subscribe(
     channelId,
-    callbackPromise.callback,
+    callbackReader.callback,
     lastEventId,
     "mcp_events"
   );
@@ -51,7 +51,7 @@ export async function* getMCPEventsForServer(
         break;
       }
       const rawEvent = await Promise.race([
-        callbackPromise.promise,
+        callbackReader.next(),
         setTimeoutAsync(MCP_EVENTS_TIMEOUT),
       ]);
 
@@ -59,9 +59,6 @@ export async function* getMCPEventsForServer(
       if (rawEvent === "timeout") {
         break;
       }
-
-      // Reset the promise for the next event.
-      callbackPromise.reset();
 
       if (rawEvent === "close") {
         break;

--- a/front/lib/utils.test.ts
+++ b/front/lib/utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { createCallbackReader } from "./utils";
+
+describe("Utils", () => {
+  describe("createCallbackReader", () => {
+    it("should create a callback reader", () => {
+      const reader = createCallbackReader<number>();
+      expect(reader).toBeDefined();
+    });
+
+    it("should push and pull values", async () => {
+      const reader = createCallbackReader<number>();
+      reader.callback(1);
+      expect(await reader.next()).toBe(1);
+    });
+
+    it("should push and pull multiple values", async () => {
+      const reader = createCallbackReader<number>();
+      reader.callback(1);
+      reader.callback(2);
+      expect(await reader.next()).toBe(1);
+      expect(await reader.next()).toBe(2);
+    });
+
+    it("should push and pull multiple values in order", async () => {
+      const reader = createCallbackReader<number>();
+      setTimeout(() => {
+        reader.callback(1);
+        reader.callback(2);
+      }, 0);
+      setTimeout(() => {
+        reader.callback(3);
+      }, 0);
+      expect(await reader.next()).toBe(1);
+      expect(await reader.next()).toBe(2);
+      expect(await reader.next()).toBe(3);
+    });
+  });
+});

--- a/front/lib/utils.test.ts
+++ b/front/lib/utils.test.ts
@@ -36,5 +36,21 @@ describe("Utils", () => {
       expect(await reader.next()).toBe(2);
       expect(await reader.next()).toBe(3);
     });
+
+    it("return a promise that resolves to the same value when calling next before it is resolved", async () => {
+      const reader = createCallbackReader<number>();
+      const promise1 = reader.next();
+      const promise2 = reader.next();
+
+      reader.callback(1);
+
+      expect(promise1).toBe(promise2);
+
+      expect(await promise1).toBe(1);
+      expect(await promise2).toBe(1);
+
+      reader.callback(2);
+      expect(await reader.next()).toBe(2);
+    });
   });
 });

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -357,26 +357,42 @@ export type CallbackReader<T> = {
 
 export function createCallbackReader<T>(): CallbackReader<T> {
   const buffered: T[] = []; // arrived but unconsumed values
-  let waiter: ((v: T) => void) | undefined; // pending `.next()` resolver
+  let waiterResolver: ((v: T) => void) | undefined; // pending `.next()` resolver
+  let waiterPromise: Promise<T> | undefined; // pending `.next()` promise
 
   return {
     callback: (v: T) => {
-      if (waiter) {
-        waiter(v);
-        waiter = undefined;
+      // If we already have a waiter on the next callback, resolve it.
+      if (waiterResolver) {
+        waiterResolver(v);
+        waiterResolver = undefined;
+        waiterPromise = undefined;
       } else {
+        // Otherwise, buffer the value.
         buffered.push(v);
       }
     },
 
     next: () => {
+      // If we have buffered values, return the first one.
       const v = buffered.shift();
       if (v !== undefined) {
         return Promise.resolve(v);
       }
 
-      // No value ready: return a fresh promise and queue its resolver.
-      return new Promise<T>((resolve) => (waiter = resolve));
+      // If we already have a waiter on the next callback, return the same promise.
+      if (waiterPromise) {
+        return waiterPromise;
+      }
+
+      // Otherwise, create a new promise and queue its resolver.
+      const promise = new Promise<T>((resolve) => {
+        waiterResolver = resolve;
+      });
+
+      waiterPromise = promise;
+
+      return promise;
     },
   };
 }


### PR DESCRIPTION
## Description

Replaces `createCallbackPromise` with `createCallbackReader` to fix a race condition where events could be dropped when multiple callbacks fire in the same Node.js event loop tick.
The new implementation uses a queue-based approach:

- Buffers events if no consumer is waiting
- Queues consumers if no events are available
- Guarantees no events are lost regardless of timing

This fixes event dropping issues in agent message streaming, particularly around delimiter tokens (`<thinking>`).

Before: Events could be lost between await promise and reset() (if the callback fires more than once in the same Node event loop tick)
After: All events are properly queued and delivered in order

## Tests

Manual

## Risk

Wide blast radius since it touches the redis consumer code.

## Deploy Plan

Deploy front