### PR TITLE
enh(Confluence): decrease `NEAR_RATE_LIMIT_DELAY`

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -208,7 +208,7 @@ const RETRY_AFTER_JITTER = 30_000; // 30 seconds
 // If Confluence returns a retry-after header with a delay greater than this value, we cap it.
 const MAX_RETRY_AFTER_DELAY = 300_000; // 5 minutes
 // If Confluence indicates that we are approaching the rate limit, we delay by this value.
-const NEAR_RATE_LIMIT_DELAY = 60_000; // 1 minute
+const NEAR_RATE_LIMIT_DELAY = 30_000; // 30 seconds
 
 // Space types that we support indexing in Dust.
 export const CONFLUENCE_SUPPORTED_SPACE_TYPES = [

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -586,11 +586,10 @@ export async function confluenceUpsertPageWithFullParentsActivity({
     return false;
   }
 
-  const { cloudId, ignoreNearRateLimit } = confluenceConfig;
   const client = await getConfluenceClient(
     {
-      cloudId,
-      ignoreNearRateLimit,
+      cloudId: confluenceConfig.cloudId,
+      ignoreNearRateLimit: confluenceConfig.ignoreNearRateLimit,
     },
     connector
   );

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -444,7 +444,8 @@ export async function confluenceCheckAndUpsertSinglePageActivity({
 
   const client = await getConfluenceClient(
     {
-      cloudId: confluenceConfig?.cloudId,
+      cloudId: confluenceConfig.cloudId,
+      ignoreNearRateLimit: confluenceConfig.ignoreNearRateLimit,
     },
     connector
   );
@@ -585,8 +586,12 @@ export async function confluenceUpsertPageWithFullParentsActivity({
     return false;
   }
 
+  const { cloudId, ignoreNearRateLimit } = confluenceConfig;
   const client = await getConfluenceClient(
-    { cloudId: confluenceConfig?.cloudId },
+    {
+      cloudId,
+      ignoreNearRateLimit,
+    },
     connector
   );
 


### PR DESCRIPTION
## Description

Looking at the notebook https://app.datadoghq.eu/notebook/196157/confluence we do not observe many repeats of near rate limit hits.
This PR decreases the `NEAR_RATE_LIMIT_DELAY` to 30 s, making it on average at 1 min if we account for the jitter.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
