### PR TITLE
[front] Create tags only on active agents

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -956,28 +956,28 @@ export async function createAgentConfiguration(
         throw new Error("Cannot remove reserved tag from agent");
       }
 
-      for (const tag of tags) {
-        const tagResource = await TagResource.fetchById(auth, tag.sId);
-        if (tagResource) {
-          if (
-            !isBuilder(owner) &&
-            tagResource.kind === "protected" &&
-            !existingReservedTags.includes(tagResource.sId)
-          ) {
-            throw new Error("Cannot add reserved tag to agent");
-          }
-          await TagAgentModel.create(
-            {
-              workspaceId: owner.id,
-              tagId: tagResource.id,
-              agentConfigurationId: agentConfigurationInstance.id,
-            },
-            { transaction: t }
-          );
-        }
-      }
-
       if (status === "active") {
+        for (const tag of tags) {
+          const tagResource = await TagResource.fetchById(auth, tag.sId);
+          if (tagResource) {
+            if (
+              !isBuilder(owner) &&
+              tagResource.kind === "protected" &&
+              !existingReservedTags.includes(tagResource.sId)
+            ) {
+              throw new Error("Cannot add reserved tag to agent");
+            }
+            await TagAgentModel.create(
+              {
+                workspaceId: owner.id,
+                tagId: tagResource.id,
+                agentConfigurationId: agentConfigurationInstance.id,
+              },
+              { transaction: t }
+            );
+          }
+        }
+
         assert(
           isLegacyAllowed(owner, agentConfigurationInstance.scope) ||
             editors.some((e) => e.sId === auth.user()?.sId) ||


### PR DESCRIPTION
## Description

Don't create tags for draft, it's not needed and this creates error for non-builders while editing company agents

## Tests

locally

## Risk

minimal


## Deploy Plan

deploy front