### PR TITLE
Fix support for global agents as sub agent

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -12,9 +12,11 @@ export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
 export const TABLE_CONFIGURATION_URI_PATTERN =
   /^table_configuration:\/\/dust\/w\/(\w+)\/table_configurations\/(\w+)$/;
 
-// URI pattern for configuring the agent to use within an action (agent calls agent, sort of Russian doll situation).
+// URI pattern for configuring the agent to use within an action.
 export const CHILD_AGENT_CONFIGURATION_URI_PATTERN =
-  /^agent:\/\/dust\/w\/(\w+)\/agents\/(\w+)$/;
+  // We accept dashes in the last part, which is the agent sId,
+  // because global agents have dashes in their sId.
+  /^agent:\/\/dust\/w\/(\w+)\/agents\/([\w-]+)$/;
 
 /**
  * Mapping between the mime types we used to identify a configurable resource and the Zod schema used to validate it.

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -191,7 +191,7 @@ describe("JSON Schema Utilities", () => {
                             uri: {
                               type: "string",
                               pattern:
-                                "^agent:\\/\\/dust\\/w\\/(\\w+)\\/agents\\/(\\w+)$",
+                                "^agent:\\/\\/dust\\/w\\/(\\w+)\\/agents\\/([\\w-]+)$",
                             },
                             mimeType: {
                               type: "string",


### PR DESCRIPTION
## Description

- Currently, it is possible to configure a global agent as a sub-agent, but it fails at tool call.
- The part that fails is the tool call, the input do not match the regexp used to parse the URI for the agent because some global agents have a `sId` that contains a dash (e.g. `claude-3-7-sonnet`).
- This PR fixes that by updating the regexp.

## Tests

- Tested locally.
- Checked [in prod](https://dust.tt/poke/0ec9852c2f/conversations/I8xPf36XB6) that this is actually the sId we use.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
