### PR TITLE
Add: connections to profile page

### DIFF
--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -408,42 +408,51 @@ export function useDeleteMCPServerConnection({
 
   const sendNotification = useSendNotification();
 
-  const deleteMCPServerConnection = async ({
-    connection,
-  }: {
-    connection: MCPServerConnectionType;
-  }): Promise<{ success: boolean }> => {
-    const response = await fetch(
-      `/api/w/${owner.sId}/mcp/connections/${connection.connectionType}/${connection.sId}`,
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-        },
+  const deleteMCPServerConnection = useCallback(
+    async ({
+      connection,
+    }: {
+      connection: MCPServerConnectionType;
+    }): Promise<{ success: boolean }> => {
+      const response = await fetch(
+        `/api/w/${owner.sId}/mcp/connections/${connection.connectionType}/${connection.sId}`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      if (response.ok) {
+        sendNotification({
+          type: "success",
+          title: "Provider disconnected",
+          description:
+            "Your capability provider has been disconnected successfully.",
+        });
+        if (connection.connectionType === "workspace") {
+          void mutateWorkspaceConnections();
+        } else if (connection.connectionType === "personal") {
+          void mutatePersonalConnections();
+        }
+      } else {
+        sendNotification({
+          type: "error",
+          title: "Failed to disconnect provider",
+          description:
+            "Could not disconnect to your provider. Please try again.",
+        });
       }
-    );
-    if (response.ok) {
-      sendNotification({
-        type: "success",
-        title: "Provider disconnected",
-        description:
-          "Your capability provider has been disconnected successfully.",
-      });
-      if (connection.connectionType === "workspace") {
-        void mutateWorkspaceConnections();
-      } else if (connection.connectionType === "personal") {
-        void mutatePersonalConnections();
-      }
-    } else {
-      sendNotification({
-        type: "error",
-        title: "Failed to disconnect provider",
-        description: "Could not disconnect to your provider. Please try again.",
-      });
-    }
 
-    return response.json();
-  };
+      return response.json();
+    },
+    [
+      owner.sId,
+      sendNotification,
+      mutateWorkspaceConnections,
+      mutatePersonalConnections,
+    ]
+  );
 
   return { deleteMCPServerConnection };
 }

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -32,9 +32,9 @@ export function useUserMetadata(key: string) {
   };
 }
 
