### PR TITLE
Add Profiler Endpoint on Front

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -193,6 +193,10 @@ const config = {
       "MULTI_ACTIONS_AGENT_ANTHROPIC_BETA_FLAGS"
     )?.split(",");
   },
+  // Profiler.
+  getProfilerSecret: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("DEBUG_PROFILER_SECRET");
+  },
 };
 
 export default config;

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,8 @@
     "coverage": "vitest --coverage",
     "initdb": "./admin/init_db.sh",
     "create-db-migration": "./create_db_migration_file.sh",
-    "prepare": "cd .. && husky .husky"
+    "prepare": "cd .. && husky .husky",
+    "debug:profiler": "tsx ./scripts/debug/run_profiler.ts"
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",

--- a/front/pages/api/debug/profiler.ts
+++ b/front/pages/api/debug/profiler.ts
@@ -9,9 +9,15 @@ import config from "@app/lib/api/config";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
 
 const CPU_PROFILE_DURATION_MS = 30000;
 const HEAP_PROFILE_DURATION_MS = 30000;
+
+export interface GetProfilerResponse {
+  cpu: string;
+  heap: string;
+}
 
 async function saveProfile({
   extension,
@@ -89,7 +95,7 @@ async function profileHeap() {
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse<WithAPIErrorResponse<GetProfilerResponse>>
 ) {
   if (req.method !== "GET") {
     return apiError(req, res, {
@@ -119,10 +125,7 @@ export default async function handler(
 
   logger.info({ cpuProfile, heapProfile }, "Profiler completed");
   res.status(200).json({
-    message: "Profiler completed",
-    profiles: {
-      cpu: cpuProfile,
-      heap: heapProfile,
-    },
+    cpu: cpuProfile,
+    heap: heapProfile,
   });
 }

--- a/front/pages/api/debug/profiler.ts
+++ b/front/pages/api/debug/profiler.ts
@@ -1,0 +1,128 @@
+import inspector from "node:inspector/promises";
+
+import fs from "fs/promises";
+import type { NextApiRequest, NextApiResponse } from "next";
+import os from "os";
+import path from "path";
+
+import config from "@app/lib/api/config";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+const CPU_PROFILE_DURATION_MS = 30000;
+const HEAP_PROFILE_DURATION_MS = 30000;
+
+async function saveProfile({
+  extension,
+  filename,
+  profile,
+}: {
+  extension: string;
+  filename: string;
+  profile: unknown;
+}) {
+  const tmpdir = os.tmpdir();
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  const profilePath = path.join(
+    tmpdir,
+    `${filename}-${timestamp}.${extension}`
+  );
+  await fs.writeFile(profilePath, JSON.stringify(profile));
+
+  return profilePath;
+}
+
+async function profileCPU() {
+  const session = new inspector.Session();
+
+  session.connect();
+  await session.post("Profiler.enable");
+  await session.post("Profiler.start");
+
+  await setTimeoutAsync(CPU_PROFILE_DURATION_MS);
+
+  const { profile } = await session.post("Profiler.stop");
+
+  const profilePath = await saveProfile({
+    extension: "cpuprofile",
+    filename: "cpu",
+    profile,
+  });
+
+  session.disconnect();
+
+  logger.info({ profilePath }, "CPU profile saved");
+
+  return profilePath;
+}
+
+async function profileHeap() {
+  const session = new inspector.Session();
+
+  session.connect();
+  await session.post("HeapProfiler.enable");
+
+  // Start allocation timeline (tracks every allocation).
+  await session.post("HeapProfiler.startSampling", {
+    samplingInterval: 32768, // Bytes between samples.
+    includeObjectsCollectedByMajorGC: true,
+    includeObjectsCollectedByMinorGC: true,
+  });
+
+  await setTimeoutAsync(HEAP_PROFILE_DURATION_MS);
+
+  const { profile } = await session.post("HeapProfiler.stopSampling");
+  const profilePath = await saveProfile({
+    extension: "heapprofile",
+    filename: "heap-timeline",
+    profile,
+  });
+
+  session.disconnect();
+
+  logger.info({ profilePath }, "Heap timeline profile saved");
+
+  return profilePath;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const { secret } = req.query;
+  const debugSecret = config.getProfilerSecret();
+
+  if (!debugSecret || typeof secret !== "string" || secret !== debugSecret) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid debug secret.",
+      },
+    });
+  }
+
+  const cpuProfile = await profileCPU();
+  const heapProfile = await profileHeap();
+
+  logger.info({ cpuProfile, heapProfile }, "Profiler completed");
+  res.status(200).json({
+    message: "Profiler completed",
+    profiles: {
+      cpu: cpuProfile,
+      heap: heapProfile,
+    },
+  });
+}

--- a/front/scripts/debug/profile_k8s_pods.ts
+++ b/front/scripts/debug/profile_k8s_pods.ts
@@ -64,18 +64,18 @@ makeScript(
       const localHeap = `heap-${podName}-${timestamp}.heapprofile`;
 
       // Copy files from pod.
-      console.log("Copying profiles from pod...");
+      logger.info("Copying profiles from pod...");
       execKubectl(`kubectl cp ${namespace}/${podName}:${cpuPath} ${localCpu}`);
       execKubectl(
         `kubectl cp ${namespace}/${podName}:${heapPath} ${localHeap}`
       );
 
-      console.log("Profiles saved locally:");
-      console.log(`  CPU:  ${localCpu}`);
-      console.log(`  Heap: ${localHeap}`);
-      console.log("");
-      console.log("To analyze:");
-      console.log(
+      logger.info("Profiles saved locally:");
+      logger.info(`  CPU:  ${localCpu}`);
+      logger.info(`  Heap: ${localHeap}`);
+      logger.info("");
+      logger.info("To analyze:");
+      logger.info(
         "  Chrome DevTools → Performance → Load Profile → select files"
       );
     } catch (err) {

--- a/front/scripts/debug/profile_k8s_pods.ts
+++ b/front/scripts/debug/profile_k8s_pods.ts
@@ -1,0 +1,86 @@
+import { execSync } from "child_process";
+
+import { makeScript } from "@app/scripts/helpers";
+
+function execKubectl(command: string): string {
+  try {
+    return execSync(command, { encoding: "utf8" });
+  } catch (error) {
+    throw new Error(`kubectl command failed: ${command}\n${error}`);
+  }
+}
+
+makeScript(
+  {
+    namespace: {
+      type: "string",
+      optional: true,
+      default: "default",
+    },
+    podName: {
+      type: "string",
+    },
+  },
+  async ({ execute, podName, namespace }, logger) => {
+    if (!execute) {
+      return;
+    }
+
+    if (!podName) {
+      throw new Error("Pod name is required");
+    }
+
+    logger.info(`Profiling pod ${podName}...`);
+
+    try {
+      const command = `kubectl exec -n ${namespace} ${podName} -- npm run debug:profiler`;
+      const output = execKubectl(command);
+
+      logger.info(`Profiling output: ${output}`);
+
+      // Extract file paths from the output.
+      const lines = output.split("\n");
+      const pathsStartIndex = lines.findIndex((line) =>
+        line.includes("PROFILE_PATHS")
+      );
+
+      if (pathsStartIndex === -1) {
+        throw new Error("Could not find PROFILE_PATHS in output");
+      }
+
+      const cpuLine = lines.find((line) => line.startsWith("cpu:"));
+      const heapLine = lines.find((line) => line.startsWith("heap:"));
+
+      if (!cpuLine || !heapLine) {
+        throw new Error("Could not extract profile paths");
+      }
+
+      const cpuPath = cpuLine.split(":").slice(1).join(":");
+      const heapPath = heapLine.split(":").slice(1).join(":");
+
+      // Generate local filenames with timestamp.
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const localCpu = `cpu-${podName}-${timestamp}.cpuprofile`;
+      const localHeap = `heap-${podName}-${timestamp}.heapprofile`;
+
+      // Copy files from pod.
+      console.log("Copying profiles from pod...");
+      execKubectl(`kubectl cp ${namespace}/${podName}:${cpuPath} ${localCpu}`);
+      execKubectl(
+        `kubectl cp ${namespace}/${podName}:${heapPath} ${localHeap}`
+      );
+
+      console.log("Profiles saved locally:");
+      console.log(`  CPU:  ${localCpu}`);
+      console.log(`  Heap: ${localHeap}`);
+      console.log("");
+      console.log("To analyze:");
+      console.log(
+        "  Chrome DevTools → Performance → Load Profile → select files"
+      );
+    } catch (err) {
+      logger.error(err);
+      throw err;
+    }
+  }
+);

--- a/front/scripts/debug/run_profiler.ts
+++ b/front/scripts/debug/run_profiler.ts
@@ -1,0 +1,50 @@
+import config from "@app/lib/api/config";
+import { getErrorFromResponse } from "@app/lib/swr/swr";
+import type { GetProfilerResponse } from "@app/pages/api/debug/profiler";
+import { makeScript } from "@app/scripts/helpers";
+import { normalizeError } from "@app/types";
+
+makeScript({}, async ({ execute }) => {
+  if (!execute) {
+    return;
+  }
+
+  const debugProfilerSecret = config.getProfilerSecret();
+  if (!debugProfilerSecret) {
+    throw new Error("Profiler secret is not set");
+  }
+
+  try {
+    console.log("Starting profiling...");
+
+    const response = await fetch(
+      `http://localhost:3000/api/debug/profiler?secret=${debugProfilerSecret}`
+    );
+
+    if (!response.ok) {
+      const error = await getErrorFromResponse(response);
+      console.error(error);
+      throw new Error(error.message);
+    }
+
+    const data: GetProfilerResponse = await response.json();
+    console.log("Profiling completed. Response:", JSON.stringify(data));
+
+    const { cpu: cpuPath, heap: heapPath } = data;
+
+    if (!cpuPath || !heapPath) {
+      throw new Error("Failed to parse profile paths from response");
+    }
+
+    console.log(`CPU profile: ${cpuPath}`);
+    console.log(`Heap profile: ${heapPath}`);
+
+    // Output paths for the local script to parse.
+    console.log("PROFILE_PATHS");
+    console.log(`cpu:${cpuPath}`);
+    console.log(`heap:${heapPath}`);
+  } catch (error) {
+    console.error("Error when running profiler", normalizeError(error).message);
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a new endpoint gated behind a secret to launch 30-seconds profiling on both CPU and memory. This will store in the temporary folder the resulting files. Another script bundles all of this so it can be a one line command for engineers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Add secret `DEBUG_PROFILER_SECRET` on `front` deplouyment.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
