### PR TITLE
Fix Reasoning and TablesQuery MCP migration scripts

### DIFF
--- a/front/migrations/20250513_migrate_reasoning_to_mcp.ts
+++ b/front/migrations/20250513_migrate_reasoning_to_mcp.ts
@@ -105,6 +105,7 @@ async function migrateWorkspaceReasoningActions({
           name: reasoningConfig.name,
           singleToolDescriptionOverride: reasoningConfig.description,
           appId: null,
+          jsonSchema: null,
         });
 
         revertSql += `UPDATE "agent_reasoning_configurations" SET "agentConfigurationId" = '${reasoningConfig.agentConfigurationId}' WHERE "id" = '${reasoningConfig.id}';\n`;

--- a/front/migrations/20250514_migrate_tables_query_to_mcp.ts
+++ b/front/migrations/20250514_migrate_tables_query_to_mcp.ts
@@ -119,6 +119,7 @@ async function migrateWorkspaceTablesQueryActions({
           name: tablesQueryConfig.name,
           singleToolDescriptionOverride: tablesQueryConfig.description,
           appId: null,
+          jsonSchema: null,
         });
 
         // Reverse: create the tables query configuration.

--- a/front/migrations/20250516_migrate_reasoning_to_mcp_globally.ts
+++ b/front/migrations/20250516_migrate_reasoning_to_mcp_globally.ts
@@ -129,6 +129,7 @@ async function migrateWorkspaceReasoningActions(
           name: reasoningConfig.name,
           singleToolDescriptionOverride: reasoningConfig.description,
           appId: null,
+          jsonSchema: null,
         });
 
         revertSql += `UPDATE "agent_reasoning_configurations" SET "agentConfigurationId" = '${reasoningConfig.agentConfigurationId}' WHERE "id" = '${reasoningConfig.id}';\n`;

--- a/front/migrations/20250516_migrate_tables_query_to_mcp_globally.ts
+++ b/front/migrations/20250516_migrate_tables_query_to_mcp_globally.ts
@@ -149,6 +149,7 @@ async function migrateWorkspaceTablesQueryActions(
               : tablesQueryConfig.name,
           singleToolDescriptionOverride: tablesQueryConfig.description,
           appId: null,
+          jsonSchema: null,
         });
 
         // Reverse: create the tables query configuration.


### PR DESCRIPTION
## Description

- The scripts that migrate reasoning and tables query actions to their MCP variant are now broken due to a missing field in the blob passed to create a new `AgentMCPServerConfiguration`.
- This PR fixes that.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- No deploy.
