### PR TITLE
Data Retention: Select conversations to remove using messages over conversation createdAt

### DIFF
--- a/front/tests/lib/resources/conversation_resource.test.ts
+++ b/front/tests/lib/resources/conversation_resource.test.ts
@@ -1,0 +1,155 @@
+import type { Transaction } from "sequelize";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+
+const setupTestAgents = async (
+  workspace: LightWorkspaceType,
+  user: UserResource,
+  t?: Transaction
+) => {
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  const agents = await Promise.all([
+    AgentConfigurationFactory.createTestAgent(auth, t, {
+      name: `Test Agent 1 ${user.name}`,
+      description: "Hidden test agent",
+      scope: "hidden",
+    }),
+    AgentConfigurationFactory.createTestAgent(auth, t, {
+      name: `Test Agent 2 ${user.name}`,
+      description: "Visible test agent",
+      scope: "visible",
+    }),
+  ]);
+
+  return agents;
+};
+
+const dateFromDaysAgo = (days: number) => {
+  return new Date(new Date().getTime() - days * 24 * 60 * 60 * 1000);
+};
+
+describe("ConversationResource", () => {
+  describe("listAllBeforeDate", () => {
+    let auth: Authenticator;
+    let convo1Id: string;
+    let convo2Id: string;
+    let convo3Id: string;
+    let convo4Id: string;
+
+    let anotherAuth: Authenticator;
+    let anotherConvoId: string;
+
+    beforeEach(async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const user = await UserFactory.basic();
+      auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      const agents = await setupTestAgents(workspace, user);
+
+      const convo1 = await ConversationFactory.create({
+        auth,
+        agentConfigurationId: agents[0].sId,
+        messagesCreatedAt: [dateFromDaysAgo(10), dateFromDaysAgo(8)],
+      });
+      const convo2 = await ConversationFactory.create({
+        auth,
+        agentConfigurationId: agents[1].sId,
+        messagesCreatedAt: [dateFromDaysAgo(100), dateFromDaysAgo(1)],
+      });
+      const convo3 = await ConversationFactory.create({
+        auth,
+        agentConfigurationId: agents[0].sId,
+        messagesCreatedAt: [dateFromDaysAgo(100), dateFromDaysAgo(91)],
+      });
+      const convo4 = await ConversationFactory.create({
+        auth,
+        agentConfigurationId: agents[1].sId,
+        messagesCreatedAt: [dateFromDaysAgo(150), dateFromDaysAgo(110)],
+      });
+
+      convo1Id = convo1.sId;
+      convo2Id = convo2.sId;
+      convo3Id = convo3.sId;
+      convo4Id = convo4.sId;
+
+      // Just to make sure we have the filter on workspaceId we also create a very very old convo for another workspace.
+      const anotherWorkspace = await WorkspaceFactory.basic();
+      const anotherUser = await UserFactory.basic();
+      anotherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        anotherUser.sId,
+        anotherWorkspace.sId
+      );
+      const anotherAgents = await setupTestAgents(
+        anotherWorkspace,
+        anotherUser
+      );
+      const anotherConvo = await ConversationFactory.create({
+        auth: anotherAuth,
+        agentConfigurationId: anotherAgents[0].sId,
+        messagesCreatedAt: [dateFromDaysAgo(800)],
+      });
+      anotherConvoId = anotherConvo.sId;
+    });
+
+    afterEach(async () => {
+      await destroyConversation(auth, {
+        conversationId: convo1Id,
+      });
+      await destroyConversation(auth, {
+        conversationId: convo2Id,
+      });
+      await destroyConversation(auth, {
+        conversationId: convo3Id,
+      });
+      await destroyConversation(auth, {
+        conversationId: convo4Id,
+      });
+      await destroyConversation(anotherAuth, {
+        conversationId: anotherConvoId,
+      });
+    });
+
+    it("should return only conversations with all messages before cutoff date: 90 days ago", async () => {
+      const oldConversations = await ConversationResource.listAllBeforeDate(
+        auth,
+        dateFromDaysAgo(90)
+      );
+      expect(oldConversations.length).toBe(2);
+      expect(oldConversations[0].sId).toBe(convo3Id);
+      expect(oldConversations[1].sId).toBe(convo4Id);
+    });
+
+    it("should return only conversations with all messages before cutoff date: 200 days ago", async () => {
+      const oldConversations = await ConversationResource.listAllBeforeDate(
+        auth,
+        dateFromDaysAgo(200)
+      );
+      expect(oldConversations.length).toBe(0);
+    });
+
+    it("should return only conversations with all messages before cutoff date: 5 days ago", async () => {
+      const oldConversations = await ConversationResource.listAllBeforeDate(
+        auth,
+        dateFromDaysAgo(5)
+      );
+      expect(oldConversations.length).toBe(3);
+      expect(oldConversations[0].sId).toBe(convo1Id);
+      expect(oldConversations[1].sId).toBe(convo3Id);
+      expect(oldConversations[2].sId).toBe(convo4Id);
+    });
+  });
+});

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -1,0 +1,154 @@
+import type { Transaction } from "sequelize";
+
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessage,
+  Message,
+  UserMessage,
+} from "@app/lib/models/assistant/conversation";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { ConversationType, ModelId, WorkspaceType } from "@app/types";
+
+export class ConversationFactory {
+  static async create({
+    auth,
+    agentConfigurationId,
+    messagesCreatedAt,
+    t,
+  }: {
+    auth: Authenticator;
+    agentConfigurationId: string;
+    messagesCreatedAt: Date[];
+    t?: Transaction;
+  }): Promise<ConversationType> {
+    const user = auth.getNonNullableUser();
+    const workspace = auth.getNonNullableWorkspace();
+
+    const conversation = await createConversation(auth, {
+      title: "Test Conversation",
+      visibility: "unlisted",
+    });
+
+    for (let i = 0; i < messagesCreatedAt.length; i++) {
+      const createdAt = messagesCreatedAt[i];
+      await createMessageAndUserMessage({
+        user,
+        workspace,
+        conversationModelId: conversation.id,
+        createdAt,
+        rank: i * 2,
+        t,
+      });
+      await createMessageAndAgentMessage({
+        workspace,
+        conversationModelId: conversation.id,
+        agentConfigurationId,
+        createdAt,
+        rank: i * 2 + 1,
+        t,
+      });
+    }
+
+    return conversation;
+  }
+}
+
+const createMessageAndUserMessage = async ({
+  user,
+  workspace,
+  conversationModelId,
+  createdAt,
+  rank,
+  t,
+}: {
+  user: UserResource;
+  workspace: WorkspaceType;
+  conversationModelId: ModelId;
+  createdAt: Date;
+  rank: number;
+  t?: Transaction;
+}) => {
+  return Message.create(
+    {
+      createdAt,
+      updatedAt: createdAt,
+      sId: generateRandomModelSId(),
+      rank,
+      conversationId: conversationModelId,
+      parentId: null,
+      userMessageId: (
+        await UserMessage.create(
+          {
+            createdAt,
+            updatedAt: createdAt,
+            userId: user.id,
+            workspaceId: workspace.id,
+            content: "Test user Message.",
+            userContextUsername: "soupinou",
+            userContextTimezone: "Europe/Paris",
+            userContextFullName: "Soupinou",
+            userContextEmail: "soupinou@dust.tt",
+            userContextProfilePictureUrl: "https://dust.tt/soupinou",
+            userContextOrigin: "web",
+            clientSideMCPServerIds: [], // TODO(MCP Clean-up): Rename field in DB.
+          },
+          { transaction: t }
+        )
+      ).id,
+      workspaceId: workspace.id,
+    },
+    {
+      transaction: t,
+    }
+  );
+};
+
+const createMessageAndAgentMessage = async ({
+  workspace,
+  conversationModelId,
+  agentConfigurationId,
+  createdAt,
+  rank,
+  t,
+}: {
+  workspace: WorkspaceType;
+  conversationModelId: ModelId;
+  agentConfigurationId: string;
+  createdAt: Date;
+  rank: number;
+  t?: Transaction;
+}) => {
+  const agentMessageRow = await AgentMessage.create(
+    {
+      createdAt,
+      updatedAt: createdAt,
+      status: "created",
+      agentConfigurationId,
+      agentConfigurationVersion: 0,
+      workspaceId: workspace.id,
+      skipToolsValidation: false,
+    },
+    { transaction: t }
+  );
+  const messageRow = await Message.create(
+    {
+      createdAt,
+      updatedAt: createdAt,
+      sId: generateRandomModelSId(),
+      rank,
+      conversationId: conversationModelId,
+      parentId: null,
+      agentMessageId: agentMessageRow.id,
+      workspaceId: workspace.id,
+    },
+    {
+      transaction: t,
+    }
+  );
+  return {
+    agentMessageRow,
+    messageRow,
+  };
+};


### PR DESCRIPTION
## Description

The data retention workflow was based on conversation updatedAt. 
This is not robust enough, we got somewhere a regression not updating this field anymore. 

We need this code to be extra robust so trying another approach based on the messages in conversations. 
We don't care if it's user message or agent messages so I queried on messages (avoids a join). 

## Tests

Added  ./admin/test.sh tests/lib/resources/conversation_resource.test.ts

## Risk

Break convo retention workflow, so sensitive. 
Please review carefully 🙏🏻 

## Deploy Plan

Deploy front. 