### PR TITLE
`personal_actions` useCase + MCPServerConnection tweaks + Salesorce tweaks

### DIFF
--- a/front/lib/actions/mcp_internal_actions/authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/authentication.ts
@@ -1,22 +1,26 @@
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import { getOAuthConnectionAccessToken } from "@app/types";
 
-// Dedicated function to get an access token for a given provider for internal MCP servers
-// Not using the one from mcp_metadata.ts to avoid circular dependency
+// Dedicated function to get an access token for a given provider for internal MCP servers.
+// Not using the one from mcp_metadata.ts to avoid circular dependency.
 export async function getAccessTokenForInternalMCPServer(
   auth: Authenticator,
   {
     mcpServerId,
+    connectionType,
   }: {
     mcpServerId: string;
+    connectionType: MCPServerConnectionConnectionType;
   }
 ) {
   const connection = await MCPServerConnectionResource.findByMCPServer({
     auth,
-    mcpServerId: mcpServerId,
+    mcpServerId,
+    connectionType,
   });
   if (connection.isOk()) {
     const token = await getOAuthConnectionAccessToken({

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -47,6 +47,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     async ({ owner, repo, title, body, assignees, labels }) => {
       const accessToken = await getAccessTokenForInternalMCPServer(auth, {
         mcpServerId,
+        connectionType: "workspace",
       });
 
       const octokit = new Octokit({ auth: accessToken });
@@ -103,6 +104,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     async ({ owner, repo, pullNumber }) => {
       const accessToken = await getAccessTokenForInternalMCPServer(auth, {
         mcpServerId,
+        connectionType: "workspace",
       });
 
       const octokit = new Octokit({ auth: accessToken });
@@ -421,6 +423,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     async ({ owner, repo, pullNumber, body, event, comments = [] }) => {
       const accessToken = await getAccessTokenForInternalMCPServer(auth, {
         mcpServerId,
+        connectionType: "workspace",
       });
 
       const octokit = new Octokit({ auth: accessToken });
@@ -474,6 +477,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     async ({ owner }) => {
       const accessToken = await getAccessTokenForInternalMCPServer(auth, {
         mcpServerId,
+        connectionType: "workspace",
       });
 
       const octokit = new Octokit({ auth: accessToken });
@@ -617,6 +621,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     async ({ owner, repo, issueNumber, projectId, field }) => {
       const accessToken = await getAccessTokenForInternalMCPServer(auth, {
         mcpServerId,
+        connectionType: "workspace",
       });
 
       const octokit = new Octokit({ auth: accessToken });

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
@@ -19,6 +19,7 @@ export const withAuth = async (
 ): Promise<CallToolResult> => {
   const accessToken = await getAccessTokenForInternalMCPServer(auth, {
     mcpServerId,
+    connectionType: "workspace",
   });
   if (!accessToken) {
     return makeMCPToolTextError(ERROR_MESSAGES.NO_ACCESS_TOKEN);

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -447,6 +447,7 @@ const getNotionClient = async (
 ): Promise<Client | null> => {
   const accessToken = await getAccessTokenForInternalMCPServer(auth, {
     mcpServerId,
+    connectionType: "workspace",
   });
   if (!accessToken) {
     return null;

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -31,11 +31,8 @@ import type {
   MCPToolType,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  MCPServerConnectionConnectionType} from "@app/lib/resources/mcp_server_connection_resource";
-import {
-  MCPServerConnectionResource,
-} from "@app/lib/resources/mcp_server_connection_resource";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import logger from "@app/logger/logger";
 import type { OAuthProvider, OAuthUseCase, Result } from "@app/types";

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -31,7 +31,11 @@ import type {
   MCPToolType,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import type {
+  MCPServerConnectionConnectionType} from "@app/lib/resources/mcp_server_connection_resource";
+import {
+  MCPServerConnectionResource,
+} from "@app/lib/resources/mcp_server_connection_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import logger from "@app/logger/logger";
 import type { OAuthProvider, OAuthUseCase, Result } from "@app/types";
@@ -77,7 +81,8 @@ export function isInternalMCPServerDefinition(
 
 async function getAccessTokenForRemoteMCPServer(
   auth: Authenticator,
-  remoteMCPServer: RemoteMCPServerResource
+  remoteMCPServer: RemoteMCPServerResource,
+  connectionType: MCPServerConnectionConnectionType
 ) {
   const metadata = remoteMCPServer.toJSON();
 
@@ -85,6 +90,7 @@ async function getAccessTokenForRemoteMCPServer(
     const connection = await MCPServerConnectionResource.findByMCPServer({
       auth,
       mcpServerId: metadata.sId,
+      connectionType,
     });
     if (connection.isOk()) {
       const token = await getOAuthConnectionAccessToken({
@@ -185,7 +191,8 @@ export const connectToMCPServer = async (
 
           const accessToken = await getAccessTokenForRemoteMCPServer(
             auth,
-            remoteMCPServer
+            remoteMCPServer,
+            "workspace"
           );
 
           const url = new URL(remoteMCPServer.url);

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -6,6 +6,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { isManaged } from "@app/lib/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type {
   OAuthAPIError,
@@ -22,9 +23,6 @@ import {
   OAuthAPI,
   Ok,
 } from "@app/types";
-
-import { MCPServerConnection } from "../models/assistant/actions/mcp_server_connection";
-import { MCPServerConnectionResource } from "../resources/mcp_server_connection_resource";
 
 export type OAuthError = {
   code:

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -164,25 +164,6 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       : new Err(new DustError("resource_not_found", "Connection not found"));
   }
 
-  static async findByProviderAndUseCaseForWorkspace({
-    auth,
-    provider,
-    useCase,
-  }: {
-    auth: Authenticator;
-    provider: string;
-    useCase: string;
-  }): Promise<MCPServerConnectionResource[]> {
-    const connections = await this.baseFetch(auth, {
-      where: {
-        connectionType: provider,
-        serverType: useCase,
-      },
-    });
-
-    return connections;
-  }
-
   static async listByWorkspace({
     auth,
   }: {

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -5,6 +5,7 @@ export const OAUTH_USE_CASES = [
   "labs_transcripts",
   "platform_actions",
   "salesforce_personal",
+  "personal_actions",
 ] as const;
 
 export type OAuthUseCase = (typeof OAUTH_USE_CASES)[number];


### PR DESCRIPTION
## Description

- Introduce `personal_actions` use case
- `MCPServerConnectionResource.findByMCPServer` add connectionType argument
- Implement oauth.ts `getRelatedCredential` for `salesforce` with `personal_actions` use case

## Tests

Covered by types
Will test github locally

## Risk

Assuming github works. low. 

## Deploy Plan

- deploy `front`