### PR TITLE
Rename `CHILD_AGENT` -> `AGENT`

### DIFF
--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -357,7 +357,7 @@ export function hasErrorActionMCP(
       requirements.requiresChildAgentConfiguration &&
       !action.configuration.childAgentId
     ) {
-      return "Please select a child agent.";
+      return "Please select an agent.";
     }
     if (
       requirements.requiresReasoningConfiguration &&

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -97,7 +97,7 @@ export async function fetchMCPServerActionConfigurations(
     where: whereClause,
   });
 
-  // Find the associated child agent configurations.
+  // Find the associated agent configurations.
   const allChildAgentConfigurations =
     await AgentChildAgentConfiguration.findAll({ where: whereClause });
 

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -97,7 +97,7 @@ export async function fetchMCPServerActionConfigurations(
     where: whereClause,
   });
 
-  // Find the associated agent configurations.
+  // Find the associated child agent configurations.
   const allChildAgentConfigurations =
     await AgentChildAgentConfiguration.findAll({ where: whereClause });
 

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -13,7 +13,7 @@ export const TABLE_CONFIGURATION_URI_PATTERN =
   /^table_configuration:\/\/dust\/w\/(\w+)\/table_configurations\/(\w+)$/;
 
 // URI pattern for configuring the agent to use within an action.
-export const CHILD_AGENT_CONFIGURATION_URI_PATTERN =
+export const AGENT_CONFIGURATION_URI_PATTERN =
   // We accept dashes in the last part, which is the agent sId,
   // because global agents have dashes in their sId.
   /^agent:\/\/dust\/w\/(\w+)\/agents\/([\w-]+)$/;
@@ -35,9 +35,9 @@ export const ConfigurableToolInputSchemas = {
       mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE),
     })
   ),
-  [INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT]: z.object({
-    uri: z.string().regex(CHILD_AGENT_CONFIGURATION_URI_PATTERN),
-    mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT),
+  [INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT]: z.object({
+    uri: z.string().regex(AGENT_CONFIGURATION_URI_PATTERN),
+    mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT),
   }),
   [INTERNAL_MIME_TYPES.TOOL_INPUT.STRING]: z.object({
     value: z.string(),

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -27,9 +27,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
 function parseAgentConfigurationUri(uri: string): Result<string, Error> {
   const match = uri.match(AGENT_CONFIGURATION_URI_PATTERN);
   if (!match) {
-    return new Err(
-      new Error(`Invalid URI for an agent configuration: ${uri}`)
-    );
+    return new Err(new Error(`Invalid URI for an agent configuration: ${uri}`));
   }
   // Safe to do this because the inputs are already checked against the zod schema here.
   return new Ok(match[2]);

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -49,9 +49,7 @@ function createServer(auth: Authenticator): McpServer {
           `The query sent to the agent. This is the question or instruction that will be processed by the agent, which will respond with its own capabilities and knowledge.`
         ),
       childAgent:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT
-        ],
+        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT],
     },
     async ({ query, childAgent: { uri } }) => {
       const childAgentIdRes = parseAgentConfigurationUri(uri);

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -4,7 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import {
-  CHILD_AGENT_CONFIGURATION_URI_PATTERN,
+  AGENT_CONFIGURATION_URI_PATTERN,
   ConfigurableToolInputSchemas,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -25,10 +25,10 @@ const serverInfo: InternalMCPServerDefinitionType = {
 };
 
 function parseAgentConfigurationUri(uri: string): Result<string, Error> {
-  const match = uri.match(CHILD_AGENT_CONFIGURATION_URI_PATTERN);
+  const match = uri.match(AGENT_CONFIGURATION_URI_PATTERN);
   if (!match) {
     return new Err(
-      new Error(`Invalid URI for a child agent configuration: ${uri}`)
+      new Error(`Invalid URI for an agent configuration: ${uri}`)
     );
   }
   // Safe to do this because the inputs are already checked against the zod schema here.
@@ -50,7 +50,7 @@ function createServer(auth: Authenticator): McpServer {
         ),
       childAgent:
         ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT
+          INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT
         ],
     },
     async ({ query, childAgent: { uri } }) => {

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -101,7 +101,7 @@ export function generateConfiguredInput({
         })) || []
       );
 
-    case INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT: {
+    case INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT: {
       const { childAgentId } = actionConfiguration;
       if (!childAgentId) {
         // Unreachable, when fetching agent configurations using getAgentConfigurations, we always fill the sId.
@@ -430,7 +430,7 @@ export function getMCPServerRequirements(
     Object.keys(
       findPathsToConfiguration({
         mcpServer: server,
-        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT,
       })
     ).length > 0;
 

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -37,7 +37,7 @@ const RESOURCES_PREFIX = {
   // Resources relative to the configuration of an MCP server.
   data_source_configuration: "dsc",
   table_configuration: "tbc",
-  child_agent_configuration: "cac",
+  agent_configuration: "cac",
 
   // Virtual resources (no database modelsassociated).
   internal_mcp_server: "ims",

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -169,8 +169,8 @@ describe("JSON Schema Utilities", () => {
       );
     });
 
-    it("should handle complex nested schemas with CHILD_AGENT configuration", () => {
-      // Create a complex schema with deeply nested CHILD_AGENT configuration
+    it("should handle complex nested schemas with AGENT configuration", () => {
+      // Create a complex schema with deeply nested AGENT configuration
       const mainSchema: JSONSchema = {
         type: "object",
         properties: {
@@ -196,7 +196,7 @@ describe("JSON Schema Utilities", () => {
                             mimeType: {
                               type: "string",
                               const:
-                                "application/vnd.dust.tool-input.child-agent",
+                                "application/vnd.dust.tool-input.agent",
                             },
                           },
                           required: ["uri", "mimeType"],
@@ -213,10 +213,10 @@ describe("JSON Schema Utilities", () => {
         },
       };
 
-      // Look for CHILD_AGENT configuration schema
+      // Look for AGENT configuration schema
       const result = findMatchingSubSchemas(
         mainSchema,
-        INTERNAL_MIME_TYPES.TOOL_INPUT.CHILD_AGENT
+        INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT
       );
       expect(Object.keys(result)).toContain(
         "workflow.steps.items.action.executor"

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -195,8 +195,7 @@ describe("JSON Schema Utilities", () => {
                             },
                             mimeType: {
                               type: "string",
-                              const:
-                                "application/vnd.dust.tool-input.agent",
+                              const: "application/vnd.dust.tool-input.agent",
                             },
                           },
                           required: ["uri", "mimeType"],

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -210,7 +210,7 @@ const TOOL_MIME_TYPES = {
     resourceTypes: [
       "DATA_SOURCE",
       "TABLE",
-      "CHILD_AGENT",
+      "AGENT",
       "STRING",
       "NUMBER",
       "BOOLEAN",


### PR DESCRIPTION
## Description

- This PR renames `CHILD_AGENT` into `AGENT` in the tool input mime types.
- The table `agent_child_agent_configurations` is not renamed, because in this context it is a child agent, only the tool input is generic.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
