### PR TITLE
[FS-like tools] Handle root node calls in list tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -44,6 +44,7 @@ import {
   stripNullBytes,
   timeFrameFromNow,
 } from "@app/types";
+import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "data_sources_file_system",
@@ -325,7 +326,6 @@ const createServer = (
           return makeMCPToolTextError("Invalid data source node ID format");
         }
 
-        // Find the configuration for this specific data source
         const dataSourceConfig = agentDataSourceConfigurations.find(
           ({ dataSource }) => dataSource.dustAPIDataSourceId === dataSourceId
         );
@@ -336,7 +336,6 @@ const createServer = (
           );
         }
 
-        // Search for nodes in this specific data source with parent_id = undefined (root nodes)
         searchResult = await coreAPI.searchNodes({
           filter: {
             data_source_views: [
@@ -345,7 +344,7 @@ const createServer = (
                 view_filter: dataSourceConfig.dataSourceView.parentsIn ?? [],
               },
             ],
-            // Omit parent_id to search for root nodes
+            parent_id: ROOT_PARENT_ID,
           },
           options,
         });

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -338,7 +338,8 @@ const createServer = (
         searchResult = await coreAPI.searchNodes({
           filter: {
             data_source_views: makeDataSourceViewFilter([dataSourceConfig]),
-            parent_id: ROOT_PARENT_ID,
+            node_ids: dataSourceConfig.parentsIn ?? undefined,
+            parent_id: dataSourceConfig.parentsIn ? undefined : ROOT_PARENT_ID,
           },
           options,
         });

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -305,13 +305,12 @@ const createServer = (
 
       if (!nodeId) {
         // When nodeId is null, search for data sources only
-        const dataSourceViewFilter = agentDataSourceConfigurations.map(
-          ({ dataSource, dataSourceView }) => ({
-            data_source_id: dataSource.dustAPIDataSourceId,
-            view_filter: dataSourceView.parentsIn ?? [],
-            search_scope: "data_source_name" as const,
-          })
-        );
+        const dataSourceViewFilter = makeDataSourceViewFilter(
+          agentDataSourceConfigurations
+        ).map((view) => ({
+          ...view,
+          search_scope: "data_source_name" as const,
+        }));
 
         searchResult = await coreAPI.searchNodes({
           filter: {
@@ -338,12 +337,7 @@ const createServer = (
 
         searchResult = await coreAPI.searchNodes({
           filter: {
-            data_source_views: [
-              {
-                data_source_id: dataSourceId,
-                view_filter: dataSourceConfig.dataSourceView.parentsIn ?? [],
-              },
-            ],
+            data_source_views: makeDataSourceViewFilter([dataSourceConfig]),
             parent_id: ROOT_PARENT_ID,
           },
           options,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -579,12 +579,10 @@ async function getAgentDataSourceConfigurations(
 function makeDataSourceViewFilter(
   agentDataSourceConfigurations: AgentDataSourceConfiguration[]
 ) {
-  return agentDataSourceConfigurations.map(
-    ({ dataSource, dataSourceView }) => ({
-      data_source_id: dataSource.dustAPIDataSourceId,
-      view_filter: dataSourceView.parentsIn ?? [],
-    })
-  );
+  return agentDataSourceConfigurations.map(({ dataSource, parentsIn }) => ({
+    data_source_id: dataSource.dustAPIDataSourceId,
+    view_filter: parentsIn ?? [],
+  }));
 }
 
 function getSortDirection(field: "title" | "timestamp"): "asc" | "desc" {

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -18,6 +18,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
+import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -44,7 +45,6 @@ import {
   stripNullBytes,
   timeFrameFromNow,
 } from "@app/types";
-import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "data_sources_file_system",

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -79,7 +79,7 @@ function makeCoreDataSourceViewFilter(
   };
 }
 
-const ROOT_PARENT_ID = "root";
+export const ROOT_PARENT_ID = "root";
 
 export async function getFlattenedContentNodesOfViewTypeForDataSourceView(
   dataSourceView: DataSourceViewResource | DataSourceViewType,


### PR DESCRIPTION
## Description

This PR changes the "list" tool of "data_sources_file_system" mcp server, so that it handles "root" calls (aka null node id) properly. 

The goal is that root calls list data sources rather than flattened contents of each data source root folder. 

When called with null node id, instead of listing via parentsIn, it searches data sources only (using the search_scope in datasourceview filter for the search node api call). Nodes that are "data sources" returned by core have a static nodeId (`pub const DATA_SOURCE_NODE_ID: &str = "datasource_node_id";` from node.rs). Here, we need data sources to have different ids, so in rendered nodes (see renderNode in data_sources_file_system.ts), node ids that refer to nodes that are data sources should be transformed to `datasource_node_id-${data_source_id}`.

We can then detect if a node id is a datasource by grepping `data_source_node_id-` at the beginning of the node id.

Then, when node id is not null:
- test if it's a data source node id. If yes, then make the search call with only that data source's filter;
- if no, then do the regular call, same as now.

Summary:
  1. Root node handling: When nodeId is null, it searches for data sources only using search_scope
  2. Data source node ID transformation: The renderNode function transforms data source node IDs to include the data source ID
  3. Data source node detection: Helper functions to detect and extract data source IDs from node IDs
  4. Updated list logic: Handles data source nodes by listing their root contents
  5. Removed parentsIn logic: The parentsIn logic has been removed from the list tool
 
A follow-up PR will apply similar logic to find/search

## Risks

- Changes the behavior of the list tool when called with null nodeId
- Modifies how data source nodes are identified through their node IDs

## Tests

Manual testing:
- Test list tool with null nodeId (should list data sources)
- Test list tool with data source node ID (should list root contents of that data source)
- Test list tool with regular node ID (should list children as before)

## Deploy Plan
- Deploy front service with the updated MCP server