### PR TITLE
[front] fix(workspace-scrub): add System group deletion

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -735,6 +735,13 @@ export async function deleteWorkspaceActivity({
     },
   });
 
+  const systemGroup = await GroupResource.internalFetchWorkspaceSystemGroup(
+    workspace.id
+  );
+  if (systemGroup) {
+    await systemGroup.delete(auth);
+  }
+
   hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 
   await Workspace.destroy({


### PR DESCRIPTION
## Description

- Several workspace deletions are stuck on an FK error on the System group ([logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZc8rOBlpB6nsQAAABhBWmM4ck9IUkFBQnlibVdPLUlEVGlnQXoAAAAkMDE5NzNjYWQtYTllOS00NmYyLThmOWYtM2M1N2VmM2E0NjQ0AAbFeA&link_source=monitor_notif&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40workflowId%3Apoke-d9c9e8d54e-delete-workspace%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22workflowId%22%2C%22value%22%3A%22poke-d9c9e8d54e-delete-workspace%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1749069451800%2C%22to%22%3A1749070351800%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1749068745145&to_ts=1749069645145&live=true)).
- This PR adds the System group deletion before deleting the workspace.
- Goal is to unlock some stuck workflows, will be reverted afterwards.

## Tests

## Risk

## Deploy Plan

- Deploy front.
