### PR TITLE
[front] fix(agent): Use result err when throwing an error

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1064,7 +1064,7 @@ export async function createAgentConfiguration(
     if (error instanceof SyntaxError) {
       return new Err(new Error(error.message));
     }
-    throw error;
+    return new Err(normalizeError(error));
   }
 }
 


### PR DESCRIPTION
## Description
- When throwing an error when creating an agent configuration, return an `Err` for know error. This avoid sending a 500.

## Tests
- Locally

## Risk
- Low

## Deploy Plan
- Deploy front
