### PR TITLE
Data retention batch where in

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -195,11 +195,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return mentions;
   }
 
-  static async listAllBeforeDate(
-    auth: Authenticator,
-    cutoffDate: Date,
-    batchSize: number = 1000
-  ): Promise<ConversationResource[]> {
+  static async listAllBeforeDate({
+    auth,
+    cutoffDate,
+    batchSize = 1000,
+  }: {
+    auth: Authenticator;
+    cutoffDate: Date;
+    batchSize?: number;
+  }): Promise<ConversationResource[]> {
     const workspaceId = auth.getNonNullableWorkspace().id;
     const inactiveConversations = await Message.findAll({
       attributes: [

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -63,10 +63,10 @@ export async function purgeConversationsBatchActivity({
 
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const conversations = await ConversationResource.listAllBeforeDate(
+    const conversations = await ConversationResource.listAllBeforeDate({
       auth,
-      cutoffDate
-    );
+      cutoffDate,
+    });
 
     logger.info(
       {

--- a/front/tests/lib/resources/conversation_resource.test.ts
+++ b/front/tests/lib/resources/conversation_resource.test.ts
@@ -166,5 +166,14 @@ describe("ConversationResource", () => {
       expect(oldConversationIds).toContain(convo3Id);
       expect(oldConversationIds).toContain(convo4Id);
     });
+
+    it("should return all old conversations no matter the batch size", async () => {
+      const oldConversations = await ConversationResource.listAllBeforeDate(
+        auth,
+        dateFromDaysAgo(1),
+        1
+      );
+      expect(oldConversations.length).toBe(4);
+    });
   });
 });

--- a/front/tests/lib/resources/conversation_resource.test.ts
+++ b/front/tests/lib/resources/conversation_resource.test.ts
@@ -137,10 +137,10 @@ describe("ConversationResource", () => {
     });
 
     it("should return only conversations with all messages before cutoff date: 90 days ago", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate(
+      const oldConversations = await ConversationResource.listAllBeforeDate({
         auth,
-        dateFromDaysAgo(90)
-      );
+        cutoffDate: dateFromDaysAgo(90),
+      });
       expect(oldConversations.length).toBe(2);
       const oldConversationIds = oldConversations.map((c) => c.sId);
       expect(oldConversationIds).toContain(convo3Id);
@@ -148,18 +148,18 @@ describe("ConversationResource", () => {
     });
 
     it("should return only conversations with all messages before cutoff date: 200 days ago", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate(
+      const oldConversations = await ConversationResource.listAllBeforeDate({
         auth,
-        dateFromDaysAgo(200)
-      );
+        cutoffDate: dateFromDaysAgo(200),
+      });
       expect(oldConversations.length).toBe(0);
     });
 
     it("should return only conversations with all messages before cutoff date: 5 days ago", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate(
+      const oldConversations = await ConversationResource.listAllBeforeDate({
         auth,
-        dateFromDaysAgo(5)
-      );
+        cutoffDate: dateFromDaysAgo(5),
+      });
       expect(oldConversations.length).toBe(3);
       const oldConversationIds = oldConversations.map((c) => c.sId);
       expect(oldConversationIds).toContain(convo1Id);
@@ -168,11 +168,11 @@ describe("ConversationResource", () => {
     });
 
     it("should return all old conversations no matter the batch size", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate(
+      const oldConversations = await ConversationResource.listAllBeforeDate({
         auth,
-        dateFromDaysAgo(1),
-        1
-      );
+        cutoffDate: dateFromDaysAgo(1),
+        batchSize: 1,
+      });
       expect(oldConversations.length).toBe(4);
     });
   });


### PR DESCRIPTION
## Description

Following this: https://github.com/dust-tt/dust/pull/12845

The first time we run the data retention workflow for a given workspace, it can process a lot of conversation, meaning a `where in` for a biiiiig array. 
I decided to limit the size of this `where in` and do multiple queries if needed.

Not that at the moment, this code is called only once from for data retention logic so this is executed from a temporal workflow.

WDYT? 

## Tests

Just tested with the automated test added. 

## Risk

Can be rolled back but any change in this code is sensitive!

## Deploy Plan

Deploy front!