### PR TITLE
feat: add support for xAI models (grok)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -74,6 +74,7 @@ pub mod providers {
     pub mod deepseek;
     pub mod fireworks;
     pub mod google_ai_studio;
+    pub mod xai;
     pub mod helpers;
     pub mod openai_compatible_helpers;
     pub mod togetherai;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -74,10 +74,10 @@ pub mod providers {
     pub mod deepseek;
     pub mod fireworks;
     pub mod google_ai_studio;
-    pub mod xai;
     pub mod helpers;
     pub mod openai_compatible_helpers;
     pub mod togetherai;
+    pub mod xai;
 }
 pub mod http {
     pub mod network;

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 
 use super::deepseek::DeepseekProvider;
 use super::fireworks::FireworksProvider;
-use super::xai::XaiProvider;
 use super::togetherai::TogetherAIProvider;
+use super::xai::XaiProvider;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use super::deepseek::DeepseekProvider;
 use super::fireworks::FireworksProvider;
+use super::xai::XaiProvider;
 use super::togetherai::TogetherAIProvider;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, ValueEnum, Deserialize)]
@@ -33,6 +34,7 @@ pub enum ProviderID {
     TogetherAI,
     Deepseek,
     Fireworks,
+    Xai,
 }
 
 impl fmt::Display for ProviderID {
@@ -46,6 +48,7 @@ impl fmt::Display for ProviderID {
             ProviderID::TogetherAI => write!(f, "togetherai"),
             ProviderID::Deepseek => write!(f, "deepseek"),
             ProviderID::Fireworks => write!(f, "fireworks"),
+            ProviderID::Xai => write!(f, "xai"),
         }
     }
 }
@@ -62,9 +65,10 @@ impl FromStr for ProviderID {
             "togetherai" => Ok(ProviderID::TogetherAI),
             "deepseek" => Ok(ProviderID::Deepseek),
             "fireworks" => Ok(ProviderID::Fireworks),
+            "xai" => Ok(ProviderID::Xai),
             _ => Err(ParseError::with_message(
                 "Unknown provider ID \
-                 (possible values: openai, azure_openai, anthropic, mistral, google_ai_studio, togetherai, deepseek, fireworks)",
+                 (possible values: openai, azure_openai, anthropic, mistral, google_ai_studio, togetherai, deepseek, fireworks, xai)",
             ))?,
         }
     }
@@ -167,5 +171,6 @@ pub fn provider(t: ProviderID) -> Box<dyn Provider + Sync + Send> {
         ProviderID::TogetherAI => Box::new(TogetherAIProvider::new()),
         ProviderID::Deepseek => Box::new(DeepseekProvider::new()),
         ProviderID::Fireworks => Box::new(FireworksProvider::new()),
+        ProviderID::Xai => Box::new(XaiProvider::new()),
     }
 }

--- a/core/src/providers/xai.rs
+++ b/core/src/providers/xai.rs
@@ -1,0 +1,230 @@
+use crate::providers::chat_messages::ChatMessage;
+use crate::providers::embedder::Embedder;
+use crate::providers::llm::ChatFunction;
+use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
+use crate::providers::provider::{Provider, ProviderID};
+use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, o200k_base_singleton, CoreBPE};
+use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
+use crate::run::Credentials;
+use crate::utils;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use hyper::Uri;
+use parking_lot::RwLock;
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::openai_compatible_helpers::{
+    openai_compatible_chat_completion, TransformSystemMessages,
+};
+
+pub struct XaiLLM {
+    id: String,
+    api_key: Option<String>,
+}
+
+impl XaiLLM {
+    pub fn new(id: String) -> Self {
+        XaiLLM { id, api_key: None }
+    }
+
+    fn chat_uri(&self) -> Result<Uri> {
+        Ok("https://api.x.ai/v1/chat/completions".parse::<Uri>()?)
+    }
+
+    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
+        o200k_base_singleton()
+    }
+
+    pub fn xai_context_size(_model_id: &str) -> usize {
+        131072
+    }
+}
+
+#[async_trait]
+impl LLM for XaiLLM {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    async fn initialize(&mut self, credentials: Credentials) -> Result<()> {
+        match credentials.get("XAI_API_KEY") {
+            Some(api_key) => {
+                self.api_key = Some(api_key.clone());
+            }
+            None => match tokio::task::spawn_blocking(|| std::env::var("XAI_API_KEY")).await? {
+                Ok(key) => {
+                    self.api_key = Some(key);
+                }
+                Err(_) => Err(anyhow!(
+                    "Credentials or environment variable `XAI_API_KEY` is not set."
+                ))?,
+            },
+        }
+        Ok(())
+    }
+
+    fn context_size(&self) -> usize {
+        Self::xai_context_size(self.id.as_str())
+    }
+
+    async fn encode(&self, text: &str) -> Result<Vec<usize>> {
+        encode_async(self.tokenizer(), text).await
+    }
+
+    async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
+        decode_async(self.tokenizer(), tokens).await
+    }
+
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
+    }
+
+    async fn generate(
+        &self,
+        _prompt: &str,
+        mut _max_tokens: Option<i32>,
+        _temperature: f32,
+        _n: usize,
+        _stop: &Vec<String>,
+        _frequency_penalty: Option<f32>,
+        _presence_penalty: Option<f32>,
+        _top_p: Option<f32>,
+        _top_logprobs: Option<i32>,
+        _extras: Option<Value>,
+        _event_sender: Option<UnboundedSender<Value>>,
+    ) -> Result<LLMGeneration> {
+        Err(anyhow!(
+            "xAI Grok models do not support text completions, only chat completions."
+        ))
+    }
+
+    async fn chat(
+        &self,
+        messages: &Vec<ChatMessage>,
+        functions: &Vec<ChatFunction>,
+        function_call: Option<String>,
+        temperature: f32,
+        top_p: Option<f32>,
+        n: usize,
+        stop: &Vec<String>,
+        max_tokens: Option<i32>,
+        presence_penalty: Option<f32>,
+        frequency_penalty: Option<f32>,
+        logprobs: Option<bool>,
+        top_logprobs: Option<i32>,
+        _extras: Option<Value>,
+        event_sender: Option<UnboundedSender<Value>>,
+    ) -> Result<LLMChatGeneration> {
+        openai_compatible_chat_completion(
+            self.chat_uri()?,
+            self.id.clone(),
+            self.api_key.clone().unwrap(),
+            messages,
+            functions,
+            function_call,
+            temperature,
+            top_p,
+            n,
+            stop,
+            max_tokens,
+            presence_penalty,
+            frequency_penalty,
+            logprobs,
+            top_logprobs,
+            None, // extras
+            event_sender,
+            false,                         // xAI models support streaming
+            TransformSystemMessages::Keep, // xAI models support system messages
+            "xAI".to_string(),
+            false, // xAI models support structured message content
+        )
+        .await
+    }
+}
+
+pub struct XaiProvider {}
+
+impl XaiProvider {
+    pub fn new() -> Self {
+        XaiProvider {}
+    }
+}
+
+#[async_trait]
+impl Provider for XaiProvider {
+    fn id(&self) -> ProviderID {
+        ProviderID::Xai
+    }
+
+    fn setup(&self) -> Result<()> {
+        utils::info("Setting up xAI:");
+        utils::info("");
+        utils::info(
+            "To use xAI's Grok models, you must set the environment variable `XAI_API_KEY`.",
+        );
+        utils::info("Your API key can be found at https://x.ai/developers");
+        utils::info("");
+        utils::info("Once ready you can check your setup with `dust provider test xai`");
+
+        Ok(())
+    }
+
+    async fn test(&self) -> Result<()> {
+        if !utils::confirm(
+            "You are about to make a request for 1 token to the `grok-3-mini-beta` model on the xAI API.",
+        )? {
+            Err(anyhow!("User aborted xAI test."))?;
+        }
+
+        let mut llm = self.llm(String::from("grok-3-mini-beta"));
+        llm.initialize(Credentials::new()).await?;
+
+        let messages = vec![
+            ChatMessage::System(super::chat_messages::SystemChatMessage {
+                role: super::llm::ChatMessageRole::System,
+                content: "You are a helpful assistant.".to_string(),
+            }),
+            ChatMessage::User(super::chat_messages::UserChatMessage {
+                role: super::llm::ChatMessageRole::User,
+                content: super::chat_messages::ContentBlock::Text(
+                    "Hello! Reply with a single word.".to_string(),
+                ),
+                name: None,
+            }),
+        ];
+
+        let _ = llm
+            .chat(
+                &messages,
+                &vec![],
+                None,
+                0.7,
+                None,
+                1,
+                &vec![],
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await?;
+
+        utils::done("Test successfully completed! xAI is ready to use.");
+
+        Ok(())
+    }
+
+    fn llm(&self, id: String) -> Box<dyn LLM + Sync + Send> {
+        Box::new(XaiLLM::new(id))
+    }
+
+    fn embedder(&self, _id: String) -> Box<dyn Embedder + Sync + Send> {
+        unimplemented!("xAI does not support embeddings")
+    }
+}

--- a/core/src/providers/xai.rs
+++ b/core/src/providers/xai.rs
@@ -118,10 +118,15 @@ impl LLM for XaiLLM {
         _extras: Option<Value>,
         event_sender: Option<UnboundedSender<Value>>,
     ) -> Result<LLMChatGeneration> {
+        let api_key = match self.api_key.clone() {
+            Some(key) => key,
+            None => Err(anyhow!("XAI_API_KEY is not set."))?,
+        };
+
         openai_compatible_chat_completion(
             self.chat_uri()?,
             self.id.clone(),
-            self.api_key.clone().unwrap(),
+            api_key,
             messages,
             functions,
             function_call,

--- a/front/components/providers/ProviderSetup.tsx
+++ b/front/components/providers/ProviderSetup.tsx
@@ -178,6 +178,28 @@ export const MODEL_PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
       </>
     ),
   },
+  xai: {
+    title: "xAI",
+    fields: [{ name: "api_key", placeholder: "xAI API Key" }],
+    instructions: (
+      <>
+        <p>
+          To use xAI's Grok models you must provide your API key. It can be found{" "}
+          <a
+            className="font-bold text-highlight-600 hover:text-highlight-500"
+            href="https://x.ai/developers"
+            target="_blank"
+          >
+            here
+          </a>
+          .
+        </p>
+        <p className="mt-2">
+          We'll never use your API key for anything other than to run your apps.
+        </p>
+      </>
+    ),
+  },
 };
 
 export const SERVICE_PROVIDER_CONFIGS: Record<string, ProviderConfig> = {

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -29,6 +29,8 @@ import {
   GPT_4_TURBO_MODEL_CONFIG,
   GPT_4O_MINI_MODEL_CONFIG,
   GPT_4O_MODEL_CONFIG,
+  GROK_3_MINI_MODEL_CONFIG,
+  GROK_3_MODEL_CONFIG,
   MISTRAL_CODESTRAL_MODEL_CONFIG,
   MISTRAL_LARGE_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
@@ -76,6 +78,9 @@ const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
   fireworks: {
     light: PlanetIcon,
   },
+  xai: {
+    light: PlanetIcon,
+  },
 };
 
 export const getModelProviderLogo = (
@@ -113,6 +118,8 @@ export const USED_MODEL_CONFIGS: readonly ModelConfig[] = [
   GEMINI_2_FLASH_LITE_PREVIEW_MODEL_CONFIG,
   GEMINI_2_PRO_PREVIEW_MODEL_CONFIG,
   GEMINI_2_5_PRO_PREVIEW_MODEL_CONFIG,
+  GROK_3_MODEL_CONFIG,
+  GROK_3_MINI_MODEL_CONFIG,
 ] as const;
 
 // Sorted by preference order

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -37,6 +37,7 @@ const prettyfiedProviderNames: { [key in ModelProviderIdType]: string } = {
   togetherai: "TogetherAI",
   deepseek: "Deepseek",
   fireworks: "Fireworks",
+  xai: "xAI",
 };
 
 const modelProviders: Record<ModelProviderIdType, string[]> = uniqBy(

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -77,6 +77,14 @@ export const modelProviders: ModelProvider[] = [
     chat: true,
     embed: false,
   },
+  {
+    providerId: "xai",
+    name: "xAI",
+    built: true,
+    enabled: false,
+    chat: true,
+    embed: false,
+  },
 ];
 
 export const APP_MODEL_PROVIDER_IDS: string[] = [
@@ -88,6 +96,7 @@ export const APP_MODEL_PROVIDER_IDS: string[] = [
   "azure_openai",
   "deepseek",
   "fireworks",
+  "xai",
 ] as const;
 
 type ServiceProvider = {

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -13,6 +13,7 @@ const {
   DUST_MANAGED_TOGETHERAI_API_KEY = "",
   DUST_MANAGED_DEEPSEEK_API_KEY = "",
   DUST_MANAGED_FIREWORKS_API_KEY = "",
+  DUST_MANAGED_XAI_API_KEY = "",
   DUST_MANAGED_FIRECRAWL_API_KEY = "",
 } = process.env;
 
@@ -71,6 +72,9 @@ export const credentialsFromProviders = (
       case "fireworks":
         credentials["FIREWORKS_API_KEY"] = config.api_key;
         break;
+      case "xai":
+        credentials["XAI_API_KEY"] = config.api_key;
+        break;
       case "firecrawl":
         credentials["FIRECRAWL_API_KEY"] = config.api_key;
         break;
@@ -93,6 +97,7 @@ export const dustManagedCredentials = (): CredentialsType => {
     TOGETHERAI_API_KEY: DUST_MANAGED_TOGETHERAI_API_KEY,
     DEEPSEEK_API_KEY: DUST_MANAGED_DEEPSEEK_API_KEY,
     FIREWORKS_API_KEY: DUST_MANAGED_FIREWORKS_API_KEY,
+    XAI_API_KEY: DUST_MANAGED_XAI_API_KEY,
     FIRECRAWL_API_KEY: DUST_MANAGED_FIRECRAWL_API_KEY,
   };
 };

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -20,6 +20,7 @@ export const MODEL_PROVIDER_IDS = [
   "togetherai",
   "deepseek",
   "fireworks",
+  "xai",
 ] as const;
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 
@@ -93,6 +94,9 @@ export function getLargeWhitelistedModel(
   }
   if (isProviderWhitelisted(owner, "mistral")) {
     return MISTRAL_LARGE_MODEL_CONFIG;
+  }
+  if (isProviderWhitelisted(owner, "xai")) {
+    return GROK_3_MODEL_CONFIG;
   }
   return null;
 }
@@ -169,6 +173,11 @@ export const DEEPSEEK_REASONER_MODEL_ID = "deepseek-reasoner" as const;
 export const FIREWORKS_DEEPSEEK_R1_MODEL_ID =
   "accounts/fireworks/models/deepseek-r1" as const;
 
+export const GROK_3_MODEL_ID = "grok-3-latest" as const;
+export const GROK_3_MINI_MODEL_ID = "grok-3-mini-latest" as const;
+export const GROK_3_FAST_MODEL_ID = "grok-3-fast-latest" as const;
+export const GROK_3_MINI_FAST_MODEL_ID = "grok-3-mini-fast-latest" as const;
+
 export const MODEL_IDS = [
   GPT_3_5_TURBO_MODEL_ID,
   GPT_4_TURBO_MODEL_ID,
@@ -214,6 +223,10 @@ export const MODEL_IDS = [
   DEEPSEEK_CHAT_MODEL_ID,
   DEEPSEEK_REASONER_MODEL_ID,
   FIREWORKS_DEEPSEEK_R1_MODEL_ID,
+  GROK_3_MODEL_ID,
+  GROK_3_MINI_MODEL_ID,
+  GROK_3_FAST_MODEL_ID,
+  GROK_3_MINI_FAST_MODEL_ID,
 ] as const;
 export type ModelIdType = (typeof MODEL_IDS)[number];
 
@@ -1141,6 +1154,70 @@ export const FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   },
 };
 
+export const GROK_3_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "xai",
+  modelId: GROK_3_MODEL_ID,
+  displayName: "Grok 3",
+  contextSize: 131_072,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 128,
+  largeModel: true,
+  description: "xAI's Grok 3 flagship model (131k context).",
+  shortDescription: "xAI's flagship model.",
+  isLegacy: false,
+  generationTokensCount: 8_192,
+  supportsVision: false,
+  supportsResponseFormat: false,
+};
+
+export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "xai",
+  modelId: GROK_3_MINI_MODEL_ID,
+  displayName: "Grok 3 Mini",
+  contextSize: 131_072,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 128,
+  largeModel: false,
+  description: "xAI's Grok 3 Mini model (131k context, reasoning).",
+  shortDescription: "xAI's reasoning model.",
+  isLegacy: false,
+  generationTokensCount: 8_192,
+  supportsVision: false,
+  supportsResponseFormat: false,
+};
+
+export const GROK_3_FAST_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "xai",
+  modelId: GROK_3_FAST_MODEL_ID,
+  displayName: "Grok 3 Fast",
+  contextSize: 131_072,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 128,
+  largeModel: true,
+  description: "xAI's Grok 3 flagship model (131k context, fast infra).",
+  shortDescription: "xAI's fast flagship model.",
+  isLegacy: false,
+  generationTokensCount: 8_192,
+  supportsVision: false,
+  supportsResponseFormat: false,
+};
+
+export const GROK_3_MINI_FAST_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "xai",
+  modelId: GROK_3_MINI_FAST_MODEL_ID,
+  displayName: "Grok 3 Mini (Fast)",
+  contextSize: 131_072,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 128,
+  largeModel: false,
+  description: "xAI's Grok 3 Mini model (131k context, reasoning, fast infra).",
+  shortDescription: "xAI's reasoning model.",
+  isLegacy: false,
+  generationTokensCount: 8_192,
+  supportsVision: false,
+  supportsResponseFormat: false,
+};
+
 export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
