### PR TITLE
Improve flexibility for generated extract schema parsing

### DIFF
--- a/front/lib/actions/process.ts
+++ b/front/lib/actions/process.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import _, { isObject } from "lodash";
 
 import {
   generateJSONFileAndSnippet,
@@ -44,6 +44,7 @@ import type {
   UserMessageType,
 } from "@app/types";
 import {
+  isString,
   Ok,
   parseTimeFrame,
   removeNulls,
@@ -275,12 +276,12 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
     }
     if (!actionConfiguration.jsonSchema) {
       if (rawInputs.schema) {
-        if (typeof rawInputs.schema === "string") {
+        if (isString(rawInputs.schema)) {
           const res = safeParseJSON(rawInputs.schema);
           if (res.isOk()) {
             actionConfiguration.jsonSchema = res.value;
           }
-        } else if (typeof rawInputs.schema === "object") {
+        } else if (isObject(rawInputs.schema)) {
           actionConfiguration.jsonSchema = rawInputs.schema;
         }
       }

--- a/front/lib/actions/process.ts
+++ b/front/lib/actions/process.ts
@@ -274,10 +274,14 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
       }
     }
     if (!actionConfiguration.jsonSchema) {
-      if (rawInputs.schema && typeof rawInputs.schema === "string") {
-        const res = safeParseJSON(rawInputs.schema);
-        if (res.isOk()) {
-          actionConfiguration.jsonSchema = res.value;
+      if (rawInputs.schema) {
+        if (typeof rawInputs.schema === "string") {
+          const res = safeParseJSON(rawInputs.schema);
+          if (res.isOk()) {
+            actionConfiguration.jsonSchema = res.value;
+          }
+        } else if (typeof rawInputs.schema === "object") {
+          actionConfiguration.jsonSchema = rawInputs.schema;
         }
       }
     }


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/2859
* Seeing that the multi-action app is generating an object parameter for schema intermittently, despite being prompted for a string parameter type. Adding flexibility to handle either outcome.

## Tests

* Manual JIT extract run locally

## Risk

* Minimal - should add flexibility

## Deploy Plan

* Deploy front