### PR TITLE
[connectors] Increase body size limit

### DIFF
--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -56,6 +56,7 @@ export function startServer(port: number) {
 
   app.use(
     bodyParser.json({
+      limit: "8mb",
       verify: (req, _res, buf) => {
         // @ts-expect-error -- rawBody is not defined on Request
         // but we need it to validate webhooks signatures
@@ -94,7 +95,7 @@ export function startServer(port: number) {
   });
 
   app.use(authMiddleware);
-  app.use(express.urlencoded({ extended: true })); // support encoded bodies
+  app.use(express.urlencoded({ extended: true, limit: "8mb" })); // support encoded bodies
 
   app.post("/connectors/create/:connector_provider", createConnectorAPIHandler);
   app.post("/connectors/update/:connector_id/", postConnectorUpdateAPIHandler);


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/2808

## Description

We get 413 from connectors json parser when trying to post a large permission changes. Default is 100kb , which is not enough when we set permissions on a large nunbers of entries. Setting to 8mb.

## Tests


## Risk

none

## Deploy Plan

deploy connectors