### PR TITLE
MCP: typed errors through lib + personal authentication required

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -665,9 +665,9 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         isError: true,
       });
 
-      // If we got a personal authentication error, we emit a `tool_error` which will get turned into
-      // an `agent_error` with metadata set such that we can disaply a invitation to connect to the
-      // user.
+      // If we got a personal authentication error, we emit a `tool_error` which will get turned
+      // into an `agent_error` with metadata set such that we can display a invitation to connect to
+      // the user.
       if (
         MCPServerPersonalAuthenticationRequiredError.is(toolCallResult?.error)
       ) {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -677,12 +677,11 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
           configurationId: agentConfiguration.sId,
           messageId: agentMessage.sId,
           error: {
-            code: "tool_error",
+            code: "mcp_server_personal_authentication_required",
             message:
               `The tool ${actionConfiguration.originalName} requires personal ` +
               `authentication, please authenticate to use it.`,
             metadata: {
-              mcp_server_personal_authentication_required: true,
               mcp_server_id: toolCallResult.error.mcpServerId,
             },
           },

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -8,6 +8,7 @@ import type {
 } from "@app/lib/actions/constants";
 import type { DustAppRunConfigurationType } from "@app/lib/actions/dust_app_run";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
+import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_internal_actions/authentication";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   MCPToolResultContentType,
@@ -191,6 +192,7 @@ type MCPErrorEvent = {
   error: {
     code: string;
     message: string;
+    metadata: Record<string, string | number | boolean> | null;
   };
 };
 
@@ -425,6 +427,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
           error: {
             code: "tool_error",
             message: "Invalid Unicode character in inputs, please retry.",
+            metadata: null,
           },
         };
         return;
@@ -538,6 +541,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
           error: {
             code: "tool_error",
             message: `Error checking action validation status: ${JSON.stringify(error)}`,
+            metadata: null,
           },
         };
         return;
@@ -620,7 +624,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
 
     let toolCallResult: Result<
       MCPToolResultContentType[],
-      Error | McpError
+      Error | McpError | MCPServerPersonalAuthenticationRequiredError
     > | null = null;
     for await (const event of tryCallMCPTool(
       auth,
@@ -660,6 +664,31 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       await action.update({
         isError: true,
       });
+
+      // If we got a personal authentication error, we emit a `tool_error` which will get turned into
+      // an `agent_error` with metadata set such that we can disaply a invitation to connect to the
+      // user.
+      if (
+        MCPServerPersonalAuthenticationRequiredError.is(toolCallResult?.error)
+      ) {
+        yield {
+          type: "tool_error",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: "tool_error",
+            message:
+              `The tool ${actionConfiguration.originalName} requires personal ` +
+              `authentication, please authenticate to use it.`,
+            metadata: {
+              mcp_server_personal_authentication_required: true,
+              mcp_server_id: toolCallResult.error.mcpServerId,
+            },
+          },
+        };
+        return;
+      }
 
       const { error: toolErr } = toolCallResult ?? {};
       let errorMessage: string;

--- a/front/lib/actions/mcp_internal_actions/authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/authentication.ts
@@ -57,3 +57,26 @@ export async function getConnectionForInternalMCPServer(
   }
   return null;
 }
+
+const MCPServerRequiresPersonalAuthenticationErrorName =
+  "MCPServerRequiresPersonalAuthenticationError";
+
+export class MCPServerPersonalAuthenticationRequiredError extends Error {
+  mcpServerId: string;
+
+  constructor(mcpServerId: string) {
+    super(`MCP server ${mcpServerId} requires personal authentication`);
+    this.name = MCPServerRequiresPersonalAuthenticationErrorName;
+    this.mcpServerId = mcpServerId;
+  }
+
+  static is(
+    error: unknown
+  ): error is MCPServerPersonalAuthenticationRequiredError {
+    return (
+      error instanceof Error &&
+      error.name === MCPServerRequiresPersonalAuthenticationErrorName &&
+      "mcpServerId" in error
+    );
+  }
+}

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -381,6 +381,21 @@ export const isBrowseResultResourceType = (
   );
 };
 
+// Personal authentication required error.
+
+export const PersonalAuthenticationRequiredErrorResourceSchema = z.object({
+  mimeType: z.literal(
+    INTERNAL_MIME_TYPES.TOOL_ERROR.PERSONAL_AUTHENTICATION_REQUIRED
+  ),
+  text: z.string(),
+  uri: z.literal(""),
+  mcpServerId: z.string(),
+});
+
+export type PersonalAuthenticationRequiredErrorResourceType = z.infer<
+  typeof PersonalAuthenticationRequiredErrorResourceSchema
+>;
+
 // Generic output types and schemas.
 
 const EmbeddedResourceSchema = z.object({
@@ -395,6 +410,7 @@ const EmbeddedResourceSchema = z.object({
     TextResourceContentsSchema,
     ThinkingOutputSchema,
     ToolGeneratedFileSchema,
+    PersonalAuthenticationRequiredErrorResourceSchema,
   ]),
 });
 

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -1,8 +1,12 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Octokit } from "@octokit/core";
 import { z } from "zod";
 
