### PR TITLE
Chg: use max page size when fetching permissions for github

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -5,6 +5,7 @@ import {
   getRepo,
   getReposPage,
   installationIdFromConnectionId,
+  MAX_REPOSITORIES_PAGE_SIZE,
 } from "@connectors/connectors/github/lib/github_api";
 import {
   getCodeRootInternalId,
@@ -271,7 +272,11 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       let nodes: ContentNode[] = [];
       let pageNumber = 1; // 1-indexed
       for (;;) {
-        const pageRes = await getReposPage(c, pageNumber);
+        const pageRes = await getReposPage(
+          c,
+          pageNumber,
+          MAX_REPOSITORIES_PAGE_SIZE
+        );
 
         if (pageRes.isErr()) {
           return new Err(

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -58,6 +58,7 @@ import {
 const API_PAGE_SIZE = 100;
 const REPOSITORIES_API_PAGE_SIZE = 25;
 const MAX_ISSUES_PAGE_SIZE = 100;
+export const MAX_REPOSITORIES_PAGE_SIZE = 100;
 
 type GithubOrg = {
   id: number;
@@ -126,7 +127,8 @@ export async function installationIdFromConnectionId(
 
 export async function getReposPage(
   connector: ConnectorResource,
-  page: number
+  page: number,
+  perPage: number = REPOSITORIES_API_PAGE_SIZE
 ): Promise<Result<GithubRepo[], ExternalOAuthTokenError>> {
   try {
     const octokit = await getOctokit(connector);
@@ -134,7 +136,7 @@ export async function getReposPage(
     return new Ok(
       (
         await octokit.request("GET /installation/repositories", {
-          per_page: REPOSITORIES_API_PAGE_SIZE,
+          per_page: perPage,
           page: page,
         })
       ).data.repositories.map((r) => ({


### PR DESCRIPTION
## Description

Use the max allowed repo per page in getPermissions of github to improve performance when loading many repo in the UI.
(note to @philipperolet : I left the lower value in case of connector activity)

## Risk

Low, will check in prod if performance are improved.

## Deploy Plan

Deploy `connectors`