### PR TITLE
[front] fix(stream): handle end-of-stream events

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -77,6 +77,10 @@ interface AgentMessageProps {
   user: UserType;
 }
 
+type AgentMessageStateWithControlEvent =
+  | AgentMessageStateEvent
+  | { type: "end-of-stream" };
+
 function makeInitialMessageStreamState(
   message: LightAgentMessageType
 ): MessageTemporaryState {
@@ -162,7 +166,7 @@ export function AgentMessage({
     (eventStr: string) => {
       const eventPayload: {
         eventId: string;
-        data: AgentMessageStateEvent;
+        data: AgentMessageStateWithControlEvent;
       } = JSON.parse(eventStr);
 
       // Handle validation dialog separately.
@@ -177,6 +181,10 @@ export function AgentMessage({
           metadata: eventPayload.data.metadata,
         });
 
+        return;
+      }
+
+      if (eventPayload.data.type === "end-of-stream") {
         return;
       }
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -184,6 +184,9 @@ export function AgentMessage({
         return;
       }
 
+      // This event is emmited in front/lib/api/assistant/pubsub.ts. It's purpose is to signal the
+      // end of the stream to the client. The message reducer does not, and should not, handle this
+      // event, so we just return.
       if (eventPayload.data.type === "end-of-stream") {
         return;
       }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Should close https://github.com/dust-tt/tasks/issues/3014

TypeScript error in production when agent messages completed:
`Error: {"type":"end-of-stream"} is not of type never. This should never happen.`
The `AgentMessage` component received `end-of-stream` control events that weren't in the `AgentMessageStateEvent` union, causing the exhaustive type check in the message reducer to fail.

=> Root Cause
`addEndOfStreamToMessageChannel()` publishes control events to signal stream termination. While `getMessagesEvents` filters these out, the `AgentMessage` component's event handler was dispatching them directly to the reducer.
Those events were not in the `event.type` enum, but were still happening here, we refrain them from reaching that point.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, added logs to see where the `end-of-stream` where going. Returned before dispatching them to the reducer to prevent the `assertNever`. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Easy and safe to rollback if needed.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.