### PR TITLE
Salesforce tool OAuth form error handling

### DIFF
--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -7,14 +7,15 @@ import {
   DialogTitle,
   useSendNotification,
 } from "@dust-tt/sparkle";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { MCPServerOAuthConnexion } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { useCreateMCPServerConnection } from "@app/lib/swr/mcp_servers";
-import type { WorkspaceType } from "@app/types";
+import type { RequiredAuthCredentials, WorkspaceType } from "@app/types";
 import {
   asDisplayName,
+  getProviderRequiredAuthCredentials,
   OAUTH_PROVIDER_NAMES,
   setupOAuthConnection,
 } from "@app/types";
@@ -39,13 +40,56 @@ export function ConnectMCPServerDialog({
     string,
     string
   > | null>(null);
+  const [requiredCredentials, setRequiredCredentials] = useState<Record<
+    string,
+    RequiredAuthCredentials
+  > | null>(null);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchCredentials = async () => {
+      if (!mcpServer?.authorization) {
+        return;
+      }
+      const credentials = await getProviderRequiredAuthCredentials(
+        mcpServer.authorization
+      );
+      setRequiredCredentials(credentials);
+      // Set the auth credentials to the values in the credentials object
+      // that already have a value as we will not ask the user for these values.
+      if (credentials) {
+        setAuthCredentials(
+          Object.entries(credentials).reduce(
+            (acc, [key, { value }]) => ({ ...acc, [key]: value }),
+            {}
+          )
+        );
+      }
+    };
+    void fetchCredentials();
+  }, [mcpServer?.authorization, setAuthCredentials]);
 
   const { createMCPServerConnection } = useCreateMCPServerConnection({ owner });
 
   const resetState = useCallback(() => {
     setIsLoading(false);
     setAuthCredentials(null);
+    setErrors([]);
   }, [setIsLoading]);
