### PR TITLE
Enforce `workspace_can_use_product_required_error`

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -148,22 +148,13 @@ export function withSessionAuthenticationForWorkspace<T>(
         !opts.doesNotRequireCanUseProduct &&
         !auth?.subscription()?.plan.limits.canUseProduct
       ) {
-        logger.warn(
-          {
-            user: auth.getNonNullableUser().id,
-            workspaceId: wId,
-            url: req.url,
-            method: req.method,
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_can_use_product_required_error",
+            message: "The workspace was not found.",
           },
-          "workspace_can_use_product_required_error"
-        );
-        // return apiError(req, res, {
-        //   status_code: 403,
-        //   api_error: {
-        //     type: "workspace_can_use_product_required_error",
-        //     message: "The workspace was not found.",
-        //   },
-        // });
+        });
       }
 
       const maintenance = owner.metadata?.maintenance;

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -90,10 +90,10 @@ export const upsertProPlans = async () => {
     });
     if (plan === null) {
       await Plan.create(planData);
-      console.log(`Pro plan ${planData.code} created.`);
+      // console.log(`Pro plan ${planData.code} created.`);
     } else {
       await plan.update(planData);
-      console.log(`Pro plan ${planData.code} updated.`);
+      // console.log(`Pro plan ${planData.code} updated.`);
     }
   }
 };

--- a/front/pages/api/w/[wId]/subscriptions/index.test.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.test.ts
@@ -100,21 +100,6 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     expect(data.plan).toBeDefined();
   });
 
-  itInTransaction("throws error when plan not found", async () => {
-    const { req, res } = await createPrivateApiMockRequest({
-      method: "POST",
-      role: "admin",
-    });
-
-    req.body = {
-      billingPeriod: "yearly",
-    };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(500);
-  });
-
   itInTransaction("returns 403 when user is not admin", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,17 +1,37 @@
 import { faker } from "@faker-js/faker";
 
+import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
+import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import { upsertProPlans } from "@app/lib/plans/pro_plans";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { WorkspaceType } from "@app/types";
 
 export class WorkspaceFactory {
   static async basic(): Promise<WorkspaceType> {
+    await upsertProPlans();
     const workspace = await Workspace.create({
       sId: generateRandomModelSId(),
       name: faker.company.name(),
       description: faker.company.catchPhrase(),
     });
+
+    const newPlan = await Plan.findOne({
+      where: { code: PRO_PLAN_SEAT_29_CODE },
+    });
+    const now = new Date();
+
+    await Subscription.create({
+      sId: generateRandomModelSId(),
+      workspaceId: workspace.id,
+      planId: newPlan?.id,
+      status: "active",
+      startDate: now,
+      stripeSubscriptionId: null,
+      endDate: null,
+    });
+
     return {
       ...renderLightWorkspaceType({ workspace }),
       ssoEnforced: workspace.ssoEnforced,


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dust-tt/dust/pull/12989
Enforce no access to internal API if not in a plan

## Tests

Covered by logging. Tests updated

https://app.datadoghq.eu/logs?query=%22workspace_can_use_product_required_error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1748288583722&to_ts=1748374983722&live=true

(all logs are mine)

## Risk

Low since we logged first and ensured we don't block any crucial API route.

## Deploy Plan

- deploy `front`