### PR TITLE
[FS-like tools] Add offset and limit support to cat tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -98,8 +98,20 @@ const createServer = (
           INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
         ],
       nodeId: z.string().describe("The ID of the node to read."),
+      offset: z
+        .number()
+        .optional()
+        .describe(
+          "The character position to start reading from (0-based). If not provided, starts from the beginning."
+        ),
+      limit: z
+        .number()
+        .optional()
+        .describe(
+          "The maximum number of characters to read. If not provided, reads all characters."
+        ),
     },
-    async ({ dataSources, nodeId }) => {
+    async ({ dataSources, nodeId, offset, limit }) => {
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
       // Gather data source configurations.
@@ -149,10 +161,12 @@ const createServer = (
       }
 
       // Read the node.
-      const readResult = await coreAPI.getDataSourceDocument({
+      const readResult = await coreAPI.getDataSourceDocumentText({
         dataSourceId: node.data_source_id,
         documentId: node.node_id,
         projectId: dustAPIProjectId,
+        offset: offset,
+        limit: limit,
       });
 
       if (readResult.isErr()) {
@@ -166,7 +180,7 @@ const createServer = (
         content: [
           {
             type: "text",
-            text: readResult.value.document.text ?? "",
+            text: readResult.value.text,
           },
         ],
       };

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -2,26 +2,26 @@ import { createParser } from "eventsource-parser";
 import * as t from "io-ts";
 
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-
-import { dustManagedCredentials } from "../api/credentials";
-import type { EmbeddingProviderIdType } from "../assistant/assistant";
-import type { ProviderVisibility } from "../connectors/connectors_api";
-import type { DataSourceViewType } from "../data_source_view";
-import type { DustAppSecretType } from "../dust_app_secret";
-import type { GroupType } from "../groups";
-import type { Project } from "../project";
-import type { CredentialsType } from "../provider";
+import { dustManagedCredentials } from "@app/types/api/credentials";
+import type { EmbeddingProviderIdType } from "@app/types/assistant/assistant";
+import type { ProviderVisibility } from "@app/types/connectors/connectors_api";
+import type { DataSourceViewType } from "@app/types/data_source_view";
+import type { DustAppSecretType } from "@app/types/dust_app_secret";
+import type { GroupType } from "@app/types/groups";
+import type { Project } from "@app/types/project";
+import type { CredentialsType } from "@app/types/provider";
 import type {
   BlockType,
   RunConfig,
   RunRunType,
   RunStatus,
   TraceType,
-} from "../run";
-import type { LoggerInterface } from "../shared/logger";
-import type { Result } from "../shared/result";
-import { Err, Ok } from "../shared/result";
-import type { LightWorkspaceType } from "../user";
+} from "@app/types/run";
+import type { LoggerInterface } from "@app/types/shared/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+
 import type { CoreAPIContentNode } from "./content_node";
 import type {
   CoreAPIDataSource,

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -22,7 +22,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 
-import type { CoreAPIContentNode } from "./content_node";
+import type { CoreAPIContentNode } from "@app/types/core/content_node";
 import type {
   CoreAPIDataSource,
   CoreAPIDataSourceConfig,
@@ -34,7 +34,7 @@ import type {
   CoreAPILightDocument,
   CoreAPITableBlob,
   EmbedderType,
-} from "./data_source";
+} from "@app/types/core/data_source";
 
 export const MAX_CHUNK_SIZE = 512;
 

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -5,6 +5,19 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { dustManagedCredentials } from "@app/types/api/credentials";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/assistant";
 import type { ProviderVisibility } from "@app/types/connectors/connectors_api";
+import type { CoreAPIContentNode } from "@app/types/core/content_node";
+import type {
+  CoreAPIDataSource,
+  CoreAPIDataSourceConfig,
+  CoreAPIDataSourceDocumentSection,
+  CoreAPIDocument,
+  CoreAPIDocumentBlob,
+  CoreAPIDocumentVersion,
+  CoreAPIFolder,
+  CoreAPILightDocument,
+  CoreAPITableBlob,
+  EmbedderType,
+} from "@app/types/core/data_source";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { DustAppSecretType } from "@app/types/dust_app_secret";
 import type { GroupType } from "@app/types/groups";
@@ -21,20 +34,6 @@ import type { LoggerInterface } from "@app/types/shared/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
-
-import type { CoreAPIContentNode } from "@app/types/core/content_node";
-import type {
-  CoreAPIDataSource,
-  CoreAPIDataSourceConfig,
-  CoreAPIDataSourceDocumentSection,
-  CoreAPIDocument,
-  CoreAPIDocumentBlob,
-  CoreAPIDocumentVersion,
-  CoreAPIFolder,
-  CoreAPILightDocument,
-  CoreAPITableBlob,
-  EmbedderType,
-} from "@app/types/core/data_source";
 
 export const MAX_CHUNK_SIZE = 512;
 

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1134,6 +1134,64 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
+  async getDataSourceDocumentText({
+    dataSourceId,
+    documentId,
+    projectId,
+    offset,
+    limit,
+    versionHash,
+    viewFilter,
+  }: {
+    dataSourceId: string;
+    documentId: string;
+    projectId: string;
+    offset?: number | null;
+    limit?: number | null;
+    versionHash?: string | null;
+    viewFilter?: CoreAPISearchFilter | null;
+  }): Promise<
+    CoreAPIResponse<{
+      text: string;
+      total_characters: number;
+      offset: number;
+      limit: number | null;
+    }>
+  > {
+    const queryParams = new URLSearchParams();
+
+    if (offset !== null && offset !== undefined) {
+      queryParams.append("offset", String(offset));
+    }
+
+    if (limit !== null && limit !== undefined) {
+      queryParams.append("limit", String(limit));
+    }
+
+    if (versionHash) {
+      queryParams.append("version_hash", versionHash);
+    }
+
+    if (viewFilter) {
+      queryParams.append("view_filter", JSON.stringify(viewFilter));
+    }
+
+    const qs = queryParams.toString();
+
+    const response = await this._fetchWithError(
+      `${this._url}/projects/${encodeURIComponent(
+        projectId
+      )}/data_sources/${encodeURIComponent(
+        dataSourceId
+      )}/documents/${encodeURIComponent(documentId)}/text${qs ? `?${qs}` : ""}`,
+      {
+        method: "GET",
+      }
+    );
+
+    return this._resultFromResponse(response);
+  }
+
   async getDataSourceDocumentVersions({
     projectId,
     dataSourceId,


### PR DESCRIPTION
## Description

This PR adds character-based offset and limit parameters to the cat tool in the data sources file system MCP server. This allows agents to read portions of large documents without loading the entire content, improving performance and usability when dealing with large files.

### Changes:
- Added new endpoint `/documents/:document_id/text` in Core API that accepts `offset` and `limit` query parameters
- The endpoint reuses the existing `data_sources_documents_retrieve` function and applies character-based slicing to the text
- Added `getDataSourceDocumentText` method to the CoreAPI TypeScript client
- Modified the cat tool to accept optional `offset` and `limit` parameters
- Updated parameter descriptions to clarify that offset/limit work with character positions (not lines)

## Risks

Low risk - the changes are additive and don't modify existing functionality. Character-based slicing is straightforward and well-tested in both Rust and TypeScript

## Tests
Tested locally

## Deploy Plan

- Deploy Core API service first (includes the new `/text` endpoint)
- Deploy Front service after Core is deployed
- No migrations required as this is purely additive functionality