### PR TITLE
enh(Confluence): improve logging wrt rate limits

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -494,19 +494,16 @@ export class ConfluenceClient {
         "status:near_rate_limit",
       ]);
 
-      throw new ConfluenceClientError(
-        `Near rate limit: ${this.apiUrl}${endpoint}`,
-        {
-          type: "http_response_error",
-          status: 429, // We fake a 429 here to make sure the error is caught in the cast_known_errors.
-          data: {
-            url: `${this.apiUrl}${endpoint}`,
-            response,
-          },
-          retryAfterMs:
-            NEAR_RATE_LIMIT_DELAY + Math.random() * RETRY_AFTER_JITTER,
-        }
-      );
+      throw new ConfluenceClientError(`Near rate limit`, {
+        type: "http_response_error",
+        status: 429, // We fake a 429 here to make sure the error is caught in the cast_known_errors.
+        data: {
+          url: `${this.apiUrl}${endpoint}`,
+          response,
+        },
+        retryAfterMs:
+          NEAR_RATE_LIMIT_DELAY + Math.random() * RETRY_AFTER_JITTER,
+      });
     }
 
     statsDClient.increment("external.api.calls", 1, [

--- a/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
@@ -27,7 +27,7 @@ export class ConfluenceCastKnownErrorsInterceptor
             if (err.retryAfterMs) {
               // Override the default retry delay of the activity policy.
               throw ApplicationFailure.create({
-                message: `Rate limit exceeded. Retry after ${err.retryAfterMs}ms`,
+                message: `${err.message}. Retry after ${err.retryAfterMs}ms`,
                 nextRetryDelay: err.retryAfterMs,
               });
             }


### PR DESCRIPTION
## Description

The error showed in Temporal is the one thrown as an Application failure.
We currently cannot differentiate rate limit retries from near rate limit ones.
This PR addresses this issue.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
