### PR TITLE
enh(connectors): Normalize errors instead of casting

### DIFF
--- a/connectors/src/connectors/bigquery/temporal/client.ts
+++ b/connectors/src/connectors/bigquery/temporal/client.ts
@@ -10,6 +10,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 
 function makeBigQuerySyncWorkflowId(connectorId: ModelId): string {
   return `bigquery-sync-${connectorId}`;
@@ -50,7 +51,7 @@ export async function launchBigQuerySyncWorkflow(
       cronSchedule: `${connector.id % 60} * * * *`,
     });
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 
   return new Ok(workflowId);
@@ -88,6 +89,6 @@ export async function stopBigQuerySyncWorkflow(
       },
       "Failed to stop BigQuery workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -319,7 +319,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
           )
         );
       }
-      // Unanhdled error, throwing to get a 500.
+      // Unhandled error, throwing to get a 500.
       throw e;
     }
   }

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -37,7 +37,7 @@ import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ConnectorPermission, ContentNode } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-import { ConfluenceClientError } from "@connectors/types";
+import { ConfluenceClientError, normalizeError } from "@connectors/types";
 
 const logger = mainLogger.child({
   connector: "confluence",
@@ -221,7 +221,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -22,7 +22,10 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
-import { makeConfluenceSyncWorkflowId } from "@connectors/types";
+import {
+  makeConfluenceSyncWorkflowId,
+  normalizeError,
+} from "@connectors/types";
 import { isScheduleAlreadyRunning } from "@connectors/types";
 
 export async function launchConfluenceSyncWorkflow(
@@ -76,7 +79,7 @@ export async function launchConfluenceSyncWorkflow(
       cronSchedule: `${minute} ${oddOrEvenHour}/2 * * *`, // Every 2 hours at minute `minute`.
     });
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 
   return new Ok(workflowId);
@@ -122,7 +125,7 @@ export async function launchConfluenceRemoveSpacesSyncWorkflow(
       },
     });
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 
   return new Ok(workflowId);
@@ -160,7 +163,7 @@ export async function stopConfluenceSyncWorkflow(
       },
       "Failed to stop Confluence workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -42,7 +42,7 @@ import type {
   ContentNodesViewType,
   DataSourceConfig,
 } from "@connectors/types";
-import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES, normalizeError } from "@connectors/types";
 
 const logger = mainLogger.child({ provider: "github" });
 
@@ -166,7 +166,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 
@@ -222,7 +222,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 
@@ -244,7 +244,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       });
       return new Ok(this.connectorId.toString());
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -64,6 +64,7 @@ import type { DataSourceConfig } from "@connectors/types";
 import {
   getGoogleSheetContentNodeInternalId,
   INTERNAL_MIME_TYPES,
+  normalizeError,
 } from "@connectors/types";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types";
 
@@ -725,7 +726,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
       return new Ok(parents.map((p) => getInternalId(p)));
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -152,7 +152,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     }
 
     // Ideally we want to check that the Google Project ID is the same as the one from the connector
-    // I couln't find an easy way to access it from the googleapis library
+    // I couldn't find an easy way to access it from the googleapis library
     // Workaround is checking the domain of the user who is updating the connector
     if (connectionId) {
       try {
@@ -291,7 +291,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
             parentId: parentDriveId,
           };
           if (isTablesView) {
-            // In tables view, we only show folders, spreadhsheets and sheets.
+            // In tables view, we only show folders, spreadsheets and sheets.
             // We filter out folders that only contain Documents.
             where.mimeType = [
               "application/vnd.google-apps.folder",
@@ -531,7 +531,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
           )
         );
       }
