### PR TITLE
Fix MCP tools with empty parameters

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -76,7 +76,21 @@ const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes.
 const MCP_NOTIFICATION_EVENT_NAME = "mcp-notification";
 const MCP_TOOL_DONE_EVENT_NAME = "TOOL_DONE" as const;
 
-const EMPTY_INPUT_SCHEMA: JSONSchema7 = { type: "object", properties: {} };
+const EMPTY_INPUT_SCHEMA: JSONSchema7 = {
+  properties: {},
+  required: [],
+  type: "object",
+};
+
+function isEmptyInputSchema(schema: JSONSchema7): boolean {
+  // By default, empty tools yields an empty input schema.
+  const isContentConsideredEmpty =
+    schema.properties === undefined &&
+    schema.required === undefined &&
+    schema.type === "object";
+
+  return isContentConsideredEmpty;
+}
 
 const MAX_TOOL_NAME_LENGTH = 64;
 
@@ -98,7 +112,10 @@ function makeServerSideMCPToolConfigurations(
     type: "mcp_configuration",
     name: tool.name,
     description: tool.description ?? null,
-    inputSchema: tool.inputSchema || EMPTY_INPUT_SCHEMA,
+    inputSchema:
+      !tool.inputSchema || isEmptyInputSchema(tool.inputSchema)
+        ? EMPTY_INPUT_SCHEMA
+        : tool.inputSchema,
     id: config.id,
     mcpServerViewId: config.mcpServerViewId,
     internalMCPServerId: config.internalMCPServerId,
@@ -129,7 +146,10 @@ function makeClientSideMCPToolConfigurations(
     clientSideMcpServerId: config.clientSideMcpServerId,
     description: tool.description ?? null,
     id: config.id,
-    inputSchema: tool.inputSchema || EMPTY_INPUT_SCHEMA,
+    inputSchema:
+      !tool.inputSchema || isEmptyInputSchema(tool.inputSchema)
+        ? EMPTY_INPUT_SCHEMA
+        : tool.inputSchema,
     mcpServerName: config.name,
     name: tool.name,
     originalName: tool.name,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/2974.

We have mainly been testing MCP Tools with Claude, testing a bit more with OpenAI models, and we hit an error when a tool has no parameters.

We get the following error:
```
ERROR: Error running agent: Error querying `openai:gpt-4.1-2025-04-14`: error=[model_error(retryable=, request_id=req_69ff3ce063083ce5dfd4abb471119c73false)] OpenAIError: [invalid_request_error] Invalid schema for function 'dust_extension__front_get_current_conversation': In context=(), object schema missing properties. (code: multi_actions_error)
```

This stems from the fact that tools with parameters have an input schema set to `{type: "object"}` which is not a valid JSONSchema, at least Open AI does not accept it ([issue](https://community.openai.com/t/on-the-function-calling-what-about-if-i-have-no-parameter-to-call/516876/2)). 

This PR ensures that we broaden our definition of empty schema.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally with different model providers, works as expected.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
