### PR TITLE
[Agentic loop] Remove time from prompt + add get current time action

### DIFF
--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -59,6 +59,10 @@ const actionsSpecification: ActionSpecifications = {
     detailsComponent: () => null,
     runningLabel: ACTION_RUNNING_LABELS.conversation_list_files_action,
   },
+  conversation_get_current_time_action: {
+    detailsComponent: () => null,
+    runningLabel: ACTION_RUNNING_LABELS.conversation_get_current_time_action,
+  },
   conversation_include_file_action: {
     detailsComponent: ConversationIncludeFileActionDetails,
     runningLabel: ACTION_RUNNING_LABELS.conversation_include_file_action,

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -23,6 +23,9 @@ export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
 export const DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME =
   "list_conversation_files";
 
+export const DEFAULT_CONVERSATION_GET_CURRENT_TIME_ACTION_NAME =
+  "get_current_time";
+
 export const DEFAULT_SEARCH_LABELS_ACTION_NAME = "search_labels";
 
 export const DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME =

--- a/front/lib/actions/conversation/get_current_time.ts
+++ b/front/lib/actions/conversation/get_current_time.ts
@@ -1,0 +1,85 @@
+import moment from "moment-timezone";
+
+import { DEFAULT_CONVERSATION_GET_CURRENT_TIME_ACTION_NAME } from "@app/lib/actions/constants";
+import type { ExtractActionBlob } from "@app/lib/actions/types";
+import { BaseAction } from "@app/lib/actions/types";
+import type {
+  AgentMessageType,
+  FunctionCallType,
+  FunctionMessageTypeModel,
+  ModelId,
+} from "@app/types";
+
+type ConversationGetCurrentTimeActionBlob =
+  ExtractActionBlob<ConversationGetCurrentTimeActionType>;
+
+export class ConversationGetCurrentTimeActionType extends BaseAction {
+  readonly id: ModelId = -1;
+  readonly agentMessageId: ModelId;
+  readonly functionCallId: string | null;
+  readonly functionCallName: string | null;
+  readonly step: number = -1;
+  readonly type = "conversation_get_current_time_action";
+  readonly timezone: string;
+
+  constructor(blob: ConversationGetCurrentTimeActionBlob) {
+    super(blob.id, blob.type);
+
+    this.agentMessageId = blob.agentMessageId;
+    this.functionCallId = blob.functionCallId;
+    this.functionCallName = blob.functionCallName;
+    this.timezone = blob.timezone;
+  }
+
+  renderForFunctionCall(): FunctionCallType {
+    return {
+      id: this.functionCallId ?? `call_${this.id.toString()}`,
+      name:
+        this.functionCallName ??
+        DEFAULT_CONVERSATION_GET_CURRENT_TIME_ACTION_NAME,
+      arguments: JSON.stringify({}),
+    };
+  }
+
+  async renderForMultiActionsModel(): Promise<FunctionMessageTypeModel> {
+    const now = moment().tz(this.timezone);
+
+    const content =
+      `Current date and time information:\n\n` +
+      `Timezone: ${this.timezone}\n` +
+      `Date: ${now.format("YYYY-MM-DD (ddd)")}\n` +
+      `Time: ${now.format("HH:mm")}\n` +
+      `Full: ${now.format("YYYY-MM-DD HH:mm:ss (Z)")}\n` +
+      `Day of week: ${now.format("dddd")}\n` +
+      `Week of year: ${now.format("W")}\n` +
+      `Unix timestamp: ${now.unix()}`;
+
+    return {
+      role: "function" as const,
+      name:
+        this.functionCallName ??
+        DEFAULT_CONVERSATION_GET_CURRENT_TIME_ACTION_NAME,
+      function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
+      content,
+    };
+  }
+}
+
+export function makeConversationGetCurrentTimeAction({
+  agentMessage,
+  timezone,
+}: {
+  agentMessage: AgentMessageType;
+  timezone: string;
+}): ConversationGetCurrentTimeActionType {
+  return new ConversationGetCurrentTimeActionType({
+    id: -1,
+    functionCallId: "call_" + Math.random().toString(36).substring(7),
+    functionCallName: DEFAULT_CONVERSATION_GET_CURRENT_TIME_ACTION_NAME,
+    agentMessageId: agentMessage.agentMessageId,
+    step: -1,
+    type: "conversation_get_current_time_action",
+    generatedFiles: [],
+    timezone,
+  });
+}

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -29,7 +29,8 @@ export type ActionGeneratedFileType = {
 
 type ConversationBaseActionType =
   | "conversation_list_files_action"
-  | "conversation_include_file_action";
+  | "conversation_include_file_action"
+  | "conversation_get_current_time_action";
 
 export type BaseActionType =
   | "browse_action"

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -382,6 +382,7 @@ async function* runMultiActionsAgent(
     agentActions,
     agentMessage,
     conversation,
+    userMessage,
   });
 
   // Get client-side MCP server configurations from user message context.

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -55,7 +55,7 @@ export async function constructPromptMultiActions(
   // CONTEXT section
   let context = "CONTEXT:\n";
   context += `assistant: @${agentConfiguration.name}\n`;
-  context += `local_time: ${d.format("YYYY-MM-DD HH:mm (ddd)")}\n`;
+  context += `local_date: ${d.format("YYYY-MM-DD (ddd)")}\n`;
   context += `model_id: ${model.modelId}\n`;
   if (conversationId) {
     context += `conversation_id: ${conversationId}\n`;

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
   DEFAULT_SEARCH_LABELS_ACTION_NAME,
 } from "@app/lib/actions/constants";
+import { makeConversationGetCurrentTimeAction } from "@app/lib/actions/conversation/get_current_time";
 import { makeConversationIncludeFileConfiguration } from "@app/lib/actions/conversation/include_file";
 import type {
   ConversationAttachmentType,
@@ -47,6 +48,7 @@ import type {
   AgentActionType,
   AgentMessageType,
   ConversationType,
+  UserMessageType,
 } from "@app/types";
 import { assertNever, CoreAPI } from "@app/types";
 
@@ -324,10 +326,12 @@ export async function getEmulatedAndJITActions(
     agentMessage,
     agentActions,
     conversation,
+    userMessage,
   }: {
     agentMessage: AgentMessageType;
     agentActions: AgentActionConfigurationType[];
     conversation: ConversationType;
+    userMessage: UserMessageType;
   }
 ): Promise<{
   emulatedActions: AgentActionType[];
@@ -335,6 +339,13 @@ export async function getEmulatedAndJITActions(
 }> {
   const emulatedActions: AgentActionType[] = [];
   let jitActions: ActionConfigurationType[] = [];
+
+  // Add get current time action
+  const getCurrentTimeAction = makeConversationGetCurrentTimeAction({
+    agentMessage,
+    timezone: userMessage.context.timezone,
+  });
+  emulatedActions.push(getCurrentTimeAction);
 
   const files = listFiles(conversation);
   const a = makeConversationListFilesAction({

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,4 +1,5 @@
 import type { BrowseActionType } from "@app/lib/actions/browse";
+import type { ConversationGetCurrentTimeActionType } from "@app/lib/actions/conversation/get_current_time";
 import type { ConversationIncludeFileActionType } from "@app/lib/actions/conversation/include_file";
 import type { ConversationListFilesActionType } from "@app/lib/actions/conversation/list_files";
 import type { DustAppRunActionType } from "@app/lib/actions/dust_app_run";
@@ -139,7 +140,8 @@ export type ConfigurableAgentActionType =
 
 export type ConversationAgentActionType =
   | ConversationListFilesActionType
-  | ConversationIncludeFileActionType;
+  | ConversationIncludeFileActionType
+  | ConversationGetCurrentTimeActionType;
 
 export type AgentActionType =
   | ConfigurableAgentActionType
@@ -154,6 +156,7 @@ export type AgentMessageStatus =
 
 export const ACTION_RUNNING_LABELS: Record<AgentActionType["type"], string> = {
   browse_action: "Browsing page",
+  conversation_get_current_time_action: "Getting current time",
   conversation_include_file_action: "Reading file",
   conversation_list_files_action: "Listing files",
   dust_app_run_action: "Running App",


### PR DESCRIPTION
## Description

Inspired from [this comment](https://github.com/dust-tt/dust/pull/13100#issuecomment-2934443882) by @fontanierh 

Caching gains would likely be very nice indeed. But if there are agents whose instructions depend on current time, they risk breaking. 

But we'll break less stuff now than later. Furthermore, we can provide a tool-like way to get the time if needed. Missing out on the caching gains would be a shame.

This PR removes the time from the base prompt, and adds a new `get_current_time` action as an emulated action that is always available to agents. The action provides current date and time information using the user's timezone from the conversation context.

### Key features:
- Provides current date, time, timezone, day of week, week of year, and Unix timestamp
- Uses the user's timezone for accurate local time
- Follows existing patterns for emulated conversation actions (similar to `list_files` action)

### Implementation details:
- Added `ConversationGetCurrentTimeActionType` class extending `BaseAction`
- Integrated into `getEmulatedAndJITActions` to make it always available
- Added necessary type definitions and UI configuration
- Passed `userMessage` to `getEmulatedAndJITActions` to access timezone information

## Risks

Low risk - this is a read-only action that provides time information and follows established patterns in the codebase.

## Tests

Manual testing recommended to verify:
- Action appears in agent capabilities
- Correct timezone is used from user context
- Time format displays correctly (HH:mm)

## Deploy Plan

- Deploy front service