### PR TITLE
Remove tools to Agent router suggest agent app

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -507,18 +507,13 @@ export async function getSuggestedAgentsForConversation(
   const agents = await getAgentConfigurations({
     auth,
     agentsGetView: "list",
-    variant: "full", // We load the full agent configuration to get the actions name and description.
+    variant: "light",
   });
 
   const formattedAgents = agents.map((a) => ({
     id: a.sId,
     displayName: `@${a.name}`,
     description: a.description,
-    tools: a.actions.map((a) => ({
-      name: a.name,
-      description: a.description,
-    })),
-    visualizationEnabled: a.visualizationEnabled,
     userFavorite: a.userFavorite,
   }));
 

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -293,7 +293,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "fcYLVzSHdU",
       appHash:
-        "b988e0a0b7c347edcfc5f263a0fff591fe4a8cd643ab9480a8bfdd5d79fca6c9",
+        "5764c8eb5d325e01213b3af3cc2230c88f5264ac6ebf438d1ad64e4c71b3a296",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

Stop exposing tools to agent router to improve slowness of the /suggest call. 
Expecting that the router will be less smart but we're willing to sacrifice some performances for performances 😄 

I decided to remove the tools and the visualization flag to not bias the model into thinking visualization is super important. 

## Tests

Locally. 

## Risk

Used internally only, can be rolled back. 

## Deploy Plan

Sync Dust app EU
Deploy front. 