### PR TITLE
enh(Confluence): Log retry-after alongside rate limit headers

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -253,7 +253,10 @@ function logRateLimitHeaders(
 ) {
   const rateLimitHeaders: Record<string, string> = {};
   response.headers.forEach((value, key) => {
-    if (key.toLowerCase().startsWith("x-ratelimit")) {
+    if (
+      key.toLowerCase().startsWith("x-ratelimit") ||
+      key.toLowerCase() === "retry-after"
+    ) {
       rateLimitHeaders[key] = value;
     }
   });


### PR DESCRIPTION
## Description

- This PR adds the `reset-after` value to the log on rate limit headers.
- Goal is to compare `now + reset-after` with the reset date.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
