### PR TITLE
[front] chore: Add workspaceId filter when getting groups from auth

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -652,6 +652,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         },
       ],
       where: {
+        workspaceId: workspace.id,
         kind: {
           // The 'as' clause is tautological but required by TS who does not
           // understand that groupKinds.filter() returns a GroupKind[]


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/2842
- Add missing `workspaceId` to `listUserGroupsInWorkspace`,  workspaceId was filtered in the join query on GroupMembershipModel, so adding is fine.

## Tests
- Locally

## Risk
- High as it touches auth, but very easy to revert

## Deploy Plan
- Deploy front
