### PR TITLE
Fetch EditAssistant data async from client side

### DIFF
--- a/front/components/assistant/AssistantDetailsPerformance.tsx
+++ b/front/components/assistant/AssistantDetailsPerformance.tsx
@@ -16,7 +16,7 @@ import { useState } from "react";
 
 import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
 import { useAgentAnalytics } from "@app/lib/swr/assistants";
-import type { AgentConfigurationType } from "@app/types";
+import type { LightAgentConfigurationType } from "@app/types";
 import type { WorkspaceType } from "@app/types";
 import { removeNulls } from "@app/types";
 
@@ -27,7 +27,7 @@ const PERIODS = [
 ];
 
 interface AssistantDetailsPerformanceProps {
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: LightAgentConfigurationType;
   owner: WorkspaceType;
   gridMode: boolean;
 }

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -437,36 +437,38 @@ export default function ActionsScreen({
           </div>
         )}
         <div className="flex h-full min-h-40 flex-col gap-4">
-          {!isLegacyConfig && builderState.actions.length === 0 ? (
-            <div className="flex h-36 w-full items-center justify-center rounded-xl bg-muted-background dark:bg-muted-background-night">
-              {isFetchingActions ? (
-                <Spinner />
-              ) : (
+          {isFetchingActions && (
+            <div className="flex h-36 w-full items-center justify-center rounded-xl">
+              <Spinner />
+            </div>
+          )}
+          {!isFetchingActions &&
+            (!isLegacyConfig && builderState.actions.length === 0 ? (
+              <div className="flex h-36 w-full items-center justify-center rounded-xl bg-muted-background dark:bg-muted-background-night">
                 <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                   Add knowledge and tools to enhance your agent's capabilities.
                 </p>
-              )}
-            </div>
-          ) : (
-            <CardGrid>
-              {builderState.actions.map((action) => (
-                <ActionCard
-                  action={action}
-                  key={action.name}
-                  editAction={() => {
-                    setAction({
-                      type: "edit",
-                      action,
-                    });
-                  }}
-                  removeAction={() => {
-                    removeAction(action);
-                  }}
-                  isLegacyConfig={isLegacyConfig}
-                />
-              ))}
-            </CardGrid>
-          )}
+              </div>
+            ) : (
+              <CardGrid>
+                {builderState.actions.map((action) => (
+                  <ActionCard
+                    action={action}
+                    key={action.name}
+                    editAction={() => {
+                      setAction({
+                        type: "edit",
+                        action,
+                      });
+                    }}
+                    removeAction={() => {
+                      removeAction(action);
+                    }}
+                    isLegacyConfig={isLegacyConfig}
+                  />
+                ))}
+              </CardGrid>
+            ))}
         </div>
       </div>
     </>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -24,6 +24,7 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
