### PR TITLE
enh(Confluence): reduce throttling on rate limits

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -393,7 +393,7 @@ export class ConfluenceClient {
       //    let Temporal retry in MAX_RETRY_AFTER_DELAY ms.
       if (response.status === 429) {
         const delayMs = getRetryAfterDuration(response.headers);
-        const body = await response.json();
+        const text = await response.text();
         const { statusText } = response;
 
         statsDClient.increment("external.api.calls", 1, [
@@ -410,7 +410,7 @@ export class ConfluenceClient {
             localLogger.warn(
               {
                 delayMs,
-                body,
+                text,
                 statusText,
               },
               "[Confluence] Rate limit hit. Performing activity-side retry."
@@ -453,7 +453,7 @@ export class ConfluenceClient {
           {
             delayMs,
             retryAfterMsForTemporal,
-            body,
+            text,
             statusText,
           },
           `[Confluence] Rate limit hit. Throwing for Temporal. Reason: ${logReason}`

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -195,7 +195,7 @@ const RATE_LIMIT_HEADERS = {
 } as const;
 
 // Ratio remaining / limit at which we start to slow down the requests.
-const THROTTLE_TRIGGER_RATIO = 0.3;
+const THROTTLE_TRIGGER_RATIO = 0.2;
 // If Confluence does not provide a retry-after header, we use this constant to signal no delay.
 const NO_RETRY_AFTER_DELAY = -1;
 // Number of times we retry when rate limited and Confluence does provide a retry-after header.
@@ -498,7 +498,7 @@ export class ConfluenceClient {
       });
     }
 
-    // When approaching the rate limit (THROTTLE_TRIGGER_RATIO of the budget remains), we slow down
+    // When approaching the rate limit (using adaptive throttle ratio based on limit size), we slow down
     // the query pace by waiting NEAR_RATE_LIMIT_DELAY ms.
     if (
       !bypassThrottle &&


### PR DESCRIPTION
## Description

- This PR improves the logging wrt rate limits, reduces the throttling nearing them and fixes an issue introduced in https://github.com/dust-tt/dust/pull/13068.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
