### PR TITLE
[assistant] - refactor: streamline AssistantDetails component structure

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -25,6 +25,7 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useEffect, useState } from "react";
 
 import { AssistantDetailsButtonBar } from "@app/components/assistant/AssistantDetailsButtonBar";
+import { AssistantDetailsPerformance } from "@app/components/assistant/AssistantDetailsPerformance";
 import { AssistantKnowledgeSection } from "@app/components/assistant/details/AssistantKnowledgeSection";
 import { AssistantToolsSection } from "@app/components/assistant/details/AssistantToolsSection";
 import { AssistantUsageSection } from "@app/components/assistant/details/AssistantUsageSection";
@@ -43,7 +44,6 @@ import { GLOBAL_AGENTS_SID, isAdmin } from "@app/types";
 
 import { AddEditorDropdown } from "../members/AddEditorsDropdown";
 import { MembersList } from "../members/MembersList";
-import { AssistantDetailsPerformance } from "@app/components/assistant/AssistantDetailsPerformance";
 
 export const SCOPE_INFO: Record<
   AgentConfigurationScope,

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -3,18 +3,9 @@ import {
   Avatar,
   BarChartIcon,
   Button,
-  CardGrid,
-  ChatBubbleLeftRightIcon,
-  ChatBubbleThoughtIcon,
   Chip,
   ContentMessage,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   DustIcon,
-  HandThumbDownIcon,
-  HandThumbUpIcon,
   InformationCircleIcon,
   LockIcon,
   Page,
@@ -29,7 +20,6 @@ import {
   TabsList,
   TabsTrigger,
   UserGroupIcon,
-  ValueCard,
 } from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useEffect, useState } from "react";
@@ -40,11 +30,7 @@ import { AssistantToolsSection } from "@app/components/assistant/details/Assista
 import { AssistantUsageSection } from "@app/components/assistant/details/AssistantUsageSection";
 import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import { RestoreAssistantDialog } from "@app/components/assistant/RestoreAssistantDialog";
-import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
-import {
-  useAgentAnalytics,
-  useAgentConfiguration,
-} from "@app/lib/swr/assistants";
+import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useEditors, useUpdateEditors } from "@app/lib/swr/editors";
 import type {
   AgentConfigurationScope,
@@ -53,10 +39,11 @@ import type {
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
-import { GLOBAL_AGENTS_SID, isAdmin, removeNulls } from "@app/types";
+import { GLOBAL_AGENTS_SID, isAdmin } from "@app/types";
 
 import { AddEditorDropdown } from "../members/AddEditorsDropdown";
 import { MembersList } from "../members/MembersList";
+import { AssistantDetailsPerformance } from "@app/components/assistant/AssistantDetailsPerformance";
 
 export const SCOPE_INFO: Record<
   AgentConfigurationScope,
@@ -88,12 +75,6 @@ export const SCOPE_INFO: Record<
     text: "Visible agents.",
   },
 } as const;