@@ -206,6 +207,7 @@ interface ActionScreenProps {
   setEdited: (edited: boolean) => void;
   setAction: (action: AssistantBuilderSetActionType) => void;
   pendingAction: AssistantBuilderPendingAction;
+  isFetchingActions: boolean;
 }
 
 export default function ActionsScreen({
@@ -215,6 +217,7 @@ export default function ActionsScreen({
   setEdited,
   setAction,
   pendingAction,
+  isFetchingActions = false,
 }: ActionScreenProps) {
   const { hasFeature } = useFeatureFlags({
     workspaceId: owner.sId,
@@ -436,9 +439,13 @@ export default function ActionsScreen({
         <div className="flex h-full min-h-40 flex-col gap-4">
           {!isLegacyConfig && builderState.actions.length === 0 ? (
             <div className="flex h-36 w-full items-center justify-center rounded-xl bg-muted-background dark:bg-muted-background-night">
-              <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                Add knowledge and tools to enhance your agent's capabilities.
-              </p>
+              {isFetchingActions ? (
+                <Spinner />
+              ) : (
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  Add knowledge and tools to enhance your agent's capabilities.
+                </p>
+              )}
             </div>
           ) : (
             <CardGrid>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -128,16 +128,18 @@ export default function AssistantBuilder({
           "There was an error retrieving the actions for this agent.",
         type: "error",
       });
-    } else if (actions) {
-      setBuilderState((prevState) => ({
-        ...prevState,
-        actions: actions.map((action) => ({
-          id: uniqueId(),
-          ...action,
-        })),
-      }));
     }
-  }, [actions, error, sendNotification]);
+  }, [error, sendNotification]);
+
+  useEffect(() => {
+    setBuilderState((prevState) => ({
+      ...prevState,
+      actions: actions.map((action) => ({
+        id: uniqueId(),
+        ...action,
+      })),
+    }));
+  }, [actions]);
 
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(
     initialBuilderState

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -116,12 +116,7 @@ export default function AssistantBuilder({
   const [descriptionError, setDescriptionError] = useState<string | null>(null);
   const [hasAnyActionsError, setHasAnyActionsError] = useState<boolean>(false);
 
-  const {
-    actions,
-    isActionsLoading,
-    error,
-    mutateAssistantConfigurationActions,
-  } = useAssistantConfigurationActions(
+  const { actions, isActionsLoading, error } = useAssistantConfigurationActions(
     owner.sId,
     agentConfiguration?.sId ?? null
   );
@@ -383,10 +378,6 @@ export default function AssistantBuilder({
         if (slackDataSource) {
           await mutateSlackChannels();
         }
-
-        // we need to clear cache on update but no need to wait otherwise
-        // it can cause UI flickering on action cards (order can be different when fetching from server)
-        void mutateAssistantConfigurationActions();
 
         if (isBuilder(owner)) {
           // Redirect to the agent list once saved.

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -40,6 +40,7 @@ import type {
 import {
   BUILDER_SCREENS,
   BUILDER_SCREENS_INFOS,
+  getDataVisualizationActionConfiguration,
   getDefaultAssistantState,
 } from "@app/components/assistant_builder/types";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
@@ -128,18 +129,21 @@ export default function AssistantBuilder({
           "There was an error retrieving the actions for this agent.",
         type: "error",
       });
+      return;
     }
-  }, [error, sendNotification]);
-
-  useEffect(() => {
     setBuilderState((prevState) => ({
       ...prevState,
-      actions: actions.map((action) => ({
-        id: uniqueId(),
-        ...action,
-      })),
+      actions: [
+        ...actions.map((action) => ({
+          id: uniqueId(),
+          ...action,
+        })),
+        ...(prevState.visualizationEnabled
+          ? [getDataVisualizationActionConfiguration()]
+          : []),
+      ],
     }));
-  }, [actions]);
+  }, [actions, error, sendNotification]);
 
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(
     initialBuilderState

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -116,7 +116,12 @@ export default function AssistantBuilder({
   const [descriptionError, setDescriptionError] = useState<string | null>(null);
   const [hasAnyActionsError, setHasAnyActionsError] = useState<boolean>(false);
 
-  const { actions, isActionsLoading, error } = useAssistantConfigurationActions(
+  const {
+    actions,
+    isActionsLoading,
+    error,
+    mutateAssistantConfigurationActions,
+  } = useAssistantConfigurationActions(
     owner.sId,
     agentConfiguration?.sId ?? null
   );
@@ -131,6 +136,7 @@ export default function AssistantBuilder({
       });
       return;
     }
+
     setBuilderState((prevState) => ({
       ...prevState,
       actions: [
@@ -377,6 +383,11 @@ export default function AssistantBuilder({
         if (slackDataSource) {
           await mutateSlackChannels();
         }
+
+        // we need to clear cache on update but no need to wait otherwise
+        // it can cause UI flickering on action cards (order can be different when fetching from server)
+        void mutateAssistantConfigurationActions();
+
         if (isBuilder(owner)) {
           // Redirect to the agent list once saved.
           if (flow === "personal_assistants") {

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -45,7 +45,7 @@ import type {
   ModelConfigurationType,
   WorkspaceType,
 } from "@app/types";
-import type { AgentConfigurationType } from "@app/types";
+import type { LightAgentConfigurationType } from "@app/types";
 import { isAssistantBuilderRightPanelTab } from "@app/types";
 
 interface AssistantBuilderRightPanelProps {
@@ -56,7 +56,7 @@ interface AssistantBuilderRightPanelProps {
   resetToTemplateActions: () => Promise<void>;
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
-  agentConfiguration: AgentConfigurationType | null;
+  agentConfiguration: LightAgentConfigurationType | null;
   setAction: (action: AssistantBuilderSetActionType) => void;
   reasoningModels: ModelConfigurationType[];
 }

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -24,9 +24,11 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type {
   AgentConfigurationScope,
+  AgentConfigurationType,
   AgentReasoningEffort,
   AppType,
   DataSourceViewSelectionConfigurations,
+  LightAgentConfigurationType,
   ModelIdType,
   ModelProviderIdType,
   PlanType,
@@ -38,7 +40,6 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
-import type { AgentConfigurationType } from "@app/types";
 import {
   assertNever,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
@@ -517,6 +518,18 @@ export type BuilderFlow = (typeof BUILDER_FLOWS)[number];
 
 export type AssistantBuilderProps = {
   agentConfiguration: AgentConfigurationType | null;
+  baseUrl: string;
+  defaultIsEdited?: boolean;
+  defaultTemplate: FetchAssistantTemplateResponse | null;
+  flow: BuilderFlow;
+  initialBuilderState: AssistantBuilderInitialState | null;
+  owner: WorkspaceType;
+  plan: PlanType;
+  subscription: SubscriptionType;
+};
+
+export type AssistantBuilderLightProps = {
+  agentConfiguration: LightAgentConfigurationType | null;
   baseUrl: string;
   defaultIsEdited?: boolean;
   defaultTemplate: FetchAssistantTemplateResponse | null;

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -516,8 +516,8 @@ export const BUILDER_FLOWS = [
 ] as const;
 export type BuilderFlow = (typeof BUILDER_FLOWS)[number];
 
-export type AssistantBuilderProps = {
-  agentConfiguration: AgentConfigurationType | null;
+type AssistantBuilderPropsBase<T> = {
+  agentConfiguration: T | null;
   baseUrl: string;
   defaultIsEdited?: boolean;
   defaultTemplate: FetchAssistantTemplateResponse | null;
@@ -528,17 +528,10 @@ export type AssistantBuilderProps = {
   subscription: SubscriptionType;
 };
 
-export type AssistantBuilderLightProps = {
-  agentConfiguration: LightAgentConfigurationType | null;
-  baseUrl: string;
-  defaultIsEdited?: boolean;
-  defaultTemplate: FetchAssistantTemplateResponse | null;
-  flow: BuilderFlow;
-  initialBuilderState: AssistantBuilderInitialState | null;
-  owner: WorkspaceType;
-  plan: PlanType;
-  subscription: SubscriptionType;
-};
+export type AssistantBuilderProps =
+  AssistantBuilderPropsBase<AgentConfigurationType>;
+export type AssistantBuilderLightProps =
+  AssistantBuilderPropsBase<LightAgentConfigurationType>;
 
 export const BUILDER_SCREENS = ["instructions", "actions", "settings"] as const;
 

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -14,6 +14,8 @@ export function useAssistantConfigurationActions(
     actionsFetcher,
     {
       disabled,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
     }
   );
 

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -9,14 +9,13 @@ export function useAssistantConfigurationActions(
 ) {
   const disabled = agentConfigurationId === null;
   const actionsFetcher: Fetcher<GetActionsResponseBody> = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error } = useSWRWithDefaults(
     `/api/w/${ownerId}/builder/assistants/${agentConfigurationId}/actions`,
     actionsFetcher,
     {
       disabled,
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
-      revalidateIfStale: false,
     }
   );
 
@@ -24,6 +23,5 @@ export function useAssistantConfigurationActions(
     actions: data?.actions ?? emptyArray(),
     isActionsLoading: !error && !data && !disabled,
     error,
-    mutateAssistantConfigurationActions: mutate,
   };
 }

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -1,0 +1,24 @@
+import type { Fetcher } from "swr";
+
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetActionsResponseBody } from "@app/pages/api/w/[wId]/builder/assistants/[aId]/actions";
+
+export function useAssistantConfigurationActions(
+  ownerId: string,
+  agentConfigurationId: string | null
+) {
+  const actionsFetcher: Fetcher<GetActionsResponseBody> = fetcher;
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${ownerId}/builder/assistants/${agentConfigurationId}/actions`,
+    actionsFetcher,
+    {
+      disabled: agentConfigurationId === null,
+    }
+  );
+
+  return {
+    actions: data?.actions ?? emptyArray(),
+    isActionsLoading: !error && !data,
+    error,
+  };
+}

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -9,13 +9,14 @@ export function useAssistantConfigurationActions(
 ) {
   const disabled = agentConfigurationId === null;
   const actionsFetcher: Fetcher<GetActionsResponseBody> = fetcher;
-  const { data, error } = useSWRWithDefaults(
+  const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${ownerId}/builder/assistants/${agentConfigurationId}/actions`,
     actionsFetcher,
     {
       disabled,
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
+      revalidateIfStale: false,
     }
   );
 
@@ -23,5 +24,6 @@ export function useAssistantConfigurationActions(
     actions: data?.actions ?? emptyArray(),
     isActionsLoading: !error && !data && !disabled,
     error,
+    mutateAssistantConfigurationActions: mutate,
   };
 }

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -7,18 +7,19 @@ export function useAssistantConfigurationActions(
   ownerId: string,
   agentConfigurationId: string | null
 ) {
+  const disabled = agentConfigurationId === null;
   const actionsFetcher: Fetcher<GetActionsResponseBody> = fetcher;
   const { data, error } = useSWRWithDefaults(
     `/api/w/${ownerId}/builder/assistants/${agentConfigurationId}/actions`,
     actionsFetcher,
     {
-      disabled: agentConfigurationId === null,
+      disabled,
     }
   );
 
   return {
     actions: data?.actions ?? emptyArray(),
-    isActionsLoading: !error && !data,
+    isActionsLoading: !error && !data && !disabled,
     error,
   };
 }

--- a/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -1,0 +1,99 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  buildInitialActions,
+  getAccessibleSourcesAndApps,
+} from "@app/components/assistant_builder/server_side_props_helpers";
+import type { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
+import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type GetActionsResponseBody = {
+  actions: (
+    | AssistantBuilderActionConfiguration
+    | ReturnType<typeof getDataVisualizationActionConfiguration>
+  )[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetActionsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const { aId } = req.query;
+  if (typeof aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent ID.",
+      },
+    });
+  }
+
+  try {
+    const agentConfiguration = await getAgentConfiguration(auth, aId, "full");
+    if (!agentConfiguration) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "Agent configuration not found.",
+        },
+      });
+    }
+
+    const { dataSourceViews, dustApps, mcpServerViews } =
+      await getAccessibleSourcesAndApps(auth);
+    const mcpServerViewsJSON = mcpServerViews.map((v) => v.toJSON());
+
+    const actions = await buildInitialActions({
+      dataSourceViews,
+      dustApps,
+      configuration: agentConfiguration,
+      mcpServerViews: mcpServerViewsJSON,
+    });
+
+    if (
+      agentConfiguration.scope !== "visible" &&
+      agentConfiguration.scope !== "hidden"
+    ) {
+      throw new Error("Invalid agent scope");
+    }
+
+    const builderStateActions: GetActionsResponseBody = {
+      actions: [
+        ...actions,
+        ...(agentConfiguration.visualizationEnabled
+          ? [getDataVisualizationActionConfiguration()]
+          : []),
+      ],
+    };
+
+    res.status(200).json(builderStateActions);
+  } catch (error) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to fetch builder state.",
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -75,16 +75,7 @@ async function handler(
       throw new Error("Invalid agent scope");
     }
 
-    const builderStateActions: GetActionsResponseBody = {
-      actions: [
-        ...actions,
-        ...(agentConfiguration.visualizationEnabled
-          ? [getDataVisualizationActionConfiguration()]
-          : []),
-      ],
-    };
-
-    res.status(200).json(builderStateActions);
+    res.status(200).json({ actions });
   } catch (error) {
     return apiError(req, res, {
       status_code: 500,

--- a/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -5,7 +5,6 @@ import {
   getAccessibleSourcesAndApps,
 } from "@app/components/assistant_builder/server_side_props_helpers";
 import type { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
-import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -13,10 +12,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
 export type GetActionsResponseBody = {
-  actions: (
-    | AssistantBuilderActionConfiguration
-    | ReturnType<typeof getDataVisualizationActionConfiguration>
-  )[];
+  actions: AssistantBuilderActionConfiguration[];
 };
 
 async function handler(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Initial task https://github.com/dust-tt/tasks/issues/2884

This PR is a first stab at the recommandation:

> One of them is breaking the endpoint into multiple ones, which is great way to fix the issue UX wise in the short term

What this PR does in essence is:
1. fetch AssistantBuilder light instead of full at server-rendering level
2. fetch actions asynchronously in the frontend
3. make the UI progressive and error friendly for the users

## Tests

https://github.com/user-attachments/assets/d70acd4a-34b5-45ae-b6c3-8fabc5f9e0bd


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
