### PR TITLE
MCPServerTPersonalACtionRequired widget

### DIFF
--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -4,14 +4,10 @@ import {
   Chip,
   CloudArrowLeftRightIcon,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useSubmitFunction } from "@app/lib/client/utils";
-import {
-  useLabsCreateSalesforcePersonalConnection,
-  useLabsSalesforceDataSourcesWithPersonalConnection,
-} from "@app/lib/swr/labs";
-import { useCreateMCPServerConnection } from "@app/lib/swr/mcp_servers";
+import { useCreatePersonalConnection } from "@app/lib/swr/mcp_servers";
 import type {
   LightWorkspaceType,
   OAuthProvider,
@@ -31,31 +27,14 @@ export function MCPServerPersonalAuthenticationRequired({
   useCase: OAuthUseCase;
   retryHandler: () => void;
 }) {
-  // const { dataSources } = useLabsSalesforceDataSourcesWithPersonalConnection({
-  //   owner,
-  // });
-  // const dataSource = dataSources[0];
-  // const { createPersonalConnection } =
-  //   useLabsCreateSalesforcePersonalConnection(owner);
-
-  // useEffect(() => {
-  //   if (dataSource && dataSource.personalConnection) {
-  //     retryHandler();
-  //   }
-  // }, [dataSource, retryHandler]);
+  const { createPersonalConnection } = useCreatePersonalConnection(owner);
 
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()
   );
 
-  // const { createMCPServerConnection } = useCreateMCPServerConnection({ owner });
+  const [isConnected, setIsConnected] = useState<boolean>(false);
 
-  const [isConnected, setIsConnected] = useState<boolean>(true);
-
-  console.log("MCPServerPersonalAuthenticationRequired rendered", isConnected);
-  console.log("mcpServerId", mcpServerId);
-  console.log("provider", provider);
-  console.log("useCase", useCase);
   return (
     <div className="flex flex-col gap-9">
       <div className="flex flex-col gap-1 sm:flex-row">
@@ -72,8 +51,16 @@ export function MCPServerPersonalAuthenticationRequired({
           size="xs"
           icon={CloudArrowLeftRightIcon}
           onClick={async () => {
-            setIsConnected(true);
-            // await createPersonalConnection(dataSource);
+            const success = await createPersonalConnection(
+              mcpServerId,
+              provider,
+              useCase
+            );
+            if (!success) {
+              setIsConnected(false);
+            } else {
+              setIsConnected(true);
+            }
           }}
         />
       </div>

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -34,48 +34,58 @@ export function MCPServerPersonalAuthenticationRequired({
   );
 
   const [isConnected, setIsConnected] = useState<boolean>(false);
+  const [isConnecting, setIsConnecting] = useState<boolean>(false);
 
   return (
     <div className="flex flex-col gap-9">
-      <div className="flex flex-col gap-1 sm:flex-row">
-        <Chip
-          color="info"
-          label={
-            "The agent took an action that requires personal authentication"
-          }
-          size="xs"
-        />
-        <Button
-          label={`Connect`}
-          variant="outline"
-          size="xs"
-          icon={CloudArrowLeftRightIcon}
-          onClick={async () => {
-            const success = await createPersonalConnection(
-              mcpServerId,
-              provider,
-              useCase
-            );
-            if (!success) {
-              setIsConnected(false);
-            } else {
-              setIsConnected(true);
-            }
-          }}
-        />
-      </div>
       {isConnected ? (
-        <div>
+        <div className="flex flex-col gap-1 sm:flex-row">
+          <Chip
+            color="success"
+            label={"You are now connected. The agent message can be retried"}
+            size="xs"
+          />
           <Button
+            label={`Retry`}
             variant="outline"
-            size="sm"
+            size="xs"
             icon={ArrowPathIcon}
-            label="Retry"
-            onClick={retry}
             disabled={isRetrying}
+            onClick={retry}
           />
         </div>
-      ) : null}
+      ) : (
+        <div className="flex flex-col gap-1 sm:flex-row">
+          <Chip
+            color="info"
+            label={
+              "The agent took an action that requires personal authentication"
+            }
+            size="xs"
+          />
+          <Button
+            label={`Connect`}
+            variant="outline"
+            size="xs"
+            icon={CloudArrowLeftRightIcon}
+            disabled={isConnecting}
+            onClick={async () => {
+              setIsConnecting(true);
+              const success = await createPersonalConnection(
+                mcpServerId,
+                provider,
+                useCase
+              );
+              setIsConnecting(false);
+              if (!success) {
+                setIsConnected(false);
+              } else {
+                setIsConnected(true);
+              }
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -1,0 +1,94 @@
+import {
+  ArrowPathIcon,
+  Button,
+  Chip,
+  CloudArrowLeftRightIcon,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+import { useSubmitFunction } from "@app/lib/client/utils";
+import {
+  useLabsCreateSalesforcePersonalConnection,
+  useLabsSalesforceDataSourcesWithPersonalConnection,
+} from "@app/lib/swr/labs";
+import { useCreateMCPServerConnection } from "@app/lib/swr/mcp_servers";
+import type {
+  LightWorkspaceType,
+  OAuthProvider,
+  OAuthUseCase,
+} from "@app/types";
+
+export function MCPServerPersonalAuthenticationRequired({
+  owner,
+  mcpServerId,
+  provider,
+  useCase,
+  retryHandler,
+}: {
+  owner: LightWorkspaceType;
+  mcpServerId: string;
+  provider: OAuthProvider;
+  useCase: OAuthUseCase;
+  retryHandler: () => void;
+}) {
+  // const { dataSources } = useLabsSalesforceDataSourcesWithPersonalConnection({
+  //   owner,
+  // });
+  // const dataSource = dataSources[0];
+  // const { createPersonalConnection } =
+  //   useLabsCreateSalesforcePersonalConnection(owner);
+
+  // useEffect(() => {
+  //   if (dataSource && dataSource.personalConnection) {
+  //     retryHandler();
+  //   }
+  // }, [dataSource, retryHandler]);
+
+  const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
+    async () => retryHandler()
+  );
+
+  // const { createMCPServerConnection } = useCreateMCPServerConnection({ owner });
+
+  const [isConnected, setIsConnected] = useState<boolean>(true);
+
+  console.log("MCPServerPersonalAuthenticationRequired rendered", isConnected);
+  console.log("mcpServerId", mcpServerId);
+  console.log("provider", provider);
+  console.log("useCase", useCase);
+  return (
+    <div className="flex flex-col gap-9">
+      <div className="flex flex-col gap-1 sm:flex-row">
+        <Chip
+          color="info"
+          label={
+            "The agent took an action that requires personal authentication"
+          }
+          size="xs"
+        />
+        <Button
+          label={`Connect`}
+          variant="outline"
+          size="xs"
+          icon={CloudArrowLeftRightIcon}
+          onClick={async () => {
+            setIsConnected(true);
+            // await createPersonalConnection(dataSource);
+          }}
+        />
+      </div>
+      {isConnected ? (
+        <div>
+          <Button
+            variant="outline"
+            size="sm"
+            icon={ArrowPathIcon}
+            label="Retry"
+            onClick={retry}
+            disabled={isRetrying}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -683,6 +683,8 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
               `authentication, please authenticate to use it.`,
             metadata: {
               mcp_server_id: toolCallResult.error.mcpServerId,
+              provider: toolCallResult.error.provider,
+              use_case: toolCallResult.error.useCase,
             },
           },
         };

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -68,7 +68,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
-import type { ModelId, Result } from "@app/types";
+import type { ModelId, OAuthProvider, OAuthUseCase, Result } from "@app/types";
 import { assertNever, Err, normalizeError, Ok, slugify } from "@app/types";
 
 const MAX_OUTPUT_ITEMS = 128;
@@ -337,7 +337,11 @@ export async function* tryCallMCPTool(
           type: "result",
           result: new Err(
             new MCPServerPersonalAuthenticationRequiredError(
-              personalAuthenticationRequiredError.resource.mcpServerId
+              personalAuthenticationRequiredError.resource.mcpServerId,
+              personalAuthenticationRequiredError.resource
+                .provider as OAuthProvider,
+              personalAuthenticationRequiredError.resource
+                .useCase as OAuthUseCase
             )
           ),
         };

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -390,6 +390,8 @@ export const PersonalAuthenticationRequiredErrorResourceSchema = z.object({
   text: z.string(),
   uri: z.literal(""),
   mcpServerId: z.string(),
+  provider: z.string(),
+  useCase: z.string(),
 });
 
 export type PersonalAuthenticationRequiredErrorResourceType = z.infer<

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -62,7 +62,10 @@ You can use it to list the objects in Salesforce: standard and custom objects.
         | undefined;
 
       if (!accessToken || !instanceUrl) {
-        return makeMCPToolPersonalAuthenticationRequiredError(mcpServerId);
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
       }
 
       const conn = new jsforce.Connection({
@@ -103,7 +106,10 @@ You can use it to list the objects in Salesforce: standard and custom objects.
         | undefined;
 
       if (!accessToken || !instanceUrl) {
-        return makeMCPToolPersonalAuthenticationRequiredError(mcpServerId);
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
       }
       const conn = new jsforce.Connection({
         instanceUrl,


### PR DESCRIPTION
## Description

Thread through provider and use_case through the tool_error metadata as we need it to figure out the arguments to the oauth flow (salesofrce PKCE stuff).

Fully functional widget

![Screenshot from 2025-05-26 18-48-15](https://github.com/user-attachments/assets/1faa60c7-78db-46e9-871d-aa5e550c277c)
![Screenshot from 2025-05-26 18-48-09](https://github.com/user-attachments/assets/ecd8d456-e056-4af5-8bf5-a043907ebc4f)


## Tests

Tested locally

## Risk

Low not used in prod yet

## Deploy Plan

- deploy `front`