### PR TITLE
fix(Confluence): remove response cloning

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -604,23 +604,7 @@ export class ConfluenceClient {
       return undefined; // Return undefined for 204 No Content.
     }
 
-    // Clone the response to avoid "Body has already been read" errors.
-    // This can happen with undici in concurrent scenarios.
-    const responseClone = response.clone();
-    let responseBody;
-    try {
-      responseBody = await response.json();
-    } catch (error) {
-      if (
-        error instanceof TypeError &&
-        error.message.includes("Body has already been read")
-      ) {
-        // Fallback to the cloned response.
-        responseBody = await responseClone.json();
-      } else {
-        throw error;
-      }
-    }
+    const responseBody = await response.json();
     const result = codec.decode(responseBody);
 
     if (isLeft(result)) {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -1,6 +1,6 @@
 import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
-import type { Response } from "undici";
+import type { Headers } from "undici";
 import { fetch as undiciFetch, ProxyAgent } from "undici";
 
 import { setTimeoutAsync } from "@connectors/lib/async_utils";


### PR DESCRIPTION
## Description

- Partly rollbacks https://github.com/dust-tt/dust/pull/13051/files.
- This PR removes the response cloning but keeps the other changes (removing the response from the thrown error).

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
