### PR TITLE
Add `connectorId` as search attribute to Temporal schedules

### DIFF
--- a/connectors/src/lib/temporal_schedules.ts
+++ b/connectors/src/lib/temporal_schedules.ts
@@ -75,6 +75,9 @@ export async function createSchedule({
       scheduleId,
       policies,
       spec,
+      searchAttributes: {
+        connectorId: connector ? [connector?.id] : undefined,
+      },
     });
 
     // Trigger the schedule to start the workflow immediately.


### PR DESCRIPTION
## Description

- We currently cannot search Temporal schedules by connector ID.
- This PR fixes that.

## Tests

- Tested locally, the search works.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
