### PR TITLE
fix(Intercom): bump default retention period in SQL

### DIFF
--- a/connectors/migrations/db/migration_75.sql
+++ b/connectors/migrations/db/migration_75.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 26, 2025
+ALTER TABLE "intercom_workspaces" ALTER COLUMN "conversationsSlidingWindow" SET DEFAULT 180;

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -38,6 +38,7 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
+  DEFAULT_CONVERSATIONS_SLIDING_WINDOW,
   IntercomHelpCenterModel,
   IntercomTeamModel,
   IntercomWorkspaceModel,
@@ -50,8 +51,6 @@ import type {
   ContentNodesViewType,
 } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
-
-const DEFAULT_CONVERSATIONS_SLIDING_WINDOW = 180;
 
 export class IntercomConnectorManager extends BaseConnectorManager<null> {
   static async create({

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -5,6 +5,8 @@ import type { IntercomSyncAllConversationsStatus } from "@connectors/connectors/
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
+export const DEFAULT_CONVERSATIONS_SLIDING_WINDOW = 180;
+
 export class IntercomWorkspaceModel extends ConnectorBaseModel<IntercomWorkspaceModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -40,7 +42,7 @@ IntercomWorkspaceModel.init(
     conversationsSlidingWindow: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      defaultValue: 90,
+      defaultValue: DEFAULT_CONVERSATIONS_SLIDING_WINDOW,
     },
     syncAllConversations: {
       type: DataTypes.STRING,


### PR DESCRIPTION
## Description

- Forgot to push a commit on https://github.com/dust-tt/dust/pull/12923 🙈 
- This PR reuses the default value in the Sequelize model and updates the default value in db.

## Tests

- Checked that adding a new connector uses the correct default value.

## Risk

- N/A.

## Deploy Plan

- Run `migration_75.sql`.
- Deploy connectors.
