### PR TITLE
[FS-like tools] Add grep parameter to cat tool

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -13,6 +13,7 @@ use axum::{
 use futures::future::try_join_all;
 use hyper::http::StatusCode;
 use parking_lot::Mutex;
+use regex::Regex;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
@@ -2198,6 +2199,7 @@ async fn data_sources_documents_retrieve(
 struct DataSourcesDocumentsRetrieveTextQuery {
     offset: Option<usize>,
     limit: Option<usize>,
+    grep: Option<String>,
     version_hash: Option<String>,
     view_filter: Option<String>, // Parsed as JSON.
 }
@@ -2244,26 +2246,47 @@ async fn data_sources_documents_retrieve_text(
             )
         }
     };
-
-    // Now we have the text, apply character-based offset and limit
+    
+    // First apply character-based offset and limit
     let offset = query.offset.unwrap_or(0);
     let limit = query.limit;
-
+    
     let text_len = text.len();
     let start = offset.min(text_len);
     let end = match limit {
         Some(l) => (start + l).min(text_len),
         None => text_len,
     };
-
+    
     let text_slice = &text[start..end];
-
+    
+    // Then apply grep filter if provided
+    let filtered_text = match &query.grep {
+        Some(pattern) => {
+            match Regex::new(pattern) {
+                Ok(re) => {
+                    let lines: Vec<&str> = text_slice.lines()
+                        .filter(|line| re.is_match(line))
+                        .collect();
+                    lines.join("\n")
+                },
+                Err(_) => return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_regex",
+                    &format!("Invalid regular expression: {}", pattern),
+                    None,
+                ),
+            }
+        },
+        None => text_slice.to_string(),
+    };
+    
     (
         StatusCode::OK,
         Json(APIResponse {
             error: None,
             response: Some(json!({
-                "text": text_slice,
+                "text": filtered_text,
                 "total_characters": text_len,
                 "offset": start,
                 "limit": limit,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -110,8 +110,14 @@ const createServer = (
         .describe(
           "The maximum number of characters to read. If not provided, reads all characters."
         ),
+      grep: z
+        .string()
+        .optional()
+        .describe(
+          "A regular expression to filter lines. Applied after offset/limit slicing. Only lines matching this pattern will be returned."
+        ),
     },
-    async ({ dataSources, nodeId, offset, limit }) => {
+    async ({ dataSources, nodeId, offset, limit, grep }) => {
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
       // Gather data source configurations.
@@ -167,6 +173,7 @@ const createServer = (
         projectId: dustAPIProjectId,
         offset: offset,
         limit: limit,
+        grep: grep,
       });
 
       if (readResult.isErr()) {

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1139,6 +1139,7 @@ export class CoreAPI {
     projectId,
     offset,
     limit,
+    grep,
     versionHash,
     viewFilter,
   }: {
@@ -1147,6 +1148,7 @@ export class CoreAPI {
     projectId: string;
     offset?: number | null;
     limit?: number | null;
+    grep?: string | null;
     versionHash?: string | null;
     viewFilter?: CoreAPISearchFilter | null;
   }): Promise<
@@ -1165,6 +1167,10 @@ export class CoreAPI {
 
     if (limit !== null && limit !== undefined) {
       queryParams.append("limit", String(limit));
+    }
+
+    if (grep) {
+      queryParams.append("grep", grep);
     }
 
     if (versionHash) {


### PR DESCRIPTION
## Description

Adds a `grep` parameter to the cat tool in the data sources file system MCP server. This allows filtering document content by regular expression patterns after applying offset/limit.

The implementation adds regex filtering to the Core API endpoint that retrieves document text, ensuring that:
- Offset/limit slicing is applied first to the document text
- Grep filtering is then applied to the sliced content
- Invalid regex patterns return appropriate error messages
- The feature integrates seamlessly with existing offset/limit functionality

## Risks

- Invalid regex patterns could cause the Core API to return errors
- Large documents with complex regex patterns might have performance implications

## Tests

Manual testing:
- Test cat tool with grep parameter alone
- Test cat tool with grep + offset + limit combined
- Verify that grep is applied after offset/limit slicing

## Deploy Plan

- Merge PR #13142 first (offset/limit support)
- Deploy Core service with the new endpoint
- Deploy Front service with the updated cat tool