### PR TITLE
Add support for `fromTs` in Gong full resync

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -229,7 +229,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
     });
     const configuration = await fetchGongConfiguration(connector);
 
-    if (!fromTs) {
+    if (fromTs === null) {
       // Resetting the last sync timestamp to run a full sync.
       await configuration.resetLastSyncTimestamp();
     } else {

--- a/connectors/src/connectors/gong/lib/cli.ts
+++ b/connectors/src/connectors/gong/lib/cli.ts
@@ -31,7 +31,7 @@ export const gong = async ({
       const configuration = await fetchGongConfiguration(connector);
 
       // If fromTs is not provided, reset the last sync timestamp to run a full sync.
-      if (!fromTs) {
+      if (fromTs === undefined) {
         await configuration.resetLastSyncTimestamp();
       } else {
         await configuration.setLastSyncTimestamp(fromTs);

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -130,6 +130,7 @@ export const GongCommandSchema = t.type({
   command: t.literal("force-resync"),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
+    fromTs: t.union([t.number, t.undefined]),
   }),
 });
 export type GongCommandType = t.TypeOf<typeof GongCommandSchema>;


### PR DESCRIPTION
## Description

- There is currently no way to force resync starting from a certain date in Gong.
- This PR addresses that by adding a `fromTs` to the `force-resync` command.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
