### PR TITLE
[Attach from Inputbar] Slack: always match threads, never messages

### DIFF
--- a/extension/shared/lib/connectors.ts
+++ b/extension/shared/lib/connectors.ts
@@ -1,4 +1,3 @@
-import { getWeekBoundaries } from "@app/shared/lib/utils";
 import type { ConnectorProvider } from "@dust-tt/client";
 
 type BaseProvider = {
@@ -146,10 +145,7 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
     },
     extractor: (url: URL): NodeCandidate => {
       // Try each type of extraction in order
-      const node =
-        extractMessageNodeId(url) ||
-        extractThreadNodeId(url) ||
-        extractChannelNodeId(url);
+      const node = extractThreadNodeId(url) || extractChannelNodeId(url);
       return node
         ? { node, provider: "slack" }
         : { node: null, provider: "slack" };
@@ -216,28 +212,20 @@ function extractThreadNodeId(url: URL): string | null {
   }
 
   const threadTs = url.searchParams.get("thread_ts");
-  if (!threadTs) {
-    return null;
+
+  // If there is a thread_ts parameter, the link was copied from inside the
+  // thread, not from the root message of the thread.
+  // Example: https://dust4ai.slack.com/archives/C05V0P20A72/p1748353621866279?thread_ts=1748353030.562719&cid=C05V0P20A72
+  if (threadTs) {
+    const channelId = pathParts[channelIndex + 1];
+    return `slack-${channelId}-thread-${threadTs}`;
   }
 
-  const channelId = pathParts[channelIndex + 1];
-  return `slack-${channelId}-thread-${threadTs}`;
-}
-
-// Extract a message node ID from a Slack archives URL
-function extractMessageNodeId(url: URL): string | null {
-  function formatDateForId(date: Date): string {
-    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-  }
-
-  const pathParts = url.pathname.split("/");
-  const channelIndex = pathParts.indexOf("archives");
-
-  if (
-    channelIndex === -1 ||
-    channelIndex + 1 >= pathParts.length ||
-    pathParts.length <= channelIndex + 2
-  ) {
+  // Otherwise, the link may have been copied from the root message of the
+  // thread, in which case we can use the channel ID and the 'p' timestamp in
+  // the URL, which is the timestamp representing the thread..
+  // Example: https://dust4ai.slack.com/archives/C05V0P20A72/p1748353030562719
+  if (pathParts.length <= channelIndex + 2) {
     return null;
   }
 
@@ -248,18 +236,12 @@ function extractMessageNodeId(url: URL): string | null {
     return null;
   }
 
-  // Extract timestamp and convert to date
+  // Extract timestamp and convert to thread timestamp (with dot at decimal 6 before last digit)
   const timestamp = messagePart.substring(1);
-  const messageDate = new Date(parseInt(timestamp) / 1000);
+  // add a dot at decimal 6 before last digit
+  const inferredThreadTs = timestamp.slice(0, -6) + "." + timestamp.slice(-6);
 
-  // Calculate week boundaries
-  const { startDate, endDate } = getWeekBoundaries(messageDate);
-
-  // Format dates for node ID
-  const startDateStr = formatDateForId(startDate);
-  const endDateStr = formatDateForId(endDate);
-
-  return `slack-${channelId}-messages-${startDateStr}-${endDateStr}`;
+  return `slack-${channelId}-thread-${inferredThreadTs}`;
 }
 
 export function nodeCandidateFromUrl(

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -1,5 +1,4 @@
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { getWeekBoundaries } from "@app/lib/utils";
 import type { ConnectorProvider } from "@app/types";
 
 function getConnectorOrder() {
@@ -231,10 +230,7 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
     },
     extractor: (url: URL): NodeCandidate => {
       // Try each type of extraction in order
-      const node =
-        extractThreadNodeId(url) ||
-        extractMessageNodeId(url) ||
-        extractChannelNodeId(url);
+      const node = extractThreadNodeId(url) || extractChannelNodeId(url);
       return node
         ? { node, provider: "slack" }
         : { node: null, provider: "slack" };
@@ -291,7 +287,7 @@ function extractChannelNodeId(url: URL): string | null {
   return null;
 }
 
-// Extract a thread node ID from a Slack archives URL
+// Extract a thread node ID from a Slack archives URL.
 function extractThreadNodeId(url: URL): string | null {
   const pathParts = url.pathname.split("/");
   const channelIndex = pathParts.indexOf("archives");
@@ -301,28 +297,20 @@ function extractThreadNodeId(url: URL): string | null {
   }
 
   const threadTs = url.searchParams.get("thread_ts");
-  if (!threadTs) {
-    return null;
+
+  // If there is a thread_ts parameter, the link was copied from inside the
+  // thread, not from the root message of the thread.
+  // Example: https://dust4ai.slack.com/archives/C05V0P20A72/p1748353621866279?thread_ts=1748353030.562719&cid=C05V0P20A72
+  if (threadTs) {
+    const channelId = pathParts[channelIndex + 1];
+    return `slack-${channelId}-thread-${threadTs}`;
   }
 
-  const channelId = pathParts[channelIndex + 1];
-  return `slack-${channelId}-thread-${threadTs}`;
-}
-
-// Extract a message node ID from a Slack archives URL
-function extractMessageNodeId(url: URL): string | null {
-  function formatDateForId(date: Date): string {
-    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-  }
-
-  const pathParts = url.pathname.split("/");
-  const channelIndex = pathParts.indexOf("archives");
-
-  if (
-    channelIndex === -1 ||
-    channelIndex + 1 >= pathParts.length ||
-    pathParts.length <= channelIndex + 2
-  ) {
+  // Otherwise, the link may have been copied from the root message of the
+  // thread, in which case we can use the channel ID and the 'p' timestamp in
+  // the URL, which is the timestamp representing the thread..
+  // Example: https://dust4ai.slack.com/archives/C05V0P20A72/p1748353030562719
+  if (pathParts.length <= channelIndex + 2) {
     return null;
   }
 
@@ -333,18 +321,12 @@ function extractMessageNodeId(url: URL): string | null {
     return null;
   }
 
-  // Extract timestamp and convert to date
+  // Extract timestamp and convert to thread timestamp (with dot at decimal 6 before last digit)
   const timestamp = messagePart.substring(1);
-  const messageDate = new Date(parseInt(timestamp) / 1000);
+  // add a dot at decimal 6 before last digit
+  const inferredThreadTs = timestamp.slice(0, -6) + "." + timestamp.slice(-6);
 
-  // Calculate week boundaries
-  const { startDate, endDate } = getWeekBoundaries(messageDate);
-
-  // Format dates for node ID
-  const startDateStr = formatDateForId(startDate);
-  const endDateStr = formatDateForId(endDate);
-
-  return `slack-${channelId}-messages-${startDateStr}-${endDateStr}`;
+  return `slack-${channelId}-thread-${inferredThreadTs}`;
 }
 
 // Extracts a nodeId from a given url


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2931

Description
---

Before when copying a link from the initial message of the thread, (looking like this
`https://dust4ai.slack.com/archives/C05DP58UKR7/p1747727989868309`)

the attachment would be the "messages from the channel".

Desired behaviour is to match the thread, like when you copy from a child message inside the thread of the form
`https://casquedelumiere.slack.com/archives/C08JW0RQR9U/p1744119075057929?thread_ts=1744119058.803019&cid=C08JW0RQR9U`

This PR fixes that. As a consequence, attaching orphaned messages will fail, when it did not before -- but that behaviour was undesirable anyways (because it matched a random window of non-threaded messages, unlikely to match user intent)

Risks
---
standard, low blast radius

Deploy
---
front
changes will be ported to extension in next release
