### PR TITLE
Stripe: when clicking on 'Cancel now' we redirect to the subscription page not to the paywall

### DIFF
--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -228,7 +228,7 @@ export default function Subscription({
             title: "Free trial cancelled",
             description: "Redirecting...",
           });
-          await router.push(`/w/${owner.sId}/subscribe`);
+          await router.push(`/w/${owner.sId}/subscription`);
         }
       } finally {
         setShowCancelFreeTrialDialog(false);


### PR DESCRIPTION
## Description

There's 2 ways to cancel a trial:
- By going to the Stripe dashboard. 
- By clicking on "Cancel subscription" on our Subscription page. 

This is fixing the second flow. 
Initially when we implemented it we used to cancel now and redirect to the paywall. 

A month ago we decided to cancel at the end of the trialing period (which is fair), was done here: https://github.com/dust-tt/dust/pull/12000/files#diff-7c746e00d7ada8d66e9260d10d832ad6acd8c113a3fc7a0834d5dfba4238b586L163
Small issue is we were still redirecting to the paywall, while the user still has access -> this was not harmful but when we debug this flow it gives the impression the subscription was ended while it was not (I just fixed it in another PR)

-> now you are redirected to the subscription page and you can see the banner with the end date. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 