### PR TITLE
Tweak Claude Code Review GH Workflow Trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [review_requested] # Runs when review is requested
+    types: [labeled] # Runs when label is added
 
 permissions:
   contents: write
@@ -14,22 +14,7 @@ jobs:
   code-review:
     runs-on: ubuntu-latest
     steps:
-      # For review_requested events, add a label to the PR
-      - name: Add review-requested label
-        if: github.event.action == 'review_requested'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: ['claude-review-requested']
-            });
-
       # Determine if we should run the review
-      # Not used at the moment.
       - name: Determine if review should run
         id: should-run
         uses: actions/github-script@v6
@@ -37,29 +22,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string
           script: |
-            // For review_requested events, always run.
-            if (context.payload.action === 'review_requested') {
+            if (context.payload.action === 'labeled' && context.payload.label.name === 'claude-review-requested') {
               console.log('Running because review was requested');
               return 'true';
-            }
-
-            // For synchronize events, check for the label.
-            if (context.payload.action === 'synchronize') {
-              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number
-              });
-
-              const hasLabel = labels.some(label => label.name === 'claude-review-requested');
-              console.log(`PR has claude-review-requested label: ${hasLabel}`);
-              return hasLabel ? 'true' : 'false';
             }
 
             // Default to not running.
             return 'false';
 
-      # Only proceed if it's a review_requested event or a synchronize with the label
+      # Only proceed if the label is added.
       - name: Checkout code
         if: steps.should-run.outputs.result == 'true'
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR tweaks the trigger for Claude Code Review GitHub workflow to ensure it only runs when the label `claude-review-requested` is set.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
