### PR TITLE
front-internal / DustAPI config clean-up

### DIFF
--- a/connectors/migrations/20240719_migrate_github_connection_id.ts
+++ b/connectors/migrations/20240719_migrate_github_connection_id.ts
@@ -21,7 +21,7 @@ async function appendRollbackCommand(
 }
 
 function getRedirectUri(): string {
-  return `${apiConfig.getDustAPIConfig().url}/oauth/${PROVIDER}/finalize`;
+  return `${apiConfig.getDustFrontAPIUrl()}/oauth/${PROVIDER}/finalize`;
 }
 
 async function migrateGithubConnectionId(

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -107,13 +107,12 @@ export async function autoReadChannel(
     }
 
     const dustAPI = new DustAPI(
-      apiConfig.getDustAPIConfig(),
+      { url: apiConfig.getDustFrontAPIUrl() },
       {
         workspaceId: connector.workspaceId,
         apiKey: connector.workspaceAPIKey,
       },
-      logger,
-      apiConfig.getDustFrontAPIUrl()
+      logger
     );
 
     // Loop through all the matching patterns. Swallow errors and continue.

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -240,7 +240,7 @@ export async function botValidateToolExecution(
     }
 
     const dustAPI = new DustAPI(
-      apiConfig.getDustAPIConfig(),
+      { url: apiConfig.getDustFrontAPIUrl() },
       {
         apiKey: connector.workspaceAPIKey,
         // We neither need group ids nor user email headers here because validate tool endpoint is not
@@ -248,8 +248,7 @@ export async function botValidateToolExecution(
         extraHeaders: {},
         workspaceId: connector.workspaceId,
       },
-      logger,
-      apiConfig.getDustFrontAPIUrl()
+      logger
     );
 
     const res = await dustAPI.validateAction({
@@ -481,7 +480,7 @@ async function answerMessage(
       : undefined;
 
   const dustAPI = new DustAPI(
-    apiConfig.getDustAPIConfig(),
+    { url: apiConfig.getDustFrontAPIUrl() },
     {
       workspaceId: connector.workspaceId,
       apiKey: connector.workspaceAPIKey,
@@ -490,8 +489,7 @@ async function answerMessage(
         ...getHeaderFromUserEmail(userEmailHeader),
       },
     },
-    logger,
-    apiConfig.getDustFrontAPIUrl()
+    logger
   );
 
   // Do not await this promise, we want to continue the execution of the function in parallel.

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -1,17 +1,31 @@
 import type { Result, WorkspaceDomainType } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
+import { DustAPI, Err, Ok } from "@dust-tt/client";
 import type { WebClient } from "@slack/web-api";
 import type {} from "@slack/web-api/dist/response/UsersInfoResponse";
 
 import { SlackExternalUserError } from "@connectors/connectors/slack/lib/errors";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import { getSlackConversationInfo } from "@connectors/connectors/slack/lib/slack_client";
+import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { getDustAPI } from "@connectors/lib/data_sources";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import type { DataSourceConfig } from "@connectors/types";
 import { cacheWithRedis } from "@connectors/types";
+
+function getDustAPI(dataSourceConfig: DataSourceConfig) {
+  return new DustAPI(
+    {
+      url: apiConfig.getDustFrontAPIUrl(),
+    },
+    {
+      apiKey: dataSourceConfig.workspaceAPIKey,
+      workspaceId: dataSourceConfig.workspaceId,
+    },
+    logger
+  );
+}
 
 async function getActiveMemberEmails(
   connector: ConnectorResource

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -7,14 +7,11 @@ export const apiConfig = {
       apiKey: EnvironmentConfig.getOptionalEnvVariable("OAUTH_API_KEY") ?? null,
     };
   },
+  getDustFrontInternalAPIUrl: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_FRONT_INTERNAL_API");
+  },
   getDustFrontAPIUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_FRONT_API");
-  },
-  getDustAPIConfig: (): { url: string; nodeEnv: string } => {
-    return {
-      url: EnvironmentConfig.getEnvVariable("DUST_FRONT_API"),
-      nodeEnv: EnvironmentConfig.getEnvVariable("NODE_ENV"),
-    };
   },
   getTextExtractionUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -69,17 +69,16 @@ export type UpsertDataSourceDocumentParams = {
   async: boolean;
 };
 
-export function getDustAPI(dataSourceConfig: DataSourceConfig) {
-  const config = apiConfig.getDustAPIConfig();
-
+function getDustAPI(dataSourceConfig: DataSourceConfig) {
   return new DustAPI(
-    config,
+    {
+      url: apiConfig.getDustFrontInternalAPIUrl(),
+    },
     {
       apiKey: dataSourceConfig.workspaceAPIKey,
       workspaceId: dataSourceConfig.workspaceId,
     },
-    logger,
-    config.nodeEnv === "development" ? "http://localhost:3000" : null
+    logger
   );
 }
 
@@ -119,7 +118,7 @@ async function _upsertDataSourceDocument({
       });
 
       const endpoint =
-        `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+        `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
         `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}`;
 
       const localLogger = logger.child({
@@ -253,7 +252,7 @@ export async function getDataSourceDocument({
   });
 
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/documents?document_ids=${documentId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -284,7 +283,7 @@ export async function deleteDataSourceDocument(
   const localLogger = logger.child({ ...loggerArgs, documentId });
 
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -382,7 +381,7 @@ async function _updateDocumentOrTableParentsField({
       ? logger.child({ ...loggerArgs, documentId: id })
       : logger.child({ ...loggerArgs, tableId: id });
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/${tableOrDocument}s/${id}/parents`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -805,7 +804,7 @@ export async function upsertDataSourceRemoteTable({
   const now = new Date();
 
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables`;
   const dustRequestPayload: UpsertDatabaseTableRequestType = {
     name: tableName,
@@ -1003,15 +1002,7 @@ export async function upsertDataSourceTableFromCsv({
     );
   }
 
-  const dustAPI = new DustAPI(
-    apiConfig.getDustAPIConfig(),
-    {
-      workspaceId: dataSourceConfig.workspaceId,
-      apiKey: dataSourceConfig.workspaceAPIKey,
-    },
-    logger,
-    apiConfig.getDustFrontAPIUrl()
-  );
+  const dustAPI = getDustAPI(dataSourceConfig);
 
   const fileRes = await dustAPI.uploadFile({
     contentType: "text/csv",
@@ -1025,7 +1016,7 @@ export async function upsertDataSourceTableFromCsv({
   }
 
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/csv`;
   const dustRequestPayload: UpsertTableFromCsvRequestType = {
     name: tableName,
@@ -1188,7 +1179,7 @@ export async function deleteDataSourceTableRow({
   const now = new Date();
 
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}/rows/${rowId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -1272,7 +1263,7 @@ async function _getDataSourceTable({
   });
 
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -1327,7 +1318,7 @@ export async function deleteDataSourceTable({
   const now = new Date();
 
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -1411,7 +1402,7 @@ export async function _getDataSourceFolder({
   });
 
   const endpoint =
-    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/folders/${folderId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {


### PR DESCRIPTION
## Description

Kill `getDustAPIConfig` which made no sense.


## Tests

Covered by type system

## Risk

Connectors ingestion (low impact), slack bot

## Deploy Plan

- add secret `DUST_FRONT_INTERNAL_API=http://front-internal-service`
- deploy `connectors`