### PR TITLE
AgentMessage.error.metadata

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -364,6 +364,7 @@ async function* runMultiActionsAgent(
         message:
           `The model you selected (${agentConfiguration.model.modelId}) ` +
           `does not support multi-actions.`,
+        metadata: null,
       },
     };
     return;
@@ -473,6 +474,7 @@ async function* runMultiActionsAgent(
       error: {
         code: "conversation_render_error",
         message: `Error rendering conversation for model: ${modelConversationRes.error.message}`,
+        metadata: null,
       },
     } satisfies AgentErrorEvent;
 
@@ -506,6 +508,7 @@ async function* runMultiActionsAgent(
         error: {
           code: "build_spec_error",
           message: `Failed to build the specification for action ${a.sId},`,
+          metadata: null,
         },
       } satisfies AgentErrorEvent;
 
@@ -536,6 +539,7 @@ async function* runMultiActionsAgent(
           message:
             `Duplicate action name in agent configuration: ${spec.name}. ` +
             "Your agents actions must have unique names.",
+          metadata: null,
         },
       } satisfies AgentErrorEvent;
 
@@ -604,6 +608,7 @@ async function* runMultiActionsAgent(
       error: {
         code: "multi_actions_error",
         message: `Error running multi-actions agent action: [${res.error.type}] ${res.error.message}`,
+        metadata: null,
       },
     } satisfies AgentErrorEvent;
 
@@ -672,6 +677,7 @@ async function* runMultiActionsAgent(
         error: {
           code: "multi_actions_error",
           message: `Error running agent: ${event.content.message}`,
+          metadata: null,
         },
       } satisfies AgentErrorEvent;
       return;
@@ -714,6 +720,7 @@ async function* runMultiActionsAgent(
           error: {
             code: "multi_actions_error",
             message: `Error running agent: ${e.error}`,
+            metadata: null,
           },
         } satisfies AgentErrorEvent;
         return;
@@ -787,6 +794,7 @@ async function* runMultiActionsAgent(
         code: "tool_use_limit_reached",
         message:
           "The agent attempted to use too many tools. This model error can be safely retried.",
+        metadata: null,
       },
     } satisfies AgentErrorEvent;
     return;
@@ -828,7 +836,10 @@ async function* runMultiActionsAgent(
           messageId: agentMessage.sId,
           error: {
             code: "action_not_found",
-            message: `The agent attempted to run an invalid action (${a.name}). This model error can be safely retried (no name).`,
+            message:
+              `The agent attempted to run an invalid action (no name). ` +
+              `This model error can be safely retried.`,
+            metadata: null,
           },
         } satisfies AgentErrorEvent;
 
@@ -861,7 +872,10 @@ async function* runMultiActionsAgent(
             messageId: agentMessage.sId,
             error: {
               code: "action_not_found",
-              message: `The agent attempted to run an invalid action (${a.name}). This model error can be safely retried (no server).`,
+              message:
+                `The agent attempted to run an invalid action (${a.name}). ` +
+                `This model error can be safely retried (no server).`,
+              metadata: null,
             },
           } satisfies AgentErrorEvent;
           return;
@@ -1007,6 +1021,7 @@ async function* runAction(
         error: {
           code: "retrieval_action_disabled",
           message: "Retrieval action is temporarily disabled",
+          metadata: null,
         },
       };
       return;
@@ -1045,6 +1060,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;
@@ -1084,6 +1100,7 @@ async function* runAction(
         error: {
           code: "parameters_generation_error",
           message: "No specification found for Dust app run action.",
+          metadata: null,
         },
       };
       return;
@@ -1120,6 +1137,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;
@@ -1171,6 +1189,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;
@@ -1218,6 +1237,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;
@@ -1273,6 +1293,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;
@@ -1320,6 +1341,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;
@@ -1367,6 +1389,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;
@@ -1408,7 +1431,11 @@ async function* runAction(
             created: event.created,
             configurationId: configuration.sId,
             messageId: agentMessage.sId,
-            error: event.error,
+            error: {
+              code: event.error.code,
+              message: event.error.message,
+              metadata: null,
+            },
           };
           return;
         case "reasoning_started":
@@ -1453,6 +1480,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;
@@ -1505,6 +1533,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
+              metadata: null,
             },
           };
           return;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1501,6 +1501,7 @@ export async function* retryAgentMessage(
       error: {
         code: "message_access_denied",
         message: "The message to retry is not accessible.",
+        metadata: null,
       },
     };
     return;
@@ -1629,6 +1630,7 @@ export async function* retryAgentMessage(
       error: {
         code: "message_not_found",
         message: "The message to retry was not found",
+        metadata: null,
       },
     };
     return;
@@ -1838,6 +1840,7 @@ async function* streamRunAgentEvents(
       error: {
         code: "agent_not_allowed",
         message: "Agent cannot be used by this user",
+        metadata: null,
       },
     };
     return;
