### PR TITLE
enh(Confluence): Add a multiplier on the retry after

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -201,7 +201,7 @@ const NO_RETRY_AFTER_DELAY = -1;
 // Number of times we retry when rate limited and Confluence does provide a retry-after header.
 const MAX_RATE_LIMIT_RETRY_COUNT = 5;
 // We take some margin on the value provided for the retry-after.
-const RETRY_AFTER_MULTIPLIER = 1.5;
+const RETRY_AFTER_JITTER = 30_000; // 30 seconds
 // If Confluence returns a retry-after header with a delay greater than this value, we cap it.
 const MAX_RETRY_AFTER_DELAY = 300_000; // 5 minutes
 // If Confluence indicates that we are approaching the rate limit, we delay by this value.
@@ -422,7 +422,8 @@ export class ConfluenceClient {
 
         if (delayMs !== NO_RETRY_AFTER_DELAY) {
           // Server provided a delay (relevant for Case 2 or if retries exhausted).
-          retryAfterMsForTemporal = delayMs * RETRY_AFTER_MULTIPLIER;
+          retryAfterMsForTemporal =
+            delayMs + Math.random() * RETRY_AFTER_JITTER;
           if (retryCount >= MAX_RATE_LIMIT_RETRY_COUNT) {
             logReason = `Activity retries exhausted. Server suggested delay ${delayMs}ms.`;
           } else {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -200,6 +200,8 @@ const THROTTLE_TRIGGER_RATIO = 0.3;
 const NO_RETRY_AFTER_DELAY = -1;
 // Number of times we retry when rate limited and Confluence does provide a retry-after header.
 const MAX_RATE_LIMIT_RETRY_COUNT = 5;
+// We take some margin on the value provided for the retry-after.
+const RETRY_AFTER_MULTIPLIER = 1.5;
 // If Confluence returns a retry-after header with a delay greater than this value, we cap it.
 const MAX_RETRY_AFTER_DELAY = 300_000; // 5 minutes
 // If Confluence indicates that we are approaching the rate limit, we delay by this value.
@@ -420,7 +422,7 @@ export class ConfluenceClient {
 
         if (delayMs !== NO_RETRY_AFTER_DELAY) {
           // Server provided a delay (relevant for Case 2 or if retries exhausted).
-          retryAfterMsForTemporal = delayMs;
+          retryAfterMsForTemporal = delayMs * RETRY_AFTER_MULTIPLIER;
           if (retryCount >= MAX_RATE_LIMIT_RETRY_COUNT) {
             logReason = `Activity retries exhausted. Server suggested delay ${delayMs}ms.`;
           } else {


### PR DESCRIPTION
## Description

This PR adds some jitter on the value received for the retry-after, up to 30 seconds (typical values for the retry after are 1 min, 5 min and 2k seconds.

This is an experiment, will possibly be rollbacked.

This multiplier works on the assumption that the rate limits implements some form of exponential backoff, highly penalizing rate limit hits and resulting in a sawtooth shape on the distribution of the retry after value for a given connector. The jitter serves two purposes here: it is only additive so it delays the request a bit instead of staying too tight with regard to the retry after provided, and it prevents a thundering herd; we're under the impression that the rate limit is shared between connectors to some extent. The goal is to never trigger their rate limiting in the first place, because once we do, we're in that penalty escalation cycle we're seeing.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
