### PR TITLE
Remove buttons to create a new workspace on `no-workspace`

### DIFF
--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -133,14 +133,6 @@ export default function NoWorkspace({
                 then use the link provided in the invitation email to access the
                 workspace.
               </span>
-              <span className="copy-md text-muted-foreground dark:text-muted-foreground-night">
-                If you're looking to establish{" "}
-                <span className="font-semibold">
-                  {" "}
-                  a new, separate workspace
-                </span>{" "}
-                continue with the following step:
-              </span>
             </div>
           )}
           {status === "revoked" && (

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -1,12 +1,5 @@
-import {
-  BarHeader,
-  Button,
-  DustLogoSquare,
-  Icon,
-  Page,
-} from "@dust-tt/sparkle";
+import { BarHeader, DustLogoSquare, Icon, Page } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
-import { useRouter } from "next/router";
 
 import { fetchRevokedWorkspace } from "@app/lib/api/user";
 import {
@@ -111,36 +104,9 @@ export default function NoWorkspace({
   workspaceName,
   workspaceVerifiedDomain,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const router = useRouter();
-
-  const onCreateWorkspace = async () => {
-    const res = await fetch("/api/create-new-workspace", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-    if (!res.ok) {
-      console.error("Failed to create new workspace");
-      return;
-    }
-    const { sId } = await res.json();
-    await router.push(`/w/${sId}/welcome`);
-  };
-
   return (
     <Page variant="normal">
-      <BarHeader
-        title="Joining Dust"
-        rightActions={
-          <Button
-            size="sm"
-            label="Create a new workspace"
-            variant="warning"
-            onClick={onCreateWorkspace}
-          />
-        }
-      />
+      <BarHeader title="Joining Dust" />
       <div className="mx-auto mt-40 flex max-w-2xl flex-col gap-8">
         <div className="flex flex-col gap-2">
           <div className="items-left justify-left flex flex-row">
@@ -199,14 +165,6 @@ export default function NoWorkspace({
               </span>
             </div>
           )}
-        </div>
-        <div className="flex flex-row justify-end">
-          <Button
-            size="sm"
-            label="Create a new workspace"
-            variant="warning"
-            onClick={onCreateWorkspace}
-          />
         </div>
       </div>
     </Page>


### PR DESCRIPTION
## Description

- This PR removes the buttons to create a new workspace on the page `no-workspace`, where we can end up when auto join is disabled.
- We don't want workspaces created then, we want the user to be invited to the workspace.

<img width="762" alt="Screenshot 2025-06-02 at 6 18 42 PM" src="https://github.com/user-attachments/assets/b4d7ed50-0e39-4d36-a2c6-c320a54eb9b5" />

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
