### PR TITLE
Fix duplicate agent flow when agent has a protected tag

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -201,7 +201,9 @@ export default function CreateAssistant({
                 maxStepsPerRun: agentConfiguration.maxStepsPerRun ?? null,
                 visualizationEnabled: agentConfiguration.visualizationEnabled,
                 templateId: templateId,
-                tags: agentConfiguration.tags,
+                tags: agentConfiguration.tags.filter(
+                  (tag) => tag.kind !== "protected"
+                ),
                 // either new, or template, or duplicate, so initially no editors
                 editors: [],
               }


### PR DESCRIPTION
## Description

If an agent has a protected tag and is duplicated by a user, this user won't be able to save the agent since they cannot add or remove protected tags.

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 