### PR TITLE
Add: misnamed action catcher

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -80,7 +80,7 @@ const EMPTY_INPUT_SCHEMA: JSONSchema7 = { type: "object", properties: {} };
 
 const MAX_TOOL_NAME_LENGTH = 64;
 
-const TOOL_NAME_SEPARATOR = "__";
+export const TOOL_NAME_SEPARATOR = "__";
 
 // Define the new type here for now, or move to a dedicated types file later.
 export interface ServerToolsAndInstructions {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -16,6 +16,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "hubspot",
   "image_generation",
   "include_data",
+  "missing_action_catcher",
   "notion",
   "primitive_types_debugger",
   "query_tables",
@@ -136,6 +137,11 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 12,
     availability: "auto",
     flag: "dev_mcp_actions",
+  },
+  missing_action_catcher: {
+    id: 13,
+    availability: "auto_hidden_builder",
+    flag: null,
   },
 
   // Dev

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -30,7 +30,7 @@ export const connectToInternalMCPServer = async (
   mcpServerId: string,
   transport: InMemoryTransport,
   auth: Authenticator,
-  agentLoopContext: AgentLoopContextType
+  agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> => {
   const res = getInternalMCPServerNameAndWorkspaceId(mcpServerId);
   if (res.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -7,6 +7,7 @@ import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/s
 import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/server";
 import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation";
 import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include";
+import { default as missingActionCatcherServer } from "@app/lib/actions/mcp_internal_actions/servers/missing_action_catcher";
 import { default as notionServer } from "@app/lib/actions/mcp_internal_actions/servers/notion";
 import { default as primitiveTypesDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/primitive_types_debugger";
 import { default as extractDataServer } from "@app/lib/actions/mcp_internal_actions/servers/process";
@@ -31,7 +32,7 @@ export async function getInternalMCPServer(
     internalMCPServerName: InternalMCPServerNameType;
     mcpServerId: string;
   },
-  agentLoopContext: AgentLoopContextType
+  agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":
@@ -43,17 +44,19 @@ export async function getInternalMCPServer(
     case "file_generation":
       return generateFileServer(auth);
     case "query_tables":
-      return tablesQueryServer(auth, agentLoopContext.runContext);
+      return tablesQueryServer(auth, agentLoopContext);
     case "query_tables_v2":
-      return tablesQueryServerV2(auth, agentLoopContext.runContext);
+      return tablesQueryServerV2(auth, agentLoopContext);
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer();
     case "think":
       return thinkServer();
     case "web_search_&_browse":
-      return webtoolsServer(agentLoopContext.runContext);
+      return webtoolsServer(agentLoopContext);
     case "search":
       return searchServer(auth, agentLoopContext);
+    case "missing_action_catcher":
+      return missingActionCatcherServer(auth, agentLoopContext);
     case "notion":
       return notionServer(auth, mcpServerId);
     case "include_data":
@@ -61,7 +64,7 @@ export async function getInternalMCPServer(
     case "run_agent":
       return runAgentServer(auth);
     case "reasoning":
-      return reasoningServer(auth, agentLoopContext.runContext);
+      return reasoningServer(auth, agentLoopContext);
     case "run_dust_app":
       return dustAppServer(auth, agentLoopContext);
     case "agent_router":

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -28,13 +28,14 @@ const createServer = (
 
     server.tool(actionName, "", {}, async () => {
       return {
-        isError: false,
+        isError: true,
         content: [
           {
             type: "text",
             text:
-              `There is no tool named "${actionName}" in the agent configuration. ` +
-              "This answer to the function call is a catch-all. Please verify that the function name is correct : " +
+              `Tool "${actionName}" not found. ` +
+              "This answer to the function call is a catch-all. " +
+              "Please verify that the function name is correct : " +
               "pay attention to case sensitivity and separators between words in the name. " +
               "It's safe to retry automatically with another name.",
           },

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -25,7 +25,6 @@ const createServer = (
     if (!actionName) {
       throw new Error("No action name found");
     }
-    console.log("actionName", actionName);
 
     server.tool(actionName, "", {}, async () => {
       return {
@@ -33,7 +32,11 @@ const createServer = (
         content: [
           {
             type: "text",
-            text: `There is no tool named "${actionName}" in the agent configuration. This answer to the function call is a catch-all. Please verify that the function name is correct : pay attention to case sensitivity and separators between words in the name. It's safe to retry automatically with another name.`,
+            text:
+              `There is no tool named "${actionName}" in the agent configuration. ` +
+              "This answer to the function call is a catch-all. Please verify that the function name is correct : " +
+              "pay attention to case sensitivity and separators between words in the name. " +
+              "It's safe to retry automatically with another name.",
           },
         ],
       };

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -1,0 +1,57 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "missing_action_catcher",
+  version: "1.0.0",
+  description: "To be used to catch errors and avoid erroring.",
+  authorization: null,
+  icon: "ActionDocumentTextIcon",
+};
+
+const createServer = (
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
+  const server = new McpServer(serverInfo);
+  if (agentLoopContext) {
+    const actionName = agentLoopContext.runContext
+      ? agentLoopContext.runContext.actionConfiguration.name
+      : agentLoopContext.listToolsContext?.agentActionConfiguration.name;
+
+    if (!actionName) {
+      throw new Error("No action name found");
+    }
+    console.log("actionName", actionName);
+
+    server.tool(actionName, "", {}, async () => {
+      return {
+        isError: false,
+        content: [
+          {
+            type: "text",
+            text: `There is no tool named "${actionName}" in the agent configuration. This answer to the function call is a catch-all. Please verify that the function name is correct : pay attention to case sensitivity and separators between words in the name. It's safe to retry automatically with another name.`,
+          },
+        ],
+      };
+    });
+  } else {
+    server.tool(
+      "placeholder_tool",
+      "This tool is a placeholder to catch missing actions.",
+      {},
+      async () => {
+        return {
+          isError: false,
+          content: [{ type: "text", text: "No action name found" }],
+        };
+      }
+    );
+  }
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -9,7 +9,7 @@ import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_acti
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { runReasoning } from "@app/lib/actions/reasoning";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { isModelId, isModelProviderId, isReasoningEffortId } from "@app/types";
@@ -25,7 +25,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
 
 function createServer(
   auth: Authenticator,
-  agentLoopRunContext?: AgentLoopRunContextType
+  agentLoopContext?: AgentLoopContextType
 ): McpServer {
   const server = new McpServer(serverInfo);
 
@@ -42,9 +42,11 @@ function createServer(
       { model: { modelId, providerId, temperature, reasoningEffort } },
       { sendNotification, _meta }
     ) => {
-      if (!agentLoopRunContext) {
+      if (!agentLoopContext?.runContext) {
         throw new Error("Unreachable: missing agentLoopRunContext.");
       }
+
+      const agentLoopRunContext = agentLoopContext.runContext;
 
       if (
         !isModelId(modelId) ||

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -262,7 +262,7 @@ async function prepareParamsWithHistory(
 
 export default async function createServer(
   auth: Authenticator,
-  agentLoopContext: AgentLoopContextType
+  agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> {
   const server = new McpServer(serverInfo);
   const owner = auth.getNonNullableWorkspace();

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -12,7 +12,7 @@ import type { MCPToolResultContentType } from "@app/lib/actions/mcp_internal_act
 import { fetchAgentTableConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { runActionStreamed } from "@app/lib/actions/server";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
 import type { CSVRecord } from "@app/lib/api/csv";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
@@ -42,7 +42,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
 
 function createServer(
   auth: Authenticator,
-  agentLoopRunContext?: AgentLoopRunContextType
+  agentLoopContext?: AgentLoopContextType
 ): McpServer {
   const server = new McpServer(serverInfo);
 
@@ -55,9 +55,11 @@ function createServer(
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
     },
     async ({ tables }) => {
-      if (!agentLoopRunContext) {
+      if (!agentLoopContext?.runContext) {
         throw new Error("Unreachable: missing agentLoopRunContext.");
       }
+
+      const agentLoopRunContext = agentLoopContext.runContext;
 
       const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -20,7 +20,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { fetchAgentTableConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
@@ -40,7 +40,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
 
 function createServer(
   auth: Authenticator,
-  agentLoopRunContext?: AgentLoopRunContextType
+  agentLoopContext?: AgentLoopContextType
 ): McpServer {
   const server = new McpServer(serverInfo);
 
@@ -131,9 +131,11 @@ function createServer(
     },
     async ({ tables, query, fileName }) => {
       // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
-      if (!agentLoopRunContext) {
-        throw new Error("Unreachable: missing agentLoopRunContext.");
+      if (!agentLoopContext?.runContext) {
+        throw new Error("Unreachable: missing agentLoopContext.");
       }
+
+      const agentLoopRunContext = agentLoopContext.runContext;
 
       // Fetch table configurations
       const agentTableConfigurationsRes = await fetchAgentTableConfigurations(

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -6,7 +6,7 @@ import type {
   BrowseResultResourceType,
   WebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset } from "@app/lib/actions/utils";
 import { getWebsearchNumResults } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
@@ -31,9 +31,7 @@ export const serverInfo: InternalMCPServerDefinitionType = {
   },
 };
 
-const createServer = (
-  agentLoopRunContext?: AgentLoopRunContextType
-): McpServer => {
+const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
   const server = new McpServer(serverInfo);
 
   server.tool(
@@ -59,11 +57,13 @@ const createServer = (
         ),
     },
     async ({ query, page }) => {
-      if (!agentLoopRunContext) {
+      if (!agentLoopContext?.runContext) {
         throw new Error(
           "agentLoopRunContext is required where the tool is called."
         );
       }
+
+      const agentLoopRunContext = agentLoopContext.runContext;
 
       const numResults = getWebsearchNumResults({
         stepActions: agentLoopRunContext.stepActions,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -140,7 +140,7 @@ export const connectToMCPServer = async (
     agentLoopContext,
   }: {
     params: MCPConnectionParams;
-    agentLoopContext: AgentLoopContextType;
+    agentLoopContext?: AgentLoopContextType;
   }
 ): Promise<Result<Client, Error>> => {
   // This is where we route the MCP client to the right server.
@@ -319,7 +319,6 @@ export async function fetchRemoteServerMetaDataByURL(
       type: "remoteMCPServerUrl",
       remoteMCPServerUrl: url,
     },
-    agentLoopContext: {},
   });
 
   if (r.isErr()) {

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -171,5 +171,4 @@ export type AgentLoopContextType =
   | {
       runContext?: never;
       listToolsContext: AgentLoopListToolsContextType;
-    }
-  | { runContext?: never; listToolsContext?: never };
+    };

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -67,7 +67,6 @@ export class InternalMCPServerInMemoryResource {
             type: "mcpServerId",
             mcpServerId: id,
           },
-          agentLoopContext: {},
         });
 
         if (s.isErr()) {


### PR DESCRIPTION
## Description

Introduce a catch-all server that will be used to answer where an action name is misspelled by the agent instead of error'ing.

## Tests

Did test locally randomly breaking the name of the action.
<img width="742" alt="image" src="https://github.com/user-attachments/assets/fb9b9c43-ac41-4c20-8e71-632dc5ddbc69" />

## Risk

Relatively low as it should only trigger in case of bogus name (which currently error anyway).

## Deploy Plan

Deploy `front`