### PR TITLE
add optional filename to read table chunk

### DIFF
--- a/front/scripts/relocation/read_front_table_chunk.ts
+++ b/front/scripts/relocation/read_front_table_chunk.ts
@@ -42,6 +42,9 @@ makeScript(
       type: "string",
       required: true,
     },
+    fileName: {
+      type: "string",
+    },
   },
   async ({
     destRegion,
@@ -50,6 +53,7 @@ makeScript(
     sourceRegion,
     tableName,
     workspaceId,
+    fileName,
     execute,
   }) => {
     if (!isRegionType(sourceRegion) || !isRegionType(destRegion)) {
@@ -73,6 +77,7 @@ makeScript(
           tableName,
           workspaceId,
           limit,
+          fileName,
         });
         logger.info(res, "readFrontTableChunk");
       } catch (err) {

--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -150,6 +150,7 @@ export async function readFrontTableChunk({
   sourceRegion,
   tableName,
   workspaceId,
+  fileName,
 }: ReadTableChunkParams) {
   const localLogger = logger.child({
     destRegion,
@@ -157,6 +158,7 @@ export async function readFrontTableChunk({
     sourceRegion,
     tableName,
     workspaceId,
+    fileName,
   });
 
   localLogger.info("[SQL Table] Reading table chunk");
@@ -190,6 +192,7 @@ export async function readFrontTableChunk({
     workspaceId,
     type: "front",
     operation: `read_table_chunk_${tableName}`,
+    fileName,
   });
 
   localLogger.info(

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -24,6 +24,7 @@ export interface ReadTableChunkParams {
   sourceRegion: RegionType;
   tableName: string;
   workspaceId: string;
+  fileName?: string;
 }
 
 export const CORE_API_CONCURRENCY_LIMIT = 48;

--- a/front/temporal/relocation/lib/file_storage/relocation.ts
+++ b/front/temporal/relocation/lib/file_storage/relocation.ts
@@ -8,15 +8,17 @@ interface RelocationStorageOptions {
   workspaceId: string;
   type: "front" | "connectors" | "core";
   operation: string;
+  /** Default to timestamps, can be overrided */
+  fileName?: string;
 }
 
 // In prod, we use pod annotations to set the service account.
 export async function writeToRelocationStorage(
   data: unknown,
-  { workspaceId, type, operation }: RelocationStorageOptions
+  { workspaceId, type, operation, fileName }: RelocationStorageOptions
 ): Promise<string> {
   const timestamp = Date.now();
-  const path = `${RELOCATION_PATH_PREFIX}/${workspaceId}/${type}/${operation}/${timestamp}.json`;
+  const path = `${RELOCATION_PATH_PREFIX}/${workspaceId}/${type}/${operation}/${fileName ?? timestamp}.json`;
 
   const relocationBucket = getBucketInstance(config.getGcsRelocationBucket(), {
     useServiceAccount: isDevelopment(),


### PR DESCRIPTION
## Description
- To complete https://github.com/dust-tt/dust/pull/13023
- Add a missing `fileName` option, as by default `readFrontTableChunk`  will use the current timestamp as a filename, but because we use that script to replay a previous workflow run, we want to customize that filename to fit the previous run.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Only for relocation

## Deploy Plan
- Deploy front
- execute script
