### PR TITLE
Poké - display usage in data source views list

### DIFF
--- a/front/components/poke/data_source_views/columns.tsx
+++ b/front/components/poke/data_source_views/columns.tsx
@@ -3,6 +3,7 @@ import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { DataSourceWithAgentsUsageType } from "@app/types";
 
 interface DataSourceView {
   dataSourceLink: string;
@@ -12,6 +13,7 @@ interface DataSourceView {
   editedBy: string | undefined;
   name: string;
   sId: string;
+  usage: DataSourceWithAgentsUsageType | null;
 }
 
 export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
@@ -62,6 +64,48 @@ export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
         );
       },
     },
+    {
+      accessorKey: "usage",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Usage</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        const usage = row.original.usage;
+        if (!usage) {
+          return (
+            <span className="text-gray-400 dark:text-gray-400-night">-</span>
+          );
+        }
+        return (
+          <div>
+            <span className="font-medium">{usage.count}</span>
+            {usage.count > 0 && (
+              <span className="ml-1 text-xs text-gray-500 dark:text-gray-500-night">
+                ({usage.agentNames.slice(0, 2).join(", ")}
+                {usage.agentNames.length > 2 && ", ..."})
+              </span>
+            )}
+          </div>
+        );
+      },
+      sortingFn: (rowA, rowB) => {
+        const usageA = rowA.original.usage?.count ?? 0;
+        const usageB = rowB.original.usage?.count ?? 0;
+        return usageA - usageB;
+      },
+    },
+
     {
       accessorKey: "editedBy",
       header: "Last edited by",

--- a/front/components/poke/data_source_views/table.tsx
+++ b/front/components/poke/data_source_views/table.tsx
@@ -2,8 +2,9 @@ import { makeColumnsForDataSourceViews } from "@app/components/poke/data_source_
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import type { DataSourceViewWithUsage } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
 import { usePokeDataSourceViews } from "@app/poke/swr/data_source_views";
-import type { DataSourceViewType, LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType } from "@app/types";
 
 interface DataSourceViewsDataTableProps {
   owner: LightWorkspaceType;
@@ -12,7 +13,7 @@ interface DataSourceViewsDataTableProps {
 
 function prepareDataSourceViewsForDisplay(
   owner: LightWorkspaceType,
-  dataSourceViews: DataSourceViewType[],
+  dataSourceViews: DataSourceViewWithUsage[],
   spaceId?: string
 ) {
   return dataSourceViews
@@ -25,6 +26,7 @@ function prepareDataSourceViewsForDisplay(
         editedAt: dsv.editedByUser?.editedAt ?? undefined,
         editedBy: dsv.editedByUser?.fullName ?? undefined,
         name: dsv.sId,
+        usage: dsv.usage,
       };
     })
     .filter((dsv) => !spaceId || dsv.spaceId === spaceId);

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
@@ -1,14 +1,23 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { DataSourceViewType, WithAPIErrorResponse } from "@app/types";
+import type {
+  DataSourceViewType,
+  DataSourceWithAgentsUsageType,
+  WithAPIErrorResponse,
+} from "@app/types";
+
+export type DataSourceViewWithUsage = DataSourceViewType & {
+  usage: DataSourceWithAgentsUsageType | null;
+};
 
 export type PokeListDataSourceViews = {
-  data_source_views: DataSourceViewType[];
+  data_source_views: DataSourceViewWithUsage[];
 };
 
 async function handler(
@@ -48,8 +57,21 @@ async function handler(
         { includeEditedBy: true }
       );
 
+      const dataSourceViewsWithUsage = await Promise.all(
+        dataSourceViews.map(async (dsv) => {
+          const usageResult = await getDataSourceViewUsage({
+            auth,
+            dataSourceView: dsv,
+          });
+          return {
+            ...dsv.toJSON(),
+            usage: usageResult.isOk() ? usageResult.value : null,
+          };
+        })
+      );
+
       return res.status(200).json({
-        data_source_views: dataSourceViews.map((dsv) => dsv.toJSON()),
+        data_source_views: dataSourceViewsWithUsage,
       });
 
     default:

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -8,7 +8,10 @@ import {
   fetcherWithBody,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { PokeListDataSourceViews } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
+import type {
+  DataSourceViewWithUsage,
+  PokeListDataSourceViews,
+} from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
 import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type {
@@ -29,7 +32,7 @@ export function usePokeDataSourceViews({
   );
 
   return {
-    data: data?.data_source_views ?? emptyArray(),
+    data: data?.data_source_views ?? emptyArray<DataSourceViewWithUsage>(),
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,


### PR DESCRIPTION
## Description

Adding the usage on Poké on the data source view list.

<img width="1715" alt="Screenshot 2025-06-03 at 09 40 49" src="https://github.com/user-attachments/assets/9eb339a4-8a4b-4f2e-9564-17e203bf40db" />

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 