### PR TITLE
Salesforce: Attempt to fix commons query errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -170,6 +170,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     tools_stakes: {
       execute_read_query: "low",
       list_objects: "low",
+      describe_object: "low",
     },
   },
   gmail: {

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -25,24 +25,50 @@ const SF_API_VERSION = "57.0";
 
 const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
   const server = new McpServer(serverInfo, {
-    instructions: `You have access to the following tools: execute_read_query & list_objects.
+    instructions: `You have access to the following tools: execute_read_query, list_objects, and describe_object.
+
+# General Workflow for Salesforce Data:
+1.  **List Objects (Optional):** If you don't know the exact name of an object, use \`list_objects\` to find it.
+2.  **Describe Object:** Use \`describe_object\` with the specific object name (e.g., \`Account\`, \`MyCustomObject__c\`) to get its detailed metadata. This will show you all available fields, their exact names, data types, and information about relationships (child relationships are particularly important for subqueries).
+3.  **Execute Read Query:** Use \`execute_read_query\` to retrieve data using SOQL. Construct your SOQL queries based on the information obtained from \`describe_object\` to ensure you are using correct field and relationship names.
+
 # execute_read_query
-You can use it to execute SOQL read queries on Salesforce: queries can be used to retrieve data or to discover data.
-We do not want to write data.
+You can use it to execute SOQL read queries on Salesforce. Queries can be used to retrieve or discover data, never to write data.
 
-**Custom objects / fields**
-If you are attempting to use a custom object or field, be sure to append the '__c' after the custom object or field name.
+**Best Practices for Querying:**
+1.  **Discover Object Structure First:** ALWAYS use \`describe_object(objectName='YourObjectName')\` to understand an object's fields and relationships before writing complex queries. Alternatively, for a quick field list directly in a query, use \`FIELDS()\` (e.g., \`SELECT FIELDS(ALL) FROM Account LIMIT 1\`). This helps prevent errors from misspelled or non-existent field/relationship names. The \`FIELDS()\` function requires a \`LIMIT\` clause, with a maximum of 200.
+2.  **Verify Field and Relationship Names:** If you encounter "No such column" or "Didn't understand relationship" errors, use \`describe_object\` for the relevant object(s) to confirm the exact names and their availability. For example, child relationship names used in subqueries (e.g., \`(SELECT Name FROM Contacts)\` or \`(SELECT Name FROM MyCustomChildren__r)\`) can be found in the output of \`describe_object\`.
 
-**FIELDS() keyword**
-Use the FIELDS() keyword in the fieldList to select groups of fields without knowing their names in advance.
-This keyword simplifies SELECT statements, avoids the need for multiple API calls, and provides a low-code method to explore the data in your org.
-- FIELDS(ALL) selects all the fields of an object
-- FIELDS(CUSTOM) selects all the custom fields of an object
-- FIELDS(STANDARD) selects all the standard fields of an object
-The SOQL FIELDS function must have a LIMIT of at most 200.
+**Custom Objects, Fields, and Relationships:**
+-   **Custom Objects & Fields:** When referencing custom objects or fields, append \`__c\` to their names (e.g., \`MyCustomField__c\`, \`MyCustomObject__c\`). Confirm these names using \`describe_object\`.
+-   **Custom Relationships:** When referencing custom relationships (typically in parent-to-child subqueries), append \`__r\` to the relationship name (e.g., \`(SELECT Name FROM MyCustomRelatedObjects__r)\`). \`describe_object\` will list these child relationship names.
+
+**FIELDS() Keyword Details (Alternative to describe_object for quick field listing in query):**
+Use \`FIELDS(ALL)\`, \`FIELDS(CUSTOM)\`, or \`FIELDS(STANDARD)\` in your \`SELECT\` statement to retrieve groups of fields.
+-   \`FIELDS(ALL)\`: Selects all fields.
+-   \`FIELDS(CUSTOM)\`: Selects all custom fields.
+-   \`FIELDS(STANDARD)\`: Selects all standard fields.
+Remember to include \`LIMIT\` (max 200) when using \`FIELDS()\`.
+
+**Relationships in Queries (Confirm names with describe_object):**
+-   **Child-to-Parent:** Use dot notation. E.g., \`SELECT Account.Name, LastName FROM Contact\`.
+-   **Parent-to-Child (Subqueries):** Use a subquery. Confirm relationship name (e.g., \`Contacts\` or \`MyCustomChildren__r\`) via \`describe_object\`.
+    -   Standard Relationship: \`SELECT Name, (SELECT FirstName, LastName FROM Contacts) FROM Account\`
+    -   Custom Relationship: \`SELECT Name, (SELECT Name FROM MyCustomChildren__r) FROM Account\`
+
+If errors persist after using \`describe_object\` and following these guidelines, the field, object, or relationship might genuinely not exist, or you may lack permissions.
 
 # list_objects
-You can use it to list the objects in Salesforce: standard and custom objects.
+You can use it to list the objects in Salesforce: standard and custom objects. Useful for finding object names if you're unsure.
+
+# describe_object
+Use this tool to get detailed metadata about a specific Salesforce object. Provide the object's API name (e.g., \`Account\`, \`Lead\`, \`MyCustomObject__c\`).
+The output includes:
+-   A list of all fields with their names, labels, types, and other properties.
+-   Details about child relationships (useful for parent-to-child subqueries in SOQL), including the relationship name.
+-   Information about record types.
+-   Other object-level properties.
+This is the most reliable way to discover the correct names for fields and relationships before writing an \`execute_read_query\`.
 `,
   });
 
@@ -137,6 +163,45 @@ You can use it to list the objects in Salesforce: standard and custom objects.
       return makeMCPToolJSONSuccess({
         message: "Operation completed successfully",
         result: objects,
+      });
+    }
+  );
+
+  server.tool(
+    "describe_object",
+    "Describe an object in Salesforce",
+    {
+      objectName: z.string().describe("The name of the object to describe"),
+    },
+    async ({ objectName }) => {
+      const connection = await getConnectionForInternalMCPServer(auth, {
+        mcpServerId,
+        connectionType: "personal",
+      });
+
+      const accessToken = connection?.access_token;
+      const instanceUrl = connection?.connection.metadata.instance_url as
+        | string
+        | undefined;
+
+      if (!accessToken || !instanceUrl) {
+        return makeMCPToolPersonalAuthenticationRequiredError(
+          mcpServerId,
+          serverInfo.authorization!
+        );
+      }
+      const conn = new jsforce.Connection({
+        instanceUrl,
+        accessToken,
+        version: SF_API_VERSION,
+      });
+      await conn.identity();
+
+      const result = await conn.describe(objectName);
+
+      return makeMCPToolJSONSuccess({
+        message: "Operation completed successfully",
+        result: result,
       });
     }
   );


### PR DESCRIPTION
## Description

I inspected the common errors that beta testers of the tool got, using this query: 

```
SELECT * FROM agent_mcp_action_output_items 
WHERE "workspaceId" = xxxxxxxxx 
AND content->>'text' LIKE '%WSDL%'
ORDER BY "createdAt" DESC 
LIMIT 100;
```

This PR is an attempt to reduce those by adding a new tool to discover the relationships & improve the instructions;. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 