-export function useDeleteMetadata(key: string) {
+export function useDeleteMetadata(prefix: string) {
   const deleteMetadata = async (spec?: string) => {
-    const fullKey = spec ? `${key}:${spec}` : key;
+    const fullKey = spec ? `${prefix}:${spec}` : prefix;
     await fetch(`/api/user/metadata/${encodeURIComponent(fullKey)}`, {
       method: "DELETE",
     });

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerConnectionFactory } from "@app/tests/utils/MCPServerConnectionFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./index";
+
+describe("MCP Connection API Handler", () => {
+  itInTransaction("GET should return the connection", async (t) => {
+    const { req, res, workspace, authenticator } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+      });
+    await SpaceFactory.system(workspace, t);
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+    const connection = await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "personal"
+    );
+
+    req.query.connectionType = "personal";
+    req.query.cId = connection.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.connection.sId).toBe(connection.sId);
+  });
+
+  itInTransaction(
+    "GET cannot return a connection from another workspace",
+    async (t) => {
+      // Create first workspace and its connection
+      const { workspace: workspace1, authenticator: authenticator1 } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+        });
+      await SpaceFactory.system(workspace1, t);
+      const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
+      const connection1 = await MCPServerConnectionFactory.remote(
+        authenticator1,
+        remoteServer1,
+        "personal"
+      );
+
+      // Create second workspace and try to access connection1
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+      });
+      req.query.connectionType = "personal";
+      req.query.cId = connection1.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "mcp_server_connection_not_found",
+          message: "Connection not found",
+        },
+      });
+    }
+  );
+
+  itInTransaction(
+    "GET cannot return a connection from another user in the same workspace",
+    async (t) => {
+      const { workspace, authenticator: authenticator1 } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+        });
+      await SpaceFactory.system(workspace, t);
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      // Create connection for first user
+      const connection1 = await MCPServerConnectionFactory.remote(
+        authenticator1,
+        remoteServer,
+        "personal"
+      );
+
+      // Create second user in the same workspace
+      await UserFactory.basic();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+      });
+      req.query.cId = connection1.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "mcp_server_connection_not_found",
+          message: "Connection not found",
+        },
+      });
+    }
+  );
+
+  itInTransaction(
+    "DELETE personal connection deletes all personal connections for the same server of the same user",
+    async (t) => {
+      const {
+        req: deleteReq,
+        res: deleteRes,
+        workspace,
+        authenticator,
+      } = await createPrivateApiMockRequest({
+        method: "DELETE",
+      });
+      await SpaceFactory.system(workspace, t);
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      // Create two personal connections for the same server
+      const connection1 = await MCPServerConnectionFactory.remote(
+        authenticator,
+        remoteServer,
+        "personal"
+      );
+      await MCPServerConnectionFactory.remote(
+        authenticator,
+        remoteServer,
+        "personal"
+      );
+
+      // Create an extra one for the same server, but for a different user
+      const user2 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user2, "user");
+      const authenticator2 = await Authenticator.fromUserIdAndWorkspaceId(
+        user2.sId,
+        workspace.sId
+      );
+      await MCPServerConnectionFactory.remote(
+        authenticator2,
+        remoteServer,
+        "personal"
+      );
+
+      // Delete the first connection
+      deleteReq.query.connectionType = "personal";
+      deleteReq.query.cId = connection1.sId;
+      await handler(deleteReq, deleteRes);
+
+      expect(deleteRes._getStatusCode()).toBe(200);
+      expect(deleteRes._getJSONData()).toEqual({ success: true });
+
+      const remainingPersonalConnections =
+        await MCPServerConnectionResource.listByWorkspace({
+          auth: authenticator,
+          connectionType: "personal",
+        });
+      expect(remainingPersonalConnections).toHaveLength(0);
+
+      const remainingUser2PersonalConnections =
+        await MCPServerConnectionResource.listByWorkspace({
+          auth: authenticator2,
+          connectionType: "personal",
+        });
+      expect(remainingUser2PersonalConnections).toHaveLength(1);
+    }
+  );
+
+  itInTransaction(
+    "DELETE workspace connection deletes all connections for the same server",
+    async (t) => {
+      const {
+        req: deleteReq,
+        res: deleteRes,
+        workspace,
+        authenticator,
+      } = await createPrivateApiMockRequest({
+        method: "DELETE",
+        role: "admin",
+      });
+      await SpaceFactory.system(workspace, t);
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      // Create both personal and workspace connections for the same server
+      await MCPServerConnectionFactory.remote(
+        authenticator,
+        remoteServer,
+        "personal"
+      );
+
+      const workspaceConnection = await MCPServerConnectionFactory.remote(
+        authenticator,
+        remoteServer,
+        "workspace"
+      );
+
+      // Delete the workspace connection
+      deleteReq.query.connectionType = "workspace";
+      deleteReq.query.cId = workspaceConnection.sId;
+      await handler(deleteReq, deleteRes);
+
+      expect(deleteRes._getStatusCode()).toBe(200);
+      expect(deleteRes._getJSONData()).toEqual({ success: true });
+
+      // Verify both connections are deleted
+      const remainingWorkspaceConnections =
+        await MCPServerConnectionResource.listByWorkspace({
+          auth: authenticator,
+          connectionType: "workspace",
+        });
+      expect(remainingWorkspaceConnections).toHaveLength(0);
+
+      const remainingPersonalConnections =
+        await MCPServerConnectionResource.listByWorkspace({
+          auth: authenticator,
+          connectionType: "personal",
+        });
+      expect(remainingPersonalConnections).toHaveLength(0);
+    }
+  );
+
+  itInTransaction(
+    "GET a non-existing connection should return 404",
+    async () => {
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+      });
+      req.query.connectionType = "personal";
+      req.query.cId = "non_existing_connection_id";
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "mcp_server_connection_not_found",
+          message: "Connection not found",
+        },
+      });
+    }
+  );
+
+  itInTransaction(
+    "DELETE a workspace connection as non-admin should return 500",
+    async (t) => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "DELETE",
+        role: "user", // Explicitly set as non-admin
+      });
+      await SpaceFactory.system(workspace, t);
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      const admin = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, admin, "admin");
+      const adminAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
+        admin.sId,
+        workspace.sId
+      );
+      const workspaceConnection = await MCPServerConnectionFactory.remote(
+        adminAuthenticator,
+        remoteServer,
+        "workspace"
+      );
+
+      req.query.connectionType = "workspace";
+      req.query.cId = workspaceConnection.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(500);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "internal_server_error",
+          message: "Failed to delete connection",
+        },
+      });
+    }
+  );
+
+  itInTransaction(
+    "DELETE a personal connection as non-admin and wrong user should return 404",
+    async (t) => {
+      // Create first user and their connection
+      const { workspace, authenticator: authenticator1 } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+        });
+      await SpaceFactory.system(workspace, t);
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+      const connection1 = await MCPServerConnectionFactory.remote(
+        authenticator1,
+        remoteServer,
+        "personal"
+      );
+
+      // Create second user and try to delete first user's connection
+      const user2 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user2, "user");
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "DELETE",
+        role: "user",
+      });
+      req.query.connectionType = "personal";
+      req.query.cId = connection1.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+    }
+  );
+});

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
@@ -37,7 +37,16 @@ async function handler(
         .status(200)
         .json({ connection: connectionResource.value.toJSON() });
     case "DELETE":
-      await connectionResource.value.delete(auth);
+      const result = await connectionResource.value.delete(auth);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to delete connection",
+          },
+        });
+      }
 
       return res.status(200).json({
         success: true,

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect } from "vitest";
+
+import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerConnectionFactory } from "@app/tests/utils/MCPServerConnectionFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
+
+import handler from "./index";
+
+describe("MCP Connections API Handler", () => {
+  itInTransaction(
+    "should return personal connections filtered by user ID",
+    async (t) => {
+      const { req, res, workspace, authenticator } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+        });
+      req.query.connectionType = "personal";
+
+      // Create a system space to hold the Remote MCP servers
+      await SpaceFactory.system(workspace, t);
+
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      // Create two connections for the same server, one newer than the other
+      await MCPServerConnectionFactory.remote(
+        authenticator,
+        remoteServer,
+        "personal"
+      );
+      const connection2 = await MCPServerConnectionFactory.remote(
+        authenticator,
+        remoteServer,
+        "personal"
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const response = res._getJSONData();
+      expect(response.connections).toHaveLength(1);
+      expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection
+    }
+  );
+
+  itInTransaction("should return workspace connections", async (t) => {
+    const { req, res, workspace, authenticator } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+    req.query.connectionType = "workspace";
+
+    // Create a system space to hold the Remote MCP servers
+    await SpaceFactory.system(workspace, t);
+
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+    // Create two workspace connections for the same server
+    await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "workspace"
+    );
+    const connection2 = await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "workspace"
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.connections).toHaveLength(1);
+    expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection
+  });
+
+  itInTransaction("should handle different server IDs correctly", async (t) => {
+    const { req, res, workspace, authenticator } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+      });
+    req.query.connectionType = "personal";
+
+    // Create a system space to hold the Remote MCP servers
+    await SpaceFactory.system(workspace, t);
+
+    const remoteServer1 = await RemoteMCPServerFactory.create(workspace);
+    const remoteServer2 = await RemoteMCPServerFactory.create(workspace);
+
+    // Create connections for different servers
+    const connection1 = await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer1,
+      "personal"
+    );
+    const connection2 = await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer2,
+      "personal"
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.connections).toHaveLength(2);
+    expect(
+      response.connections.map((c: MCPServerConnectionType) => c.sId).sort()
+    ).toEqual([connection1.sId, connection2.sId].sort());
+  });
+
+  itInTransaction("should handle internal server connections", async () => {
+    const { req, res, authenticator } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    req.query.connectionType = "personal";
+
+    // Create two internal connections for the same server
+    await MCPServerConnectionFactory.internal(
+      authenticator,
+      "internal_server_1",
+      "personal"
+    );
+    const connection2 = await MCPServerConnectionFactory.internal(
+      authenticator,
+      "internal_server_1",
+      "personal"
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.connections).toHaveLength(1);
+    expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection
+  });
+
+  itInTransaction("should return 400 for invalid connection type", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    req.query.connectionType = "invalid";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Invalid connection type",
+      },
+    });
+  });
+
+  itInTransaction(
+    "should not leak personal connections across workspaces",
+    async (t) => {
+      // Create first workspace and its connections
+      const { workspace: workspace1, authenticator: authenticator1 } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+        });
+      await SpaceFactory.system(workspace1, t);
+      const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
+      const connection1 = await MCPServerConnectionFactory.remote(
+        authenticator1,
+        remoteServer1,
+        "personal"
+      );
+
+      // Create second workspace and its connections
+      const {
+        req,
+        res,
+        workspace: workspace2,
+        authenticator: authenticator2,
+      } = await createPrivateApiMockRequest({
+        method: "GET",
+      });
+      req.query.connectionType = "personal";
+      await SpaceFactory.system(workspace2, t);
+      const remoteServer2 = await RemoteMCPServerFactory.create(workspace2);
+      const connection2 = await MCPServerConnectionFactory.remote(
+        authenticator2,
+        remoteServer2,
+        "personal"
+      );
+
+      // Query connections from workspace2
+      await handler(req, res);
+
+      // Should only see connections from workspace2
+      expect(res._getStatusCode()).toBe(200);
+      const response = res._getJSONData();
+      expect(response.connections).toHaveLength(1);
+      expect(response.connections[0].sId).toBe(connection2.sId);
+      expect(response.connections[0].sId).not.toBe(connection1.sId);
+    }
+  );
+
+  itInTransaction(
+    "should not leak workspace connections across workspaces",
+    async (t) => {
+      // Create first workspace and its connections
+      const { workspace: workspace1, authenticator: authenticator1 } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+      await SpaceFactory.system(workspace1, t);
+      const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
+      const connection1 = await MCPServerConnectionFactory.remote(
+        authenticator1,
+        remoteServer1,
+        "workspace"
+      );
+
+      // Create second workspace and its connections
+      const {
+        req,
+        res,
+        workspace: workspace2,
+        authenticator: authenticator2,
+      } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+      req.query.connectionType = "workspace";
+      await SpaceFactory.system(workspace2, t);
+      const remoteServer2 = await RemoteMCPServerFactory.create(workspace2);
+      const connection2 = await MCPServerConnectionFactory.remote(
+        authenticator2,
+        remoteServer2,
+        "workspace"
+      );
+
+      // Query connections from workspace2
+      await handler(req, res);
+
+      // Should only see connections from workspace2
+      expect(res._getStatusCode()).toBe(200);
+      const response = res._getJSONData();
+      expect(response.connections).toHaveLength(1);
+      expect(response.connections[0].sId).toBe(connection2.sId);
+      expect(response.connections[0].sId).not.toBe(connection1.sId);
+    }
+  );
+});

