### PR TITLE
fix(workos): update rule to fetch by email

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -204,9 +204,6 @@ const config = {
   getWorkOSCookiePassword: (): string => {
     return EnvironmentConfig.getEnvVariable("WORKOS_COOKIE_PASSWORD");
   },
-  getWorkOSRedirectUri: (): string => {
-    return `${config.getClientFacingUrl()}/api/workos/callback`;
-  },
 
   // Profiler.
   getProfilerSecret: (): string | undefined => {

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -149,9 +149,8 @@ export class UserResource extends BaseResource<UserModel> {
       // Best effort strategy as user db entries are not updated often.
       return b.updatedAt.getTime() - a.updatedAt.getTime();
     });
-    const usersWithAuth0Sub = sortedUsers.filter((u) => u.auth0Sub !== null);
 
-    // Most recently updated user with an Auth0 sub if any, otherwise most recently updated user.
+    // Most recently updated user if any.
     return usersWithAuth0Sub[0] ?? sortedUsers[0] ?? null;
   }
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -151,7 +151,7 @@ export class UserResource extends BaseResource<UserModel> {
     });
 
     // Most recently updated user if any.
-    return usersWithAuth0Sub[0] ?? sortedUsers[0] ?? null;
+    return sortedUsers[0] ?? null;
   }
 
   static async fetchByProvider(


### PR DESCRIPTION
## Description

- Update rule on `fetchByEmail` to ensure retrocompatibility.
- This PR also removes the function `getWorkOSRedirectUri` (https://github.com/dust-tt/dust/pull/13019#discussion_r2114383012), which was not used and should have been moved out of `lib/config`.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- No deploy.
