### PR TITLE
Improve format handling when parsing MCP metadata

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -6,6 +6,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { Implementation, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { Ajv } from "ajv";
+import addFormats from "ajv-formats";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { getGlobalDispatcher } from "undici";
 
@@ -351,7 +352,8 @@ export function extractMetadataFromServerVersion(
 export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
   return tools.map((tool) => {
     let inputSchema: JSONSchema | undefined;
-    const ajv = new Ajv();
+    const ajv = new Ajv({ strict: false });
+    addFormats(ajv); // This adds support for standard formats including date-time
 
     if (ajv.validateSchema(tool.inputSchema)) {
       inputSchema = tool.inputSchema as JSONSchema; // unfortunately, ajv does not assert the type when returning.

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -46,6 +46,7 @@
         "@uiw/react-textarea-code-editor": "^3.0.2",
         "@workos-inc/node": "^7.50.0",
         "ajv": "^8.17.1",
+        "ajv-formats": "^1.3.1",
         "auth0": "^4.3.1",
         "blake3": "^2.1.7",
         "bottleneck": "^2.19.5",
@@ -10307,6 +10308,23 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.3.1.tgz",
+      "integrity": "sha512-7YsjGQym+Z6fSxprhCjn4dL7ca8ZWAypAkxtLX3NzcE281xnOeN+HlGdoS8yn9iOIcG3D5SI31eKGX3HaB+UrQ==",
+      "deprecated": "Package has been renamed 'ajv-formats-draft2019'. Please update your package.json accordingly.",
+      "license": "MIT",
+      "dependencies": {
+        "isemail": "^3.2.0",
+        "punycode": "^2.1.1",
+        "schemes": "^1.1.1",
+        "tldjs": "^2.3.1",
+        "uri-js": "^4.2.2"
+      },
+      "peerDependencies": {
+        "ajv": "*"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -18058,6 +18076,18 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "punycode": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -24121,6 +24151,15 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/schemes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.4.0.tgz",
+      "integrity": "sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.0"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -25854,6 +25893,25 @@
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.1.tgz",
+      "integrity": "sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/tldjs/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/tldts": {
       "version": "6.1.71",

--- a/front/package.json
+++ b/front/package.json
@@ -63,6 +63,7 @@
     "@uiw/react-textarea-code-editor": "^3.0.2",
     "@workos-inc/node": "^7.50.0",
     "ajv": "^8.17.1",
+    "ajv-formats": "^1.3.1",
     "auth0": "^4.3.1",
     "blake3": "^2.1.7",
     "bottleneck": "^2.19.5",


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/3015.
- This PR makes the JSONSchema more lenient + adds support for other formats such as datetime.
- Goal here is to swallow errors such as [this](https://app.datadoghq.eu/logs?query=%22Error%20Posting%20message%22%20service%3Afront%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZcVndW3biuBtwAAABhBWmNWbmVVbkFBQk8wTjNZYmU4T2lBQUQAAAAkMDE5NzE1OWYtNTJjNS00MDllLWE5MzgtNGE5YzAzY2Q3Y2RiAAJlnQ&fromUser=true&graphType=flamegraph&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=2262245571216381684&storage=hot&stream_sort=desc&viz=stream&from_ts=1748413783000&to_ts=1748414383000&live=false).

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