+
+  const isValidCredentials = () => {
+    const erroredLabels: string[] = [];
+    Object.entries(requiredCredentials ?? {}).forEach(([key, credential]) => {
+      if (
+        credential.isValidFunction &&
+        !credential.isValidFunction(authCredentials?.[key])
+      ) {
+        erroredLabels.push(credential.label);
+      }
+    });
+    setErrors(erroredLabels);
+    return Object.keys(erroredLabels).length === 0;
+  };
 
   const handleSave = async () => {
     if (!mcpServer?.authorization) {
@@ -56,7 +100,7 @@ export function ConnectMCPServerDialog({
 
     setIsLoading(true);
 
-    // First setup connection
+    // First setup connection.
     const cRes = await setupOAuthConnection({
       dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
       owner,
@@ -70,15 +114,14 @@ export function ConnectMCPServerDialog({
         title: `Failed to connect ${OAUTH_PROVIDER_NAMES[mcpServer.authorization.provider]}`,
         description: cRes.error.message,
       });
-      return;
+    } else {
+      // Then associate connection.
+      await createMCPServerConnection({
+        connectionId: cRes.value.connection_id,
+        mcpServerId: mcpServer.sId,
+        provider: mcpServer.authorization.provider,
+      });
     }
-
-    // Then associate connection
-    await createMCPServerConnection({
-      connectionId: cRes.value.connection_id,
-      mcpServerId: mcpServer.sId,
-      provider: mcpServer.authorization.provider,
-    });
 
     setIsLoading(false);
   };
@@ -100,6 +143,8 @@ export function ConnectMCPServerDialog({
             authorization={mcpServer?.authorization ?? null}
             authCredentials={authCredentials}
             setAuthCredentials={setAuthCredentials}
+            requiredCredentials={requiredCredentials}
+            errors={errors}
           />
         </DialogContainer>
         <DialogFooter
@@ -111,7 +156,14 @@ export function ConnectMCPServerDialog({
           rightButtonProps={{
             label: mcpServer?.authorization ? "Save and connect" : "Save",
             variant: "primary",
-            onClick: handleSave,
+            onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (isValidCredentials()) {
+                void handleSave();
+                setIsOpen(false);
+              }
+            },
           }}
         />
       </DialogContent>

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -1,57 +1,49 @@
-import { Input, Label } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import {
+  ContentMessage,
+  InformationCircleIcon,
+  Input,
+  Label,
+} from "@dust-tt/sparkle";
 
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
-import {
-  getProviderRequiredAuthCredentials,
-  OAUTH_PROVIDER_NAMES,
-} from "@app/types";
+import type { RequiredAuthCredentials } from "@app/types";
+import { OAUTH_PROVIDER_NAMES } from "@app/types";
 
 type MCPServerOauthConnexionProps = {
   authorization: AuthorizationInfo | null;
   authCredentials: Record<string, string> | null;
   setAuthCredentials: (authCredentials: Record<string, string>) => void;
+  requiredCredentials: Record<string, RequiredAuthCredentials> | null;
+  errors: string[];
 };
 
 export function MCPServerOAuthConnexion({
   authorization,
   authCredentials,
   setAuthCredentials,
+  requiredCredentials,
+  errors,
 }: MCPServerOauthConnexionProps) {
-  const [requiredCredentials, setRequiredCredentials] = useState<Record<
-    string,
-    { label: string; value: string | number | undefined }
-  > | null>(null);
-
-  useEffect(() => {
-    const fetchCredentials = async () => {
-      const credentials =
-        await getProviderRequiredAuthCredentials(authorization);
-      setRequiredCredentials(credentials);
-      // Set the auth credentials to the values in the credentials object
-      // that already have a value as we will not ask the user for these values.
-      if (credentials) {
-        setAuthCredentials(
-          Object.entries(credentials).reduce(
-            (acc, [key, { value }]) => ({ ...acc, [key]: value }),
-            {}
-          )
-        );
-      }
-    };
-    void fetchCredentials();
-  }, [authorization, setAuthCredentials]);
-
   return (
     authorization && (
       <div className="flex flex-col items-center gap-2">
         {requiredCredentials ? (
           <>
-            <Label className="self-start">
-              These tools require authentication with{" "}
+            <span className="text-500 w-full font-semibold">
+              These tools require admin authentication with{" "}
               {OAUTH_PROVIDER_NAMES[authorization.provider]}, we need the
-              following information to set them up:
-            </Label>
+              following information to set them up. Please follow{" "}
+              <a
+                href="https://docs.dust.tt/docs/salesforce"
+                className="text-highlight-600"
+                target="_blank"
+              >
+                this guide
+              </a>{" "}
+              to learn how to set up a Salesforce app to get the Client ID and
+              Client Secret.
+            </span>
+
             {Object.entries(requiredCredentials).map(([key, value]) =>
               requiredCredentials[key].value ? null : (
                 <div key={key} className="w-full">
@@ -65,6 +57,10 @@ export function MCPServerOAuthConnexion({
                         [key]: e.target.value,
                       })
                     }
+                    message={requiredCredentials[key].message ?? ""}
+                    messageStatus={
+                      errors.includes(value.label) ? "error" : "default"
+                    }
                   />
                 </div>
               )
@@ -76,20 +72,31 @@ export function MCPServerOAuthConnexion({
             {OAUTH_PROVIDER_NAMES[authorization.provider]}.
           </Label>
         )}
-
-        {authorization.use_case === "platform_actions" && (
-          <span className="w-full font-semibold text-red-500">
-            Authentication credentials will be shared by all users of this
-            workspace when they use these tools.
-          </span>
-        )}
-        {authorization.use_case === "personal_actions" && (
-          <span className="text-500 w-full font-semibold">
-            Once setup for the workspace, each user will link their own{" "}
-            {OAUTH_PROVIDER_NAMES[authorization.provider]} credentials when
-            interacting with these tools for the first time.
-          </span>
-        )}
+        <div className="w-full pt-4">
+          {authorization.use_case === "platform_actions" && (
+            <ContentMessage
+              size="md"
+              variant="warning"
+              title="These tools are using workspace level credentials."
+              icon={InformationCircleIcon}
+            >
+              Authentication credentials will be shared by all users of this
+              workspace when they use these tools.
+            </ContentMessage>
+          )}
+          {authorization.use_case === "personal_actions" && (
+            <ContentMessage
+              size="md"
+              variant="highlight"
+              title="These tools are using personal level credentials."
+              icon={InformationCircleIcon}
+            >
+              Once setup for the workspace, each user will have to connect their
+              own {OAUTH_PROVIDER_NAMES[authorization.provider]} credentials to
+              interact with these tools.
+            </ContentMessage>
+          )}
+        </div>
       </div>
     )
   );

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -47,12 +47,16 @@ export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
   hubspot: "Hubspot",
 };
 
+export type RequiredAuthCredentials = {
+  label: string;
+  value: string | number | undefined;
+  message?: string;
+  isValidFunction?: (value: string | number | undefined) => boolean;
+};
+
 export const getProviderRequiredAuthCredentials = async (
   authentication: AuthorizationInfo | null
-): Promise<Record<
-  string,
-  { label: string; value: string | number | undefined }
-> | null> => {
+): Promise<Record<string, RequiredAuthCredentials> | null> => {
   if (!authentication) {
     return null;
   }
@@ -63,9 +67,25 @@ export const getProviderRequiredAuthCredentials = async (
         const { code_verifier, code_challenge } = await getPKCEConfig();
 
         return {
-          client_id: { label: "oAuth client Id", value: undefined },
-          client_secret: { label: "oAuth client secret", value: undefined },
-          instance_url: { label: "Instance URL", value: undefined },
+          instance_url: {
+            label: "Instance URL",
+            value: undefined,
+            message:
+              "Must be a valid Salesforce domain in https and ending with .salesforce.com",
+            isValidFunction: isValidSalesforceDomain,
+          },
+          client_id: {
+            label: "OAuth client Id",
+            message: "The client ID from your Salesforce connected app.",
+            value: undefined,
+            isValidFunction: isValidSalesforceClientId,
+          },
+          client_secret: {
+            label: "OAuth client secret",
+            value: undefined,
+            message: "The client secret from your Salesforce connected app.",
+            isValidFunction: isValidSalesforceClientSecret,
+          },
           code_verifier: { label: "Code verifier", value: code_verifier },
           code_challenge: { label: "Code challenge", value: code_challenge },
         };


### PR DESCRIPTION
## Description

- Adds link to guide explaining how to create the Salesforce app. This guide is for the connection so not 100% accurate for this use case but the part to create the app is the same. 
- Prevent launching the oAuth flow if the form is not valid. 
- Display the fields as errored when they contain errors. 

Not perfect but better than before! 

<img width="714" alt="Screenshot 2025-05-26 at 18 19 22" src="https://github.com/user-attachments/assets/2be80478-1c2c-4e12-97a4-b19f16e590af" />

## Tests

Locally. 

## Risk

Only used for Salesforce at the moment. 

## Deploy Plan

Deploy front. 