-import { getAccessTokenForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
+import {
+  getAccessTokenForInternalMCPServer,
+  MCPServerPersonalAuthenticationRequiredError,
+} from "@app/lib/actions/mcp_internal_actions/authentication";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { normalizeError } from "@app/types";
@@ -479,6 +483,24 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         mcpServerId,
         connectionType: "workspace",
       });
+
+      return {
+        isError: true,
+        content: [
+          {
+            type: "resource",
+            resource: {
+              mimeType:
+                INTERNAL_MIME_TYPES.TOOL_ERROR.PERSONAL_AUTHENTICATION_REQUIRED,
+              uri: "",
+              text: new MCPServerPersonalAuthenticationRequiredError(
+                mcpServerId
+              ).message,
+              mcpServerId,
+            },
+          },
+        ],
+      };
 
       const octokit = new Octokit({ auth: accessToken });
 

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -1,12 +1,8 @@
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Octokit } from "@octokit/core";
 import { z } from "zod";
 
-import {
-  getAccessTokenForInternalMCPServer,
-  MCPServerPersonalAuthenticationRequiredError,
-} from "@app/lib/actions/mcp_internal_actions/authentication";
+import { getAccessTokenForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { normalizeError } from "@app/types";

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -484,24 +484,6 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         connectionType: "workspace",
       });
 
-      return {
-        isError: true,
-        content: [
-          {
-            type: "resource",
-            resource: {
-              mimeType:
-                INTERNAL_MIME_TYPES.TOOL_ERROR.PERSONAL_AUTHENTICATION_REQUIRED,
-              uri: "",
-              text: new MCPServerPersonalAuthenticationRequiredError(
-                mcpServerId
-              ).message,
-              mcpServerId,
-            },
-          },
-        ],
-      };
-
       const octokit = new Octokit({ auth: accessToken });
 
       try {

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { getConnectionForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
 import {
   makeMCPToolJSONSuccess,
-  makeMCPToolTextError,
+  makeMCPToolPersonalAuthenticationRequiredError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -62,7 +62,7 @@ You can use it to list the objects in Salesforce: standard and custom objects.
         | undefined;
 
       if (!accessToken || !instanceUrl) {
-        return makeMCPToolTextError("No access token or instance URL found");
+        return makeMCPToolPersonalAuthenticationRequiredError(mcpServerId);
       }
 
       const conn = new jsforce.Connection({
@@ -103,7 +103,7 @@ You can use it to list the objects in Salesforce: standard and custom objects.
         | undefined;
 
       if (!accessToken || !instanceUrl) {
-        return makeMCPToolTextError("No access token or instance URL found");
+        return makeMCPToolPersonalAuthenticationRequiredError(mcpServerId);
       }
       const conn = new jsforce.Connection({
         instanceUrl,

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -7,6 +7,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { ZodError } from "zod";
 
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_internal_actions/authentication";
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import {
   ConfigurableToolInputJSONSchemas,
@@ -31,6 +32,27 @@ export function makeMCPToolTextError(text: string): MCPToolResult {
       {
         type: "text",
         text,
+      },
+    ],
+  };
+}
+
+export function makeMCPToolPersonalAuthenticationRequiredError(
+  mcpServerId: string
+): MCPToolResult {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "resource",
+        resource: {
+          mimeType:
+            INTERNAL_MIME_TYPES.TOOL_ERROR.PERSONAL_AUTHENTICATION_REQUIRED,
+          uri: "",
+          text: new MCPServerPersonalAuthenticationRequiredError(mcpServerId)
+            .message,
+          mcpServerId,
+        },
       },
     ],
   };

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1533,7 +1533,7 @@ async function* runAction(
             error: {
               code: event.error.code,
               message: event.error.message,
-              metadata: null,
+              metadata: event.error.metadata,
             },
           };
           return;

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -246,6 +246,10 @@ const TOOL_MIME_TYPES = {
       "WEBSEARCH_RESULT",
     ],
   }),
+  TOOL_ERROR: generateToolMimeTypes({
+    category: "TOOL_ERROR",
+    resourceTypes: ["PERSONAL_AUTHENTICATION_REQUIRED"],
+  }),
 };
 
 export const INTERNAL_MIME_TYPES = {


### PR DESCRIPTION
## Description

Adds new `TOOL_ERROR` mimeType such that we can detect selected errors across MCP boundary (throws are catched all). Use that to detect `PERSONAL_AUTHENTICATION_REQUIRED` errors and re-emit a result with a typed error `MCPServerPersonalAuthenticationRequiredError` which is then used to create a proper `tool_error` with metadata that will get turned into an `agent_error`

## Tests

N/A not used yet

## Risk

Low

## Deploy Plan

- deploy `front`