### PR TITLE
Opt: cache sId computation in memory

### DIFF
--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -49,6 +49,8 @@ const ALL_RESOURCES_PREFIXES = Object.values(RESOURCES_PREFIX);
 
 type ResourceNameType = keyof typeof RESOURCES_PREFIX;
 
+const sIdCache = new Map<string, string>();
+
 export function makeSId(
   resourceName: ResourceNameType,
   {
@@ -61,7 +63,17 @@ export function makeSId(
 ): string {
   const idsToEncode = [LEGACY_REGION_BIT, LEGACY_SHARD_BIT, workspaceId, id];
 
-  return `${RESOURCES_PREFIX[resourceName]}_${sqids.encode(idsToEncode)}`;
+  // Computing the sId is relatively expensive and we have a lot of them.
+  // We cache them in memory to avoid recomputing them, they are immutable.
+  const key = `${resourceName}_${idsToEncode.join("_")}`;
+  const cached = sIdCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const sId = `${RESOURCES_PREFIX[resourceName]}_${sqids.encode(idsToEncode)}`;
+  sIdCache.set(key, sId);
+  return sId;
 }
 
 function getIdsFromSId(sId: string): Result<


### PR DESCRIPTION
## Description

We noticed via profiling that we compute sIds a LOT and it's quite costly when cumulated.

## Tests

Locally

## Risk

Medium, we use sIds everywhere, but the diff is relatively small.

## Deploy Plan

Deploy `front`