### PR TITLE
fix(Confluence): prevent response bodies from being read twice

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -604,8 +604,8 @@ export class ConfluenceClient {
       return undefined; // Return undefined for 204 No Content.
     }
 
-    // Clone the response to avoid "Body has already been read" errors
-    // This can happen with undici in concurrent scenarios
+    // Clone the response to avoid "Body has already been read" errors.
+    // This can happen with undici in concurrent scenarios.
     const responseClone = response.clone();
     let responseBody;
     try {
@@ -615,7 +615,7 @@ export class ConfluenceClient {
         error instanceof TypeError &&
         error.message.includes("Body has already been read")
       ) {
-        // Fallback to the cloned response
+        // Fallback to the cloned response.
         responseBody = await responseClone.json();
       } else {
         throw error;


### PR DESCRIPTION
## Description

- Fix the error "Body is unusable: Body has already been used" (logs [here](https://app.datadoghq.eu/logs?query=%22Body%20is%20unusable%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1733653464474&to_ts=1733657064474&live=true)).

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
