### PR TITLE
[front] update loader UI in AB preview

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -29,6 +29,23 @@ import { compareAgentsForSort } from "@app/types";
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
+interface AssistantInputBarProps {
+  owner: WorkspaceType;
+  onSubmit: (
+    input: string,
+    mentions: MentionType[],
+    contentFragments: ContentFragmentsType
+  ) => Promise<Result<undefined, DustError>>;
+  conversationId: string | null;
+  stickyMentions?: AgentMention[];
+  additionalAgentConfiguration?: LightAgentConfigurationType;
+  actions?: InputBarContainerProps["actions"];
+  disableAutoFocus: boolean;
+  isFloating?: boolean;
+  isFloatingWithoutMargin?: boolean;
+  isLoading?: boolean;
+}
+
 /**
  *
  * @param additionalAgentConfiguration when trying an agent in a modal or drawer we
@@ -44,22 +61,9 @@ export function AssistantInputBar({
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
   isFloating = true,
-}: {
-  owner: WorkspaceType;
-  onSubmit: (
-    input: string,
-    mentions: MentionType[],
-    contentFragments: ContentFragmentsType
-  ) => Promise<Result<undefined, DustError>>;
-  conversationId: string | null;
-  stickyMentions?: AgentMention[];
-  additionalAgentConfiguration?: LightAgentConfigurationType;
-  actions?: InputBarContainerProps["actions"];
-  disableAutoFocus: boolean;
-  isFloating?: boolean;
-  isFloatingWithoutMargin?: boolean;
-}) {
-  const [disableSendButton, setDisableSendButton] = useState(false);
+  isLoading = false,
+}: AssistantInputBarProps) {
+  const [disableSendButton, setDisableSendButton] = useState(isLoading);
   const [isFocused, setIsFocused] = useState(false);
   const rainbowEffectRef = useRef<HTMLDivElement>(null);
 
@@ -293,6 +297,10 @@ export function AssistantInputBar({
       setIsStopping(false);
     }
   }, [isStopping, generationContext.generatingMessages, conversationId]);
+
+  useEffect(() => {
+    setDisableSendButton(isLoading);
+  }, [isLoading]);
 
   return (
     <div className="flex w-full flex-col">

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -43,7 +43,7 @@ interface AssistantInputBarProps {
   disableAutoFocus: boolean;
   isFloating?: boolean;
   isFloatingWithoutMargin?: boolean;
-  isLoading?: boolean;
+  disableButton?: boolean;
 }
 
 /**
@@ -61,9 +61,9 @@ export function AssistantInputBar({
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
   isFloating = true,
-  isLoading = false,
+  disableButton = false,
 }: AssistantInputBarProps) {
-  const [disableSendButton, setDisableSendButton] = useState(isLoading);
+  const [disableSendButton, setDisableSendButton] = useState(disableButton);
   const [isFocused, setIsFocused] = useState(false);
   const rainbowEffectRef = useRef<HTMLDivElement>(null);
 
@@ -299,8 +299,8 @@ export function AssistantInputBar({
   }, [isStopping, generationContext.generatingMessages, conversationId]);
 
   useEffect(() => {
-    setDisableSendButton(isLoading);
-  }, [isLoading]);
+    setDisableSendButton(disableButton);
+  }, [disableButton]);
 
   return (
     <div className="flex w-full flex-col">

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -11,13 +11,11 @@ import {
   Markdown,
   MoreIcon,
   Page,
-  Spinner,
   Tabs,
   TabsList,
   TabsTrigger,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { Label } from "@dust-tt/sparkle";
 import { Separator } from "@radix-ui/react-select";
 import { useContext, useEffect } from "react";
 import { useState } from "react";
@@ -78,10 +76,9 @@ export default function AssistantBuilderRightPanel({
   const [rightPanelTab, setRightPanelTab] =
     useState<AssistantBuilderRightPanelTabType>("Preview");
 
-  const { draftAssistant, isFading } = usePreviewAssistant({
+  const { draftAssistant, isFading, isSavingDraftAgent } = usePreviewAssistant({
     owner,
     builderState,
-    isPreviewOpened: rightPanelTab === "Preview",
     reasoningModels,
   });
 
@@ -145,53 +142,49 @@ export default function AssistantBuilderRightPanel({
       >
         {rightPanelTab === "Preview" && user && (
           <div className="flex h-full w-full flex-1 flex-col justify-between overflow-x-hidden">
-            {draftAssistant ? (
-              isBuilderStateEmpty ? (
-                <div className="flex h-full w-full items-center justify-center">
-                  <div className="text-center">
-                    <span className="block cursor-pointer whitespace-nowrap px-4 py-2 text-muted-foreground">
-                      Start configuring your assistant and try it out!
-                    </span>
-                  </div>
+            {isBuilderStateEmpty ? (
+              <div className="flex h-full w-full items-center justify-center">
+                <div className="text-center">
+                  <span className="block cursor-pointer whitespace-nowrap px-4 py-2 text-muted-foreground">
+                    Start configuring your assistant and try it out!
+                  </span>
                 </div>
-              ) : (
-                <ConversationsNavigationProvider>
-                  <ActionValidationProvider>
-                    <GenerationContextProvider>
-                      <div className="flex-grow overflow-y-auto">
-                        {conversation && (
-                          <ConversationViewer
-                            owner={owner}
-                            user={user}
-                            conversationId={conversation.sId}
-                            onStickyMentionsChange={setStickyMentions}
-                            isInModal
-                            isFading={isFading}
-                            key={conversation.sId}
-                          />
-                        )}
-                      </div>
-                      <div className="shrink-0">
-                        <AssistantInputBar
-                          owner={owner}
-                          onSubmit={handleSubmit}
-                          stickyMentions={stickyMentions}
-                          conversationId={conversation?.sId || null}
-                          additionalAgentConfiguration={draftAssistant}
-                          actions={["attachment"]}
-                          disableAutoFocus
-                          isFloating={false}
-                        />
-                      </div>
-                    </GenerationContextProvider>
-                  </ActionValidationProvider>
-                </ConversationsNavigationProvider>
-              )
-            ) : (
-              <div className="flex h-full w-full flex-col items-center justify-center gap-2">
-                <Label>Try out your assistant...</Label>
-                <Spinner />
               </div>
+            ) : (
+              <ConversationsNavigationProvider>
+                <ActionValidationProvider>
+                  <GenerationContextProvider>
+                    <div className="flex-grow overflow-y-auto">
+                      {conversation && (
+                        <ConversationViewer
+                          owner={owner}
+                          user={user}
+                          conversationId={conversation.sId}
+                          onStickyMentionsChange={setStickyMentions}
+                          isInModal
+                          isFading={isFading}
+                          key={conversation.sId}
+                        />
+                      )}
+                    </div>
+                    <div className="shrink-0">
+                      <AssistantInputBar
+                        isLoading={isSavingDraftAgent}
+                        owner={owner}
+                        onSubmit={handleSubmit}
+                        stickyMentions={stickyMentions}
+                        conversationId={conversation?.sId || null}
+                        additionalAgentConfiguration={
+                          draftAssistant ?? undefined
+                        }
+                        actions={["attachment"]}
+                        disableAutoFocus
+                        isFloating={false}
+                      />
+                    </div>
+                  </GenerationContextProvider>
+                </ActionValidationProvider>
+              </ConversationsNavigationProvider>
             )}
           </div>
         )}

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -169,7 +169,7 @@ export default function AssistantBuilderRightPanel({
                     </div>
                     <div className="shrink-0">
                       <AssistantInputBar
-                        isLoading={isSavingDraftAgent}
+                        disableButton={isSavingDraftAgent}
                         owner={owner}
                         onSubmit={handleSubmit}
                         stickyMentions={stickyMentions}

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -40,7 +40,7 @@ export function usePreviewAssistant({
     useState<LightAgentConfigurationType | null>();
   const [animateDrawer, setAnimateDrawer] = useState(false);
   const [isFading, setIsFading] = useState(false);
-  const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(true); // We always make the draft agent on initial page load so we can set it true
+  const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(true); // We always make the draft agent on initial page load so we can set it true.
   const drawerAnimationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
   const sendNotification = useSendNotification();

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -24,26 +24,23 @@ import type {
 } from "@app/types";
 import { Err, Ok } from "@app/types";
 
+interface UsePreviewAssistantProps {
+  owner: WorkspaceType;
+  builderState: AssistantBuilderState;
+  reasoningModels: ModelConfigurationType[];
+}
+
 export function usePreviewAssistant({
   owner,
   builderState,
-  isPreviewOpened,
   reasoningModels,
-}: {
-  owner: WorkspaceType;
-  builderState: AssistantBuilderState;
-  isPreviewOpened: boolean;
-  reasoningModels: ModelConfigurationType[];
-}): {
-  shouldAnimate: boolean;
-  isFading: boolean; // Add isFading to the return type
-  draftAssistant: LightAgentConfigurationType | null;
-} {
+}: UsePreviewAssistantProps) {
   const animationLength = 1000;
   const [draftAssistant, setDraftAssistant] =
     useState<LightAgentConfigurationType | null>();
   const [animateDrawer, setAnimateDrawer] = useState(false);
   const [isFading, setIsFading] = useState(false);
+  const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(true); // We always make the draft agent on initial page load so we can set it true
   const drawerAnimationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
   const sendNotification = useSendNotification();
@@ -73,14 +70,12 @@ export function usePreviewAssistant({
   }, [builderState]);
 
   const submit = useCallback(async () => {
-    if (!isPreviewOpened) {
-      // Preview is not opened, no need to submit
-      return;
-    }
     if (draftAssistant && !hasChanged) {
       // No changes since the last submission
       return;
     }
+
+    setIsSavingDraftAgent(true);
 
     const aRes = await submitAssistantBuilderForm({
       owner,
@@ -107,6 +102,8 @@ export function usePreviewAssistant({
       reasoningModels,
     });
 
+    setIsSavingDraftAgent(false);
+
     if (!aRes.isOk()) {
       sendNotification({
         title: "Error saving Draft Agent",
@@ -124,7 +121,6 @@ export function usePreviewAssistant({
       setHasChanged(false);
     }, animationLength / 2);
   }, [
-    isPreviewOpened,
     draftAssistant,
     hasChanged,
     owner,
@@ -150,6 +146,7 @@ export function usePreviewAssistant({
     shouldAnimate: animateDrawer,
     isFading,
     draftAssistant: draftAssistant ?? null,
+    isSavingDraftAgent,
   };
 }
 


### PR DESCRIPTION
## Description
This PR is to improve loading experience in Assistant Builder. We've got several feedback for this loading screen, it's catching too much attention from users and feels useless when a user first time opens a page because it feels like nothing happens. Fixes a part of https://github.com/dust-tt/tasks/issues/2885

I discussed with @Duncid what is the best:
Ideal scenario: we don't show a loader, and if a user sends a message and if we are still waiting for saving draft agents we wait until it's done and send a chat after saving the latest version.

This is more complex since I need to manipulate TipTap input, I went an easy solution which is disabling a button and show a loader there when we are saving draft agents. I didn't disable inputs, users can still type while we are saving (ideally we should disable if it's the first page load for a new agent, but it's complex and I assume people don't go there straightaway)

before:

<img width="1506" alt="Screenshot 2025-05-20 at 08 32 25" src="https://github.com/user-attachments/assets/ef1d3a06-b32a-4d88-a266-3d6d523417ee" />

after:
<img width="433" alt="Screenshot 2025-05-20 at 08 32 52" src="https://github.com/user-attachments/assets/8dfbaacd-b332-488a-91d2-9e2787f007cd" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
