### PR TITLE
[front] feat(relocation): Add script to read and upload a table chunk

### DIFF
--- a/front/scripts/relocation/read_front_table_chunk.ts
+++ b/front/scripts/relocation/read_front_table_chunk.ts
@@ -1,0 +1,85 @@
+import type { RegionType } from "@app/lib/api/regions/config";
+import {
+  config,
+  isRegionType,
+  SUPPORTED_REGIONS,
+} from "@app/lib/api/regions/config";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { readFrontTableChunk } from "@app/temporal/relocation/activities/source_region/front";
+
+function assertCorrectRegion(region: RegionType) {
+  if (config.getCurrentRegion() !== region) {
+    throw new Error(
+      `Relocation must be run from ${region}. Current region is ${config.getCurrentRegion()}.`
+    );
+  }
+}
+
+makeScript(
+  {
+    destRegion: {
+      type: "string",
+      choices: SUPPORTED_REGIONS,
+      required: true,
+    },
+    lastId: {
+      type: "number",
+    },
+    limit: {
+      type: "number",
+      require: true,
+    },
+    sourceRegion: {
+      type: "string",
+      choices: SUPPORTED_REGIONS,
+    },
+    tableName: {
+      type: "string",
+      required: true,
+    },
+    workspaceId: {
+      type: "string",
+      required: true,
+    },
+  },
+  async ({
+    destRegion,
+    lastId,
+    limit,
+    sourceRegion,
+    tableName,
+    workspaceId,
+    execute,
+  }) => {
+    if (!isRegionType(sourceRegion) || !isRegionType(destRegion)) {
+      logger.error("Invalid region.");
+      return;
+    }
+
+    if (sourceRegion === destRegion) {
+      logger.error("Source and destination regions must be different.");
+      return;
+    }
+
+    assertCorrectRegion(sourceRegion);
+
+    if (execute) {
+      try {
+        const res = await readFrontTableChunk({
+          destRegion,
+          lastId,
+          sourceRegion,
+          tableName,
+          workspaceId,
+          limit,
+        });
+        logger.info(res, "readFrontTableChunk");
+      } catch (err) {
+        logger.error(err);
+      }
+    } else {
+      logger.info("Nothing will be executed");
+    }
+  }
+);


### PR DESCRIPTION
## Description
- During relocation, if the `processFrontTableChunk` gets stuck because of the input data, there is no way to just replay the previous step with new code.
- This adds a script to run the `readFrontTableChunk` from a script, with given parameters, which will re-upload a new file (created with new code) that'll be read by the `processFrontTableChunk`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Only for relocation, so fairly located.

## Deploy Plan
- Deploy front
- Go into front-relocation-worker
- execute script
