### PR TITLE
run_agent: dynamic name and description

### DIFF
--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -12,6 +12,7 @@ import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { ConfigurationSectionContainer } from "@app/components/assistant_builder/actions/configuration/ConfigurationSectionContainer";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import type { LightWorkspaceType } from "@app/types";
+import { isGlobalAgentId } from "@app/types";
 
 interface ChildAgentSelectorProps {
   owner: LightWorkspaceType;
@@ -91,7 +92,8 @@ export function ChildAgentConfigurationSection({
               <AssistantPicker
                 owner={owner}
                 assistants={agentConfigurations.filter(
-                  (agent) => agent.sId !== selectedAgentId
+                  (agent) =>
+                    agent.sId !== selectedAgentId && !isGlobalAgentId(agent.sId)
                 )}
                 onItemClick={(agent) => {
                   onAgentSelect(agent.sId);
@@ -99,7 +101,7 @@ export function ChildAgentConfigurationSection({
                 pickerButton={
                   <Button
                     size="sm"
-                    label="Select another agent"
+                    label="Select agent"
                     isLoading={isAgentConfigurationsLoading}
                   />
                 }
@@ -114,7 +116,9 @@ export function ChildAgentConfigurationSection({
           <div className="flex h-full w-full items-center justify-center">
             <AssistantPicker
               owner={owner}
-              assistants={agentConfigurations}
+              assistants={agentConfigurations.filter(
+                (agent) => !isGlobalAgentId(agent.sId)
+              )}
               onItemClick={(agent) => {
                 onAgentSelect(agent.sId);
               }}

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -214,7 +214,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   },
   run_agent: {
     id: 1008,
-    availability: "manual",
+    availability: "auto",
     flag: "dev_mcp_actions",
   },
   query_tables_v2: {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -65,7 +65,7 @@ export async function getInternalMCPServer(
     case "include_data":
       return includeDataServer(auth, agentLoopContext);
     case "run_agent":
-      return runAgentServer(auth);
+      return runAgentServer(auth, agentLoopContext);
     case "reasoning":
       return reasoningServer(auth, agentLoopContext);
     case "run_dust_app":

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -120,17 +120,13 @@ export default async function createServer(
     );
   }
 
-  let toolName = "run_agent_tool_not_available";
-  let toolDescription =
-    "No child agent configured for this tool, as the child agent was probably archived. " +
-    "Do not attempt to run the tool and warn the user instead.";
-
-  // If we have no child agent ID, return a dummy server, this logic is required by the MCP library
-  // but should never happe.
+  // If we have no child ID (unexpected) or the child agent was archived, return a dummy server
+  // whose tool name and description informs the agent of the situation.
   if (!agentBlob) {
     server.tool(
-      toolName,
-      toolDescription,
+      "run_agent_tool_not_available",
+      "No child agent configured for this tool, as the child agent was probably archived. " +
+        "Do not attempt to run the tool and warn the user instead.",
       {
         childAgent:
           ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT],
@@ -150,12 +146,9 @@ export default async function createServer(
     return server;
   }
 
-  toolName = `run_${agentBlob.name}`;
-  toolDescription = `Run agent ${agentBlob.name} - ${agentBlob.description}`;
-
   server.tool(
-    toolName,
-    toolDescription,
+    `run_${agentBlob.name}`,
+    `Run agent ${agentBlob.name} (${agentBlob.description})`,
     {
       query: z
         .string()

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -33,10 +33,7 @@ import type {
 } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
-import {
-  getGlobalAgents,
-  isGlobalAgentId,
-} from "@app/lib/api/assistant/global_agents";
+import { getGlobalAgents } from "@app/lib/api/assistant/global_agents";
 import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import { Authenticator } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
@@ -90,6 +87,7 @@ import {
   Err,
   isAdmin,
   isBuilder,
+  isGlobalAgentId,
   isTimeFrame,
   MAX_STEPS_USE_PER_RUN_LIMIT,
   normalizeError,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -28,7 +28,6 @@ import type {
   ConnectorProvider,
   DataSourceViewType,
   GlobalAgentStatus,
-  isGlobalAgentId,
 } from "@app/types";
 import {
   CLAUDE_2_DEFAULT_MODEL_CONFIG,
@@ -46,6 +45,7 @@ import {
   GLOBAL_AGENTS_SID,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_1_MODEL_CONFIG,
+  isGlobalAgentId,
   isProviderWhitelisted,
   MISTRAL_LARGE_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -28,6 +28,7 @@ import type {
   ConnectorProvider,
   DataSourceViewType,
   GlobalAgentStatus,
+  isGlobalAgentId,
 } from "@app/types";
 import {
   CLAUDE_2_DEFAULT_MODEL_CONFIG,
@@ -1650,10 +1651,6 @@ function getGlobalAgent(
 /**
  * Exported functions
  */
-
-export function isGlobalAgentId(sId: string): boolean {
-  return (Object.values(GLOBAL_AGENTS_SID) as string[]).includes(sId);
-}
 
 // This is the list of global agents that we want to support in past conversations but we don't want
 // to be accessible to users moving forward.

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -5,7 +5,6 @@ import {
   getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration";
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
-import { isGlobalAgentId } from "@app/lib/api/assistant/global_agents";
 import config from "@app/lib/api/config";
 import {
   getDataSources,
@@ -28,13 +27,13 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { TagResource } from "@app/lib/resources/tags_resource";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { ConnectorsAPI, removeNulls } from "@app/types";
-import { TagResource } from "@app/lib/resources/tags_resource";
+import { ConnectorsAPI, removeNulls, isGlobalAgentId } from "@app/types";
 
 export async function sendDataDeletionEmail({
   remainingDays,

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1336,7 +1336,6 @@ export enum GLOBAL_AGENTS_SID {
   DEEPSEEK_R1 = "deepseek-r1",
 }
 
-
 export function isGlobalAgentId(sId: string): boolean {
   return (Object.values(GLOBAL_AGENTS_SID) as string[]).includes(sId);
 }

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1336,6 +1336,11 @@ export enum GLOBAL_AGENTS_SID {
   DEEPSEEK_R1 = "deepseek-r1",
 }
 
+
+export function isGlobalAgentId(sId: string): boolean {
+  return (Object.values(GLOBAL_AGENTS_SID) as string[]).includes(sId);
+}
+
 export function getGlobalAgentAuthorName(agentId: string): string {
   switch (agentId) {
     case GLOBAL_AGENTS_SID.GPT4:


### PR DESCRIPTION
## Description

- Dynamically present agent name in tool name and agent name and description in tool description.
- Prevents selecting global agents (there is a very nasty dependency cycle with global agents that will be super hard to unfurl). Show the tool as not available if a global agent sId is there.
- Show the tool as not available with sensible description if the child agent was archived (tested locally)
- Moved run_agent to availability `auto` (no tools validation is the goal here)

Note: I decided to not work on self-reference since it might make sense in some cases.

Next step: recursive depth protection.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`