### PR TITLE
Add a new group kind for provisioned groups

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1100,6 +1100,11 @@ export class GroupResource extends BaseResource<GroupModel> {
   isRegular(): boolean {
     return this.kind === "regular";
   }
+
+  isProvisioned(): boolean {
+    return this.kind === "provisioned";
+  }
+
   /**
    * Associates a group with an agent configuration.
    */

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -12,6 +12,9 @@ export class GroupModel extends WorkspaceAwareModel<GroupModel> {
 
   declare name: string;
   declare kind: GroupKind;
+
+  declare workOSGroupId: string | null;
+  declare directoryId: string | null;
 }
 
 GroupModel.init(
@@ -34,12 +37,21 @@ GroupModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    workOSGroupId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    directoryId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     modelName: "groups",
     sequelize: frontSequelize,
     indexes: [
       { unique: true, fields: ["workspaceId", "name"] },
+      { unique: true, fields: ["workspaceId", "workOSGroupId"] },
       { fields: ["workspaceId", "kind"] },
     ],
   }

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -13,8 +13,6 @@ export class GroupModel extends WorkspaceAwareModel<GroupModel> {
   declare name: string;
   declare kind: GroupKind;
 
-  // Group ID, we map a group on Work OS to a group in db.
-  declare workOSGroupId: string | null;
   // Directory ID on the provider's side (e.g. Okta directory).
   declare directoryId: string | null;
 }
@@ -39,10 +37,6 @@ GroupModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    workOSGroupId: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
     directoryId: {
       type: DataTypes.STRING,
       allowNull: true,
@@ -53,7 +47,6 @@ GroupModel.init(
     sequelize: frontSequelize,
     indexes: [
       { unique: true, fields: ["workspaceId", "name"] },
-      { unique: true, fields: ["workspaceId", "workOSGroupId"] },
       { fields: ["workspaceId", "kind"] },
     ],
   }

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -13,7 +13,9 @@ export class GroupModel extends WorkspaceAwareModel<GroupModel> {
   declare name: string;
   declare kind: GroupKind;
 
+  // Group ID, we map a group on Work OS to a group in db.
   declare workOSGroupId: string | null;
+  // Directory ID on the provider's side (e.g. Okta directory).
   declare directoryId: string | null;
 }
 

--- a/front/migrations/db/migration_workos_2.sql
+++ b/front/migrations/db/migration_workos_2.sql
@@ -1,0 +1,4 @@
+-- Migration created on May 23, 2025
+ALTER TABLE "public"."groups" ADD COLUMN "workOSGroupId" VARCHAR(255);
+ALTER TABLE "public"."groups" ADD COLUMN "directoryId" VARCHAR(255);
+CREATE UNIQUE INDEX "groups_workspace_id_work_o_s_group_id" ON "groups" ("workspaceId", "workOSGroupId");

--- a/front/migrations/db/migration_workos_2.sql
+++ b/front/migrations/db/migration_workos_2.sql
@@ -1,4 +1,2 @@
 -- Migration created on May 23, 2025
-ALTER TABLE "public"."groups" ADD COLUMN "workOSGroupId" VARCHAR(255);
 ALTER TABLE "public"."groups" ADD COLUMN "directoryId" VARCHAR(255);
-CREATE UNIQUE INDEX "groups_workspace_id_work_o_s_group_id" ON "groups" ("workspaceId", "workOSGroupId");

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -13,12 +13,15 @@ import type { ModelId } from "./shared/model_id";
  * agent_editors group: Group specific to represent agent editors, tied to an
  *  agent. Has special permissions: not restricted only to admins. Users can
  *  create, and members of the group can update it.
+ *
+ *  provisioned group: Contains all users from a provisioned group.
  */
 export const GROUP_KINDS = [
   "regular",
   "global",
   "system",
   "agent_editors",
+  "provisioned",
 ] as const;
 export type GroupKind = (typeof GROUP_KINDS)[number];
 


### PR DESCRIPTION
## Description

- This PR adds a new group kind `provisioned`.
- This PR also updates the Group model to add the necessary columns to link data from Work OS with our DB.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Run migration_workos_2.sql.
