### PR TITLE
Reduce Number of Confluence API Calls To Retrieve Child Pages

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -167,7 +167,7 @@ export async function getActiveChildPageRefs(
   });
 
   const activeChildPageIds = childPages
-    .filter((p) => p.status === "current" && p.type === "page")
+    .filter((p) => p.status === "current")
     .map((p) => p.id);
 
   if (activeChildPageIds.length === 0) {

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -1,7 +1,10 @@
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
-import type { ConfluenceSpaceType } from "@connectors/connectors/confluence/lib/confluence_client";
+import type {
+  ConfluenceSearchPageType,
+  ConfluenceSpaceType,
+} from "@connectors/connectors/confluence/lib/confluence_client";
 import {
   CONFLUENCE_SUPPORTED_SPACE_TYPES,
   ConfluenceClient,
@@ -12,6 +15,8 @@ import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 import { getOAuthConnectionAccessToken } from "@connectors/types";
+
+const PAGE_FETCH_LIMIT = 250;
 
 export async function getConfluenceCloudInformation(accessToken: string) {
   const client = new ConfluenceClient(accessToken);
@@ -126,43 +131,51 @@ export interface ConfluencePageRef {
   version: number;
 }
 
-const PAGE_FETCH_LIMIT = 100;
+function getConfluencePageRef(page: ConfluenceSearchPageType) {
+  const hasReadRestrictions =
+    page.restrictions.read.restrictions.group.results.length > 0 ||
+    page.restrictions.read.restrictions.user.results.length > 0;
+
+  return {
+    hasChildren: page.childTypes.page.value,
+    hasReadRestrictions,
+    id: page.id,
+    // Ancestors is an array of the page's ancestors, starting with the root page.
+    parentId: page.ancestors[page.ancestors.length - 1]?.id ?? null,
+    version: page.version.number,
+  };
+}
 
 export async function getActiveChildPageRefs(
   client: ConfluenceClient,
   {
     pageCursor,
     parentPageId,
-    spaceId,
     spaceKey,
   }: {
     pageCursor: string | null;
     parentPageId: string;
-    spaceId: string;
     spaceKey: string;
   }
 ) {
   // Fetch the child pages of the parent page.
   const { pages: childPages, nextPageCursor } = await client.getChildPages({
-    parentPageId,
-    pageCursor,
     limit: PAGE_FETCH_LIMIT,
+    pageCursor,
+    parentPageId,
+    spaceKey,
   });
 
   const activeChildPageIds = childPages
-    .filter((p) => p.status === "current" && p.spaceId === spaceId)
+    .filter((p) => p.status === "current" && p.type === "page")
     .map((p) => p.id);
 
   if (activeChildPageIds.length === 0) {
     return { childPageRefs: [], nextPageCursor };
   }
 
-  // Fetch child page metadata (version, parent, permissions, etc.).
-  const childPageRefs = await bulkFetchConfluencePageRefs(client, {
-    limit: PAGE_FETCH_LIMIT,
-    pageIds: activeChildPageIds,
-    spaceKey,
-  });
+  const childPageRefs: ConfluencePageRef[] =
+    childPages.map(getConfluencePageRef);
 
   return { childPageRefs, nextPageCursor };
 }
@@ -186,20 +199,8 @@ export async function bulkFetchConfluencePageRefs(
     limit,
   });
 
-  const pageRefs: ConfluencePageRef[] = pagesWithDetails.results.map((p) => {
-    const hasReadRestrictions =
-      p.restrictions.read.restrictions.group.results.length > 0 ||
-      p.restrictions.read.restrictions.user.results.length > 0;
-
-    return {
-      hasChildren: p.childTypes.page.value,
-      hasReadRestrictions,
-      id: p.id,
-      // Ancestors is an array of the page's ancestors, starting with the root page.
-      parentId: p.ancestors[p.ancestors.length - 1]?.id ?? null,
-      version: p.version.number,
-    };
-  });
+  const pageRefs: ConfluencePageRef[] =
+    pagesWithDetails.results.map(getConfluencePageRef);
 
   return pageRefs;
 }

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -9,8 +9,6 @@ import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { ConfluenceClientError, EnvironmentConfig } from "@connectors/types";
 
-const DEFAULT_PAGE_LIMIT = 100;
-
 const CatchAllCodec = t.record(t.string, t.unknown); // Catch-all for unknown properties.
 
 const ConfluenceAccessibleResourcesCodec = t.array(
@@ -65,7 +63,7 @@ const ConfluencePageCodec = t.intersection([
 const SearchConfluencePageCodec = t.intersection([
   t.type({
     id: t.string,
-    type: t.string,
+    type: t.literal("page"),
     status: t.string,
     title: t.string,
 
@@ -586,12 +584,12 @@ export class ConfluenceClient {
   }
 
   async getChildPages({
-    limit = DEFAULT_PAGE_LIMIT,
+    limit,
     pageCursor,
     parentPageId,
     spaceKey,
   }: {
-    limit?: number;
+    limit: number;
     pageCursor: string | null;
     parentPageId: string;
     spaceKey: string;
@@ -608,7 +606,7 @@ export class ConfluenceClient {
         "childTypes.page", // To know if it has children.
         "ancestors", // To get parent info.
       ].join(","),
-      limit: "2", // limit.toString(),
+      limit: limit.toString(),
     });
 
     if (pageCursor) {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -9,6 +9,8 @@ import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { ConfluenceClientError, EnvironmentConfig } from "@connectors/types";
 
+const DEFAULT_PAGE_LIMIT = 100;
+
 const CatchAllCodec = t.record(t.string, t.unknown); // Catch-all for unknown properties.
 
 const ConfluenceAccessibleResourcesCodec = t.array(
@@ -103,6 +105,10 @@ const SearchConfluencePageCodec = t.intersection([
   CatchAllCodec,
 ]);
 
+export type ConfluenceSearchPageType = t.TypeOf<
+  typeof SearchConfluencePageCodec
+>;
+
 const ConfluencePageWithBodyCodec = t.intersection([
   ConfluencePageCodec,
   t.type({
@@ -125,18 +131,6 @@ const ConfluencePageWithBodyCodec = t.intersection([
 export type ConfluencePageWithBodyType = t.TypeOf<
   typeof ConfluencePageWithBodyCodec
 >;
-
-const ConfluenceChildPagesCodec = t.intersection([
-  t.type({
-    id: t.string,
-    status: t.string,
-    title: t.string,
-    spaceId: t.string,
-  }),
-  t.partial({
-    childPosition: t.number,
-  }),
-]);
 
 const ConfluenceUserProfileCodec = t.intersection([
   t.type({
@@ -430,12 +424,14 @@ export class ConfluenceClient {
         "status:error",
       ]);
 
+      const text = await response.text();
+
       throw new ConfluenceClientError(
         `Confluence API responded with status: ${response.status}: ${this.apiUrl}${endpoint}`,
         {
           type: "http_response_error",
           status: response.status,
-          data: { url: `${this.apiUrl}${endpoint}`, response },
+          data: { url: `${this.apiUrl}${endpoint}`, response, text },
         }
       );
     }
@@ -590,17 +586,29 @@ export class ConfluenceClient {
   }
 
   async getChildPages({
-    parentPageId,
+    limit = DEFAULT_PAGE_LIMIT,
     pageCursor,
-    limit,
+    parentPageId,
+    spaceKey,
   }: {
-    parentPageId: string;
-    pageCursor: string | null;
     limit?: number;
+    pageCursor: string | null;
+    parentPageId: string;
+    spaceKey: string;
   }) {
+    // Build CQL query to get pages with specific IDs.
+    const cqlQuery = `type=page AND space="${spaceKey}" AND parent=${parentPageId}`;
+
     const params = new URLSearchParams({
-      sort: "id",
-      limit: limit?.toString() ?? "100",
+      cql: cqlQuery,
+      expand: [
+        "version", // To check if page changed.
+        "restrictions.read.restrictions.user", // To check user permissions.
+        "restrictions.read.restrictions.group", // To check group permissions.
+        "childTypes.page", // To know if it has children.
+        "ancestors", // To get parent info.
+      ].join(","),
+      limit: "2", // limit.toString(),
     });
 
     if (pageCursor) {
@@ -608,24 +616,20 @@ export class ConfluenceClient {
     }
 
     try {
-      const pages = await this.request(
-        `${
-          this.restApiBaseUrl
-        }/pages/${parentPageId}/children?${params.toString()}`,
-        ConfluencePaginatedResults(ConfluenceChildPagesCodec)
+      const res = await this.request(
+        `${this.legacyRestApiBaseUrl}/content/search?${params.toString()}`,
+        ConfluencePaginatedResults(SearchConfluencePageCodec)
       );
-      const nextPageCursor = extractCursorFromLinks(pages._links);
 
       return {
-        pages: pages.results,
-        nextPageCursor,
+        nextPageCursor: extractCursorFromLinks(res._links),
+        pages: res.results,
       };
     } catch (err) {
       if (err instanceof ConfluenceClientError && err.status === 404) {
-        // If the child page is not found, return empty array.
         return {
-          pages: [],
           nextPageCursor: null,
+          pages: [],
         };
       }
 
@@ -715,11 +719,11 @@ export class ConfluenceClient {
       cql: cqlQuery,
       limit: limit?.toString() ?? "25",
       expand: [
-        "version", // to check if page changed.
-        "restrictions.read.restrictions.user", // to check user permissions.
-        "restrictions.read.restrictions.group", // to check group permissions.
-        "childTypes.page", // to know if it has children.
-        "ancestors", // to get parent info.
+        "version", // To check if page changed.
+        "restrictions.read.restrictions.user", // To check user permissions.
+        "restrictions.read.restrictions.group", // To check group permissions.
+        "childTypes.page", // To know if it has children.
+        "ancestors", // To get parent info.
       ].join(","),
     });
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -674,7 +674,6 @@ export async function confluenceGetActiveChildPageRefsActivity({
   return getActiveChildPageRefs(client, {
     pageCursor,
     parentPageId,
-    spaceId,
     spaceKey,
   });
 }
@@ -799,7 +798,6 @@ export async function confluenceGetTopLevelPageIdsActivity({
     {
       pageCursor,
       parentPageId: rootPageId,
-      spaceId,
       spaceKey,
     }
   );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at reducing number of API calls required to fetch child pages in a Confluence pages:
- It updates the limit to 250 (2.5x current limit) to do less calls
- Removes once extra call on each page to list all the child pages for a given page id

This should help reducing cardinalities on this connector as we observe several rate limitations.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally. Safe to rollback.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
