### PR TITLE
Fix: wrong description in agent builder

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -67,7 +67,8 @@ export function isInternalMCPServerDefinition(
 ): server is InternalMCPServerDefinitionType {
   return (
     "authorization" in server &&
-    isAuthorizationInfo(server.authorization) &&
+    (isAuthorizationInfo(server.authorization) ||
+      server.authorization === null) &&
     "description" in server &&
     typeof server.description === "string" &&
     "icon" in server &&


### PR DESCRIPTION
## Description

Over sensitive type guard

## Tests

Local

## Risk

None

## Deploy Plan

Deploy `front`