### PR TITLE
Salesforce: Fix bug oauth refresh token missing salesforce url

### DIFF
--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -202,6 +202,11 @@ pub struct ConnectionAccessTokenResponse {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct ConnectionMetadataResponse {
+    pub connection: ConnectionInfo,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct ConnectionInfo {
     connection_id: String,
     created: u64,
@@ -267,6 +272,40 @@ async fn connections_access_token(
                 }),
             ),
         },
+    }
+}
+async fn connections_metadata(
+    State(state): State<Arc<OAuthState>>,
+    Path(connection_id): Path<String>,
+) -> (StatusCode, Json<APIResponse>) {
+    match state.store.retrieve_connection(&connection_id).await {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to retrieve connection",
+            Some(e),
+        ),
+        Ok(None) => error_response(
+            StatusCode::NOT_FOUND,
+            "connection_not_found",
+            "Requested connection was not found",
+            None,
+        ),
+        Ok(Some(c)) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!(ConnectionMetadataResponse {
+                    connection: ConnectionInfo {
+                        connection_id: c.connection_id(),
+                        created: c.created(),
+                        provider: c.provider(),
+                        status: c.status(),
+                        metadata: c.metadata().clone(),
+                    },
+                })),
+            }),
+        ),
     }
 }
 
@@ -400,6 +439,10 @@ pub async fn create_app() -> Result<Router> {
         .route(
             "/connections/:connection_id/access_token",
             get(connections_access_token),
+        )
+        .route(
+            "/connections/:connection_id/metadata",
+            get(connections_metadata),
         )
         .route("/credentials", post(credentials_create))
         .route("/credentials/:credential_id", get(credentials_retrieve))

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -443,6 +443,7 @@ const PROVIDER_STRATEGIES: Record<
       userId,
       useCase
     ) => {
+      // SALESFORCE CONNECTION TO BE DEPRECATED.
       if (useCase === "salesforce_personal") {
         // For personal connection, we reuse the existing connection credential id
         // from the existing data source, if it exists.
@@ -514,7 +515,7 @@ const PROVIDER_STRATEGIES: Record<
           }
 
           const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-          const connectionRes = await oauthApi.getAccessToken({
+          const connectionRes = await oauthApi.getConnectionMetadata({
             connectionId: mcpServerConnectionRes.value.connectionId,
           });
           if (connectionRes.isErr()) {
@@ -735,7 +736,6 @@ export async function createConnectionAndGetSetupUrl(
       userId,
       useCase
     );
-
     if (result) {
       relatedCredential = result.credential;
       extraConfig = result.cleanedConfig;

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -1,4 +1,3 @@
-import { keyBy } from "lodash";
 import type { WhereOptions } from "sequelize";
 import type {
   Attributes,
@@ -210,12 +209,15 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
 
     // Only return the latest connection for a given MCP server.
     // Ideally we would filter in the query directly.
-    const connectionsByServerId = keyBy(
-      connections,
-      (c) => c.internalMCPServerId ?? `${c.remoteMCPServerId}`
-    );
-
-    return Object.values(connectionsByServerId);
+    const latestConnectionsMap = new Map<string, MCPServerConnectionResource>();
+    for (const connection of connections) {
+      const serverKey =
+        connection.internalMCPServerId ?? `${connection.remoteMCPServerId}`;
+      if (!latestConnectionsMap.has(serverKey)) {
+        latestConnectionsMap.set(serverKey, connection);
+      }
+    }
+    return Array.from(latestConnectionsMap.values());
   }
 
   // Deletion.

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -78,13 +78,15 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
 
   private static async baseFetch(
     auth: Authenticator,
-    { where }: ResourceFindOptions<MCPServerConnection> = {}
+    { where, limit, order }: ResourceFindOptions<MCPServerConnection> = {}
   ) {
     const connections = await this.model.findAll({
       where: {
         ...where,
         workspaceId: auth.getNonNullableWorkspace().id,
       } as WhereOptions<MCPServerConnection>,
+      limit,
+      order,
       include: [
         {
           model: UserModel,

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
@@ -19,7 +19,7 @@ describe("MCP Connections API Handler", () => {
         });
       req.query.connectionType = "personal";
 
-      // Create a system space to hold the Remote MCP servers
+      // Create a system space to hold the Remote MCP servers.
       await SpaceFactory.system(workspace, t);
 
       const remoteServer = await RemoteMCPServerFactory.create(workspace);
@@ -41,7 +41,7 @@ describe("MCP Connections API Handler", () => {
       expect(res._getStatusCode()).toBe(200);
       const response = res._getJSONData();
       expect(response.connections).toHaveLength(1);
-      expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection
+      expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection.
     }
   );
 
@@ -58,12 +58,13 @@ describe("MCP Connections API Handler", () => {
 
     const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
-    // Create two workspace connections for the same server
+    // Create two workspace connections for the same server.
     await MCPServerConnectionFactory.remote(
       authenticator,
       remoteServer,
       "workspace"
     );
+    await new Promise((resolve) => setTimeout(resolve, 50));
     const connection2 = await MCPServerConnectionFactory.remote(
       authenticator,
       remoteServer,
@@ -75,7 +76,7 @@ describe("MCP Connections API Handler", () => {
     expect(res._getStatusCode()).toBe(200);
     const response = res._getJSONData();
     expect(response.connections).toHaveLength(1);
-    expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection
+    expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection.
   });
 
   itInTransaction("should handle different server IDs correctly", async (t) => {
@@ -91,7 +92,7 @@ describe("MCP Connections API Handler", () => {
     const remoteServer1 = await RemoteMCPServerFactory.create(workspace);
     const remoteServer2 = await RemoteMCPServerFactory.create(workspace);
 
-    // Create connections for different servers
+    // Create connections for different servers.
     const connection1 = await MCPServerConnectionFactory.remote(
       authenticator,
       remoteServer1,
@@ -119,12 +120,13 @@ describe("MCP Connections API Handler", () => {
     });
     req.query.connectionType = "personal";
 
-    // Create two internal connections for the same server
+    // Create two internal connections for the same server.
     await MCPServerConnectionFactory.internal(
       authenticator,
       "internal_server_1",
       "personal"
     );
+    await new Promise((resolve) => setTimeout(resolve, 50));
     const connection2 = await MCPServerConnectionFactory.internal(
       authenticator,
       "internal_server_1",
@@ -136,7 +138,7 @@ describe("MCP Connections API Handler", () => {
     expect(res._getStatusCode()).toBe(200);
     const response = res._getJSONData();
     expect(response.connections).toHaveLength(1);
-    expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection
+    expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection.
   });
 
   itInTransaction("should return 400 for invalid connection type", async () => {
@@ -159,7 +161,7 @@ describe("MCP Connections API Handler", () => {
   itInTransaction(
     "should not leak personal connections across workspaces",
     async (t) => {
-      // Create first workspace and its connections
+      // Create first workspace and its connections.
       const { workspace: workspace1, authenticator: authenticator1 } =
         await createPrivateApiMockRequest({
           method: "GET",
@@ -172,7 +174,7 @@ describe("MCP Connections API Handler", () => {
         "personal"
       );
 
-      // Create second workspace and its connections
+      // Create second workspace and its connections.
       const {
         req,
         res,
@@ -190,10 +192,10 @@ describe("MCP Connections API Handler", () => {
         "personal"
       );
 
-      // Query connections from workspace2
+      // Query connections from workspace2.
       await handler(req, res);
 
-      // Should only see connections from workspace2
+      // Should only see connections from workspace2.
       expect(res._getStatusCode()).toBe(200);
       const response = res._getJSONData();
       expect(response.connections).toHaveLength(1);
@@ -205,7 +207,7 @@ describe("MCP Connections API Handler", () => {
   itInTransaction(
     "should not leak workspace connections across workspaces",
     async (t) => {
-      // Create first workspace and its connections
+      // Create first workspace and its connections.
       const { workspace: workspace1, authenticator: authenticator1 } =
         await createPrivateApiMockRequest({
           method: "GET",
@@ -219,7 +221,7 @@ describe("MCP Connections API Handler", () => {
         "workspace"
       );
 
-      // Create second workspace and its connections
+      // Create second workspace and its connections.
       const {
         req,
         res,
@@ -238,10 +240,10 @@ describe("MCP Connections API Handler", () => {
         "workspace"
       );
 
-      // Query connections from workspace2
+      // Query connections from workspace2.
       await handler(req, res);
 
-      // Should only see connections from workspace2
+      // Should only see connections from workspace2.
       expect(res._getStatusCode()).toBe(200);
       const response = res._getJSONData();
       expect(response.connections).toHaveLength(1);

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
@@ -57,18 +57,20 @@ describe("MCP Connections API Handler", () => {
     await SpaceFactory.system(workspace, t);
 
     const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    const now = new Date();
 
     // Create two workspace connections for the same server.
     await MCPServerConnectionFactory.remote(
       authenticator,
       remoteServer,
-      "workspace"
+      "workspace",
+      new Date(now.getTime() - 60000) // 1 min ago.
     );
-    await new Promise((resolve) => setTimeout(resolve, 50));
     const connection2 = await MCPServerConnectionFactory.remote(
       authenticator,
       remoteServer,
-      "workspace"
+      "workspace",
+      now
     );
 
     await handler(req, res);
@@ -120,17 +122,20 @@ describe("MCP Connections API Handler", () => {
     });
     req.query.connectionType = "personal";
 
+    const now = new Date();
+
     // Create two internal connections for the same server.
     await MCPServerConnectionFactory.internal(
       authenticator,
       "internal_server_1",
-      "personal"
+      "personal",
+      new Date(now.getTime() - 60000) // 1 min ago.
     );
-    await new Promise((resolve) => setTimeout(resolve, 50));
     const connection2 = await MCPServerConnectionFactory.internal(
       authenticator,
       "internal_server_1",
-      "personal"
+      "personal",
+      now
     );
 
     await handler(req, res);

--- a/front/tests/utils/MCPServerConnectionFactory.ts
+++ b/front/tests/utils/MCPServerConnectionFactory.ts
@@ -9,13 +9,15 @@ export class MCPServerConnectionFactory {
   static async internal(
     auth: Authenticator,
     internalMCPServerId: string,
-    connectionType: MCPServerConnectionConnectionType
+    connectionType: MCPServerConnectionConnectionType,
+    createdAt?: Date
   ): Promise<MCPServerConnectionResource> {
     const connection = await MCPServerConnectionResource.makeNew(auth, {
       connectionId: "con_" + faker.string.alphanumeric(8),
       connectionType,
       serverType: "internal",
       internalMCPServerId,
+      createdAt: createdAt ?? new Date(),
     });
 
     return connection;
@@ -24,13 +26,15 @@ export class MCPServerConnectionFactory {
   static async remote(
     auth: Authenticator,
     remoteMCPServer: RemoteMCPServerResource,
-    connectionType: MCPServerConnectionConnectionType
+    connectionType: MCPServerConnectionConnectionType,
+    createdAt?: Date
   ): Promise<MCPServerConnectionResource> {
     const connection = await MCPServerConnectionResource.makeNew(auth, {
       connectionId: "con_" + faker.string.alphanumeric(8),
       connectionType,
       serverType: "remote",
       remoteMCPServerId: remoteMCPServer.id,
+      createdAt: createdAt ?? new Date(),
     });
 
     return connection;

--- a/front/types/oauth/oauth_api.ts
+++ b/front/types/oauth/oauth_api.ts
@@ -148,6 +148,21 @@ export class OAuthAPI {
     return this._resultFromResponse(response);
   }
 
+  async getConnectionMetadata({
+    connectionId,
+  }: {
+    connectionId: string;
+  }): Promise<
+    OAuthAPIResponse<{
+      connection: OAuthConnectionType;
+    }>
+  > {
+    const response = await this._fetchWithError(
+      `${this._url}/connections/${connectionId}/metadata`
+    );
+    return this._resultFromResponse(response);
+  }
+
   async postCredentials({
     provider,
     userId,


### PR DESCRIPTION
## Description

Fixing the bug "Missing instance url", which was actually 2 bugs. 

First issue is the refresh token fail. @tdraier is sure that this is because we're using too many connections for this account. Since we do not need the refresh token of the account set up by the admin, we got a workaround by introducing a new route in oauth to only fetch the connection metadata. 

Then there was a second issue. The function `findByMCPServer` was correctly attempting to fetch only the latest `MCPServerConnection` but it was using `baseFetch` and `baseFetch` was not applying the `order` and `limit` parameter of the query, so we were retrieving the earliest. 


## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy oauth. 
Deploy front. 