### PR TITLE
feat(deep-search): add semantic search tool with dynamic parentsIn

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -1,16 +1,29 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import assert from "assert";
 import { z } from "zod";
 
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import { fetchAgentDataSourceConfiguration } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import {
+  fetchAgentDataSourceConfiguration,
+  getCoreSearchArgs,
+} from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
+import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getDataSourceNameFromView,
+  getDisplayNameForDocument,
+} from "@app/lib/data_sources";
 import type { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -19,7 +32,16 @@ import type {
   CoreAPISearchNodesResponse,
   Result,
 } from "@app/types";
-import { CoreAPI, Err, Ok, removeNulls } from "@app/types";
+import {
+  CoreAPI,
+  dustManagedCredentials,
+  Err,
+  Ok,
+  parseTimeFrame,
+  removeNulls,
+  stripNullBytes,
+  timeFrameFromNow,
+} from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "data_sources_file_system",
@@ -60,7 +82,10 @@ const OPTION_PARAMETERS = {
     ),
 };
 
-const createServer = (): McpServer => {
+const createServer = (
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
   const server = new McpServer(serverInfo);
 
   server.tool(
@@ -336,6 +361,193 @@ const createServer = (): McpServer => {
         message: "Content items found successfully.",
         result: renderSearchResults(searchResult.value),
       });
+    }
+  );
+
+  server.tool(
+    "search",
+    "Perform a semantic search within the folders and files designated by `nodeIds`. All children " +
+      "of the designated nodes will be searched.",
+    {
+      nodeIds: z
+        .array(z.string())
+        .describe(
+          "Array of exact content node IDs to search within. These are the 'id' values from " +
+            "previous search results, which can be folders or files. All children of the designated " +
+            "nodes will be searched."
+        ),
+      dataSources:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+        ],
+      query: z
+        .string()
+        .describe(
+          "The query to search for. This is a natural language query. It doesn't support any " +
+            "specific filter syntax."
+        ),
+
+      relativeTimeFrame: z
+        .string()
+        .regex(/^(all|\d+[hdwmy])$/)
+        .describe(
+          "The time frame (relative to LOCAL_TIME) to restrict the search based on the file updated " +
+            "time." +
+            " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
+            " where {k} is a number. Be strict, do not invent invalid values."
+        ),
+    },
+    async ({ nodeIds, dataSources, query, relativeTimeFrame }) => {
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      const credentials = dustManagedCredentials();
+      const timeFrame = parseTimeFrame(relativeTimeFrame);
+
+      if (!agentLoopContext?.runContext) {
+        throw new Error(
+          "agentLoopRunContext is required where the tool is called."
+        );
+      }
+
+      // Compute the topK and refsOffset for the search.
+      const topK = getRetrievalTopK({
+        agentConfiguration: agentLoopContext.runContext.agentConfiguration,
+        stepActions: agentLoopContext.runContext.stepActions,
+      });
+      const refsOffset = actionRefsOffset({
+        agentConfiguration: agentLoopContext.runContext.agentConfiguration,
+        stepActionIndex: agentLoopContext.runContext.stepActionIndex,
+        stepActions: agentLoopContext.runContext.stepActions,
+        refsOffset: agentLoopContext.runContext.citationsRefsOffset,
+      });
+
+      const coreSearchArgsResults = await concurrentExecutor(
+        dataSources,
+        async (dataSourceConfiguration) =>
+          getCoreSearchArgs(auth, dataSourceConfiguration),
+        { concurrency: 10 }
+      );
+
+      const coreSearchArgs = removeNulls(
+        coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
+      ).map((coreSearchArgs) => {
+        return {
+          ...coreSearchArgs,
+          filter: {
+            ...coreSearchArgs.filter,
+            parents: { in: nodeIds, not: [] },
+          },
+        };
+      });
+
+      if (coreSearchArgs.length === 0) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "Search action must have at least one data source configured.",
+            },
+          ],
+        };
+      }
+
+      const searchResults = await coreAPI.searchDataSources(
+        query,
+        topK,
+        credentials,
+        false,
+        coreSearchArgs.map((args) => {
+          return {
+            projectId: args.projectId,
+            dataSourceId: args.dataSourceId,
+            filter: {
+              ...args.filter,
+              tags: {
+                in: null,
+                not: null,
+              },
+              timestamp: {
+                gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
+                lt: null,
+              },
+            },
+            view_filter: args.view_filter,
+          };
+        })
+      );
+
+      if (searchResults.isErr()) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: searchResults.error.message,
+            },
+          ],
+        };
+      }
+
+      if (refsOffset + topK > getRefs().length) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "The search exhausted the total number of references available for citations",
+            },
+          ],
+        };
+      }
+
+      const refs = getRefs().slice(refsOffset, refsOffset + topK);
+
+      const results: SearchResultResourceType[] =
+        searchResults.value.documents.map((doc) => {
+          const dataSourceView = coreSearchArgs.find(
+            (args) =>
+              args.dataSourceView.dataSource.dustAPIDataSourceId ===
+              doc.data_source_id
+          )?.dataSourceView;
+
+          assert(dataSourceView, "DataSource view not found");
+
+          return {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+            uri: doc.source_url ?? "",
+            text: getDisplayNameForDocument(doc),
+
+            id: doc.document_id,
+            source: {
+              provider:
+                dataSourceView.dataSource.connectorProvider ?? undefined,
+              name: getDataSourceNameFromView(dataSourceView),
+            },
+            tags: doc.tags,
+            ref: refs.shift() as string,
+            chunks: doc.chunks.map((chunk) => stripNullBytes(chunk.text)),
+          };
+        });
+
+      return {
+        isError: false,
+        content: [
+          ...results.map((result) => ({
+            type: "resource" as const,
+            resource: result,
+          })),
+          {
+            type: "resource" as const,
+            resource: {
+              // TODO: use proper mime type, but curently useful to debug.
+              text: `"${query}" (timeFrame=${relativeTimeFrame}, topK=${topK}, nodeIds=${nodeIds.join(
+                ", "
+              )})`,
+              uri: "",
+            },
+          },
+        ],
+      };
     }
   );
 

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -79,7 +79,7 @@ export async function getInternalMCPServer(
     case "gmail":
       return gmailServer(auth, mcpServerId);
     case "data_sources_file_system":
-      return dataSourcesFileSystemServer();
+      return dataSourcesFileSystemServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -199,6 +199,18 @@ export function isMCPInternalInclude(
   );
 }
 
