### PR TITLE
Add logic for Hubspot In/Not In filters

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -209,16 +209,16 @@ export const getObjectByEmail = async (
   return objects.results[0];
 };
 
-function buildHubspotFilters(
-  filters: Array<{
-    propertyName: string;
-    operator: FilterOperatorEnum;
-    value?: string;
-    values?: string[];
-  }>
-) {
+interface HubspotFilter {
+  propertyName: string;
+  operator: FilterOperatorEnum;
+  value?: string;
+  values?: string[];
+}
+
+function buildHubspotFilters(filters: Array<HubspotFilter>) {
   return filters.map(({ propertyName, operator, value, values }) => {
-    const filter: any = {
+    const filter: HubspotFilter = {
       propertyName,
       operator,
     };
@@ -233,7 +233,11 @@ function buildHubspotFilters(
         operator === FilterOperatorEnum.NotIn
       ) {
         // For string properties, values must be lowercase
-        filter.values = values?.map((v) => v.toLowerCase());
+        if (values?.length) {
+          filter.values = values?.map((v) => v.toLowerCase());
+        } else {
+          throw new Error(`Values array is required for ${operator} operator`);
+        }
       } else {
         filter.value = value;
       }

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -168,7 +168,16 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
             operator: z
               .nativeEnum(FilterOperatorEnum)
               .describe("The operator to use for comparison."),
-            value: z.string().describe("The value to compare against."),
+            value: z
+              .string()
+              .optional()
+              .describe("The value to compare against"),
+            values: z
+              .array(z.string())
+              .optional()
+              .describe(
+                "The values to compare against. Required for IN/NOT_IN operators."
+              ),
           })
         )
         .describe("Array of property filters to apply."),
@@ -205,7 +214,16 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
             operator: z
               .nativeEnum(FilterOperatorEnum)
               .describe("The operator to use for comparison."),
-            value: z.string().describe("The value to compare against."),
+            value: z
+              .string()
+              .optional()
+              .describe("The value to compare against"),
+            values: z
+              .array(z.string())
+              .optional()
+              .describe(
+                "The values to compare against. Required for IN/NOT_IN operators."
+              ),
           })
         )
         .describe("Array of property filters to apply."),


### PR DESCRIPTION
## Description

* Found a quirk in the Hubspot APIs. The In / not In filters require the values property, not value. This is preventing implementation of a subset of Hubspot use cases - https://developers.hubspot.com/docs/guides/api/crm/search

## Tests

```
Inputs
{
  "filters": [
    {
      "values": [
        "default",
        "Prospect pipeline"
      ],
      "operator": "IN",
      "propertyName": "pipeline"
    }
  ],
  "objectType": "deals"
}

Output
Operation completed successfully
[
```

## Risk

* Scoped to hubspot MCP

## Deploy Plan

* Deploy front