### PR TITLE
[front] - fix(AB): agent draft creation

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -83,18 +83,13 @@ export default function AssistantBuilderRightPanel({
     });
 
   const { user } = useUser();
-  const {
-    conversation,
-    setConversation,
-    stickyMentions,
-    setStickyMentions,
-    handleSubmit,
-  } = useTryAssistantCore({
-    owner,
-    user,
-    assistant: draftAssistant,
-    createDraftAgent,
-  });
+  const { conversation, stickyMentions, setStickyMentions, handleSubmit } =
+    useTryAssistantCore({
+      owner,
+      user,
+      assistant: draftAssistant,
+      createDraftAgent,
+    });
 
   const isBuilderStateEmpty =
     !builderState.instructions?.trim() && !builderState.actions.length;

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -28,19 +28,21 @@ interface UsePreviewAssistantProps {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
   reasoningModels: ModelConfigurationType[];
+  isInputFocused: boolean;
 }
 
 export function usePreviewAssistant({
   owner,
   builderState,
   reasoningModels,
+  isInputFocused,
 }: UsePreviewAssistantProps) {
   const animationLength = 1000;
   const [draftAssistant, setDraftAssistant] =
     useState<LightAgentConfigurationType | null>();
   const [animateDrawer, setAnimateDrawer] = useState(false);
   const [isFading, setIsFading] = useState(false);
-  const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(true); // We always make the draft agent on initial page load so we can set it true.
+  const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(false);
   const drawerAnimationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
   const sendNotification = useSendNotification();
@@ -72,6 +74,12 @@ export function usePreviewAssistant({
   const submit = useCallback(async () => {
     if (draftAssistant && !hasChanged) {
       // No changes since the last submission
+      return;
+    }
+
+    // Only create draft agent if input is focused
+    if (!isInputFocused) {
+      setIsSavingDraftAgent(false);
       return;
     }
 
@@ -123,6 +131,7 @@ export function usePreviewAssistant({
   }, [
     draftAssistant,
     hasChanged,
+    isInputFocused,
     owner,
     builderState.handle,
     builderState.instructions,
@@ -141,6 +150,13 @@ export function usePreviewAssistant({
   useEffect(() => {
     debounce(debounceHandle, submit, 1500);
   }, [submit]);
+
+  // Reset saving state when input is not focused
+  useEffect(() => {
+    if (!isInputFocused) {
+      setIsSavingDraftAgent(false);
+    }
+  }, [isInputFocused]);
 
   return {
     shouldAnimate: animateDrawer,

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -38,7 +38,7 @@ export function usePreviewAssistant({
   const [draftAssistant, setDraftAssistant] =
     useState<LightAgentConfigurationType | null>(null);
   const [isFading, setIsFading] = useState(false);
-  const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(true);
+  const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(false);
   const [draftCreationFailed, setDraftCreationFailed] = useState(false);
 
   const drawerAnimationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -119,7 +119,7 @@ export function usePreviewAssistant({
       if (
         hasContent &&
         !draftAssistant &&
-        isSavingDraftAgent &&
+        !isSavingDraftAgent &&
         !draftCreationFailed
       ) {
         await createDraftAgent();

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -44,7 +44,6 @@ export function usePreviewAssistant({
 
   const previousBuilderState = useRef<AssistantBuilderState>(builderState);
   const [hasChanged, setHasChanged] = useState(false);
-  const initialCreationAttempted = useRef(false);
 
   const animate = () => {
     if (drawerAnimationTimeoutRef.current) {
@@ -133,17 +132,12 @@ export function usePreviewAssistant({
   useEffect(() => {
     const hasContent =
       builderState.instructions?.trim() || builderState.actions.length > 0;
-    if (hasContent && !initialCreationAttempted.current) {
-      initialCreationAttempted.current = true;
+    if (hasContent && !draftAssistant && isSavingDraftAgent) {
       createDraftAgent().catch(console.error);
-    } else if (!hasContent && !initialCreationAttempted.current) {
+    } else if (!hasContent) {
       setIsSavingDraftAgent(false);
     }
-  }, [
-    builderState.actions.length,
-    builderState.instructions,
-    createDraftAgent,
-  ]);
+  }, []);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Description

This PR optimizes the draft agent creation process in the AssistantBuilderPreviewDrawer to prevent excessive database growth. Instead of automatically creating a draft on page load, draft agents are now only created when the user sends a message. 

We also stop clearing the conversation when the `builderState` changes.


## Tests

- [x] Local 
- [x] Front-edge 

## Risk

Breaking the preview system

## Deploy Plan

- Deploy front