### PR TITLE
fix(gdrive): skip file if export restricted

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -96,14 +96,47 @@ async function handleGoogleDriveExport(
       return null;
     }
   } catch (e) {
-    if (e instanceof GaxiosError && e.response?.status === 404) {
-      localLogger.info(
-        {
-          error: e,
-        },
-        "Can't export Gdrive document. 404 error returned, even though we know the file exists. Skipping."
-      );
-      return null;
+    if (e instanceof GaxiosError) {
+      if (e.response?.status === 404) {
+        localLogger.info(
+          {
+            error: e,
+          },
+          "Can't export Gdrive document. 404 error returned, even though we know the file exists. Skipping."
+        );
+        return null;
+      }
+
+      if (e.response?.status === 403) {
+        const skippableReasons = ["exportRestricted"];
+
+        const body = Buffer.from(e.response.data).toString("utf-8").trim();
+        const parsedBody = JSON.parse(body);
+        const errors: { reason: string }[] | undefined =
+          parsedBody.error?.errors;
+        const firstSkippableReason = errors?.find((error) =>
+          skippableReasons.includes(error.reason)
+        )?.reason;
+        if (firstSkippableReason) {
+          localLogger.info(
+            { error: parsedBody.error },
+            `Can't export Gdrive document. Skippable reason: ${firstSkippableReason}. Skipping.`
+          );
+          return null;
+        }
+      }
+
+      // Check if the error message indicates the file is too large to export
+      if (
+        e.message &&
+        e.message.includes("This file is too large to be exported")
+      ) {
+        localLogger.info(
+          { error: e.message },
+          "File is too large to be exported. Skipping."
+        );
+        return null;
+      }
     }
 
     localLogger.error({ error: e }, "Error exporting Google document");


### PR DESCRIPTION
## Description

If the export is restricted or the file is too large to be exported, we should skip the file instead of having the activity churn.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
