### PR TITLE
[sparkle] - feat(BarHeader): new variant

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.514",
+  "version": "0.2.515",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.514",
+      "version": "0.2.515",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.514",
+  "version": "0.2.515",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/BarHeader.tsx
+++ b/sparkle/src/components/BarHeader.tsx
@@ -1,3 +1,4 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import React from "react";
 
 import { Tooltip } from "@sparkle/components/Tooltip";
@@ -7,11 +8,27 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@sparkle/icons/app";
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 
 import { Button } from "./Button";
 
-interface BarHeaderProps {
+const barHeaderVariants = cva(
+  "s-flex s-h-16 s-flex-row s-items-center s-gap-3 s-border-b s-px-4",
+  {
+    variants: {
+      variant: {
+        full: "s-fixed s-left-0 s-right-0 s-top-0 s-z-30 s-backdrop-blur s-border-border-dark/70 s-bg-background/80 dark:s-border-border-dark-night/70 dark:s-bg-background-night/80",
+        default:
+          "s-relative s-z-10 s-border-structure-200 s-bg-structure-50 dark:s-border-structure-200-night dark:s-bg-structure-50-night",
+      },
+    },
+    defaultVariants: {
+      variant: "full",
+    },
+  }
+);
+
+interface BarHeaderProps extends VariantProps<typeof barHeaderVariants> {
   title: string;
   tooltip?: string;
   leftActions?: React.ReactNode;
@@ -24,24 +41,17 @@ export function BarHeader({
   tooltip,
   leftActions,
   rightActions,
-  className = "",
+  className,
+  variant,
 }: BarHeaderProps) {
-  const titleClasses = classNames(
+  const titleClasses = cn(
     "s-text-foreground dark:s-text-foreground-night",
     "s-heading-base s-truncate s-grow"
   );
-  const buttonBarClasses = "s-flex s-gap-1";
 
   return (
-    <div
-      className={classNames(
-        "s-fixed s-left-0 s-right-0 s-top-0 s-z-30 s-flex s-h-16 s-flex-row s-items-center s-gap-3 s-border-b s-px-4 s-backdrop-blur",
-        "s-border-border-dark/70 s-bg-background/80",
-        "dark:s-border-border-dark-night/70 dark:s-bg-background-night/80",
-        className
-      )}
-    >
-      {leftActions && <div className={buttonBarClasses}>{leftActions}</div>}
+    <div className={cn(barHeaderVariants({ variant }), className)}>
+      {leftActions && <div className="s-flex s-gap-1">{leftActions}</div>}
       <div className={titleClasses}>
         {tooltip ? (
           <Tooltip
@@ -53,7 +63,7 @@ export function BarHeader({
           title
         )}
       </div>
-      {rightActions && <div className={buttonBarClasses}>{rightActions}</div>}
+      {rightActions && <div className="s-flex s-gap-1">{rightActions}</div>}
     </div>
   );
 }

--- a/sparkle/src/stories/BarHeader.stories.tsx
+++ b/sparkle/src/stories/BarHeader.stories.tsx
@@ -3,7 +3,13 @@ import React from "react";
 
 import { ChatBubbleBottomCenterTextIcon } from "@sparkle/icons/app";
 
-import { BarHeader, Page } from "../index_with_tw_base";
+import {
+  BarHeader,
+  Page,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "../index_with_tw_base";
 
 const meta = {
   title: "Modules/BarHeader",
@@ -183,3 +189,76 @@ export const BasicBarHeaderValidateSaveDisabledWithTooltip = () => (
     </div>
   </div>
 );
+
+export const DefaultVariantInPanel = () => {
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  return (
+    <div className="s-h-full s-w-full">
+      <ResizablePanelGroup direction="horizontal" className="s-h-full s-w-full">
+        <ResizablePanel defaultSize={70} minSize={30}>
+          <div className="s-flex s-h-full s-flex-col s-bg-white s-shadow-sm">
+            <BarHeader
+              variant="default"
+              title="Agent Builder"
+              rightActions={
+                <BarHeader.ButtonBar
+                  variant="validate"
+                  isSaving={isSaving}
+                  onCancel={() => alert("Cancelled!")}
+                  onSave={() => {
+                    setIsSaving(true);
+                    setTimeout(() => {
+                      setIsSaving(false);
+                      alert("Saved!");
+                    }, 2000);
+                  }}
+                />
+              }
+            />
+            <div className="s-flex-1 s-overflow-y-auto s-p-4">
+              <Page.Header
+                title="Left Panel Content"
+                icon={ChatBubbleBottomCenterTextIcon}
+              />
+              <p className="s-text-sm s-text-gray-600">
+                This demonstrates the "default" variant of BarHeader that is
+                contained within its parent container, perfect for panels and
+                sidebars. This panel uses ResizablePanelGroup like
+                AgentBuilderLayout.
+              </p>
+            </div>
+          </div>
+        </ResizablePanel>
+
+        <ResizableHandle />
+
+        <ResizablePanel defaultSize={30} minSize={20}>
+          <div className="s-flex s-h-full s-flex-col s-bg-white s-shadow-sm">
+            <BarHeader
+              variant="default"
+              title="Preview Panel"
+              rightActions={
+                <BarHeader.ButtonBar
+                  variant="close"
+                  onClose={() => alert("Closed!")}
+                />
+              }
+            />
+            <div className="s-flex-1 s-overflow-y-auto s-p-4">
+              <Page.Header
+                title="Right Panel Content"
+                icon={ChatBubbleBottomCenterTextIcon}
+              />
+              <p className="s-text-sm s-text-gray-600">
+                Notice how each BarHeader is scoped to its own panel width,
+                unlike the "full" variant which would span the entire viewport
+                width. You can resize this panel!
+              </p>
+            </div>
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

This introduces a new variant to the sparkle `BarHeader` that is relatively positioned within its container. This will be needed 
for the split layout in the new agent builder.

## Risk

None, not used yet.

## Deploy Plan

Publish sparkle
