### PR TITLE
chore: Don't use workflow to relocate apps

### DIFF
--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -28,7 +28,7 @@ export interface ReadTableChunkParams {
 }
 
 export const CORE_API_CONCURRENCY_LIMIT = 48;
-export const CORE_API_LIST_NODES_BATCH_SIZE = 64;
+export const CORE_API_LIST_NODES_BATCH_SIZE = 32;
 
 // Core.
 

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -440,14 +440,14 @@ export async function workspaceRelocateConnectorsTableWorkflow({
 
 export const getCoreSourceRegionActivities = (region: RegionType) => {
   return proxyActivities<typeof coreSourceActivities>({
-    startToCloseTimeout: "10 minutes",
+    startToCloseTimeout: "15 minutes",
     taskQueue: RELOCATION_QUEUES_PER_REGION[region],
   });
 };
 
 export const getCoreDestinationRegionActivities = (region: RegionType) => {
   return proxyActivities<typeof coreDestinationActivities>({
-    startToCloseTimeout: "10 minutes",
+    startToCloseTimeout: "15 minutes",
     taskQueue: RELOCATION_QUEUES_PER_REGION[region],
   });
 };

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -438,14 +438,14 @@ export async function workspaceRelocateConnectorsTableWorkflow({
  * Core relocation workflows.
  */
 
-const getCoreSourceRegionActivities = (region: RegionType) => {
+export const getCoreSourceRegionActivities = (region: RegionType) => {
   return proxyActivities<typeof coreSourceActivities>({
     startToCloseTimeout: "10 minutes",
     taskQueue: RELOCATION_QUEUES_PER_REGION[region],
   });
 };
 
-const getCoreDestinationRegionActivities = (region: RegionType) => {
+export const getCoreDestinationRegionActivities = (region: RegionType) => {
   return proxyActivities<typeof coreDestinationActivities>({
     startToCloseTimeout: "10 minutes",
     taskQueue: RELOCATION_QUEUES_PER_REGION[region],

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -71,18 +71,18 @@ export async function workspaceRelocationWorkflow({
   });
 
   // 4) Relocate the apps to the destination region.
-  await executeChild(workspaceRelocateAppsWorkflow, {
-    workflowId: `workspaceRelocateAppsWorkflow-${workspaceId}`,
-    searchAttributes: parentSearchAttributes,
-    args: [
-      {
-        workspaceId,
-        sourceRegion,
-        destRegion,
-      },
-    ],
-    memo,
-  });
+  // await executeChild(workspaceRelocateAppsWorkflow, {
+  //   workflowId: `workspaceRelocateAppsWorkflow-${workspaceId}`,
+  //   searchAttributes: parentSearchAttributes,
+  //   args: [
+  //     {
+  //       workspaceId,
+  //       sourceRegion,
+  //       destRegion,
+  //     },
+  //   ],
+  //   memo,
+  // });
 }
 
 /**


### PR DESCRIPTION
## Description
- Don't use the temporal workflow if relocating apps manually
- If not executing, still go through all apps and log it. When executing it will add the `processApp` step
- Comment `workspaceRelocateAppsWorkflow` so it's not automatically executed later during relocation
- reduce table process batch size and increase core activities timeout

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
