### PR TITLE
Add: ability to setup credentials when connecting or reconnecting a tool

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -9,7 +9,7 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
 
 import { AddActionMenu } from "@app/components/actions/mcp/AddActionMenu";
-import { CreateMCPServerModal } from "@app/components/actions/mcp/CreateMCPServerModal";
+import { CreateMCPServerDialog } from "@app/components/actions/mcp/CreateMCPServerDialog";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
@@ -241,7 +241,7 @@ export const AdminActionsList = ({
 
   return (
     <>
-      <CreateMCPServerModal
+      <CreateMCPServerDialog
         isOpen={isCreateOpen}
         internalMCPServer={internalMCPServerToCreate}
         setIsOpen={setIsCreateOpen}

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -1,0 +1,120 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import { useCallback, useState } from "react";
+
+import { MCPServerOAuthConnexion } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+import type { MCPServerType } from "@app/lib/api/mcp";
+import { useCreateMCPServerConnection } from "@app/lib/swr/mcp_servers";
+import type { WorkspaceType } from "@app/types";
+import {
+  asDisplayName,
+  OAUTH_PROVIDER_NAMES,
+  setupOAuthConnection,
+} from "@app/types";
+
+type ConnectMCPServerDialogProps = {
+  owner: WorkspaceType;
+  mcpServer: MCPServerType | null;
+  setIsLoading: (isCreating: boolean) => void;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+export function ConnectMCPServerDialog({
+  owner,
+  mcpServer,
+  setIsLoading,
+  isOpen = false,
+  setIsOpen,
+}: ConnectMCPServerDialogProps) {
+  const sendNotification = useSendNotification();
+  const [authCredentials, setAuthCredentials] = useState<Record<
+    string,
+    string
+  > | null>(null);
+
+  const { createMCPServerConnection } = useCreateMCPServerConnection({ owner });
+
+  const resetState = useCallback(() => {
+    setIsLoading(false);
+    setAuthCredentials(null);
+  }, [setIsLoading]);
+
+  const handleSave = async () => {
+    if (!mcpServer?.authorization) {
+      throw new Error(
+        "MCP server has no authorization while trying to connect"
+      );
+    }
+
+    setIsLoading(true);
+
+    // First setup connection
+    const cRes = await setupOAuthConnection({
+      dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
+      owner,
+      provider: mcpServer.authorization.provider,
+      useCase: mcpServer.authorization.use_case,
+      extraConfig: authCredentials ?? {},
+    });
+    if (cRes.isErr()) {
+      sendNotification({
+        type: "error",
+        title: `Failed to connect ${OAUTH_PROVIDER_NAMES[mcpServer.authorization.provider]}`,
+        description: cRes.error.message,
+      });
+      return;
+    }
+
+    // Then associate connection
+    await createMCPServerConnection({
+      connectionId: cRes.value.connection_id,
+      mcpServerId: mcpServer.sId,
+      provider: mcpServer.authorization.provider,
+    });
+
+    setIsLoading(false);
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        resetState();
+      }}
+    >
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>Connect {asDisplayName(mcpServer?.name)}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <MCPServerOAuthConnexion
+            authorization={mcpServer?.authorization ?? null}
+            authCredentials={authCredentials}
+            setAuthCredentials={setAuthCredentials}
+          />
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "ghost",
+            onClick: resetState,
+          }}
+          rightButtonProps={{
+            label: mcpServer?.authorization ? "Save and connect" : "Save",
+            variant: "primary",
+            onClick: handleSave,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -21,6 +21,7 @@ import {
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useEffect, useState } from "react";
 
+import { ConnectMCPServerDialog } from "@app/components/actions/mcp/ConnectMCPServerDialog";
 import { MCPServerDetailsInfo } from "@app/components/actions/mcp/MCPServerDetailsInfo";
 import { MCPServerDetailsSharing } from "@app/components/actions/mcp/MCPServerDetailsSharing";
 import { MCPActionHeader } from "@app/components/actions/MCPActionHeader";
@@ -84,13 +85,21 @@ export function MCPServerDetails({
   );
 
   const [isLoading, setIsLoading] = useState(false);
-  const { createAndSaveMCPServerConnection, deleteMCPServerConnection } =
-    useMCPConnectionManagement({
-      owner,
-    });
+  const { deleteMCPServerConnection } = useMCPConnectionManagement({
+    owner,
+  });
+
+  const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
 
   return (
     <>
+      <ConnectMCPServerDialog
+        owner={owner}
+        mcpServer={mcpServer}
+        setIsLoading={setIsLoading}
+        isOpen={isConnectDialogOpen}
+        setIsOpen={setIsConnectDialogOpen}
+      />
       <Dialog
         open={mcpServerToDelete !== undefined}
         onOpenChange={(open) => {
@@ -159,10 +168,7 @@ export function MCPServerDetails({
                     label={"Connect"}
                     size="sm"
                     onClick={() => {
-                      void createAndSaveMCPServerConnection({
-                        authorizationInfo: authorization,
-                        mcpServerId: effectiveMCPServer?.sId,
-                      });
+                      setIsConnectDialogOpen(true);
                     }}
                   />
                 </div>

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -1,0 +1,96 @@
+import { Input, Label } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
+import {
+  getProviderRequiredAuthCredentials,
+  OAUTH_PROVIDER_NAMES,
+} from "@app/types";
+
+type MCPServerOauthConnexionProps = {
+  authorization: AuthorizationInfo | null;
+  authCredentials: Record<string, string> | null;
+  setAuthCredentials: (authCredentials: Record<string, string>) => void;
+};
+
+export function MCPServerOAuthConnexion({
+  authorization,
+  authCredentials,
+  setAuthCredentials,
+}: MCPServerOauthConnexionProps) {
+  const [requiredCredentials, setRequiredCredentials] = useState<Record<
+    string,
+    { label: string; value: string | number | undefined }
+  > | null>(null);
+
+  useEffect(() => {
+    const fetchCredentials = async () => {
+      const credentials =
+        await getProviderRequiredAuthCredentials(authorization);
+      setRequiredCredentials(credentials);
+      // Set the auth credentials to the values in the credentials object
+      // that already have a value as we will not ask the user for these values.
+      if (credentials) {
+        setAuthCredentials(
+          Object.entries(credentials).reduce(
+            (acc, [key, { value }]) => ({ ...acc, [key]: value }),
+            {}
+          )
+        );
+      }
+    };
+    void fetchCredentials();
+  }, [authorization, setAuthCredentials]);
+
+  return (
+    authorization && (
+      <div className="flex flex-col items-center gap-2">
+        {requiredCredentials ? (
+          <>
+            <Label className="self-start">
+              These tools require authentication with{" "}
+              {OAUTH_PROVIDER_NAMES[authorization.provider]}, we need the
+              following information to set them up:
+            </Label>
+            {Object.entries(requiredCredentials).map(([key, value]) =>
+              requiredCredentials[key].value ? null : (
+                <div key={key} className="w-full">
+                  <Label htmlFor={key}>{value.label}</Label>
+                  <Input
+                    id={key}
+                    value={authCredentials?.[key] ?? ""}
+                    onChange={(e) =>
+                      setAuthCredentials({
+                        ...authCredentials,
+                        [key]: e.target.value,
+                      })
+                    }
+                  />
+                </div>
+              )
+            )}
+          </>
+        ) : (
+          <Label className="self-start">
+            These tools require authentication with{" "}
+            {OAUTH_PROVIDER_NAMES[authorization.provider]}.
+          </Label>
+        )}
+
+        {authorization.use_case === "platform_actions" && (
+          <span className="w-full font-semibold text-red-500">
+            Authentication credentials will be shared by all users of this
+            workspace when they use these tools.
+          </span>
+        )}
+        {authorization.use_case === "personal_actions" && (
+          <span className="text-500 w-full font-semibold">
+            Once setup for the workspace, each user will link their own{" "}
+            {OAUTH_PROVIDER_NAMES[authorization.provider]} credentials when
+            interacting with these tools for the first time.
+          </span>
+        )}
+      </div>
+    )
+  );
+}

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -1,5 +1,10 @@
 import * as t from "io-ts";
 
+import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
+import { getPKCEConfig } from "@app/lib/utils/pkce";
+
+import { assertNever } from "../shared/utils/assert_never";
+
 export const OAUTH_USE_CASES = [
   "connection",
   "labs_transcripts",
@@ -40,6 +45,56 @@ export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
   zendesk: "Zendesk",
   salesforce: "Salesforce",
   hubspot: "Hubspot",
+};
+
+export const getProviderRequiredAuthCredentials = async (
+  authentication: AuthorizationInfo | null
+): Promise<Record<
+  string,
+  { label: string; value: string | number | undefined }
+> | null> => {
+  if (!authentication) {
+    return null;
+  }
+
+  switch (authentication.provider) {
+    case "salesforce":
+      if (authentication.use_case === "personal_actions") {
+        const { code_verifier, code_challenge } = await getPKCEConfig();
+
+        return {
+          client_id: { label: "oAuth client Id", value: undefined },
+          client_secret: { label: "oAuth client secret", value: undefined },
+          instance_url: { label: "Instance URL", value: undefined },
+          code_verifier: { label: "Code verifier", value: code_verifier },
+          code_challenge: { label: "Code challenge", value: code_challenge },
+        };
+      } else {
+        return null;
+      }
+    case "hubspot":
+      return null;
+    case "zendesk":
+      return null;
+    case "slack":
+      return null;
+    case "gong":
+      return null;
+    case "microsoft":
+      return null;
+    case "notion":
+      return null;
+    case "confluence":
+      return null;
+    case "github":
+      return null;
+    case "google_drive":
+      return null;
+    case "intercom":
+      return null;
+    default:
+      assertNever(authentication.provider);
+  }
 };
 
 export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];


### PR DESCRIPTION
## Description

Add the ability to pass credentials information when setting up an MCP server connexion (or reconnecting).

## Tests

Tested locally (also tested GitHub to avoid breaking existing flows).

## Risk

Low, the action is behind a feature flag.

## Deploy Plan

Deploy `front`
