### PR TITLE
wip: add support for extended thinking with Claude Sonnet 4

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1960,18 +1960,14 @@ impl LLM for AnthropicLLM {
 
         let thinking = match &extras {
             None => None,
-            // We don't pass the thinking parameters in tool use.
-            Some(v) => match tool_choice.is_some() {
-                true => None,
-                false => match v.get("anthropic_beta_thinking") {
-                    Some(Value::Object(s)) => match (s.get("type"), s.get("budget_tokens")) {
-                        (Some(Value::String(t)), Some(Value::Number(b))) => {
-                            Some((t.clone(), b.as_u64().unwrap_or(1024)))
-                        }
-                        _ => None,
-                    },
+            Some(v) => match v.get("anthropic_beta_thinking") {
+                Some(Value::Object(s)) => match (s.get("type"), s.get("budget_tokens")) {
+                    (Some(Value::String(t)), Some(Value::Number(b))) => {
+                        Some((t.clone(), b.as_u64().unwrap_or(1024)))
+                    }
                     _ => None,
                 },
+                _ => None,
             },
         };
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -68,6 +68,7 @@ import type {
   UserMessageType,
   WorkspaceType,
 } from "@app/types";
+import { CLAUDE_4_SONNET_20250514_MODEL_ID } from "@app/types";
 import { assertNever, removeNulls, SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
@@ -569,6 +570,14 @@ async function* runMultiActionsAgent(
       agentConfiguration.model.responseFormat
     );
   }
+  if (model.modelId === CLAUDE_4_SONNET_20250514_MODEL_ID) {
+    // Pass some extra field: https://docs.anthropic.com/en/docs/about-claude/models/extended-thinking-models#extended-output-capabilities-beta
+    runConfig.MODEL.anthropic_beta_thinking = {
+      type: "enabled",
+      budget_tokens: 6400,
+    };
+  }
+
   const anthropicBetaFlags = config.getMultiActionsAgentAnthropicBetaFlags();
   if (anthropicBetaFlags) {
     runConfig.MODEL.anthropic_beta_flags = anthropicBetaFlags;


### PR DESCRIPTION
## Description

This PR contains the minimal diff to test extended thinking with Claude Sonnet 4.

The current state of affairs is that we do get this error when running tool use.
<img width="371" alt="Screenshot 2025-06-02 at 12 06 19 AM" src="https://github.com/user-attachments/assets/047a6b22-0b34-42be-8a44-bfe8393c8a0b" />

This means that we need to somehow add a separate channel for the thinking tokens to give them back accordingly.
I could not trigger a hit on the `redacted_thinking` so we probably do not need a second stream for these, and could potentially error when getting them in function call (ugly but the most desirable IMHO).

The `interleaved_thinking` is yet another topic that will be unlocked by this.

If we get this to work, goal is to add a separate model for Claude Sonnet 4 with extended thinking.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
