### PR TITLE
enh(Intercom): bump default retention period to 180 days

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -51,6 +51,8 @@ import type {
 } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 
+const DEFAULT_CONVERSATIONS_SLIDING_WINDOW = 180;
+
 export class IntercomConnectorManager extends BaseConnectorManager<null> {
   static async create({
     dataSourceConfig,
@@ -75,7 +77,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     const intercomConfigurationBlob = {
       intercomWorkspaceId: intercomWorkspace.id,
       name: intercomWorkspace.name,
-      conversationsSlidingWindow: 180,
+      conversationsSlidingWindow: DEFAULT_CONVERSATIONS_SLIDING_WINDOW,
       region: intercomWorkspace.region,
       syncAllConversations: "disabled" as const,
       shouldSyncNotes: true,

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -75,7 +75,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     const intercomConfigurationBlob = {
       intercomWorkspaceId: intercomWorkspace.id,
       name: intercomWorkspace.name,
-      conversationsSlidingWindow: 90,
+      conversationsSlidingWindow: 180,
       region: intercomWorkspace.region,
       syncAllConversations: "disabled" as const,
       shouldSyncNotes: true,


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/2972.
- This PR bumps the default value for the retention period (`conversationsSlidingWindow`) from 90 days to 180 days, in an effort to align it with Zendesk.
- This only affects newly created connectors.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Run `migration_75.sql`.
- Deploy connectors.
