### PR TITLE
Add batch deletion capability for Auth0 users

### DIFF
--- a/front/lib/api/poke/plugins/global/delete_auth0_user.ts
+++ b/front/lib/api/poke/plugins/global/delete_auth0_user.ts
@@ -4,40 +4,67 @@ import {
 } from "@app/lib/api/auth0";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { isEmailValid } from "@app/lib/utils";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types";
 
 export const deleteAuth0UserPlugin = createPlugin({
   manifest: {
     id: "delete-auth0-user",
     name: "Delete Auth0 User",
-    description: "Delete a user from Auth0.",
+    description: "Delete one or more users from Auth0.",
     resourceTypes: ["global"],
     args: {
-      email: {
-        type: "string",
-        label: "Email",
-        description: "The email of the user to delete",
+      emails: {
+        type: "text",
+        label: "Emails",
+        description:
+          "Comma or newline separated list of emails of the users to delete",
       },
     },
   },
-  execute: async (auth, _, args) => {
-    const email = args.email.trim();
-    if (isEmailValid(email) === false) {
-      return new Err(new Error("Email address is invalid."));
+  execute: async (_auth, _resource, args) => {
+    const emails = args.emails
+      .split(/[\n,]/g)
+      .map((e) => e.trim())
+      .filter((e) => e.length > 0);
+
+    if (emails.length === 0) {
+      return new Err(new Error("At least one email is required."));
     }
 
-    const [auth0User] = await getAuth0UsersFromEmail([email]);
-    if (!auth0User) {
-      return new Err(new Error("User not found in Auth0."));
+    const invalidEmails = emails.filter((e) => !isEmailValid(e));
+    if (invalidEmails.length > 0) {
+      return new Err(
+        new Error(`Invalid email addresses: ${invalidEmails.join(", ")}`)
+      );
     }
 
-    await getAuth0ManagemementClient().users.delete({
-      id: auth0User.user_id,
-    });
+    const auth0Users = await getAuth0UsersFromEmail(emails);
+    const missingEmails = emails.filter(
+      (e) =>
+        !auth0Users.some(
+          (u) => u.email && u.email.toLowerCase() === e.toLowerCase()
+        )
+    );
+
+    if (missingEmails.length > 0) {
+      return new Err(
+        new Error(`Users not found in Auth0: ${missingEmails.join(", ")}`)
+      );
+    }
+
+    for (const user of auth0Users) {
+      await getAuth0ManagemementClient().users.delete({
+        id: user.user_id,
+      });
+      await setTimeoutAsync(200);
+    }
 
     return new Ok({
       display: "text",
-      value: "User deleted from Auth0.",
+      value: `Deleted ${auth0Users.length} user${
+        auth0Users.length > 1 ? "s" : ""
+      } from Auth0.`,
     });
   },
 });


### PR DESCRIPTION
## Summary
- update Delete Auth0 User poke plugin to accept multiple emails
- delete all listed Auth0 users sequentially with a short delay