### PR TITLE
feat(async-agent-loop): temporal scaffolding

### DIFF
--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -3,6 +3,7 @@ import { hideBin } from "yargs/helpers";
 
 import logger from "@app/logger/logger";
 import { runPokeWorker } from "@app/poke/temporal/worker";
+import { runAgentLoopWorker } from "@app/temporal/agent_loop/worker";
 import { runDataRetentionWorker } from "@app/temporal/data_retention/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runLabsConnectionsWorker } from "@app/temporal/labs/connections/worker";
@@ -40,7 +41,8 @@ type WorkerName =
   | "tracker_notification"
   | "update_workspace_usage"
   | "upsert_queue"
-  | "upsert_table_queue";
+  | "upsert_table_queue"
+  | "agent_loop";
 
 const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   data_retention: runDataRetentionWorker,
@@ -59,6 +61,7 @@ const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   update_workspace_usage: runUpdateWorkspaceUsageWorker,
   upsert_queue: runUpsertQueueWorker,
   upsert_table_queue: runUpsertTableQueueWorker,
+  agent_loop: runAgentLoopWorker,
 };
 
 const ALL_WORKERS = Object.keys(workerFunctions);

--- a/front/temporal/agent_loop/activities.ts
+++ b/front/temporal/agent_loop/activities.ts
@@ -1,25 +1,43 @@
 export async function planActivity({
   agentMessageId,
+  conversationId,
   step,
 }: {
-  agentMessageId: string;
+  agentMessageId: number;
+  conversationId: string;
   step: number;
-}): Promise<number> {
+}): Promise<
+  | {
+      maxStepsExhausted: true;
+      toolCallsCount: 0;
+    }
+  | {
+      maxStepsExhausted: false;
+      toolCallsCount: number;
+    }
+> {
   void agentMessageId;
+  void conversationId;
   void step;
-  return 0;
+  return {
+    maxStepsExhausted: false,
+    toolCallsCount: 0,
+  };
 }
 
 export async function runToolActivity({
   agentMessageId,
+  conversationId,
   step,
   index,
 }: {
-  agentMessageId: string;
+  agentMessageId: number;
+  conversationId: string;
   step: number;
   index: number;
 }): Promise<void> {
   void agentMessageId;
+  void conversationId;
   void step;
   void index;
 }

--- a/front/temporal/agent_loop/activities.ts
+++ b/front/temporal/agent_loop/activities.ts
@@ -1,0 +1,25 @@
+export async function planActivity({
+  agentMessageId,
+  step,
+}: {
+  agentMessageId: string;
+  step: number;
+}): Promise<number> {
+  void agentMessageId;
+  void step;
+  return 0;
+}
+
+export async function runToolActivity({
+  agentMessageId,
+  step,
+  index,
+}: {
+  agentMessageId: string;
+  step: number;
+  index: number;
+}): Promise<void> {
+  void agentMessageId;
+  void step;
+  void index;
+}

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -1,0 +1,24 @@
+import { getTemporalClient } from "@app/lib/temporal";
+import type { Result } from "@app/types";
+import { Ok } from "@app/types";
+
+import { QUEUE_NAME } from "./config";
+import { agentLoopWorkflow } from "./workflows";
+
+export async function launchAgentLoopWorkflow({
+  agentMessageId,
+}: {
+  agentMessageId: string;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClient();
+
+  const workflowId = `agent-loop-workflow-${agentMessageId}`;
+
+  await client.workflow.start(agentLoopWorkflow, {
+    args: [{ agentMessageId }],
+    taskQueue: QUEUE_NAME,
+    workflowId,
+  });
+
+  return new Ok(undefined);
+}

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -7,15 +7,17 @@ import { agentLoopWorkflow } from "./workflows";
 
 export async function launchAgentLoopWorkflow({
   agentMessageId,
+  conversationId,
 }: {
-  agentMessageId: string;
+  agentMessageId: number;
+  conversationId: string;
 }): Promise<Result<undefined, Error>> {
   const client = await getTemporalClient();
 
-  const workflowId = `agent-loop-workflow-${agentMessageId}`;
+  const workflowId = `agent-loop-workflow-${conversationId}__${agentMessageId}`;
 
   await client.workflow.start(agentLoopWorkflow, {
-    args: [{ agentMessageId }],
+    args: [{ agentMessageId, conversationId }],
     taskQueue: QUEUE_NAME,
     workflowId,
   });

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `agent-loop-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -1,0 +1,30 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { getTemporalWorkerConnection } from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/agent_loop/activities";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runAgentLoopWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    taskQueue: QUEUE_NAME,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -8,21 +8,27 @@ const { planActivity, runToolActivity } = proxyActivities<typeof activities>({
 
 export async function agentLoopWorkflow({
   agentMessageId,
+  conversationId,
 }: {
-  agentMessageId: string;
+  agentMessageId: number;
+  conversationId: string;
 }) {
   let step = 0;
 
   for (;;) {
-    const toolCallsCount = await planActivity({ agentMessageId, step });
+    const { maxStepsExhausted, toolCallsCount } = await planActivity({
+      agentMessageId,
+      conversationId,
+      step,
+    });
 
-    if (!toolCallsCount) {
+    if (maxStepsExhausted || toolCallsCount === 0) {
       return;
     }
 
     await Promise.all(
       Array.from({ length: toolCallsCount }).map((_, index) =>
-        runToolActivity({ agentMessageId, step, index })
+        runToolActivity({ agentMessageId, conversationId, step, index })
       )
     );
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -1,0 +1,31 @@
+import { proxyActivities } from "@temporalio/workflow";
+
+import type * as activities from "@app/temporal/agent_loop/activities";
+
+const { planActivity, runToolActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minute",
+});
+
+export async function agentLoopWorkflow({
+  agentMessageId,
+}: {
+  agentMessageId: string;
+}) {
+  let step = 0;
+
+  for (;;) {
+    const toolCallsCount = await planActivity({ agentMessageId, step });
+
+    if (!toolCallsCount) {
+      return;
+    }
+
+    await Promise.all(
+      Array.from({ length: toolCallsCount }).map((_, index) =>
+        runToolActivity({ agentMessageId, step, index })
+      )
+    );
+
+    step += 1;
+  }
+}


### PR DESCRIPTION
## Description

This doesn't really do anything, and is just boilerplate / scaffolding for the temporal workflow that will power the async agent loop.

The workflow should be pretty stable, but the activities are currently empty.

## Tests

N/A

## Risk

N/A

## Deploy Plan

Deploy front, and make an infra PR so the new worker is ran (for now, on the default `front_worker`)