### PR TITLE
fix(Confluence): prevent request retries on near rate limits

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -485,7 +485,7 @@ export class ConfluenceClient {
       );
     }
 
-    // When approaching the rate limit (30% of any budget remains), we slow down
+    // When approaching the rate limit (THROTTLE_TRIGGER_RATIO of the budget remains), we slow down
     // the query pace by waiting NEAR_RATE_LIMIT_DELAY ms.
     if (
       !bypassThrottle &&

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -497,8 +497,7 @@ export class ConfluenceClient {
         "status:near_rate_limit",
       ]);
 
-      const delayMs =
-        NEAR_RATE_LIMIT_DELAY + sampleJitter();
+      const delayMs = NEAR_RATE_LIMIT_DELAY + sampleJitter();
       logger.warn(
         {
           endpoint,


### PR DESCRIPTION
## Description

When a near rate limit event was detected we used to defer the retry to Temporal's strategy.
This behavior was implemented when the strategy was an exponential backoff.

Now that we've upgraded the version of Temporal and have the possibility to set a custom reset duration at the activity level, this type of retry is less relevant.

This PR replaces it with an activity-side sleep, which comes down to the same except that it does not do the request twice. Indeed, the retry here comes down to throwing right after doing the request (at this point the response is available and is discarded), and then in the subsequent activity we rerun all the code prior to the request and then redo it.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
