### PR TITLE
Fix: broken Add to space shortcut on search results

### DIFF
--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -466,7 +466,9 @@ function SearchResultsTable({
   const addToSpace = React.useCallback(
     async (node: DataSourceViewContentNode, spaceId: string) => {
       const existingViewForSpace = dataSourceViews.find(
-        (d) => d.spaceId === spaceId && d.sId === node.dataSourceView.sId
+        (d) =>
+          d.spaceId === spaceId &&
+          d.dataSource.sId === node.dataSourceView.dataSource.sId
       );
 
       try {


### PR DESCRIPTION
## Description

"Add to space" shortcut wasn't working on search results as we were checking for existing datasource view by comparing node datasource view id and existing datasource views id instead of datasource ids.

## Tests

Local, before / after.

## Risk

Low

## Deploy Plan

Deploy `front`