### PR TITLE
Reduce search endpoint limit + reduce delay on near rate limit

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -16,7 +16,7 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import type { ModelId } from "@connectors/types";
 import { getOAuthConnectionAccessToken } from "@connectors/types";
 
-const PAGE_FETCH_LIMIT = 250;
+const PAGE_FETCH_LIMIT = 100;
 
 export async function getConfluenceCloudInformation(accessToken: string) {
   const client = new ConfluenceClient(accessToken);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/12974.

This PR reduces the limit used on the search endpoint as we observe some query timeout (we time out after 30 seconds). Lowering it back to 100 (previous value). We also leverage the more precise delay when we reach the 80% usage of the rate limit of an endpoint, to sleep for 2 minutes rather than using the exponential backoff. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
