### PR TITLE
fix(Confluence): reduce max exponential backoff and ratio

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -47,8 +47,8 @@ const {
   startToCloseTimeout: "30 minutes",
   retry: {
     initialInterval: "60 seconds",
-    backoffCoefficient: 4,
-    maximumInterval: "5400 seconds",
+    backoffCoefficient: 2,
+    maximumInterval: "3600 seconds",
   },
 });
 


### PR DESCRIPTION
## Description

- This PR rolls back https://github.com/dust-tt/dust/pull/12458.
- It reduces the exponential backoff coefficient (4 to 2) and the max interval (5400s to 3600s). These are the default values and are mostly not used as we rely on the retry-after value for rate limits.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
