### PR TITLE
[front] - fix(AgentBuilder): preview panel default state

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -7,6 +7,9 @@ import {
   useHashParam,
   useSendNotification,
 } from "@dust-tt/sparkle";
+import { Button } from "@dust-tt/sparkle";
+import { ChevronDoubleRightIcon } from "@dust-tt/sparkle";
+import { ChevronDoubleLeftIcon } from "@dust-tt/sparkle";
 import assert from "assert";
 import { uniqueId } from "lodash";
 import { useRouter } from "next/router";
@@ -191,7 +194,8 @@ export default function AssistantBuilder({
     agentConfigurationId,
   });
   useNavigationLock(edited && !disableUnsavedChangesPrompt);
-  const { mcpServerViews } = useContext(AssistantBuilderContext);
+  const { mcpServerViews, isPreviewPanelOpen, setIsPreviewPanelOpen } =
+    useContext(AssistantBuilderContext);
 
   const checkUsernameTimeout = React.useRef<NodeJS.Timeout | null>(null);
 
@@ -422,7 +426,7 @@ export default function AssistantBuilder({
         <BuilderLayout
           leftPanel={
             <div className="flex h-full flex-col gap-4 pb-6 pt-4">
-              <div className="flex flex-wrap justify-between gap-4 sm:flex-row">
+              <div className="flex flex-row justify-between gap-4 sm:flex-row">
                 <Tabs
                   className="w-full"
                   onValueChange={(t) => {
@@ -443,6 +447,15 @@ export default function AssistantBuilder({
                     ))}
                   </TabsList>
                 </Tabs>
+                <Button
+                  icon={
+                    isPreviewPanelOpen
+                      ? ChevronDoubleRightIcon
+                      : ChevronDoubleLeftIcon
+                  }
+                  variant="outline"
+                  onClick={() => setIsPreviewPanelOpen(!isPreviewPanelOpen)}
+                />
               </div>
               <div className="flex h-full justify-center">
                 <div className="h-full w-full max-w-4xl">

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -453,7 +453,8 @@ export default function AssistantBuilder({
                       ? ChevronDoubleRightIcon
                       : ChevronDoubleLeftIcon
                   }
-                  variant="outline"
+                  variant="ghost"
+                  tooltip={isPreviewPanelOpen ? "Hide preview" : "Open preview"}
                   onClick={() => setIsPreviewPanelOpen(!isPreviewPanelOpen)}
                 />
               </div>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1,6 +1,8 @@
 import "react-image-crop/dist/ReactCrop.css";
 
 import {
+  SidebarRightCloseIcon,
+  SidebarRightOpenIcon,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -8,8 +10,6 @@ import {
   useSendNotification,
 } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
-import { ChevronDoubleRightIcon } from "@dust-tt/sparkle";
-import { ChevronDoubleLeftIcon } from "@dust-tt/sparkle";
 import assert from "assert";
 import { uniqueId } from "lodash";
 import { useRouter } from "next/router";
@@ -426,7 +426,7 @@ export default function AssistantBuilder({
         <BuilderLayout
           leftPanel={
             <div className="flex h-full flex-col gap-4 pb-6 pt-4">
-              <div className="flex flex-row justify-between gap-4 sm:flex-row">
+              <div className="flex flex-row justify-between sm:flex-row">
                 <Tabs
                   className="w-full"
                   onValueChange={(t) => {
@@ -447,16 +447,20 @@ export default function AssistantBuilder({
                     ))}
                   </TabsList>
                 </Tabs>
-                <Button
-                  icon={
-                    isPreviewPanelOpen
-                      ? ChevronDoubleRightIcon
-                      : ChevronDoubleLeftIcon
-                  }
-                  variant="ghost"
-                  tooltip={isPreviewPanelOpen ? "Hide preview" : "Open preview"}
-                  onClick={() => setIsPreviewPanelOpen(!isPreviewPanelOpen)}
-                />
+                <div className="border-b border-border">
+                  <Button
+                    icon={
+                      isPreviewPanelOpen
+                        ? SidebarRightCloseIcon
+                        : SidebarRightOpenIcon
+                    }
+                    variant="ghost"
+                    tooltip={
+                      isPreviewPanelOpen ? "Hide preview" : "Open preview"
+                    }
+                    onClick={() => setIsPreviewPanelOpen(!isPreviewPanelOpen)}
+                  />
+                </div>
               </div>
               <div className="flex h-full justify-center">
                 <div className="h-full w-full max-w-4xl">

--- a/front/components/assistant_builder/AssistantBuilderContext.tsx
+++ b/front/components/assistant_builder/AssistantBuilderContext.tsx
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, useState } from "react";
 
 import { mcpServerViewSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -9,6 +9,8 @@ type AssistantBuilderContextType = {
   dataSourceViews: DataSourceViewType[];
   spaces: SpaceType[];
   mcpServerViews: MCPServerViewType[];
+  isPreviewPanelOpen: boolean;
+  setIsPreviewPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const AssistantBuilderContext =
@@ -17,6 +19,8 @@ export const AssistantBuilderContext =
     dataSourceViews: [],
     spaces: [],
     mcpServerViews: [],
+    isPreviewPanelOpen: true,
+    setIsPreviewPanelOpen: () => {},
   });
 
 export function AssistantBuilderProvider({
@@ -25,9 +29,14 @@ export function AssistantBuilderProvider({
   spaces,
   mcpServerViews,
   children,
-}: AssistantBuilderContextType & {
+}: Omit<
+  AssistantBuilderContextType,
+  "isPreviewPanelOpen" | "setIsPreviewPanelOpen"
+> & {
   children: React.ReactNode;
 }) {
+  const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState(false);
+
   return (
     <AssistantBuilderContext.Provider
       value={{
@@ -35,6 +44,8 @@ export function AssistantBuilderProvider({
         dataSourceViews,
         spaces,
         mcpServerViews: mcpServerViews.sort(mcpServerViewSortingFn),
+        isPreviewPanelOpen,
+        setIsPreviewPanelOpen,
       }}
     >
       {children}

--- a/front/components/assistant_builder/AssistantBuilderContext.tsx
+++ b/front/components/assistant_builder/AssistantBuilderContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useState } from "react";
+import { useEffect } from "react";
 
 import { mcpServerViewSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -35,8 +36,24 @@ export function AssistantBuilderProvider({
 > & {
   children: React.ReactNode;
 }) {
-  const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState(false);
+  const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return window.innerWidth >= 1024;
+  });
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
+
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      setIsPreviewPanelOpen(event.matches);
+    };
+    mediaQuery.addEventListener("change", handleMediaChange);
+    return () => {
+      mediaQuery.removeEventListener("change", handleMediaChange);
+    };
+  }, []);
   return (
     <AssistantBuilderContext.Provider
       value={{

--- a/front/components/assistant_builder/BuilderLayout.tsx
+++ b/front/components/assistant_builder/BuilderLayout.tsx
@@ -1,4 +1,8 @@
-import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@dust-tt/sparkle";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@dust-tt/sparkle";
 import { useContext, useEffect, useRef, useState } from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 
@@ -58,9 +62,7 @@ export function BuilderLayout({ leftPanel, rightPanel }: BuilderLayoutProps) {
               : "overflow-hidden"
           }
         >
-          <div
-            className="h-full w-full overflow-y-auto px-6 transition-all duration-200 ease-in-out"
-          >
+          <div className="h-full w-full overflow-y-auto px-6 transition-all duration-200 ease-in-out">
             {rightPanel}
           </div>
         </ResizablePanel>

--- a/front/components/assistant_builder/BuilderLayout.tsx
+++ b/front/components/assistant_builder/BuilderLayout.tsx
@@ -1,8 +1,8 @@
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@dust-tt/sparkle";
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@dust-tt/sparkle";
+import { useContext, useEffect, useRef, useState } from "react";
+import type { ImperativePanelHandle } from "react-resizable-panels";
+
+import { AssistantBuilderContext } from "./AssistantBuilderContext";
 
 interface BuilderLayoutProps {
   leftPanel: React.ReactNode;
@@ -10,19 +10,59 @@ interface BuilderLayoutProps {
 }
 
 export function BuilderLayout({ leftPanel, rightPanel }: BuilderLayoutProps) {
+  const { isPreviewPanelOpen } = useContext(AssistantBuilderContext);
+  const previewPanelRef = useRef<ImperativePanelHandle>(null);
+  const [isResizing, setIsResizing] = useState(false);
+
+  useEffect(() => {
+    if (previewPanelRef.current) {
+      if (isPreviewPanelOpen) {
+        previewPanelRef.current.expand();
+      } else {
+        previewPanelRef.current.collapse();
+      }
+    }
+  }, [isPreviewPanelOpen]);
+
   return (
     <div className="flex h-full w-full">
       <ResizablePanelGroup
+        id="assistant-builder-layout"
         autoSaveId="assistant-builder-layout"
         direction="horizontal"
         className="h-full w-full"
       >
-        <ResizablePanel defaultSize={70} minSize={30}>
+        <ResizablePanel
+          defaultSize={70}
+          minSize={30}
+          className={
+            !isResizing ? "transition-all duration-300 ease-in-out" : ""
+          }
+        >
           <div className="h-full w-full overflow-y-auto px-6">{leftPanel}</div>
         </ResizablePanel>
-        <ResizableHandle />
-        <ResizablePanel defaultSize={30} minSize={20}>
-          <div className="h-full w-full overflow-y-auto px-6">{rightPanel}</div>
+
+        <ResizableHandle
+          onDragging={(isDragging) => setIsResizing(isDragging)}
+        />
+
+        <ResizablePanel
+          ref={previewPanelRef}
+          id="preview-panel"
+          defaultSize={30}
+          minSize={20}
+          collapsible={true}
+          className={
+            !isResizing
+              ? "overflow-hidden transition-all duration-300 ease-in-out"
+              : "overflow-hidden"
+          }
+        >
+          <div
+            className="h-full w-full overflow-y-auto px-6 transition-all duration-200 ease-in-out"
+          >
+            {rightPanel}
+          </div>
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/front/components/assistant_builder/BuilderLayout.tsx
+++ b/front/components/assistant_builder/BuilderLayout.tsx
@@ -36,13 +36,7 @@ export function BuilderLayout({ leftPanel, rightPanel }: BuilderLayoutProps) {
         direction="horizontal"
         className="h-full w-full"
       >
-        <ResizablePanel
-          defaultSize={70}
-          minSize={30}
-          className={
-            !isResizing ? "transition-all duration-300 ease-in-out" : ""
-          }
-        >
+        <ResizablePanel defaultSize={70} minSize={30}>
           <div className="h-full w-full overflow-y-auto px-6">{leftPanel}</div>
         </ResizablePanel>
 
@@ -62,9 +56,7 @@ export function BuilderLayout({ leftPanel, rightPanel }: BuilderLayoutProps) {
               : "overflow-hidden"
           }
         >
-          <div className="h-full w-full overflow-y-auto px-6 transition-all duration-200 ease-in-out">
-            {rightPanel}
-          </div>
+          <div className="h-full w-full overflow-y-auto px-6">{rightPanel}</div>
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.506",
+        "@dust-tt/sparkle": "^0.2.508",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1080,9 +1080,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.506",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.506.tgz",
-      "integrity": "sha512-z1zLB7Gjha4sJAqDZeg0YKGUGTsxseZbdFTISeL+YT3EjODo0/851RaluWQ4tXbl1XaITA8e3TGClnWEfbxi8g==",
+      "version": "0.2.508",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.508.tgz",
+      "integrity": "sha512-r9vHvdCHqF7/brzbldhzPQ53By1HsTPggoLSJvAPl0S+HKcAf5T2hY7QWSas9ZWCH80FCozrnKnC+27i4YVNLQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.506",
+    "@dust-tt/sparkle": "^0.2.508",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR aims at introducing the following behaviours:
- a button to toggle/untoggle the right panel
- have the right panel hidden/visible by default based on the viewport size.

![Screenshot 2025-05-20 at 15 36 55](https://github.com/user-attachments/assets/57b9c2e2-5f17-4508-90c4-f263f44f4f65)

## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy front