-
-const PERIODS = [
-  { value: 7, label: "Last 7 days" },
-  { value: 15, label: "Last 15 days" },
-  { value: 30, label: "Last 30 days" },
-];
 
 type AssistantDetailsProps = {
   owner: WorkspaceType;
@@ -149,166 +130,6 @@ function AssistantDetailsInfo({
         agentConfiguration={agentConfiguration}
         owner={owner}
       />
-    </>
-  );
-}
-
-function AssistantDetailsPerformance({
-  agentConfiguration,
-  owner,
-}: {
-  agentConfiguration: AgentConfigurationType;
-  owner: WorkspaceType;
-}) {
-  const [period, setPeriod] = useState(30);
-  const { agentAnalytics, isAgentAnayticsLoading } = useAgentAnalytics({
-    workspaceId: owner.sId,
-    agentConfigurationId: agentConfiguration.sId,
-    period,
-  });
-
-  return (
-    <>
-      <div className="flex flex-row items-center justify-between gap-3">
-        <Page.H variant="h5">Analytics</Page.H>
-        <div className="self-end">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                label={PERIODS.find((p) => p.value === period)?.label}
-                variant="outline"
-                isSelect
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              {PERIODS.map((p) => (
-                <DropdownMenuItem
-                  key={p.value}
-                  label={p.label}
-                  onClick={() => {
-                    setPeriod(p.value);
-                  }}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-
-      {isAgentAnayticsLoading ? (
-        <div className="w-full p-6">
-          <Spinner variant="dark" />
-        </div>
-      ) : (
-        <CardGrid>
-          <ValueCard
-            title="Active Users"
-            content={
-              <div className="heading-lg text-foreground dark:text-foreground-night">
-                <div className="heading-lg flex flex-col gap-1">
-                  {agentAnalytics?.users ? (
-                    <>
-                      <div className="truncate text-foreground dark:text-foreground-night">
-                        {agentAnalytics.users.length}
-                      </div>
-
-                      <Avatar.Stack
-                        size="md"
-                        hasMagnifier={false}
-                        avatars={removeNulls(
-                          agentAnalytics.users.map((top) => top.user)
-                        )
-                          .slice(0, 5)
-                          .map((user) => ({
-                            size: "sm",
-                            name: user.fullName,
-                            visual: user.image,
-                          }))}
-                      />
-                    </>
-                  ) : (
-                    "-"
-                  )}
-                </div>
-              </div>
-            }
-            className="h-32"
-          />
-
-          <ValueCard
-            title="Reactions"
-            content={
-              <div className="heading-lg flex flex-row gap-2">
-                {agentConfiguration.scope !== "global" &&
-                agentAnalytics?.feedbacks ? (
-                  <>
-                    <div className="flex flex-row items-center">
-                      <div>
-                        <HandThumbUpIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
-                      </div>
-                      <div>{agentAnalytics.feedbacks.positiveFeedbacks}</div>
-                    </div>
-                    <div className="flex flex-row items-center">
-                      <div>
-                        <HandThumbDownIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
-                      </div>
-                      <div>{agentAnalytics.feedbacks.negativeFeedbacks}</div>
-                    </div>
-                  </>
-                ) : (
-                  "-"
-                )}
-              </div>
-            }
-            className="h-32"
-          />
-          <ValueCard
-            title="Conversations"
-            content={
-              <div className="heading-lg flex flex-row gap-2">
-                <div className="flex flex-row items-center">
-                  <div>
-                    <ChatBubbleLeftRightIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
-                  </div>
-                  <div>
-                    {agentAnalytics?.mentions
-                      ? `${agentAnalytics.mentions.conversationCount}`
-                      : "-"}
-                  </div>
-                </div>
-              </div>
-            }
-            className="h-32"
-          />
-          <ValueCard
-            title="Messages"
-            content={
-              <div className="heading-lg flex flex-row gap-2">
-                <div className="flex flex-row items-center">
-                  <div>
-                    <ChatBubbleThoughtIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
-                  </div>
-                  <div>
-                    {agentAnalytics?.mentions
-                      ? `${agentAnalytics.mentions.messageCount}`
-                      : "-"}
-                  </div>
-                </div>
-              </div>
-            }
-            className="h-32"
-          />
-        </CardGrid>
-      )}
-      {agentConfiguration.scope !== "global" && (
-        <div>
-          <Page.SectionHeader title="Feedback" />
-          <FeedbacksSection
-            owner={owner}
-            agentConfigurationId={agentConfiguration.sId}
-          />
-        </div>
-      )}
     </>
   );
 }
@@ -544,6 +365,7 @@ export function AssistantDetails({
                     <AssistantDetailsPerformance
                       agentConfiguration={agentConfiguration}
                       owner={owner}
+                      gridMode={false}
                     />
                   )}
                   {showEditorsTabs && selectedTab === "editors" && (

--- a/front/components/assistant/AssistantDetailsPerformance.tsx
+++ b/front/components/assistant/AssistantDetailsPerformance.tsx
@@ -1,8 +1,3 @@
-import type { AgentConfigurationType } from "@app/types";
-import type { WorkspaceType } from "@app/types";
-import { removeNulls } from "@app/types";
-import { useState } from "react";
-import { useAgentAnalytics } from "@app/lib/swr/assistants";
 import { Page } from "@dust-tt/sparkle";
 import { DropdownMenu } from "@dust-tt/sparkle";
 import { DropdownMenuTrigger } from "@dust-tt/sparkle";
@@ -17,7 +12,13 @@ import { HandThumbUpIcon } from "@dust-tt/sparkle";
 import { HandThumbDownIcon } from "@dust-tt/sparkle";
 import { ChatBubbleLeftRightIcon } from "@dust-tt/sparkle";
 import { ChatBubbleThoughtIcon } from "@dust-tt/sparkle";
+import { useState } from "react";
+
 import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
+import { useAgentAnalytics } from "@app/lib/swr/assistants";
+import type { AgentConfigurationType } from "@app/types";
+import type { WorkspaceType } from "@app/types";
+import { removeNulls } from "@app/types";
 
 const PERIODS = [
   { value: 7, label: "Last 7 days" },

--- a/front/components/assistant/AssistantDetailsPerformance.tsx
+++ b/front/components/assistant/AssistantDetailsPerformance.tsx
@@ -26,15 +26,17 @@ const PERIODS = [
   { value: 30, label: "Last 30 days" },
 ];
 
+interface AssistantDetailsPerformanceProps {
+  agentConfiguration: AgentConfigurationType;
+  owner: WorkspaceType;
+  gridMode: boolean;
+}
+
 export function AssistantDetailsPerformance({
   agentConfiguration,
   owner,
   gridMode,
-}: {
-  agentConfiguration: AgentConfigurationType;
-  owner: WorkspaceType;
-  gridMode: boolean;
-}) {
+}: AssistantDetailsPerformanceProps) {
   const [period, setPeriod] = useState(30);
   const { agentAnalytics, isAgentAnayticsLoading } = useAgentAnalytics({
     workspaceId: owner.sId,

--- a/front/components/assistant/AssistantDetailsPerformance.tsx
+++ b/front/components/assistant/AssistantDetailsPerformance.tsx
@@ -1,0 +1,189 @@
+import type { AgentConfigurationType } from "@app/types";
+import type { WorkspaceType } from "@app/types";
+import { removeNulls } from "@app/types";
+import { useState } from "react";
+import { useAgentAnalytics } from "@app/lib/swr/assistants";
+import { Page } from "@dust-tt/sparkle";
+import { DropdownMenu } from "@dust-tt/sparkle";
+import { DropdownMenuTrigger } from "@dust-tt/sparkle";
+import { Button } from "@dust-tt/sparkle";
+import { DropdownMenuContent } from "@dust-tt/sparkle";
+import { DropdownMenuItem } from "@dust-tt/sparkle";
+import { Spinner } from "@dust-tt/sparkle";
+import { CardGrid } from "@dust-tt/sparkle";
+import { ValueCard } from "@dust-tt/sparkle";
+import { Avatar } from "@dust-tt/sparkle";
+import { HandThumbUpIcon } from "@dust-tt/sparkle";
+import { HandThumbDownIcon } from "@dust-tt/sparkle";
+import { ChatBubbleLeftRightIcon } from "@dust-tt/sparkle";
+import { ChatBubbleThoughtIcon } from "@dust-tt/sparkle";
+import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
+
+const PERIODS = [
+  { value: 7, label: "Last 7 days" },
+  { value: 15, label: "Last 15 days" },
+  { value: 30, label: "Last 30 days" },
+];
+
+export function AssistantDetailsPerformance({
+  agentConfiguration,
+  owner,
+  gridMode,
+}: {
+  agentConfiguration: AgentConfigurationType;
+  owner: WorkspaceType;
+  gridMode: boolean;
+}) {
+  const [period, setPeriod] = useState(30);
+  const { agentAnalytics, isAgentAnayticsLoading } = useAgentAnalytics({
+    workspaceId: owner.sId,
+    agentConfigurationId: agentConfiguration.sId,
+    period,
+  });
+
+  return (
+    <>
+      <div className="flex flex-row items-center justify-between gap-3">
+        <Page.H variant="h5">Analytics</Page.H>
+        <div className="self-end">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                label={PERIODS.find((p) => p.value === period)?.label}
+                variant="outline"
+                isSelect
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {PERIODS.map((p) => (
+                <DropdownMenuItem
+                  key={p.value}
+                  label={p.label}
+                  onClick={() => {
+                    setPeriod(p.value);
+                  }}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {isAgentAnayticsLoading ? (
+        <div className="w-full p-6">
+          <Spinner variant="dark" />
+        </div>
+      ) : (
+        <CardGrid>
+          <ValueCard
+            title="Active Users"
+            content={
+              <div className="heading-lg text-foreground dark:text-foreground-night">
+                <div className="heading-lg flex flex-col gap-1">
+                  {agentAnalytics?.users ? (
+                    <>
+                      <div className="truncate text-foreground dark:text-foreground-night">
+                        {agentAnalytics.users.length}
+                      </div>
+
+                      <Avatar.Stack
+                        size="md"
+                        hasMagnifier={false}
+                        avatars={removeNulls(
+                          agentAnalytics.users.map((top) => top.user)
+                        )
+                          .slice(0, 5)
+                          .map((user) => ({
+                            size: "sm",
+                            name: user.fullName,
+                            visual: user.image,
+                          }))}
+                      />
+                    </>
+                  ) : (
+                    "-"
+                  )}
+                </div>
+              </div>
+            }
+            className="h-32"
+          />
+
+          <ValueCard
+            title="Reactions"
+            content={
+              <div className="heading-lg flex flex-row gap-2">
+                {agentConfiguration.scope !== "global" &&
+                agentAnalytics?.feedbacks ? (
+                  <>
+                    <div className="flex flex-row items-center">
+                      <div>
+                        <HandThumbUpIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
+                      </div>
+                      <div>{agentAnalytics.feedbacks.positiveFeedbacks}</div>
+                    </div>
+                    <div className="flex flex-row items-center">
+                      <div>
+                        <HandThumbDownIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
+                      </div>
+                      <div>{agentAnalytics.feedbacks.negativeFeedbacks}</div>
+                    </div>
+                  </>
+                ) : (
+                  "-"
+                )}
+              </div>
+            }
+            className="h-32"
+          />
+          <ValueCard
+            title="Conversations"
+            content={
+              <div className="heading-lg flex flex-row gap-2">
+                <div className="flex flex-row items-center">
+                  <div>
+                    <ChatBubbleLeftRightIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
+                  </div>
+                  <div>
+                    {agentAnalytics?.mentions
+                      ? `${agentAnalytics.mentions.conversationCount}`
+                      : "-"}
+                  </div>
+                </div>
+              </div>
+            }
+            className="h-32"
+          />
+          <ValueCard
+            title="Messages"
+            content={
+              <div className="heading-lg flex flex-row gap-2">
+                <div className="flex flex-row items-center">
+                  <div>
+                    <ChatBubbleThoughtIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
+                  </div>
+                  <div>
+                    {agentAnalytics?.mentions
+                      ? `${agentAnalytics.mentions.messageCount}`
+                      : "-"}
+                  </div>
+                </div>
+              </div>
+            }
+            className="h-32"
+          />
+        </CardGrid>
+      )}
+      {agentConfiguration.scope !== "global" && (
+        <div>
+          <Page.SectionHeader title="Feedback" />
+          <FeedbacksSection
+            owner={owner}
+            agentConfigurationId={agentConfiguration.sId}
+            gridMode={gridMode}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -74,7 +74,7 @@ export default function AssistantBuilder({
   subscription,
   plan,
   initialBuilderState,
-  agentConfigurationId,
+  agentConfiguration,
   flow,
   defaultIsEdited,
   baseUrl,
@@ -175,7 +175,7 @@ export default function AssistantBuilder({
     isPrivateAssistant: builderState.scope === "hidden",
     isBuilder: isBuilder(owner),
     isEdited: edited,
-    agentConfigurationId,
+    agentConfigurationId: agentConfiguration?.sId ?? null,
   });
   useNavigationLock(edited && !disableUnsavedChangesPrompt);
   const { mcpServerViews, isPreviewPanelOpen, setIsPreviewPanelOpen } =
@@ -189,14 +189,14 @@ export default function AssistantBuilder({
     if (isUserError || isUserLoading || !user) {
       return;
     }
-    if (agentConfigurationId && initialBuilderState) {
+    if (agentConfiguration?.sId && initialBuilderState) {
       assert(
         isAdmin(owner) ||
           initialBuilderState.editors.some((m) => m.sId === user.sId),
         "Unreachable: User is not in editors nor admin"
       );
     }
-    if (!agentConfigurationId) {
+    if (!agentConfiguration?.sId) {
       setBuilderState((state) => ({
         ...state,
         editors: state.editors.some((m) => m.sId === user.sId)
@@ -209,7 +209,7 @@ export default function AssistantBuilder({
     isUserError,
     user,
     owner,
-    agentConfigurationId,
+    agentConfiguration?.sId,
     initialBuilderState,
   ]);
 
@@ -330,7 +330,7 @@ export default function AssistantBuilder({
       const res = await submitAssistantBuilderForm({
         owner,
         builderState,
-        agentConfigurationId,
+        agentConfigurationId: agentConfiguration?.sId ?? null,
         slackData: {
           selectedSlackChannels: selectedSlackChannels || [],
           slackChannelsLinkedWithAgent,
@@ -369,7 +369,7 @@ export default function AssistantBuilder({
     Boolean(template !== null && builderState.instructions)
   );
 
-  const modalTitle = agentConfigurationId
+  const modalTitle = agentConfiguration
     ? `Edit @${builderState.handle}`
     : "New Agent";
 
@@ -461,7 +461,9 @@ export default function AssistantBuilder({
                             instructionsError={instructionsError}
                             doTypewriterEffect={doTypewriterEffect}
                             setDoTypewriterEffect={setDoTypewriterEffect}
-                            agentConfigurationId={agentConfigurationId}
+                            agentConfigurationId={
+                              agentConfiguration?.sId ?? null
+                            }
                             models={models}
                             setIsInstructionDiffMode={setIsInstructionDiffMode}
                             isInstructionDiffMode={isInstructionDiffMode}
@@ -482,7 +484,9 @@ export default function AssistantBuilder({
                       case "settings":
                         return (
                           <SettingsScreen
-                            agentConfigurationId={agentConfigurationId}
+                            agentConfigurationId={
+                              agentConfiguration?.sId ?? null
+                            }
                             baseUrl={baseUrl}
                             owner={owner}
                             builderState={builderState}
@@ -526,7 +530,7 @@ export default function AssistantBuilder({
               }}
               owner={owner}
               builderState={builderState}
-              agentConfigurationId={agentConfigurationId}
+              agentConfiguration={agentConfiguration}
               setAction={setAction}
               reasoningModels={reasoningModels}
             />

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -19,6 +19,7 @@ import {
 import { Separator } from "@radix-ui/react-select";
 import { useContext, useEffect, useRef, useState } from "react";
 
+import { AssistantDetailsPerformance } from "@app/components/assistant/AssistantDetailsPerformance";
 import { ActionValidationProvider } from "@app/components/assistant/conversation/ActionValidationProvider";
 import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
@@ -44,9 +45,8 @@ import type {
   ModelConfigurationType,
   WorkspaceType,
 } from "@app/types";
-import { isAssistantBuilderRightPanelTab } from "@app/types";
 import type { AgentConfigurationType } from "@app/types";
-import { AssistantDetailsPerformance } from "@app/components/assistant/AssistantDetailsPerformance";
+import { isAssistantBuilderRightPanelTab } from "@app/types";
 
 interface AssistantBuilderRightPanelProps {
   screen: BuilderScreen;

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -24,7 +24,6 @@ import { ConversationsNavigationProvider } from "@app/components/assistant/conve
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
 import {
   usePreviewAssistant,
   useTryAssistantCore,
@@ -46,6 +45,8 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { isAssistantBuilderRightPanelTab } from "@app/types";
+import type { AgentConfigurationType } from "@app/types";
+import { AssistantDetailsPerformance } from "@app/components/assistant/AssistantDetailsPerformance";
 
 interface AssistantBuilderRightPanelProps {
   screen: BuilderScreen;
@@ -55,7 +56,7 @@ interface AssistantBuilderRightPanelProps {
   resetToTemplateActions: () => Promise<void>;
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
-  agentConfigurationId: string | null;
+  agentConfiguration: AgentConfigurationType | null;
   setAction: (action: AssistantBuilderSetActionType) => void;
   reasoningModels: ModelConfigurationType[];
 }
@@ -68,7 +69,7 @@ export default function AssistantBuilderRightPanel({
   resetToTemplateActions,
   owner,
   builderState,
-  agentConfigurationId,
+  agentConfiguration,
   setAction,
   reasoningModels,
 }: AssistantBuilderRightPanelProps) {
@@ -129,7 +130,7 @@ export default function AssistantBuilderRightPanel({
               icon={ChatBubbleBottomCenterTextIcon}
             />
             {/* The agentConfigurationId is truthy if not a new agent */}
-            {agentConfigurationId && (
+            {agentConfiguration && (
               <TabsTrigger
                 value="Performance"
                 label="Performance"
@@ -264,12 +265,11 @@ export default function AssistantBuilderRightPanel({
             </div>
           </div>
         )}
-        {rightPanelTab === "Performance" && agentConfigurationId && (
-          <div className="ml-4 mt-4">
-            <Page.SectionHeader title="Feedback" />
-            <FeedbacksSection
+        {rightPanelTab === "Performance" && agentConfiguration && (
+          <div className="flex flex-col gap-5 pt-6 text-sm text-foreground dark:text-foreground-night">
+            <AssistantDetailsPerformance
+              agentConfiguration={agentConfiguration}
               owner={owner}
-              agentConfigurationId={agentConfigurationId}
               gridMode
             />
           </div>

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -38,12 +38,12 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
+import type { AgentConfigurationType } from "@app/types";
 import {
   assertNever,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
   DEFAULT_MAX_STEPS_USE_PER_RUN,
 } from "@app/types";
-import type { AgentConfigurationType } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
 export const ACTION_MODES = [

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -43,6 +43,7 @@ import {
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
   DEFAULT_MAX_STEPS_USE_PER_RUN,
 } from "@app/types";
+import type { AgentConfigurationType } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
 export const ACTION_MODES = [
@@ -515,7 +516,7 @@ export const BUILDER_FLOWS = [
 export type BuilderFlow = (typeof BUILDER_FLOWS)[number];
 
 export type AssistantBuilderProps = {
-  agentConfigurationId: string | null;
+  agentConfiguration: AgentConfigurationType | null;
   baseUrl: string;
   defaultIsEdited?: boolean;
   defaultTemplate: FetchAssistantTemplateResponse | null;

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -195,7 +195,7 @@ export default function EditAssistant({
           tags: agentConfiguration.tags,
           editors: agentEditors,
         }}
-        agentConfigurationId={agentConfiguration.sId}
+        agentConfiguration={agentConfiguration}
         baseUrl={baseUrl}
         defaultTemplate={null}
       />

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -207,7 +207,7 @@ export default function CreateAssistant({
               }
             : null
         }
-        agentConfigurationId={null}
+        agentConfiguration={null}
         defaultIsEdited={assistantTemplate !== null}
         baseUrl={baseUrl}
         defaultTemplate={assistantTemplate}


### PR DESCRIPTION
## Description

This PR aims at making sure that the "Preview" tab in the agent builder is consistent with the assistant details modal.

**References:**
- Report [here](https://dust4ai.slack.com/archives/C07KY510DH7/p1748419253321339)

## Risk

Low

## Deploy Plan

Deploy front