### PR TITLE
[sparkle] - fix(DropdownMenuTagItem): event propagation

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.511",
+  "version": "0.2.512",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.511",
+      "version": "0.2.512",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.511",
+  "version": "0.2.512",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -445,7 +445,7 @@ interface DropdownMenuTagItemProps
   size?: React.ComponentProps<typeof Chip>["size"];
   color?: React.ComponentProps<typeof Chip>["color"];
   onRemove?: () => void;
-  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onClick?: () => void;
 }
 
 const DropdownMenuTagItem = React.forwardRef<
@@ -464,21 +464,20 @@ const DropdownMenuTagItem = React.forwardRef<
     },
     ref
   ) => {
-    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-      if (onClick) {
-        onClick(e);
-      }
-    };
-
     return (
       <DropdownMenuPrimitive.Item
         ref={ref}
         className={cn(menuStyleClasses.item({ variant: "default" }), className)}
         {...props}
         asChild
-        onClick={handleClick}
       >
-        <Chip label={label} size={size} color={color} onRemove={onRemove} />
+        <Chip
+          label={label}
+          size={size}
+          color={color}
+          onRemove={onRemove}
+          onClick={onClick}
+        />
       </DropdownMenuPrimitive.Item>
     );
   }

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -475,6 +475,7 @@ const DropdownMenuTagItem = React.forwardRef<
         ref={ref}
         className={cn(menuStyleClasses.item({ variant: "default" }), className)}
         {...props}
