### PR TITLE
Factor salesforce specificities out of `useCreatePersonalConnection`

### DIFF
--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -549,7 +549,7 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
           use_case: useCase,
         });
       if (additionalCredentials) {
-        Object.entries(additionalCredentials).forEach(([key, { value }]) => {
+        Object.entries(additionalCredentials).forEach(([key, value]) => {
           if (typeof value === "string") {
             extraConfig[key] = value;
           }

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -33,8 +33,7 @@ import type {
   SpaceType,
 } from "@app/types";
 import { setupOAuthConnection } from "@app/types";
-
-import { getPKCEConfig } from "../utils/pkce";
+import { getProviderAdditionalClientSideAuthCredentials } from "@app/types/oauth/lib";
 
 /**
  * Hook to fetch a specific remote MCP server by ID
@@ -540,19 +539,21 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
     useCase: OAuthUseCase
   ): Promise<boolean> => {
     try {
-      const extraConfig: {
-        mcp_server_id: string;
-        code_verifier?: string;
-        code_challenge?: string;
-      } = {
+      const extraConfig: Record<string, string> = {
         mcp_server_id: mcpServerId,
       };
 
-      // TODO(spolu): clean that up
-      if (provider === "salesforce") {
-        const { code_verifier, code_challenge } = await getPKCEConfig();
-        extraConfig.code_verifier = code_verifier;
-        extraConfig.code_challenge = code_challenge;
+      const additionalCredentials =
+        await getProviderAdditionalClientSideAuthCredentials({
+          provider,
+          use_case: useCase,
+        });
+      if (additionalCredentials) {
+        Object.entries(additionalCredentials).forEach(([key, { value }]) => {
+          if (typeof value === "string") {
+            extraConfig[key] = value;
+          }
+        });
       }
 
       const cRes = await setupOAuthConnection({

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -101,13 +101,13 @@ export const getProviderRequiredAuthCredentials = async (
           client_secret: { label: "OAuth client secret", value: undefined },
           instance_url: { label: "Instance URL", value: undefined },
         };
-        
+
         if (additionalCredentials) {
           Object.entries(additionalCredentials).forEach(([key, value]) => {
             result[key] = { label: key, value };
           });
         }
-        
+
         return result;
       }
       return null;
@@ -115,18 +115,18 @@ export const getProviderRequiredAuthCredentials = async (
       if (authentication.use_case === "personal_actions") {
         const additionalCredentials =
           await getProviderAdditionalClientSideAuthCredentials(authentication);
-        
+
         const result: Record<string, { label: string; value: string | number | undefined }> = {
           client_id: { label: "oAuth client Id", value: undefined },
           client_secret: { label: "oAuth client secret", value: undefined },
         };
-        
+
         if (additionalCredentials) {
           Object.entries(additionalCredentials).forEach(([key, value]) => {
             result[key] = { label: key, value };
           });
         }
-        
+
         return result;
       }
       return null;
@@ -140,18 +140,18 @@ export const getProviderRequiredAuthCredentials = async (
     case "github":
     case "google_drive":
     case "intercom":
-      const additionalCredentials = 
+      const additionalCredentials =
         await getProviderAdditionalClientSideAuthCredentials(authentication);
-      
+
       if (!additionalCredentials) {
         return null;
       }
-      
+
       const result: Record<string, { label: string; value: string | number | undefined }> = {};
       Object.entries(additionalCredentials).forEach(([key, value]) => {
         result[key] = { label: key, value };
       });
-      
+
       return Object.keys(result).length > 0 ? result : null;
     default:
       assertNever(authentication.provider);

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -56,6 +56,7 @@ export const getProviderAdditionalClientSideAuthCredentials = async (
   }
   switch (authentication.provider) {
     case "salesforce":
+    case "gmail":
       if (authentication.use_case === "personal_actions") {
         const { code_verifier, code_challenge } = await getPKCEConfig();
         return {
@@ -64,7 +65,6 @@ export const getProviderAdditionalClientSideAuthCredentials = async (
         };
       }
       return null;
-    case "gmail":
     case "hubspot":
     case "zendesk":
     case "slack":
@@ -90,12 +90,12 @@ export const getProviderRequiredAuthCredentials = async (
   if (!authentication) {
     return null;
   }
+  const additionalCredentials =
+    await getProviderAdditionalClientSideAuthCredentials(authentication);
 
   switch (authentication.provider) {
     case "salesforce":
       if (authentication.use_case === "personal_actions") {
-        const additionalCredentials =
-          await getProviderAdditionalClientSideAuthCredentials(authentication);
         const result: Record<
           string,
           { label: string; value: string | number | undefined }
@@ -116,9 +116,6 @@ export const getProviderRequiredAuthCredentials = async (
       return null;
     case "gmail":
       if (authentication.use_case === "personal_actions") {
-        const additionalCredentials =
-          await getProviderAdditionalClientSideAuthCredentials(authentication);
-
         const result: Record<
           string,
           { label: string; value: string | number | undefined }
@@ -146,9 +143,6 @@ export const getProviderRequiredAuthCredentials = async (
     case "github":
     case "google_drive":
     case "intercom":
-      const additionalCredentials =
-        await getProviderAdditionalClientSideAuthCredentials(authentication);
-
       if (!additionalCredentials) {
         return null;
       }

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -96,7 +96,10 @@ export const getProviderRequiredAuthCredentials = async (
       if (authentication.use_case === "personal_actions") {
         const additionalCredentials =
           await getProviderAdditionalClientSideAuthCredentials(authentication);
-        const result: Record<string, { label: string; value: string | number | undefined }> = {
+        const result: Record<
+          string,
+          { label: string; value: string | number | undefined }
+        > = {
           client_id: { label: "OAuth client Id", value: undefined },
           client_secret: { label: "OAuth client secret", value: undefined },
           instance_url: { label: "Instance URL", value: undefined },
@@ -116,7 +119,10 @@ export const getProviderRequiredAuthCredentials = async (
         const additionalCredentials =
           await getProviderAdditionalClientSideAuthCredentials(authentication);
 
-        const result: Record<string, { label: string; value: string | number | undefined }> = {
+        const result: Record<
+          string,
+          { label: string; value: string | number | undefined }
+        > = {
           client_id: { label: "oAuth client Id", value: undefined },
           client_secret: { label: "oAuth client secret", value: undefined },
         };
@@ -147,7 +153,10 @@ export const getProviderRequiredAuthCredentials = async (
         return null;
       }
 
-      const result: Record<string, { label: string; value: string | number | undefined }> = {};
+      const result: Record<
+        string,
+        { label: string; value: string | number | undefined }
+      > = {};
       Object.entries(additionalCredentials).forEach(([key, value]) => {
         result[key] = { label: key, value };
       });


### PR DESCRIPTION
## Description

- Introduce `getProviderAdditionalClientSideAuthCredentials`
- Factor salesforce specific code out of `useCreatePersonalConnection`

## Tests

Tested in dev

## Risk

Low (salesforce only)

## Deploy Plan

- deploy `front`