### PR TITLE
Disable call suggest agents if message is placeholder

### DIFF
--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -49,6 +49,8 @@ export function AgentSuggestion({
     workspaceId: owner.sId,
     conversationId,
     messageId: userMessage.sId,
+    disabled:
+      userMessage.id === -1 || userMessage.sId.startsWith("placeholder"),
   });
 
   const sendNotification = useSendNotification();

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -173,7 +173,7 @@ export function useSuggestedAgentConfigurations({
   return {
     suggestedAgentConfigurations:
       dataToUse?.agentConfigurations ?? emptyArray(),
-    isSuggestedAgentConfigurationsLoading: !error && !dataToUse,
+    isSuggestedAgentConfigurationsLoading: !error && !dataToUse && !disabled,
     isSuggestedAgentConfigurationsError: error,
     mutate,
     mutateRegardlessOfQueryParams,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -147,10 +147,12 @@ export function useSuggestedAgentConfigurations({
   workspaceId,
   conversationId,
   messageId,
+  disabled,
 }: {
   workspaceId: string;
   conversationId: string;
   messageId: string;
+  disabled?: boolean;
 }) {
   const agentConfigurationsFetcher: Fetcher<GetAgentConfigurationsResponseBody> =
     fetcher;
@@ -163,7 +165,7 @@ export function useSuggestedAgentConfigurations({
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
     useSWRWithDefaults(key, agentConfigurationsFetcher, {
-      disabled: inCache,
+      disabled: inCache || disabled,
     });
 
   const dataToUse = cachedData || data;


### PR DESCRIPTION
## Description

Fixes https://app.datadoghq.eu/logs?query=status%3Aerror%20service%3Afront%20%40apiError.api_error.message%3A%22Error%20suggesting%20agents%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZbogrWwNJHEfwAAABhBWmJvZ3Nic0FBQmtSd1BoM1V3cTdRQVoAAAAkMDE5NmU4ODMtY2FkMC00OTdiLThjODQtNzU2MTdhMWMxMjJmAAJkGg&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1747052936088&to_ts=1747657736088&live=true

We do not want to suggest agent for the placeholder message of optimistic rendering. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 