### PR TITLE
[front] - refacto(MCP): migrate Dust App configurations to MCP

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1018,6 +1018,12 @@ function ActionEditor({
 
   const shouldDisplayAdvancedSettings = !["DUST_APP_RUN"].includes(action.type);
 
+  const actionName =
+    action.type === "MCP" &&
+    isDustAppRunConfiguration(action.configuration.dustAppConfiguration)
+      ? action.configuration.dustAppConfiguration.name
+      : action.name;
+
   return (
     <div className="flex flex-col gap-4 px-1">
       <ActionModeSection show={true}>
@@ -1058,7 +1064,7 @@ function ActionEditor({
                   <Input
                     name="actionName"
                     placeholder="My tool name…"
-                    value={action.name}
+                    value={actionName}
                     onChange={(e) => {
                       updateAction({
                         actionName: e.target.value.toLowerCase(),

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -95,7 +95,6 @@ import { useTools } from "@app/components/assistant_builder/useTools";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
-import { isDustAppRunConfiguration } from "@app/lib/actions/types/guards";
 import {
   ACTION_SPECIFICATIONS,
   DATA_VISUALIZATION_SPECIFICATION,
@@ -183,19 +182,8 @@ function actionDisplayName(
   action: AssistantBuilderActionAndDataVisualizationConfiguration,
   mcpServerView: MCPServerViewType | null
 ) {
-  if (mcpServerView) {
-    if (
-      action.type === "MCP" &&
-      isDustAppRunConfiguration(action.configuration.dustAppConfiguration)
-    ) {
-      const { dustAppConfiguration } = action.configuration;
-      const displayNameSuffix = dustAppConfiguration?.name
-        ? ` - ${dustAppConfiguration.name}`
-        : "";
-      return getMcpServerViewDisplayName(mcpServerView) + displayNameSuffix;
-    }
-
-    return getMcpServerViewDisplayName(mcpServerView);
+  if (mcpServerView && action.type === "MCP") {
+    return getMcpServerViewDisplayName(mcpServerView, action);
   }
 
   if (action.type === "DATA_VISUALIZATION") {
@@ -1018,12 +1006,6 @@ function ActionEditor({
 
   const shouldDisplayAdvancedSettings = !["DUST_APP_RUN"].includes(action.type);
 
-  const actionName =
-    action.type === "MCP" &&
-    isDustAppRunConfiguration(action.configuration.dustAppConfiguration)
-      ? action.configuration.dustAppConfiguration.name
-      : action.name;
-
   return (
     <div className="flex flex-col gap-4 px-1">
       <ActionModeSection show={true}>
@@ -1064,7 +1046,7 @@ function ActionEditor({
                   <Input
                     name="actionName"
                     placeholder="My tool name…"
-                    value={actionName}
+                    value={action.name}
                     onChange={(e) => {
                       updateAction({
                         actionName: e.target.value.toLowerCase(),

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -95,6 +95,7 @@ import { useTools } from "@app/components/assistant_builder/useTools";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isDustAppRunConfiguration } from "@app/lib/actions/types/guards";
 import {
   ACTION_SPECIFICATIONS,
   DATA_VISUALIZATION_SPECIFICATION,
@@ -114,7 +115,6 @@ import {
 } from "@app/types";
 
 import { DataDescription } from "./actions/DataDescription";
-import { isDustAppRunConfiguration } from "@app/lib/actions/types/guards";
 
 const DATA_SOURCES_ACTION_CATEGORIES = [
   "RETRIEVAL_SEARCH",

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -114,6 +114,7 @@ import {
 } from "@app/types";
 
 import { DataDescription } from "./actions/DataDescription";
+import { isDustAppRunConfiguration } from "@app/lib/actions/types/guards";
 
 const DATA_SOURCES_ACTION_CATEGORIES = [
   "RETRIEVAL_SEARCH",
@@ -183,6 +184,17 @@ function actionDisplayName(
   mcpServerView: MCPServerViewType | null
 ) {
   if (mcpServerView) {
+    if (
+      action.type === "MCP" &&
+      isDustAppRunConfiguration(action.configuration.dustAppConfiguration)
+    ) {
+      const { dustAppConfiguration } = action.configuration;
+      const displayNameSuffix = dustAppConfiguration?.name
+        ? ` - ${dustAppConfiguration.name}`
+        : "";
+      return getMcpServerViewDisplayName(mcpServerView) + displayNameSuffix;
+    }
+
     return getMcpServerViewDisplayName(mcpServerView);
   }
 

--- a/front/components/assistant_builder/SettingsScreen.tsx
+++ b/front/components/assistant_builder/SettingsScreen.tsx
@@ -894,7 +894,7 @@ function TagsSection({
           ) !== -1
       )
       .slice(0, 3);
-  }, [tagsSuggestions, tags]);
+  }, [tagsSuggestions, builderState.tags, tags, owner]);
 
   const updateTagsSuggestions = useCallback(async () => {
     setTagsSuggestionsLoading(true);

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -22,6 +22,7 @@ import type {
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/utils";
+import { isDustAppRunConfiguration } from "@app/lib/actions/types/guards";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { LightWorkspaceType, SpaceType, TimeFrame } from "@app/types";
 import { asDisplayName, assertNever } from "@app/types";
@@ -124,14 +125,31 @@ export function MCPAction({
       ) => AssistantBuilderMCPServerConfiguration
     ) => {
       setEdited(true);
+
+      let actionName: string = action.name;
+      if (
+        action.type === "MCP" &&
+        isDustAppRunConfiguration(action.configuration.dustAppConfiguration)
+      ) {
+        const { dustAppConfiguration } = action.configuration;
+        actionName = dustAppConfiguration?.name;
+      }
+
       updateAction({
-        actionName: action.name,
+        actionName,
         actionDescription: action.description,
         getNewActionConfig: (old) =>
           getNewConfig(old as AssistantBuilderMCPServerConfiguration),
       });
     },
-    [action.description, action.name, setEdited, updateAction]
+    [
+      action.configuration,
+      action.description,
+      action.name,
+      action.type,
+      setEdited,
+      updateAction,
+    ]
   );
 
   if (action.type !== "MCP") {

--- a/front/components/assistant_builder/useTools.ts
+++ b/front/components/assistant_builder/useTools.ts
@@ -11,6 +11,7 @@ import type {
   AssistantBuilderDataVisualizationConfiguration,
 } from "@app/components/assistant_builder/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/utils";
 import {
   ACTION_SPECIFICATIONS,
@@ -18,7 +19,6 @@ import {
 } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { SpaceType } from "@app/types";
-import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 
 const DEFAULT_TOOLS_WITH_CONFIGURATION = [
   "DUST_APP_RUN",

--- a/front/components/assistant_builder/useTools.ts
+++ b/front/components/assistant_builder/useTools.ts
@@ -10,6 +10,7 @@ import type {
   AssistantBuilderActionType,
   AssistantBuilderDataVisualizationConfiguration,
 } from "@app/components/assistant_builder/types";
+import { ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME } from "@app/components/assistant_builder/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -135,7 +136,11 @@ export const useTools = ({ actions }: UseToolsProps) => {
         case "DUST_APP_RUN":
           return mcpServerViews.some((v) => {
             const r = getInternalMCPServerNameAndWorkspaceId(v.server.sId);
-            return r.isOk() && r.value.name === "run_dust_app";
+            return (
+              r.isOk() &&
+              r.value.name ===
+                ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME
+            );
           });
         default:
           return false;

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -14,6 +14,7 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ModelId } from "@app/types";
 import { asDisplayName } from "@app/types";
+import { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
 
 export const getServerTypeAndIdFromSId = (
   mcpServerId: string
@@ -96,12 +97,22 @@ export function mcpServerIsRemote(
   return serverType === "remote";
 }
 
-export function getMcpServerViewDisplayName(view: MCPServerViewType) {
+export function getMcpServerViewDisplayName(
+  view: MCPServerViewType,
+  action?: AssistantBuilderActionConfiguration
+) {
   // Unreleased internal servers are displayed with a suffix in the UI.
   const res = getInternalMCPServerNameAndWorkspaceId(view.server.sId);
-  if (res.isOk() && INTERNAL_MCP_SERVERS[res.value.name].flag != null) {
-    return `${asDisplayName(view.server.name)} (Preview)`;
-  }
+  let displayName = asDisplayName(view.server.name);
 
-  return asDisplayName(view.server.name);
+  if (res.isOk()) {
+    if (INTERNAL_MCP_SERVERS[res.value.name].flag != null) {
+      displayName += " (Preview)";
+    }
+    // Will append Dust App name.
+    if (res.value.name === "run_dust_app" && action) {
+      displayName += " - " + action.name;
+    }
+  }
+  return displayName;
 }

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -1,3 +1,4 @@
+import { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   getInternalMCPServerNameAndWorkspaceId,
@@ -14,7 +15,6 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ModelId } from "@app/types";
 import { asDisplayName } from "@app/types";
-import { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
 
 export const getServerTypeAndIdFromSId = (
   mcpServerId: string

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -1,4 +1,4 @@
-import { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
+import type { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   getInternalMCPServerNameAndWorkspaceId,

--- a/front/migrations/20250521_migrate_dust_app_mcp.ts
+++ b/front/migrations/20250521_migrate_dust_app_mcp.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 import { Op } from "sequelize";
 
 import { ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME } from "@app/components/assistant_builder/types";
@@ -218,6 +219,11 @@ makeScript(
       });
     }
 
+    const migrationDir = "migration_dust_app_run";
+    if (execute) {
+      fs.mkdirSync(migrationDir, { recursive: true });
+    }
+
     let revertSql = "";
     for (const workspace of workspaces) {
       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -229,7 +235,10 @@ makeScript(
 
       if (execute) {
         fs.writeFileSync(
-          `${now}_dust_app_run_to_mcp_revert_${workspace.sId}.sql`,
+          path.join(
+            migrationDir,
+            `${now}_dust_app_run_to_mcp_revert_${workspace.sId}.sql`
+          ),
           workspaceRevertSql
         );
       }
@@ -237,7 +246,10 @@ makeScript(
     }
 
     if (execute) {
-      fs.writeFileSync(`${now}_dust_app_run_to_mcp_revert_all.sql`, revertSql);
+      fs.writeFileSync(
+        path.join(migrationDir, `${now}_dust_app_run_to_mcp_revert_all.sql`),
+        revertSql
+      );
     }
   }
 );

--- a/front/migrations/20250521_migrate_dust_app_mcp.ts
+++ b/front/migrations/20250521_migrate_dust_app_mcp.ts
@@ -1,0 +1,221 @@
+import fs from "fs";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { Workspace } from "@app/lib/models/workspace";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getInsertSQL } from "@app/lib/utils/sql_utils";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types";
+
+async function findWorkspacesWithDustAppRunConfigurations(): Promise<
+  ModelId[]
+> {
+  const dustAppRunConfigurations = await AgentDustAppRunConfiguration.findAll({
+    attributes: ["workspaceId"],
+    include: [
+      {
+        attributes: [],
+        model: AgentConfiguration,
+        required: true,
+        where: {
+          status: "active",
+        },
+      },
+    ],
+    order: [["id", "ASC"]],
+  });
+
+  return dustAppRunConfigurations.map((config) => config.workspaceId);
+}
+
+async function migrateWorkspaceDustAppRunActions(
+  auth: Authenticator,
+  {
+    execute,
+    parentLogger,
+  }: {
+    execute: boolean;
+    parentLogger: typeof Logger;
+  }
+): Promise<string> {
+  const logger = parentLogger.child({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+  });
+
+  logger.info("Starting migration of dust app run actions to MCP.");
+
+  const dustAppConfigs = await AgentDustAppRunConfiguration.findAll({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+    include: [
+      {
+        attributes: [],
+        model: AgentConfiguration,
+        required: true,
+        where: {
+          status: "active",
+        },
+      },
+    ],
+    order: [["id", "ASC"]],
+  });
+
+  if (dustAppConfigs.length === 0) {
+    return "";
+  }
+
+  logger.info(
+    `Found ${dustAppConfigs.length} dust app run configurations to migrate.`
+  );
+
+  if (execute) {
+    try {
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+    } catch (e) {
+      logger.error(
+        { error: e },
+        "Error creating MCP server views, skipping migration."
+      );
+      return "";
+    }
+  }
+
+  const mcpServerView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "run_dust_app"
+    );
+  if (!mcpServerView) {
+    throw new Error("Run Dust App MCP server view not found.");
+  }
+
+  let revertSql = "";
+
+  await concurrentExecutor(
+    dustAppConfigs,
+    async (dustAppConfig) => {
+      if (!dustAppConfig.agentConfigurationId) {
+        logger.info(
+          { dustAppConfigurationId: dustAppConfig.id },
+          `Already an MCP dust app config, skipping.`
+        );
+        return;
+      }
+
+      if (execute) {
+        const mcpConfig = await AgentMCPServerConfiguration.create({
+          sId: generateRandomModelSId(),
+          agentConfigurationId: dustAppConfig.agentConfigurationId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          mcpServerViewId: mcpServerView.id,
+          internalMCPServerId: mcpServerView.mcpServerId,
+          additionalConfiguration: {},
+          timeFrame: null,
+          appId: dustAppConfig.appId,
+        });
+
+        revertSql +=
+          getInsertSQL(
+            AgentDustAppRunConfiguration,
+            dustAppConfig.get({ plain: true })
+          ) + "\n";
+        revertSql += `UPDATE "agent_dust_app_run_configurations" SET "agentConfigurationId" = '${dustAppConfig.agentConfigurationId}', "mcpServerConfigurationId" = NULL WHERE "id" = '${dustAppConfig.id}';\n`;
+        revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
+
+        await dustAppConfig.destroy();
+
+        logger.info(
+          {
+            dustAppConfigurationId: dustAppConfig.id,
+            mcpServerConfigurationId: mcpConfig.id,
+          },
+          `Migrated dust app config to MCP server config.`
+        );
+      } else {
+        logger.info(
+          {
+            dustAppConfigurationId: dustAppConfig.id,
+          },
+          `Would create MCP server config and migrate dust app config to it.`
+        );
+      }
+    },
+    { concurrency: 10 }
+  );
+
+  if (execute) {
+    logger.info(
+      `Successfully migrated ${dustAppConfigs.length} dust app configurations to MCP.`
+    );
+  } else {
+    logger.info(
+      `Would have migrated ${dustAppConfigs.length} dust app configurations to MCP.`
+    );
+  }
+
+  return revertSql;
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Workspace SID to migrate",
+      required: false,
+    },
+  },
+  async ({ execute, workspaceId }, parentLogger) => {
+    const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
+
+    let workspaces: Workspace[] = [];
+    if (workspaceId) {
+      const workspace = await Workspace.findOne({
+        where: {
+          sId: workspaceId,
+        },
+      });
+      if (!workspace) {
+        throw new Error(`Workspace with SID ${workspaceId} not found.`);
+      }
+      workspaces = [workspace];
+    } else {
+      const workspaceIds = await findWorkspacesWithDustAppRunConfigurations();
+      workspaces = await Workspace.findAll({
+        where: {
+          id: { [Op.in]: workspaceIds },
+        },
+        order: [["id", "ASC"]],
+      });
+    }
+
+    let revertSql = "";
+    for (const workspace of workspaces) {
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const workspaceRevertSql = await migrateWorkspaceDustAppRunActions(auth, {
+        execute,
+        parentLogger,
+      });
+
+      if (execute) {
+        fs.writeFileSync(
+          `${now}_dust_app_run_to_mcp_revert_${workspace.sId}.sql`,
+          workspaceRevertSql
+        );
+      }
+      revertSql += workspaceRevertSql;
+    }
+
+    if (execute) {
+      fs.writeFileSync(`${now}_dust_app_run_to_mcp_revert_all.sql`, revertSql);
+    }
+  }
+);

--- a/front/migrations/20250521_migrate_dust_app_mcp.ts
+++ b/front/migrations/20250521_migrate_dust_app_mcp.ts
@@ -1,9 +1,7 @@
 import fs from "fs";
 import { Op } from "sequelize";
 
-import {
-  ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME,
-} from "@app/components/assistant_builder/types";
+import { ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME } from "@app/components/assistant_builder/types";
 import { Authenticator } from "@app/lib/auth";
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";

--- a/front/migrations/20250521_migrate_dust_app_mcp.ts
+++ b/front/migrations/20250521_migrate_dust_app_mcp.ts
@@ -1,20 +1,22 @@
 import fs from "fs";
 import { Op } from "sequelize";
 
+import {
+  ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME,
+} from "@app/components/assistant_builder/types";
 import { Authenticator } from "@app/lib/auth";
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { Workspace } from "@app/lib/models/workspace";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getInsertSQL } from "@app/lib/utils/sql_utils";
 import type Logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { ModelId } from "@app/types";
-import { AppModel } from "@app/lib/resources/storage/models/apps";
-import { ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME } from "@app/components/assistant_builder/types";
 
 async function findWorkspacesWithDustAppRunConfigurations(): Promise<
   ModelId[]


### PR DESCRIPTION
## Description

This PR adds a script to transition existing Active Dust App Run Configurations to new MCP Server Configurations

## Risk

High

## Deploy Plan

- Test locally
- Migrate our workspace