### PR TITLE
Edit labs transcript to use sId; Use user auth to detect new transcripts

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -397,7 +397,7 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error("Missing --cId argument");
       }
       const transcriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchByModelId(args.cId);
+        await LabsTranscriptsConfigurationResource.fetchById(args.cId);
 
       if (!transcriptsConfiguration) {
         throw new Error(
@@ -421,7 +421,7 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error("Missing --cId argument");
       }
       const transcriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchByModelId(args.cId);
+        await LabsTranscriptsConfigurationResource.fetchById(args.cId);
 
       if (!transcriptsConfiguration) {
         throw new Error(

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -461,14 +461,9 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
       const allWorkspaces = await Workspace.findAll();
       let activeConfigSIds: string[] = [];
       for (const ws of allWorkspaces) {
-        const configs = await LabsTranscriptsConfigurationModel.findAll({
-          where: { workspaceId: ws.id },
-        });
-        for (const configModel of configs) {
-          const config = new LabsTranscriptsConfigurationResource(
-            LabsTranscriptsConfigurationModel,
-            configModel.get()
-          );
+        const configs =
+          await LabsTranscriptsConfigurationResource.findByWorkspaceId(ws.id);
+        for (const config of configs) {
           if (config.isActive === true || !!config.dataSourceViewId) {
             activeConfigSIds.push(config.sId);
             if (execute) {

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -99,10 +99,14 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       return [];
     }
 
+    return LabsTranscriptsConfigurationResource.findByWorkspaceId(owner.id);
+  }
+
+  static async findByWorkspaceId(
+    workspaceId: number
+  ): Promise<LabsTranscriptsConfigurationResource[]> {
     const configurations = await LabsTranscriptsConfigurationModel.findAll({
-      where: {
-        workspaceId: owner.id,
-      },
+      where: { workspaceId },
     });
 
     return configurations.map(

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -14,11 +14,13 @@ import {
   LabsTranscriptsHistoryModel,
 } from "@app/lib/resources/storage/models/labs_transcripts";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   LabsTranscriptsConfigurationType,
   LabsTranscriptsProviderType,
   LightWorkspaceType,
+  ModelId,
   Result,
 } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
@@ -145,6 +147,27 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       : null;
   }
 
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("transcripts_configuration", { id, workspaceId });
+  }
+
+  static async fetchById(
+    sId: string,
+    transaction?: Transaction
+  ): Promise<LabsTranscriptsConfigurationResource | null> {
+    const resourceId = getResourceIdFromSId(sId);
+    if (!resourceId) {
+      return null;
+    }
+    return this.fetchByModelId(resourceId, transaction);
+  }
+
   async getUser(): Promise<UserResource | null> {
     return UserResource.fetchByModelId(this.userId);
   }
@@ -234,12 +257,27 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
   /**
    * History
    */
-
-  async recordHistory(
-    blob: Omit<CreationAttributes<LabsTranscriptsHistoryModel>, "id">
-  ): Promise<InferAttributes<LabsTranscriptsHistoryModel>> {
-    const history = await LabsTranscriptsHistoryModel.create(blob);
-
+  async recordHistory({
+    workspace,
+    fileId,
+    fileName,
+    conversationId,
+    stored,
+  }: {
+    workspace: LightWorkspaceType;
+    fileId: string;
+    fileName: string;
+    conversationId?: string | null;
+    stored?: boolean;
+  }): Promise<InferAttributes<LabsTranscriptsHistoryModel>> {
+    const history = await LabsTranscriptsHistoryModel.create({
+      configurationId: this.id,
+      workspaceId: workspace.id,
+      fileId,
+      fileName,
+      conversationId: conversationId,
+      stored: stored,
+    });
     return history.get();
   }
 
@@ -323,6 +361,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
   toJSON(): LabsTranscriptsConfigurationType {
     return {
       id: this.id,
+      sId: this.sId,
       workspaceId: this.workspaceId,
       provider: this.provider,
       agentConfigurationId: this.agentConfigurationId,
@@ -332,5 +371,12 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       dataSourceViewId: this.dataSourceViewId,
       useConnectorConnection: this.useConnectorConnection,
     };
+  }
+
+  get sId(): string {
+    return LabsTranscriptsConfigurationResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
   }
 }

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -33,13 +33,14 @@ const RESOURCES_PREFIX = {
   mcp_server_view: "msv",
   remote_mcp_server: "rms",
   tag: "tag",
+  transcripts_configuration: "tsc",
 
   // Resources relative to the configuration of an MCP server.
   data_source_configuration: "dsc",
   table_configuration: "tbc",
   child_agent_configuration: "cac",
 
-  // Virtual resources (no database modelsassociated).
+  // Virtual resources (no database models associated).
   internal_mcp_server: "ims",
 };
 

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -112,7 +112,7 @@ export function useUpdateTranscriptsConfiguration({
     data: Partial<PatchTranscriptsConfiguration>
   ): Promise<Result<undefined, Error>> => {
     const response = await fetch(
-      `/api/w/${owner.sId}/labs/transcripts/${transcriptsConfiguration.id}`,
+      `/api/w/${owner.sId}/labs/transcripts/${transcriptsConfiguration.sId}`,
       {
         method: "PATCH",
         headers: {

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -63,7 +63,7 @@ async function handler(
   }
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchByModelId(
+    await LabsTranscriptsConfigurationResource.fetchById(
       transcriptsConfigurationId
     );
   // TODO(2024-04-19 flav) Consider adding auth to `fetchById` to move this permission check within the method.
@@ -121,7 +121,7 @@ async function handler(
       if (isActive !== undefined) {
         logger.info(
           {
-            configurationId: transcriptsConfiguration.id,
+            configurationId: transcriptsConfiguration.sId,
             isActive,
           },
           "Setting transcript configuration active status."
@@ -166,8 +166,8 @@ async function handler(
       }
 
       const updatedTranscriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.fetchByModelId(
-          transcriptsConfiguration.id
+        await LabsTranscriptsConfigurationResource.fetchById(
+          transcriptsConfiguration.sId
         );
 
       if (!updatedTranscriptsConfiguration) {
@@ -187,7 +187,7 @@ async function handler(
       if (shouldStartWorkflow) {
         logger.info(
           {
-            configurationId: updatedTranscriptsConfiguration.id,
+            configurationId: updatedTranscriptsConfiguration.sId,
           },
           "Starting transcript retrieval workflow."
         );

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -78,7 +78,7 @@ async function handler(
       }
 
       return res.status(200).json({
-        configuration: transcriptsConfiguration,
+        configuration: transcriptsConfiguration.toJSON(),
       });
   }
 }

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -24,7 +24,6 @@ import { useLabsTranscriptsConfiguration } from "@app/lib/swr/labs";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type {
   DataSourceViewType,
-  ModelId,
   SubscriptionType,
   WhitelistableFeature,
   WorkspaceType,
@@ -93,7 +92,7 @@ export default function LabsTranscriptsIndex({
   const sendNotification = useSendNotification();
 
   const handleDisconnectProvider = async (
-    transcriptConfigurationId: ModelId | null
+    transcriptConfigurationId: string | null
   ) => {
     if (!transcriptConfigurationId) {
       return;
@@ -168,7 +167,7 @@ export default function LabsTranscriptsIndex({
           onClose={() => setIsDeleteProviderDialogOpened(false)}
           onConfirm={async () => {
             await handleDisconnectProvider(
-              transcriptsConfiguration?.id || null
+              transcriptsConfiguration?.sId || null
             );
           }}
         />

--- a/front/poke/swr/agent_configurations.ts
+++ b/front/poke/swr/agent_configurations.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -42,14 +42,14 @@ import { Err } from "@app/types";
 import { CoreAPI } from "@app/types";
 
 export async function retrieveNewTranscriptsActivity(
-  transcriptsConfigurationId: ModelId
+  transcriptsConfigurationId: string
 ): Promise<string[]> {
   const localLogger = mainLogger.child({
-    transcriptsConfigurationId,
+    transcriptsConfigurationId: transcriptsConfigurationId,
   });
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchByModelId(
+    await LabsTranscriptsConfigurationResource.fetchById(
       transcriptsConfigurationId
     );
 
@@ -129,7 +129,7 @@ export async function retrieveNewTranscriptsActivity(
 }
 
 export async function processTranscriptActivity(
-  transcriptsConfigurationId: ModelId,
+  transcriptsConfigurationId: string,
   fileId: string
 ) {
   function convertCitationsToLinks(
@@ -187,7 +187,7 @@ export async function processTranscriptActivity(
   }
 
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.fetchByModelId(
+    await LabsTranscriptsConfigurationResource.fetchById(
       transcriptsConfigurationId
     );
 
@@ -342,10 +342,9 @@ export async function processTranscriptActivity(
 
   try {
     await transcriptsConfiguration.recordHistory({
-      configurationId: transcriptsConfiguration.id,
       fileId,
       fileName: transcriptTitle.substring(0, 255),
-      workspaceId: owner.id,
+      workspace: owner,
     });
   } catch (error) {
     if (error instanceof UniqueConstraintError) {

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -74,7 +74,18 @@ export async function retrieveNewTranscriptsActivity(
     );
   }
 
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const user = await UserResource.fetchByModelId(
+    transcriptsConfiguration.userId
+  );
+  if (!user) {
+    await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
+    localLogger.error({}, "[retrieveNewTranscripts] User not found. Stopping.");
+    return [];
+  }
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
 
   if (!auth.workspace()) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);

--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -18,12 +18,12 @@ export async function launchRetrieveTranscriptsWorkflow(
 
   try {
     await client.workflow.start(retrieveNewTranscriptsWorkflow, {
-      args: [transcriptsConfiguration.id],
+      args: [transcriptsConfiguration.sId],
       taskQueue: TRANSCRIPTS_QUEUE_NAME,
       workflowId: workflowId,
       cronSchedule: "*/5 * * * *",
       memo: {
-        configurationId: transcriptsConfiguration.id,
+        configurationId: transcriptsConfiguration.sId,
         IsProcessingTranscripts: transcriptsConfiguration.isActive,
         IsStoringTranscripts:
           transcriptsConfiguration.dataSourceViewId !== null,

--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -18,7 +18,7 @@ export async function launchRetrieveTranscriptsWorkflow(
 
   try {
     await client.workflow.start(retrieveNewTranscriptsWorkflow, {
-      args: [transcriptsConfiguration],
+      args: [transcriptsConfiguration.sId],
       taskQueue: TRANSCRIPTS_QUEUE_NAME,
       workflowId: workflowId,
       cronSchedule: "*/5 * * * *",

--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -18,7 +18,7 @@ export async function launchRetrieveTranscriptsWorkflow(
 
   try {
     await client.workflow.start(retrieveNewTranscriptsWorkflow, {
-      args: [transcriptsConfiguration.sId],
+      args: [transcriptsConfiguration],
       taskQueue: TRANSCRIPTS_QUEUE_NAME,
       workflowId: workflowId,
       cronSchedule: "*/5 * * * *",

--- a/front/temporal/labs/transcripts/config.ts
+++ b/front/temporal/labs/transcripts/config.ts
@@ -1,3 +1,3 @@
-const QUEUE_VERSION = 1;
+const QUEUE_VERSION = 2;
 
 export const TRANSCRIPTS_QUEUE_NAME = `labs-transcripts-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/labs/transcripts/utils.ts
+++ b/front/temporal/labs/transcripts/utils.ts
@@ -8,11 +8,11 @@ export function makeRetrieveTranscriptWorkflowId(
 }
 
 export function makeProcessTranscriptWorkflowId({
-  transcriptsConfiguration,
+  transcriptsConfigurationId,
   fileId,
 }: {
-  transcriptsConfiguration: LabsTranscriptsConfigurationResource;
+  transcriptsConfigurationId: string;
   fileId: string;
 }): string {
-  return `labs-transcripts-process-${transcriptsConfiguration.id}-${fileId}`;
+  return `labs-transcripts-process-${transcriptsConfigurationId}-${fileId}`;
 }

--- a/front/temporal/labs/transcripts/utils.ts
+++ b/front/temporal/labs/transcripts/utils.ts
@@ -4,14 +4,14 @@ import type { ModelId } from "@app/types";
 export function makeRetrieveTranscriptWorkflowId(
   transcriptsConfiguration: LabsTranscriptsConfigurationResource
 ): string {
-  return `labs-transcripts-retrieve-${transcriptsConfiguration.id}`;
+  return `labs-transcripts-retrieve-${transcriptsConfiguration.sId}`;
 }
 
 export function makeProcessTranscriptWorkflowId({
   transcriptsConfigurationId,
   fileId,
 }: {
-  transcriptsConfigurationId: ModelId;
+  transcriptsConfigurationId: string;
   fileId: string;
 }): string {
   return `labs-transcripts-process-${transcriptsConfigurationId}-${fileId}`;

--- a/front/temporal/labs/transcripts/utils.ts
+++ b/front/temporal/labs/transcripts/utils.ts
@@ -4,15 +4,15 @@ import type { ModelId } from "@app/types";
 export function makeRetrieveTranscriptWorkflowId(
   transcriptsConfiguration: LabsTranscriptsConfigurationResource
 ): string {
-  return `labs-transcripts-retrieve-${transcriptsConfiguration.sId}`;
+  return `labs-transcripts-retrieve-${transcriptsConfiguration.id}`;
 }
 
 export function makeProcessTranscriptWorkflowId({
-  transcriptsConfigurationId,
+  transcriptsConfiguration,
   fileId,
 }: {
-  transcriptsConfigurationId: string;
+  transcriptsConfiguration: LabsTranscriptsConfigurationResource;
   fileId: string;
 }): string {
-  return `labs-transcripts-process-${transcriptsConfigurationId}-${fileId}`;
+  return `labs-transcripts-process-${transcriptsConfiguration.id}-${fileId}`;
 }

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -209,7 +209,7 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.id,
+          transcriptsConfigurationId: transcriptsConfiguration.sId,
         },
         "[retrieveGongTranscripts] User not found. Skipping."
       );
@@ -232,7 +232,7 @@ export async function retrieveGongTranscriptContent(
         localLogger.error(
           {
             fileId,
-            transcriptsConfigurationId: transcriptsConfiguration.id,
+            transcriptsConfigurationId: transcriptsConfiguration.sId,
             status: response.status,
           },
           "[retrieveGongTranscripts] Error fetching Gong users. Skipping."
@@ -264,7 +264,7 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.id,
+          transcriptsConfigurationId: transcriptsConfiguration.sId,
           userEmail: user.email,
         },
         "[retrieveGongTranscripts] Gong user not found. Skipping."
@@ -297,7 +297,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[retrieveGongTranscripts] Error fetching call from Gong. Skipping."
     );
@@ -317,7 +317,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[retrieveGongTranscripts] Call data not found from Gong. Skipping."
     );

--- a/front/temporal/labs/transcripts/utils/modjo.ts
+++ b/front/temporal/labs/transcripts/utils/modjo.ts
@@ -340,7 +340,7 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[processTranscriptActivity] Error fetching call from Modjo. Skipping."
     );
@@ -364,7 +364,7 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[processTranscriptActivity] Call data not found from Modjo. Skipping."
     );

--- a/front/temporal/labs/transcripts/workflows.ts
+++ b/front/temporal/labs/transcripts/workflows.ts
@@ -6,7 +6,6 @@ import {
 
 import type * as activities from "./activities";
 import { makeProcessTranscriptWorkflowId } from "./utils";
-import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 
 const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
   proxyActivities<typeof activities>({
@@ -14,20 +13,19 @@ const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
   });
 
 export async function retrieveNewTranscriptsWorkflow(
-  transcriptsConfiguration: LabsTranscriptsConfigurationResource
+  transcriptsConfigurationId: string
 ) {
   const filesToProcess = await retrieveNewTranscriptsActivity(
-    transcriptsConfiguration.sId
+    transcriptsConfigurationId
   );
 
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
   for (const fileId of filesToProcess) {
     const workflowId = makeProcessTranscriptWorkflowId({
-      transcriptsConfiguration,
+      transcriptsConfigurationId,
       fileId,
     });
-    const transcriptsConfigurationId = transcriptsConfiguration.sId;
     await executeChild(processTranscriptWorkflow, {
       workflowId,
       searchAttributes: parentSearchAttributes,

--- a/front/temporal/labs/transcripts/workflows.ts
+++ b/front/temporal/labs/transcripts/workflows.ts
@@ -4,8 +4,6 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
-import type { ModelId } from "@app/types";
-
 import type * as activities from "./activities";
 import { makeProcessTranscriptWorkflowId } from "./utils";
 
@@ -15,7 +13,7 @@ const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
   });
 
 export async function retrieveNewTranscriptsWorkflow(
-  transcriptsConfigurationId: ModelId
+  transcriptsConfigurationId: string
 ) {
   const filesToProcess = await retrieveNewTranscriptsActivity(
     transcriptsConfigurationId
@@ -47,7 +45,7 @@ export async function processTranscriptWorkflow({
   transcriptsConfigurationId,
 }: {
   fileId: string;
-  transcriptsConfigurationId: ModelId;
+  transcriptsConfigurationId: string;
 }): Promise<void> {
   await processTranscriptActivity(transcriptsConfigurationId, fileId);
 }

--- a/front/temporal/labs/transcripts/workflows.ts
+++ b/front/temporal/labs/transcripts/workflows.ts
@@ -6,6 +6,7 @@ import {
 
 import type * as activities from "./activities";
 import { makeProcessTranscriptWorkflowId } from "./utils";
+import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 
 const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
   proxyActivities<typeof activities>({
@@ -13,19 +14,20 @@ const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
   });
 
 export async function retrieveNewTranscriptsWorkflow(
-  transcriptsConfigurationId: string
+  transcriptsConfiguration: LabsTranscriptsConfigurationResource
 ) {
   const filesToProcess = await retrieveNewTranscriptsActivity(
-    transcriptsConfigurationId
+    transcriptsConfiguration.sId
   );
 
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
   for (const fileId of filesToProcess) {
     const workflowId = makeProcessTranscriptWorkflowId({
-      transcriptsConfigurationId,
+      transcriptsConfiguration,
       fileId,
     });
+    const transcriptsConfigurationId = transcriptsConfiguration.sId;
     await executeChild(processTranscriptWorkflow, {
       workflowId,
       searchAttributes: parentSearchAttributes,

--- a/front/types/labs.ts
+++ b/front/types/labs.ts
@@ -24,6 +24,7 @@ export type LabsConnectionType = (typeof labsConnections)[number];
 
 export type LabsTranscriptsConfigurationType = {
   id: ModelId;
+  sId: string;
   workspaceId: ModelId;
   provider: LabsTranscriptsProviderType;
   agentConfigurationId: string | null;


### PR DESCRIPTION
## Description

* Undoing revert for -> https://github.com/dust-tt/dust/pull/12610 - This was reverted given that I realized that we did not have a good script to pause / restart workflows.
* Adding script to pause then restart workflows
* Using user auth instead of admin auth in new transcript activity

## Tests

* Performed pause/restart locally. Able to see transcripts processed successfully.

## Risk

* Scoped to labs 

## Deploy Plan

1. pause transcript workflows
2. deploy front
3. restart transcript workflows that were paused