### PR TITLE
Add google calendar personal connection MCP tool

### DIFF
--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -61,7 +61,12 @@ export function ConnectMCPServerDialog({
       owner,
       provider: mcpServer.authorization.provider,
       useCase: mcpServer.authorization.use_case,
-      extraConfig: authCredentials ?? {},
+      extraConfig: {
+        ...(authCredentials ?? {}),
+        ...(mcpServer.authorization.scope
+          ? { scope: mcpServer.authorization.scope }
+          : {}),
+      },
     });
     if (cRes.isErr()) {
       sendNotification({
@@ -102,6 +107,7 @@ export function ConnectMCPServerDialog({
             authCredentials={authCredentials}
             setAuthCredentials={setAuthCredentials}
             setIsFormValid={setIsFormValid}
+            documentationUrl={mcpServer?.documentationUrl}
           />
         </DialogContainer>
         <DialogFooter

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -91,7 +91,10 @@ export function CreateMCPServerDialog({
           owner,
           provider: authorization.provider,
           useCase: authorization.use_case,
-          extraConfig: authCredentials ?? {},
+          extraConfig: {
+            ...(authCredentials ?? {}),
+            ...(authorization.scope ? { scope: authorization.scope } : {}),
+          },
         });
         if (cRes.isErr()) {
           sendNotification({
@@ -223,6 +226,7 @@ export function CreateMCPServerDialog({
             authCredentials={authCredentials}
             setAuthCredentials={setAuthCredentials}
             setIsFormValid={setIsFormValid}
+            documentationUrl={internalMCPServer?.documentationUrl}
           />
         </DialogContainer>
         <DialogFooter

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -4,7 +4,7 @@ import {
   Input,
   Label,
 } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { OAuthCredentialInputs, OAuthCredentials } from "@app/types";
@@ -19,6 +19,7 @@ type MCPServerOauthConnexionProps = {
   authCredentials: OAuthCredentials | null;
   setAuthCredentials: (authCredentials: OAuthCredentials) => void;
   setIsFormValid: (isFormValid: boolean) => void;
+  documentationUrl?: string;
 };
 
 export function MCPServerOAuthConnexion({
@@ -26,6 +27,7 @@ export function MCPServerOAuthConnexion({
   authCredentials,
   setAuthCredentials,
   setIsFormValid,
+  documentationUrl,
 }: MCPServerOauthConnexionProps) {
   const [inputs, setInputs] = useState<OAuthCredentialInputs | null>(null);
 
@@ -72,11 +74,6 @@ export function MCPServerOAuthConnexion({
     }
   }, [authCredentials, inputs, setIsFormValid]);
 
-  // This is hacky, we should have a better way to get the doc url for each provider.
-  const docUrl = useMemo(() => {
-    return `https://docs.dust.tt/docs/${authorization?.provider}`;
-  }, [authorization]);
-
   return (
     authorization && (
       <div className="flex flex-col items-center gap-2">
@@ -84,11 +81,21 @@ export function MCPServerOAuthConnexion({
           <>
             <span className="text-500 w-full font-semibold">
               These tools require admin authentication with{" "}
-              {OAUTH_PROVIDER_NAMES[authorization.provider]}. Please follow{" "}
-              <a href={docUrl} className="text-highlight-600" target="_blank">
-                this guide
-              </a>{" "}
-              to learn how to set it up.
+              {OAUTH_PROVIDER_NAMES[authorization.provider]}
+              {documentationUrl && (
+                <>
+                  . Please follow{" "}
+                  <a
+                    href={documentationUrl}
+                    className="text-highlight-600"
+                    target="_blank"
+                  >
+                    this guide
+                  </a>{" "}
+                  to learn how to set it up
+                </>
+              )}
+              .
             </span>
             {Object.entries(inputs).map(([key, inputData]) => {
               if (inputData.value) {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -66,6 +66,7 @@ import {
   isOAuthProvider,
   isOAuthUseCase,
   isSupportedImageContentType,
+  isValidScope,
 } from "@app/types";
 
 interface AgentMessageProps {
@@ -501,7 +502,8 @@ export function AgentMessage({
         typeof agentMessage.error.metadata?.mcp_server_id === "string" &&
         agentMessage.error.metadata?.mcp_server_id.length > 0 &&
         isOAuthProvider(agentMessage.error.metadata?.provider) &&
-        isOAuthUseCase(agentMessage.error.metadata?.use_case)
+        isOAuthUseCase(agentMessage.error.metadata?.use_case) &&
+        isValidScope(agentMessage.error.metadata?.scope)
       ) {
         return (
           <MCPServerPersonalAuthenticationRequired
@@ -509,6 +511,7 @@ export function AgentMessage({
             mcpServerId={agentMessage.error.metadata.mcp_server_id}
             provider={agentMessage.error.metadata.provider}
             useCase={agentMessage.error.metadata.use_case}
+            scope={agentMessage.error.metadata.scope}
             retryHandler={async () => retryHandler(agentMessage)}
           />
         );

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -14,12 +14,14 @@ export function MCPServerPersonalAuthenticationRequired({
   mcpServerId,
   provider,
   useCase,
+  scope,
   retryHandler,
 }: {
   owner: LightWorkspaceType;
   mcpServerId: string;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
+  scope?: string;
   retryHandler: () => void;
 }) {
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
@@ -59,7 +61,8 @@ export function MCPServerPersonalAuthenticationRequired({
               const success = await createPersonalConnection(
                 mcpServerId,
                 provider,
-                useCase
+                useCase,
+                scope
               );
               setIsConnecting(false);
               if (!success) {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -689,6 +689,9 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
               mcp_server_id: toolCallResult.error.mcpServerId,
               provider: toolCallResult.error.provider,
               use_case: toolCallResult.error.useCase,
+              ...(toolCallResult.error.scope && {
+                scope: toolCallResult.error.scope,
+              }),
             },
           },
         };

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -346,7 +346,8 @@ export async function* tryCallMCPTool(
               personalAuthenticationRequiredError.resource
                 .provider as OAuthProvider,
               personalAuthenticationRequiredError.resource
-                .useCase as OAuthUseCase
+                .useCase as OAuthUseCase,
+              personalAuthenticationRequiredError.resource.scope
             )
           ),
         };

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -16,6 +16,7 @@ import {
   ActionTimeIcon,
   Avatar,
   CommandLineIcon,
+  GcalLogo,
   GithubLogo,
   GmailLogo,
   HubspotLogo,
@@ -52,6 +53,7 @@ export const InternalActionIcons = {
   NotionLogo,
   SalesforceLogo,
   GmailLogo,
+  GcalLogo,
 };
 
 export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);

--- a/front/lib/actions/mcp_internal_actions/authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/authentication.ts
@@ -74,17 +74,20 @@ export class MCPServerPersonalAuthenticationRequiredError extends Error {
   mcpServerId: string;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
+  scope?: string;
 
   constructor(
     mcpServerId: string,
     provider: OAuthProvider,
-    useCase: OAuthUseCase
+    useCase: OAuthUseCase,
+    scope?: string
   ) {
     super(`MCP server ${mcpServerId} requires personal authentication`);
     this.name = MCPServerRequiresPersonalAuthenticationErrorName;
     this.mcpServerId = mcpServerId;
     this.provider = provider;
     this.useCase = useCase;
+    this.scope = scope;
   }
 
   static is(
@@ -114,11 +117,13 @@ export function makeMCPToolPersonalAuthenticationRequiredError(
           text: new MCPServerPersonalAuthenticationRequiredError(
             mcpServerId,
             authorization.provider,
-            authorization.use_case
+            authorization.use_case,
+            authorization.scope
           ).message,
           mcpServerId,
           provider: authorization.provider,
           useCase: authorization.use_case,
+          scope: authorization.scope,
         },
       },
     ],

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -29,6 +29,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "search",
   "think",
   "web_search_&_browse",
+  "google_calendar",
 ] as const;
 
 // Whether the server is available by default in the global space.
@@ -194,6 +195,19 @@ export const INTERNAL_MCP_SERVERS: Record<
     tools_stakes: {
       get_drafts: "never_ask",
       create_draft: "low",
+    },
+  },
+  google_calendar: {
+    id: 16,
+    availability: "manual",
+    flag: "google_calendar_tool",
+    tools_stakes: {
+      "list-calendars": "never_ask",
+      "list-events": "never_ask",
+      "get-event": "never_ask",
+      "create-event": "low",
+      "update-event": "low",
+      "delete-event": "low",
     },
   },
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -202,12 +202,12 @@ export const INTERNAL_MCP_SERVERS: Record<
     availability: "manual",
     flag: "google_calendar_tool",
     tools_stakes: {
-      "list-calendars": "never_ask",
-      "list-events": "never_ask",
-      "get-event": "never_ask",
-      "create-event": "low",
-      "update-event": "low",
-      "delete-event": "low",
+      list_calendars: "never_ask",
+      list_events: "never_ask",
+      get_event: "never_ask",
+      create_event: "low",
+      update_event: "low",
+      delete_event: "low",
     },
   },
 

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -392,6 +392,7 @@ export const PersonalAuthenticationRequiredErrorResourceSchema = z.object({
   mcpServerId: z.string(),
   provider: z.string(),
   useCase: z.string(),
+  scope: z.string().optional(),
 });
 
 export type PersonalAuthenticationRequiredErrorResourceType = z.infer<

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -9,6 +9,7 @@ import {
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import { GMAIL_SCOPE_TYPES } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 
@@ -19,8 +20,10 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "gmail" as const,
     use_case: "personal_actions" as const,
+    scope: GMAIL_SCOPE_TYPES.EMAIL,
   },
   icon: "GmailLogo",
+  documentationUrl: "https://docs.dust.tt/docs/gmail-tool-setup",
 };
 
 const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -9,7 +9,6 @@ import {
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-import { GMAIL_SCOPE_TYPES } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 
@@ -20,7 +19,8 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "gmail" as const,
     use_case: "personal_actions" as const,
-    scope: GMAIL_SCOPE_TYPES.EMAIL,
+    scope:
+      "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose" as const,
   },
   icon: "GmailLogo",
   documentationUrl: "https://docs.dust.tt/docs/gmail-tool-setup",

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -9,7 +9,6 @@ import {
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-import { GMAIL_SCOPE_TYPES } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -20,7 +19,8 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "gmail",
     use_case: "personal_actions",
-    scope: GMAIL_SCOPE_TYPES.CALENDAR,
+    scope:
+      "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events" as const,
   },
   icon: "GcalLogo",
   documentationUrl: "https://docs.dust.tt/docs/google-calendar",

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -11,6 +11,7 @@ import {
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { GMAIL_SCOPE_TYPES } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "google_calendar",
@@ -72,8 +73,10 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           message: "Calendars listed successfully",
           result: res.data,
         });
-      } catch (err: any) {
-        return makeMCPToolTextError(err.message || "Failed to list calendars");
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to list calendars"
+        );
       }
     }
   );
@@ -132,9 +135,9 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           message: "Events listed successfully",
           result: res.data,
         });
-      } catch (err: any) {
+      } catch (err) {
         return makeMCPToolTextError(
-          err.message || "Failed to list/search events"
+          normalizeError(err).message || "Failed to list/search events"
         );
       }
     }
@@ -167,8 +170,10 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           message: "Event fetched successfully",
           result: res.data,
         });
-      } catch (err: any) {
-        return makeMCPToolTextError(err.message || "Failed to get event");
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to get event"
+        );
       }
     }
   );
@@ -214,7 +219,15 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         );
       }
       try {
-        const event: any = {
+        const event: {
+          summary: string;
+          description?: string;
+          start: { dateTime: string };
+          end: { dateTime: string };
+          attendees?: { email: string }[];
+          location?: string;
+          colorId?: string;
+        } = {
           summary,
           description,
           start,
@@ -237,8 +250,10 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           message: "Event created successfully",
           result: res.data,
         });
-      } catch (err: any) {
-        return makeMCPToolTextError(err.message || "Failed to create event");
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to create event"
+        );
       }
     }
   );
