### PR TITLE
[front] mcp: better slice tool names

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -1,10 +1,10 @@
 import { assert, describe, expect, it } from "vitest";
 
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import {
   getPrefixedToolName,
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/mcp_actions";
-import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 
 describe("getPrefixedToolName", () => {
   const mockConfig: ServerSideMCPServerConfigurationType = {

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -1,0 +1,80 @@
+import { assert, describe, expect, it } from "vitest";
+
+import {
+  getPrefixedToolName,
+  TOOL_NAME_SEPARATOR,
+} from "@app/lib/actions/mcp_actions";
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+
+describe("getPrefixedToolName", () => {
+  const mockConfig: ServerSideMCPServerConfigurationType = {
+    name: "Test Server",
+    type: "mcp_server_configuration",
+    sId: "sId1234",
+    id: 1,
+    description: "Test server description",
+    mcpServerViewId: "test-view-id",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    reasoningModel: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    dustAppConfiguration: null,
+    internalMCPServerId: null,
+  };
+
+  it("should correctly prefix and slugify tool names", () => {
+    const result = getPrefixedToolName(mockConfig, "My Tool");
+    expect(result.isOk()).toBe(true);
+    assert(result.isOk());
+    expect(result.value).toBe(`test_server${TOOL_NAME_SEPARATOR}my_tool`);
+  });
+
+  it("should handle tool names that are too long for prefixing", () => {
+    const longToolName = "a".repeat(60);
+    const result = getPrefixedToolName(mockConfig, longToolName);
+    expect(result.isOk()).toBe(true);
+    assert(result.isOk());
+    expect(result.value).toBe("a".repeat(60));
+  });
+
+  it("should handle tool names that are too long to use at all", () => {
+    const extremelyLongName = "a".repeat(65);
+    const result = getPrefixedToolName(mockConfig, extremelyLongName);
+    expect(result.isErr()).toBe(true);
+    assert(result.isErr());
+    expect(result.error.message).toBe(
+      `Tool name "${extremelyLongName}" is too long. Maximum length is 64 characters.`
+    );
+  });
+
+  it("should truncate server name when needed", () => {
+    const longServerConfig: ServerSideMCPServerConfigurationType = {
+      ...mockConfig,
+      name: "a".repeat(100),
+    };
+    const shortToolName = "tool";
+    const result = getPrefixedToolName(longServerConfig, shortToolName);
+    expect(result.isOk()).toBe(true);
+    assert(result.isOk());
+    const expectedServerNameLength =
+      64 - shortToolName.length - TOOL_NAME_SEPARATOR.length;
+    expect(result.value).toBe(
+      `a`.repeat(expectedServerNameLength) + TOOL_NAME_SEPARATOR + shortToolName
+    );
+  });
+
+  it("should handle minimum prefix length requirement", () => {
+    const shortServerConfig: ServerSideMCPServerConfigurationType = {
+      ...mockConfig,
+      name: "ab",
+    };
+    const longToolName = "a".repeat(60);
+    const result = getPrefixedToolName(shortServerConfig, longToolName);
+    expect(result.isOk()).toBe(true);
+    assert(result.isOk());
+    expect(result.value).toBe("a".repeat(60));
+  });
+});

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -431,18 +431,18 @@ function getPrefixedToolName(
     );
   }
 
-  // We want to keep the original name entirely, but we need to ensure that the
-  // prefixed name does not exceed the maximum length.
+  // Calculate if we have enough room for a meaningful prefix (3 chars) plus separator
+  const minPrefixLength = 3 + separator.length;
+  const availableSpace = MAX_TOOL_NAME_LENGTH - slugifiedOriginalName.length;
 
-  // Calculate the maximum allowed length for the config name portion.
-  const maxConfigNameLength =
-    MAX_TOOL_NAME_LENGTH - slugifiedOriginalName.length - separator.length;
-  // If the full prefixed name would be too long, truncate the config name portion.
-  const truncatedConfigName =
-    slugifiedConfigName.length > maxConfigNameLength
-      ? slugifiedConfigName.slice(0, maxConfigNameLength)
-      : slugifiedConfigName;
+  // If we don't have enough room for a meaningful prefix, just return the original name
+  if (availableSpace < minPrefixLength) {
+    return new Ok(slugifiedOriginalName);
+  }
 
+  // Calculate the maximum allowed length for the config name portion
+  const maxConfigNameLength = availableSpace - separator.length;
+  const truncatedConfigName = slugifiedConfigName.slice(0, maxConfigNameLength);
   const prefixedName = `${truncatedConfigName}${separator}${slugifiedOriginalName}`;
 
   return new Ok(prefixedName);

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -414,7 +414,7 @@ async function getMCPClientConnectionParams(
   });
 }
 
-function getPrefixedToolName(
+export function getPrefixedToolName(
   config: MCPServerConfigurationType,
   originalName: string
 ): Result<string, Error> {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Following https://dust4ai.slack.com/archives/C07EEJQT0RX/p1748553041749729
Closing https://github.com/dust-tt/tasks/issues/3035

When two MCP Servers have the same tool, if the server names are too long, and they're added to the same agent, the tool names collide.

This PR implements a way to circumvent this problem.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Actions still work.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks, easy to rollback

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front