### PR TITLE
Improve MCP Extract action details UX

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -2,6 +2,7 @@ import { cn, CodeBlock, CollapsibleComponent } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import { MCPBrowseActionDetails } from "@app/components/actions/mcp/details/MCPBrowseActionDetails";
+import { MCPExtractActionDetails } from "@app/components/actions/mcp/details/MCPExtractActionDetails";
 import { MCPIncludeActionDetails } from "@app/components/actions/mcp/details/MCPIncludeActionDetails";
 import { MCPReasoningActionDetails } from "@app/components/actions/mcp/details/MCPReasoningActionDetails";
 import { MCPSearchActionDetails } from "@app/components/actions/mcp/details/MCPSearchActionDetails";
@@ -15,6 +16,7 @@ import {
   isReasoningSuccessOutput,
   isSearchResultResourceType,
   isSqlQueryOutput,
+  isToolGeneratedFile,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
@@ -33,6 +35,11 @@ export function MCPActionDetails(
   // Hack to find out whether the output comes from the reasoning tool, links back to the TODO above.
   const isReasoning = props.action.output?.some(isReasoningSuccessOutput);
 
+  // Detect extract/process action by checking for generated JSON files and process_documents function name
+  const isExtract =
+    props.action.output?.some(isToolGeneratedFile) &&
+    props.action.functionCallName === "process_documents";
+
   if (isSearch) {
     return <MCPSearchActionDetails {...props} />;
   } else if (isInclude) {
@@ -45,6 +52,8 @@ export function MCPActionDetails(
     return <MCPTablesQueryActionDetails {...props} />;
   } else if (isReasoning) {
     return <MCPReasoningActionDetails {...props} />;
+  } else if (isExtract) {
+    return <MCPExtractActionDetails {...props} />;
   } else {
     return <GenericActionDetails {...props} />;
   }

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -12,11 +12,11 @@ import type { ActionDetailsComponentBaseProps } from "@app/components/actions/ty
 import type { MCPActionType } from "@app/lib/actions/mcp";
 import {
   isBrowseResultResourceType,
+  isExtractResultResourceType,
   isIncludeResultResourceType,
   isReasoningSuccessOutput,
   isSearchResultResourceType,
   isSqlQueryOutput,
-  isToolGeneratedFile,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
@@ -30,15 +30,11 @@ export function MCPActionDetails(
   const isWebsearch = props.action.output?.some(isWebsearchResultResourceType);
   const isBrowse = props.action.output?.some(isBrowseResultResourceType);
   const isTablesQuery = props.action.output?.some(isSqlQueryOutput);
+  const isExtract = props.action.output?.some(isExtractResultResourceType);
 
   // TODO(mcp): rationalize the display of results for MCP to remove the need for specific checks.
   // Hack to find out whether the output comes from the reasoning tool, links back to the TODO above.
   const isReasoning = props.action.output?.some(isReasoningSuccessOutput);
-
-  // Detect extract/process action by checking for generated JSON files and process_documents function name
-  const isExtract =
-    props.action.output?.some(isToolGeneratedFile) &&
-    props.action.functionCallName === "process_documents";
 
   if (isSearch) {
     return <MCPSearchActionDetails {...props} />;

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -8,6 +8,7 @@ import {
   ScanIcon,
 } from "@dust-tt/sparkle";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { useState } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
@@ -17,6 +18,27 @@ import {
   isExtractResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isTimeFrame } from "@app/types/shared/utils/time_frame";
+
+interface MCPExtractActionQueryProps {
+  action: MCPActionType;
+  queryResource?: {
+    text: string;
+    mimeType: string;
+    uri: string;
+  };
+}
+
+interface MCPExtractActionResultsProps {
+  resultResource?: {
+    text: string;
+    uri: string;
+    mimeType: string;
+    fileId: string;
+    title: string;
+    contentType: string;
+    snippet: string | null;
+  };
+}
 
 export function MCPExtractActionDetails({
   action,
@@ -93,14 +115,7 @@ export function MCPExtractActionDetails({
 function MCPExtractActionQuery({
   action,
   queryResource,
-}: {
-  action: MCPActionType;
-  queryResource?: {
-    text: string;
-    mimeType: string;
-    uri: string;
-  };
-}) {
+}: MCPExtractActionQueryProps) {
   const timeFrameParam = action.params?.timeFrame;
 
   if (queryResource) {
@@ -111,7 +126,7 @@ function MCPExtractActionQuery({
     );
   }
 
-  // Fallback: Format timeframe description from params
+  // Fallback: Format timeframe description from params.
   const timeFrameAsString =
     timeFrameParam && isTimeFrame(timeFrameParam)
       ? "the last " +
@@ -129,17 +144,9 @@ function MCPExtractActionQuery({
 
 function MCPExtractActionResults({
   resultResource,
-}: {
-  resultResource?: {
-    text: string;
-    uri: string;
-    mimeType: string;
-    fileId: string;
-    title: string;
-    contentType: string;
-    snippet: string | null;
-  };
-}) {
+}: MCPExtractActionResultsProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+
   if (!resultResource) {
     return (
       <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
@@ -148,11 +155,14 @@ function MCPExtractActionResults({
     );
   }
 
-  const handleDownload = () => {
+  const handleDownload = async () => {
+    setIsDownloading(true);
     try {
       window.open(resultResource.uri, "_blank");
     } catch (error) {
       console.error("Download failed:", error);
+    } finally {
+      setIsDownloading(false);
     }
   };
 
@@ -164,6 +174,7 @@ function MCPExtractActionResults({
           containerClassName="my-2"
           onClick={handleDownload}
           tooltip={resultResource.title}
+          isLoading={isDownloading}
         >
           <CitationIcons>
             <Icon visual={ScanIcon} />

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -1,0 +1,181 @@
+import {
+  Citation,
+  CitationIcons,
+  CitationTitle,
+  CodeBlock,
+  CollapsibleComponent,
+  Icon,
+  ScanIcon,
+} from "@dust-tt/sparkle";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
+import type { MCPActionType } from "@app/lib/actions/mcp";
+import { isToolGeneratedFile } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { isTimeFrame } from "@app/types/shared/utils/time_frame";
+
+export function MCPExtractActionDetails({
+  action,
+  defaultOpen,
+}: ActionDetailsComponentBaseProps<MCPActionType>) {
+  const generatedFile = action.output
+    ?.filter(isToolGeneratedFile)
+    .map((o) => o.resource)?.[0];
+
+  const jsonSchema = action.params?.jsonSchema as JSONSchema | undefined;
+
+  return (
+    <ActionDetailsWrapper
+      actionName="Extract data"
+      defaultOpen={defaultOpen}
+      visual={ScanIcon}
+    >
+      <div className="flex flex-col gap-4 pl-6 pt-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+            Query
+          </span>
+          <MCPExtractActionQuery action={action} />
+        </div>
+
+        {jsonSchema && (
+          <div>
+            <CollapsibleComponent
+              rootProps={{ defaultOpen: false }}
+              triggerChildren={
+                <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                  Schema
+                </span>
+              }
+              contentChildren={
+                <div className="py-2">
+                  <CodeBlock
+                    className="language-json max-h-60 overflow-y-auto"
+                    wrapLongLines={true}
+                  >
+                    {JSON.stringify(jsonSchema, null, 2)}
+                  </CodeBlock>
+                </div>
+              }
+            />
+          </div>
+        )}
+
+        <div>
+          <CollapsibleComponent
+            rootProps={{ defaultOpen }}
+            triggerChildren={
+              <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                Results
+              </span>
+            }
+            contentChildren={
+              <MCPExtractActionResults generatedFile={generatedFile} />
+            }
+          />
+        </div>
+      </div>
+    </ActionDetailsWrapper>
+  );
+}
+
+function MCPExtractActionQuery({ action }: { action: MCPActionType }) {
+  const timeFrameParam = action.params?.timeFrame;
+
+  // Extract document count from action output text
+  const outputText = action.output
+    ?.filter((o): o is { type: "text"; text: string } => o.type === "text")
+    .map((o) => o.text)
+    .join(" ");
+
+  const documentCountMatch = outputText?.match(
+    /Extracted from (\d+) documents?/
+  );
+  const documentCount = documentCountMatch ? documentCountMatch[1] : null;
+
+  // Format timeframe description
+  const timeFrameAsString =
+    timeFrameParam && isTimeFrame(timeFrameParam)
+      ? "the last " +
+        (timeFrameParam.duration > 1
+          ? `${timeFrameParam.duration} ${timeFrameParam.unit}s`
+          : `${timeFrameParam.unit}`)
+      : "all time";
+
+  const baseDescription = documentCount
+    ? `Extracted from ${documentCount} documents over ${timeFrameAsString}.`
+    : `Extracted from documents over ${timeFrameAsString}.`;
+
+  return (
+    <p className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+      {baseDescription}
+    </p>
+  );
+}
+
+function MCPExtractActionResults({
+  generatedFile,
+}: {
+  generatedFile?: {
+    fileId: string;
+    title: string;
+    snippet: string | null;
+    uri: string;
+  };
+}) {
+  if (!generatedFile) {
+    return (
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        No data was extracted.
+      </div>
+    );
+  }
+
+  const handleDownload = () => {
+    try {
+      window.open(generatedFile.uri, "_blank");
+    } catch (error) {
+      console.error("Download failed:", error);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <Citation
+          className="w-48 min-w-48 max-w-48"
+          containerClassName="my-2"
+          onClick={handleDownload}
+          tooltip={generatedFile.title}
+        >
+          <CitationIcons>
+            <Icon visual={ScanIcon} />
+          </CitationIcons>
+          <CitationTitle>{generatedFile.title}</CitationTitle>
+        </Citation>
+      </div>
+
+      {generatedFile.snippet && (
+        <CollapsibleComponent
+          rootProps={{ defaultOpen: false }}
+          triggerChildren={
+            <span className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground-night">
+              Preview
+            </span>
+          }
+          contentChildren={
+            <div className="py-2">
+              <CodeBlock
+                className="language-json max-h-60 overflow-y-auto"
+                wrapLongLines={true}
+              >
+                {generatedFile.snippet}
+              </CodeBlock>
+            </div>
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -398,6 +398,52 @@ export type PersonalAuthenticationRequiredErrorResourceType = z.infer<
   typeof PersonalAuthenticationRequiredErrorResourceSchema
 >;
 
+// Extract data outputs: query and results.
+
+export const ExtractQueryResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_QUERY),
+  text: z.string(),
+  uri: z.literal(""),
+});
+
+export type ExtractQueryResourceType = z.infer<
+  typeof ExtractQueryResourceSchema
+>;
+
+export const isExtractQueryResourceType = (
+  outputBlock: MCPToolResultContentType
+): outputBlock is { type: "resource"; resource: ExtractQueryResourceType } => {
+  return (
+    outputBlock.type === "resource" &&
+    ExtractQueryResourceSchema.safeParse(outputBlock.resource).success
+  );
+};
+
+export const ExtractResultResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT),
+  uri: z.string(),
+  text: z.string(),
+
+  // File metadata
+  fileId: z.string(),
+  title: z.string(),
+  contentType: z.string(),
+  snippet: z.string().nullable(),
+});
+
+export type ExtractResultResourceType = z.infer<
+  typeof ExtractResultResourceSchema
+>;
+
+export const isExtractResultResourceType = (
+  outputBlock: MCPToolResultContentType
+): outputBlock is { type: "resource"; resource: ExtractResultResourceType } => {
+  return (
+    outputBlock.type === "resource" &&
+    ExtractResultResourceSchema.safeParse(outputBlock.resource).success
+  );
+};
+
 // Generic output types and schemas.
 
 const EmbeddedResourceSchema = z.object({
@@ -409,6 +455,8 @@ const EmbeddedResourceSchema = z.object({
     ExampleRowsResourceSchema,
     SearchQueryResourceSchema,
     SearchResultResourceSchema,
+    ExtractQueryResourceSchema,
+    ExtractResultResourceSchema,
     TextResourceContentsSchema,
     ThinkingOutputSchema,
     ToolGeneratedFileSchema,

--- a/front/lib/actions/mcp_internal_actions/servers/process.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process.ts
@@ -489,23 +489,30 @@ async function generateProcessToolOutput({
       isError: false,
       content: [
         {
-          type: "text" as const,
-          text:
-            "Extracted from " +
-            outputs?.total_documents +
-            " documents over " +
-            timeFrameAsString +
-            ".",
+          type: "resource" as const,
+          resource: {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_QUERY,
+            text:
+              "Extracted from " +
+              outputs?.total_documents +
+              " documents over " +
+              timeFrameAsString +
+              ".",
+            uri: "",
+          },
         },
         {
           type: "resource" as const,
           resource: {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT,
             text:
               "This file contains data extracted from available documents according to the provided schema. Here is  a preview of its contents: \n" +
               generatedFile.snippet,
             uri: jsonFile.getPublicUrl(auth),
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-            ...generatedFile,
+            fileId: generatedFile.fileId,
+            title: generatedFile.title,
+            contentType: generatedFile.contentType,
+            snippet: generatedFile.snippet,
           },
         },
       ],


### PR DESCRIPTION
## Description

The current MCP Extract action details uses the `GenericActionDetails` component from `MCPActionDetails.tsx`, which looks like this (a little ugly):
![mcp-process-details](https://github.com/user-attachments/assets/24ef39a3-1f00-4429-a7d2-9e1401988a6d)


The legacy Extract action has better looking details, implemented in `ProcessActionDetails.tsx`, like so:
![legacy-process-details](https://github.com/user-attachments/assets/782afa16-3e48-4ea1-80b6-4d2745e2e6d6)


This PR implements better looking details for the new MCP action inspired from the legacy action (although not perfectly the same). It also improves them by adding a clean view of the JSON Schema argument.

The new details provide:
- Clean "Extract data" title with ScanIcon matching legacy design
- Query section showing document count and timeframe extracted from action output  
- Schema section displaying JSON schema argument in a clean, collapsible format
- Results section with file citation and click-to-download functionality
- Preview section with JSON output in collapsible CodeBlock

### Implementation Overview
- **Created**: `MCPExtractActionDetails.tsx` - New specialized component for extract actions
- **Modified**: `MCPActionDetails.tsx` - Added detection logic using `isToolGeneratedFile` + `process_documents` function name to route extract actions to new component

## Risks

- Low risk: New component follows established patterns from existing MCP action details (`MCPSearchActionDetails`, `MCPIncludeActionDetails`)
- No breaking changes: Only enhances UX for extract actions, maintains backward compatibility
- Type safety: Proper TypeScript typing and type guards throughout implementation

## Tests

- All linting passes
- Code formatting applied  
- TypeScript compilation successful
- Follows established component patterns from codebase
- Manual verification shows improved UX with clean, organized interface

## Deploy Plan

- Deploy front service (frontend-only changes)
- No migrations required
- No special deployment steps needed