### PR TITLE
Fix trackers sync in Gong

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -96,24 +96,21 @@ export type GongTranscriptMetadataWithoutTrackers = t.TypeOf<
 const GongTranscriptMetadataCodec = t.intersection([
   GongTranscriptMetadataWithoutTrackersCodec,
   t.type({
-    content: t.union([
-      t.intersection([
-        t.type({
-          trackers: t.array(
-            t.intersection([
-              t.type({
-                id: t.string,
-                name: t.string,
-                count: t.number,
-                type: t.string,
-              }),
-              CatchAllCodec,
-            ])
-          ),
-        }),
-        CatchAllCodec,
-      ]),
-      t.undefined,
+    content: t.intersection([
+      t.type({
+        trackers: t.array(
+          t.intersection([
+            t.type({
+              id: t.string,
+              name: t.string,
+              count: t.number,
+              type: t.string,
+            }),
+            CatchAllCodec,
+          ])
+        ),
+      }),
+      CatchAllCodec,
     ]),
   }),
 ]);

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -364,8 +364,8 @@ export class GongClient {
       contentSelector: {
         exposedFields: {
           parties: true,
+          ...(smartTrackersEnabled ? { content: { trackers: true } } : {}),
         },
-        ...(smartTrackersEnabled ? { content: { trackers: true } } : {}),
       },
     };
     try {

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -96,21 +96,24 @@ export type GongTranscriptMetadataWithoutTrackers = t.TypeOf<
 const GongTranscriptMetadataCodec = t.intersection([
   GongTranscriptMetadataWithoutTrackersCodec,
   t.type({
-    content: t.intersection([
-      t.type({
-        trackers: t.array(
-          t.intersection([
-            t.type({
-              id: t.string,
-              name: t.string,
-              count: t.number,
-              type: t.string,
-            }),
-            CatchAllCodec,
-          ])
-        ),
-      }),
-      CatchAllCodec,
+    content: t.union([
+      t.intersection([
+        t.type({
+          trackers: t.array(
+            t.intersection([
+              t.type({
+                id: t.string,
+                name: t.string,
+                count: t.number,
+                type: t.string,
+              }),
+              CatchAllCodec,
+            ])
+          ),
+        }),
+        CatchAllCodec,
+      ]),
+      t.undefined,
     ]),
   }),
 ]);
@@ -362,7 +365,7 @@ export class GongClient {
         exposedFields: {
           parties: true,
         },
-        ...(smartTrackersEnabled ? { content: { transcript: true } } : {}),
+        ...(smartTrackersEnabled ? { content: { trackers: true } } : {}),
       },
     };
     try {

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -130,9 +130,10 @@ export async function syncGongTranscript({
 
   // We add tags for the trackers to the document but not to the prefixes.
   // These are meant to be used for filtering purposes rather than for semantic search.
-  const trackerTags = transcriptMetadata.content.trackers.map(
-    (tracker) => `tracker:${tracker.name}`
-  );
+  const trackerTags =
+    transcriptMetadata.content?.trackers.map(
+      (tracker) => `tracker:${tracker.name}`
+    ) ?? [];
 
   await upsertDataSourceDocument({
     dataSourceConfig,

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -130,10 +130,9 @@ export async function syncGongTranscript({
 
   // We add tags for the trackers to the document but not to the prefixes.
   // These are meant to be used for filtering purposes rather than for semantic search.
-  const trackerTags =
-    transcriptMetadata.content?.trackers.map(
-      (tracker) => `tracker:${tracker.name}`
-    ) ?? [];
+  const trackerTags = transcriptMetadata.content.trackers.map(
+    (tracker) => `tracker:${tracker.name}`
+  );
 
   await upsertDataSourceDocument({
     dataSourceConfig,


### PR DESCRIPTION
## Description

- We observed some validation errors when checking the content received from the API (logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_q=%40activityName&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZbs9fumNjGfBwAAABhBWmJzOWYzYkFBQ2duU3BVaWdSajVnQUMAAAAkMDE5NmVjZjYtMGY3MC00MjllLTk4ZjUtYTE5MzM3OWM0MDBkAAAChQ&fromUser=true&link_source=monitor_notif&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40activityName%3AgongSyncTranscriptsActivity%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22activityName%22%2C%22value%22%3A%22gongSyncTranscriptsActivity%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1747728698000%2C%22to%22%3A1747732298000%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1747728682291&to_ts=1747732282291&live=true)).
- There was an error in the body of the payload, causing the trackers to not be included in the response.

## Tests

- We don't have trackers on our Gong, cannot test locally.
- Easy to track (launch a sync).

## Risk

- N/A.

## Deploy Plan

- Deploy front.
