### PR TITLE
feat: add flag for sfdc connector on pro plan

### DIFF
--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -153,6 +153,7 @@ export const AddConnectionMenu = ({
     [owner, systemSpace]
   );
 
+  // Filter available integrations
   const availableIntegrations = integrations.filter((i) => {
     const hide = CONNECTOR_CONFIGURATIONS[i.connectorProvider].hide;
     const rolloutFlag =
@@ -160,7 +161,11 @@ export const AddConnectionMenu = ({
     const hasFlag = rolloutFlag && featureFlags.includes(rolloutFlag);
 
     return (
-      isConnectorProviderAllowedForPlan(plan, i.connectorProvider) &&
+      isConnectorProviderAllowedForPlan(
+        plan,
+        i.connectorProvider,
+        featureFlags
+      ) &&
       isConnectionIdRequiredForProvider(i.connectorProvider) &&
       // If the connector is hidden, it should only be shown if the feature flag is enabled.
       (!hide || hasFlag)
@@ -278,7 +283,8 @@ export const AddConnectionMenu = ({
 
     const isProviderAllowed = isConnectorProviderAllowedForPlan(
       plan,
-      configuration.connectorProvider
+      configuration.connectorProvider,
+      featureFlags
     );
 
     if (!isProviderAllowed) {

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -27,6 +27,7 @@ import { SalesforceOauthExtraConfig } from "@app/components/data_source/salesfor
 import { SlackBotEnableView } from "@app/components/data_source/SlackBotEnableView";
 import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
 import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
+import { isProPlan } from "@app/lib/plans/plan_codes";
 import type {
   ConnectorPermission,
   ConnectorProvider,
@@ -417,7 +418,8 @@ export const isValidConnectorSuffix = (suffix: string): boolean => {
 
 export const isConnectorProviderAllowedForPlan = (
   plan: PlanType,
-  provider: ConnectorProvider
+  provider: ConnectorProvider,
+  featureFlags: WhitelistableFeature[]
 ): boolean => {
   switch (provider) {
     case "confluence":
@@ -435,7 +437,14 @@ export const isConnectorProviderAllowedForPlan = (
     case "webcrawler":
       return plan.limits.connections.isWebCrawlerAllowed;
     case "salesforce":
-      return plan.limits.connections.isSalesforceAllowed;
+      // Either salesforce is allowed for the plan, or the workspace
+      // is pro plan but has the pro_plan_salesforce_connector feature flag enabled
+      return (
+        plan.limits.connections.isSalesforceAllowed ||
+        (isProPlan(plan.code) &&
+          !!featureFlags?.includes("pro_plan_salesforce_connector"))
+      );
+
     case "microsoft":
     case "snowflake":
     case "zendesk":

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -9,7 +9,7 @@ import { createDataSourceWithoutProvider } from "@app/lib/api/data_sources";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getOrCreateSystemApiKey } from "@app/lib/auth";
+import { getFeatureFlags, getOrCreateSystemApiKey } from "@app/lib/auth";
 import {
   getDefaultDataSourceDescription,
   getDefaultDataSourceName,
@@ -240,10 +240,13 @@ const handleDataSourceWithProvider = async ({
     });
   }
 
+  const featureFlags = await getFeatureFlags(owner);
+
   // Checking that the provider is allowed for the workspace plan
   const isDataSourceAllowedInPlan = isConnectorProviderAllowedForPlan(
     plan,
-    provider
+    provider,
+    featureFlags
   );
   if (!isDataSourceAllowedInPlan) {
     return apiError(req, res, {

--- a/front/scripts/toggle_feature_flags.ts
+++ b/front/scripts/toggle_feature_flags.ts
@@ -27,7 +27,7 @@ async function enableFeatureFlag(
   if (execute) {
     await FeatureFlag.create({
       workspaceId,
-      name: featureFlag as WhitelistableFeature,
+      name: featureFlag satisfies WhitelistableFeature,
     });
   }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -21,6 +21,7 @@ export const WHITELISTABLE_FEATURES = [
   "openai_o1_high_reasoning_feature",
   "openai_o1_mini_feature",
   "salesforce_feature",
+  "pro_plan_salesforce_connector",
   "show_debug_tools",
   "usage_data_api",
   "custom_webcrawler",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -815,6 +815,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_high_reasoning_custom_assistants_feature"
   | "openai_o1_high_reasoning_feature"
   | "openai_o1_mini_feature"
+  | "pro_plan_salesforce_connector"
   | "salesforce_feature"
   | "search_knowledge_builder"
   | "show_debug_tools"
@@ -822,6 +823,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "usage_data_api"
   | "custom_webcrawler"
   | "exploded_tables_query"
+  | "pro_plan_salesforce_connector"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

context: https://dust4ai.slack.com/archives/C06SYAESP8R/p1747216879234039

We want to allow trialing the Salesforce connection on pro plan.
This flag should not remain enabled forever on any workspace.

## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy front