### PR TITLE
Fix tool validation approval when user is null 

### DIFF
--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -337,8 +337,8 @@ export async function getExecutionStatusFromConfig(
     case "never_ask":
       return { status: "allowed_implicitly" };
     case "low": {
-      const user = auth.getNonNullableUser();
-      const neverAskSetting = await user.getMetadata(
+      const user = auth.user();
+      const neverAskSetting = await user?.getMetadata(
         `toolsValidations:${actionConfiguration.toolServerId}`
       );
 


### PR DESCRIPTION
## Description
When a request comes via public api, there might be no user and it fails without sending tool approval. Instead of using `getNonNullableUser`, get `user` and if user doesn't exist we can skip `neverAskSetting` check and show a tool validation dialog to end users. 
 https://github.com/dust-tt/dust/blob/47428ad2c30ce52d32d08dde195beb80d29fa8f5/front/lib/auth.ts#L790-L799

Discussed [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1749022335009209)
 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
