### PR TITLE
Fix welcome routing

### DIFF
--- a/front/pages/w/[wId]/subscription/payment_processing.tsx
+++ b/front/pages/w/[wId]/subscription/payment_processing.tsx
@@ -54,7 +54,8 @@ export default function PaymentProcessing({
       if (subscription.plan.code === router.query.plan_code) {
         // Then we remove the query params to avoid going through this logic again.
         void router.replace({
-          pathname: `/w/${owner.sId}/assistant/new?welcome=true`,
+          pathname: `/w/${owner.sId}/assistant/new`,
+          query: { welcome: true },
         });
       } else {
         // If the Stripe webhook is not yet received, we try waiting for it and reload the page every 5 seconds until it's done.


### PR DESCRIPTION
## Description

Router replace was not properly injecting the welcome=true query parameter leading to a conversation not found error on first login from successful payment processing.

Before:
![Screenshot from 2025-05-27 16-10-16](https://github.com/user-attachments/assets/2f855e83-ade8-4d58-968c-b4008f2dcace)

After:
![Screenshot from 2025-05-27 16-10-49](https://github.com/user-attachments/assets/a89f08ba-f73a-425a-aad2-bc8b56ff0ae4)


## Tests

Found and fix tested in dev

## Risk

Low

## Deploy Plan

- deploy `front`