### PR TITLE
Move expensive workspace usage queries to read replica

### DIFF
--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -198,10 +198,12 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     startDate,
     endDate,
     workspace,
+    transaction,
   }: {
     startDate: Date;
     endDate: Date;
     workspace: WorkspaceType;
+    transaction?: Transaction;
   }) {
     const agentMessageFeedback = await AgentMessageFeedback.findAll({
       where: {
@@ -225,6 +227,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         },
       ],
       order: [["id", "ASC"]],
+      transaction,
     });
 
     return agentMessageFeedback


### PR DESCRIPTION
## Description

Attempt to move expensive workspace usage queries to read replicas.

## Tests

Tested locally. Will test on front-edge

## Risk

None once tested on front-edge

## Deploy Plan

- deploy `front`