### PR TITLE
Add coding rules for writing internal MCP servers

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -269,6 +269,19 @@ class Conversation extends Model { }
 class ConversationModel extends Model { }
 ```
 
+## MCP
+
+### [MCP1] Server description at the top of the file
+
+For MCP internal servers, the object `serverInfo` of type `InternalMCPServerDefinitionType` that
+holds the metadata of the server must be defined at the top of the file.
+
+### [MCP2] Single file internal servers
+
+If possible, MCP internal servers should fit in one file. If not possible, they should be placed
+into a folder that contains a file `server.ts` from where the `createServer` function that
+creates the server will be exported.
+
 ## TESTING
 
 ### [TEST1] Functionally test endpoints

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -273,12 +273,12 @@ class ConversationModel extends Model { }
 
 ### [MCP1] Server description at the top of the file
 
-For MCP internal servers, the object `serverInfo` of type `InternalMCPServerDefinitionType` that
+For internal MCP servers, the object `serverInfo` of type `InternalMCPServerDefinitionType` that
 holds the metadata of the server must be defined at the top of the file.
 
 ### [MCP2] Single file internal servers
 
-If possible, MCP internal servers should fit in one file. If not possible, they should be placed
+If possible, internal MCP servers should fit in one file. If not possible, they should be placed
 into a folder that contains a file `server.ts` from where the `createServer` function that
 creates the server will be exported.
 


### PR DESCRIPTION
## Description

This PR adds two coding rules for writing internal MCP servers.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- No deploy.
