### PR TITLE
Allow CSV from google drive in tables query

### DIFF
--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -3,7 +3,7 @@ import type {
   LightContentNode,
   TimeframeUnit,
 } from "@app/types";
-import { assertNever, isGoogleSheetContentNodeInternalId } from "@app/types";
+import { assertNever } from "@app/types";
 
 export const TIME_FRAME_UNIT_TO_LABEL: Record<TimeframeUnit, string> = {
   hour: "hour(s)",

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -247,14 +247,6 @@ export function getTableIdForContentNode(
 
   // We specify whether the connector supports TableQuery as a safeguard in case somehow a non-table node was selected.
   switch (dataSource.connectorProvider) {
-    case "google_drive":
-      if (!isGoogleSheetContentNodeInternalId(contentNode.internalId)) {
-        throw new Error(
-          `Google Drive ContentNode internalId ${contentNode.internalId} is not a Google Sheet internal ID`
-        );
-      }
-      return contentNode.internalId;
-
     // For static tables, the tableId is the contentNode internalId.
     case null:
     case "bigquery":
@@ -262,6 +254,7 @@ export function getTableIdForContentNode(
     case "notion":
     case "salesforce":
     case "snowflake":
+    case "google_drive":
       return contentNode.internalId;
 
     case "confluence":


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/3020

This code would prevent selecting a CSV for Tables Query from google drive. Removing it and solely relying on the fact ( a few lines above) that the type is `table`.

Iinitial PR https://github.com/dust-tt/dust/pull/6768 

That seems surprising that there was 0 report of failure on that. Also CSV are not enabled by default on Google Drive...

## Tests

Tested in dev.

## Risk

Low

## Deploy Plan

- deploy `front`