### PR TITLE
feat(about): add joshua's profile to about page

### DIFF
--- a/front/pages/home/about.tsx
+++ b/front/pages/home/about.tsx
@@ -290,7 +290,7 @@ const PEOPLE: Record<
     image: "https://avatars.githubusercontent.com/u/192242584?v=4",
     github: "https://github.com/jgr142",
     linkedIn: "https://www.linkedin.com/in/joshuagisiger",
-  }
+  },
 };
 
 const Person = ({ handle }: { handle: string }) => {

--- a/front/pages/home/about.tsx
+++ b/front/pages/home/about.tsx
@@ -284,6 +284,13 @@ const PEOPLE: Record<
     github: "https://github.com/btoueg",
     linkedIn: "https://www.linkedin.com/in/toueg",
   },
+  joshua: {
+    name: "Joshua Gisiger",
+    title: "Software Engineer Intern",
+    image: "https://avatars.githubusercontent.com/u/192242584?v=4",
+    github: "https://github.com/jgr142",
+    linkedIn: "https://www.linkedin.com/in/joshuagisiger",
+  }
 };
 
 const Person = ({ handle }: { handle: string }) => {


### PR DESCRIPTION
## Description

Added Joshua Gisiger to about page.
<img width="1185" alt="Screenshot 2025-05-26 at 17 27 56" src="https://github.com/user-attachments/assets/dcb78028-83c5-46a2-a01b-719e9475b49d" />


## Tests

No tests.

## Risk

This could only break the ui of the page if I wrote incorrect syntax.

## Deploy Plan

Deployment plan should not change.