### PR TITLE
fix: Map missing templateId when relocation

### DIFF
--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -201,11 +201,11 @@ export async function readFrontTableChunk({
       75: 274877906951, // legalReview
     };
 
-    rows.forEach((row: any) => {
-      if (row.templateId && templateIdMapping[row.templateId]) {
+    for (const row of rows as [{ id: ModelId; templateId: number | null }]) {
+      if (row.templateId != null && templateIdMapping[row.templateId]) {
         row.templateId = templateIdMapping[row.templateId];
       }
-    });
+    }
   }
 
   const blob: RelocationBlob = {

--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -180,6 +180,34 @@ export async function readFrontTableChunk({
     }
   );
 
+  // Apply template ID mapping for agent_configurations
+  // because some templates have a different ID in EU region
+  if (
+    tableName === "agent_configurations" &&
+    sourceRegion === "us-central1" &&
+    destRegion === "europe-west1"
+  ) {
+    const templateIdMapping: Record<number, number> = {
+      64: 274877906952, // prospectQuestions
+      65: 274877906944, // accountSnapshot
+      66: 274877906953, // research
+      68: 274877906957, // discoveryPrep
+      69: 274877906948, // docBuilder
+      70: 274877906954, // ticketClassify
+      71: 274877906958, // incidentCommunication
+      72: 274877906956, // dataCatalogExplorer
+      73: 274877906950, // ITHelpDesk
+      74: 274877906955, // askLegal
+      75: 274877906951, // legalReview
+    };
+
+    rows.forEach((row: any) => {
+      if (row.templateId && templateIdMapping[row.templateId]) {
+        row.templateId = templateIdMapping[row.templateId];
+      }
+    });
+  }
+
   const blob: RelocationBlob = {
     statements: {
       [tableName]: generateParameterizedInsertStatements(tableName, rows, {

--- a/front/temporal/relocation/lib/file_storage/relocation.ts
+++ b/front/temporal/relocation/lib/file_storage/relocation.ts
@@ -18,6 +18,7 @@ export async function writeToRelocationStorage(
   { workspaceId, type, operation, fileName }: RelocationStorageOptions
 ): Promise<string> {
   const timestamp = Date.now();
+  // default to timestamp if custom fileName if not provided
   const path = `${RELOCATION_PATH_PREFIX}/${workspaceId}/${type}/${operation}/${fileName ?? timestamp}.json`;
 
   const relocationBucket = getBucketInstance(config.getGcsRelocationBucket(), {


### PR DESCRIPTION
## Description
- Some templates doesn't have the same ID between US & EU
- Add a mapping function when moving agent_configurations from US to EU to get new IDs

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Relocation only, if wrong, would just put the wrong template in the agent.

## Deploy Plan
- Deploy front
- execute script
