### PR TITLE
Fix search to handle word separators (_) in data source names

### DIFF
--- a/core/src/search_stores/indices/data_sources_nodes_4.settings.local.json
+++ b/core/src/search_stores/indices/data_sources_nodes_4.settings.local.json
@@ -17,7 +17,7 @@
       "edge_analyzer": {
         "type": "custom",
         "tokenizer": "icu_tokenizer",
-        "filter": ["lowercase", "edge_ngram_filter"]
+        "filter": ["preserve_word_delimiter", "lowercase", "edge_ngram_filter"]
       },
       "tag_edge_analyzer": {
         "type": "custom",
@@ -35,7 +35,9 @@
       "preserve_word_delimiter": {
         "type": "word_delimiter",
         "split_on_numerics": false,
-        "split_on_case_change": false
+        "split_on_case_change": true,
+        "preserve_original": true,
+        "stem_english_possessive": false
       },
       "edge_ngram_filter": {
         "type": "edge_ngram",

--- a/core/src/search_stores/migrations/20250527_fix_datasources_underscore_word_delimiter.http
+++ b/core/src/search_stores/migrations/20250527_fix_datasources_underscore_word_delimiter.http
@@ -1,4 +1,4 @@
-PUT core.data_sources/_settings
+PUT core.data_sources/_settings?reopen=true
 {
   "analysis": {
     "analyzer": {

--- a/core/src/search_stores/migrations/20250527_fix_datasources_underscore_word_delimiter.http
+++ b/core/src/search_stores/migrations/20250527_fix_datasources_underscore_word_delimiter.http
@@ -1,19 +1,7 @@
+PUT core.data_sources/_settings
 {
-  "number_of_shards": 1,
-  "number_of_replicas": 0,
-  "refresh_interval": "30s",
   "analysis": {
     "analyzer": {
-      "icu_analyzer": {
-        "type": "custom",
-        "tokenizer": "icu_tokenizer",
-        "filter": [
-          "icu_folding",
-          "lowercase",
-          "asciifolding",
-          "preserve_word_delimiter"
-        ]
-      },
       "edge_analyzer": {
         "type": "custom",
         "tokenizer": "icu_tokenizer",
@@ -27,11 +15,6 @@
         "split_on_case_change": true,
         "preserve_original": true,
         "stem_english_possessive": false
-      },
-      "edge_ngram_filter": {
-        "type": "edge_ngram",
-        "min_gram": 1,
-        "max_gram": 20
       }
     }
   }

--- a/core/src/search_stores/migrations/20250527_fix_underscore_word_delimiter.http
+++ b/core/src/search_stores/migrations/20250527_fix_underscore_word_delimiter.http
@@ -1,4 +1,4 @@
-PUT core.data_sources_nodes/_settings
+PUT core.data_sources_nodes/_settings?reopen=true
 {
   "analysis": {
     "analyzer": {

--- a/core/src/search_stores/migrations/20250527_fix_underscore_word_delimiter.http
+++ b/core/src/search_stores/migrations/20250527_fix_underscore_word_delimiter.http
@@ -1,19 +1,7 @@
+PUT core.data_sources_nodes/_settings
 {
-  "number_of_shards": 1,
-  "number_of_replicas": 0,
-  "refresh_interval": "30s",
   "analysis": {
     "analyzer": {
-      "icu_analyzer": {
-        "type": "custom",
-        "tokenizer": "icu_tokenizer",
-        "filter": [
-          "icu_folding",
-          "lowercase",
-          "asciifolding",
-          "preserve_word_delimiter"
-        ]
-      },
       "edge_analyzer": {
         "type": "custom",
         "tokenizer": "icu_tokenizer",
@@ -27,11 +15,6 @@
         "split_on_case_change": true,
         "preserve_original": true,
         "stem_english_possessive": false
-      },
-      "edge_ngram_filter": {
-        "type": "edge_ngram",
-        "min_gram": 1,
-        "max_gram": 20
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2876

## Description

Fix the data source search interface to properly handle underscores as word separators. Previously, searching for "Mirova" wouldn't find "Demo_Mirova" because the search analyzer wasn't splitting on underscores.

**Changes made:**
- Add `preserve_word_delimiter` filter to the `edge_analyzer` in both data source indices
- Configure word delimiter filter with proper settings for underscore splitting
- Enable `preserve_original: true` to keep both original and split tokens
- Enable `split_on_case_change: true` for camelCase handling

**How it works:**
- "Demo_Mirova" gets tokenized into ["Demo_Mirova", "Demo", "Mirova"] 
- Edge n-grams are generated from all tokens
- Search for "Mirova" now matches the "Mirova" token

## Risks

- **Low risk**: Only changes analyzer settings, doesn't affect existing data
- Existing documents benefit gradually as they get reindexed through normal operations
- New searches work immediately with updated analyzer

## Tests

- Apply migrations to update live index settings
- Run bulk reindex to immediately apply changes to all existing documents
- Test search for partial words in underscore-separated data source names

## Deploy Plan

1. **Apply Elasticsearch migrations:**
   ```bash
   cd core
   ./admin/elasticsearch_run_command_from_file.sh src/search_stores/migrations/20250527_fix_underscore_word_delimiter.http
   ./admin/elasticsearch_run_command_from_file.sh src/search_stores/migrations/20250527_fix_datasources_underscore_word_delimiter.http
   ```

2. **Trigger bulk reindexing (for immediate effect):**
```
POST core.data_sources_nodes/_update_by_query?conflicts=proceed
POST core.data_sources/_update_by_query?conflicts=proceed
```

3. No service to deploy
