### PR TITLE
Poké: Agent detail display author name & email on top of ID

### DIFF
--- a/front/lib/api/assistant/editors.ts
+++ b/front/lib/api/assistant/editors.ts
@@ -1,0 +1,13 @@
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { LightAgentConfigurationType, UserType } from "@app/types";
+import { removeNulls } from "@app/types";
+
+export const getAuthors = async (
+  agentConfigurations: LightAgentConfigurationType[]
+): Promise<UserType[]> => {
+  const authorIds = new Set(
+    removeNulls(agentConfigurations.map((a) => a.versionAuthorId))
+  );
+  const authors = await UserResource.fetchByModelIds(Array.from(authorIds));
+  return authors.map((a) => a.toJSON());
+};

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -6,12 +6,18 @@ import type { ReactElement } from "react";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAuthors } from "@app/lib/api/assistant/editors";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import type { AgentConfigurationType, WorkspaceType } from "@app/types";
+import type {
+  AgentConfigurationType,
+  UserType,
+  WorkspaceType,
+} from "@app/types";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   agentConfigurations: AgentConfigurationType[];
+  authors: UserType[];
   workspace: WorkspaceType;
 }>(async (context, auth) => {
   const aId = context.params?.aId;
@@ -30,6 +36,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       agentConfigurations,
+      authors: await getAuthors(agentConfigurations),
       workspace: auth.getNonNullableWorkspace(),
     },
   };
@@ -37,6 +44,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
 const AssistantDetailsPage = ({
   agentConfigurations,
+  authors,
   workspace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { isDark } = useTheme();
@@ -50,70 +58,82 @@ const AssistantDetailsPage = ({
       </h3>
       <Page.Vertical align="stretch">
         <ContextItem.List>
-          {agentConfigurations.map((a) => (
-            <ContextItem
-              key={a.version}
-              title={`@${a.name} (${a.sId}) v${a.version}`}
-              visual={<></>}
-            >
-              <ContextItem.Description>
-                <div className="flex flex-col gap-2">
-                  <div className="ml-4 pt-2 text-sm text-muted-foreground">
-                    <div className="font-bold">Created At:</div>
-                    <div>{`${a.versionCreatedAt}`}</div>
-                  </div>
-                  <div className="ml-4 pt-2 text-sm text-muted-foreground">
-                    <div className="font-bold">Scope:</div>
-                    <div>{a.scope}</div>
-                  </div>
-                  <div className="ml-4 pt-2 text-sm text-muted-foreground">
-                    <div className="font-bold">versionAuthorId:</div>
-                    <div>{a.versionAuthorId}</div>
-                  </div>
-                  <div className="ml-4 pt-2 text-sm text-muted-foreground">
-                    <div className="font-bold">Description:</div>
-                    <div>{a.description}</div>
-                  </div>
-                  <div className="ml-4 text-sm text-muted-foreground">
-                    <div className="font-bold">Instructions:</div>
-                    <TextArea placeholder="" value={a.instructions ?? ""} />
-                  </div>
-                  <div className="ml-4 text-sm text-muted-foreground">
-                    <div className="font-bold">
-                      Model:{" "}
-                      {SUPPORTED_MODEL_CONFIGS.find(
-                        (m) => m.modelId === a.model.modelId
-                      )?.displayName ?? `Unknown Model (${a.model.modelId})`}
+          {agentConfigurations.map((a) => {
+            const author = authors.find(
+              (user) => user.id === a.versionAuthorId
+            );
+            return (
+              <ContextItem
+                key={a.version}
+                title={`@${a.name} (${a.sId}) v${a.version}`}
+                visual={<></>}
+              >
+                <ContextItem.Description>
+                  <div className="flex flex-col gap-2">
+                    <div className="ml-4 pt-2 text-sm text-muted-foreground">
+                      <div className="font-bold">Created At:</div>
+                      <div>{`${a.versionCreatedAt}`}</div>
                     </div>
-                    <JsonViewer
-                      theme={isDark ? "dark" : "light"}
-                      value={a.model}
-                      rootName={false}
-                      defaultInspectDepth={0}
-                    />
-                  </div>
-                  <div className="ml-4 text-sm text-muted-foreground">
-                    {a.actions.map((action, index) => (
-                      <div key={index}>
-                        <div className="font-bold">
-                          Action {index + 1}: {action.type} (
-                          {action.type === "retrieval_configuration" &&
-                            (action.query === "auto" ? "search" : "include")}
-                          )
+                    <div className="ml-4 pt-2 text-sm text-muted-foreground">
+                      <div className="font-bold">Scope:</div>
+                      <div>{a.scope}</div>
+                    </div>
+                    <div className="ml-4 pt-2 text-sm text-muted-foreground">
+                      <div className="font-bold">Author:</div>
+                      <div>ID: {a.versionAuthorId}</div>
+                      {author && (
+                        <div>
+                          Name: {author.fullName}
+                          <br />
+                          Email: {author.email}
                         </div>
-                        <JsonViewer
-                          theme={isDark ? "dark" : "light"}
-                          value={action}
-                          rootName={false}
-                          defaultInspectDepth={0}
-                        />
+                      )}
+                    </div>
+                    <div className="ml-4 pt-2 text-sm text-muted-foreground">
+                      <div className="font-bold">Description:</div>
+                      <div>{a.description}</div>
+                    </div>
+                    <div className="ml-4 text-sm text-muted-foreground">
+                      <div className="font-bold">Instructions:</div>
+                      <TextArea placeholder="" value={a.instructions ?? ""} />
+                    </div>
+                    <div className="ml-4 text-sm text-muted-foreground">
+                      <div className="font-bold">
+                        Model:{" "}
+                        {SUPPORTED_MODEL_CONFIGS.find(
+                          (m) => m.modelId === a.model.modelId
+                        )?.displayName ?? `Unknown Model (${a.model.modelId})`}
                       </div>
-                    ))}
+                      <JsonViewer
+                        theme={isDark ? "dark" : "light"}
+                        value={a.model}
+                        rootName={false}
+                        defaultInspectDepth={0}
+                      />
+                    </div>
+                    <div className="ml-4 text-sm text-muted-foreground">
+                      {a.actions.map((action, index) => (
+                        <div key={index}>
+                          <div className="font-bold">
+                            Action {index + 1}: {action.type} (
+                            {action.type === "retrieval_configuration" &&
+                              (action.query === "auto" ? "search" : "include")}
+                            )
+                          </div>
+                          <JsonViewer
+                            theme={isDark ? "dark" : "light"}
+                            value={action}
+                            rootName={false}
+                            defaultInspectDepth={0}
+                          />
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              </ContextItem.Description>
-            </ContextItem>
-          ))}
+                </ContextItem.Description>
+              </ContextItem>
+            );
+          })}
         </ContextItem.List>
       </Page.Vertical>
     </div>


### PR DESCRIPTION
## Description

On poké on the assistant page, we were displaying only the user id as Author. 
This PR improves this to display also the full name and email of the author. 

<kbd>
<img width="258" alt="Screenshot 2025-05-20 at 15 59 57" src="https://github.com/user-attachments/assets/25932221-1466-4286-b8b9-19ddf1e54df1" />
</kbd>

Review with hidden whitespaces advised!

## Tests

Locally. 

## Risk

/

## Deploy Plan

Deploy front. 
