### PR TITLE
Add selection method when fetching users by email

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -145,7 +145,14 @@ export class UserResource extends BaseResource<UserModel> {
 
   static async fetchByEmail(email: string): Promise<UserResource | null> {
     const users = await this.listByEmail(email.toLowerCase());
-    return users.length > 0 ? users[0] : null;
+    const sortedUsers = users.sort((a, b) => {
+      // Best effort strategy as user db entries are not updated often.
+      return b.updatedAt.getTime() - a.updatedAt.getTime();
+    });
+    const usersWithAuth0Sub = sortedUsers.filter((u) => u.auth0Sub !== null);
+
+    // Most recently updated user with an Auth0 sub if any, otherwise most recently updated user.
+    return usersWithAuth0Sub[0] ?? sortedUsers[0] ?? null;
   }
 
   static async fetchByProvider(


### PR DESCRIPTION
## Description

This PR adds a selection strategy when fetching users by email:
- If we have users with an Auth0 sub, we take the most recently updated one.
- If not, we take the most recently updated one.

This change will ensure that when provisioning users we update the correct one (the one who can actually log in) in cases of conflict.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- No deploy.
