### PR TITLE
enh(Confluence): remove throttling on near rate limits

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -237,15 +237,20 @@ function getRetryAfterDuration(response: Response): number {
 }
 
 function checkNearRateLimit(response: Response): boolean {
-  const nearLimit = response.headers.get(RATE_LIMIT_HEADERS.nearLimit);
-  const remaining = response.headers.get(RATE_LIMIT_HEADERS.remaining);
-  const limit = response.headers.get(RATE_LIMIT_HEADERS.limit);
+  const nearLimitHeader = response.headers.get(RATE_LIMIT_HEADERS.nearLimit);
+  const remainingHeader = response.headers.get(RATE_LIMIT_HEADERS.remaining);
+  const limitHeader = response.headers.get(RATE_LIMIT_HEADERS.limit);
+
+  const remaining = remainingHeader ? parseInt(remainingHeader, 10) : null;
+  const limit = limitHeader ? parseInt(limitHeader, 10) : null;
 
   return (
-    nearLimit?.toLowerCase() === "true" ||
+    nearLimitHeader?.toLowerCase() === "true" ||
     (!!remaining &&
       !!limit &&
-      parseInt(remaining, 10) / parseInt(limit, 10) < THROTTLE_TRIGGER_RATIO)
+      // If we have no request remaining, we are already rate limited. This should be unreachable.
+      remaining > 0 &&
+      remaining / limit < THROTTLE_TRIGGER_RATIO)
   );
 }
 

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -503,7 +503,8 @@ export class ConfluenceClient {
             url: `${this.apiUrl}${endpoint}`,
             response,
           },
-          retryAfterMs: NEAR_RATE_LIMIT_DELAY,
+          retryAfterMs:
+            NEAR_RATE_LIMIT_DELAY + Math.random() * RETRY_AFTER_JITTER,
         }
       );
     }


### PR DESCRIPTION
## Description

- This PR prevents near rate limit hits from causing a retry if the remaining number of request is zero.
- This code path should be unreachable because we would have got a 429 but it happens, and in this case we want the next request to fail in order to get a correct value of retry after.
- This PR also adds jitter to the near rate limit retry duration.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
