### PR TITLE
enh(gdrive) add more heartbeats to incremental sync

### DIFF
--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -3,6 +3,7 @@ import { Op } from "sequelize";
 
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { GoogleDriveFolders } from "@connectors/lib/models/google_drive";
+import { heartbeat } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 import type { GoogleDriveObjectType } from "@connectors/types";
@@ -31,6 +32,7 @@ async function getFileParents(
   const parents: string[] = [driveFile.id];
   let currentObject = driveFile;
   while (currentObject.parent) {
+    await heartbeat();
     const parent = await getGoogleDriveObject({
       connectorId,
       authCredentials,

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -422,6 +422,8 @@ export async function incrementalSync(
         driveId: driveId,
       };
     }
+
+    await heartbeat();
     const changesRes: GaxiosResponse<drive_v3.Schema$ChangeList> =
       await driveClient.changes.list(opts);
 
@@ -515,6 +517,7 @@ export async function incrementalSync(
 
       const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
+      await heartbeat();
       const driveFile: GoogleDriveObjectType = await driveObjectToDustType(
         connectorId,
         change.file,
@@ -571,6 +574,7 @@ export async function incrementalSync(
 
         continue;
       } else {
+        await heartbeat();
         await syncOneFile(
           connectorId,
           authCredentials,


### PR DESCRIPTION
## Description

We're seeing some heartbeat timeouts on gdrive incremental sync. Attempting to resolve the issue by adding more hearbeat calls
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
