### PR TITLE
feat(reject-mcp-content-size): added logic to reject remote mcp serve…

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -632,7 +632,6 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       auth,
       inputs,
       agentLoopRunContext,
-      actionConfiguration,
       {
         progressToken: action.id,
       }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -632,6 +632,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       auth,
       inputs,
       agentLoopRunContext,
+      actionConfiguration,
       {
         progressToken: action.id,
       }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -368,10 +368,10 @@ export async function* tryCallMCPTool(
       contentData: {
         type: "text" | "image" | "resource";
         byteSize: number;
-        max_size: number;
+        maxSize: number;
       }[]
     ): boolean => {
-      return !contentData.some((data) => data.byteSize > data.max_size);
+      return !contentData.some((data) => data.byteSize > data.maxSize);
     };
 
     const generateContentMetadata = (
@@ -379,13 +379,20 @@ export async function* tryCallMCPTool(
     ): {
       type: "text" | "image" | "resource";
       byteSize: number;
-      max_size: number;
+      maxSize: number;
     }[] => {
-      return content.map((item) => ({
-        type: item.type,
-        byteSize: calculateContentSize(item),
-        max_size: getMaxSize(item),
-      }));
+      const result = [];
+      for (const item of content) {
+        const byteSize = calculateContentSize(item);
+        const maxSize = getMaxSize(item);
+        const metadata = { type: item.type, byteSize, maxSize };
+        result.push(metadata);
+
+        if (byteSize > maxSize) {
+          break;
+        }
+      }
+      return result;
     };
 
     const getMaxSize = (item: MCPToolResultContentType) => {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -390,7 +390,7 @@ export async function* tryCallMCPTool(
     const { serverType } = getServerTypeAndIdFromSId(toolConfig.toolServerId);
 
     if (serverType === "remote") {
-      if (isValidContentSize(content)) {
+      if (!isValidContentSize(content)) {
         yield {
           type: "result",
           result: new Err(new Error(`MCP Server content size is too large.`)),

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -382,13 +382,9 @@ export async function* tryCallMCPTool(
     const isValidContentSize = (
       content: MCPToolResultContentType[]
     ): boolean => {
-      content.forEach((item) => {
-        const size = calculateContentSize(item);
-        if (size > MAX_CONTENT_SIZE) {
-          return false;
-        }
-      });
-      return true;
+      return !content.some(
+        (item) => calculateContentSize(item) > MAX_CONTENT_SIZE
+      );
     };
 
     const { serverType } = getServerTypeAndIdFromSId(toolConfig.toolServerId);

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -187,7 +187,7 @@ export async function* tryCallMCPTool(
   auth: Authenticator,
   inputs: Record<string, unknown> | undefined,
   agentLoopRunContext: AgentLoopRunContextType,
-  toolConfig: MCPToolConfigurationType,
+  toolConfiguration: MCPToolConfigurationType,
   {
     progressToken,
   }: {
@@ -392,7 +392,9 @@ export async function* tryCallMCPTool(
       );
     };
 
-    const { serverType } = getServerTypeAndIdFromSId(toolConfig.toolServerId);
+    const { serverType } = getServerTypeAndIdFromSId(
+      toolConfiguration.toolServerId
+    );
 
     if (serverType === "remote") {
       if (!isValidContentSize(content)) {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -96,7 +96,8 @@ function isEmptyInputSchema(schema: JSONSchema7): boolean {
 
 const MAX_TOOL_NAME_LENGTH = 64;
 
-const MAX_CONTENT_SIZE = 64 * 1024;
+const MAX_TEXT_CONTENT_SIZE = 64 * 1024;
+const MAX_NON_TEXT_CONTENT_SIZE = 2 * 1024 * 1024;
 
 export const TOOL_NAME_SEPARATOR = "__";
 
@@ -383,7 +384,11 @@ export async function* tryCallMCPTool(
       content: MCPToolResultContentType[]
     ): boolean => {
       return !content.some(
-        (item) => calculateContentSize(item) > MAX_CONTENT_SIZE
+        (item) =>
+          calculateContentSize(item) >
+          (item.type === "text"
+            ? MAX_TEXT_CONTENT_SIZE
+            : MAX_NON_TEXT_CONTENT_SIZE)
       );
     };
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -393,7 +393,7 @@ export async function* tryCallMCPTool(
       if (!isValidContentSize(content)) {
         yield {
           type: "result",
-          result: new Err(new Error(`MCP Server content size is too large.`)),
+          result: new Err(new Error(`MCP tool result content size too large.`)),
         };
       }
     }


### PR DESCRIPTION
Reject output if too large

## Description

Restrict MCP server output.

## Tests

Manually tested locally with custom agent who just uses my tool. Seemed to be able to use my tool just fine without crashing and correctly said the file was too large. 

## Risk

Could prove troublesome for MCP server outputs?

## Deploy Plan

No change.