### PR TITLE
[front] Moved method from script helpers

### DIFF
--- a/front/lib/utils/sql_utils.ts
+++ b/front/lib/utils/sql_utils.ts
@@ -1,5 +1,6 @@
-import { frontSequelize } from "@app/lib/resources/storage";
 import { injectReplacements } from "sequelize/lib/utils/sql";
+
+import { frontSequelize } from "@app/lib/resources/storage";
 
 export function getInsertSQL(model: any, data: any) {
   // Build an instance but don't save it

--- a/front/lib/utils/sql_utils.ts
+++ b/front/lib/utils/sql_utils.ts
@@ -1,0 +1,35 @@
+import { injectReplacements } from "sequelize/lib/utils/sql";
+import { frontSequelize } from "@app/lib/resources/storage";
+
+export function getInsertSQL(model: any, data: any) {
+  // Build an instance but don't save it
+  const instance = model.build(data);
+
+  // Get the QueryGenerator for this dialect
+  const queryGenerator = model.sequelize.getQueryInterface().queryGenerator;
+
+  // Get the table name and attributes
+  const tableName = model.tableName;
+  const values = instance.get({ plain: true });
+
+  // Use the internal insertQuery method
+  // This generates the SQL without executing it
+  const parameterizedQuery = queryGenerator.insertQuery(
+    tableName,
+    values,
+    model.rawAttributes,
+    {}
+  );
+
+  // For PostgreSQL, use the bind method from Sequelize Utils
+  if (parameterizedQuery.query && parameterizedQuery.bind) {
+    // Use the format method to bind parameters
+    // This is the proper way to use Sequelize's internal binding
+    return injectReplacements(
+      parameterizedQuery.query.replace(/\$\d+/g, "?"),
+      // @ts-expect-error I know there is a dialect
+      frontSequelize.dialect,
+      parameterizedQuery.bind
+    );
+  }
+}

--- a/front/lib/utils/sql_utils.ts
+++ b/front/lib/utils/sql_utils.ts
@@ -1,5 +1,5 @@
-import { injectReplacements } from "sequelize/lib/utils/sql";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { injectReplacements } from "sequelize/lib/utils/sql";
 
 export function getInsertSQL(model: any, data: any) {
   // Build an instance but don't save it

--- a/front/migrations/20250516_migrate_retrieval_to_mcp.ts
+++ b/front/migrations/20250516_migrate_retrieval_to_mcp.ts
@@ -12,8 +12,9 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type Logger from "@app/logger/logger";
-import { getInsertSQL, makeScript } from "@app/scripts/helpers";
+import { makeScript } from "@app/scripts/helpers";
 import type { ModelId } from "@app/types";
+import { getInsertSQL } from "@app/lib/utils/sql_utils";
 
 async function findWorkspacesWithRetrievalConfigurations(): Promise<ModelId[]> {
   const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({

--- a/front/scripts/helpers.ts
+++ b/front/scripts/helpers.ts
@@ -1,9 +1,7 @@
-import { injectReplacements } from "sequelize/lib/utils/sql";
 import type { Options } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { frontSequelize } from "@app/lib/resources/storage";
 import type { Logger } from "@app/logger/logger";
 import logger from "@app/logger/logger";
 
@@ -74,37 +72,4 @@ export function makeScript<T extends ArgumentSpecs>(
       console.error("An error occurred:", error);
       process.exit(1);
     });
-}
-
-export function getInsertSQL(model: any, data: any) {
-  // Build an instance but don't save it
-  const instance = model.build(data);
-
-  // Get the QueryGenerator for this dialect
-  const queryGenerator = model.sequelize.getQueryInterface().queryGenerator;
-
-  // Get the table name and attributes
-  const tableName = model.tableName;
-  const values = instance.get({ plain: true });
-
-  // Use the internal insertQuery method
-  // This generates the SQL without executing it
-  const parameterizedQuery = queryGenerator.insertQuery(
-    tableName,
-    values,
-    model.rawAttributes,
-    {}
-  );
-
-  // For PostgreSQL, use the bind method from Sequelize Utils
-  if (parameterizedQuery.query && parameterizedQuery.bind) {
-    // Use the format method to bind parameters
-    // This is the proper way to use Sequelize's internal binding
-    return injectReplacements(
-      parameterizedQuery.query.replace(/\$\d+/g, "?"),
-      // @ts-expect-error I know there is a dialect
-      frontSequelize.dialect,
-      parameterizedQuery.bind
-    );
-  }
 }


### PR DESCRIPTION
## Description

Moved method out from script helper to avoid importing front sequelize here. This breaks the execution of script check_registry_apps.ts which is ran without front_database_uri


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

none