@@ -1851,6 +1854,7 @@ async function* streamRunAgentEvents(
           status: "failed",
           errorCode: event.error.code,
           errorMessage: event.error.message,
+          errorMetadata: event.error.metadata,
         });
 
         logger.error(

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -234,6 +234,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       let error: {
         code: string;
         message: string;
+        metadata: Record<string, string | number | boolean> | null;
       } | null = null;
 
       if (
@@ -243,6 +244,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         error = {
           code: agentMessage.errorCode,
           message: agentMessage.errorMessage,
+          metadata: agentMessage.errorMetadata,
         };
       }
 

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -246,6 +246,7 @@ export class AgentMessage extends WorkspaceAwareModel<AgentMessage> {
 
   declare errorCode: string | null;
   declare errorMessage: string | null;
+  declare errorMetadata: Record<string, string | number | boolean> | null;
 
   declare skipToolsValidation: boolean;
 
@@ -287,6 +288,31 @@ AgentMessage.init(
     errorMessage: {
       type: DataTypes.TEXT,
       allowNull: true,
+    },
+    errorMetadata: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: null,
+      validate: {
+        isValidJSON(value: any) {
+          if (value !== null && typeof value !== "object") {
+            throw new Error("errorMetadata must be an object or null");
+          }
+          if (
+            value !== null &&
+            !Object.values(value).every(
+              (v) =>
+                typeof v === "string" ||
+                typeof v === "number" ||
+                typeof v === "boolean"
+            )
+          ) {
+            throw new Error(
+              "errorMetadata values must be string | number | boolean"
+            );
+          }
+        },
+      },
     },
     skipToolsValidation: {
       type: DataTypes.BOOLEAN,

--- a/front/migrations/db/migration_271.sql
+++ b/front/migrations/db/migration_271.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 26, 2025
+ALTER TABLE "public"."agent_messages" ADD COLUMN "errorMetadata" JSONB DEFAULT NULL;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -4,11 +4,11 @@ import type {
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
 import type { TagType } from "@app/types/tag";
+import type { UserType } from "@app/types/user";
 
 import type { ModelId } from "../shared/model_id";
 import type { ModelIdType, ModelProviderIdType } from "./assistant";
 import type { AgentActionType, AgentMessageType } from "./conversation";
-import { UserType } from "@app/types/user";
 
 /**
  * Agent configuration
@@ -197,7 +197,8 @@ export type AgentMessageErrorEvent = {
   };
 };
 
-// Generic event sent when an error occured (whether it's during the action or the message generation).
+// Generic event sent when an error occured (whether it's during the action or the message
+// generation).
 export type AgentErrorEvent = {
   type: "agent_error";
   created: number;
@@ -206,6 +207,7 @@ export type AgentErrorEvent = {
   error: {
     code: string;
     message: string;
+    metadata: Record<string, string | number | boolean> | null;
   };
 };
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -8,12 +8,12 @@ import type { ReasoningActionType } from "@app/lib/actions/reasoning";
 import type { RetrievalActionType } from "@app/lib/actions/retrieval";
 import type { SearchLabelsActionType } from "@app/lib/actions/search_labels";
 import type { TablesQueryActionType } from "@app/lib/actions/tables_query";
-import type { WebsearchActionType } from "@app/lib/actions/websearch";
-
-import {
+import type {
   ActionGeneratedFileType,
   BaseAgentActionType,
 } from "@app/lib/actions/types";
+import type { WebsearchActionType } from "@app/lib/actions/websearch";
+
 import type { ContentFragmentType } from "../content_fragment";
 import type { ModelId } from "../shared/model_id";
 import type { UserType, WorkspaceType } from "../user";
@@ -191,6 +191,7 @@ export type BaseAgentMessageType = {
   error: {
     code: string;
     message: string;
+    metadata: Record<string, string | number | boolean> | null;
   } | null;
 };
 
@@ -206,10 +207,6 @@ export type AgentMessageType = BaseAgentMessageType & {
     step: number;
     content: string;
   }>;
-  error: {
-    code: string;
-    message: string;
-  } | null;
 };
 
 export type LightAgentMessageType = BaseAgentMessageType & {


### PR DESCRIPTION
## Description

Adds `metadata` to AgentMessage `error` which is stored from error with type `agent_error`. This will allow us to pass `mcp_server_id` when erroring on personal actions authentication.

## Tests

Testing normal conversation + errors in dev

```
dust_front=# SELECT * FROM agent_messages WHERE "errorCode"='test_agent_error';
         createdAt          |         updatedAt          | runIds | status |    errorCode     |        errorMessage        | agentConfigurationId | agentConfigurationVersion | workspaceId | id  | skipToolsValidation |      errorMetadata       
----------------------------+----------------------------+--------+--------+------------------+----------------------------+----------------------+---------------------------+-------------+-----+---------------------+--------------------------
 2025-05-26 10:00:19.376+00 | 2025-05-26 10:00:19.405+00 |        | failed | test_agent_error | This is a test agent error | dust                 |                         0 |           1 | 123 | f                   | {"mcp_server_id": "foo"}
 2025-05-26 09:59:50.739+00 | 2025-05-26 09:59:50.81+00  |        | failed | test_agent_error | This is a test agent error | dust                 |                         0 |           1 | 121 | f                   | 
 2025-05-26 10:00:12.67+00  | 2025-05-26 10:00:12.706+00 |        | failed | test_agent_error | This is a test agent error | dust                 |                         0 |           1 | 122 | f                   | {"mcp_server_id": "foo"}
 2025-05-26 10:01:14.743+00 | 2025-05-26 10:01:14.779+00 |        | failed | test_agent_error | This is a test agent error | dust                 |                         0 |           1 | 124 | f                   | {"mcp_server_id": "foo"}
```

## Risk

Touches AgentMessage so kinda high

## Deploy Plan

- run migration
- deploy `front`