### PR TITLE
Fix: fetch multiple times to avoid truncating the nodes selection to the server side limit

### DIFF
--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -44,6 +44,10 @@ interface EditSpaceManagedDataSourcesViewsProps {
   space: SpaceType;
 }
 
+/*
+ * If you pass a dataSourceView to this component, it will be used to edit the data source view selection.
+ * If you don't pass a dataSourceView, it will allow you to edit data from multiple data sources at once.
+ */
 export function EditSpaceManagedDataSourcesViews({
   dataSourceView,
   isAdmin,
@@ -213,7 +217,7 @@ export function EditSpaceManagedDataSourcesViews({
                 selectionConfiguration.selectedResources.length === 0
               ) {
                 throw new Error(
-                  "We should never have a view with no data in the selection, " +
+                  `We should never have a view with no data in the selection (${existingViewForDs.dataSource.name}), ` +
                     "it should have been removed. Action: check the DataSourceViewSelector component."
                 );
               } else {

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -5,12 +5,14 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  Spinner,
 } from "@dust-tt/sparkle";
 import type { SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { DataSourceViewsSelector } from "@app/components/data_source_view/DataSourceViewSelector";
 import { useMultipleDataSourceViewsContentNodes } from "@app/lib/swr/data_source_views";
+import { emptyArray } from "@app/lib/swr/swr";
 import type {
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
@@ -62,7 +64,7 @@ export default function SpaceManagedDataSourcesViewsModal({
   const defaultSelectedDataSources = useStabilizedValue(
     initialSelectedDataSources,
     isOpen,
-    []
+    emptyArray()
   );
 
   const [systemDataSourceViews, spaceDataSourceViews] = useMemo(() => {
@@ -96,6 +98,7 @@ export default function SpaceManagedDataSourcesViewsModal({
     owner,
     viewType: "all",
   });
+
   const [selectionConfigurations, setSelectionConfigurations] =
     useState<DataSourceViewSelectionConfigurations>({});
 
@@ -142,6 +145,9 @@ export default function SpaceManagedDataSourcesViewsModal({
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
+          // This is required to avoid a stale state when closing and reopening the modal.
+          // Before, we used SWR, so we had invalidation for free, but now we need to do it manually.
+          initialConfigurations.invalidate();
           onClose();
         }
       }}
@@ -152,16 +158,22 @@ export default function SpaceManagedDataSourcesViewsModal({
         </SheetHeader>
         <SheetContainer>
           <div className="overflow-x-auto">
-            <DataSourceViewsSelector
-              useCase="spaceDatasourceManagement"
-              dataSourceViews={systemSpaceDataSourceViews}
-              owner={owner}
-              selectionConfigurations={selectionConfigurations}
-              setSelectionConfigurations={setSelectionConfigurationsCallback}
-              viewType="all"
-              isRootSelectable={true}
-              space={systemSpace}
-            />
+            {initialConfigurations.isNodesLoading ? (
+              <div className="flex items-center justify-center">
+                <Spinner />
+              </div>
+            ) : (
+              <DataSourceViewsSelector
+                useCase="spaceDatasourceManagement"
+                dataSourceViews={systemSpaceDataSourceViews}
+                owner={owner}
+                selectionConfigurations={selectionConfigurations}
+                setSelectionConfigurations={setSelectionConfigurationsCallback}
+                viewType="all"
+                isRootSelectable={true}
+                space={systemSpace}
+              />
+            )}
           </div>
         </SheetContainer>
         <SheetFooter

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -1,11 +1,10 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Fetcher, KeyedMutator, SWRConfiguration } from "swr";
 
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import {
   emptyArray,
   fetcher,
-  fetcherMultiple,
   fetcherWithBody,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -50,6 +49,12 @@ export function useDataSourceViews(
   };
 }
 
+/*
+ * This is a helper function to fetch the content-nodes of multiple data source views at once.
+ * As it has to be exhaustive, it sometimes needs to fetch multiple pages of content-nodes.
+ * We are using fetch() instead of SWR hooks as we want to call fetch() imperatively.
+ * Maybe it's possible using SWR hooks, but I don't know how to do it.
+ */
 export function useMultipleDataSourceViewsContentNodes({
   dataSourceViewsAndInternalIds,
   owner,
@@ -62,42 +67,117 @@ export function useMultipleDataSourceViewsContentNodes({
   dataSourceViewsAndNodes: DataSourceViewsAndNodes[];
   isNodesLoading: boolean;
   isNodesError: boolean;
+  // We need to return an invalidation function to avoid stale data.
+  invalidate: () => void;
 } {
-  const urlsAndOptions = dataSourceViewsAndInternalIds.map(
-    ({ dataSourceView, internalIds }) => {
-      const url = `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes`;
-      const body = JSON.stringify({
-        internalIds,
-        viewType,
-      });
-      const options = {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body,
-      };
-      return { url, options };
-    }
-  );
+  const [dataSourceViewsAndNodes, setDataSourceViewsAndNodes] =
+    useState<DataSourceViewsAndNodes[]>(emptyArray());
+  const [isNodesLoading, setIsNodesLoading] = useState(false);
+  const [isNodesError, setIsNodesError] = useState(false);
 
-  const { data: results, error } = useSWRWithDefaults(
-    urlsAndOptions,
-    fetcherMultiple<GetDataSourceViewContentNodes>
-  );
-  const isNodesError = !!error;
-  const isNodesLoading = !results?.every((r) => r.nodes);
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsNodesLoading(true);
+      setIsNodesError(false);
+
+      const dsvIdToNodes: Map<string, GetDataSourceViewContentNodes["nodes"]> =
+        new Map();
+      const MAX_ITERATIONS = 50;
+      const NODES_PER_PAGE = 500; // Upper-limit server side.
+      const dsvIdToPageCursor: Map<string, string | null> = new Map();
+
+      // Do not loop infinitely, we need to stop at some point
+      for (let i = MAX_ITERATIONS; i >= 0; i--) {
+        if (i === 0) {
+          throw new Error(
+            `We looped more than ${MAX_ITERATIONS} times when fetching content-nodes for ${dataSourceViewsAndInternalIds.length} data source views and ${dataSourceViewsAndInternalIds.reduce((acc, curr) => acc + curr.internalIds.length, 0)} internal ids, something is wrong. Action: check the limit server-side (at time of writing, it was 1000)`
+          );
+        }
+        const isFirstIteration = i === MAX_ITERATIONS;
+
+        // Loop through the data source views and internal ids to fetch the content-nodes of the current page.
+        const promises = [];
+        for (const {
+          dataSourceView,
+          internalIds,
+        } of dataSourceViewsAndInternalIds) {
+          const pageCursor = dsvIdToPageCursor.get(dataSourceView.sId);
+          // Either it's the first iteration or we have a page cursor, so we need to fetch the content-nodes of the current page.
+          // When the page cursor is null, it means that we have fetched all the content-nodes for the current data source view.
+          if (isFirstIteration || pageCursor) {
+            // Note: for the cursor to be taken into account, we need to set a limit as well otherwise it will be ignored server-side.
+            const params = new URLSearchParams();
+            params.append("limit", NODES_PER_PAGE.toString());
+            if (pageCursor) {
+              params.append("cursor", pageCursor);
+            }
+
+            const url = `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes?${params}`;
+
+            const body = {
+              internalIds,
+              viewType,
+            };
+
+            promises.push(fetcherWithBody([url, body, "POST"]));
+          }
+        }
+
+        if (promises.length === 0) {
+          // We have fetched all the content-nodes for all the data source views and internal ids, so we can break the loop.
+          break;
+        }
+        try {
+          // Clear all cursors
+          dsvIdToPageCursor.clear();
+
+          // Wait for all the fetches to be done.
+          const r = await Promise.all<GetDataSourceViewContentNodes>(promises);
+
+          //  Append the nodes to the existing ones in the map.
+          r.forEach(({ nodes, nextPageCursor }) => {
+            if (nodes.length > 0) {
+              const dsvId = nodes[0].dataSourceView.sId;
+              dsvIdToNodes.set(dsvId, [
+                ...(dsvIdToNodes.get(dsvId) ?? []),
+                ...nodes,
+              ]);
+              dsvIdToPageCursor.set(dsvId, nextPageCursor);
+            }
+          });
+        } catch (error) {
+          setIsNodesError(true);
+          break;
+        }
+      }
+
+      // Once we are out of the loop, we can set the data source views and nodes.
+      setDataSourceViewsAndNodes(
+        dataSourceViewsAndInternalIds.map(({ dataSourceView }) => ({
+          dataSourceView,
+          nodes: dsvIdToNodes.get(dataSourceView.sId) ?? [],
+        }))
+      );
+      setIsNodesLoading(false);
+    };
+
+    if (dataSourceViewsAndInternalIds.length > 0) {
+      void fetchData();
+    }
+  }, [dataSourceViewsAndInternalIds, owner.sId, viewType]);
 
   return useMemo(
     () => ({
-      dataSourceViewsAndNodes: dataSourceViewsAndInternalIds.map(
-        ({ dataSourceView }, i) => ({
-          dataSourceView,
-          nodes: results ? results[i].nodes : [],
-        })
-      ),
-      isNodesError,
+      dataSourceViewsAndNodes,
       isNodesLoading,
+      isNodesError,
+      invalidate: () => {
+        setDataSourceViewsAndNodes(emptyArray());
+        setIsNodesLoading(false);
+        setIsNodesError(false);
+      },
     }),
-    [dataSourceViewsAndInternalIds, isNodesError, isNodesLoading, results]
+    [dataSourceViewsAndNodes, isNodesLoading, isNodesError]
   );
 }
 

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -3,9 +3,9 @@ import type { Fetcher, KeyedMutator } from "swr";
 
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
 import {
+  emptyArray,
   fetcher,
   fetcherWithBody,
-  emptyArray,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { PokeListDataSourceViews } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";


### PR DESCRIPTION
## Description

Fixes a latent bug, affecting a few customers so far, that we would always truncate the selection to whatever the server limit is (1000 today).

To fix it, we refactored the `useMultipleDataSourceViewsContentNodes` hook to fetch all the content-nodes pages exhaustively.

Notable changes:
- moved from SWR to direct fetch calls as I needed to call them imperatively in the loop.
- lost the "invalidation" from SWR for free so I added a manual invalidation when modal is closed.
- fixed an infinite warning in the console until we loaded something (`[]` => `emptyArray()`) in `useStabilizedValue()` call.
- added a spinner when while we load the content.

Notes:
- to avoid an infinite loop of fetches "just in case", I limited the number of pages to 50 (so a total of 50*500 nodes).
- the /content-nodes endpoint without explicit limit [has a default of 1000](https://github.com/dust-tt/dust/blob/49f28c59bab3c5f4baeee5a88aca0200c21504a0/front/lib/api/data_source_view.ts#L22) but if you pass an explicit limit, it can't be [more than 500](https://github.com/dust-tt/dust/blob/49f28c59bab3c5f4baeee5a88aca0200c21504a0/front/lib/api/pagination.ts#L38)
- also, [if you don't set a limit, the cursor is ignored](https://github.com/dust-tt/dust/blob/49f28c59bab3c5f4baeee5a88aca0200c21504a0/front/lib/api/pagination.ts#L103)


## Tests

Did a bunch locally.

## Risk

Medium, could break datasource selection in spaces.

## Deploy Plan

Deploy `front`