### PR TITLE
Retrieval: tweak rendering in conversation + description

### DIFF
--- a/front/lib/actions/retrieval.ts
+++ b/front/lib/actions/retrieval.ts
@@ -311,7 +311,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
         );
       } else {
         let description =
-          "Retrieve from the data sources the fixed content specified by the user. " +
+          "Retrieve from the data sources the content specified by the user (most recent first). " +
           "This tool does not take any argument.";
         if (
           actionConfiguration.relativeTimeFrame === "auto" ||

--- a/front/lib/actions/retrieval.ts
+++ b/front/lib/actions/retrieval.ts
@@ -149,16 +149,23 @@ export class RetrievalActionType extends BaseAction {
   }
 
   renderForFunctionCall(): FunctionCallType {
-    const timeFrame = this.params.relativeTimeFrame;
-    const params = {
-      query: this.params.query,
-      relativeTimeFrame: timeFrame
-        ? `${timeFrame.duration}${timeFrame.unit}`
-        : "all",
-      topK: this.params.topK,
-      tagsIn: this.params.tagsIn,
-      tagsNot: this.params.tagsNot,
-    };
+    const params: Record<string, any> = {};
+    if (this.params.query) {
+      params.query = this.params.query;
+    }
+    if (this.params.relativeTimeFrame) {
+      const timeFrame = this.params.relativeTimeFrame;
+      params.relativeTimeFrame = `${timeFrame.duration}${timeFrame.unit}`;
+    }
+    if (this.params.topK) {
+      params.topK = this.params.topK;
+    }
+    if (this.params.tagsIn) {
+      params.tagsIn = this.params.tagsIn;
+    }
+    if (this.params.tagsNot) {
+      params.tagsNot = this.params.tagsNot;
+    }
 
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
@@ -304,7 +311,8 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
         );
       } else {
         let description =
-          "Retrieve the most recent content from the data sources specified by the user";
+          "Retrieve from the data sources the fixed content specified by the user. " +
+          "This tool does not take any argument.";
         if (
           actionConfiguration.relativeTimeFrame === "auto" ||
           actionConfiguration.relativeTimeFrame === "none"


### PR DESCRIPTION
## Description

Context here: https://dust4ai.slack.com/archives/C050SM8NSPK/p1748441351037729
Fixes: https://github.com/dust-tt/tasks/issues/3012

We render the full retrieval params when rendering the conversation. Claude 4 is smart enough to understand them and reuse them with the include tool it has even if the specification of the tool says otherwise.

![image](https://github.com/user-attachments/assets/fe3830f6-800c-4b24-89b0-7e81cb7523f5)

Do not render params if we don't have them + tweak to description to tell the model that include does  not take any parameter (we don't have dynamic tags there). This should be fixed by MCP as I believe we record the raw params we saw from the model.

## Tests

N/A minor tweaks

## Risk

Low given change but touches retrieval, but only the function call rendering.

## Deploy Plan

- deploy `front`