-      // Unanhdled error, throwing to get a 500.
+      // Unhandled error, throwing to get a 500.
       throw e;
     }
   }

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -14,7 +14,10 @@ import { getTemporalClient, terminateWorkflow } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
-import { googleDriveIncrementalSyncWorkflowId } from "@connectors/types";
+import {
+  googleDriveIncrementalSyncWorkflowId,
+  normalizeError,
+} from "@connectors/types";
 
 import {
   googleDriveFixParentsConsistencyWorkflow,
@@ -95,7 +98,7 @@ export async function launchGoogleDriveFullSyncWorkflow(
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -145,7 +148,7 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -195,7 +198,7 @@ export async function launchGoogleGarbageCollector(
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -247,6 +250,6 @@ export async function launchGoogleFixParentsConsistencyWorkflow(
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -11,7 +11,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
-import { getIntercomSyncWorkflowId } from "@connectors/types";
+import { getIntercomSyncWorkflowId, normalizeError } from "@connectors/types";
 
 export async function launchIntercomSyncWorkflow({
   connectorId,
@@ -86,7 +86,7 @@ export async function launchIntercomSyncWorkflow({
       cronSchedule: "30 * * * *", // Every hour, at 30 of the hour.
     });
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 
   return new Ok(workflowId);
@@ -124,6 +124,6 @@ export async function stopIntercomSyncWorkflow(
       },
       "[Intercom] Failed stopping workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -23,6 +23,7 @@ import {
   typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import { normalizeError } from "@connectors/types";
 
 export async function clientApiGet(
   logger: LoggerInterface,
@@ -601,7 +602,7 @@ export async function wrapMicrosoftGraphAPIWithResult<T>(
   try {
     return new Ok(await fn());
   } catch (error) {
-    return new Err(error as Error);
+    return new Err(normalizeError(error));
   }
 }
 

--- a/connectors/src/connectors/microsoft/temporal/client.ts
+++ b/connectors/src/connectors/microsoft/temporal/client.ts
@@ -19,7 +19,10 @@ import { getTemporalClient, terminateWorkflow } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
-import { microsoftGarbageCollectionWorkflowId } from "@connectors/types";
+import {
+  microsoftGarbageCollectionWorkflowId,
+  normalizeError,
+} from "@connectors/types";
 
 export async function launchMicrosoftFullSyncWorkflow(
   connectorId: ModelId,
@@ -86,7 +89,7 @@ export async function launchMicrosoftFullSyncWorkflow(
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -133,7 +136,7 @@ export async function launchMicrosoftIncrementalSyncWorkflow(
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -204,6 +207,6 @@ export async function launchMicrosoftGarbageCollectionWorkflow(
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -32,6 +32,7 @@ import type { DataSourceConfig } from "@connectors/types";
 import {
   getOAuthConnectionAccessToken,
   INTERNAL_MIME_TYPES,
+  normalizeError,
 } from "@connectors/types";
 
 import { getOrphanedCount, hasChildren } from "./lib/parents";
@@ -264,7 +265,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         "Error stopping notion sync workflow"
       );
 
-      return new Err(e as Error);
+      return new Err(normalizeError(e));
     }
 
     return new Ok(undefined);
@@ -414,7 +415,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         "Error stopping notion sync workflow."
       );
 
-      return new Err(e as Error);
+      return new Err(normalizeError(e));
     }
 
     notionConnectorState.fullResyncStartTime = new Date();

--- a/connectors/src/connectors/salesforce/temporal/client.ts
+++ b/connectors/src/connectors/salesforce/temporal/client.ts
@@ -10,6 +10,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 
 function makeSalesforceSyncWorkflowId(connectorId: ModelId): string {
   return `salesforce-sync-${connectorId}`;
@@ -49,7 +50,7 @@ export async function launchSalesforceSyncWorkflow(
       cronSchedule: `${connector.id % 30} */2 * * *`, // Runs every 30 minutes at minute ${connector.id % 30} (0-29).
     });
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 
   return new Ok(workflowId);
@@ -87,6 +88,6 @@ export async function stopSalesforceSyncWorkflow(
       },
       "Failed to stop Salesforce workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -12,6 +12,7 @@ import type { ModelId } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 import {
   isTextExtractionSupportedContentType,
+  normalizeError,
   pagePrefixesPerMimeType,
   parseAndStringifyCsv,
   slugify,
@@ -92,7 +93,7 @@ export async function handleCsvFile({
     );
   } catch (err) {
     localLogger.warn({ error: err }, "Error while parsing or upserting table");
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
   return new Ok(null);
 }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -44,6 +44,7 @@ import type { DataSourceConfig } from "@connectors/types";
 import {
   INTERNAL_MIME_TYPES,
   isSlackAutoReadPatterns,
+  normalizeError,
   safeParseJSON,
 } from "@connectors/types";
 
@@ -435,7 +436,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
           )
         );
       }
-      // Unanhdled error, throwing to get a 500.
+      // Unhandled error, throwing to get a 500.
       throw e;
     }
   }
@@ -572,7 +573,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         return new Err(workflowRes.error);
       }
     } catch (e) {
-      return new Err(e as Error);
+      return new Err(normalizeError(e));
     }
 
     return new Ok(undefined);

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -6,6 +6,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 
 import { getWeekStart } from "../lib/utils";
 import { getChannelsToSync } from "./activities";
@@ -74,7 +75,7 @@ export async function launchSlackSyncWorkflow(
       },
       `Failed starting the Slack sync.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -150,7 +151,7 @@ export async function launchSlackSyncOneThreadWorkflow(
       { error: e, connectorId, channelId, threadTs, workflowId },
       "Failed launchSlackSyncOneThreadWorkflow"
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -228,7 +229,7 @@ export async function launchSlackSyncOneMessageWorkflow(
       { error: e, connectorId, channelId, threadTs, workflowId },
       "Failed launchSlackSyncOneMessageWorkflow"
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -267,6 +268,6 @@ export async function launchSlackGarbageCollectWorkflow(connectorId: ModelId) {
       },
       `Failed starting slackGarbageCollector workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/connectors/src/connectors/snowflake/temporal/client.ts
+++ b/connectors/src/connectors/snowflake/temporal/client.ts
@@ -10,6 +10,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 
 function makeSnowflakeSyncWorkflowId(connectorId: ModelId): string {
   return `snowflake-sync-${connectorId}`;
@@ -50,7 +51,7 @@ export async function launchSnowflakeSyncWorkflow(
       cronSchedule: `${connector.id % 60} * * * *`,
     });
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 
   return new Ok(workflowId);