@@ -288,7 +303,15 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         );
       }
       try {
-        const event: any = {};
+        const event: {
+          summary?: string;
+          description?: string;
+          start?: { dateTime: string };
+          end?: { dateTime: string };
+          attendees?: { email: string }[];
+          location?: string;
+          colorId?: string;
+        } = {};
         if (summary) {
           event.summary = summary;
         }
@@ -319,8 +342,10 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           message: "Event updated successfully",
           result: res.data,
         });
-      } catch (err: any) {
-        return makeMCPToolTextError(err.message || "Failed to update event");
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to update event"
+        );
       }
     }
   );
@@ -352,8 +377,10 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           message: "Event deleted successfully",
           result: "",
         });
-      } catch (err: any) {
-        return makeMCPToolTextError(err.message || "Failed to delete event");
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to delete event"
+        );
       }
     }
   );

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -1,0 +1,364 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { google } from "googleapis";
+import { z } from "zod";
+
+import { makeMCPToolPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_internal_actions/authentication";
+import { getConnectionForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
+import {
+  makeMCPToolJSONSuccess,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import { GMAIL_SCOPE_TYPES } from "@app/lib/api/oauth";
+import type { Authenticator } from "@app/lib/auth";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "google_calendar",
+  version: "1.0.0",
+  description: "Tools for managing Google calendars and events.",
+  authorization: {
+    provider: "gmail",
+    use_case: "personal_actions",
+    scope: GMAIL_SCOPE_TYPES.CALENDAR,
+  },
+  icon: "GcalLogo",
+  documentationUrl: "https://docs.dust.tt/docs/google-calendar",
+};
+
+const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
+  const server = new McpServer(serverInfo);
+
+  async function getCalendarClient() {
+    const connection = await getConnectionForInternalMCPServer(auth, {
+      mcpServerId,
+      connectionType: "personal",
+    });
+    const accessToken = connection?.access_token;
+    if (!accessToken) {
+      return null;
+    }
+    const oauth2Client = new google.auth.OAuth2();
+    oauth2Client.setCredentials({ access_token: accessToken });
+    return google.calendar({
+      version: "v3",
+      auth: oauth2Client,
+    });
+  }
+
+  server.tool(
+    "list-calendars",
+    "List all calendars accessible by the user. Supports pagination via pageToken.",
+    {
+      pageToken: z.string().optional().describe("Page token for pagination."),
+      maxResults: z
+        .number()
+        .optional()
+        .describe("Maximum number of calendars to return (max 250)."),
+    },
+    async ({ pageToken, maxResults }) => {
+      const calendar = await getCalendarClient();
+      if (!calendar) {
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
+      }
+      try {
+        const res = await calendar.calendarList.list({
+          pageToken,
+          maxResults: maxResults ? Math.min(maxResults, 250) : undefined,
+        });
+        return makeMCPToolJSONSuccess({
+          message: "Calendars listed successfully",
+          result: res.data,
+        });
+      } catch (err: any) {
+        return makeMCPToolTextError(err.message || "Failed to list calendars");
+      }
+    }
+  );
+
+  server.tool(
+    "list-events",
+    "List or search events from a Google Calendar. If 'q' is provided, performs a free-text search.",
+    {
+      calendarId: z
+        .string()
+        .default("primary")
+        .describe("The calendar ID (default: 'primary')."),
+      q: z
+        .string()
+        .optional()
+        .describe("Free text search query for event fields."),
+      timeMin: z
+        .string()
+        .optional()
+        .describe("RFC3339 lower bound for event start time (inclusive)."),
+      timeMax: z
+        .string()
+        .optional()
+        .describe("RFC3339 upper bound for event end time (exclusive)."),
+      maxResults: z
+        .number()
+        .optional()
+        .describe("Maximum number of events to return (max 2500)."),
+      pageToken: z.string().optional().describe("Page token for pagination."),
+    },
+    async ({
+      calendarId = "primary",
+      q,
+      timeMin,
+      timeMax,
+      maxResults,
+      pageToken,
+    }) => {
+      const calendar = await getCalendarClient();
+      if (!calendar) {
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
+      }
+      try {
+        const res = await calendar.events.list({
+          calendarId,
+          q,
+          timeMin,
+          timeMax,
+          maxResults: maxResults ? Math.min(maxResults, 2500) : undefined,
+          pageToken,
+        });
+        return makeMCPToolJSONSuccess({
+          message: "Events listed successfully",
+          result: res.data,
+        });
+      } catch (err: any) {
+        return makeMCPToolTextError(
+          err.message || "Failed to list/search events"
+        );
+      }
+    }
+  );
+
+  server.tool(
+    "get-event",
+    "Get a single event from a Google Calendar by event ID.",
+    {
+      calendarId: z
+        .string()
+        .default("primary")
+        .describe("The calendar ID (default: 'primary')."),
+      eventId: z.string().describe("The ID of the event to retrieve."),
+    },
+    async ({ calendarId = "primary", eventId }) => {
+      const calendar = await getCalendarClient();
+      if (!calendar) {
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
+      }
+      try {
+        const res = await calendar.events.get({
+          calendarId,
+          eventId,
+        });
+        return makeMCPToolJSONSuccess({
+          message: "Event fetched successfully",
+          result: res.data,
+        });
+      } catch (err: any) {
+        return makeMCPToolTextError(err.message || "Failed to get event");
+      }
+    }
+  );
+
+  server.tool(
+    "create-event",
+    "Create a new event in a Google Calendar.",
+    {
+      calendarId: z
+        .string()
+        .default("primary")
+        .describe("The calendar ID (default: 'primary')."),
+      summary: z.string().describe("Title of the event."),
+      description: z.string().optional().describe("Description of the event."),
+      start: z
+        .object({ dateTime: z.string().describe("RFC3339 start time") })
+        .describe("Start time object."),
+      end: z
+        .object({ dateTime: z.string().describe("RFC3339 end time") })
+        .describe("End time object."),
+      attendees: z
+        .array(z.string())
+        .optional()
+        .describe("List of attendee email addresses."),
+      location: z.string().optional().describe("Location of the event."),
+      colorId: z.string().optional().describe("Color ID for the event."),
+    },
+    async ({
+      calendarId = "primary",
+      summary,
+      description,
+      start,
+      end,
+      attendees,
+      location,
+      colorId,
+    }) => {
+      const calendar = await getCalendarClient();
+      if (!calendar) {
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
+      }
+      try {
+        const event: any = {
+          summary,
+          description,
+          start,
+          end,
+        };
+        if (attendees) {
+          event.attendees = attendees.map((email: string) => ({ email }));
+        }
+        if (location) {
+          event.location = location;
+        }
+        if (colorId) {
+          event.colorId = colorId;
+        }
+        const res = await calendar.events.insert({
+          calendarId,
+          requestBody: event,
+        });
+        return makeMCPToolJSONSuccess({
+          message: "Event created successfully",
+          result: res.data,
+        });
+      } catch (err: any) {
+        return makeMCPToolTextError(err.message || "Failed to create event");
+      }
+    }
+  );
+
+  server.tool(
+    "update-event",
+    "Update an existing event in a Google Calendar.",
+    {
+      calendarId: z
+        .string()
+        .default("primary")
+        .describe("The calendar ID (default: 'primary')."),
+      eventId: z.string().describe("The ID of the event to update."),
+      summary: z.string().optional().describe("Title of the event."),
+      description: z.string().optional().describe("Description of the event."),
+      start: z
+        .object({ dateTime: z.string().describe("RFC3339 start time") })
+        .optional()
+        .describe("Start time object."),
+      end: z
+        .object({ dateTime: z.string().describe("RFC3339 end time") })
+        .optional()
+        .describe("End time object."),
+      attendees: z
+        .array(z.string())
+        .optional()
+        .describe("List of attendee email addresses."),
+      location: z.string().optional().describe("Location of the event."),
+      colorId: z.string().optional().describe("Color ID for the event."),
+    },
+    async ({
+      calendarId = "primary",
+      eventId,
+      summary,
+      description,
+      start,
+      end,
+      attendees,
+      location,
+      colorId,
+    }) => {
+      const calendar = await getCalendarClient();
+      if (!calendar) {
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
+      }
+      try {
+        const event: any = {};
+        if (summary) {
+          event.summary = summary;
+        }
+        if (description) {
+          event.description = description;
+        }
+        if (start) {
+          event.start = start;
+        }
+        if (end) {
+          event.end = end;
+        }
+        if (attendees) {
+          event.attendees = attendees.map((email: string) => ({ email }));
+        }
+        if (location) {
+          event.location = location;
+        }
+        if (colorId) {
+          event.colorId = colorId;
+        }
+        const res = await calendar.events.patch({
+          calendarId,
+          eventId,
+          requestBody: event,
+        });
+        return makeMCPToolJSONSuccess({
+          message: "Event updated successfully",
+          result: res.data,
+        });
+      } catch (err: any) {
+        return makeMCPToolTextError(err.message || "Failed to update event");
+      }
+    }
+  );
+
+  server.tool(
+    "delete-event",
+    "Delete an event from a Google Calendar.",
+    {
+      calendarId: z
+        .string()
+        .default("primary")
+        .describe("The calendar ID (default: 'primary')."),
+      eventId: z.string().describe("The ID of the event to delete."),
+    },
+    async ({ calendarId = "primary", eventId }) => {
+      const calendar = await getCalendarClient();
+      if (!calendar) {
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
+      }
+      try {
+        await calendar.events.delete({
+          calendarId,
+          eventId,
+        });
+        return makeMCPToolJSONSuccess({
+          message: "Event deleted successfully",
+          result: "",
+        });
+      } catch (err: any) {
+        return makeMCPToolTextError(err.message || "Failed to delete event");
+      }
+    }
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -47,7 +47,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
   }
 
   server.tool(
-    "list-calendars",
+    "list_calendars",
     "List all calendars accessible by the user. Supports pagination via pageToken.",
     {
       pageToken: z.string().optional().describe("Page token for pagination."),
@@ -82,7 +82,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
   );
 
   server.tool(
-    "list-events",
+    "list_events",
     "List or search events from a Google Calendar. If 'q' is provided, performs a free-text search.",
     {
       calendarId: z
@@ -144,7 +144,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
   );
 
   server.tool(
-    "get-event",
+    "get_event",
     "Get a single event from a Google Calendar by event ID.",
     {
       calendarId: z
@@ -179,7 +179,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
   );
 
   server.tool(
-    "create-event",
+    "create_event",
     "Create a new event in a Google Calendar.",
     {
       calendarId: z
@@ -259,7 +259,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
   );
 
   server.tool(
-    "update-event",
+    "update_event",
     "Update an existing event in a Google Calendar.",
     {
       calendarId: z
@@ -351,7 +351,7 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
   );
 
   server.tool(
-    "delete-event",
+    "delete_event",
     "Delete an event from a Google Calendar.",
     {
       calendarId: z

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -6,6 +6,7 @@ import { default as dataSourcesFileSystemServer } from "@app/lib/actions/mcp_int
 import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/file_generation";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
 import { default as gmailServer } from "@app/lib/actions/mcp_internal_actions/servers/gmail";
+import { default as calendarServer } from "@app/lib/actions/mcp_internal_actions/servers/google_calendar";
 import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/server";
 import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation";
 import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include";
@@ -78,6 +79,8 @@ export async function getInternalMCPServer(
       return salesforceServer(auth, mcpServerId);
     case "gmail":
       return gmailServer(auth, mcpServerId);
+    case "google_calendar":
+      return calendarServer(auth, mcpServerId);
     case "data_sources_file_system":
       return dataSourcesFileSystemServer(auth, agentLoopContext);
     default:

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -29,6 +29,7 @@ import type {
   MCPServerType,
   MCPToolType,
 } from "@app/lib/api/mcp";
+import type { GmailScope } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -49,6 +50,7 @@ import { createSSRFInterceptor } from "@app/types/shared/utils/ssrf";
 export type AuthorizationInfo = {
   provider: OAuthProvider;
   use_case: OAuthUseCase;
+  scope?: GmailScope;
 };
 
 export function isAuthorizationInfo(a: unknown): a is AuthorizationInfo {
@@ -336,6 +338,9 @@ export function extractMetadataFromServerVersion(
         ? r.description
         : DEFAULT_MCP_ACTION_DESCRIPTION,
       icon: isInternalMCPServerDefinition(r) ? r.icon : DEFAULT_MCP_SERVER_ICON,
+      documentationUrl: isInternalMCPServerDefinition(r)
+        ? r.documentationUrl
+        : undefined,
     };
   }
 

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -29,7 +29,6 @@ import type {
   MCPServerType,
   MCPToolType,
 } from "@app/lib/api/mcp";
-import type { GmailScope } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -50,7 +49,7 @@ import { createSSRFInterceptor } from "@app/types/shared/utils/ssrf";
 export type AuthorizationInfo = {
   provider: OAuthProvider;
   use_case: OAuthUseCase;
-  scope?: GmailScope;
+  scope?: string;
 };
 
 export function isAuthorizationInfo(a: unknown): a is AuthorizationInfo {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -47,6 +47,7 @@ export type MCPServerType = {
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   availability: MCPServerAvailability;
+  documentationUrl?: string;
 };
 
 export type RemoteMCPServerType = MCPServerType & {

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -45,26 +45,6 @@ function finalizeUriForProvider(provider: OAuthProvider): string {
   return config.getClientFacingUrl() + `/oauth/${provider}/finalize`;
 }
 
-export enum GMAIL_SCOPE_TYPES {
-  EMAIL = "EMAIL",
-  CALENDAR = "CALENDAR",
-}
-export type GmailScope =
-  (typeof GMAIL_SCOPE_TYPES)[keyof typeof GMAIL_SCOPE_TYPES];
-
-const PROVIDER_SCOPES: Record<string, Record<string, string[]>> = {
-  gmail: {
-    [GMAIL_SCOPE_TYPES.EMAIL]: [
-      "https://www.googleapis.com/auth/gmail.readonly",
-      "https://www.googleapis.com/auth/gmail.compose",
-    ],
-    [GMAIL_SCOPE_TYPES.CALENDAR]: [
-      "https://www.googleapis.com/auth/calendar",
-      "https://www.googleapis.com/auth/calendar.events",
-    ],
-  },
-};
-
 const PROVIDER_STRATEGIES: Record<
   OAuthProvider,
   {
@@ -585,7 +565,7 @@ const PROVIDER_STRATEGIES: Record<
         client_id: clientId,
         state: connection.connection_id,
         redirect_uri: finalizeUriForProvider("gmail"),
-        scope: PROVIDER_SCOPES.gmail[extraConfig.scope].join(" "),
+        scope: extraConfig.scope,
         access_type: "offline",
         prompt: "consent",
       });

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -545,7 +545,8 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
   const createPersonalConnection = async (
     mcpServerId: string,
     provider: OAuthProvider,
-    useCase: OAuthUseCase
+    useCase: OAuthUseCase,
+    scope?: string
   ): Promise<boolean> => {
     try {
       const extraConfig: Record<string, string> = {
@@ -563,6 +564,9 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
             extraConfig[key] = value;
           }
         });
+      }
+      if (scope) {
+        extraConfig.scope = scope;
       }
 
       const cRes = await setupOAuthConnection({

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -84,6 +84,7 @@ const SUPPORTED_OAUTH_CREDENTIALS = [
   "instance_url",
   "code_verifier",
   "code_challenge",
+  "scope",
 ] as const;
 
 export type SupportedOAuthCredentials =
@@ -211,6 +212,10 @@ export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
 
 export function isOAuthProvider(obj: unknown): obj is OAuthProvider {
   return OAUTH_PROVIDERS.includes(obj as OAuthProvider);
+}
+
+export function isValidScope(obj: unknown): obj is string | undefined {
+  return !obj || typeof obj === "string";
 }
 
 export type OAuthConnectionType = {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -31,6 +31,7 @@ export const WHITELISTABLE_FEATURES = [
   "workos",
   "salesforce_tool",
   "gmail_tool",
+  "google_calendar_tool",
   "agent_builder_v2",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -835,6 +835,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "workos"
   | "salesforce_tool"
   | "gmail_tool"
+  | "google_calendar_tool"
   | "agent_builder_v2"
 >();
 


### PR DESCRIPTION
## Description

* Adding personal connection MCP tool for google calendar / events actions. This was kept as a separate tool from gmail as it requires an entirely different scope of permissions and customers will likely want to manage them separately.
* Adding ability to define documentation URL with internal mcp server
* Adding ability to re-use oauth providers with different permission scopes. I suspect my approach will be controversial. I added a new 'scope' authorization field to determine which scope of permissions to request during oauth setup. Alternatively, I could have (1) re-used the 'use case' field, but I was worried about abusing that constant as we already use it to differentiate between personal and non-personal connections. (2) I could have made a new google calendar oauth provider. This approach I don't believe entirely scales as we will want to re-use oauth providers in the future, with different sets of permissions. Would like feedback on my decision here.

## Tests

```
Here is the summary of the steps performed on your Google Calendar:
Listed Calendars: Successfully listed your calendars.
Identified Calendar ID: Your primary calendar ID is "frank@dust.tt".
Listed Today's Events: Retrieved events scheduled for today.
Fetched Event Details: Successfully fetched details for today's events.
Created New Event: A new event titled "New Event with Frank" was created successfully.
Updated Event: The event was updated to "Updated Event with Frank".
Deleted Event: The event was successfully deleted.
```

## Risk

* Minimal - behind FF

## Deploy Plan

* Deploy front. Currently behind FF. Open to releasing when we are ready to publicly release personal connections