### PR TITLE
[front] fix(workspace-scrub): fix conversation deletion

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -6,6 +6,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { AgentConversationIncludeFileAction } from "@app/lib/models/assistant/actions/conversation/include_file";
 import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
+import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import { AgentReasoningAction } from "@app/lib/models/assistant/actions/reasoning";
 import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
@@ -76,6 +77,9 @@ async function destroyActionsRelatedResources(
     where: { agentMessageId: agentMessageIds },
   });
   await AgentReasoningAction.destroy({
+    where: { agentMessageId: agentMessageIds },
+  });
+  await AgentMCPAction.destroy({
     where: { agentMessageId: agentMessageIds },
   });
 }


### PR DESCRIPTION
## Description

- A workspace scrub is stuck on a conversation deletion (logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZc8q2QE-hcX5gAAABhBWmM4cTI3VUFBRHNuQjNPd2lpS3h3RTIAAAAkMDE5NzNjYWItODM0OS00NWVjLThmZDgtZTM0NjkxMjFjOWE4AADP7g&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1749068745145&to_ts=1749069645145&live=true)).
- The current flow does not delete the `AgentMCPAction` beforehand, causing an FK constraint.
- This PR fixes that.

## Tests

- N/A.

## Risk

- Low, admin action where we want to delete everything.

## Deploy Plan

- Deploy front.
