### PR TITLE
Rename Gong smart trackers to trackers

### DIFF
--- a/connectors/migrations/db/migration_74.sql
+++ b/connectors/migrations/db/migration_74.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 21, 2025
+ALTER TABLE "public"."gong_configurations" ADD COLUMN "trackersEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/connectors/migrations/db/migration_74.sql
+++ b/connectors/migrations/db/migration_74.sql
@@ -1,2 +1,3 @@
 -- Migration created on May 21, 2025
 ALTER TABLE "public"."gong_configurations" ADD COLUMN "trackersEnabled" BOOLEAN NOT NULL DEFAULT false;
+UPDATE "public"."gong_configurations" SET "trackersEnabled" = "smartTrackersEnabled";

--- a/connectors/migrations/db/migration_74.sql
+++ b/connectors/migrations/db/migration_74.sql
@@ -1,3 +1,2 @@
 -- Migration created on May 21, 2025
-ALTER TABLE "public"."gong_configurations" ADD COLUMN "trackersEnabled" BOOLEAN NOT NULL DEFAULT false;
-UPDATE "public"."gong_configurations" SET "trackersEnabled" = "smartTrackersEnabled";
+ALTER TABLE "public"."gong_configurations" RENAME COLUMN "smartTrackersEnabled" TO "trackersEnabled";

--- a/connectors/migrations/db/migration_75.sql
+++ b/connectors/migrations/db/migration_75.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 21, 2025
+ALTER TABLE "public"."gong_configurations" DROP COLUMN "smartTrackersEnabled";

--- a/connectors/migrations/db/migration_75.sql
+++ b/connectors/migrations/db/migration_75.sql
@@ -1,2 +1,0 @@
--- Migration created on May 21, 2025
-ALTER TABLE "public"."gong_configurations" DROP COLUMN "smartTrackersEnabled";

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -41,7 +41,7 @@ const TRANSCRIPTS_FOLDER_TITLE = "Transcripts";
 
 const RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 
-const SMART_TRACKERS_CONFIG_KEY = "gongSmartTrackersEnabled";
+const TRACKERS_CONFIG_KEY = "gongTrackersEnabled";
 
 // This function generates a connector-wise unique schedule ID for the Gong sync.
 // The IDs of the workflows spawned by this schedule will follow the pattern:
@@ -79,7 +79,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       },
       {
         baseUrl: baseUrlRes.value,
-        smartTrackersEnabled: false,
+        trackersEnabled: false,
       }
     );
 
@@ -306,8 +306,8 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
     switch (configKey) {
       case RETENTION_PERIOD_CONFIG_KEY:
         return new Ok(configuration.retentionPeriodDays?.toString() || null);
-      case SMART_TRACKERS_CONFIG_KEY:
-        return new Ok(configuration.smartTrackersEnabled.toString());
+      case TRACKERS_CONFIG_KEY:
+        return new Ok(configuration.trackersEnabled.toString());
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
@@ -357,8 +357,8 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
 
         return new Ok(undefined);
       }
