### PR TITLE
chore(relocation): Try not stringify arrays of objects

### DIFF
--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -53,11 +53,13 @@ export function generateParameterizedInsertStatements(
         if (
           JSONB_COLUMNS.some(
             (c) => c.tableName === tableName && c.columns.includes(col)
-          ) &&
-          // Only transform if it's a string - leave objects as-is.
-          typeof row[col] === "string"
+          )
         ) {
-          params.push(JSON.stringify(row[col]));
+          if (typeof row[col] === "string") {
+            params.push(JSON.stringify(row[col]));
+          } else {
+            params.push(row[col]);
+          }
           continue;
         }
 


### PR DESCRIPTION
## Description
- only stringify jsonb for string value, otherwise keep it as array of objects or objects

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Relocation only

## Deploy Plan
- Deploy front
- Execute script to replay readFrontTableChunk
