### PR TITLE
[front] increase the clickable area for never ask again checkbox

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -256,7 +256,7 @@ export function ActionValidationProvider({
             </div>
             {currentValidation?.stake === "low" && (
               <div className="mt-5">
-                <Label className="copy-sm flex cursor-pointer flex-row items-center gap-2 py-1 font-normal">
+                <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
                   <Checkbox
                     checked={neverAskAgain}
                     onCheckedChange={(check) => {

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -2,6 +2,7 @@ import {
   ActionPieChartIcon,
   Avatar,
   Button,
+  Checkbox,
   CodeBlock,
   CollapsibleComponent,
   Dialog,
@@ -11,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
   Icon,
+  Label,
   Spinner,
 } from "@dust-tt/sparkle";
 import { createContext, useCallback, useEffect, useState } from "react";
@@ -252,20 +254,21 @@ export function ActionValidationProvider({
                 </div>
               )}
             </div>
-          </DialogContainer>
-          <DialogFooter
-            permanentValidation={
-              currentValidation?.stake === "low"
-                ? {
-                    label: "Always allow this tool",
-                    checked: neverAskAgain,
-                    onChange: (check) => {
+            {currentValidation?.stake === "low" && (
+              <div className="mt-5">
+                <Label className="copy-sm flex cursor-pointer flex-row items-center gap-2 font-normal">
+                  <Checkbox
+                    checked={neverAskAgain}
+                    onCheckedChange={(check) => {
                       setNeverAskAgain(!!check);
-                    },
-                  }
-                : undefined
-            }
-          >
+                    }}
+                  />
+                  <span>Always allow this tool</span>
+                </Label>
+              </div>
+            )}
+          </DialogContainer>
+          <DialogFooter>
             <Button
               label="Decline"
               variant="outline"

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -256,7 +256,7 @@ export function ActionValidationProvider({
             </div>
             {currentValidation?.stake === "low" && (
               <div className="mt-5">
-                <Label className="copy-sm flex cursor-pointer flex-row items-center gap-2 font-normal">
+                <Label className="copy-sm flex cursor-pointer flex-row items-center gap-2 py-1 font-normal">
                   <Checkbox
                     checked={neverAskAgain}
                     onCheckedChange={(check) => {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is to let users able to click label for checking "Never ask again" checkbox for Tool validation dialog. We had this UI in sparkle but it should not live in Sparkle, I will cleanup sparkle in a separate PR. 


https://github.com/user-attachments/assets/7e3616a7-90cc-43b6-9574-fff8f9526672

 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
