### PR TITLE
Remove the "Add tags" button for global agents

### DIFF
--- a/front/components/assistant/manager/TableTagSelector.tsx
+++ b/front/components/assistant/manager/TableTagSelector.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useUpdateAgentTags } from "@app/lib/swr/tags";
 import type { WorkspaceType } from "@app/types";
+import { isGlobalAgentId } from "@app/types";
 import { isBuilder } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
@@ -39,6 +40,10 @@ export const TableTagSelector = ({
   const updateAgentTags = useUpdateAgentTags({
     owner,
   });
+  if (isGlobalAgentId(agentConfigurationId)) {
+    return null;
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Description

- This PR removes the "Add tags" button in the "Manage Agents" screen for global agents.
- We got errors in prod where user tried to add a tag to gemini-pro (logs [here](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZc3rTwZxPxyPgAAABhBWmMzclVPbEFBQXUwRTJuZHE3bWNBQUcAAAAkMDE5NzM3YWUtYmFlZC00N2UxLWE0ZTMtN2UwZWZhZjg0MTJmAAPSAw&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1748985492000&to_ts=1748985792000&live=false)).

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
