### PR TITLE
Improve coding rule MCP2

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -278,9 +278,10 @@ holds the metadata of the server must be defined at the top of the file.
 
 ### [MCP2] Single file internal servers
 
-If possible, internal MCP servers should fit in one file. If not possible, they should be placed
-into a folder that contains a file `server.ts` from where the `createServer` function that
-creates the server will be exported.
+If possible, internal MCP servers should fit in one file. The name of the file must match the
+name of the server. If having only one file is not possible, they should be placed into a folder
+that contains a file `server.ts` from where the `createServer` function that creates the server
+will be exported.
 
 ## TESTING
 


### PR DESCRIPTION
## Description

- Improve the coding rule relative to single-file internal MCP servers to mention that the name of the file should match the server name.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- No deploy.
