### PR TITLE
[front] Tag search improvements

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -224,11 +224,8 @@ export function AssistantBrowser({
                 <DropdownMenuItem
                   key={tag.sId}
                   onClick={() => {
-                    if (selectedTags.includes(tag.sId)) {
-                      setSelectedTags(
-                        selectedTags.filter((t) => t !== tag.sId)
-                      );
-                    } else {
+                    setSelectedTab("all");
+                    if (!selectedTags.includes(tag.sId)) {
                       setSelectedTags([...selectedTags, tag.sId]);
                     }
                     setAssistantSearch("");

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -223,12 +223,21 @@ export function AssistantBrowser({
               {filteredTags.map((tag) => (
                 <DropdownMenuItem
                   key={tag.sId}
-                  onClick={() => {
+                  onClick={(e) => {
                     setSelectedTab("all");
-                    if (!selectedTags.includes(tag.sId)) {
-                      setSelectedTags([...selectedTags, tag.sId]);
-                    }
                     setAssistantSearch("");
+                    setTimeout(() => {
+                      const element = document.getElementById(
+                        `anchor-${tag.sId}`
+                      );
+                      if (element) {
+                        element.scrollIntoView({
+                          behavior: "smooth",
+                          block: "start",
+                          inline: "nearest",
+                        });
+                      }
+                    }, 300); // Need to wait for the dropdown to close before scrolling
                   }}
                 >
                   <Chip label={tag.name} color="golden" size="xs" />
@@ -389,6 +398,7 @@ export function AssistantBrowser({
               )
               .map((tag) => (
                 <React.Fragment key={tag.sId}>
+                  <a id={`anchor-${tag.sId}`} />
                   <span className="heading-base">{tag.name}</span>
                   <AgentGrid
                     agentConfigurations={agentsByTab.all.filter((a) =>

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -223,7 +223,7 @@ export function AssistantBrowser({
               {filteredTags.map((tag) => (
                 <DropdownMenuItem
                   key={tag.sId}
-                  onClick={(e) => {
+                  onClick={() => {
                     setSelectedTab("all");
                     setAssistantSearch("");
                     setTimeout(() => {


### PR DESCRIPTION
## Description

When search for a tag and clicking on it, we now : 
- switch back to the "All agents" tab (as tags are not visible on other tabs)
- instead of switching the filter, scroll down to the tag section

## Tests

Locally

## Risk

minimal, UI only

## Deploy Plan

deploy front
