### PR TITLE
Fix: get the right personal connection

### DIFF
--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -162,6 +162,10 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
           ? { remoteMCPServerId: id }
           : { internalMCPServerId: mcpServerId }),
         connectionType,
+        userId:
+          connectionType === "personal"
+            ? auth.getNonNullableUser().id
+            : undefined,
       },
       // Only returns the latest connection for a given MCP server.
       order: [["createdAt", "DESC"]],


### PR DESCRIPTION
## Description

Fix that we were not retrieving the correct personal connection.

## Tests

Local (will add)

## Risk

Low

## Deploy Plan

Deploy `front`
