### PR TITLE
[front] max height to action card and handle more special display name

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -704,6 +704,7 @@ function ActionCard({
   return (
     <Card
       variant="primary"
+      className="max-h-40"
       onClick={editAction}
       action={
         <CardActionButton
@@ -733,11 +734,11 @@ function ActionCard({
             />
           </div>
         ) : (
-          <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
+          <div className="line-clamp-4 text-muted-foreground dark:text-muted-foreground-night">
             {actionError ? (
               <span className="text-warning-500">{actionError}</span>
             ) : (
-              <>{action.description}</>
+              <p className="">{action.description}</p>
             )}
           </div>
         )}

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -738,7 +738,7 @@ function ActionCard({
             {actionError ? (
               <span className="text-warning-500">{actionError}</span>
             ) : (
-              action.description
+              <p>{action.description}</p>
             )}
           </div>
         )}

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -738,7 +738,7 @@ function ActionCard({
             {actionError ? (
               <span className="text-warning-500">{actionError}</span>
             ) : (
-              <p className="">{action.description}</p>
+              action.description
             )}
           </div>
         )}

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -112,6 +112,18 @@ export function hasNullUnicodeCharacter(text: string): boolean {
   return text.includes("\u0000");
 }
 
+const SPECIAL_CASES = {
+  github: "GitHub",
+  hubspot: "HubSpot",
+  mcp: "MCP",
+};
+
+// Create a single regex pattern for all special cases
+const SPECIAL_CASES_PATTERN = new RegExp(
+  Object.keys(SPECIAL_CASES).join("|"),
+  "g"
+);
+
 export function asDisplayName(name?: string | null) {
   if (!name) {
     return "";
@@ -120,6 +132,9 @@ export function asDisplayName(name?: string | null) {
   return name
     .toLowerCase()
     .replace(/_/g, " ")
-    .replace(/github/g, "GitHub")
+    .replace(
+      SPECIAL_CASES_PATTERN,
+      (match) => SPECIAL_CASES[match as keyof typeof SPECIAL_CASES]
+    )
     .replace(/\b\w/g, (char) => char.toUpperCase());
 }


### PR DESCRIPTION
## Description
This PR is to improve a few UI
- Set max height and line clamp for Action Cards in Assistant Builder
- Add more special display name handling 🙈

Action card should look like this when it has long description: 
<img width="296" alt="Screenshot 2025-05-21 at 11 54 14" src="https://github.com/user-attachments/assets/ae18cdc3-a17c-446e-9194-0b1b25f2a048" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
