### PR TITLE
Suggest route: do not load usage

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -514,20 +514,8 @@ export async function getSuggestedAgentsForConversation(
     agentsGetView: "list",
     variant: "full", // We load the full agent configuration to get the actions name and description.
   });
-  const agentUsages = await getAgentsUsage({
-    workspaceId: owner.sId,
-  });
 
-  // Filter out agents that have not been used in any conversation.
-  const usedAgents = agents.filter((a: AgentConfigurationType) => {
-    const usage = agentUsages.find((u: AgentUsageCount) => u.agentId === a.sId);
-    return usage?.messageCount ? usage.conversationCount > 0 : false;
-  });
-
-  // If no agents have been used, suggest all agents any way.
-  const agentsToSuggest = usedAgents.length > 0 ? usedAgents : agents;
-
-  const formattedAgents = agentsToSuggest.map((a) => ({
+  const formattedAgents = agents.map((a) => ({
     id: a.sId,
     displayName: `@${a.name}`,
     description: a.description,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -4,11 +4,7 @@ import type { Transaction } from "sequelize";
 import { runActionStreamed } from "@app/lib/actions/server";
 import type { AgentActionSpecificEvent } from "@app/lib/actions/types/agent";
 import { runAgent } from "@app/lib/api/assistant/agent";
-import type { AgentUsageCount } from "@app/lib/api/assistant/agent_usage";
-import {
-  getAgentsUsage,
-  signalAgentUsage,
-} from "@app/lib/api/assistant/agent_usage";
+import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import {
   getAgentConfigurations,
   getLightAgentConfiguration,
@@ -55,7 +51,6 @@ import logger from "@app/logger/logger";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 import type {
   AgentActionSuccessEvent,
-  AgentConfigurationType,
   AgentDisabledErrorEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,


### PR DESCRIPTION
## Description

The suggest route is taking too long to load. It loads 2 heavy things: 
1/ The full agent configurations (we present the tool name/description to the model in the dust app); 
2/ The usage to exclude unused agents. 

Step 1: Remove usage to check if it has an impact on prod. 

## Tests

Locally. 

## Risk

Feature activated for Dust only. 

## Deploy Plan

Deploy front. 
