### PR TITLE
Fix background color for `while` blocks in apps

### DIFF
--- a/front/components/app/blocks/WhileEnd.tsx
+++ b/front/components/app/blocks/WhileEnd.tsx
@@ -105,28 +105,21 @@ export function While({
           <div className="flex flex-initial items-center">condition :</div>
           <div className="flex w-full font-normal">
             <div className="w-full leading-4">
-              <div
-                className={classNames(
-                  "border bg-muted-background",
-                  "border-border"
-                )}
-              >
-                <CodeEditor
-                  data-color-mode={isDark ? "dark" : "light"}
-                  readOnly={readOnly}
-                  value={block.spec.condition_code}
-                  language="js"
-                  placeholder=""
-                  onChange={(e) => handleConditionCodeChange(e.target.value)}
-                  padding={15}
-                  style={{
-                    fontSize: 12,
-                    fontFamily:
-                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                    backgroundColor: "rgb(241 245 249)",
-                  }}
-                />
-              </div>
+              <CodeEditor
+                data-color-mode={isDark ? "dark" : "light"}
+                readOnly={readOnly}
+                value={block.spec.condition_code}
+                language="js"
+                placeholder=""
+                onChange={(e) => handleConditionCodeChange(e.target.value)}
+                padding={15}
+                className="rounded-lg bg-muted-background dark:bg-muted-background-night"
+                style={{
+                  fontSize: 12,
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                }}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

- Ran into an issue when debugging a dust app run where I could not read the content of the block.
- In dark mode, the background color of the code block in a While block of a Dust app is white.

Before:
<img width="695" alt="Screenshot 2025-05-22 at 5 07 42 PM" src="https://github.com/user-attachments/assets/a94859f9-3155-4260-a306-e9167a6a347c" />

After:
<img width="695" alt="Screenshot 2025-05-22 at 5 06 02 PM" src="https://github.com/user-attachments/assets/d9660d78-1c72-49e6-bb12-c5b423ab46fb" />

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
