### PR TITLE
enh(relocation): bump activities `startToClose` timeout

### DIFF
--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -91,14 +91,14 @@ export async function workspaceRelocationWorkflow({
 
 const getFrontSourceRegionActivities = (region: RegionType) => {
   return proxyActivities<typeof frontSourceActivities>({
-    startToCloseTimeout: "10 minutes",
+    startToCloseTimeout: "15 minutes",
     taskQueue: RELOCATION_QUEUES_PER_REGION[region],
   });
 };
 
 const getFrontDestinationRegionActivities = (region: RegionType) => {
   return proxyActivities<typeof frontDestinationActivities>({
-    startToCloseTimeout: "10 minutes",
+    startToCloseTimeout: "15 minutes",
     taskQueue: RELOCATION_QUEUES_PER_REGION[region],
   });
 };


### PR DESCRIPTION
## Description

- This PR bumps the activity `startToClose` timeout from 10 min to 15 min.
- We had occurrences of `getDataSourcesDocuments` activities taking just above 10 min.
- The timeout for the activities in the destination region were bumped too out of consistency.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
