### PR TITLE
[front] chore: Skip active membership count if there is no pagination

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -186,7 +186,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
     let count = rows.length;
 
-    // Only do the count if we are paginating, otherwise we can use the lenght of the rows as there is no limit by default
+    // Only do the count if we are paginating, otherwise we can use the length of the rows as there is no limit by default
     if (paginationParams) {
       // Need a separate query to get the total count, findAndCountAll does not support pagination based on where clause.
       count = await MembershipModel.count(findOptions);

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -184,8 +184,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
-    // Need a separate query to get the total count, findAndCountAll does not support pagination based on where clause.
-    const count = await MembershipModel.count(findOptions);
+    let count = rows.length;
+
+    // Only do the count if we are paginating, otherwise we can use the lenght of the rows as there is no limit by default
+    if (paginationParams) {
+      // Need a separate query to get the total count, findAndCountAll does not support pagination based on where clause.
+      count = await MembershipModel.count(findOptions);
+    }
 
     let nextPageParams: MembershipsPaginationParams | undefined;
     if (paginationParams?.limit && rows.length === paginationParams.limit) {


### PR DESCRIPTION
## Description
- If there is no paginate params, no need for doing the count as the findAll will give us the total array.

## Tests
- Locally

## Risk
- Low

## Deploy Plan
- Deploy front
