### PR TITLE
Opt: filter early when listing datasource views excluding conversations

### DIFF
--- a/front/lib/resources/data_source_view_resource.test.ts
+++ b/front/lib/resources/data_source_view_resource.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+describe("DataSourceViewResource", () => {
+  describe("listByWorkspace", () => {
+    itInTransaction(
+      "should only return views for the current workspace",
+      async (t) => {
+        // Create two workspaces
+        const workspace1 = await WorkspaceFactory.basic();
+        const workspace2 = await WorkspaceFactory.basic();
+
+        // Create spaces for each workspace
+        const space1 = await SpaceFactory.regular(workspace1, t);
+        const space2 = await SpaceFactory.regular(workspace2, t);
+        await SpaceFactory.conversations(workspace1, t);
+        await SpaceFactory.conversations(workspace2, t);
+
+        // Create data source views for both workspaces
+        await DataSourceViewFactory.folder(workspace1, space1, t);
+        await DataSourceViewFactory.folder(workspace1, space1, t);
+        await DataSourceViewFactory.folder(workspace2, space2, t);
+        await DataSourceViewFactory.folder(workspace2, space2, t);
+
+        // Create a user for workspace1
+        const { globalGroup } = await GroupFactory.defaults(workspace1);
+        const user1 = await UserFactory.superUser();
+        await MembershipFactory.associate(workspace1, user1, "user");
+        await GroupSpaceFactory.associate(space1, globalGroup);
+
+        const auth = await Authenticator.fromUserIdAndWorkspaceId(
+          user1.sId,
+          workspace1.sId
+        );
+
+        // List views for workspace1
+        const views1 = await DataSourceViewResource.listByWorkspace(auth);
+
+        // Verify we only get views for workspace1
+        expect(views1).toHaveLength(2);
+        expect(views1[0].workspaceId).toBe(workspace1.id);
+        expect(views1[1].workspaceId).toBe(workspace1.id);
+
+        // Create auth for workspace2
+        const auth2 = await Authenticator.internalAdminForWorkspace(
+          workspace2.sId
+        );
+
+        // List views for workspace2
+        const views2 = await DataSourceViewResource.listByWorkspace(auth2);
+
+        // Verify we only get views for workspace2
+        expect(views2).toHaveLength(2);
+        expect(views2[0].workspaceId).toBe(workspace2.id);
+        expect(views2[1].workspaceId).toBe(workspace2.id);
+      }
+    );
+
+    itInTransaction(
+      "should respect fetchDataSourceViewOptions parameters",
+      async (t) => {
+        // Create workspace and spaces
+        const workspace = await WorkspaceFactory.basic();
+        const space = await SpaceFactory.regular(workspace, t);
+        await SpaceFactory.conversations(workspace, t);
+
+        // Create data source views
+        const editor = await UserFactory.basic();
+        const view1 = await DataSourceViewFactory.folder(
+          workspace,
+          space,
+          t,
+          editor
+        );
+        const view2 = await DataSourceViewFactory.folder(
+          workspace,
+          space,
+          t,
+          editor
+        );
+        const view3 = await DataSourceViewFactory.folder(
+          workspace,
+          space,
+          t,
+          editor
+        );
+
+        // Create auth
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+
+        // Test limit parameter
+        const limitedViews = await DataSourceViewResource.listByWorkspace(
+          auth,
+          {
+            limit: 2,
+          }
+        );
+        expect(limitedViews).toHaveLength(2);
+
+        // Test order parameter
+        const orderedViews = await DataSourceViewResource.listByWorkspace(
+          auth,
+          {
+            order: [["createdAt", "DESC"]],
+          }
+        );
+        expect(orderedViews).toHaveLength(3);
+        expect(orderedViews[0].id).toBe(view3.id);
+        expect(orderedViews[1].id).toBe(view2.id);
+        expect(orderedViews[2].id).toBe(view1.id);
+
+        // Test includeEditedBy parameter
+        const viewsWithEditedBy = await DataSourceViewResource.listByWorkspace(
+          auth,
+          {
+            includeEditedBy: true,
+          }
+        );
+        expect(viewsWithEditedBy).toHaveLength(3);
+        expect(viewsWithEditedBy[0].editedByUser).toBeDefined();
+      }
+    );
+
+    itInTransaction(
+      "should respect includeConversationDataSources parameter",
+      async (t) => {
+        // Create workspace
+        const workspace = await WorkspaceFactory.basic();
+
+        // Create regular space and conversation space
+        const regularSpace = await SpaceFactory.regular(workspace, t);
+        const conversationSpace = await SpaceFactory.conversations(
+          workspace,
+          t
+        );
+
+        // Create data source views in both spaces
+        await DataSourceViewFactory.folder(workspace, regularSpace, t);
+        await DataSourceViewFactory.folder(workspace, conversationSpace, t);
+
+        // Create auth
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+
+        // Test without including conversation data sources
+        const viewsWithoutConversations =
+          await DataSourceViewResource.listByWorkspace(auth, undefined, false);
+        expect(viewsWithoutConversations).toHaveLength(1);
+        expect(viewsWithoutConversations[0].space.id).toBe(regularSpace.id);
+
+        // Test including conversation data sources
+        const viewsWithConversations =
+          await DataSourceViewResource.listByWorkspace(auth, undefined, true);
+        expect(viewsWithConversations).toHaveLength(2);
+        expect(viewsWithConversations.map((v) => v.space.id).sort()).toEqual(
+          [regularSpace.id, conversationSpace.id].sort()
+        );
+      }
+    );
+  });
+});

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -258,21 +258,33 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     fetchDataSourceViewOptions?: FetchDataSourceViewOptions,
     includeConversationDataSources?: boolean
   ) {
+    const options: ResourceFindOptions<DataSourceViewModel> = {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    };
+
+    if (!includeConversationDataSources) {
+      // We make an extra request to fetch the conversation space first.
+      // This allows early filtering of the data source views as there is no way to know
+      // if a datasource view is related to a conversation from it's attributes alone.
+      const conversationSpace =
+        await SpaceResource.fetchWorkspaceConversationsSpace(auth);
+      options.where = {
+        ...options.where,
+        vaultId: {
+          [Op.notIn]: [conversationSpace.id],
+        },
+      };
+    }
+
     const dataSourceViews = await this.baseFetch(
       auth,
       fetchDataSourceViewOptions,
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-        },
-      }
+      options
     );
 