@@ -88,6 +89,6 @@ export async function stopSnowflakeSyncWorkflow(
       },
       "Failed to stop Snowflake workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -16,7 +16,7 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
 import type { ModelId } from "@connectors/types";
-import { WebcrawlerCustomCrawler } from "@connectors/types";
+import { normalizeError, WebcrawlerCustomCrawler } from "@connectors/types";
 
 import { WebCrawlerQueueNames } from "./config";
 import {
@@ -82,7 +82,7 @@ export async function launchCrawlWebsiteWorkflow(
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -111,7 +111,7 @@ export async function stopCrawlWebsiteWorkflow(
       },
       `Failed stopping workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -27,6 +27,7 @@ import {
 import {
   getZendeskGarbageCollectionWorkflowId,
   getZendeskSyncWorkflowId,
+  normalizeError,
 } from "@connectors/types";
 
 export async function launchZendeskSyncWorkflow(
@@ -93,7 +94,7 @@ export async function launchZendeskSyncWorkflow(
       cronSchedule: `${minute},${30 + minute} * * * *`, // Every 30 minutes.
     });
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 
   return new Ok(undefined);
@@ -110,8 +111,7 @@ export async function stopZendeskWorkflows(
   ];
   for (const workflowId of workflowIds) {
     try {
-      const handle: WorkflowHandle<typeof zendeskSyncWorkflow> =
-        client.workflow.getHandle(workflowId);
+      const handle: WorkflowHandle<typeof zendeskSyncWorkflow> =        client.workflow.getHandle(workflowId);
       try {
         await handle.terminate();
       } catch (e) {
@@ -124,7 +124,7 @@ export async function stopZendeskWorkflows(
         { workflowId, error: e },
         "[Zendesk] Failed to stop the workflow."
       );
-      return new Err(e as Error);
+      return new Err(normalizeError(e));
     }
   }
   return new Ok(undefined);
@@ -188,7 +188,7 @@ export async function launchZendeskGarbageCollectionWorkflow(
   } catch (err: unknown) {
     // ignoring errors caused by relaunching the gc workflow
     if (!(err instanceof WorkflowExecutionAlreadyStartedError)) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -111,7 +111,8 @@ export async function stopZendeskWorkflows(
   ];
   for (const workflowId of workflowIds) {
     try {
-      const handle: WorkflowHandle<typeof zendeskSyncWorkflow> =        client.workflow.getHandle(workflowId);
+      const handle: WorkflowHandle<typeof zendeskSyncWorkflow> =
+        client.workflow.getHandle(workflowId);
       try {
         await handle.terminate();
       } catch (e) {

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -21,6 +21,7 @@ import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
 import type { ConnectorType, ModelId } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -201,7 +202,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
 
         return new Ok(undefined);
       } catch (err) {
-        return new Err(err as Error);
+        return new Err(normalizeError(err));
       }
     });
   }

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -16,6 +16,7 @@ import {
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ConnectorResource } from "@connectors/resources/connector_resource"; // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
+import { normalizeError } from "@connectors/types";
 
 function minutesToMs(minutes: number) {
   return minutes * 60 * 1000;
@@ -230,7 +231,7 @@ export class GongUserResource extends BaseResource<GongUserModel> {
         transaction,
       });
     } catch (error) {
-      return new Err(error as Error);
+      return new Err(normalizeError(error));
     }
 
     return new Ok(undefined);

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -12,12 +12,13 @@ import {
 import logger from "@connectors/logger/logger";
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
+import type { ModelId } from "@connectors/types";
 import type {
   SlackAutoReadPattern,
   SlackbotWhitelistType,
   SlackConfigurationType,
 } from "@connectors/types";
-import type { ModelId } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -329,7 +330,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/connectors/src/types/shared/rate_limiter.ts
+++ b/connectors/src/types/shared/rate_limiter.ts
@@ -3,6 +3,8 @@ import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import { v4 as uuidv4 } from "uuid";
 
+import { normalizeError } from "@connectors/types";
+
 import type { RedisUsageTagsType } from "../shared/redis_client";
 import { redisClient } from "../shared/redis_client";
 import { getStatsDClient } from "./statsd";
@@ -118,6 +120,6 @@ export async function expireRateLimiterKey({
 
     return new Ok(isExpired);
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 }


### PR DESCRIPTION
## Description

- The pattern `err as Error` to cast a random error into an error of type `Error` is quite widespread.
- This cast can be incorrect given that it is possible in JS to throw anything (string, number, random object, ...).
- Some errors are still reflected in the logs with an `[object Object]`, which is not usable at all.
- An util function `normalizeError` was introduced to properly check what was being thrown and to convert it into an actual `Error` (the type that has a field `message`).
- This PR refactors the `connectors` code to use this util function.

## Tests

- Tested locally.

## Risk

- High blast radius but low risk.
- No workflow code changed so no risk of non deterministic error.

## Deploy Plan

- Deploy `connectors`.
