### PR TITLE
[sparkle] - fix(Popover): width

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.506",
+  "version": "0.2.507",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.506",
+      "version": "0.2.507",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.506",
+  "version": "0.2.507",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Popover.tsx
+++ b/sparkle/src/components/Popover.tsx
@@ -48,7 +48,7 @@ const PopoverContent = React.forwardRef<
           "s-border s-border-border dark:s-border-border-night",
           "s-bg-background dark:s-bg-background-night",
           "s-text-primary-950 dark:s-text-primary-950-night",
-          fullWidth ? "s-w-full" : "s-w-72 s-p-4",
+          fullWidth ? "s-grow" : "s-w-72 s-p-4",
           className
         )}
         {...props}

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -208,7 +208,7 @@ function BaseSearchInputWithPopover<T>(
       </PopoverTrigger>
       <PopoverContent
         className={cn(
-          "s-max-w-[--radix-popover-trigger-width] s-rounded-lg s-border s-bg-background s-shadow-md dark:s-bg-background-night",
+          "s-w-[--radix-popover-trigger-width] s-rounded-lg s-border s-bg-background s-shadow-md dark:s-bg-background-night",
           contentClassName
         )}
         sideOffset={0}


### PR DESCRIPTION
## Description

This PR fixes the `Popover` width such that it can leverage the radix variables to fit its trigger's width.

## Tests

Locally (search tool configuration + welcome guide)

## Risk

Low

## Deploy Plan

- Publish sparkle
- Upgrade sparkle in front
- Deploy front