### PR TITLE
Disable folders Edit/Delete from menu items in search results

### DIFF
--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -182,7 +182,11 @@ export const getMenuItems = (
     });
   }
 
-  if (canWriteInSpace && isFolder(dataSourceView.dataSource)) {
+  if (
+    canWriteInSpace &&
+    isFolder(dataSourceView.dataSource) &&
+    contentActionsRef.current !== null
+  ) {
     actions.push({
       kind: "item",
       label: "Edit",

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -13,10 +13,7 @@ import React from "react";
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import type { ContentActionsRef } from "@app/components/spaces/ContentActions";
-import {
-  ContentActions,
-  getMenuItems,
-} from "@app/components/spaces/ContentActions";
+import { getMenuItems } from "@app/components/spaces/ContentActions";
 import { makeColumnsForSearchResults } from "@app/components/spaces/search/columns";
 import { SearchLocation } from "@app/components/spaces/search/SearchingInSpace";
 import type { SpaceSearchContextType } from "@app/components/spaces/search/SpaceSearchContext";

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -13,7 +13,10 @@ import React from "react";
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import type { ContentActionsRef } from "@app/components/spaces/ContentActions";
-import { getMenuItems } from "@app/components/spaces/ContentActions";
+import {
+  ContentActions,
+  getMenuItems,
+} from "@app/components/spaces/ContentActions";
 import { makeColumnsForSearchResults } from "@app/components/spaces/search/columns";
 import { SearchLocation } from "@app/components/spaces/search/SearchingInSpace";
 import type { SpaceSearchContextType } from "@app/components/spaces/search/SpaceSearchContext";
@@ -461,6 +464,8 @@ function SearchResultsTable({
 
   const sendNotification = useSendNotification();
 
+  // `contentActionsRef` is always null in a search context as results are pulled across data
+  // sources views. We still create the ref to comply to the API of getMenuItems.
   const contentActionsRef = React.useRef<ContentActionsRef>(null);
 
   const addToSpace = React.useCallback(


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/3023

ContentActions requires to be added in the tree knowing the dataSourceView we're operating on. They can't be available in search results as a consequence since they operate across data source view. Simply do not show related actions with the ref is null.

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`