### PR TITLE
feat: Add script to manually start a DataSource relocation workflow

### DIFF
--- a/front/scripts/relocation/relocate_data_source.ts
+++ b/front/scripts/relocation/relocate_data_source.ts
@@ -6,6 +6,7 @@ import {
   SUPPORTED_REGIONS,
 } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { makeScript } from "@app/scripts/helpers";
 import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
@@ -62,16 +63,22 @@ makeScript(
       "Must run from source region"
     );
 
-    const dataSource = await DataSourceModel.findOne({
-      attributes: ["id", "dustAPIDataSourceId", "dustAPIProjectId"],
-      where: {
-        id: dataSourceId,
-      },
-      order: [["id", "ASC"]],
+    const dataSource = await DataSourceModel.findByPk(dataSourceId, {
+      include: [
+        {
+          model: Workspace,
+          required: true,
+        },
+      ],
     });
 
     if (!dataSource) {
       logger.error("DataSource not found");
+      return;
+    }
+
+    if (dataSource.workspace.sId !== workspaceId) {
+      logger.error("DataSource is not part of the workspaceId you gave");
       return;
     }
 

--- a/front/scripts/relocation/relocate_data_source.ts
+++ b/front/scripts/relocation/relocate_data_source.ts
@@ -50,14 +50,6 @@ makeScript(
       return;
     }
 
-    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
-    const owner = auth.getNonNullableWorkspace();
-
-    if (owner.metadata?.maintenance !== "relocation") {
-      logger.error("Workspace is not relocating.");
-      return;
-    }
-
     assert(
       config.getCurrentRegion() === sourceRegion,
       "Must run from source region"

--- a/front/scripts/relocation/relocate_data_source.ts
+++ b/front/scripts/relocation/relocate_data_source.ts
@@ -5,7 +5,6 @@ import {
   isRegionType,
   SUPPORTED_REGIONS,
 } from "@app/lib/api/regions/config";
-import { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { makeScript } from "@app/scripts/helpers";

--- a/front/scripts/relocation/relocate_data_source.ts
+++ b/front/scripts/relocation/relocate_data_source.ts
@@ -1,0 +1,103 @@
+import assert from "assert";
+
+import {
+  config,
+  isRegionType,
+  SUPPORTED_REGIONS,
+} from "@app/lib/api/regions/config";
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { makeScript } from "@app/scripts/helpers";
+import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
+import { getTemporalRelocationClient } from "@app/temporal/relocation/temporal";
+import { workspaceRelocateDataSourceCoreWorkflow } from "@app/temporal/relocation/workflows";
+
+makeScript(
+  {
+    workspaceId: {
+      alias: "wId",
+      type: "string",
+      required: true,
+    },
+    sourceRegion: {
+      type: "string",
+      choices: SUPPORTED_REGIONS,
+      demandOption: true,
+    },
+    destRegion: {
+      type: "string",
+      choices: SUPPORTED_REGIONS,
+      demandOption: true,
+    },
+    dataSourceId: {
+      alias: "dsId",
+      type: "number",
+      required: true,
+    },
+  },
+  async (
+    { workspaceId, sourceRegion, destRegion, dataSourceId, execute },
+    logger
+  ) => {
+    if (!isRegionType(sourceRegion) || !isRegionType(destRegion)) {
+      logger.error("Invalid region.");
+      return;
+    }
+
+    if (sourceRegion === destRegion) {
+      logger.error("Source and destination regions must be different.");
+      return;
+    }
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+    const owner = auth.getNonNullableWorkspace();
+
+    if (owner.metadata?.maintenance !== "relocation") {
+      logger.error("Workspace is not relocating.");
+      return;
+    }
+
+    assert(
+      config.getCurrentRegion() === sourceRegion,
+      "Must run from source region"
+    );
+
+    const dataSource = await DataSourceModel.findOne({
+      attributes: ["id", "dustAPIDataSourceId", "dustAPIProjectId"],
+      where: {
+        id: dataSourceId,
+      },
+      order: [["id", "ASC"]],
+    });
+
+    if (!dataSource) {
+      logger.error("DataSource not found");
+      return;
+    }
+
+    const client = await getTemporalRelocationClient();
+
+    const workflowId = `workspaceRelocateDataSourceCoreWorkflow-${workspaceId}-${
+      dataSourceId
+    }`;
+
+    if (execute) {
+      await client.workflow.start(workspaceRelocateDataSourceCoreWorkflow, {
+        workflowId,
+        args: [
+          {
+            dataSourceCoreIds: {
+              id: dataSourceId,
+              dustAPIProjectId: dataSource.dustAPIDataSourceId,
+              dustAPIDataSourceId: dataSource.dustAPIProjectId,
+            },
+            destRegion,
+            sourceRegion,
+            workspaceId,
+          },
+        ],
+        taskQueue: RELOCATION_QUEUES_PER_REGION[sourceRegion],
+      });
+    }
+  }
+);


### PR DESCRIPTION
## Description
- Script to manually trigger the start in temporal a `workspaceRelocateDataSourceCoreWorkflow` for the given `dataSourceId`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Deploy front
- Go into a front-relocation-worker and execute
