### PR TITLE
Add: support for streamable http for MCP

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -1,5 +1,8 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { Implementation, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { Ajv } from "ajv";
@@ -208,8 +211,7 @@ export const connectToMCPServer = async (
               },
             };
 
-            const sseTransport = new SSEClientTransport(url, req);
-            await mcpClient.connect(sseTransport);
+            await connectToRemoteMCPServer(mcpClient, url, req);
           } catch (e: unknown) {
             return new Err(
               new Error("Error establishing connection to remote MCP server.")
@@ -234,8 +236,7 @@ export const connectToMCPServer = async (
         },
       };
       try {
-        const sseTransport = new SSEClientTransport(url, req);
-        await mcpClient.connect(sseTransport);
+        await connectToRemoteMCPServer(mcpClient, url, req);
       } catch (e: unknown) {
         return new Err(
           new Error("Error establishing connection to remote MCP server.")
@@ -267,6 +268,30 @@ export const connectToMCPServer = async (
 
   return new Ok(mcpClient);
 };
+
+// Try to connect via streamableHttpTransport first, and if that fails, fall back to sseTransport.
+async function connectToRemoteMCPServer(
+  mcpClient: Client,
+  url: URL,
+  req: SSEClientTransportOptions | StreamableHTTPClientTransportOptions
+) {
+  try {
+    const streamableHttpTransport = new StreamableHTTPClientTransport(url, req);
+    await mcpClient.connect(streamableHttpTransport);
+  } catch (error) {
+    // Check if error message contains "HTTP 4xx" as suggested by the official doc.
+    // Doc is here https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#client-side-compatibility.
+    if (error instanceof Error && /HTTP 4\d\d/.test(error.message)) {
+      console.log(
+        "Error establishing connection to remote MCP server via streamableHttpTransport, falling back to sseTransport."
+      );
+      const sseTransport = new SSEClientTransport(url, req);
+      await mcpClient.connect(sseTransport);
+    } else {
+      throw error;
+    }
+  }
+}
 
 export function extractMetadataFromServerVersion(
   r: Implementation | undefined


### PR DESCRIPTION
## Description

Add support for the new StreamableHttpTransport for remote MCP servers.

## Tests

Locally, tried both kind of servers to confirm fallback is working.

## Risk

low

## Deploy Plan

Deploy `front`
