### PR TITLE
Salesforce empty tool

### DIFF
--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -18,6 +18,7 @@ import {
   GithubLogo,
   HubspotLogo,
   NotionLogo,
+  SalesforceLogo,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import type { ComponentProps } from "react";
@@ -46,6 +47,7 @@ export const InternalActionIcons = {
   HubspotLogo,
   CommandLineIcon,
   NotionLogo,
+  SalesforceLogo,
 };
 
 export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -26,6 +26,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "search",
   "think",
   "web_search_&_browse",
+  "salesforce",
 ] as const;
 
 // Whether the server is available by default in the global space.
@@ -142,6 +143,11 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 13,
     availability: "auto_hidden_builder",
     flag: null,
+  },
+  salesforce: {
+    id: 14,
+    availability: "manual",
+    flag: "tool_personal_credentials",
   },
 
   // Dev

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -147,7 +147,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   salesforce: {
     id: 14,
     availability: "manual",
-    flag: "tool_personal_credentials",
+    flag: "salesforce_tool",
   },
 
   // Dev

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -14,6 +14,7 @@ import { default as extractDataServer } from "@app/lib/actions/mcp_internal_acti
 import { default as reasoningServer } from "@app/lib/actions/mcp_internal_actions/servers/reasoning";
 import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/run_agent";
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
+import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
 import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server_v2";
@@ -71,6 +72,8 @@ export async function getInternalMCPServer(
       return agentRouterServer(auth);
     case "extract_data":
       return extractDataServer(auth, agentLoopContext);
+    case "salesforce":
+      return salesforceServer(auth, mcpServerId);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -11,7 +11,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Salesforce tools.",
   authorization: {
     provider: "salesforce" as const,
-    use_case: "platform_actions" as const,
+    use_case: "personal_actions" as const,
   },
   icon: "SalesforceLogo",
 };

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -1,0 +1,34 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { withAuth } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils";
+import { makeMCPToolJSONSuccess } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "salesforce",
+  version: "1.0.0",
+  description: "Salesforce tools.",
+  authorization: {
+    provider: "salesforce" as const,
+    use_case: "platform_actions" as const,
+  },
+  icon: "SalesforceLogo",
+};
+
+const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
+  const server = new McpServer(serverInfo);
+
+  server.tool("hello_world", "Greet the user", {}, async () => {
+    return withAuth(auth, mcpServerId, async () => {
+      return makeMCPToolJSONSuccess({
+        message: "Operation completed successfully",
+        result: "Hello Soupinou",
+      });
+    });
+  });
+
+  return server;
+};
+
+export default createServer;

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -4,6 +4,7 @@ export const OAUTH_USE_CASES = [
   "connection",
   "labs_transcripts",
   "platform_actions",
+  "personal_actions",
   "salesforce_personal",
 ] as const;
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -27,6 +27,7 @@ export const WHITELISTABLE_FEATURES = [
   "usage_data_api",
   "custom_webcrawler",
   "exploded_tables_query",
+  "tool_personal_credentials",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -27,7 +27,7 @@ export const WHITELISTABLE_FEATURES = [
   "usage_data_api",
   "custom_webcrawler",
   "exploded_tables_query",
-  "tool_personal_credentials",
+  "salesforce_tool",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -827,6 +827,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "custom_webcrawler"
   | "exploded_tables_query"
   | "pro_plan_salesforce_connector"
+  | "salesforce_tool"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Skeleton for the Salesforce Tool. 
Under a new feature flag called `tool_personal_credentials`.

It does not work yet, trying to activate the tool with end up in: 
http://localhost:3000/w/XfGEztL6cC/oauth/salesforce/setup?useCase=platform_actions&extraConfig=%7B%7D

-> this is the oauth part to manage. 
-> I'll be first making progress on the tool. 

## Tests

/ 

## Risk

Under a feature flag. 

## Deploy Plan

/ 