### PR TITLE
[front] Skip query if tag manager is not open

### DIFF
--- a/front/components/assistant/TagsManager.tsx
+++ b/front/components/assistant/TagsManager.tsx
@@ -104,7 +104,7 @@ export type TagsManagerProps = {
 };
 
 export function TagsManager({ open, setOpen, owner }: TagsManagerProps) {
-  const { isTagsLoading, tags } = useTagsUsage({ owner });
+  const { isTagsLoading, tags } = useTagsUsage({ owner, disabled: !open });
   const [tagActionModal, setTagActionModal] = useState<{
     type: "delete" | "edit";
     tag: TagTypeWithUsage;


### PR DESCRIPTION
## Description

Skip query if tag manager is not open. Not needed as long as tag manager is closed
Query is possible only for admin, manager can opened by admin only 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

non

## Deploy Plan

deploy front