--- a/front/tests/utils/MCPServerConnectionFactory.ts
+++ b/front/tests/utils/MCPServerConnectionFactory.ts
@@ -1,0 +1,38 @@
+import { faker } from "@faker-js/faker";
+
+import type { Authenticator } from "@app/lib/auth";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import type { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+
+export class MCPServerConnectionFactory {
+  static async internal(
+    auth: Authenticator,
+    internalMCPServerId: string,
+    connectionType: MCPServerConnectionConnectionType
+  ): Promise<MCPServerConnectionResource> {
+    const connection = await MCPServerConnectionResource.makeNew(auth, {
+      connectionId: "con_" + faker.string.alphanumeric(8),
+      connectionType,
+      serverType: "internal",
+      internalMCPServerId,
+    });
+
+    return connection;
+  }
+
+  static async remote(
+    auth: Authenticator,
+    remoteMCPServer: RemoteMCPServerResource,
+    connectionType: MCPServerConnectionConnectionType
+  ): Promise<MCPServerConnectionResource> {
+    const connection = await MCPServerConnectionResource.makeNew(auth, {
+      connectionId: "con_" + faker.string.alphanumeric(8),
+      connectionType,
+      serverType: "remote",
+      remoteMCPServerId: remoteMCPServer.id,
+    });
+
+    return connection;
+  }
+}

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -17,7 +17,7 @@ vi.mock(import("../../lib/auth"), async (importOriginal) => {
   };
 });
 
-import { getSession } from "../../lib/auth";
+import { Authenticator, getSession } from "../../lib/auth";
 
 /**
  * Creates a mock request with authentication for testing private API endpoints.
@@ -82,5 +82,9 @@ export const createPrivateApiMockRequest = async ({
     membership,
     globalGroup,
     systemGroup,
+    authenticator: await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    ),
   };
 };


### PR DESCRIPTION
## Description

- Show connections status and ability to disconnect in profile page.
- Fix a few issues with MCPServerConnection (such as, the inability for non-admins to create connection...)
- Delete all related connections when a workspace connection is deleted
- Delete all personal connections of the user when a personal connection is deleted

## Tests

Added a bunch of those.

## Risk

Low

## Deploy Plan

Deploy `front`