### PR TITLE
[front] update reasoning v2 editing panel 

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -418,6 +418,7 @@ export default function ActionsScreen({
                 nonDefaultMCPActions={selectableNonMCPActions}
                 defaultMCPServerViews={selectableDefaultMCPServerViews}
                 nonDefaultMCPServerViews={selectableNonDefaultMCPServerViews}
+                reasoningModels={reasoningModels}
               />
 
               <div className="flex-grow" />

--- a/front/components/assistant_builder/AddToolsDropdown.tsx
+++ b/front/components/assistant_builder/AddToolsDropdown.tsx
@@ -122,7 +122,7 @@ export function AddToolsDropdown({
     assert(action);
 
     // For reasoning v2, we set the first reasoning model in the list as the default.
-    // (The higher prioirity model is placed first in the list.)
+    // The higher prioirity model is placed first in the list.
     if (action.type === "MCP" && action.name === "reasoning_v2") {
       const defaultReasoningAction = reasoningModels[0];
 

--- a/front/components/assistant_builder/actions/configuration/ReasoningModelConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ReasoningModelConfigurationSection.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Button,
   Card,
   ContentMessage,
@@ -40,7 +39,9 @@ export function ReasoningModelConfigurationSection({
       reasoningModels.find(
         (m) =>
           m.modelId === selectedReasoningModel.modelId &&
-          m.providerId === selectedReasoningModel.providerId
+          m.providerId === selectedReasoningModel.providerId &&
+          (m.reasoningEffort ?? null) ===
+            (selectedReasoningModel.reasoningEffort ?? null)
       ),
     [selectedReasoningModel, reasoningModels]
   );
@@ -83,87 +84,53 @@ export function ReasoningModelConfigurationSection({
             <Spinner />
           </div>
         </Card>
-      ) : selectedReasoningModelConfig ? (
-        <Card size="sm" className="w-full">
-          <div className="flex w-full p-3">
-            <div className="flex w-full flex-grow flex-col gap-2 overflow-hidden">
-              <div className="text-md flex items-center gap-2 font-medium">
-                <Avatar
-                  icon={getModelProviderLogo(
-                    selectedReasoningModelConfig.providerId,
-                    false
-                  )}
-                  size="sm"
-                />
-                {selectedReasoningModelConfig.displayName}
-              </div>
-              <div className="max-h-24 overflow-y-auto text-sm text-muted-foreground dark:text-muted-foreground-night">
-                {selectedReasoningModelConfig.description}
-              </div>
-            </div>
-            <div className="ml-4 flex-shrink-0 self-start">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    size="sm"
-                    label="Select another model"
-                    variant="outline"
-                    isSelect
-                  />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent>
-                  {reasoningModels.map((model) => (
-                    <DropdownMenuItem
-                      key={`${model.modelId}-${model.providerId}-${model.reasoningEffort ?? ""}`}
-                      label={model.displayName}
-                      icon={getModelProviderLogo(model.providerId, isDark)}
-                      onClick={() =>
-                        onModelSelect({
-                          modelId: model.modelId,
-                          providerId: model.providerId,
-                          reasoningEffort: model.reasoningEffort ?? null,
-                          temperature: null,
-                        })
-                      }
-                    />
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-        </Card>
       ) : (
-        <Card size="sm" className="h-36 w-full">
-          <div className="flex h-full w-full items-center justify-center">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  label="Select a reasoning model"
-                  variant="outline"
-                  size="sm"
-                  isSelect
+        <>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                label={
+                  selectedReasoningModelConfig?.displayName ??
+                  "Select a reasoning model"
+                }
+                icon={
+                  selectedReasoningModelConfig?.providerId
+                    ? getModelProviderLogo(
+                        selectedReasoningModelConfig?.providerId,
+                        isDark
+                      )
+                    : undefined
+                }
+                variant="outline"
+                size="sm"
+                isSelect
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="max-w-xl">
+              {reasoningModels.map((model) => (
+                <DropdownMenuItem
+                  key={`${model.modelId}-${model.providerId}-${model.reasoningEffort ?? ""}`}
+                  label={model.displayName}
+                  icon={getModelProviderLogo(model.providerId, isDark)}
+                  description={model.reasoningDescription || model.description}
+                  onClick={() =>
+                    onModelSelect({
+                      modelId: model.modelId,
+                      providerId: model.providerId,
+                      reasoningEffort: model.reasoningEffort ?? null,
+                      temperature: null,
+                    })
+                  }
                 />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                {reasoningModels.map((model) => (
-                  <DropdownMenuItem
-                    key={`${model.modelId}-${model.providerId}-${model.reasoningEffort ?? ""}`}
-                    label={model.displayName}
-                    icon={getModelProviderLogo(model.providerId, isDark)}
-                    onClick={() =>
-                      onModelSelect({
-                        modelId: model.modelId,
-                        providerId: model.providerId,
-                        reasoningEffort: model.reasoningEffort ?? null,
-                        temperature: null,
-                      })
-                    }
-                  />
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </Card>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {selectedReasoningModelConfig?.reasoningDescription && (
+            <p className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {selectedReasoningModelConfig.reasoningDescription}
+            </p>
+          )}
+        </>
       )}
     </div>
   );

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -231,6 +231,7 @@ export type ModelConfigurationType = {
   description: string;
   shortDescription: string;
   isLegacy: boolean;
+  reasoningDescription?: string; // Only used for the models you can use for reasoning
 
   // Allows configuring parsing of special delimiters in the streamed model output.
   delimitersConfiguration?: {
@@ -399,6 +400,7 @@ export const O1_MODEL_CONFIG: ModelConfigurationType = {
     "OpenAI's reasoning model designed to solve hard problems across domains (Limited preview access).",
   shortDescription: "OpenAI's reasoning model.",
   isLegacy: false,
+  reasoningDescription: "Best for deep analytical problems across domains.",
   generationTokensCount: 2048,
   supportsVision: true,
   featureFlag: "openai_o1_feature",
@@ -417,6 +419,8 @@ export const O1_HIGH_REASONING_MODEL_CONFIG: ModelConfigurationType = {
     "OpenAI's reasoning model designed to solve hard problems across domains (Limited preview access). High reasoning effort.",
   shortDescription: "OpenAI's reasoning model (high effort).",
   isLegacy: false,
+  reasoningDescription:
+    "Optimal for intensive problems requiring thorough analysis.",
   generationTokensCount: 2048,
   supportsVision: true,
   reasoningEffort: "high",
@@ -437,6 +441,8 @@ export const O1_MINI_MODEL_CONFIG: ModelConfigurationType = {
     "OpenAI's fast reasoning model particularly good at coding, math, and science.",
   shortDescription: "OpenAI's fast reasoning model.",
   isLegacy: false,
+  reasoningDescription:
+    "Specialized for coding, math, and scientific problems.",
   generationTokensCount: 2048,
   supportsVision: false,
   featureFlag: "openai_o1_mini_feature",
@@ -456,6 +462,7 @@ export const O3_MODEL_CONFIG: ModelConfigurationType = {
     "OpenAI's most advanced reasoning model particularly good at coding, math, and science.",
   shortDescription: "OpenAI's best reasoning model.",
   isLegacy: false,
+  reasoningDescription: "Best for complex coding, math, and science problems.",
   generationTokensCount: 2048,
   supportsVision: true,
   supportsResponseFormat: true,
@@ -475,6 +482,7 @@ export const O3_MINI_MODEL_CONFIG: ModelConfigurationType = {
     "OpenAI's fast reasoning model particularly good at coding, math, and science.",
   shortDescription: "OpenAI's fast reasoning model.",
   isLegacy: false,
+  reasoningDescription: "Efficient for coding, math, and science tasks.",
   generationTokensCount: 2048,
   supportsVision: false,
   supportsResponseFormat: true,
@@ -491,6 +499,8 @@ export const O3_MINI_HIGH_REASONING_MODEL_CONFIG: ModelConfigurationType = {
     "OpenAI's fast reasoning model particularly good at coding, math, and science. High reasoning effort.",
   shortDescription: "OpenAI's fast reasoning model.",
   isLegacy: false,
+  reasoningDescription:
+    "Optimal for complex coding, math, and science with thorough analysis.",
   generationTokensCount: 2048,
   supportsVision: false,
   reasoningEffort: "high",
@@ -508,6 +518,8 @@ export const O4_MINI_MODEL_CONFIG: ModelConfigurationType = {
   description: "OpenAI's o4 mini model (200k context).",
   shortDescription: "OpenAI's fast o4 model.",
   isLegacy: false,
+  reasoningDescription:
+    "Effective for analytical problems requiring efficient solutions.",
   generationTokensCount: 100_000,
   supportsVision: true,
   supportsResponseFormat: true,
@@ -525,6 +537,7 @@ export const O4_MINI_HIGH_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   description: "OpenAI's o4 mini model (200k context). High reasoning effort.",
   shortDescription: "OpenAI's fast o4 model.",
   isLegacy: false,
+  reasoningDescription: "Best for complex problems needing detailed analysis.",
   generationTokensCount: 100_000,
   supportsVision: true,
   supportsResponseFormat: true,
@@ -665,6 +678,8 @@ export const CLAUDE_3_7_SONNET_REASONING_MODEL_CONFIG: ModelConfigurationType =
     description: "Anthropic's latest Claude 3.7 Sonnet model (200k context).",
     shortDescription: "Anthropic's best model.",
     isLegacy: false,
+    reasoningDescription:
+      "Advanced reasoning capabilities with thorough analysis and creative problem-solving.",
     delimitersConfiguration: ANTHROPIC_DELIMITERS_CONFIGURATION,
     generationTokensCount: 64_000,
     supportsVision: true,
@@ -941,6 +956,8 @@ export const GEMINI_2_FLASH_THINKING_PREVIEW_MODEL_CONFIG: ModelConfigurationTyp
     generationTokensCount: 2048,
     supportsVision: true,
     featureFlag: "google_ai_studio_experimental_models_feature",
+    reasoningDescription:
+      "Suitable for basic tasks with straightforward solutions.",
   };
 
 export const TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_CONFIG: ModelConfigurationType =
@@ -1094,6 +1111,8 @@ export const FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
       },
     ],
   },
+  reasoningDescription:
+    "Optimal for complex problems needing detailed analysis.",
 };
 
 export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -231,7 +231,7 @@ export type ModelConfigurationType = {
   description: string;
   shortDescription: string;
   isLegacy: boolean;
-  reasoningDescription?: string; // Only used for the models you can use for reasoning
+  reasoningDescription?: string; // Only used for the models you can use for reasoning.
 
   // Allows configuring parsing of special delimiters in the streamed model output.
   delimitersConfiguration?: {


### PR DESCRIPTION
## Description
This PR is to improve Reasoning V2 configuration screen in Assistant Builder. Currently you only see the description after you select it, and not every description is helpful to determine which model to use for reasoning. The goal is to make it slightly easier for users to choose the reasoning model based on their use case. 

before:
<img width="754" alt="Screenshot 2025-05-19 at 22 21 44" src="https://github.com/user-attachments/assets/d5be9dad-7270-464e-9ca2-638dbc217f04" />

<img width="757" alt="Screenshot 2025-05-19 at 22 21 48" src="https://github.com/user-attachments/assets/8b3d5c34-1ccf-4810-9a45-f0c97f9e40c7" />

after (with [this PR](https://github.com/dust-tt/dust/pull/12736) which contains styling update):
<img width="565" alt="Screenshot 2025-05-19 at 22 27 59" src="https://github.com/user-attachments/assets/00247eca-21ff-4fec-a719-de41180cfdc7" />

<img width="520" alt="Screenshot 2025-05-19 at 22 53 59" src="https://github.com/user-attachments/assets/8bb9f28f-1499-4373-a16a-208cd97f28df" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

