### PR TITLE
[front] Fixes on agent scopes

### DIFF
--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -84,7 +84,7 @@ export function usePreviewAssistant({
         description: "Draft Agent",
         instructions: builderState.instructions,
         avatarUrl: builderState.avatarUrl ?? getDefaultAvatarUrlForPreview(),
-        scope: "private",
+        scope: "hidden",
         generationSettings: builderState.generationSettings,
         actions: builderState.actions,
         maxStepsPerRun: builderState.maxStepsPerRun,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -308,7 +308,7 @@ export function getDefaultAssistantState() {
     // We enable it by default so we should push it to actions list.
     actions: [getDataVisualizationActionConfiguration()],
     handle: null,
-    scope: "private",
+    scope: "hidden",
     description: null,
     instructions: null,
     avatarUrl: null,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -391,7 +391,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     case "published":
       return AgentConfiguration.findAll({
         ...baseAgentsSequelizeQuery,
-        where: baseConditionsAndScopesIn(["published"]),
+        where: baseConditionsAndScopesIn(["published", "visible"]),
       });
 
     case "list":

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -174,7 +174,7 @@ export async function searchAgentConfigurationsByName(
     where: {
       workspaceId: owner.id,
       status: "active",
-      scope: { [Op.in]: ["workspace", "published"] },
+      scope: { [Op.in]: ["workspace", "published", "visible"] },
       name: {
         [Op.iLike]: `%${name}%`,
       },

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -35,7 +35,7 @@ export async function generateMockAgentConfigurationFromTemplate(
         ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature],
     },
     name: template.handle,
-    scope: flow === "personal_assistants" ? "private" : "workspace",
+    scope: flow === "personal_assistants" ? "hidden" : "visible",
     pictureUrl: template.pictureUrl,
     visualizationEnabled: false,
     tags: [],

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -49,6 +49,7 @@ const viewRequiresUser = (view?: string): boolean =>
  *           The view to use when retrieving agents:
  *           - all: Retrieves all non-private agents (default if not authenticated)
  *           - list: Retrieves all active agents accessible to the user (default if authenticated)
+ *           - published: Retrieves all agents with published scope
  *           - global: Retrieves all global agents
  *           - favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)
  *         schema:
@@ -129,8 +130,8 @@ async function handler(
       let agentConfigurations = await getAgentConfigurations({
         auth,
         agentsGetView:
-          agentsGetView === "published" || agentsGetView === "workspace"
-            ? "all" // workspace and published are deprecated, return all visible agents
+          agentsGetView === "workspace"
+            ? "published" // workspace is deprecated, return all visible agents
             : agentsGetView,
         variant: "light",
       });

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -49,8 +49,6 @@ const viewRequiresUser = (view?: string): boolean =>
  *           The view to use when retrieving agents:
  *           - all: Retrieves all non-private agents (default if not authenticated)
  *           - list: Retrieves all active agents accessible to the user (default if authenticated)
- *           - workspace: Retrieves all agents with workspace scope
- *           - published: Retrieves all agents with published scope
  *           - global: Retrieves all global agents
  *           - favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)
  *         schema:

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -130,7 +130,10 @@ async function handler(
 
       let agentConfigurations = await getAgentConfigurations({
         auth,
-        agentsGetView,
+        agentsGetView:
+          agentsGetView === "published" || agentsGetView === "workspace"
+            ? "all" // workspace and published are deprecated, return all visible agents
+            : agentsGetView,
         variant: "light",
       });
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -84,11 +84,7 @@ async function handler(
         limit,
       });
 
-      if (
-        !agentConfigurations ||
-        (agentConfigurations[0].scope === "private" &&
-          agentConfigurations[0].versionAuthorId !== auth.user()?.id)
-      ) {
+      if (!agentConfigurations || !agentConfigurations[0].canRead) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -66,21 +66,6 @@ async function setupTestAgents(
   // Create a few test agents with different configurations
   testAgents = await Promise.all([
     AgentConfigurationFactory.createTestAgent(auth, t, {
-      name: `Test Agent / Workspace / ${user.name}`,
-      description: "Workspace test agent",
-      scope: "workspace",
-    }),
-    AgentConfigurationFactory.createTestAgent(auth, t, {
-      name: `Test Agent / Published / ${user.name}`,
-      description: "Published test agent",
-      scope: "published",
-    }),
-    AgentConfigurationFactory.createTestAgent(auth, t, {
-      name: `Test Agent / Private / ${user.name}`,
-      description: "Private test agent",
-      scope: "private",
-    }),
-    AgentConfigurationFactory.createTestAgent(auth, t, {
       name: `Test Agent / Hidden / ${user.name}`,
       description: "Hidden test agent",
       scope: "hidden",
@@ -150,26 +135,7 @@ describe("GET /api/w/[wId]/assistant/agent_configurations", () => {
       });
 
       await setupTestAgents(workspace, user, t);
-      req.query.view = "workspace";
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      const data = JSON.parse(res._getData());
-      expect(data.agentConfigurations).toBeDefined();
-      expect(Array.isArray(data.agentConfigurations)).toBe(true);
-      expect(data.agentConfigurations.length).toBe(1);
-    }
-  );
-
-  itInTransaction(
-    "returns workspace agent configurations successfully",
-    async (t) => {
-      const { req, res, workspace, user } = await createPrivateApiMockRequest({
-        method: "GET",
-      });
-
-      await setupTestAgents(workspace, user, t);
-      req.query.view = "workspace";
+      req.query.view = "published";
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -97,8 +97,8 @@ async function handler(
       let agentConfigurations = await getAgentConfigurations({
         auth,
         agentsGetView:
-          viewParam === "workspace" || viewParam === "published"
-            ? "all" // workspace and published are deprecated, return all visible agents
+          viewParam === "workspace"
+            ? "published" // workspace is deprecated, return all visible agents
             : viewParam,
         variant: "light",
         limit,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -96,7 +96,10 @@ async function handler(
       }
       let agentConfigurations = await getAgentConfigurations({
         auth,
-        agentsGetView: viewParam,
+        agentsGetView:
+          viewParam === "workspace" || viewParam === "published"
+            ? "all" // workspace and published are deprecated, return all visible agents
+            : viewParam,
         variant: "light",
         limit,
         sort,

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -41,7 +41,7 @@
             "in": "query",
             "name": "view",
             "required": false,
-            "description": "The view to use when retrieving agents:\n- all: Retrieves all non-private agents (default if not authenticated)\n- list: Retrieves all active agents accessible to the user (default if authenticated)\n- global: Retrieves all global agents\n- favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)\n",
+            "description": "The view to use when retrieving agents:\n- all: Retrieves all non-private agents (default if not authenticated)\n- list: Retrieves all active agents accessible to the user (default if authenticated)\n- published: Retrieves all agents with published scope\n- global: Retrieves all global agents\n- favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)\n",
             "schema": {
               "type": "string",
               "enum": [

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -41,7 +41,7 @@
             "in": "query",
             "name": "view",
             "required": false,
-            "description": "The view to use when retrieving agents:\n- all: Retrieves all non-private agents (default if not authenticated)\n- list: Retrieves all active agents accessible to the user (default if authenticated)\n- workspace: Retrieves all agents with workspace scope\n- published: Retrieves all agents with published scope\n- global: Retrieves all global agents\n- favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)\n",
+            "description": "The view to use when retrieving agents:\n- all: Retrieves all non-private agents (default if not authenticated)\n- list: Retrieves all active agents accessible to the user (default if authenticated)\n- global: Retrieves all global agents\n- favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)\n",
             "schema": {
               "type": "string",
               "enum": [


### PR DESCRIPTION
## Description

Some agents are still created with workspace or private scope : 
- draft are private
- agents coming from template can be workspace or private

Fixes in public api to return visible agents

## Tests

locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