-    return dataSourceViews.filter(
-      (dsv) =>
-        (!dsv.space.isConversations() || includeConversationDataSources) &&
-        dsv.canReadOrAdministrate(auth)
-    );
+    return dataSourceViews.filter((dsv) => dsv.canReadOrAdministrate(auth));
   }
 
   static async listBySpace(

--- a/front/tests/utils/DataSourceViewFactory.ts
+++ b/front/tests/utils/DataSourceViewFactory.ts
@@ -3,13 +3,15 @@ import type { Transaction } from "sequelize";
 
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceType } from "@app/types";
 
 export class DataSourceViewFactory {
   static async folder(
     workspace: WorkspaceType,
     space: SpaceResource,
-    t: Transaction
+    t: Transaction,
+    editedByUser?: UserResource | null
   ) {
     return DataSourceViewResource.createDataSourceAndDefaultView(
       {
@@ -21,7 +23,7 @@ export class DataSourceViewFactory {
         workspaceId: workspace.id,
       },
       space,
-      null,
+      editedByUser,
       t
     );
   }

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -51,4 +51,16 @@ export class SpaceFactory {
       t
     );
   }
+
+  static async conversations(workspace: WorkspaceType, t: Transaction) {
+    return SpaceResource.makeNew(
+      {
+        name: "space " + faker.string.alphanumeric(8),
+        kind: "conversations",
+        workspaceId: workspace.id,
+      },
+      [],
+      t
+    );
+  }
 }


### PR DESCRIPTION
## Description

Optimize the cost when fetching the datasource views for a workspace when we don't care about the conversations datasource views (~~99.9%~~ 100% of the time looking at the calls).
Instead of filtering out **after** receiving all the views, we fetch the conversation space first and exclude the space ID from the query.
I believe the extra query, which will be probably always be cached by the DB, is definitely worth it. We could also add an attribute to `DataSourceView` but I'm not sure it's necessary.

## Tests

Added some.

## Risk

Low

## Deploy Plan

Deploy `front`