-      case SMART_TRACKERS_CONFIG_KEY: {
-        await configuration.setSmartTrackersEnabled(configValue === "true");
+      case TRACKERS_CONFIG_KEY: {
+        await configuration.setTrackersEnabled(configValue === "true");
 
         return new Ok(undefined);
       }

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -336,7 +336,7 @@ export class GongClient {
   async getCallsMetadata({
     callIds,
     pageCursor = null,
-    trackersEnabled: trackersEnabled = false,
+    trackersEnabled = false,
   }: {
     callIds: string[];
     pageCursor?: string | null;

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -336,11 +336,11 @@ export class GongClient {
   async getCallsMetadata({
     callIds,
     pageCursor = null,
-    smartTrackersEnabled = false,
+    trackersEnabled: trackersEnabled = false,
   }: {
     callIds: string[];
     pageCursor?: string | null;
-    smartTrackersEnabled?: boolean;
+    trackersEnabled?: boolean;
   }): Promise<{
     callsMetadata: GongTranscriptMetadata[];
     nextPageCursor: string | null;
@@ -361,12 +361,12 @@ export class GongClient {
       contentSelector: {
         exposedFields: {
           parties: true,
-          ...(smartTrackersEnabled ? { content: { trackers: true } } : {}),
+          ...(trackersEnabled ? { content: { trackers: true } } : {}),
         },
       },
     };
     try {
-      if (smartTrackersEnabled) {
+      if (trackersEnabled) {
         const callsMetadata = await this.postRequest(
           "/calls/extensive",
           body,

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -68,7 +68,7 @@ export async function getTranscriptsMetadata({
   configuration: GongConfigurationResource;
 }): Promise<GongTranscriptMetadata[]> {
   const gongClient = await getGongClient(connector);
-  const { smartTrackersEnabled } = configuration;
+  const { trackersEnabled } = configuration;
 
   const metadata = [];
   let cursor = null;
@@ -76,7 +76,7 @@ export async function getTranscriptsMetadata({
     const { callsMetadata, nextPageCursor } = await gongClient.getCallsMetadata(
       {
         callIds,
-        smartTrackersEnabled,
+        trackersEnabled,
       }
     );
     metadata.push(...callsMetadata);

--- a/connectors/src/lib/models/gong.ts
+++ b/connectors/src/lib/models/gong.ts
@@ -12,7 +12,7 @@ export class GongConfigurationModel extends ConnectorBaseModel<GongConfiguration
   declare lastGarbageCollectionTimestamp: number | null;
   declare baseUrl: string;
   declare retentionPeriodDays: number | null;
-  declare smartTrackersEnabled: boolean;
+  declare trackersEnabled: boolean;
 }
 
 GongConfigurationModel.init(
@@ -43,7 +43,7 @@ GongConfigurationModel.init(
       type: DataTypes.INTEGER,
       allowNull: true,
     },
-    smartTrackersEnabled: {
+    trackersEnabled: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -101,9 +101,9 @@ export class GongConfigurationResource extends BaseResource<GongConfigurationMod
     return new this(this.model, configuration.get());
   }
 
-  async setSmartTrackersEnabled(smartTrackersEnabled: boolean): Promise<void> {
+  async setTrackersEnabled(trackersEnabled: boolean): Promise<void> {
     await this.update({
-      smartTrackersEnabled,
+      trackersEnabled,
     });
   }
 

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -97,7 +97,7 @@ export function GongOptionComponent({
         description:
           configKey === GONG_RETENTION_PERIOD_CONFIG_KEY
             ? "Retention period successfully updated."
-            : "Smart trackers synchronization successfully enabled.",
+            : "Trackers synchronization successfully enabled.",
       });
     } else {
       setLoading(false);
@@ -164,7 +164,7 @@ export function GongOptionComponent({
         </ContextItem>
 
         <ContextItem
-          title="Enable Smart Trackers"
+          title="Enable Trackers (Keyword and Smart)"
           visual={<ContextItem.Visual visual={GongLogo} />}
           action={
             <div className="relative">
@@ -184,8 +184,8 @@ export function GongOptionComponent({
         >
           <ContextItem.Description>
             <div className="text-muted-foreground dark:text-muted-foreground-night">
-              If activated, Dust will sync the list of smart trackers associated
-              to each call transcript.
+              If activated, Dust will sync the list of keyword and smart
+              trackers associated to each call transcript.
               <br />
               {/* The procedure to follow to backfill existing transcripts is a full sync. */}
               Only new transcripts will be affected, please contact us at

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -15,7 +15,7 @@ import { normalizeError } from "@app/types";
 
 // TODO(2025-03-17): share these variables between connectors and front.
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
-const GONG_SMART_TRACKERS_CONFIG_KEY = "gongSmartTrackersEnabled";
+const GONG_TRACKERS_CONFIG_KEY = "gongTrackersEnabled";
 
 function checkIsNonNegativeInteger(value: string) {
   return /^[0-9]+$/.test(value);
@@ -43,14 +43,14 @@ export function GongOptionComponent({
     configKey: GONG_RETENTION_PERIOD_CONFIG_KEY,
   });
   const {
-    configValue: smartTrackersConfigValue,
-    mutateConfig: mutateSmartTrackersConfig,
+    configValue: trackersConfigValue,
+    mutateConfig: mutateTrackersConfig,
   } = useConnectorConfig({
     owner,
     dataSource,
-    configKey: GONG_SMART_TRACKERS_CONFIG_KEY,
+    configKey: GONG_TRACKERS_CONFIG_KEY,
   });
-  const smartTrackersEnabled = smartTrackersConfigValue === "true";
+  const trackersEnabled = trackersConfigValue === "true";
 
   const [retentionPeriod, setRetentionPeriod] = useState<string>(
     retentionPeriodConfigValue || ""
@@ -87,8 +87,8 @@ export function GongOptionComponent({
     if (res.ok) {
       if (configKey === GONG_RETENTION_PERIOD_CONFIG_KEY) {
         await mutateRetentionPeriodConfig();
-      } else if (configKey === GONG_SMART_TRACKERS_CONFIG_KEY) {
-        await mutateSmartTrackersConfig();
+      } else if (configKey === GONG_TRACKERS_CONFIG_KEY) {
+        await mutateTrackersConfig();
       }
       setLoading(false);
       sendNotification({
@@ -172,11 +172,11 @@ export function GongOptionComponent({
                 size="xs"
                 onClick={async () => {
                   await handleConfigUpdate(
-                    GONG_SMART_TRACKERS_CONFIG_KEY,
-                    (!smartTrackersEnabled).toString()
+                    GONG_TRACKERS_CONFIG_KEY,
+                    (!trackersEnabled).toString()
                   );
                 }}
-                selected={smartTrackersEnabled}
+                selected={trackersEnabled}
                 disabled={readOnly || !isAdmin || loading}
               />
             </div>

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -86,7 +86,7 @@ async function handler(
       "zendeskSyncUnresolvedTicketsEnabled",
       "zendeskHideCustomerDetails",
       "gongRetentionPeriodDays",
-      "gongSmartTrackersEnabled",
+      "gongTrackersEnabled",
     ].includes(configKey)
   ) {
     return apiError(req, res, {


### PR DESCRIPTION
## Description

- The feature was always referred to as "Smart trackers" in customer interactions but it turns out there are actually two types of trackers: Smart and Keyword and we are syncing both of them.
- This PR does the renaming and fixes the copy in the UI.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Run `migration_74.sql`.
- Deploy `connectors`.
- Deploy `front`.
