### PR TITLE
enh(front): Normalize errors instead of casting

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -132,9 +132,9 @@ guaranteed to trigger a internal error (and return a 500).
 ### [ERR2] Do not rely on `err as Error`
 
 Never catch and cast what was caught as `Error`. JS allows throwing anything (string, number,
-random object, ...) so the cast may be invalid and hide errors from the logs. Use `normalizeError`
-instead, this util function properly checks the content of the caught object and always returns
-a valid `Error` object.
+random object, ...) so the cast may be invalid and hides errors from the logs. Use `normalizeError`
+instead, this function properly checks the content of the caught object and always returns a valid
+`Error` object.
 
 Example:
 

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -134,7 +134,7 @@ guaranteed to trigger a internal error (and return a 500).
 Never catch and cast what was caught as `Error`. JS allows throwing anything (string, number,
 random object, ...) so the cast may be invalid and hide errors from the logs. Use `normalizeError`
 instead, this util function properly checks the content of the caught object and always returns
-an `Error`.
+a valid `Error` object.
 
 Example:
 

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -199,7 +199,7 @@ for all new code and migrate to it from `PQueue` when modifying existing code th
 ### [BACK7] Avoid `Promise.all` on dynamic arrays
 
 Never use `Promise.all` on anything else than static arrays of promises with a known length (8 max).
-To parallelize asyncrhonous handling of dynamic arrays, use `ConcurrentExecutor`.
+To parallelize asynchronous handling of dynamic arrays, use `ConcurrentExecutor`.
 
 ### [BACK8] Favor typeguards over other methods
 

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -129,6 +129,31 @@ we don't control), but otherwise errors that may alter the execution upstream sh
 using our `Result<>` pattern. It is OK to throw errors, since we can't catch them these are
 guaranteed to trigger a internal error (and return a 500).
 
+### [ERR2] Do not rely on `err as Error`
+
+Never catch and cast what was caught as `Error`. JS allows throwing anything (string, number,
+random object, ...) so the cast may be invalid and hide errors from the logs. Use `normalizeError`
+instead, this util function properly checks the content of the caught object and always returns
+an `Error`.
+
+Example:
+
+```
+// BAD
+try {
+  // Some code.
+} catch (err) {
+  return new Err(err as Err);
+}
+
+// GOOD
+try {
+  // Some code.
+} catch(err) {
+  return new Err(normalizeError(err));
+}
+```
+
 ## BACKEND
 
 ### [BACK1] No sequelize models in API routes

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -93,6 +93,7 @@ import {
   isTimeFrame,
   isUser,
   MAX_STEPS_USE_PER_RUN_LIMIT,
+  normalizeError,
   Ok,
   removeNulls,
 } from "@app/types";
@@ -1743,7 +1744,7 @@ export async function removeGroupFromAgentConfiguration({
 
     return new Ok(undefined);
   } catch (error) {
-    return new Err(error as Error);
+    return new Err(normalizeError(error));
   }
 }
 
@@ -1800,7 +1801,7 @@ export async function updateAgentPermissions(
     return result;
   } catch (error) {
     // Catch errors thrown from within the transaction
-    return new Err(error as Error);
+    return new Err(normalizeError(error));
   }
 }
 

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -10,7 +10,7 @@ import type {
   Result,
   UserType,
 } from "@app/types";
