### PR TITLE
Fix JSONSchema validation to prevent throwing

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -45,6 +45,7 @@ import {
   Ok,
 } from "@app/types";
 import { createSSRFInterceptor } from "@app/types/shared/utils/ssrf";
+import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 
 export type AuthorizationInfo = {
   provider: OAuthProvider;
@@ -351,12 +352,14 @@ export function extractMetadataFromServerVersion(
 export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
   return tools.map((tool) => {
     let inputSchema: JSONSchema | undefined;
-    const ajv = new Ajv();
 
-    if (ajv.validateSchema(tool.inputSchema)) {
-      inputSchema = tool.inputSchema as JSONSchema; // unfortunately, ajv does not assert the type when returning.
+    const { isValid, error } = validateJsonSchema(tool.inputSchema);
+    if (isValid) {
+      inputSchema = tool.inputSchema as JSONSchema;
     } else {
-      logger.error(`[MCP] Invalid input schema for tool: ${tool.name}.`);
+      logger.error(
+        `[MCP] Invalid input schema for tool: ${tool.name} (${error}).`
+      );
     }
     return {
       name: tool.name,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -5,7 +5,6 @@ import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { Implementation, Tool } from "@modelcontextprotocol/sdk/types.js";
-import { Ajv } from "ajv";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { getGlobalDispatcher } from "undici";
 
@@ -34,6 +33,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { OAuthProvider, OAuthUseCase, Result } from "@app/types";
 import {
@@ -45,7 +45,6 @@ import {
   Ok,
 } from "@app/types";
 import { createSSRFInterceptor } from "@app/types/shared/utils/ssrf";
-import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 
 export type AuthorizationInfo = {
   provider: OAuthProvider;


### PR DESCRIPTION
## Description

We are observing some stream dropping error due to an error popping up in `ajv` ([logs](https://app.datadoghq.eu/logs?query=%22Error%20Posting%20message%22%20service%3Afront%20region%3Aus-central1&agg_m=count&agg_t=count&cols=host%2Cservice&fromUser=true&index=%2A&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1749066943000&to_ts=1749067543000&live=false)).
The only code path that seems to allow for this has been narrowed down to the validation in `extractMetadataFromTools`.
This PR addressed the issue by reusing `extractMetadataFromTools` there, which cannot throw.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
