### PR TITLE
enh(Confluence): Reduce throttle duration on near rate limits

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -208,7 +208,7 @@ const RETRY_AFTER_JITTER = 30_000; // 30 seconds
 // If Confluence returns a retry-after header with a delay greater than this value, we cap it.
 const MAX_RETRY_AFTER_DELAY = 300_000; // 5 minutes
 // If Confluence indicates that we are approaching the rate limit, we delay by this value.
-const NEAR_RATE_LIMIT_DELAY = 120_000; // 2 minutes
+const NEAR_RATE_LIMIT_DELAY = 60_000; // 1 minute
 
 // Space types that we support indexing in Dust.
 export const CONFLUENCE_SUPPORTED_SPACE_TYPES = [

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -195,6 +195,9 @@ const RATE_LIMIT_HEADERS = {
 } as const;
 
 // Ratio remaining / limit at which we start to slow down the requests.
+// Note: we throttle either based on this ratio or when we get the nearLimit header, which is
+// supposed to trigger at 20% (it seems to be a bit more than this since THROTTLE_TRIGGER_RATIO = 0.2
+// is always superseded by the header and THROTTLE_TRIGGER_RATIO = 0.3 never is).
 const THROTTLE_TRIGGER_RATIO = 0.2;
 // If Confluence does not provide a retry-after header, we use this constant to signal no delay.
 const NO_RETRY_AFTER_DELAY = -1;


### PR DESCRIPTION
## Description

- This PR reduces `NEAR_RATE_LIMIT_DELAY` from 2 minutes to 1 minute.
- Now that we have a jitter of 30s on it, 2 minutes seems a bit much and may slow down the sync unnecessarily.
- 1 minute is a bit aggressive, this will be monitored closely through the ratio rate limit hits vs near rate limit hits, the main hypothesis remain that rate limit hits are heavily penalized.
- Ideally these remain the same.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy conectors.
