### PR TITLE
Reduce Sharp Memory Usage with Config and jemalloc Allocator

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -1,6 +1,7 @@
 FROM node:20.13.0 AS front
 
-RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop
+RUN apt-get update && \
+  apt-get install -y vim redis-tools postgresql-client htop libjemalloc2 libjemalloc-dev
 
 ARG COMMIT_HASH
 ARG NEXT_PUBLIC_VIZ_URL
@@ -32,5 +33,8 @@ RUN find . -name "*.test.tsx" -delete
 # fake database URIs are needed because Sequelize will throw if the `url` parameter
 # is undefined, and `next build` imports the `models.ts` file while "Collecting page data"
 RUN FRONT_DATABASE_URI="sqlite:foo.sqlite" npm run build
+
+# Preload jemalloc for all processes:
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 CMD ["npm", "--silent", "run", "start"]

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -78,6 +78,12 @@ const resizeAndUploadToFileStorage: ProcessingFunction = async (
     version: "original",
   });
 
+  // Explicitly disable Sharp's cache to prevent memory accumulation.
+  sharp.cache(false);
+
+  // Set global concurrency limit to prevent too many parallel operations.
+  sharp.concurrency(2);
+
   // Anthropic https://docs.anthropic.com/en/docs/build-with-claude/vision#evaluate-image-size
   // OpenAI https://platform.openai.com/docs/guides/vision#calculating-costs
 


### PR DESCRIPTION
## Description

We identified memory fragmentation and high memory usage in our Next.js image processing, which uses the sharp library. This was causing excessive resident memory (RSS) growth, mostly due to glibc’s allocator being unsuitable for long-running, multi-threaded processes with many small allocations (see [sharp install docs](https://sharp.pixelplumbing.com/install/#linux-memory-allocator)).

This PR does two things:
- It disables caching to prevents sharp from holding onto processed image buffers, reducing retained memory and restricts sharp to two concurrent image processing tasks, preventing memory spikes under load.
- It replaces glibc’s allocator with jemalloc, which is known to handle sharp’s memory allocation patterns much better, reducing fragmentation and keeping RSS stable.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
