### PR TITLE
More logs on forbidden_tables logs

### DIFF
--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use tracing::info;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -350,15 +351,14 @@ impl RemoteDatabase for BigQueryRemoteDatabase {
                 remote_database = "bigquery",
                 used_forbidden_tables = used_forbidden_tables.join(", "),
                 used_forbidden_tables_count = used_forbidden_tables.len(),
-                allowed_tables = allowed_tables.into_iter().collect::<Vec<_>>().join(", "),
                 allowed_tables_count = allowed_tables.len(),
+                allowed_tables = allowed_tables.into_iter().collect::<Vec<_>>().join(", "),
                 "Query uses tables that are not allowed",
             );
             Err(QueryDatabaseError::ExecutionError(
                 format!(
-                    "Query uses tables that are not allowed: {} (allowed: {})",
+                    "Query uses tables that are not allowed: {}",
                     used_forbidden_tables.join(", "),
-                    allowed_tables.into_iter().collect::<Vec<_>>().join(", ")
                 ),
                 Some(query.to_string()),
             ))?

--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -346,6 +346,14 @@ impl RemoteDatabase for BigQueryRemoteDatabase {
             .collect::<Vec<_>>();
 
         if !used_forbidden_tables.is_empty() {
+            info!(
+                remote_database = "bigquery",
+                used_forbidden_tables = used_forbidden_tables.join(", "),
+                used_forbidden_tables_count = used_forbidden_tables.len(),
+                allowed_tables = allowed_tables.into_iter().collect::<Vec<_>>().join(", "),
+                allowed_tables_count = allowed_tables.len(),
+                "Query uses tables that are not allowed",
+            );
             Err(QueryDatabaseError::ExecutionError(
                 format!(
                     "Query uses tables that are not allowed: {} (allowed: {})",

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -321,8 +321,11 @@ impl SnowflakeRemoteDatabase {
 
         if !used_forbidden_tables.is_empty() {
             info!(
+                remote_database = "snowflake",
                 used_forbidden_tables = used_forbidden_tables.join(", "),
+                used_forbidden_tables_count = used_forbidden_tables.len(),
                 allowed_tables = allowed_tables.into_iter().collect::<Vec<_>>().join(", "),
+                allowed_tables_count = allowed_tables.len(),
                 "Query uses tables that are not allowed",
             );
             Err(QueryDatabaseError::ExecutionError(

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -324,8 +324,8 @@ impl SnowflakeRemoteDatabase {
                 remote_database = "snowflake",
                 used_forbidden_tables = used_forbidden_tables.join(", "),
                 used_forbidden_tables_count = used_forbidden_tables.len(),
-                allowed_tables = allowed_tables.into_iter().collect::<Vec<_>>().join(", "),
                 allowed_tables_count = allowed_tables.len(),
+                allowed_tables = allowed_tables.into_iter().collect::<Vec<_>>().join(", "),
                 "Query uses tables that are not allowed",
             );
             Err(QueryDatabaseError::ExecutionError(


### PR DESCRIPTION
## Description

Goal is to better understand this log which does not make a ton of sense:
https://app.datadoghq.eu/logs?query=%22Query%20uses%20tables%20that%20are%20not%20allowed%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZc20vUrjoH_4wAAABhBWmMyMHYxN0FBQ2ctMEU2UXBhU3F3SzcAAAAkMDE5NzM2ZDQtNWE3MC00MWFjLWI4MzUtNjExZWI5NTlmYmE4AAaktQ&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1748420114678&to_ts=1749024914678&live=true

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `core`