### PR TITLE
chore(relocation): stringify JSONB column when it's an array

### DIFF
--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -55,10 +55,11 @@ export function generateParameterizedInsertStatements(
             (c) => c.tableName === tableName && c.columns.includes(col)
           )
         ) {
-          if (typeof row[col] === "string") {
+          if (
+            typeof row[col] === "string" ||
+            (Array.isArray(row[col]) && row[col].length > 0)
+          ) {
             params.push(JSON.stringify(row[col]));
-          } else {
-            params.push(row[col]);
           }
           continue;
         }


### PR DESCRIPTION
## Description
So far only string and array of objects are stringified, but some elements can be a list of mixed elements (string and objects), which are not stringified, creating an error during sequalized request.

## Tests
- Locally tested a insert with binds using sequelize, once I stubble upon a non stringified array of string and object I get the same error as the relocation workflow "invalid input syntax for type json". If I try to stringify arrays, totally fine.

## Risk
- Low, relocation only

## Deploy Plan
- Deploy front
- Execute readFrontTableChunk from previous steps
