### PR TITLE
Fix: keep the shared secret after registering a new remote mcp server

### DIFF
--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -171,10 +171,7 @@ async function handler(
 
         return res.status(201).json({
           success: true,
-          server: {
-            ...metadata,
-            sId: newRemoteMCPServer.sId,
-          },
+          server: newRemoteMCPServer.toJSON(),
         });
       } else {
         const { name } = body;


### PR DESCRIPTION
## Description

We were losing the shared secret if one was saving immediately after registering.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
