### PR TITLE
run_agent: agent not available or archived

### DIFF
--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -64,6 +64,22 @@ export function ChildAgentConfigurationSection({
     (agent) => agent.sId === selectedAgentId
   );
 
+  if (selectedAgentId && !selectedAgent) {
+    return (
+      <ContentMessage
+        title="The agent selected is not available to you"
+        icon={InformationCircleIcon}
+        variant="warning"
+        size="sm"
+      >
+        The agent ({selectedAgentId}) selected is not available to you, either
+        because it was archived or because you have lot access to it (based on a
+        restricted space you're not a part of). As an editor you can still
+        remove the Run Agent tool to add a new one pointing to another agent.
+      </ContentMessage>
+    );
+  }
+
   return (
     <ConfigurationSectionContainer title="Selected Agent">
       {isAgentConfigurationsLoading ? (

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -73,8 +73,8 @@ export function ChildAgentConfigurationSection({
         size="sm"
       >
         The agent ({selectedAgentId}) selected is not available to you, either
-        because it was archived or because you have lot access to it (based on a
-        restricted space you're not a part of). As an editor you can still
+        because it was archived or because you have lost access to it (based on
+        a restricted space you're not a part of). As an editor you can still
         remove the Run Agent tool to add a new one pointing to another agent.
       </ContentMessage>
     );


### PR DESCRIPTION
## Description

Can be improved but at least gives you indication if you don't have access to an agent (archived or lost access)

![image](https://github.com/user-attachments/assets/a51b6336-8685-42cd-b225-8db33e1c1a8f)


## Tests

Tested locally

## Risk

N/A

## Deploy Plan

- deploy `front`