### PR TITLE
run_agent: server/tool rename

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -9,7 +9,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // We'll prefix all tools with the server name to avoid conflicts.
   // It's okay to change the name of the server as we don't refer to it directly.
   "agent_router",
-  "ask_agent",
+  "run_agent",
   "extract_data",
   "file_generation",
   "github",
@@ -150,7 +150,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     availability: "auto",
     flag: null,
   },
-  ask_agent: {
+  run_agent: {
     id: 1008,
     availability: "manual",
     flag: "dev_mcp_actions",

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -2,7 +2,6 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { default as agentRouterServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
-import { default as askAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/ask_agent";
 import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/file_generation";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
 import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/server";
@@ -12,6 +11,7 @@ import { default as notionServer } from "@app/lib/actions/mcp_internal_actions/s
 import { default as primitiveTypesDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/primitive_types_debugger";
 import { default as extractDataServer } from "@app/lib/actions/mcp_internal_actions/servers/process";
 import { default as reasoningServer } from "@app/lib/actions/mcp_internal_actions/servers/reasoning";
+import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/run_agent";
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
 import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
@@ -58,8 +58,8 @@ export async function getInternalMCPServer(
       return notionServer(auth, mcpServerId);
     case "include_data":
       return includeDataServer(auth, agentLoopContext);
-    case "ask_agent":
-      return askAgentServer(auth);
+    case "run_agent":
+      return runAgentServer(auth, agentLoopContext);
     case "reasoning":
       return reasoningServer(auth, agentLoopContext.runContext);
     case "run_dust_app":

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -59,7 +59,7 @@ export async function getInternalMCPServer(
     case "include_data":
       return includeDataServer(auth, agentLoopContext);
     case "run_agent":
-      return runAgentServer(auth, agentLoopContext);
+      return runAgentServer(auth);
     case "reasoning":
       return reasoningServer(auth, agentLoopContext.runContext);
     case "run_dust_app":

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -8,7 +8,6 @@ import {
   ConfigurableToolInputSchemas,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
 import apiConfig from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -17,11 +16,10 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, getHeaderFromGroupIds, normalizeError, Ok } from "@app/types";
 
-
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "ask_agent",
+  name: "run_agent",
   version: "1.0.0",
-  description: "Offload a query to another agent.",
+  description: "Run an agent (agent as tool).",
   icon: "ActionRobotIcon",
   authorization: null,
 };
@@ -37,10 +35,7 @@ function parseAgentConfigurationUri(uri: string): Result<string, Error> {
   return new Ok(match[2]);
 }
 
-function createServer(
-  auth: Authenticator,
-  agentLoopContext: AgentLoopContextType
-): McpServer {
+function createServer(auth: Authenticator): McpServer {
   const server = new McpServer(serverInfo);
 
   server.tool(
@@ -48,9 +43,11 @@ function createServer(
     // TODO(mcp): we probably want to make this description configurable to guide the model on when to use this sub-agent.
     "Run an agent.",
     {
-      query: z.string().describe(
-        `The query sent to the agent. This is the question or instruction that will be processed by the agent, which will respond with its own capabilities and knowledge.`
-      ),
+      query: z
+        .string()
+        .describe(
+          `The query sent to the agent. This is the question or instruction that will be processed by the agent, which will respond with its own capabilities and knowledge.`
+        ),
       childAgent:
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -8,6 +8,7 @@ import {
   ConfigurableToolInputSchemas,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import apiConfig from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -15,6 +16,7 @@ import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, getHeaderFromGroupIds, normalizeError, Ok } from "@app/types";
+
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "ask_agent",
@@ -35,19 +37,19 @@ function parseAgentConfigurationUri(uri: string): Result<string, Error> {
   return new Ok(match[2]);
 }
 
-function createServer(auth: Authenticator): McpServer {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext: AgentLoopContextType
+): McpServer {
   const server = new McpServer(serverInfo);
 
   server.tool(
-    "ask_agent",
+    "run_agent",
     // TODO(mcp): we probably want to make this description configurable to guide the model on when to use this sub-agent.
-    "Query another agent.",
+    "Run an agent.",
     {
       query: z.string().describe(
-        `The text prompt to send to the child agent.
-          This is the question or instruction that will be processed by the selected agent,
-          which will respond with its own capabilities and knowledge.
-          Be specific and clear to get the most relevant response.`
+        `The query sent to the agent. This is the question or instruction that will be processed by the agent, which will respond with its own capabilities and knowledge.`
       ),
       childAgent:
         ConfigurableToolInputSchemas[
@@ -75,7 +77,7 @@ function createServer(auth: Authenticator): McpServer {
 
       const user = auth.getNonNullableUser();
       const convRes = await api.createConversation({
-        title: `MCP ask_agent - ${new Date().toISOString()}`,
+        title: `run_agent - ${new Date().toISOString()}`,
         visibility: "unlisted",
         message: {
           content: query,


### PR DESCRIPTION
## Description

Renames `ask_agent` into `run_agent`.
I believe this rename to be safe since the server Id does not change + this is obviously for `dev_mcp_actions` anyway.

@Fraggle I presume changing the server.id does require a migration, you confirm?

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`