### PR TITLE
[sparkle] - feat(Dropdown): add DropdownMenuTagItem

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.510",
+  "version": "0.2.511",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.510",
+      "version": "0.2.511",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.510",
+  "version": "0.2.511",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -9,6 +9,7 @@ import { ScrollArea } from "@sparkle/components/ScrollArea";
 import { SearchInput, SearchInputProps } from "@sparkle/components/SearchInput";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
+import { Chip } from "@sparkle/components/Chip";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 
@@ -437,6 +438,37 @@ const DropdownMenuRadioItem = React.forwardRef<
   </DropdownMenuPrimitive.RadioItem>
 ));
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+export interface DropdownMenuTagItemProps
+  extends Omit<DropdownMenuItemProps, "label" | "icon"> {
+  label: string;
+  size?: React.ComponentProps<typeof Chip>["size"];
+  color?: React.ComponentProps<typeof Chip>["color"];
+  onRemove?: () => void;
+}
+
+export const DropdownMenuTagItem = React.forwardRef<
+  HTMLDivElement,
+  DropdownMenuTagItemProps
+>(
+  (
+    { label, size = "xs", color = "primary", onRemove, className, ...props },
+    ref
+  ) => {
+    return (
+      <DropdownMenuPrimitive.Item
+        ref={ref}
+        className={cn(menuStyleClasses.item({ variant: "default" }), className)}
+        {...props}
+        asChild
+      >
+        <Chip label={label} size={size} color={color} onRemove={onRemove} />
+      </DropdownMenuPrimitive.Item>
+    );
+  }
+);
+
+DropdownMenuTagItem.displayName = "DropdownMenuTagItem";
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -649,6 +649,6 @@ export {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
   DropdownMenuTagItem,
+  DropdownMenuTrigger,
 };

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -3,13 +3,13 @@ import { cva } from "class-variance-authority";
 import * as React from "react";
 import { useRef } from "react";
 
+import { Chip } from "@sparkle/components/Chip";
 import { Icon } from "@sparkle/components/Icon";
 import { LinkWrapper, LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import { ScrollArea } from "@sparkle/components/ScrollArea";
 import { SearchInput, SearchInputProps } from "@sparkle/components/SearchInput";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
-import { Chip } from "@sparkle/components/Chip";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 
@@ -439,7 +439,7 @@ const DropdownMenuRadioItem = React.forwardRef<
 ));
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
-export interface DropdownMenuTagItemProps
+interface DropdownMenuTagItemProps
   extends Omit<DropdownMenuItemProps, "label" | "icon"> {
   label: string;
   size?: React.ComponentProps<typeof Chip>["size"];
@@ -447,7 +447,7 @@ export interface DropdownMenuTagItemProps
   onRemove?: () => void;
 }
 
-export const DropdownMenuTagItem = React.forwardRef<
+const DropdownMenuTagItem = React.forwardRef<
   HTMLDivElement,
   DropdownMenuTagItemProps
 >(
@@ -650,4 +650,5 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  DropdownMenuTagItem,
 };

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -76,6 +76,7 @@ export {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
+  DropdownMenuTagItem,
   DropdownMenuTrigger,
 } from "./Dropdown";
 export { default as DropzoneOverlay } from "./DropzoneOverlay";

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta } from "@storybook/react";
 import React from "react";
 import { useState } from "react";
 
+import { Spinner } from "@sparkle/components";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -65,7 +66,6 @@ import {
   UserIcon,
 } from "../index_with_tw_base";
 import { Chip } from "../index_with_tw_base";
-import { Spinner } from "@sparkle/components";
 
 const meta = {
   title: "Primitives/Dropdown",

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -1,6 +1,7 @@
 import { DropdownMenuCheckboxItemProps } from "@radix-ui/react-dropdown-menu";
 import type { Meta } from "@storybook/react";
 import React from "react";
+import { useState } from "react";
 
 import {
   DropdownMenu,
@@ -20,6 +21,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@sparkle/components/Dropdown";
+import { DropdownMenuTagItem } from "@sparkle/components/Dropdown";
 import {
   AnthropicLogo,
   DriveLogo,
@@ -62,6 +64,8 @@ import {
   UserGroupIcon,
   UserIcon,
 } from "../index_with_tw_base";
+import { Chip } from "../index_with_tw_base";
+import { Spinner } from "@sparkle/components";
 
 const meta = {
   title: "Primitives/Dropdown",
@@ -729,3 +733,99 @@ function StaticItemDropdownDemo() {
     </DropdownMenu>
   );
 }
+
+export const TagsDropdownExample = () => {
+  const [tags, setTags] = useState([
+    "react",
+    "typescript",
+    "ui",
+    "design-system",
+  ]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTags(tags.filter((tag) => tag !== tagToRemove));
+  };
+
+  const handleAddTag = () => {
+    setIsLoading(true);
+
+    // Simulate API call delay
+    setTimeout(() => {
+      const newTag = `tag-${Math.floor(Math.random() * 1000)}`;
+      setTags([...tags, newTag]);
+      setIsLoading(false);
+    }, 1500);
+  };
+
+  return (
+    <div className="s-flex s-flex-col s-gap-4 s-p-4">
+      <div className="s-flex s-items-center s-gap-2">
+        <DropdownMenu open={true}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              label="Select Tags"
+              icon={PlusIcon}
+              size="sm"
+              isSelect
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="s-w-80">
+            <DropdownMenuLabel label="Available Tags" />
+            <DropdownMenuSeparator />
+
+            <div className="s-w-full">
+              {tags.map((tag) => (
+                <DropdownMenuTagItem
+                  key={tag}
+                  label={tag}
+                  color="highlight"
+                  className="s-m-0.5"
+                  onRemove={() => handleRemoveTag(tag)}
+                  onClick={() => console.log(tag)}
+                />
+              ))}
+            </div>
+
+            <DropdownMenuSeparator />
+            <div className="s-p-2">
+              <Button
+                label={isLoading ? "Adding..." : "Add Random Tag"}
+                onClick={handleAddTag}
+                className="s-w-full"
+                size="sm"
+                disabled={isLoading}
+                icon={
+                  isLoading
+                    ? () => <Spinner size="xs" variant="color" />
+                    : undefined
+                }
+              />
+            </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <div className="s-text-sm s-text-muted-foreground">
+          Click to view available tags
+        </div>
+      </div>
+
+      <div className="s-flex s-flex-wrap s-gap-2 s-rounded-lg s-border s-border-border s-p-4">
+        <span className="s-mr-2 s-text-sm s-text-muted-foreground">
+          Current tags:
+        </span>
+        {tags.map((tag) => (
+          <div key={tag} className="s-inline-flex">
+            <Chip
+              label={tag}
+              color="highlight"
+              size="xs"
+              onRemove={() => handleRemoveTag(tag)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

This PR aims at adding a new component `DropdownMenuTagItem` to be able to squeeze tags on the same line.

![Screenshot 2025-05-22 at 16 43 51](https://github.com/user-attachments/assets/00ab15e9-a93f-40c2-a7dd-efef99c9012e)


**References:**
- https://github.com/dust-tt/tasks/issues/2955

## Risk

Low

## Deploy Plan

- Publish sparkle