-import { ConversationError, Err, Ok } from "@app/types";
+import { ConversationError, Err, normalizeError, Ok } from "@app/types";
 
 /**
  * We retrieve the feedbacks for a whole conversation, not just a single message.
@@ -126,7 +126,7 @@ export async function upsertMessageFeedback(
       isConversationShared: isConversationShared ?? false,
     });
   } catch (e) {
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
   return new Ok(undefined);
 }

--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -7,7 +7,7 @@ import sgMail from "@sendgrid/mail";
 import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { Err, isDevelopment, Ok } from "@app/types";
+import { Err, isDevelopment, normalizeError, Ok } from "@app/types";
 
 let sgMailClient: sgMail.MailService | null = null;
 
@@ -223,6 +223,6 @@ export async function sendEmailWithTemplate({
       },
       "Error sending email."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/front/lib/api/poke/plugins/data_sources/mark_connector_as_error.ts
+++ b/front/lib/api/poke/plugins/data_sources/mark_connector_as_error.ts
@@ -8,7 +8,7 @@ import { CONNECTORS_ERROR_TYPES, ConnectorsAPI, Err, Ok } from "@app/types";
 export const markConnectorAsErrorPlugin = createPlugin({
   manifest: {
     id: "mark-connector-as-error",
-    name: "Mark connector as error",
+    name: "Mark connector as errored",
     description: "Mark a connector as errored with a specific error type",
     resourceTypes: ["data_sources"],
     args: {

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -36,7 +36,13 @@ import type {
   Result,
   SupportedContentFragmentType,
 } from "@app/types";
-import { CoreAPI, Err, isSupportedImageContentType, normalizeError, Ok } from "@app/types";
+import {
+  CoreAPI,
+  Err,
+  isSupportedImageContentType,
+  normalizeError,
+  Ok,
+} from "@app/types";
 
 export const CONTENT_OUTDATED_MSG =
   "Content is outdated. Please refer to the latest version of this content.";

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -36,7 +36,7 @@ import type {
   Result,
   SupportedContentFragmentType,
 } from "@app/types";
-import { CoreAPI, Err, isSupportedImageContentType, Ok } from "@app/types";
+import { CoreAPI, Err, isSupportedImageContentType, normalizeError, Ok } from "@app/types";
 
 export const CONTENT_OUTDATED_MSG =
   "Content is outdated. Please refer to the latest version of this content.";
@@ -237,7 +237,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -23,7 +23,13 @@ import type {
   LightAgentConfigurationType,
   Result,
 } from "@app/types";
-import { ConversationError, Err, Ok, removeNulls } from "@app/types";
+import {
+  ConversationError,
+  Err,
+  normalizeError,
+  Ok,
+  removeNulls,
+} from "@app/types";
 
 import { GroupResource } from "./group_resource";
 import { frontSequelize } from "./storage";
@@ -473,7 +479,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       });
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/extension.ts
+++ b/front/lib/resources/extension.ts
@@ -11,7 +11,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ExtensionConfigurationType, ModelId, Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -76,7 +76,7 @@ export class ExtensionConfigurationResource extends BaseResource<ExtensionConfig
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 
@@ -94,7 +94,7 @@ export class ExtensionConfigurationResource extends BaseResource<ExtensionConfig
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -24,7 +24,7 @@ import type {
   Result,
   UserType,
 } from "@app/types";
-import { Err, FILE_FORMATS, Ok, removeNulls } from "@app/types";
+import { Err, FILE_FORMATS, normalizeError, Ok, removeNulls } from "@app/types";
 
 import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_models";
 
@@ -159,7 +159,7 @@ export class FileResource extends BaseResource<FileModel> {
 
       return new Ok(undefined);
     } catch (error) {
-      return new Err(error as Error);
+      return new Err(normalizeError(error));
     }
   }
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -36,7 +36,7 @@ import type {
   RolePermission,
   UserType,
 } from "@app/types";
-import { Err, Ok, removeNulls } from "@app/types";
+import { Err, normalizeError, Ok, removeNulls } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -1026,7 +1026,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 
@@ -1138,7 +1138,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
       return new Ok(undefined);
     } catch (error) {
-      return new Err(error as Error);
+      return new Err(normalizeError(error));
     }
   }
 

--- a/front/lib/resources/labs_connections_resource.ts
+++ b/front/lib/resources/labs_connections_resource.ts
@@ -8,7 +8,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { Result, SyncStatus } from "@app/types";
 import type { LabsConnectionType } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -216,7 +216,7 @@ export class LabsConnectionsConfigurationResource extends BaseResource<LabsConne
       });
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/labs_salesforce_personal_connection_resource.ts
+++ b/front/lib/resources/labs_salesforce_personal_connection_resource.ts
@@ -5,7 +5,7 @@ import { LabsPersonalSalesforceConnection as LabsSalesforcePersonalConnection } 
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { DataSourceType, Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export type LabsPersonalSalesforceConnectionType = {
   connectionId: string;
@@ -90,7 +90,7 @@ export class LabsSalesforcePersonalConnectionResource extends BaseResource<LabsS
       });
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
   // Serialization.

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -21,7 +21,7 @@ import type {
   LightWorkspaceType,
   Result,
 } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -227,7 +227,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       });
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 
@@ -316,7 +316,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -21,7 +21,13 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { ModelId, Result } from "@app/types";
-import { Err, formatUserFullName, normalizeError, Ok, removeNulls } from "@app/types";
+import {
+  Err,
+  formatUserFullName,
+  normalizeError,
+  Ok,
+  removeNulls,
+} from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -21,7 +21,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { ModelId, Result } from "@app/types";
-import { Err, formatUserFullName, Ok, removeNulls } from "@app/types";
+import { Err, formatUserFullName, normalizeError, Ok, removeNulls } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -183,7 +183,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       });
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -22,7 +22,7 @@ import type {
   RequireAtLeastOne,
   Result,
 } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { assertNever, Err, normalizeError, Ok } from "@app/types";
 
 import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_models";
 
@@ -642,7 +642,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/plugin_run_resource.ts
+++ b/front/lib/resources/plugin_run_resource.ts
@@ -21,7 +21,7 @@ import type {
   PluginResourceTarget,
   Result,
 } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 import type { UserResource } from "./user_resource";
 
@@ -139,7 +139,7 @@ export class PluginRunResource extends BaseResource<PluginRunModel> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -19,7 +19,7 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { LightAgentConfigurationType, ModelId, Result } from "@app/types";
-import { Err, Ok, removeNulls } from "@app/types";
+import { Err, normalizeError, Ok, removeNulls } from "@app/types";
 import type { TagKind, TagTypeWithUsage } from "@app/types/tag";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -262,7 +262,7 @@ export class TagResource extends BaseResource<TagModel> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -18,7 +18,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelId, Result, TemplateVisibility } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -88,7 +88,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -23,7 +23,7 @@ import type {
   UserProviderType,
   UserType,
 } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export interface SearchMembersPaginationParams {
   orderColumn: "name";
@@ -226,7 +226,7 @@ export class UserResource extends BaseResource<UserModel> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 
@@ -243,7 +243,7 @@ export class UserResource extends BaseResource<UserModel> {
 
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -30,6 +30,7 @@ import type {
   LightWorkspaceType,
   UserType,
 } from "@app/types";
+import { normalizeError } from "@app/types";
 
 export function useAssistantTemplates() {
   const assistantTemplatesFetcher: Fetcher<FetchAssistantTemplatesResponse> =
@@ -647,7 +648,8 @@ export function useUpdateAgentScope({
       } catch (error) {
         sendNotification({
           title: `Error updating agent sharing.`,
-          description: (error as Error).message || "An unknown error occurred",
+          description:
+            normalizeError(error).message || "An unknown error occurred",
           type: "error",
         });
         return false;
@@ -727,7 +729,8 @@ export function useUpdateUserFavorite({
       } catch (error) {
         sendNotification({
           title: `Error updating agent list.`,
-          description: (error as Error).message || "An unknown error occurred",
+          description:
+            normalizeError(error).message || "An unknown error occurred",
           type: "error",
         });
         return false;

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -4,7 +4,7 @@ import type { RedisUsageTagsType } from "@app/lib/utils/redis_client";
 import { redisClient } from "@app/lib/utils/redis_client";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { LoggerInterface, Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export class RateLimitError extends Error {}
 
@@ -117,6 +117,6 @@ export async function expireRateLimiterKey({
 
     return new Ok(isExpired);
   } catch (err) {
-    return new Err(err as Error);
+    return new Err(normalizeError(err));
   }
 }

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
@@ -8,7 +8,11 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { APIErrorType, WithAPIErrorResponse } from "@app/types";
-import { CheckBigQueryCredentialsSchema, removeNulls } from "@app/types";
+import {
+  CheckBigQueryCredentialsSchema,
+  normalizeError,
+  removeNulls,
+} from "@app/types";
 
 const PostCheckBigQueryRegionsRequestBodySchema = t.type({
   credentials: CheckBigQueryCredentialsSchema,
@@ -122,12 +126,11 @@ async function handler(
       ),
     });
   } catch (err) {
-    const error = err as Error;
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error" as APIErrorType,
-        message: `Failed to check BigQuery locations: ${error.message}`,
+        message: `Failed to check BigQuery locations: ${normalizeError(err).message}`,
       },
     });
   }

--- a/front/poke/temporal/client.ts
+++ b/front/poke/temporal/client.ts
@@ -43,7 +43,7 @@ export async function launchScrubDataSourceWorkflow(
         "Failed starting scrub data source workflow."
       );
     }
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 

--- a/front/temporal/hard_delete/client.ts
+++ b/front/temporal/hard_delete/client.ts
@@ -8,7 +8,7 @@ import logger from "@app/logger/logger";
 import { getPurgeRunExecutionsScheduleId } from "@app/temporal/hard_delete/utils";
 import { purgeRunExecutionsCronWorkflow } from "@app/temporal/hard_delete/workflows";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 import { QUEUE_NAME } from "./config";
 
@@ -41,7 +41,7 @@ export async function launchPurgeRunExecutionsSchedule(): Promise<
     if (!(err instanceof ScheduleAlreadyRunning)) {
       logger.error({}, "Failed to start purge run executions.");
 
-      return new Err(err as Error);
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/temporal/labs/connections/client.ts
+++ b/front/temporal/labs/connections/client.ts
@@ -16,7 +16,7 @@ import {
   incrementalSyncLabsConnectionWorkflow,
 } from "@app/temporal/labs/connections/workflows";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export async function launchLabsConnectionWorkflow(
   connectionConfiguration: LabsConnectionsConfigurationResource
@@ -78,7 +78,7 @@ export async function launchLabsConnectionWorkflow(
       },
       "Labs connection sync workflow failed."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -123,6 +123,6 @@ export async function stopLabsConnectionWorkflow(
       },
       "Failed stopping workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/front/temporal/labs/connections/providers/hubspot/sync.ts
+++ b/front/temporal/labs/connections/providers/hubspot/sync.ts
@@ -34,7 +34,13 @@ import {
   markSyncStarted,
 } from "@app/temporal/labs/connections/utils";
 import type { ModelId, Result } from "@app/types";
-import { Err, isHubspotCredentials, OAuthAPI, Ok } from "@app/types";
+import {
+  Err,
+  isHubspotCredentials,
+  normalizeError,
+  OAuthAPI,
+  Ok,
+} from "@app/types";
 import { CoreAPI, dustManagedCredentials } from "@app/types";
 
 function formatDate(dateString: string): string {
@@ -597,12 +603,12 @@ export async function syncHubspotConnection(
       const errorMsg = `${error instanceof Error ? error.message : String(error)}`;
       logger.error({ error }, errorMsg);
       await markSyncFailed(configuration, errorMsg);
-      return new Err(error as Error);
+      return new Err(normalizeError(error));
     }
   } catch (error) {
     const errorMsg = `${error instanceof Error ? error.message : String(error)}`;
     logger.error({ error }, errorMsg);
     await markSyncFailed(configuration, errorMsg);
-    return new Err(error as Error);
+    return new Err(normalizeError(error));
   }
 }

--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -8,7 +8,7 @@ import { TRANSCRIPTS_QUEUE_NAME } from "@app/temporal/labs/transcripts/config";
 import { makeRetrieveTranscriptWorkflowId } from "@app/temporal/labs/transcripts/utils";
 import { retrieveNewTranscriptsWorkflow } from "@app/temporal/labs/transcripts/workflows";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export async function launchRetrieveTranscriptsWorkflow(
   transcriptsConfiguration: LabsTranscriptsConfigurationResource
@@ -44,7 +44,7 @@ export async function launchRetrieveTranscriptsWorkflow(
       },
       "Transcript retrieval workflow failed."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -77,6 +77,6 @@ export async function stopRetrieveTranscriptsWorkflow(
       },
       "Failed stopping workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/front/temporal/labs/transcripts/utils/google.ts
+++ b/front/temporal/labs/transcripts/utils/google.ts
@@ -7,6 +7,7 @@ import { getTranscriptsGoogleAuth } from "@app/lib/labs/transcripts/utils/helper
 import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import type { Logger } from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
+import { normalizeError } from "@app/types";
 
 export async function retrieveRecentGoogleTranscripts(
   {
@@ -80,7 +81,7 @@ export async function retrieveGoogleTranscripts(
       { error, transcriptsConfiguration },
       "[retrieveGoogleTranscripts] Error retrieving recent Google transcripts."
     );
-    return new Err(error as Error);
+    return new Err(normalizeError(error));
   }
 
   for (const recentTranscriptFile of recentTranscriptFiles) {

--- a/front/temporal/mentions_count_queue/client.ts
+++ b/front/temporal/mentions_count_queue/client.ts
@@ -3,7 +3,7 @@ import { WorkflowNotFoundError } from "@temporalio/client";
 import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 import { QUEUE_NAME } from "./config";
 import { mentionsCountWorkflow } from "./workflows";
@@ -62,6 +62,6 @@ export async function launchMentionsCountWorkflow({
       },
       "Failed starting workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/front/temporal/permissions_queue/client.ts
+++ b/front/temporal/permissions_queue/client.ts
@@ -9,7 +9,7 @@ import type { UpdateSpacePermissionsSignal } from "@app/temporal/permissions_que
 import { updateSpacePermissionsSignal } from "@app/temporal/permissions_queue/signals";
 import { updateSpacePermissionsWorkflow } from "@app/temporal/permissions_queue/workflows";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 const DEBOUNCE_MS = 10 * 1000; // 10 seconds.
 
@@ -62,6 +62,6 @@ export async function launchUpdateSpacePermissionsWorkflow(
       );
     }
 
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/front/temporal/production_checks/client.ts
+++ b/front/temporal/production_checks/client.ts
@@ -3,7 +3,7 @@ import { WorkflowNotFoundError } from "@temporalio/client";
 import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 import { QUEUE_NAME } from "./config";
 import { runAllChecksWorkflow } from "./workflows";
@@ -44,6 +44,6 @@ export async function launchProductionChecksWorkflow(): Promise<
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/front/temporal/scrub_workspace/client.ts
+++ b/front/temporal/scrub_workspace/client.ts
@@ -8,7 +8,7 @@ import {
   scheduleWorkspaceScrubWorkflow,
 } from "@app/temporal/scrub_workspace/workflows";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 import { QUEUE_NAME } from "./config";
 
@@ -44,7 +44,7 @@ export async function launchScheduleWorkspaceScrubWorkflow({
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -80,7 +80,7 @@ export async function launchImmediateWorkspaceScrubWorkflow({
       },
       `Failed starting workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 
@@ -113,7 +113,7 @@ export async function terminateScheduleWorkspaceScrubWorkflow({
       },
       `Failed terminating workflow.`
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }
 

--- a/front/temporal/upsert_queue/client.ts
+++ b/front/temporal/upsert_queue/client.ts
@@ -1,7 +1,7 @@
 import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 import { QUEUE_NAME } from "./config";
 import { upsertDocumentWorkflow } from "./workflows";
@@ -47,6 +47,6 @@ export async function launchUpsertDocumentWorkflow({
       },
       "Failed starting workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/front/temporal/upsert_tables/client.ts
+++ b/front/temporal/upsert_tables/client.ts
@@ -1,7 +1,7 @@
 import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 import { QUEUE_NAME } from "./config";
 import { upsertTableWorkflow } from "./workflows";
@@ -47,6 +47,6 @@ export async function launchUpsertTableWorkflow({
       },
       "Failed starting workflow."
     );
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -6,7 +6,7 @@ import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/usage_queue/config";
 import { updateWorkspaceUsageWorkflow } from "@app/temporal/usage_queue/workflows";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 async function shouldProcessUsageUpdate(workflowId: string) {
   // Compute the max usage of the workspace once per hour.
@@ -65,6 +65,6 @@ export async function launchUpdateUsageWorkflow({
         "Failed starting usage workflow."
       );
     }
-    return new Err(e as Error);
+    return new Err(normalizeError(e));
   }
 }


### PR DESCRIPTION
## Description

- The pattern `err as Error` to cast a random error into an error of type `Error` is quite widespread.
- This cast can be incorrect given that it is possible in JS to throw anything (string, number, random object, ...).
- Some errors are still reflected in the logs with an `[object Object]`, which is not usable at all.
- An util function `normalizeError` was introduced to properly check what was being thrown and to convert it into an actual `Error` (the type that has a field `message`).
- This PR refactors the `front` code to use this util function and adds a `CODING_RULE` so that `CodingRules` will catch them from now on. 

## Tests

- Tested locally.

## Risk

- High blast radius but low risk.

## Deploy Plan

- Deploy `front`.
