### PR TITLE
Improve loading state of suggested agents when no mention in user message

### DIFF
--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -5,7 +5,6 @@ import {
   LoadingBlock,
   Page,
   RobotIcon,
-  Spinner,
   useSendNotification,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -2,6 +2,7 @@ import {
   AssistantCard,
   AssistantCardMore,
   Button,
+  LoadingBlock,
   Page,
   RobotIcon,
   Spinner,
@@ -123,59 +124,60 @@ export function AgentSuggestion({
 
   return (
     <div className="flex flex-col items-start gap-6">
+      <Page.SectionHeader
+        title="Best-matching Agents"
+        description="Selected based on agents' descriptions, names, and available tools."
+      />
       {suggestedAgents.length === 0 ? (
-        <div className="flex min-h-28 w-full items-center justify-center">
-          <Spinner />
+        <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4">
+          <LoadingBlock className="h-[130px] w-full rounded-xl" />
+          <LoadingBlock className="h-[130px] w-full rounded-xl" />
+          <LoadingBlock className="h-[130px] w-full rounded-xl" />
+          <LoadingBlock className="h-[130px] w-full rounded-xl" />
         </div>
       ) : (
-        <>
-          <Page.SectionHeader
-            title="Best-matching Agents"
-            description="Selected based on agents' descriptions, names, and available tools."
-          />
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4">
-            {suggestedAgents.map((agent, id) => (
-              <AssistantCard
-                key={`${agent.sId}-${id}`}
-                description={agent.description}
-                subtitle={agent.lastAuthors?.join(", ") ?? ""}
-                title={agent.name}
-                pictureUrl={agent.pictureUrl}
-                onClick={() => handleSelectSuggestion(agent)}
-                variant="secondary"
-                action={
-                  <AssistantCardMore
-                    onClick={() => showAssistantDetails(agent)}
-                  />
-                }
-              />
-            ))}
-          </div>
-          <div className="flex flex-row items-center gap-2">
-            <p className="flex text-base text-muted-foreground">Or</p>
-            <AssistantPicker
-              owner={owner}
-              assistants={allSortedAgents}
-              onItemClick={async (agent) => {
-                if (!isLoading) {
-                  setIsLoading(true);
-                  await handleSelectSuggestion(agent);
-                  setIsLoading(false);
-                }
-              }}
-              pickerButton={
-                <Button
-                  variant="outline"
-                  size="sm"
-                  icon={RobotIcon}
-                  label="Pick an agent"
-                  isSelect
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4">
+          {suggestedAgents.map((agent, id) => (
+            <AssistantCard
+              key={`${agent.sId}-${id}`}
+              description={agent.description}
+              subtitle={agent.lastAuthors?.join(", ") ?? ""}
+              title={agent.name}
+              pictureUrl={agent.pictureUrl}
+              onClick={() => handleSelectSuggestion(agent)}
+              variant="secondary"
+              action={
+                <AssistantCardMore
+                  onClick={() => showAssistantDetails(agent)}
                 />
               }
             />
-          </div>
-        </>
+          ))}
+        </div>
       )}
+      <div className="flex flex-row items-center gap-2">
+        <p className="flex text-base text-muted-foreground">Or</p>
+        <AssistantPicker
+          owner={owner}
+          assistants={allSortedAgents}
+          onItemClick={async (agent) => {
+            if (!isLoading) {
+              setIsLoading(true);
+              await handleSelectSuggestion(agent);
+              setIsLoading(false);
+            }
+          }}
+          pickerButton={
+            <Button
+              variant="outline"
+              size="sm"
+              icon={RobotIcon}
+              label="Pick an agent"
+              isSelect
+            />
+          }
+        />
+      </div>
     </div>
   );
 }

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -156,7 +156,7 @@ export function AgentSuggestion({
         </div>
       )}
       <div className="flex flex-row items-center gap-2">
-        <p className="flex text-base text-muted-foreground">Or</p>
+        <p className="flex text-sm text-muted-foreground">Or</p>
         <AssistantPicker
           owner={owner}
           assistants={allSortedAgents}


### PR DESCRIPTION
## Description

Pure design change: when the suggestions are loading we do display the title and button to suggest agents, we just replace the AssistantCards by LoadingBlcoks. 

Note: We cannot know in advance whether we'll have 4 suggestion (could be less). We're always displaying 4 loading blocks. 

Other note: Review with hidden whitespaces recommended: https://github.com/dust-tt/dust/pull/12759/files?diff=split&w=1

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 