### PR TITLE
enh(Poke): prevent reload on agent archive/restore

### DIFF
--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -24,7 +24,7 @@ type AgentConfigurationDisplayType = {
 
 export function makeColumnsForAssistants(
   owner: LightWorkspaceType,
-  reload: () => void
+  onAgentArchivedOrRestored: () => Promise<void>
 ): ColumnDef<AgentConfigurationDisplayType>[] {
   return [
     {
@@ -106,8 +106,16 @@ export function makeColumnsForAssistants(
               variant="outline"
               onClick={async () => {
                 await (assistant.status !== "archived"
-                  ? archiveAssistant(owner, reload, assistant)
-                  : restoreAssistant(owner, reload, assistant));
+                  ? archiveAssistant(
+                      owner,
+                      onAgentArchivedOrRestored,
+                      assistant
+                    )
+                  : restoreAssistant(
+                      owner,
+                      onAgentArchivedOrRestored,
+                      assistant
+                    ));
               }}
             />
             <Link
@@ -130,7 +138,7 @@ export function makeColumnsForAssistants(
 
 async function archiveAssistant(
   owner: LightWorkspaceType,
-  reload: () => void,
+  onAgentArchived: () => Promise<void>,
   agentConfiguration: AgentConfigurationDisplayType
 ) {
   if (
@@ -155,7 +163,7 @@ async function archiveAssistant(
       throw new Error("Failed to archive agent configuration.");
     }
 
-    reload();
+    await onAgentArchived();
   } catch (e) {
     console.error(e);
     window.alert("An error occurred while archiving the agent configuration.");
@@ -164,7 +172,7 @@ async function archiveAssistant(
 
 async function restoreAssistant(
   owner: LightWorkspaceType,
-  reload: () => void,
+  onAgentRestored: () => Promise<void>,
   agentConfiguration: AgentConfigurationDisplayType
 ) {
   if (
@@ -189,7 +197,7 @@ async function restoreAssistant(
       throw new Error("Failed to restore agent configuration.");
     }
 
-    reload();
+    await onAgentRestored();
   } catch (e) {
     console.error(e);
     window.alert("An error occurred while restoring the agent configuration.");

--- a/front/components/poke/assistants/table.tsx
+++ b/front/components/poke/assistants/table.tsx
@@ -109,9 +109,11 @@ export function AssistantsDataTable({ owner }: AssistantsDataTableProps) {
         owner={owner}
         useSWRHook={usePokeAgentConfigurations}
       >
-        {(data) => (
+        {(data, mutate) => (
           <PokeDataTable
-            columns={makeColumnsForAssistants(owner, router.reload)}
+            columns={makeColumnsForAssistants(owner, async () => {
+              await mutate();
+            })}
             data={prepareAgentConfigurationForDisplay(data)}
           />
         )}
@@ -129,13 +131,11 @@ function RestoreAssistantModal({
   onClose: () => void;
   owner: LightWorkspaceType;
 }) {
-  const { data: archivedAssistants } = usePokeAgentConfigurations({
+  const { data: archivedAssistants, mutate } = usePokeAgentConfigurations({
     owner,
     disabled: !show,
     agentsGetView: "archived",
   });
-
-  const router = useRouter();
 
   return (
     <Sheet
@@ -153,7 +153,9 @@ function RestoreAssistantModal({
         <SheetContainer>
           {!!archivedAssistants?.length && (
             <PokeDataTable
-              columns={makeColumnsForAssistants(owner, router.reload)}
+              columns={makeColumnsForAssistants(owner, async () => {
+                await mutate();
+              })}
               data={prepareAgentConfigurationForDisplay(archivedAssistants)}
             />
           )}


### PR DESCRIPTION
## Description

- Currently, when deleting an agent from Poke (in the `DataTable` on the workspace page) the whole page reloads after the deletion.
- This is not an issue by itself, but the agent `DataTable` closes after the reload, forcing the user to open it back. This makes deleting several agents successively slower.
- This PR addresses the issue by mutating the list of agents instead of reloading.
- This new behavior mimics what was done for the data sources.

## Tests

- Tested locally. Very smooth experience.

## Risk

- Very low, only super admin access, does not change the core functionality. Will be further tested in prod.

## Deploy Plan

- Deploy front.
