### PR TITLE
run_agent depth protection

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -165,8 +165,9 @@ export default async function createServer(
         agentLoopContext?.runContext,
         "agentLoopContext is required where the tool is called."
       );
-      const { agentConfiguration: mainAgent, conversation: mainConversation } =
-        agentLoopContext.runContext;
+      const {
+        agentConfiguration: mainAgent /*, conversation: mainConversation*/,
+      } = agentLoopContext.runContext;
 
       const childAgentIdRes = parseAgentConfigurationUri(uri);
       if (childAgentIdRes.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -165,9 +165,8 @@ export default async function createServer(
         agentLoopContext?.runContext,
         "agentLoopContext is required where the tool is called."
       );
-      const {
-        agentConfiguration: mainAgent /*, conversation: mainConversation*/,
-      } = agentLoopContext.runContext;
+      const { agentConfiguration: mainAgent, conversation: mainConversation } =
+        agentLoopContext.runContext;
 
       const childAgentIdRes = parseAgentConfigurationUri(uri);
       if (childAgentIdRes.isErr()) {
@@ -190,6 +189,7 @@ export default async function createServer(
       const convRes = await api.createConversation({
         title: `run_agent ${mainAgent.name} > ${childAgentBlob.name}`,
         visibility: "unlisted",
+        depth: mainConversation.depth + 1,
         message: {
           content: query,
           mentions: [{ configurationId: childAgentId }],

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -122,17 +122,20 @@ export async function createConversation(
   {
     title,
     visibility,
+    depth = 0,
   }: {
     title: string | null;
     visibility: ConversationVisibility;
+    depth?: number;
   }
 ): Promise<ConversationType> {
   const owner = auth.getNonNullableWorkspace();
 
   const conversation = await ConversationResource.makeNew(auth, {
     sId: generateRandomModelSId(),
-    title: title,
-    visibility: visibility,
+    title,
+    visibility,
+    depth,
     requestedGroupIds: [],
   });
 
@@ -143,6 +146,7 @@ export async function createConversation(
     sId: conversation.sId,
     title: conversation.title,
     visibility: conversation.visibility,
+    depth: conversation.depth,
     content: [],
     requestedGroupIds:
       conversation.getConversationRequestedGroupIdsFromModel(auth),
@@ -300,6 +304,7 @@ export async function getConversation(
     owner,
     title: conversation.title,
     visibility: conversation.visibility,
+    depth: conversation.depth,
     content,
     requestedGroupIds:
       conversation.getConversationRequestedGroupIdsFromModel(auth),

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -22,6 +22,7 @@ export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare sId: string;
   declare title: string | null;
   declare visibility: CreationOptional<ConversationVisibility>;
+  declare depth: CreationOptional<number>;
 
   declare requestedGroupIds: number[][];
 }
@@ -50,6 +51,11 @@ ConversationModel.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "unlisted",
+    },
+    depth: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
     },
     requestedGroupIds: {
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT)),

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -277,6 +277,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       owner,
       title: conversation.title,
       visibility: conversation.visibility,
+      depth: conversation.depth,
       requestedGroupIds:
         conversation.getConversationRequestedGroupIdsFromModel(auth),
     });
@@ -347,6 +348,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           owner,
           title: c.title,
           visibility: c.visibility,
+          depth: c.depth,
           requestedGroupIds: new this(
             this.model,
             c.get()

--- a/front/migrations/db/migration_273.sql
+++ b/front/migrations/db/migration_273.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 03, 2025
+ALTER TABLE "public"."conversations" ADD COLUMN "depth" INTEGER NOT NULL DEFAULT 0;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -38,6 +38,8 @@ import {
   isEmptyString,
 } from "@app/types";
 
+const MAX_CONVERSATION_DEPTH = 4;
+
 /**
  * @swagger
  * /api/v1/w/{wId}/assistant/conversations:
@@ -210,6 +212,16 @@ async function handler(
             });
           }
         }
+      }
+
+      if (depth && depth >= MAX_CONVERSATION_DEPTH) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Recursive run_agent calls exceeded depth of ${MAX_CONVERSATION_DEPTH}`,
+          },
+        });
       }
 
       const resolvedFragments = contentFragments ?? [];

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -133,6 +133,7 @@ async function handler(
       const {
         title,
         visibility,
+        depth,
         message,
         contentFragment,
         contentFragments,
@@ -249,6 +250,7 @@ async function handler(
       let conversation = await createConversation(auth, {
         title: title ?? null,
         visibility,
+        depth,
       });
 
       let newContentFragment: ContentFragmentType | null = null;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -255,6 +255,7 @@ export type ConversationWithoutContentType = {
   sId: string;
   title: string | null;
   visibility: ConversationVisibility;
+  depth: number;
   requestedGroupIds: string[][];
 };
 

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -618,6 +618,7 @@ export class DustAPI {
   async createConversation({
     title,
     visibility,
+    depth,
     message,
     contentFragment,
     contentFragments,
@@ -630,6 +631,7 @@ export class DustAPI {
       body: {
         title,
         visibility,
+        depth,
         message,
         contentFragment,
         contentFragments,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2070,6 +2070,7 @@ export const PublicPostConversationsRequestBodySchema = z.intersection(
       .enum(["unlisted", "workspace", "deleted", "test"])
       .optional()
       .default("unlisted"),
+    depth: z.number().optional(),
     message: z.union([
       z.intersection(
         z.object({


### PR DESCRIPTION
## Description

Adds a depth parameter to the conversation object
Enforce a maximal depth of 4 when creating a conversation on the public API
Increment depth through run_agent calls

## Tests

Tested locally

## Risk

High but mitigated through test in dev

## Deploy Plan

- run migration
- deploy `front`