### PR TITLE
fix(gdrive): handle error response data correctly

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -110,8 +110,11 @@ async function handleGoogleDriveExport(
       if (e.response?.status === 403) {
         const skippableReasons = ["exportRestricted"];
 
-        const body = Buffer.from(e.response.data).toString("utf-8").trim();
-        const parsedBody = JSON.parse(body);
+        const parsedBody =
+          typeof e.response.data === "string"
+            ? JSON.parse(e.response.data)
+            : e.response.data;
+
         const errors: { reason: string }[] | undefined =
           parsedBody.error?.errors;
         const firstSkippableReason = errors?.find((error) =>
@@ -180,8 +183,10 @@ async function handleFileExport(
       if (e.response?.status === 403) {
         const skippableReasons = ["cannotDownloadAbusiveFile"];
         try {
-          const body = Buffer.from(e.response.data).toString("utf-8").trim();
-          const parsedBody = JSON.parse(body);
+          const parsedBody =
+            typeof e.response.data === "string"
+              ? JSON.parse(e.response.data)
+              : e.response.data;
           const errors: { reason: string }[] | undefined =
             parsedBody.error?.errors;
           const firstSkippableReason = errors?.find((error) =>


### PR DESCRIPTION
## Description

The Google Drive API client returns error response data as a parsed object, not a Buffer. This fix checks the type of e.response.data and only parses it if it's a string, preventing TypeError when processing 403 errors.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
