### PR TITLE
Salesforce tool: change list object output

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -6,7 +6,10 @@ import {
   getConnectionForInternalMCPServer,
   makeMCPToolPersonalAuthenticationRequiredError,
 } from "@app/lib/actions/mcp_internal_actions/authentication";
-import { makeMCPToolJSONSuccess } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  makeMCPToolJSONSuccess,
+  makeMCPToolTextSuccess,
+} from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -154,13 +157,10 @@ This is the most reliable way to discover the correct names for fields and relat
           }
           return object.custom === (filter === "custom");
         })
-        .map((object) => ({
-          name: object.name,
-          label: object.label,
-          custom: object.custom,
-        }));
+        .map((object) => `${object.name} (display_name="${object.label}")`)
+        .join("\n");
 
-      return makeMCPToolJSONSuccess({
+      return makeMCPToolTextSuccess({
         message: "Operation completed successfully",
         result: objects,
       });


### PR DESCRIPTION
## Description

Changing the output of the list object tool from a json to a string: 
Goal is to clarify the object names versus their display name and take less token. 

From:
```
[
  {
    "name": "AIApplication",
    "label": "AI Application",
    "custom": false
  },
  {
    "name": "AIApplicationConfig",
    "label": "AI Application config",
    "custom": false
  },
```
To:

```
AIApplication (display_name="AI Application")
AIApplicationConfig (display_name="AI Application config")
```

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 