### PR TITLE
feat: Bump max pages limit to 1024

### DIFF
--- a/connectors/src/types/webcrawler.ts
+++ b/connectors/src/types/webcrawler.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts";
 
 export const WEBCRAWLER_MAX_DEPTH = 5;
-export const WEBCRAWLER_MAX_PAGES = 512;
+export const WEBCRAWLER_MAX_PAGES = 1024;
 
 export const CrawlingModes = ["child", "website"] as const;
 export type CrawlingMode = (typeof CrawlingModes)[number];

--- a/front/types/connectors/webcrawler.ts
+++ b/front/types/connectors/webcrawler.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts";
 
 export const WEBCRAWLER_MAX_DEPTH = 5;
-export const WEBCRAWLER_MAX_PAGES = 512;
+export const WEBCRAWLER_MAX_PAGES = 1024;
 
 export const CrawlingModes = ["child", "website"] as const;
 export type CrawlingMode = (typeof CrawlingModes)[number];


### PR DESCRIPTION
## Description
- Now that we've migrated all webcrawler connectors to firecrawl and we're not the one taking the load, bumping the max pages limit to continue offering a better webcrawler to our users.
- No backfill, this new limit will be available when setting up the crawler (new or update)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Scraping too much.

## Deploy Plan
- Deploy front
- Deploy connectors