+        asChild
         onClick={handleClick}
       >
         <Chip label={label} size={size} color={color} onRemove={onRemove} />

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -27,18 +27,26 @@ export const menuStyleClasses = {
   ),
   item: cva(
     cn(
-      "s-relative s-flex s-gap-2 s-cursor-pointer s-select-none s-items-center s-outline-none s-rounded-md s-text-sm s-font-semibold s-px-2 s-py-2 s-transition-colors s-duration-300 data-[disabled]:s-pointer-events-none",
+      "s-relative s-flex s-gap-2 s-cursor-pointer s-select-none s-items-center s-outline-none s-rounded-md s-text-sm s-font-semibold s-transition-colors s-duration-300 data-[disabled]:s-pointer-events-none",
       "data-[disabled]:s-text-primary-400 dark:data-[disabled]:s-text-primary-400-night"
     ),
     {
       variants: {
         variant: {
           default: cn(
+            "s-p-2",
+            "focus:s-text-foreground dark:focus:s-text-foreground-night",
+            "hover:s-bg-muted-background dark:hover:s-bg-primary-900",
+            "focus:s-bg-muted-background dark:focus:s-bg-primary-900"
+          ),
+          tags: cn(
+            "s-p-0.5",
             "focus:s-text-foreground dark:focus:s-text-foreground-night",
             "hover:s-bg-muted-background dark:hover:s-bg-primary-900",
             "focus:s-bg-muted-background dark:focus:s-bg-primary-900"
           ),
           warning: cn(
+            "s-p-2",
             "s-text-warning-500 dark:s-text-warning-500-night",
             "hover:s-bg-warning-50 dark:hover:s-bg-warning-50-night",
             "focus:s-bg-warning-50 dark:focus:s-bg-warning-50-night",
@@ -467,9 +475,8 @@ const DropdownMenuTagItem = React.forwardRef<
     return (
       <DropdownMenuPrimitive.Item
         ref={ref}
-        className={cn(menuStyleClasses.item({ variant: "default" }), className)}
+        className={cn(menuStyleClasses.item({ variant: "tags" }), className)}
         {...props}
-        asChild
       >
         <Chip
           label={label}
@@ -484,6 +491,24 @@ const DropdownMenuTagItem = React.forwardRef<
 );
 
 DropdownMenuTagItem.displayName = "DropdownMenuTagItem";
+
+interface DropdownMenuTagListProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const DropdownMenuTagList = React.forwardRef<
+  HTMLDivElement,
+  DropdownMenuTagListProps
+>(({ children, className }, ref) => {
+  return (
+    <div ref={ref} className={cn("s-flex s-flex-wrap", className)}>
+      {children}
+    </div>
+  );
+});
+
+DropdownMenuTagList.displayName = "DropdownMenuTagList";
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
@@ -665,5 +690,6 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTagItem,
+  DropdownMenuTagList,
   DropdownMenuTrigger,
 };

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -452,6 +452,7 @@ interface DropdownMenuTagItemProps
   label: string;
   size?: React.ComponentProps<typeof Chip>["size"];
   color?: React.ComponentProps<typeof Chip>["color"];
+  icon?: React.ComponentProps<typeof Chip>["icon"];
   onRemove?: () => void;
   onClick?: () => void;
 }
@@ -465,6 +466,7 @@ const DropdownMenuTagItem = React.forwardRef<
       label,
       size = "xs",
       color = "primary",
+      icon,
       onRemove,
       className,
       onClick,
@@ -484,6 +486,7 @@ const DropdownMenuTagItem = React.forwardRef<
           color={color}
           onRemove={onRemove}
           onClick={onClick}
+          icon={icon}
         />
       </DropdownMenuPrimitive.Item>
     );

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -440,11 +440,12 @@ const DropdownMenuRadioItem = React.forwardRef<
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 interface DropdownMenuTagItemProps
-  extends Omit<DropdownMenuItemProps, "label" | "icon"> {
+  extends Omit<DropdownMenuItemProps, "label" | "icon" | "onClick"> {
   label: string;
   size?: React.ComponentProps<typeof Chip>["size"];
   color?: React.ComponentProps<typeof Chip>["color"];
   onRemove?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 const DropdownMenuTagItem = React.forwardRef<
@@ -452,15 +453,29 @@ const DropdownMenuTagItem = React.forwardRef<
   DropdownMenuTagItemProps
 >(
   (
-    { label, size = "xs", color = "primary", onRemove, className, ...props },
+    {
+      label,
+      size = "xs",
+      color = "primary",
+      onRemove,
+      className,
+      onClick,
+      ...props
+    },
     ref
   ) => {
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (onClick) {
+        onClick(e);
+      }
+    };
+
     return (
       <DropdownMenuPrimitive.Item
         ref={ref}
         className={cn(menuStyleClasses.item({ variant: "default" }), className)}
         {...props}
-        asChild
+        onClick={handleClick}
       >
         <Chip label={label} size={size} color={color} onRemove={onRemove} />
       </DropdownMenuPrimitive.Item>

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -77,6 +77,7 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTagItem,
+  DropdownMenuTagList,
   DropdownMenuTrigger,
 } from "./Dropdown";
 export { default as DropzoneOverlay } from "./DropzoneOverlay";

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -20,9 +20,10 @@ import {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
+  DropdownMenuTagItem,
+  DropdownMenuTagList,
   DropdownMenuTrigger,
 } from "@sparkle/components/Dropdown";
-import { DropdownMenuTagItem } from "@sparkle/components/Dropdown";
 import {
   AnthropicLogo,
   DriveLogo,
@@ -774,19 +775,17 @@ export const TagsDropdownExample = () => {
           <DropdownMenuContent className="s-w-80">
             <DropdownMenuLabel label="Available Tags" />
             <DropdownMenuSeparator />
-
-            <div className="s-w-full">
+            <DropdownMenuTagList>
               {tags.map((tag) => (
                 <DropdownMenuTagItem
                   key={tag}
                   label={tag}
                   color="highlight"
-                  className="s-m-0.5"
                   onRemove={() => handleRemoveTag(tag)}
                   onClick={() => console.log(tag)}
                 />
               ))}
-            </div>
+            </DropdownMenuTagList>
 
             <DropdownMenuSeparator />
             <div className="s-p-2">


### PR DESCRIPTION
## Description

This PR aims at fixing an event propagation error that was due to the "asChild" prop on the `DropdownMenuPrimitive.Item`. I removed it and hence had to introduce a `DropdownMenuTagList` component to fix the layout issue (which is unchanged).

## Risk

None, not used yet

## Deploy Plan

- Publish sparkle