@@ -1188,6 +1265,10 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   DEEPSEEK_CHAT_MODEL_CONFIG,
   DEEPSEEK_REASONER_MODEL_CONFIG,
   FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG,
+  GROK_3_MODEL_CONFIG,
+  GROK_3_MINI_MODEL_CONFIG,
+  GROK_3_FAST_MODEL_CONFIG,
+  GROK_3_MINI_FAST_MODEL_CONFIG,
 ];
 
 export type ModelConfig = (typeof SUPPORTED_MODEL_CONFIGS)[number];

--- a/front/types/provider.ts
+++ b/front/types/provider.ts
@@ -19,5 +19,6 @@ export type CredentialsType = {
   TOGETHERAI_API_KEY?: string;
   DEEPSEEK_API_KEY?: string;
   FIREWORKS_API_KEY?: string;
+  XAI_API_KEY?: string;
   FIRECRAWL_API_KEY?: string;
 };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -24,6 +24,7 @@ const ModelProviderIdSchema = FlexibleEnumSchema<
   | "togetherai"
   | "deepseek"
   | "fireworks"
+  | "xai"
 >();
 
 const ModelLLMIdSchema = FlexibleEnumSchema<
@@ -71,6 +72,10 @@ const ModelLLMIdSchema = FlexibleEnumSchema<
   | "deepseek-chat" // deepseek api
   | "deepseek-reasoner" // deepseek api
   | "accounts/fireworks/models/deepseek-r1" // fireworks
+  | "grok-3-latest" // xAI
+  | "grok-3-mini-latest" // xAI
+  | "grok-3-fast-latest" // xAI
+  | "grok-3-mini-fast-latest" // xAI
 >();
 
 const EmbeddingProviderIdSchema = FlexibleEnumSchema<"openai" | "mistral">();


### PR DESCRIPTION
## Description

Adds support for the Grok 3 models from xAI. 

Currently exposing Grok 3 and Grok 3 Mini models in the builder (not the fast variants that are more expensive)

## Tests

Local

## Risk

N/A

## Deploy Plan

Deploy front (already added the new secret + ran the refresh)