### PR TITLE
Sparkle: Fix Input margin when message is set without a messageStatus

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.516",
+  "version": "0.2.517",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.516",
+      "version": "0.2.517",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.516",
+  "version": "0.2.517",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -123,7 +123,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         {message && (
           <div
             className={cn(
-              "s-ml-3.5 s-flex s-items-center s-gap-1 s-text-xs",
+              "s-flex s-items-center s-gap-1 s-text-xs",
               messageVariant({ status: messageStatus })
             )}
           >


### PR DESCRIPTION
## Description

Before: 
<kbd>
<img width="1050" alt="Screenshot 2025-05-30 at 10 26 40" src="https://github.com/user-attachments/assets/3564f8d8-6be6-44b8-8825-fc7646d7f719" />
</kbd>

After: 
<kbd>
<img width="1057" alt="Screenshot 2025-05-30 at 10 25 49" src="https://github.com/user-attachments/assets/c2b9ad07-bb33-4c8e-8bc1-d85219b6ecd8" />
</kbd>


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
