### PR TITLE
[assistant] - fix: adjust read/edit permissions based on draft status

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1819,8 +1819,8 @@ export function getAgentPermissions(
     case "visible":
       const member = memberAgents.includes(agentConfiguration.id);
       return {
-        canRead: member || agentConfiguration.scope === "visible",
-        canEdit: member,
+        canRead: member || agentConfiguration.status === "draft",
+        canEdit: member || agentConfiguration.status === "draft",
       };
     case "private":
       const isAuthor = agentConfiguration.versionAuthorId === auth.user()?.id;


### PR DESCRIPTION
## Description

This PR aims at fixing one of the error we currently have: editing an assistant and trying to chat with it through the preview leads to an error (see [thread](https://dust4ai.slack.com/archives/C06SYAESP8R/p1747839902338809)).

Note: a more viable solution will be to PATCH on "sId", "status=draft". However the API currently doesn't support such behaviour.

## Test

Was able to reproduce the bug locally and this fixes it.

## Risk

Low

## Deploy Plan

Deploy front