### PR TITLE
[front] chore(auth): Use transaction to share pool co during auth

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -113,6 +113,9 @@ export class Authenticator {
   private static transaction<T>(
     callback: (t?: Transaction) => Promise<T>
   ): Promise<T> {
+    // Skipping in test as in doesn't behave well with itInTransaction.
+    // The transaction in the test is not passed here, so data fed when
+    // initializing script is not accessible here.
     if (process.env.NODE_ENV === "test") {
       return callback();
     }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -5,7 +5,7 @@ import type {
   NextApiRequest,
   NextApiResponse,
 } from "next";
-import type { Transaction } from "sequelize";
+import { Transaction } from "sequelize";
 
 import type { Auth0JwtPayload } from "@app/lib/api/auth0";
 import config from "@app/lib/api/config";
@@ -111,9 +111,16 @@ export class Authenticator {
    * Note: READ_UNCOMMITTED is not supported in PG
    */
   private static transaction<T>(
-    callback: (t: Transaction) => Promise<T>
+    callback: (t?: Transaction) => Promise<T>
   ): Promise<T> {
-    return frontSequelize.transaction(callback);
+    if (process.env.NODE_ENV === "test") {
+      return callback();
+    }
+
+    return frontSequelize.transaction(
+      { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+      callback
+    );
   }
 
   /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -181,11 +181,11 @@ export class Authenticator {
 
       if (user && workspace) {
         [role, groups, subscription] = await Promise.all([
-          MembershipResource.getActiveMembershipOfUserInWorkspace({
+          MembershipResource.getActiveRoleForUserInWorkspace({
             user,
             workspace: renderLightWorkspaceType({ workspace }),
             transaction: t,
-          }).then((m) => m?.role ?? "none"),
+          }),
           GroupResource.listUserGroupsInWorkspace({
             user,
             workspace: renderLightWorkspaceType({ workspace }),
@@ -285,10 +285,10 @@ export class Authenticator {
 
     if (user && workspace) {
       [role, groups, subscription] = await Promise.all([
-        MembershipResource.getActiveMembershipOfUserInWorkspace({
+        MembershipResource.getActiveRoleForUserInWorkspace({
           user,
           workspace: renderLightWorkspaceType({ workspace }),
-        }).then((m) => m?.role ?? "none"),
+        }),
         GroupResource.listUserGroupsInWorkspace({
           user,
           workspace: renderLightWorkspaceType({ workspace }),
@@ -365,11 +365,11 @@ export class Authenticator {
       let subscription: SubscriptionResource | null = null;
 
       [role, groups, subscription] = await Promise.all([
-        MembershipResource.getActiveMembershipOfUserInWorkspace({
+        MembershipResource.getActiveRoleForUserInWorkspace({
           user: user,
           workspace: renderLightWorkspaceType({ workspace }),
           transaction: t,
-        }).then((m) => m?.role ?? "none"),
+        }),
         GroupResource.listUserGroupsInWorkspace({
           user,
           workspace: renderLightWorkspaceType({ workspace }),

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -5,7 +5,7 @@ import type {
   NextApiRequest,
   NextApiResponse,
 } from "next";
-import { Transaction } from "sequelize";
+import type { Transaction } from "sequelize";
 
 import type { Auth0JwtPayload } from "@app/lib/api/auth0";
 import config from "@app/lib/api/config";
@@ -113,15 +113,7 @@ export class Authenticator {
   private static transaction<T>(
     callback: (t: Transaction) => Promise<T>
   ): Promise<T> {
-    return frontSequelize.transaction(
-      {
-        isolationLevel:
-          process.env.NODE_ENV === "test"
-            ? Transaction.ISOLATION_LEVELS.REPEATABLE_READ
-            : Transaction.ISOLATION_LEVELS.READ_COMMITTED,
-      },
-      callback
-    );
+    return frontSequelize.transaction(callback);
   }
 
   /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -229,7 +229,7 @@ export class Authenticator {
               transaction: t,
             })
           : null,
-        session ? UserResource.fetchByAuth0Sub(session.user.sub) : null,
+        session ? UserResource.fetchByAuth0Sub(session.user.sub, t) : null,
       ]);
 
       let groups: GroupResource[] = [];
@@ -240,6 +240,7 @@ export class Authenticator {
           user?.isDustSuperUser
             ? GroupResource.internalFetchAllWorkspaceGroups({
                 workspaceId: workspace.id,
+                transaction: t,
               })
             : [],
           SubscriptionResource.fetchActiveByWorkspace(

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -114,7 +114,12 @@ export class Authenticator {
     callback: (t: Transaction) => Promise<T>
   ): Promise<T> {
     return frontSequelize.transaction(
-      { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+      {
+        isolationLevel:
+          process.env.NODE_ENV === "test"
+            ? Transaction.ISOLATION_LEVELS.REPEATABLE_READ
+            : Transaction.ISOLATION_LEVELS.READ_COMMITTED,
+      },
       callback
     );
   }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -642,6 +642,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           workspaceId: workspace.id,
           kind: "global",
         },
+        transaction,
       });
 
       if (!globalGroup) {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -312,10 +312,15 @@ export class GroupResource extends BaseResource<GroupModel> {
   // Internal fetcher for Authenticator only
 
   // Use with care as this gives access to all groups in the workspace.
-  static async internalFetchAllWorkspaceGroups(
-    workspaceId: ModelId,
-    groupKinds: GroupKind[] = ["global", "regular", "system"]
-  ): Promise<GroupResource[]> {
+  static async internalFetchAllWorkspaceGroups({
+    workspaceId,
+    groupKinds = ["global", "regular", "system"],
+    transaction,
+  }: {
+    workspaceId: ModelId;
+    groupKinds?: GroupKind[];
+    transaction?: Transaction;
+  }): Promise<GroupResource[]> {
     const groups = await this.model.findAll({
       where: {
         workspaceId,
@@ -323,6 +328,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           [Op.in]: groupKinds,
         },
       },
+      transaction,
     });
 
     return groups.map((group) => new this(GroupModel, group.get()));
@@ -378,13 +384,15 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   static async internalFetchWorkspaceGlobalGroup(
-    workspaceId: ModelId
+    workspaceId: ModelId,
+    transaction?: Transaction
   ): Promise<GroupResource | null> {
     const group = await this.model.findOne({
       where: {
         workspaceId,
         kind: "global",
       },
+      transaction,
     });
 
     if (!group) {
@@ -607,16 +615,19 @@ export class GroupResource extends BaseResource<GroupModel> {
     user,
     workspace,
     groupKinds = ["global", "regular", "agent_editors"],
+    transaction,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
     groupKinds?: Omit<GroupKind, "system">[];
+    transaction?: Transaction;
   }): Promise<GroupResource[]> {
     // First we need to check if the user is a member of the workspace.
     const workspaceMembership =
       await MembershipResource.getActiveMembershipOfUserInWorkspace({
         user,
         workspace,
+        transaction,
       });
     if (!workspaceMembership) {
       return [];
@@ -659,6 +670,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           [Op.in]: groupKinds.filter((k) => k !== "global") as GroupKind[],
         },
       },
+      transaction,
     });
 
     const groups = [...(globalGroup ? [globalGroup] : []), ...userGroups];

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -333,6 +333,32 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return memberships[0];
   }
 
+  static async getActiveRoleForUserInWorkspace({
+    user,
+    workspace,
+    transaction,
+  }: {
+    user: UserResource;
+    workspace: LightWorkspaceType;
+    transaction?: Transaction;
+  }): Promise<Attributes<MembershipModel>["role"] | "none"> {
+    const membership = await this.model.findOne({
+      where: {
+        userId: user.id,
+        workspaceId: workspace.id,
+        startAt: {
+          [Op.lte]: new Date(),
+        },
+        endAt: {
+          [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }],
+        },
+      },
+      transaction,
+    });
+
+    return membership?.role ?? "none";
+  }
+
   static async getActiveMembershipOfUserInWorkspace({
     user,
     workspace,

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -343,6 +343,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     transaction?: Transaction;
   }): Promise<Attributes<MembershipModel>["role"] | "none"> {
     const membership = await this.model.findOne({
+      attributes: ["role"],
       where: {
         userId: user.id,
         workspaceId: workspace.id,

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -49,6 +49,7 @@ MembershipModel.init(
       { fields: ["userId", "role"] },
       { fields: ["startAt"] },
       { fields: ["endAt"] },
+      { fields: ["workspaceId", "userId", "startAt", "endAt"] },
     ],
   }
 );

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -80,14 +80,19 @@ export class SubscriptionResource extends BaseResource<Subscription> {
   }
 
   static async fetchActiveByWorkspace(
-    workspace: LightWorkspaceType
+    workspace: LightWorkspaceType,
+    transaction?: Transaction
   ): Promise<SubscriptionResource> {
-    const res = await SubscriptionResource.fetchActiveByWorkspaces([workspace]);
+    const res = await SubscriptionResource.fetchActiveByWorkspaces(
+      [workspace],
+      transaction
+    );
     return res[workspace.sId];
   }
 
   static async fetchActiveByWorkspaces(
-    workspaces: LightWorkspaceType[]
+    workspaces: LightWorkspaceType[],
+    transaction?: Transaction
   ): Promise<{ [key: string]: SubscriptionResource }> {
     const workspaceModelBySid = _.keyBy(workspaces, "sId");
 
@@ -117,6 +122,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
             required: true,
           },
         ],
+        transaction,
       }),
       "workspaceId"
     );

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -104,20 +104,28 @@ export class UserResource extends BaseResource<UserModel> {
     return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
-  static async fetchById(userId: string): Promise<UserResource | null> {
+  static async fetchById(
+    userId: string,
+    transaction?: Transaction
+  ): Promise<UserResource | null> {
     const user = await UserModel.findOne({
       where: {
         sId: userId,
       },
+      transaction,
     });
     return user ? new UserResource(UserModel, user.get()) : null;
   }
 
-  static async fetchByAuth0Sub(sub: string): Promise<UserResource | null> {
+  static async fetchByAuth0Sub(
+    sub: string,
+    transaction?: Transaction
+  ): Promise<UserResource | null> {
     const user = await UserModel.findOne({
       where: {
         auth0Sub: sub,
       },
+      transaction,
     });
     return user ? new UserResource(UserModel, user.get()) : null;
   }

--- a/front/migrations/db/migration_270.sql
+++ b/front/migrations/db/migration_270.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 23, 2025
+CREATE INDEX "memberships_workspace_id_user_id_start_at_end_at" ON "memberships" ("workspaceId", "userId", "startAt", "endAt");

--- a/front/migrations/db/migration_270.sql
+++ b/front/migrations/db/migration_270.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 23, 2025
-CREATE INDEX "memberships_workspace_id_user_id_start_at_end_at" ON "memberships" ("workspaceId", "userId", "startAt", "endAt");
+CREATE INDEX CONCURRENTLY "memberships_workspace_id_user_id_start_at_end_at" ON "memberships" ("workspaceId", "userId", "startAt", "endAt");


### PR DESCRIPTION
## Description
In the goal of optimizing db access, added unmanaged transaction when creating an `Authenticator`.  Multiple reason do to so:
- By using a transaction we can make sure a group of request we do a lot and together can share the same connection, so no more extra connection acquisition.
- Using manged transaction instead of unmanaged, because for a unknown reason (as of right now), an unmanaged transaction struggle to acquire a connection, timeout almost all the time, and also lots of tests were failing.
- Skip the transaction in Authenticator during test, as it doesn't behave well with the other transaction in `itInTransaction`. So skipping it to avoid rewriting too much things or having to install `cls-hooked`. Feels that's ok as it wouldn't change the behavior as before.
- Use `READ_COMMITTED` isolation is the fastest and lower overhead one, great for read-only.
- Create proper method in the MembershipResource to get the role of a user in a given workspace, this will avoid few extra duplicate or useless request.

## Tests
- [x] Locally signin / signout, access pages here and there
 - [x] change my role
- [x] Did the same on front-edge

## Risk
- High blast as it's the Authenticator, but should be fast to revert.

## Deploy Plan
- Run migration
- Deploy front
