### PR TITLE
Allow more simultaneous clientside mcp servers

### DIFF
--- a/front/lib/api/actions/mcp/client_side_registry.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.ts
@@ -6,7 +6,7 @@ import { Err, Ok, slugify } from "@app/types";
 // TTL for MCP server registrations (5 minutes).
 const MCP_SERVER_REGISTRATION_TTL = 5 * 60;
 
-const MAX_SERVER_INSTANCES = 50;
+const MAX_SERVER_INSTANCES = 256;
 
 export class MCPServerInstanceLimitError extends Error {
   constructor(serverName: string) {


### PR DESCRIPTION
## Description

Saw [the error in prod](https://app.datadoghq.eu/logs?query=service%3Afront%20status%3Aerror%20%40apiError.api_error.message%3A%22Maximum%20number%20of%20servers%20%2850%29%20with%20name%20%5C%22Dust%20Extension%5C%22%20reached%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1748421324713&to_ts=1749026124713&live=true). With the dust extension using client-side MCP, the value was a bit low.
We probably need to distinguish between our own stuff and others.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`