### PR TITLE
Make notion MCP publicly available

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -143,7 +143,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   notion: {
     id: 11,
     availability: "manual",
-    flag: "dev_mcp_actions",
+    flag: null,
     tools_stakes: {
       search: "never_ask",
       retrieve_page: "never_ask",
@@ -160,7 +160,6 @@ export const INTERNAL_MCP_SERVERS: Record<
       insert_row_into_database: "low",
       create_database: "low",
       update_page: "low",
-      append_block_children: "low",
       add_page_content: "low",
       create_comment: "low",
       delete_block: "low",


### PR DESCRIPTION
## Description

* Public release of MCP notion action (will be associated with documentation). No known blockers for pushing this, but please note any concerns.
* (Also removing deprecated action from constants.ts)

## Tests

* N/a

## Risk

* No functional risk, but will release notion as a public mcp action to customers. 

## Deploy Plan

1. Publish public documentation
2. Deploy front