### PR TITLE
[front] mcp: move sharedSecret to Bearer

### DIFF
--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -289,15 +289,19 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
                 <>
                   <Input
                     {...field}
-                    label="Bearer Token"
+                    label="Bearer Token (Authorization)"
                     isError={!!form.formState.errors.sharedSecret}
                     message={form.formState.errors.sharedSecret?.message}
-                    placeholder="Paste the bearer here"
+                    placeholder="Paste the Bearer Token here"
                   />
                   <p className="text-xs text-gray-500 dark:text-gray-500-night">
                     This will be sent alongside the request made to your server
-                    as a Bearer token.
+                    as a Bearer token in the headers.
                   </p>
+                  {/** NOTE: Once we implemented the OAuth flow for remote servers
+                   * we should remove this field if the server is using OAuth.
+                   * It's one or the other.
+                   */}
                 </>
               )}
             />

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -167,14 +167,16 @@ export const connectToMCPServer = async (
                   createSSRFInterceptor()
                 ),
                 headers: {
-                  ...(accessToken
-                    ? { Authorization: `Bearer ${accessToken}` }
-                    : {}),
                   ...(remoteMCPServer.sharedSecret
                     ? {
                         Authorization: `Bearer ${remoteMCPServer.sharedSecret}`,
                       }
                     : {}),
+                  ...(accessToken
+                    ? { Authorization: `Bearer ${accessToken}` }
+                    : {}),
+                  // NOTE: For now, we are not using the access token. Once it's used,
+                  // it will take over the shared secret Bearer. This is intended.
                 },
               },
             };

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -171,7 +171,9 @@ export const connectToMCPServer = async (
                     ? { Authorization: `Bearer ${accessToken}` }
                     : {}),
                   ...(remoteMCPServer.sharedSecret
-                    ? { "X-Dust-Secret": remoteMCPServer.sharedSecret }
+                    ? {
+                        Authorization: `Bearer ${remoteMCPServer.sharedSecret}`,
+                      }
                     : {}),
                 },
               },

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -53,7 +53,7 @@ export type RemoteMCPServerType = MCPServerType & {
   url?: string;
   cachedName?: string;
   cachedDescription?: string | null;
-  sharedSecret?: string;
+  sharedSecret?: string | null;
   lastSyncAt?: Date | null;
   icon: RemoteAllowedIconType; // We enforce that we pass an icon here (among the ones we allow).
 };

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -23,7 +23,7 @@ export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerMod
   declare cachedTools: MCPToolType[];
 
   declare lastSyncAt: Date | null;
-  declare sharedSecret: string;
+  declare sharedSecret: string | null;
   declare authorization: AuthorizationInfo | null;
 }
 
@@ -79,7 +79,7 @@ RemoteMCPServerModel.init(
     },
     sharedSecret: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     authorization: {
       type: DataTypes.JSONB,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -194,12 +194,17 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
 
   const createWithUrlSync = async (
     url: string,
-    includeGlobal: boolean
+    includeGlobal: boolean,
+    sharedSecret?: string
   ): Promise<CreateMCPServerResponseBody> => {
+    const body: any = { url, serverType: "remote", includeGlobal };
+    if (sharedSecret) {
+      body.sharedSecret = sharedSecret;
+    }
     const response = await fetch(`/api/w/${owner.sId}/mcp`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ url, serverType: "remote", includeGlobal }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {
@@ -290,6 +295,7 @@ export function useUpdateRemoteMCPServer(
     name: string;
     icon: string;
     description: string;
+    sharedSecret?: string;
   }): Promise<PatchMCPServerResponseBody> => {
     const response = await fetch(`/api/w/${owner.sId}/mcp/${serverId}`, {
       method: "PATCH",

--- a/front/migrations/db/migration_268.sql
+++ b/front/migrations/db/migration_268.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 20, 2025
+ALTER TABLE "remote_mcp_servers" ALTER COLUMN "sharedSecret" DROP NOT NULL;ALTER TABLE "remote_mcp_servers" ALTER COLUMN "sharedSecret" DROP DEFAULT;ALTER TABLE "remote_mcp_servers" ALTER COLUMN "sharedSecret" TYPE VARCHAR(255);

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -116,9 +116,9 @@ async function handler(
         });
       }
 
-      const { name, icon, description } = req.body;
+      const { name, icon, description, sharedSecret } = req.body;
 
-      if (!name && !icon && !description) {
+      if (!name && !icon && !description && !sharedSecret) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -132,6 +132,7 @@ async function handler(
         name,
         icon,
         description,
+        sharedSecret,
         lastSyncAt: new Date(),
       });
 

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -35,6 +35,7 @@ const PostQueryParamsSchema = t.union([
     serverType: t.literal("remote"),
     url: t.string,
     includeGlobal: t.union([t.boolean, t.undefined]),
+    sharedSecret: t.union([t.string, t.undefined]),
   }),
   t.type({
     serverType: t.literal("internal"),
@@ -96,7 +97,7 @@ async function handler(
 
       const body = r.right;
       if (body.serverType === "remote") {
-        const { url } = body;
+        const { url, sharedSecret } = body;
 
         if (!url) {
           return apiError(req, res, {
@@ -147,6 +148,7 @@ async function handler(
             ? metadata.icon
             : DEFAULT_MCP_SERVER_ICON,
           version: metadata.version,
+          sharedSecret: sharedSecret || null,
         });
 
         if (body.includeGlobal) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Move the "X-Dust-Shared-Secret" to a Bearer token.
It still is named sharedSecret in the code.
It is now optional.
It's editable in the Remote MCP Server Modal.

<img width="565" alt="Capture d’écran 2025-05-21 à 09 00 32" src="https://github.com/user-attachments/assets/b90b1ab8-876f-4106-9277-ba5cf59ec08e" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Created some by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks, safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Apply migration.
Deploy front.