### PR TITLE
Swallow certain invalid patterns in JSONSchemas validation

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -374,7 +374,7 @@ export function augmentInputsWithConfiguration({
 
   const inputs = { ...rawInputs };
 
-  const ajv = new Ajv({ allErrors: true });
+  const ajv = new Ajv({ allErrors: true, strict: false });
 
   // Note: When using AJV validation, string patterns must use regex syntax (e.g. /^fil_/) instead
   // of startsWith() to avoid "Invalid escape" errors. This is important because our Zod schemas are


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/3032 hopefully, otherwise the other locations of `new AJV` have to be checked (will follow up).
- This PR makes the schema validation more lenient to swallow certain invalidities in JSONSchemas.

<img width="260" alt="Screenshot 2025-06-04 at 11 04 56 AM" src="https://github.com/user-attachments/assets/9803d0e6-8a58-4178-a869-440428766eb7" />

## Tests

- Tested locally that the input hiding/reinjection mechanism still works.

## Risk

- High blast radius but low risk.

## Deploy Plan

- Deploy front.
