### PR TITLE
Subscription end date: display the banner only if ends in < 60 days + display it on subscription page

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -74,12 +74,17 @@ export const NavigationSidebar = React.forwardRef<
     [navs, activePath]
   );
 
+  // We display the banner if the end date is in 60 days or less.
+  const endDate = subscription.endDate;
+  const shouldDisplaySubscriptionEndBanner =
+    endDate && endDate < Date.now() + 60 * 24 * 60 * 60 * 1000;
+
   return (
     <div ref={ref} className="flex min-w-0 grow flex-col">
       <div className="flex flex-col gap-2 pt-3">
         <AppStatusBanner />
-        {subscription.endDate && (
-          <SubscriptionEndBanner endDate={subscription.endDate} />
+        {shouldDisplaySubscriptionEndBanner && endDate && (
+          <SubscriptionEndBanner endDate={endDate} />
         )}
         {subscription.paymentFailingSince && isAdmin(owner) && (
           <SubscriptionPastDueBanner />

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   CardIcon,
   Chip,
+  ContentMessage,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -249,6 +250,14 @@ export default function Subscription({
 
   const displayPricingTable = subscription.stripeSubscriptionId === null;
 
+  const endDate = subscription.endDate
+    ? new Date(subscription.endDate).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : null;
+
   return (
     <AppContentLayout
       subscription={subscription}
@@ -286,6 +295,26 @@ export default function Subscription({
         />
         <Page.Vertical align="stretch" gap="md">
           <Page.H variant="h5">Your plan </Page.H>
+
+          {endDate && (
+            <ContentMessage
+              title={`Your subscription ends on ${endDate}.`}
+              variant="warning"
+            >
+              <>
+                Connections will be deleted and members will be revoked. Details{" "}
+                <Link
+                  href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
+                  target="_blank"
+                  className="underline"
+                >
+                  here
+                </Link>
+                .
+              </>
+            </ContentMessage>
+          )}
+
           <div>
             {isWebhookProcessing ? (
               <Spinner />


### PR DESCRIPTION
## Description

- We display the banner on the sidebar only if ends in < 60 days + display it on subscription page
- On the subscription page we display a content message if there is an end date. 

<kbd>
<img width="699" alt="Screenshot 2025-05-30 at 11 51 32" src="https://github.com/user-attachments/assets/6568a9ce-600f-4fb4-b18f-786b918d7840" />
</kbd>

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
