### PR TITLE
[Attach in Inputbar] Confluence: support long-format URLs

### DIFF
--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -357,6 +357,8 @@ export function nodeCandidateFromUrl(
     for (const provider of Object.values(providers)) {
       if (provider.matcher(urlObj)) {
         if (provider.extractor && provider.urlNormalizer) {
+          // For providers with both extractor and urlNormalizer, we try to
+          // extract the nodeId first, since it avoids a search in the database.
           const result = provider.extractor(urlObj);
           if (result.node) {
             return result;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/2835

In the inputbar, we currently detect confluence URLs pointing to documents in our database via URL search, `URLCandidate` as written in lib/connectors.ts: we will lookup documents (stored in elasticsearch) to see if any document's url match.

But we store shortened document URLs, eg. `https://dust4ai.atlassian.net/wiki/x/BYD8Aw`. If the user pastes a long-form URL for the same document, here `https://dust4ai.atlassian.net/wiki/spaces/KB/pages/66879493/Aubin+test`, we won't detect it via search.

However, we *could* match it using the page node, which is in the long URL form (here 66879493), using in that case `NodeCandidate`.

This PR implements this by:
- Adding a new ProviderWithBoth type to allow a provider to have both urlNormalizer and extractor
- Implementing an extractor for Confluence to extract page IDs from long URLs
- Updating nodeCandidateFromUrl to detect the URL format and choose the appropriate method

## Risks

Low risk change limited to Confluence URL handling in the inputbar. 
The changes are well-contained and only affect the URL detection logic for Confluence.

## Tests

Manually tested by:
1. Pasting short-format Confluence URLs in the inputbar (existing functionality)
2. Pasting long-format Confluence URLs in the inputbar (new functionality)

## Deploy Plan

No migration or configuration changes required. Simply deploy the front end.