### PR TITLE
Prevent overriding server names when migrating TablesQuery

### DIFF
--- a/front/migrations/20250516_migrate_tables_query_to_mcp_globally.ts
+++ b/front/migrations/20250516_migrate_tables_query_to_mcp_globally.ts
@@ -2,6 +2,7 @@ import { format } from "date-fns";
 import fs from "fs";
 import { Op } from "sequelize";
 
+import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/actions/constants";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import {
@@ -142,7 +143,10 @@ async function migrateWorkspaceTablesQueryActions(
           internalMCPServerId: mcpServerView.internalMCPServerId,
           additionalConfiguration: {},
           timeFrame: null,
-          name: tablesQueryConfig.name,
+          name:
+            tablesQueryConfig.name === DEFAULT_TABLES_QUERY_ACTION_NAME
+              ? null
+              : tablesQueryConfig.name,
           singleToolDescriptionOverride: tablesQueryConfig.description,
           appId: null,
         });


### PR DESCRIPTION
## Description

- The column `name` in the table `agent_mcp_server_configurations` should be null if the name of the tool was not overridden in the Agent Builder.
- The script that migrates existing Tables Query actions to the MCP variant always fills the value of the name.
- This PR fixes that.
- 246 out of 2008 tables query actions had their name overridden:
```sql
SELECT COUNT(*) FROM agent_tables_query_configurations atq
JOIN agent_configurations ac
ON ac.id = atq."agentConfigurationId"
WHERE ac.status = 'active'
AND atq.name != 'query_tables';
```
- Many of them were automatic renames into `query_tables_2`.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- No deploy.
