### PR TITLE
add poke plugin to whitelist domain

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -91,16 +91,19 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.50",
+      "version": "1.0.52",
       "license": "ISC",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.11.4",
         "@types/json-schema": "^7.0.15",
+        "event-source-polyfill": "^1.0.31",
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",
+        "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "^22.7.5",
         "@types/uuid": "^9.0.7",
         "dts-cli": "^2.0.5",

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -91,19 +91,16 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.52",
+      "version": "1.0.50",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.4",
         "@types/json-schema": "^7.0.15",
-        "event-source-polyfill": "^1.0.31",
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",
-        "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "^22.7.5",
         "@types/uuid": "^9.0.7",
         "dts-cli": "^2.0.5",

--- a/front/lib/api/poke/plugins/workspaces/add_authorized_domain.ts
+++ b/front/lib/api/poke/plugins/workspaces/add_authorized_domain.ts
@@ -1,0 +1,57 @@
+import { UniqueConstraintError } from "sequelize";
+
+import { createPlugin } from "@app/lib/api/poke/types";
+import { WorkspaceHasDomainModel } from "@app/lib/models/workspace_has_domain";
+import { isDomain } from "@app/lib/utils";
+import { Err, Ok } from "@app/types";
+
+export const addAuthorizedDomain = createPlugin({
+  manifest: {
+    id: "add-authorized-domain",
+    name: "Add Authorized Domain",
+    description: "Add an authorized domain to the workspace",
+    resourceTypes: ["workspaces"],
+    args: {
+      domain: {
+        type: "string",
+        label: "Domain",
+        description: "Domain to authorize (e.g. example.com)",
+      },
+      autoJoinEnabled: {
+        type: "boolean",
+        label: "Auto Join Enabled",
+        description:
+          "Whether to automatically add users with this domain email",
+        default: false,
+      },
+    },
+  },
+  execute: async (auth, _, args) => {
+    const workspace = auth.getNonNullableWorkspace();
+    const domain = args.domain.trim().toLowerCase();
+
+    if (!isDomain(domain)) {
+      return new Err(new Error("Invalid domain format."));
+    }
+
+    try {
+      await WorkspaceHasDomainModel.create({
+        domain,
+        domainAutoJoinEnabled: args.autoJoinEnabled,
+        workspaceId: workspace.id,
+      });
+
+      return new Ok({
+        display: "text",
+        value: `Domain ${domain} has been added to the workspace${args.autoJoinEnabled ? " with auto-join enabled" : ""}.`,
+      });
+    } catch (err) {
+      if (err instanceof UniqueConstraintError) {
+        return new Err(
+          new Error("This domain is already authorized for another workspace.")
+        );
+      }
+      return new Err(new Error("Failed to add domain to workspace."));
+    }
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/add_authorized_domain.ts
+++ b/front/lib/api/poke/plugins/workspaces/add_authorized_domain.ts
@@ -1,4 +1,5 @@
 import { createPlugin } from "@app/lib/api/poke/types";
+import { Workspace } from "@app/lib/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/models/workspace_has_domain";
 import { isDomain } from "@app/lib/utils";
 import { Err, Ok } from "@app/types";
@@ -35,8 +36,14 @@ export const addAuthorizedDomain = createPlugin({
     // Check if domain exists in any workspace
     const existingDomain = await WorkspaceHasDomainModel.findOne({
       where: { domain },
+      include: [
+        {
+          model: Workspace,
+          as: "workspace",
+          required: true,
+        },
+      ],
     });
-
     if (existingDomain) {
       if (existingDomain.workspaceId === workspace.id) {
         return new Ok({
@@ -45,7 +52,9 @@ export const addAuthorizedDomain = createPlugin({
         });
       }
       return new Err(
-        new Error("This domain is already authorized for another workspace.")
+        new Error(
+          `This domain is already authorized for workspace ${existingDomain.workspace.sId}.`
+        )
       );
     }
 

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -1,3 +1,4 @@
+export * from "./add_authorized_domain";
 export * from "./check_seat_count";
 export * from "./compute_statistics";
 export * from "./conversations_retention";


### PR DESCRIPTION
## Description

Sometimes users are stuck 

Single Sign-On (SSO) is not available because your domain isn't verified yet. Contact us at support@dust.tt for assistance.

<img width="215" alt="image" src="https://github.com/user-attachments/assets/097d051b-292e-493b-93b9-c8573882660d" />

This can happen in this instance
- User@example.com has created a workspace A with domain example.com
- example.com becomes a verified domain of workspace A
- Then the rest of the company creates and joins workspace B
- the example.com entry is present in table workspace_has_domains in workspace A, but not workspace B
- you get this error message when trying to turn on SSO on workspace B

--- 

This poke plugin allows a support member to solve the situation without performing DB ops or requiring eng-runner

## Tests

Local testing