+export function isMCPInternalDataSourceFileSystem(
+  arg: ActionConfigurationType
+): arg is ServerSideMCPToolConfigurationType {
+  return (
+    isServerSideMCPToolConfiguration(arg) &&
+    isInternalMCPServerOfName(
+      arg.internalMCPServerId,
+      "data_sources_file_system"
+    )
+  );
+}
+
 export function isMCPInternalWebsearch(
   arg: ActionConfigurationType
 ): arg is ServerSideMCPToolConfigurationType {

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -19,6 +19,7 @@ import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { isInternalMCPServerOfName } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
 import {
+  isMCPInternalDataSourceFileSystem,
   isMCPInternalInclude,
   isMCPInternalSearch,
   isMCPInternalWebsearch,
@@ -125,9 +126,13 @@ export function getRetrievalTopK({
   const retrievalActions = stepActions.filter(isRetrievalConfiguration);
   const searchActions = stepActions.filter(isMCPInternalSearch);
   const includeActions = stepActions.filter(isMCPInternalInclude);
+  const dsFsActions = stepActions.filter(isMCPInternalDataSourceFileSystem);
 
   const actionsCount =
-    retrievalActions.length + searchActions.length + includeActions.length;
+    retrievalActions.length +
+    searchActions.length +
+    includeActions.length +
+    dsFsActions.length;
 
   if (actionsCount === 0) {
     return 0;
@@ -153,6 +158,11 @@ export function getRetrievalTopK({
     .concat(
       includeActions.map(() => {
         return model.recommendedExhaustiveTopK;
+      })
+    )
+    .concat(
+      dsFsActions.map(() => {
+        return model.recommendedTopK;
       })
     );
 


### PR DESCRIPTION
## Description

Builds on top of the new file system internal server and adds a semantic search tool that lets the model dynamically filter on specific node IDs.

## Tests

Manually in local (works)


## Risk

N/A (gated)

## Deploy Plan

Deploy front