### PR TITLE
Introduce DUST_INTERNAL_CLIENT_FACING_URL for front-internal-service

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -4,6 +4,15 @@ export const PRODUCTION_DUST_API = "https://dust.tt";
 
 const config = {
   getClientFacingUrl: (): string => {
+    // We override the NEXT_PUBLIC_DUST_CLIENT_FACING_URL in `front-internal` to ensure that the
+    // uploadUrl returned by the file API points to the `http://front-internal-service` and not our
+    // public API URL.
+    const override = EnvironmentConfig.getOptionalEnvVariable(
+      "DUST_INTERNAL_CLIENT_FACING_URL"
+    );
+    if (override) {
+      return override;
+    }
     return EnvironmentConfig.getEnvVariable(
       "NEXT_PUBLIC_DUST_CLIENT_FACING_URL"
     );


### PR DESCRIPTION
## Description

Allow override of `NEXT_PUBLIC_DUST_CLIENT_FACING_URL` (set at build time to match the region) to `DUST_INTERNAL_CLIENT_FACING_URL` when set.

We will set it in `front-internal-service`

## Tests

N/A

## Risk

`front-internal` received only connectors traffic excluding slack bots so risk is bounded to retriable activities.

## Deploy Plan

- env variable was already added to front-internal (see https://github.com/dust-tt/dust-infra/pull/290)
- deploy `front`