### PR TITLE
Fix data source view `parentsIn` update

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -542,6 +542,9 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
           ],
           node_ids: parentsToAdd,
         },
+        options: {
+          cursor: nextPageCursor,
+        },
       });
 
       if (coreRes.isErr()) {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -528,26 +528,31 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     // Check parentsToAdd exist in core as part of this data source view.
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-    const coreRes = await coreAPI.searchNodes({
-      filter: {
-        data_source_views: [
-          {
-            data_source_id: this.dataSource.dustAPIDataSourceId,
-            view_filter: [],
-          },
-        ],
-        node_ids: parentsToAdd,
-      },
-    });
+    const allNodes = [];
+    let nextPageCursor;
 
-    if (coreRes.isErr()) {
-      return new Err(new Error(coreRes.error.message));
-    }
+    do {
+      const coreRes = await coreAPI.searchNodes({
+        filter: {
+          data_source_views: [
+            {
+              data_source_id: this.dataSource.dustAPIDataSourceId,
+              view_filter: [],
+            },
+          ],
+          node_ids: parentsToAdd,
+        },
+      });
+
+      if (coreRes.isErr()) {
+        return new Err(new Error(coreRes.error.message));
+      }
+      allNodes.push(...coreRes.value.nodes);
+      nextPageCursor = coreRes.value.next_page_cursor;
+    } while (nextPageCursor);
 
     // set to avoid O(n**2) complexity in check below
-    const coreParents = new Set(
-      coreRes.value.nodes.map((node) => node.node_id)
-    );
+    const coreParents = new Set(allNodes.map((node) => node.node_id));
     if (parentsToAdd.some((parent) => !coreParents.has(parent))) {
       return new Err(
         new Error("Some parents do not exist in this data source view.")


### PR DESCRIPTION
## Description

- Fix https://github.com/dust-tt/tasks/issues/2756#issuecomment-2868616439.
- This PR paginates the call when patching the `parentsIn` of a data source view.
- This fixes a bug where adding nodes (Slack channels in the observed issue) to a data source view would cause certain nodes to be removed.

## Tests

- Tested locally for non regression.

## Risk

- Very safe change.

## Deploy Plan

- Deploy front.
- Rerun migration to fix the main issue.
