### PR TITLE
[MCP Extract] Full output as text in results

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/process.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process.ts
@@ -483,6 +483,12 @@ async function generateProcessToolOutput({
         : `${timeFrame.unit}`)
     : "all time";
 
+  const extractResult =
+    "PROCESSED OUTPUTS:\n" +
+    (outputs?.data && outputs.data.length > 0
+      ? outputs.data.map((d) => JSON.stringify(d)).join("\n")
+      : "(none)");
+
   return {
     jsonFile,
     processToolOutput: {
@@ -505,9 +511,7 @@ async function generateProcessToolOutput({
           type: "resource" as const,
           resource: {
             mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT,
-            text:
-              "This file contains data extracted from available documents according to the provided schema. Here is  a preview of its contents: \n" +
-              generatedFile.snippet,
+            text: extractResult,
             uri: jsonFile.getPublicUrl(auth),
             fileId: generatedFile.fileId,
             title: generatedFile.title,


### PR DESCRIPTION
Description
---
Previously, only a snippet was available, and model was supposed to read the generated file. Turns out model doesn't always want to read the file, and stops at the snippet level, degrading results

Risks
---
low, gated

Deploy
---
front