### PR TITLE
Add a fallback when no tags are available

### DIFF
--- a/front/components/assistant/manager/TableTagSelector.tsx
+++ b/front/components/assistant/manager/TableTagSelector.tsx
@@ -10,7 +10,6 @@ import {
   DropdownMenuTagList,
   DropdownMenuTrigger,
   Spinner,
-  TagIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 

--- a/front/components/assistant/manager/TableTagSelector.tsx
+++ b/front/components/assistant/manager/TableTagSelector.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTagList,
   DropdownMenuTrigger,
   Spinner,
+  TagIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -66,34 +67,40 @@ export const TableTagSelector = ({
         <DropdownMenuLabel label="Available tags" />
         <DropdownMenuSeparator />
         <DropdownMenuTagList>
-          {tags
-            .filter((t) => isBuilder(owner) || t.kind !== "protected")
-            .map((t) => {
-              const isChecked = agentTags.some((x) => x.sId === t.sId);
-              return (
-                <div
-                  key={t.sId}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                >
-                  <DropdownMenuTagItem
-                    label={t.name}
-                    color="golden"
-                    icon={isChecked ? CheckIcon : undefined}
-                    onClick={async () => {
-                      setIsLoading(true);
-                      await updateAgentTags(agentConfigurationId, {
-                        addTagIds: isChecked ? [] : [t.sId],
-                        removeTagIds: isChecked ? [t.sId] : [],
-                      });
-                      await onChange();
+          {tags.length === 0 ? (
+            <div className="px-2 py-2 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+              No tags available
+            </div>
+          ) : (
+            tags
+              .filter((t) => isBuilder(owner) || t.kind !== "protected")
+              .map((t) => {
+                const isChecked = agentTags.some((x) => x.sId === t.sId);
+                return (
+                  <div
+                    key={t.sId}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
                     }}
-                  />
-                </div>
-              );
-            })}
+                  >
+                    <DropdownMenuTagItem
+                      label={t.name}
+                      color="golden"
+                      icon={isChecked ? CheckIcon : undefined}
+                      onClick={async () => {
+                        setIsLoading(true);
+                        await updateAgentTags(agentConfigurationId, {
+                          addTagIds: isChecked ? [] : [t.sId],
+                          removeTagIds: isChecked ? [t.sId] : [],
+                        });
+                        await onChange();
+                      }}
+                    />
+                  </div>
+                );
+              })
+          )}
         </DropdownMenuTagList>
         {isLoading && (
           <div className="absolute inset-0 flex items-center justify-center bg-white/50 dark:bg-black/50">


### PR DESCRIPTION
## Description

- This PR adds a fallback in the "Add tags" button in the "Manage Agents" screen when no tags are available.

<img width="260" alt="Screenshot 2025-06-04 at 12 11 11 PM" src="https://github.com/user-attachments/assets/57d4518c-5b01-4b0c-b517-7c75b4a38f9c" />

<img width="260" alt="Screenshot 2025-06-04 at 12 10 49 PM" src="https://github.com/user-attachments/assets/30723c43-0bf0-4c1b-8aab-8fcc81d5be9e" />

## Tests

- N/A

## Risk

- N/A

## Deploy Plan

- Deploy front.
