### PR TITLE
Improve display of Poke dropdowns

### DIFF
--- a/front/components/poke/shadcn/ui/select.tsx
+++ b/front/components/poke/shadcn/ui/select.tsx
@@ -79,7 +79,12 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "bg-popover text-popover-foreground relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "text-popover-foreground relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border pb-1 pt-1",
+        "bg-muted-background shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95",
+        "data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2",
+        "data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2",
+        "data-[side=top]:slide-in-from-bottom-2 dark:bg-muted-background-night",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -122,7 +127,9 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default select-none",
+      "items-center rounded-sm bg-muted-background py-1.5 pl-6 pr-2 text-sm outline-none",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:bg-muted-background-night",
       "dark:text-white",
       className
     )}
@@ -145,7 +152,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("-mx-1 my-1 h-px bg-muted dark:bg-muted-night", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Description

Before
<img width="473" alt="Screenshot 2025-06-04 at 6 23 37 PM" src="https://github.com/user-attachments/assets/06ce0464-58fc-433c-bfa8-5270eb6c90c7" />

After
<img width="473" alt="Screenshot 2025-06-04 at 6 23 16 PM" src="https://github.com/user-attachments/assets/7ae6c89b-d8fe-43c6-9104-030566585e78" />

The transparent background is now gone and there's a tiny bit more padding above and below.

## Tests

## Risk

## Deploy Plan

- Deploy front.
