### PR TITLE
Add: support for oauth 2.1 authentification for Remote MCP Server

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -136,6 +136,7 @@ pub mod oauth {
         pub mod google_drive;
         pub mod hubspot;
         pub mod intercom;
+        pub mod mcp;
         pub mod microsoft;
         pub mod mock;
         pub mod notion;

--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -159,7 +159,8 @@ async fn connections_finalize(
             Err(e) => error_response(
                 match e.code {
                     connection::ConnectionErrorCode::TokenRevokedError => StatusCode::UNAUTHORIZED,
-                    connection::ConnectionErrorCode::ConnectionAlreadyFinalizedError => {
+                    connection::ConnectionErrorCode::ConnectionAlreadyFinalizedError
+                    | connection::ConnectionErrorCode::InvalidMetadataError => {
                         StatusCode::BAD_REQUEST
                     }
                     _ => StatusCode::INTERNAL_SERVER_ERROR,
@@ -244,7 +245,8 @@ async fn connections_access_token(
             Err(e) => error_response(
                 match e.code {
                     connection::ConnectionErrorCode::TokenRevokedError => StatusCode::UNAUTHORIZED,
-                    connection::ConnectionErrorCode::ConnectionNotFinalizedError => {
+                    connection::ConnectionErrorCode::ConnectionNotFinalizedError
+                    | connection::ConnectionErrorCode::InvalidMetadataError => {
                         StatusCode::BAD_REQUEST
                     }
                     _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -54,6 +54,8 @@ pub enum ConnectionErrorCode {
     // Refresh Access Token
     ConnectionNotFinalizedError,
     ProviderAccessTokenRefreshError,
+    // Invalid Metadata
+    InvalidMetadataError,
     // Internal Errors
     InternalError,
 }
@@ -275,13 +277,13 @@ impl ProviderError {
                 code: ConnectionErrorCode::TokenRevokedError,
                 message: self.to_string(),
             },
+            ProviderError::InvalidMetadataError(_) => ConnectionError {
+                code: ConnectionErrorCode::InvalidMetadataError,
+                message: self.to_string(),
+            },
             ProviderError::InternalError(_) => ConnectionError {
                 code: ConnectionErrorCode::InternalError,
                 message: "Failed to finalize connection.".to_string(),
-            },
-            ProviderError::InvalidMetadataError(_) => ConnectionError {
-                code: ConnectionErrorCode::InternalError,
-                message: self.to_string(),
             },
         }
     }
@@ -298,13 +300,13 @@ impl ProviderError {
                 code: ConnectionErrorCode::TokenRevokedError,
                 message: self.to_string(),
             },
+            ProviderError::InvalidMetadataError(_) => ConnectionError {
+                code: ConnectionErrorCode::InvalidMetadataError,
+                message: self.to_string(),
+            },
             ProviderError::InternalError(_) => ConnectionError {
                 code: ConnectionErrorCode::InternalError,
                 message: "Failed to refresh access token.".to_string(),
-            },
-            ProviderError::InvalidMetadataError(_) => ConnectionError {
-                code: ConnectionErrorCode::InternalError,
-                message: self.to_string(),
             },
         }
     }

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -4,10 +4,10 @@ use crate::oauth::{
         confluence::ConfluenceConnectionProvider, github::GithubConnectionProvider,
         gmail::GmailConnectionProvider, gong::GongConnectionProvider,
         google_drive::GoogleDriveConnectionProvider, hubspot::HubspotConnectionProvider,
-        intercom::IntercomConnectionProvider, microsoft::MicrosoftConnectionProvider,
-        mock::MockConnectionProvider, notion::NotionConnectionProvider,
-        salesforce::SalesforceConnectionProvider, slack::SlackConnectionProvider,
-        zendesk::ZendeskConnectionProvider,
+        intercom::IntercomConnectionProvider, mcp::MCPConnectionProvider,
+        microsoft::MicrosoftConnectionProvider, mock::MockConnectionProvider,
+        notion::NotionConnectionProvider, salesforce::SalesforceConnectionProvider,
+        slack::SlackConnectionProvider, zendesk::ZendeskConnectionProvider,
     },
     store::OAuthStore,
 };
@@ -99,6 +99,7 @@ pub enum ConnectionProvider {
     Zendesk,
     Salesforce,
     Hubspot,
+    Mcp,
 }
 
 impl FromStr for ConnectionProvider {
@@ -233,6 +234,7 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
         ConnectionProvider::Zendesk => Box::new(ZendeskConnectionProvider::new()),
         ConnectionProvider::Salesforce => Box::new(SalesforceConnectionProvider::new()),
         ConnectionProvider::Hubspot => Box::new(HubspotConnectionProvider::new()),
+        ConnectionProvider::Mcp => Box::new(MCPConnectionProvider::new()),
     }
 }
 
@@ -250,6 +252,8 @@ pub enum ProviderError {
     InternalError(anyhow::Error),
     #[error("Token revoked.")]
     TokenRevokedError,
+    #[error("Invalid metadata: {0}.")]
+    InvalidMetadataError(String),
 }
 
 impl From<anyhow::Error> for ProviderError {
@@ -275,6 +279,10 @@ impl ProviderError {
                 code: ConnectionErrorCode::InternalError,
                 message: "Failed to finalize connection.".to_string(),
             },
+            ProviderError::InvalidMetadataError(_) => ConnectionError {
+                code: ConnectionErrorCode::InternalError,
+                message: self.to_string(),
+            },
         }
     }
 
@@ -293,6 +301,10 @@ impl ProviderError {
             ProviderError::InternalError(_) => ConnectionError {
                 code: ConnectionErrorCode::InternalError,
                 message: "Failed to refresh access token.".to_string(),
+            },
+            ProviderError::InvalidMetadataError(_) => ConnectionError {
+                code: ConnectionErrorCode::InternalError,
+                message: self.to_string(),
             },
         }
     }

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -23,6 +23,7 @@ pub enum CredentialProvider {
     Hubspot,
     Linear,
     Gmail,
+    Mcp,
 }
 
 impl From<ConnectionProvider> for CredentialProvider {
@@ -31,6 +32,7 @@ impl From<ConnectionProvider> for CredentialProvider {
             ConnectionProvider::Microsoft => CredentialProvider::Microsoft,
             ConnectionProvider::Salesforce => CredentialProvider::Salesforce,
             ConnectionProvider::Gmail => CredentialProvider::Gmail,
+            ConnectionProvider::Mcp => CredentialProvider::Mcp,
             _ => panic!("Unsupported provider: {:?}", provider),
         }
     }
@@ -186,6 +188,9 @@ impl Credential {
                 vec!["client_id", "client_secret"]
             }
             CredentialProvider::Gmail => {
+                vec!["client_id", "client_secret"]
+            }
+            CredentialProvider::Mcp => {
                 vec!["client_id", "client_secret"]
             }
         };

--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -21,9 +21,6 @@ pub struct MCPConnectionMetadata {
     pub client_id: String,
     pub token_endpoint: String,
     pub authorization_endpoint: String,
-    pub response_types_supported: Vec<String>,
-    pub grant_types_supported: Option<Vec<String>>,
-    pub code_challenge_methods_supported: Option<Vec<String>>,
     pub code_verifier: String,
     pub code_challenge: String,
 }
@@ -85,17 +82,6 @@ impl Provider for MCPConnectionProvider {
             .map_err(|e| ProviderError::InvalidMetadataError(e.to_string()))?;
 
         let grant_type = "authorization_code";
-
-        if metadata.grant_types_supported.is_some()
-            && !metadata
-                .grant_types_supported
-                .unwrap()
-                .contains(&grant_type.to_string())
-        {
-            return Err(ProviderError::ActionNotSupportedError(
-                "Grant type not supported".to_string(),
-            ));
-        }
 
         let form_data = [
             ("grant_type", grant_type),
@@ -163,17 +149,6 @@ impl Provider for MCPConnectionProvider {
             .map_err(|e| ProviderError::InvalidMetadataError(e.to_string()))?;
 
         let grant_type = "refresh_token";
-
-        if metadata.grant_types_supported.is_some()
-            && !metadata
-                .grant_types_supported
-                .unwrap()
-                .contains(&grant_type.to_string())
-        {
-            return Err(ProviderError::ActionNotSupportedError(
-                "Grant type not supported".to_string(),
-            ));
-        }
 
         let form_data = [
             ("grant_type", grant_type),

--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -1,0 +1,286 @@
+use crate::{
+    oauth::{
+        connection::{
+            Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
+            PROVIDER_TIMEOUT_SECONDS,
+        },
+        credential::{Credential, CredentialProvider},
+        providers::utils::execute_request,
+    },
+    utils,
+};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use tracing::info;
+
+use super::utils::ProviderHttpRequestError;
+
+#[derive(Debug, Deserialize)]
+pub struct MCPConnectionMetadata {
+    pub client_id: String,
+    pub token_endpoint: String,
+    pub authorization_endpoint: String,
+    pub response_types_supported: Vec<String>,
+    pub grant_types_supported: Option<Vec<String>>,
+    pub code_challenge_methods_supported: Option<Vec<String>>,
+    pub code_verifier: String,
+    pub code_challenge: String,
+}
+
+pub struct MCPConnectionProvider {}
+
+impl MCPConnectionProvider {
+    pub fn new() -> Self {
+        MCPConnectionProvider {}
+    }
+
+    /// Gets the MCP credentials (client_id and client_secret) from the related credential
+    pub async fn get_credentials(credentials: Option<Credential>) -> Result<(String, String)> {
+        let credentials =
+            credentials.ok_or_else(|| anyhow!("Missing credentials for MCP connection"))?;
+
+        let content = credentials.unseal_encrypted_content()?;
+        let provider = credentials.provider();
+
+        // Fetch credential
+        if provider != CredentialProvider::Mcp {
+            return Err(anyhow!(
+                "Invalid credential provider: {:?}, expected MCP",
+                provider
+            ));
+        }
+
+        // Extract client ID and secret
+        let client_id = content
+            .get("client_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing client_id in MCP credential"))?;
+
+        let client_secret = content
+            .get("client_secret")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing client_secret in MCP credential"))?;
+
+        Ok((client_id.to_string(), client_secret.to_string()))
+    }
+}
+
+#[async_trait]
+impl Provider for MCPConnectionProvider {
+    fn id(&self) -> ConnectionProvider {
+        ConnectionProvider::Mcp
+    }
+
+    async fn finalize(
+        &self,
+        connection: &Connection,
+        related_credentials: Option<Credential>,
+        code: &str,
+        redirect_uri: &str,
+    ) -> Result<FinalizeResult, ProviderError> {
+        let (client_id, client_secret) = Self::get_credentials(related_credentials).await?;
+
+        let metadata: MCPConnectionMetadata = serde_json::from_value(connection.metadata().clone())
+            .map_err(|e| ProviderError::InvalidMetadataError(e.to_string()))?;
+
+        let grant_type = "authorization_code";
+
+        if metadata.grant_types_supported.is_some()
+            && !metadata
+                .grant_types_supported
+                .unwrap()
+                .contains(&grant_type.to_string())
+        {
+            return Err(ProviderError::ActionNotSupportedError(
+                "Grant type not supported".to_string(),
+            ));
+        }
+
+        let form_data = [
+            ("grant_type", grant_type),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+            ("code", code),
+            ("code_verifier", &metadata.code_verifier),
+            ("redirect_uri", redirect_uri),
+        ];
+
+        let req = self
+            .reqwest_client()
+            .post(metadata.token_endpoint)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&form_data);
+
+        let raw_json = execute_request(ConnectionProvider::Mcp, req)
+            .await
+            .map_err(|e| self.handle_provider_request_error(e))?;
+
+        let access_token = match raw_json["access_token"].as_str() {
+            Some(token) => token,
+            None => Err(anyhow!("Missing `access_token` in response from MCP"))?,
+        };
+
+        let expires_in = match raw_json.get("expires_in") {
+            Some(serde_json::Value::Number(n)) => match n.as_u64() {
+                Some(n) => n,
+                None => Err(anyhow!("Invalid `expires_in` in response from MCP"))?,
+            },
+            _ => Err(anyhow!("Missing `expires_in` in response from MCP"))?,
+        };
+
+        let refresh_token = match raw_json["refresh_token"].as_str() {
+            Some(token) => token,
+            None => Err(anyhow!("Missing `refresh_token` in response from MCP"))?,
+        };
+
+        Ok(FinalizeResult {
+            redirect_uri: redirect_uri.to_string(),
+            code: code.to_string(),
+            access_token: access_token.to_string(),
+            access_token_expiry: Some(
+                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
+            ),
+            refresh_token: Some(refresh_token.to_string()),
+            raw_json,
+        })
+    }
+
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        related_credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
+        let refresh_token = match connection.unseal_refresh_token() {
+            Ok(Some(token)) => token,
+            Ok(None) => Err(anyhow!("Missing `refresh_token` in MCP connection"))?,
+            Err(e) => Err(e)?,
+        };
+
+        let (client_id, client_secret) = Self::get_credentials(related_credentials).await?;
+
+        let metadata: MCPConnectionMetadata = serde_json::from_value(connection.metadata().clone())
+            .map_err(|e| ProviderError::InvalidMetadataError(e.to_string()))?;
+
+        let grant_type = "refresh_token";
+
+        if metadata.grant_types_supported.is_some()
+            && !metadata
+                .grant_types_supported
+                .unwrap()
+                .contains(&grant_type.to_string())
+        {
+            return Err(ProviderError::ActionNotSupportedError(
+                "Grant type not supported".to_string(),
+            ));
+        }
+
+        let form_data = [
+            ("grant_type", grant_type),
+            ("client_id", &client_id),
+            ("client_secret", &client_secret),
+            ("refresh_token", &refresh_token),
+        ];
+
+        let req = self
+            .reqwest_client()
+            .post(metadata.token_endpoint)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&form_data);
+
+        let raw_json = execute_request(ConnectionProvider::Mcp, req)
+            .await
+            .map_err(|e| self.handle_provider_request_error(e))?;
+
+        let access_token = match raw_json["access_token"].as_str() {
+            Some(token) => token,
+            None => Err(anyhow!("Missing `access_token` in response from MCP"))?,
+        };
+
+        let expires_in = match raw_json.get("expires_in") {
+            Some(serde_json::Value::Number(n)) => match n.as_u64() {
+                Some(n) => n,
+                None => Err(anyhow!("Invalid `expires_in` in response from MCP"))?,
+            },
+            _ => Err(anyhow!("Missing `expires_in` in response from MCP"))?,
+        };
+
+        match raw_json["scope"].as_str() {
+            Some(_) => (),
+            None => Err(anyhow!("Missing `scope` in response from MCP"))?,
+        };
+
+        match raw_json["token_type"].as_str() {
+            Some(_) => (),
+            None => Err(anyhow!("Missing `token_type` in response from MCP"))?,
+        };
+
+        let existing_raw_json = connection.unseal_raw_json()?;
+
+        let mut merged_raw_json = match existing_raw_json {
+            Some(serde_json::Value::Object(map)) => map,
+            _ => Err(anyhow!("Invalid `raw_json` stored on connection."))?,
+        };
+
+        // Some MCP servers do not return a new refresh token when refreshing an access token.
+        // So we merge the new raw_json information in the existing one to preserve original
+        // refresh token.
+        match raw_json["refresh_token"].as_str() {
+            Some(refresh_token) => {
+                merged_raw_json["refresh_token"] =
+                    serde_json::Value::String(refresh_token.to_string())
+            }
+            None => (),
+        };
+
+        // We checked above the presence of each of these fields in raw_json.
+        merged_raw_json["access_token"] = raw_json["access_token"].clone();
+        merged_raw_json["expires_in"] = raw_json["expires_in"].clone();
+        merged_raw_json["token_type"] = raw_json["token_type"].clone();
+        merged_raw_json["scope"] = raw_json["scope"].clone();
+
+        Ok(RefreshResult {
+            access_token: access_token.to_string(),
+            access_token_expiry: Some(
+                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
+            ),
+            refresh_token: Some(refresh_token.to_string()),
+            raw_json: serde_json::Value::Object(merged_raw_json),
+        })
+    }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value> {
+        let raw_json = match raw_json.clone() {
+            serde_json::Value::Object(mut map) => {
+                map.remove("access_token");
+                map.remove("refresh_token");
+                map.remove("expires_in");
+                serde_json::Value::Object(map)
+            }
+            _ => Err(anyhow!("Invalid raw_json, not an object"))?,
+        };
+
+        Ok(raw_json)
+    }
+
+    fn handle_provider_request_error(&self, error: ProviderHttpRequestError) -> ProviderError {
+        match &error {
+            ProviderHttpRequestError::RequestFailed {
+                status, message, ..
+            } if *status == 400 => {
+                let is_revoked = message.contains("invalid_grant");
+                info!(message, is_revoked, "MCP 400 error");
+                if is_revoked {
+                    ProviderError::TokenRevokedError
+                } else {
+                    // Call the default implementation for other 400 errors.
+                    self.default_handle_provider_request_error(error)
+                }
+            }
+            _ => {
+                // Call the default implementation for other cases.
+                self.default_handle_provider_request_error(error)
+            }
+        }
+    }
+}

--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -74,10 +74,6 @@ export function useMcpServer() {
           setServerId(result.serverId);
           setIsConnected(true);
           setError(null);
-          console.log(
-            "MCP server connected successfully with ID:",
-            result.serverId
-          );
         }
       } catch (err) {
         console.error("Error setting up MCP server:", err);

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -73,14 +73,14 @@ type AdminActionsListProps = {
   owner: LightWorkspaceType;
   filter: string;
   systemSpace: SpaceType;
-  setMcpServer: (mcpServer: MCPServerType) => void;
+  setMcpServerToShow: (mcpServer: MCPServerType) => void;
 };
 
 export const AdminActionsList = ({
   owner,
   filter,
   systemSpace,
-  setMcpServer,
+  setMcpServerToShow,
 }: AdminActionsListProps) => {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [internalMCPServerToCreate, setInternalMCPServerToCreate] = useState<
@@ -233,11 +233,13 @@ export const AdminActionsList = ({
         mcpServerView,
         spaces: spaces.filter((s) => spaceIds?.includes(s.sId)),
         isConnected: !!connections.find(
-          (c) => c.internalMCPServerId === mcpServer.sId
+          (c) =>
+            c.internalMCPServerId === mcpServer.sId ||
+            c.remoteMCPServerId === mcpServer.sId
         ),
         onClick: () => {
           if (mcpServerView && mcpServer) {
-            setMcpServer(mcpServer);
+            setMcpServerToShow(mcpServer);
           }
         },
       };
@@ -253,7 +255,7 @@ export const AdminActionsList = ({
         setIsOpen={setIsCreateOpen}
         setIsLoading={setIsLoading}
         owner={owner}
-        setMCPServer={setMcpServer}
+        setMCPServerToShow={setMcpServerToShow}
       />
       {rows.length > 0 &&
         portalToHeader(

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -15,7 +15,6 @@ import {
   isRemoteMCPServerType,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
-import type { MCPOAuthExtraConfig } from "@app/lib/api/oauth/providers/mcp";
 import {
   useCheckOAuthConnection,
   useCreateMCPServerConnection,
@@ -64,8 +63,7 @@ export function ConnectMCPServerDialog({
 
     setIsLoading(true);
 
-    let extraConfig: OAuthCredentials | MCPOAuthExtraConfig =
-      authCredentials ?? {};
+    let extraConfig: OAuthCredentials = authCredentials ?? {};
 
     if (isRemoteMCPServerType(mcpServer) && mcpServer.url) {
       const checkOAuthConnectionRes = await checkOAuthConnection(mcpServer.url);
@@ -75,7 +73,7 @@ export function ConnectMCPServerDialog({
       ) {
         extraConfig = {
           ...extraConfig,
-          ...checkOAuthConnectionRes.value.extraConfig,
+          ...checkOAuthConnectionRes.value.connectionMetadata,
         };
       }
     }

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -10,9 +10,16 @@ import {
 import { useCallback, useState } from "react";
 
 import { MCPServerOAuthConnexion } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
-import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import {
+  getMcpServerDisplayName,
+  isRemoteMCPServerType,
+} from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
-import { useCreateMCPServerConnection } from "@app/lib/swr/mcp_servers";
+import type { MCPOAuthExtraConfig } from "@app/lib/api/oauth/providers/mcp";
+import {
+  useCheckOAuthConnection,
+  useCreateMCPServerConnection,
+} from "@app/lib/swr/mcp_servers";
 import type { OAuthCredentials, WorkspaceType } from "@app/types";
 import { OAUTH_PROVIDER_NAMES, setupOAuthConnection } from "@app/types";
 
@@ -41,6 +48,8 @@ export function ConnectMCPServerDialog({
     connectionType: "workspace",
   });
 
+  const { checkOAuthConnection } = useCheckOAuthConnection(owner);
+
   const resetState = useCallback(() => {
     setIsLoading(false);
     setAuthCredentials(null);
@@ -55,6 +64,22 @@ export function ConnectMCPServerDialog({
 
     setIsLoading(true);
 
+    let extraConfig: OAuthCredentials | MCPOAuthExtraConfig =
+      authCredentials ?? {};
+
+    if (isRemoteMCPServerType(mcpServer) && mcpServer.url) {
+      const checkOAuthConnectionRes = await checkOAuthConnection(mcpServer.url);
+      if (
+        checkOAuthConnectionRes.isOk() &&
+        checkOAuthConnectionRes.value.oauthRequired
+      ) {
+        extraConfig = {
+          ...extraConfig,
+          ...checkOAuthConnectionRes.value.extraConfig,
+        };
+      }
+    }
+
     // First setup connection
     const cRes = await setupOAuthConnection({
       dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
@@ -62,7 +87,7 @@ export function ConnectMCPServerDialog({
       provider: mcpServer.authorization.provider,
       useCase: mcpServer.authorization.use_case,
       extraConfig: {
-        ...(authCredentials ?? {}),
+        ...extraConfig,
         ...(mcpServer.authorization.scope
           ? { scope: mcpServer.authorization.scope }
           : {}),
@@ -80,7 +105,7 @@ export function ConnectMCPServerDialog({
     // Then associate connection
     await createMCPServerConnection({
       connectionId: cRes.value.connection_id,
-      mcpServerId: mcpServer.sId,
+      mcpServer: mcpServer,
       provider: mcpServer.authorization.provider,
     });
 

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -16,8 +16,8 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
-  useCheckOAuthConnection,
   useCreateMCPServerConnection,
+  useDiscoverOAuthMetadata,
 } from "@app/lib/swr/mcp_servers";
 import type { OAuthCredentials, WorkspaceType } from "@app/types";
 import { OAUTH_PROVIDER_NAMES, setupOAuthConnection } from "@app/types";
@@ -47,7 +47,7 @@ export function ConnectMCPServerDialog({
     connectionType: "workspace",
   });
 
-  const { checkOAuthConnection } = useCheckOAuthConnection(owner);
+  const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
 
   const resetState = useCallback(() => {
     setIsLoading(false);
@@ -66,14 +66,16 @@ export function ConnectMCPServerDialog({
     let extraConfig: OAuthCredentials = authCredentials ?? {};
 
     if (isRemoteMCPServerType(mcpServer) && mcpServer.url) {
-      const checkOAuthConnectionRes = await checkOAuthConnection(mcpServer.url);
+      const discoverOAuthMetadataRes = await discoverOAuthMetadata(
+        mcpServer.url
+      );
       if (
-        checkOAuthConnectionRes.isOk() &&
-        checkOAuthConnectionRes.value.oauthRequired
+        discoverOAuthMetadataRes.isOk() &&
+        discoverOAuthMetadataRes.value.oauthRequired
       ) {
         extraConfig = {
           ...extraConfig,
-          ...checkOAuthConnectionRes.value.connectionMetadata,
+          ...discoverOAuthMetadataRes.value.connectionMetadata,
         };
       }
     }

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -16,6 +16,7 @@ import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
+  useCheckOAuthConnection,
   useCreateInternalMCPServer,
   useCreateMCPServerConnection,
   useCreateRemoteMCPServer,
@@ -30,7 +31,7 @@ import {
 type RemoteMCPServerDetailsProps = {
   owner: WorkspaceType;
   internalMCPServer?: MCPServerType;
-  setMCPServer: (server: MCPServerType) => void;
+  setMCPServerToShow: (server: MCPServerType) => void;
   setIsLoading: (isCreating: boolean) => void;
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
@@ -39,13 +40,13 @@ type RemoteMCPServerDetailsProps = {
 export function CreateMCPServerDialog({
   owner,
   internalMCPServer,
-  setMCPServer,
+  setMCPServerToShow,
   setIsLoading,
   isOpen = false,
   setIsOpen,
 }: RemoteMCPServerDetailsProps) {
   const sendNotification = useSendNotification();
-  const [url, setUrl] = useState("");
+  const [remoteServerUrl, setRemoteServerUrl] = useState("");
   const [sharedSecret, setSharedSecret] = useState<string | undefined>(
     undefined
   );
@@ -57,7 +58,8 @@ export function CreateMCPServerDialog({
     null
   );
 
-  const { createWithUrlSync } = useCreateRemoteMCPServer(owner);
+  const { checkOAuthConnection } = useCheckOAuthConnection(owner);
+  const { createWithURL } = useCreateRemoteMCPServer(owner);
   const { createMCPServerConnection } = useCreateMCPServerConnection({
     owner,
     connectionType: "workspace",
@@ -67,17 +69,16 @@ export function CreateMCPServerDialog({
   useEffect(() => {
     if (internalMCPServer) {
       setAuthorization(internalMCPServer.authorization);
-    } else {
-      setAuthorization(null);
     }
   }, [internalMCPServer]);
 
   const resetState = useCallback(() => {
     setIsLoading(false);
     setError(null);
-    setUrl("");
+    setRemoteServerUrl("");
     setSharedSecret(undefined);
     setAuthCredentials(null);
+    setAuthorization(null);
   }, [setIsLoading]);
 
   const handleSave = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -115,7 +116,7 @@ export function CreateMCPServerDialog({
         if (createServerRes.success) {
           await createMCPServerConnection({
             connectionId: cRes.value.connection_id,
-            mcpServerId: createServerRes.server.sId,
+            mcpServer: createServerRes.server,
             provider: authorization.provider,
           });
         } else {
@@ -130,9 +131,7 @@ export function CreateMCPServerDialog({
       setIsLoading(false);
       return;
     } else {
-      // TODO: Handle Authorization for remote servers
-
-      const urlValidation = validateUrl(url);
+      const urlValidation = validateUrl(remoteServerUrl);
 
       if (!urlValidation.valid) {
         e.preventDefault();
@@ -144,21 +143,56 @@ export function CreateMCPServerDialog({
 
       try {
         setIsLoading(true);
-        const result = await createWithUrlSync(url, true, sharedSecret);
 
-        if (result.success) {
+        let connectionId: string | undefined;
+        const checkOAuthConnectionRes =
+          await checkOAuthConnection(remoteServerUrl);
+        if (
+          checkOAuthConnectionRes.isOk() &&
+          checkOAuthConnectionRes.value.oauthRequired
+        ) {
+          sendNotification({
+            title: "Authorization required",
+            type: "info",
+            description:
+              "You must authorize the MCP server to access your data.",
+          });
+          const cRes = await setupOAuthConnection({
+            dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
+            owner,
+            provider: "mcp",
+            useCase: "platform_actions",
+            extraConfig: checkOAuthConnectionRes.value.extraConfig,
+          });
+          if (cRes.isOk()) {
+            connectionId = cRes.value.connection_id;
+          }
+        }
+
+        const createRes = await createWithURL({
+          url: remoteServerUrl,
+          includeGlobal: true,
+          sharedSecret,
+          connectionId,
+        });
+
+        if (createRes.isOk()) {
           sendNotification({
             title: "Success",
             type: "success",
-            description: "MCP server synchronized successfully.",
+            description: `${getMcpServerDisplayName(createRes.value.server)} added successfully.`,
           });
-          setMCPServer(result.server);
+          setMCPServerToShow(createRes.value.server);
         } else {
-          throw new Error("Failed to synchronize MCP server");
+          sendNotification({
+            title: "Error creating MCP server",
+            type: "error",
+            description: createRes.error.message,
+          });
         }
       } catch (error) {
         sendNotification({
-          title: "Error synchronizing MCP server",
+          title: "Error creating MCP server",
           type: "error",
           description:
             error instanceof Error ? error.message : "An error occurred",
@@ -195,8 +229,8 @@ export function CreateMCPServerDialog({
                     <Input
                       id="url"
                       placeholder="https://example.com/api/mcp"
-                      value={url}
-                      onChange={(e) => setUrl(e.target.value)}
+                      value={remoteServerUrl}
+                      onChange={(e) => setRemoteServerUrl(e.target.value)}
                       isError={!!error}
                       message={error}
                       autoFocus

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -162,7 +162,7 @@ export function CreateMCPServerDialog({
             owner,
             provider: "mcp",
             useCase: "platform_actions",
-            extraConfig: checkOAuthConnectionRes.value.extraConfig,
+            extraConfig: checkOAuthConnectionRes.value.connectionMetadata,
           });
           if (cRes.isOk()) {
             connectionId = cRes.value.connection_id;

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -16,10 +16,10 @@ import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
-  useCheckOAuthConnection,
   useCreateInternalMCPServer,
   useCreateMCPServerConnection,
   useCreateRemoteMCPServer,
+  useDiscoverOAuthMetadata,
 } from "@app/lib/swr/mcp_servers";
 import type { OAuthCredentials, WorkspaceType } from "@app/types";
 import {
@@ -58,7 +58,7 @@ export function CreateMCPServerDialog({
     null
   );
 
-  const { checkOAuthConnection } = useCheckOAuthConnection(owner);
+  const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
   const { createWithURL } = useCreateRemoteMCPServer(owner);
   const { createMCPServerConnection } = useCreateMCPServerConnection({
     owner,
@@ -145,11 +145,11 @@ export function CreateMCPServerDialog({
         setIsLoading(true);
 
         let connectionId: string | undefined;
-        const checkOAuthConnectionRes =
-          await checkOAuthConnection(remoteServerUrl);
+        const discoverOAuthMetadataRes =
+          await discoverOAuthMetadata(remoteServerUrl);
         if (
-          checkOAuthConnectionRes.isOk() &&
-          checkOAuthConnectionRes.value.oauthRequired
+          discoverOAuthMetadataRes.isOk() &&
+          discoverOAuthMetadataRes.value.oauthRequired
         ) {
           sendNotification({
             title: "Authorization required",
@@ -162,7 +162,7 @@ export function CreateMCPServerDialog({
             owner,
             provider: "mcp",
             useCase: "platform_actions",
-            extraConfig: checkOAuthConnectionRes.value.connectionMetadata,
+            extraConfig: discoverOAuthMetadataRes.value.connectionMetadata,
           });
           if (cRes.isOk()) {
             connectionId = cRes.value.connection_id;

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -84,7 +84,9 @@ export function MCPServerDetails({
   });
 
   const connection = connections.find(
-    (c) => c.internalMCPServerId === effectiveMCPServer?.sId
+    (c) =>
+      c.internalMCPServerId === effectiveMCPServer?.sId ||
+      c.remoteMCPServerId === effectiveMCPServer?.sId
   );
 
   const [isLoading, setIsLoading] = useState(false);
@@ -189,6 +191,7 @@ export function MCPServerDetails({
                     onClick={() => {
                       void deleteMCPServerConnection({
                         connection,
+                        mcpServer: effectiveMCPServer,
                       });
                     }}
                   />

--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -2,7 +2,7 @@ import { RemoteMCPForm } from "@app/components/actions/mcp/RemoteMCPForm";
 import { ToolsList } from "@app/components/actions/mcp/ToolsList";
 import {
   getServerTypeAndIdFromSId,
-  mcpServerIsRemote,
+  isRemoteMCPServerType,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { LightWorkspaceType } from "@app/types";
@@ -19,7 +19,7 @@ export function MCPServerDetailsInfo({
   const serverType = getServerTypeAndIdFromSId(mcpServer.sId).serverType;
   return (
     <div className="flex flex-col gap-2">
-      {mcpServerIsRemote(mcpServer) && (
+      {isRemoteMCPServerType(mcpServer) && (
         <RemoteMCPForm mcpServer={mcpServer} owner={owner} />
       )}
       <h3 className="heading-base mb-4 font-semibold text-foreground dark:text-foreground-night">

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -85,9 +85,9 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
           void mutateMCPServers();
 
           sendNotification({
-            title: "MCP server updated",
+            title: `${getMcpServerDisplayName(mcpServer)} updated`,
             type: "success",
-            description: "The MCP server has been successfully updated.",
+            description: `${getMcpServerDisplayName(mcpServer)} has been successfully updated.`,
           });
 
           form.reset(values);
@@ -96,13 +96,13 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
         }
       } catch (err) {
         sendNotification({
-          title: "Error updating MCP server",
+          title: `Error updating ${getMcpServerDisplayName(mcpServer)}`,
           type: "error",
           description: err instanceof Error ? err.message : "An error occurred",
         });
       }
     },
-    [updateServer, mutateMCPServers, sendNotification, form]
+    [updateServer, mutateMCPServers, sendNotification, form, mcpServer]
   );
 
   const handleSynchronize = useCallback(async () => {
@@ -117,22 +117,21 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
         sendNotification({
           title: "Success",
           type: "success",
-          description: "MCP server synchronized successfully.",
+          description: `${getMcpServerDisplayName(mcpServer)} synchronized successfully.`,
         });
       } else {
         throw new Error("Failed to synchronize MCP server");
       }
     } catch (error) {
-      console.error("Error synchronizing with MCP:", error);
       sendNotification({
-        title: "Error synchronizing MCP server",
+        title: `Error synchronizing ${getMcpServerDisplayName(mcpServer)}`,
         type: "error",
         description: normalizeError(error ?? "An error occured").message,
       });
     } finally {
       setIsSynchronizing(false);
     }
-  }, [syncServer, mutateMCPServers, sendNotification]);
+  }, [syncServer, mutateMCPServers, sendNotification, mcpServer]);
 
   const closePopover = () => {
     setIsPopoverOpen(false);

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -2,7 +2,10 @@ import { Button, Chip, CloudArrowLeftRightIcon } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { useCreatePersonalConnection } from "@app/lib/swr/mcp_servers";
+import {
+  useCreatePersonalConnection,
+  useMCPServer,
+} from "@app/lib/swr/mcp_servers";
 import type {
   LightWorkspaceType,
   OAuthProvider,
@@ -24,6 +27,10 @@ export function MCPServerPersonalAuthenticationRequired({
   scope?: string;
   retryHandler: () => void;
 }) {
+  const { server: mcpServer } = useMCPServer({
+    owner,
+    serverId: mcpServerId,
+  });
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
 
   const { submit: retry } = useSubmitFunction(async () => retryHandler());
@@ -50,29 +57,31 @@ export function MCPServerPersonalAuthenticationRequired({
             }
             size="xs"
           />
-          <Button
-            label={`Connect`}
-            variant="outline"
-            size="xs"
-            icon={CloudArrowLeftRightIcon}
-            disabled={isConnecting}
-            onClick={async () => {
-              setIsConnecting(true);
-              const success = await createPersonalConnection(
-                mcpServerId,
-                provider,
-                useCase,
-                scope
-              );
-              setIsConnecting(false);
-              if (!success) {
-                setIsConnected(false);
-              } else {
-                setIsConnected(true);
-                await retry();
-              }
-            }}
-          />
+          {mcpServer && (
+            <Button
+              label={`Connect`}
+              variant="outline"
+              size="xs"
+              icon={CloudArrowLeftRightIcon}
+              disabled={isConnecting}
+              onClick={async () => {
+                setIsConnecting(true);
+                const success = await createPersonalConnection(
+                  mcpServer,
+                  provider,
+                  useCase,
+                  scope
+                );
+                setIsConnecting(false);
+                if (!success) {
+                  setIsConnected(false);
+                } else {
+                  setIsConnected(true);
+                  await retry();
+                }
+              }}
+            />
+          )}
         </div>
       )}
     </div>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -987,7 +987,9 @@ function ActionEditor({
   });
 
   const isConnected = connections.some(
-    (c) => c.internalMCPServerId === selectedMCPServerView?.server.sId
+    (c) =>
+      c.internalMCPServerId === selectedMCPServerView?.server.sId ||
+      c.remoteMCPServerId === selectedMCPServerView?.server.sId
   );
 
   // This is to show the data description input.

--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -157,6 +157,7 @@ export function UserToolsTable({ owner }: UserToolsTableProps) {
                       onClick: () =>
                         deleteMCPServerConnection({
                           connection: row.original.connection!,
+                          mcpServer: row.original.serverView.server,
                         }),
                       kind: "item" as const,
                     },

--- a/front/components/spaces/SystemSpaceActionsList.tsx
+++ b/front/components/spaces/SystemSpaceActionsList.tsx
@@ -18,8 +18,9 @@ export const SystemSpaceActionsList = ({
   isAdmin,
   space,
 }: SpaceActionsListProps) => {
-  const [mcpServer, setMcpServer] = useState<MCPServerType | null>(null);
-  const [isDetailsPanelOpened, setIsDetailsPanelOpened] = useState(false);
+  const [mcpServerToShow, setMcpServerToShow] = useState<MCPServerType | null>(
+    null
+  );
 
   const { q: searchParam } = useQueryParams(["q"]);
   const searchTerm = searchParam.value || "";
@@ -30,23 +31,22 @@ export const SystemSpaceActionsList = ({
 
   return (
     <>
-      {mcpServer && (
+      {mcpServerToShow && (
         <MCPServerDetails
           owner={owner}
-          mcpServer={mcpServer}
+          mcpServer={mcpServerToShow}
           onClose={() => {
-            setIsDetailsPanelOpened(false);
+            setMcpServerToShow(null);
           }}
-          isOpen={isDetailsPanelOpened}
+          isOpen={!!mcpServerToShow}
         />
       )}
       <AdminActionsList
         owner={owner}
         filter={searchTerm}
         systemSpace={space}
-        setMcpServer={(mcpServer) => {
-          setMcpServer(mcpServer);
-          setIsDetailsPanelOpened(true);
+        setMcpServerToShow={(mcpServer) => {
+          setMcpServerToShow(mcpServer);
         }}
       />
     </>

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -90,7 +90,7 @@ export const mcpServersSortingFn = (
   return aServerType < bServerType ? -1 : 1;
 };
 
-export function mcpServerIsRemote(
+export function isRemoteMCPServerType(
   server: MCPServerType
 ): server is RemoteMCPServerType {
   const serverType = getServerTypeAndIdFromSId(server.sId).serverType;

--- a/front/lib/actions/mcp_oauth_error.ts
+++ b/front/lib/actions/mcp_oauth_error.ts
@@ -1,0 +1,13 @@
+import type { MCPOAuthExtraConfig } from "@app/lib/api/oauth/providers/mcp";
+
+export class MCPOAuthRequiredError extends Error {
+  extraConfig: MCPOAuthExtraConfig;
+
+  constructor(extraConfig: MCPOAuthExtraConfig) {
+    super(
+      "You must do an OAuth registration flow before using this MCP server."
+    );
+    this.name = "MCPOAuthRequiredError";
+    this.extraConfig = extraConfig;
+  }
+}

--- a/front/lib/actions/mcp_oauth_error.ts
+++ b/front/lib/actions/mcp_oauth_error.ts
@@ -1,13 +1,13 @@
-import type { MCPOAuthExtraConfig } from "@app/lib/api/oauth/providers/mcp";
+import type { MCPOAuthConnectionMetadataType } from "@app/lib/api/oauth/providers/mcp";
 
 export class MCPOAuthRequiredError extends Error {
-  extraConfig: MCPOAuthExtraConfig;
+  connectionMetadata: MCPOAuthConnectionMetadataType;
 
-  constructor(extraConfig: MCPOAuthExtraConfig) {
+  constructor(connectionMetadata: MCPOAuthConnectionMetadataType) {
     super(
       "You must do an OAuth registration flow before using this MCP server."
     );
     this.name = "MCPOAuthRequiredError";
-    this.extraConfig = extraConfig;
+    this.connectionMetadata = connectionMetadata;
   }
 }

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -1,0 +1,190 @@
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthMetadata,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+
+import { MCPOAuthRequiredError } from "@app/lib/actions/mcp_oauth_error";
+import config from "@app/lib/api/config";
+import apiConfig from "@app/lib/api/config";
+import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import type { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import logger from "@app/logger/logger";
+import { assertNever } from "@app/types";
+import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
+
+async function getAccessTokenForRemoteMCPServer(
+  auth: Authenticator,
+  remoteMCPServer: RemoteMCPServerResource,
+  connectionType: MCPServerConnectionConnectionType
+) {
+  const metadata = remoteMCPServer.toJSON();
+
+  if (metadata.authorization) {
+    const connection = await MCPServerConnectionResource.findByMCPServer({
+      auth,
+      mcpServerId: metadata.sId,
+      connectionType,
+    });
+    if (connection.isOk()) {
+      const token = await getOAuthConnectionAccessToken({
+        config: apiConfig.getOAuthAPIConfig(),
+        logger,
+        connectionId: connection.value.connectionId,
+      });
+      return token.isOk() ? token.value : null;
+    }
+  }
+}
+
+export class MCPOAuthProvider implements OAuthClientProvider {
+  private readonly remoteMCPServer: RemoteMCPServerResource | undefined;
+  private auth: Authenticator;
+  private metadata: OAuthMetadata | undefined;
+
+  constructor(auth: Authenticator, remoteMCPServer?: RemoteMCPServerResource) {
+    this.auth = auth;
+    this.remoteMCPServer = remoteMCPServer ?? undefined;
+  }
+  get redirectUrl(): string {
+    throw new Error(
+      "Method redirectUrl not implemented. We should never reach this point."
+    );
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      redirect_uris: [finalizeUriForProvider("mcp")],
+      client_name: "Dust",
+      client_uri: config.getClientFacingUrl(),
+      logo_uri: "https://avatars.githubusercontent.com/u/116068963?s=200&v=4",
+      contacts: ["support@dust.com"],
+      tos_uri: config.getClientFacingUrl() + "/terms",
+      policy_uri: config.getClientFacingUrl() + "/privacy",
+      software_id: "dust",
+    };
+  }
+
+  saveAuthorizationServerMetadata(
+    metadata?: OAuthMetadata
+  ): void | Promise<void> {
+    // Save for a later step.
+    this.metadata = metadata;
+  }
+
+  clientInformation(): OAuthClientInformationFull | undefined {
+    return undefined;
+  }
+
+  saveClientInformation(
+    clientInformation: OAuthClientInformationFull
+  ): void | Promise<void> {
+    if (!this.metadata) {
+      // This should never happen.
+      throw new Error("Metadata not found, unable to create an oauth flow.");
+    }
+
+    if (!clientInformation.client_secret) {
+      throw new Error(
+        "Client secret not found, unable to create an oauth flow."
+      );
+    }
+
+    // Raise an error to let the client know that the server requires an OAuth connection.
+    // We pass the metadata to the client to allow them to handle the oauth flow.
+    throw new MCPOAuthRequiredError({
+      client_id: clientInformation.client_id,
+      client_secret: clientInformation.client_secret,
+      token_endpoint: this.metadata.token_endpoint,
+      authorization_endpoint: this.metadata.authorization_endpoint,
+      response_types_supported: this.metadata.response_types_supported,
+      grant_types_supported: this.metadata.grant_types_supported,
+      code_challenge_methods_supported:
+        this.metadata.code_challenge_methods_supported,
+    });
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    if (this.remoteMCPServer) {
+      // Case of a remote MCP server with a user-provided bearer token.
+      if (this.remoteMCPServer.sharedSecret) {
+        return {
+          token_type: "bearer",
+          access_token: this.remoteMCPServer.sharedSecret,
+          refresh_token: undefined,
+          expires_in: undefined,
+        };
+      }
+
+      // TODO(mcp): change this to the correct connection type later.
+      // eslint-disable-next-line no-constant-condition
+      const connectionType: MCPServerConnectionConnectionType = true
+        ? "workspace"
+        : "personal";
+
+      // Case of a remote MCP server requiring an OAuth connection.
+      const accessToken = await getAccessTokenForRemoteMCPServer(
+        this.auth,
+        this.remoteMCPServer,
+        connectionType
+      );
+
+      if (!accessToken) {
+        switch (connectionType) {
+          case "workspace": {
+            // This will let the oauth flow continue to the metadata discovery step.
+            return undefined;
+          }
+          case "personal": {
+            throw new Error(
+              "For now, personal connections are not supported for remote MCP servers."
+            );
+          }
+          default: {
+            assertNever(connectionType);
+          }
+        }
+      }
+
+      return {
+        token_type: "bearer",
+        access_token: accessToken.access_token,
+        refresh_token: undefined,
+        expires_in: accessToken.access_token_expiry ?? undefined,
+      };
+    }
+
+    // If we don't have a remoteMCPServer, it means we are trying to add via an URL.
+    // In this case, we don't have any tokens to return.
+    return undefined;
+  }
+
+  saveTokens() {
+    throw new Error(
+      "Method saveTokens not implemented. We should never reach this point."
+    );
+  }
+
+  redirectToAuthorization() {
+    throw new Error(
+      "Method redirectToAuthorization not implemented. We should never reach this point."
+    );
+  }
+
+  saveCodeVerifier() {
+    throw new Error(
+      "Method saveCodeVerifier not implemented. We should never reach this point."
+    );
+  }
+
+  codeVerifier(): string | Promise<string> {
+    throw new Error(
+      "Method codeVerifier not implemented. We should never reach this point."
+    );
+  }
+}

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -95,6 +95,26 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       );
     }
 
+    const responseType = "code";
+    const codeChallengeMethod = "S256";
+
+    if (!this.metadata.response_types_supported.includes(responseType)) {
+      throw new Error(
+        `Incompatible auth server: does not support response type ${responseType}`
+      );
+    }
+
+    if (
+      !this.metadata.code_challenge_methods_supported ||
+      !this.metadata.code_challenge_methods_supported.includes(
+        codeChallengeMethod
+      )
+    ) {
+      throw new Error(
+        `Incompatible auth server: does not support code challenge method ${codeChallengeMethod}`
+      );
+    }
+
     // Raise an error to let the client know that the server requires an OAuth connection.
     // We pass the metadata to the client to allow them to handle the oauth flow.
     throw new MCPOAuthRequiredError({
@@ -102,10 +122,6 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       client_secret: clientInformation.client_secret,
       token_endpoint: this.metadata.token_endpoint,
       authorization_endpoint: this.metadata.authorization_endpoint,
-      response_types_supported: this.metadata.response_types_supported,
-      grant_types_supported: this.metadata.grant_types_supported,
-      code_challenge_methods_supported:
-        this.metadata.code_challenge_methods_supported,
     });
   }
 

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -1,13 +1,24 @@
 import type { ParsedUrlQuery } from "querystring";
-import querystring from "querystring";
 
 import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import { ConfluenceOAuthProvider } from "@app/lib/api/oauth/providers/confluence";
+import { GithubOAuthProvider } from "@app/lib/api/oauth/providers/github";
+import { GmailOAuthProvider } from "@app/lib/api/oauth/providers/gmail";
+import { GongOAuthProvider } from "@app/lib/api/oauth/providers/gong";
+import { GoogleDriveOAuthProvider } from "@app/lib/api/oauth/providers/google_drive";
+import { HubspotOAuthProvider } from "@app/lib/api/oauth/providers/hubspot";
+import { IntercomOAuthProvider } from "@app/lib/api/oauth/providers/intercom";
+import { MCPOAuthProvider } from "@app/lib/api/oauth/providers/mcp";
+import { MicrosoftOAuthProvider } from "@app/lib/api/oauth/providers/microsoft";
+import { NotionOAuthProvider } from "@app/lib/api/oauth/providers/notion";
+import { SalesforceOAuthProvider } from "@app/lib/api/oauth/providers/salesforce";
+import { SlackOAuthProvider } from "@app/lib/api/oauth/providers/slack";
+import { ZendeskOAuthProvider } from "@app/lib/api/oauth/providers/zendesk";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { isManaged } from "@app/lib/data_sources";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import type {
   OAuthAPIError,
   OAuthConnectionType,
@@ -15,14 +26,7 @@ import type {
   OAuthUseCase,
   Result,
 } from "@app/types";
-import {
-  ConnectorsAPI,
-  Err,
-  isValidSalesforceDomain,
-  isValidZendeskSubdomain,
-  OAuthAPI,
-  Ok,
-} from "@app/types";
+import { Err, OAuthAPI, Ok } from "@app/types";
 
 export type OAuthError = {
   code:
@@ -33,677 +37,34 @@ export type OAuthError = {
   oAuthAPIError?: OAuthAPIError;
 };
 
-function getStringFromQuery(query: ParsedUrlQuery, key: string): string | null {
-  const value = query[key];
-  if (typeof value != "string") {
-    return null;
-  }
-  return value;
-}
-
 function finalizeUriForProvider(provider: OAuthProvider): string {
   return config.getClientFacingUrl() + `/oauth/${provider}/finalize`;
 }
 
-const PROVIDER_STRATEGIES: Record<
+export const PROVIDER_STRATEGIES: Record<
   OAuthProvider,
-  {
-    setupUri: ({
-      connection,
-      useCase,
-      clientId,
-      forceLabelsScope,
-      relatedCredential,
-      extraConfig,
-    }: {
-      connection: OAuthConnectionType;
-      useCase: OAuthUseCase;
-      clientId?: string;
-      forceLabelsScope?: boolean;
-      relatedCredential?: {
-        content: Record<string, unknown>;
-        metadata: { workspace_id: string; user_id: string };
-      };
-      extraConfig?: Record<string, string>;
-    }) => string;
-    codeFromQuery: (query: ParsedUrlQuery) => string | null;
-    connectionIdFromQuery: (query: ParsedUrlQuery) => string | null;
-    isExtraConfigValid: (
-      extraConfig: Record<string, string>,
-      useCase: OAuthUseCase
-    ) => boolean;
-    getRelatedCredential?: (
-      auth: Authenticator,
-      extraConfig: Record<string, string>,
-      workspaceId: string,
-      userId: string,
-      useCase: OAuthUseCase
-    ) => Promise<{
-      credential: {
-        content: Record<string, unknown>;
-        metadata: { workspace_id: string; user_id: string };
-      };
-      cleanedConfig: Record<string, string>;
-    } | null>;
-  }
+  BaseOAuthStrategyProvider
 > = {
-  github: {
-    setupUri: ({ connection, useCase }) => {
-      const app =
-        useCase === "platform_actions"
-          ? config.getOAuthGithubAppPlatformActions()
-          : config.getOAuthGithubApp();
-      // Only the `installations/new` URL supports state passing.
-      return (
-        `https://github.com/apps/${app}/installations/new` +
-        `?state=${connection.connection_id}`
-      );
-    },
-    // {
-    //   installation_id: '52689080',
-    //   setup_action: 'update',
-    //   state: 'con_...-...',
-    //   provider: 'github'
-    // }
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "installation_id");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return Object.keys(extraConfig).length === 0;
-    },
-  },
-  google_drive: {
-    setupUri: ({ connection, useCase, forceLabelsScope }) => {
-      const scopes =
-        useCase === "labs_transcripts"
-          ? ["https://www.googleapis.com/auth/drive.meet.readonly"]
-          : [
-              "https://www.googleapis.com/auth/drive.metadata.readonly",
-              "https://www.googleapis.com/auth/drive.readonly",
-            ];
-
-      if (forceLabelsScope) {
-        scopes.push("https://www.googleapis.com/auth/drive.labels.readonly");
-      }
-      const qs = querystring.stringify({
-        response_type: "code",
-        client_id: config.getOAuthGoogleDriveClientId(),
-        state: connection.connection_id,
-        redirect_uri: finalizeUriForProvider("google_drive"),
-        scope: scopes.join(" "),
-        access_type: "offline",
-        prompt: "consent",
-      });
-      return `https://accounts.google.com/o/oauth2/auth?${qs}`;
-    },
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return Object.keys(extraConfig).length === 0;
-    },
-  },
-  notion: {
-    setupUri: ({ connection, useCase }) => {
-      const clientId =
-        useCase === "platform_actions"
-          ? config.getOAuthNotionPlatformActionsClientId()
-          : config.getOAuthNotionClientId();
-      return (
-        `https://api.notion.com/v1/oauth/authorize?owner=user` +
-        `&response_type=code` +
-        `&client_id=${clientId}` +
-        `&state=${connection.connection_id}` +
-        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("notion"))}`
-      );
-    },
-    // {
-    //   code: '03...',
-    //   state: 'con_...-...',
-    // }
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return Object.keys(extraConfig).length === 0;
-    },
-  },
-  slack: {
-    setupUri: ({ connection }) => {
-      const scopes = [
-        "app_mentions:read",
-        "channels:history",
-        "channels:join",
-        "channels:read",
-        "chat:write",
-        "groups:history",
-        "groups:read",
-        "im:history",
-        "metadata.message:read",
-        "mpim:read",
-        "team:read",
-        "users:read",
-        "users:read.email",
-        "im:read",
-        "mpim:history",
-        "files:read",
-      ];
-      return (
-        `https://slack.com/oauth/v2/authorize?` +
-        `client_id=${config.getOAuthSlackClientId()}` +
-        `&scope=${encodeURIComponent(scopes.join(" "))}` +
-        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("slack"))}` +
-        `&state=${connection.connection_id}`
-      );
-    },
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return Object.keys(extraConfig).length === 0;
-    },
-  },
-  confluence: {
-    setupUri: ({ connection }) => {
-      const scopes = [
-        "read:confluence-space.summary",
-        "read:confluence-content.all",
-        "read:confluence-user",
-        "search:confluence",
-        "read:space:confluence",
-        "read:page:confluence",
-        "read:confluence-props",
-        "read:confluence-content.summary",
-        "report:personal-data",
-        "read:me",
-        "read:label:confluence",
-        "offline_access",
-      ];
-      return (
-        `https://auth.atlassian.com/authorize?audience=api.atlassian.com` +
-        `&client_id=${config.getOAuthConfluenceClientId()}` +
-        `&scope=${encodeURIComponent(scopes.join(" "))}` +
-        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("confluence"))}` +
-        `&state=${connection.connection_id}` +
-        `&response_type=code&prompt=consent`
-      );
-    },
-    // {
-    //   code: 'ey...',
-    //   state: 'con_...-...',
-    // }
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return Object.keys(extraConfig).length === 0;
-    },
-  },
-  intercom: {
-    setupUri: ({ connection }) => {
-      return (
-        `https://app.intercom.com/oauth` +
-        `?client_id=${config.getOAuthIntercomClientId()}` +
-        `&state=${connection.connection_id}` +
-        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("intercom"))}`
-      );
-    },
-    codeFromQuery: (connection) => {
-      return getStringFromQuery(connection, "code");
-    },
-    connectionIdFromQuery: (connection) => {
-      return getStringFromQuery(connection, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return Object.keys(extraConfig).length === 0;
-    },
-  },
-  gong: {
-    setupUri: ({ connection }) => {
-      const scopes = [
-        "api:calls:read:transcript",
-        "api:calls:read:extensive",
-        "api:calls:read:basic",
-        "api:users:read",
-      ];
-      return (
-        `https://app.gong.io/oauth2/authorize?` +
-        `client_id=${config.getOAuthGongClientId()}` +
-        `&scope=${encodeURIComponent(scopes.join(" "))}` +
-        `&response_type=code` +
-        `&state=${connection.connection_id}` +
-        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("gong"))}`
-      );
-    },
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return Object.keys(extraConfig).length === 0;
-    },
-  },
-  microsoft: {
-    setupUri: ({ connection, relatedCredential }) => {
-      const scopes = [
-        "User.Read",
-        "Sites.Read.All",
-        "Directory.Read.All",
-        "Files.Read.All",
-        "Team.ReadBasic.All",
-        "ChannelSettings.Read.All",
-        "ChannelMessage.Read.All",
-        "offline_access",
-      ];
-      if (relatedCredential) {
-        return `${config.getClientFacingUrl()}/oauth/microsoft/finalize?provider=microsoft&code=client&state=${connection.connection_id}`;
-      } else {
-        const qs = querystring.stringify({
-          response_type: "code",
-          client_id: config.getOAuthMicrosoftClientId(),
-          state: connection.connection_id,
-          redirect_uri: finalizeUriForProvider("microsoft"),
-          scope: scopes.join(" "),
-        });
-        return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${qs}`;
-      }
-    },
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return (
-        Object.keys(extraConfig).length === 0 ||
-        !!(
-          extraConfig.client_id &&
-          extraConfig.client_secret &&
-          extraConfig.tenant_id
-        )
-      );
-    },
-    getRelatedCredential: async (auth, extraConfig, workspaceId, userId) => {
-      const { client_id, client_secret, ...restConfig } = extraConfig;
-      if (!client_id || !client_secret) {
-        return null;
-      }
-      return {
-        credential: {
-          content: {
-            client_id,
-            client_secret,
-          },
-          metadata: { workspace_id: workspaceId, user_id: userId },
-        },
-        cleanedConfig: restConfig,
-      };
-    },
-  },
-  zendesk: {
-    setupUri: ({ connection }) => {
-      const scopes = ["read"];
-      if (!isValidZendeskSubdomain(connection.metadata.zendesk_subdomain)) {
-        throw "Invalid Zendesk subdomain";
-      }
-      return (
-        `https://${connection.metadata.zendesk_subdomain}.zendesk.com/oauth/authorizations/new?` +
-        `client_id=${config.getOAuthZendeskClientId()}` +
-        `&scope=${encodeURIComponent(scopes.join(" "))}` +
-        `&response_type=code` +
-        `&state=${connection.connection_id}` +
-        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("zendesk"))}`
-      );
-    },
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      if (Object.keys(extraConfig).length !== 1) {
-        return false;
-      }
-      // Ensure the string is less than 63 characters.
-      return isValidZendeskSubdomain(extraConfig.zendesk_subdomain);
-    },
-  },
-  salesforce: {
-    setupUri: ({ connection, clientId }) => {
-      if (!connection.metadata.instance_url) {
-        throw new Error("Missing Salesforce instance URL");
-      }
-      if (
-        !connection.metadata.code_verifier ||
-        !connection.metadata.code_challenge
-      ) {
-        throw new Error("Missing PKCE code verifier or challenge");
-      }
-
-      if (!clientId) {
-        throw new Error("Missing Salesforce client ID");
-      }
-      return (
-        `${connection.metadata.instance_url}/services/oauth2/authorize` +
-        `?response_type=code` +
-        `&client_id=${clientId}` +
-        `&state=${connection.connection_id}` +
-        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("salesforce"))}` +
-        `&code_challenge=${connection.metadata.code_challenge}` +
-        `&code_challenge_method=S256`
-      );
-    },
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig, useCase) => {
-      if (useCase === "personal_actions") {
-        // If we have an mcp_server_id it means the admin already setup the connection and we have
-        // everything we need, otherwise we'll need the instance_url and client_id.
-        if (extraConfig.mcp_server_id) {
-          return true;
-        }
-      }
-
-      if (useCase === "salesforce_personal") {
-        return true;
-      }
-
-      if (!extraConfig.instance_url || !extraConfig.client_id) {
-        return false;
-      }
-      return isValidSalesforceDomain(extraConfig.instance_url);
-    },
-    getRelatedCredential: async (
-      auth,
-      extraConfig,
-      workspaceId,
-      userId,
-      useCase
-    ) => {
-      // SALESFORCE CONNECTION TO BE DEPRECATED.
-      if (useCase === "salesforce_personal") {
-        // For personal connection, we reuse the existing connection credential id
-        // from the existing data source, if it exists.
-        const dataSources = await DataSourceResource.listByConnectorProvider(
-          auth,
-          "salesforce"
-        );
-        if (dataSources.length !== 1) {
-          return null;
-        }
-        const dataSource = dataSources[0].toJSON();
-        if (!isManaged(dataSource)) {
-          return null;
-        }
-
-        const connectorsAPI = new ConnectorsAPI(
-          config.getConnectorsAPIConfig(),
-          logger
-        );
-        const connectorRes =
-          await connectorsAPI.getConnectorFromDataSource(dataSource);
-        if (connectorRes.isErr()) {
-          return null;
-        }
-
-        const connector = connectorRes.value;
-
-        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-        const connectionRes = await oauthApi.getAccessToken({
-          connectionId: connector.connectionId,
-        });
-        if (connectionRes.isErr()) {
-          return null;
-        }
-        const connection = connectionRes.value.connection;
-        const connectionId = connection.connection_id;
-
-        return {
-          credential: {
-            content: {
-              from_connection_id: connectionId,
-            },
-            metadata: { workspace_id: workspaceId, user_id: userId },
-          },
-          cleanedConfig: {
-            client_id: connection.metadata.client_id as string,
-            instance_url: connection.metadata.instance_url as string,
-            ...extraConfig,
-          },
-        };
-      }
-
-      if (useCase === "personal_actions") {
-        // For personal actions we reuse the existing connection credential id from the existing
-        // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
-        // we have client_secret and instance_url (initial admin setup).
-        const { mcp_server_id, ...restConfig } = extraConfig;
-
-        if (mcp_server_id) {
-          const mcpServerConnectionRes =
-            await MCPServerConnectionResource.findByMCPServer({
-              auth,
-              mcpServerId: mcp_server_id,
-              connectionType: "workspace",
-            });
-
-          if (mcpServerConnectionRes.isErr()) {
-            return null;
-          }
-
-          const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-          const connectionRes = await oauthApi.getConnectionMetadata({
-            connectionId: mcpServerConnectionRes.value.connectionId,
-          });
-          if (connectionRes.isErr()) {
-            return null;
-          }
-          const connection = connectionRes.value.connection;
-          const connectionId = connection.connection_id;
-
-          return {
-            credential: {
-              content: {
-                from_connection_id: connectionId,
-              },
-              metadata: { workspace_id: workspaceId, user_id: userId },
-            },
-            cleanedConfig: {
-              client_id: connection.metadata.client_id as string,
-              instance_url: connection.metadata.instance_url as string,
-              ...restConfig,
-            },
-          };
-        }
-      }
-
-      const { client_secret, ...restConfig } = extraConfig;
-      // Keep client_id in metadata in clear text.
-      return {
-        credential: {
-          content: {
-            client_secret,
-            client_id: extraConfig.client_id,
-          },
-          metadata: { workspace_id: workspaceId, user_id: userId },
-        },
-        cleanedConfig: restConfig,
-      };
-    },
-  },
-  gmail: {
-    setupUri: ({ connection, clientId, extraConfig }) => {
-      if (!extraConfig || !extraConfig.scope) {
-        throw new Error("Missing authorization scope");
-      }
-
-      const qs = querystring.stringify({
-        response_type: "code",
-        client_id: clientId,
-        state: connection.connection_id,
-        redirect_uri: finalizeUriForProvider("gmail"),
-        scope: extraConfig.scope,
-        access_type: "offline",
-        prompt: "consent",
-      });
-      return `https://accounts.google.com/o/oauth2/auth?${qs}`;
-    },
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig, useCase) => {
-      if (useCase === "personal_actions") {
-        // If we have an mcp_server_id it means the admin already setup the connection and we have
-        // everything we need, otherwise we'll need the client_id and client_secret.
-        if (extraConfig.mcp_server_id) {
-          return true;
-        }
-        return !!(extraConfig.client_id && extraConfig.client_secret);
-      }
-      return Object.keys(extraConfig).length === 0;
-    },
-    getRelatedCredential: async (
-      auth,
-      extraConfig,
-      workspaceId,
-      userId,
-      useCase
-    ) => {
-      if (useCase === "personal_actions") {
-        // For personal actions we reuse the existing connection credential id from the existing
-        // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
-        // we have client_secret (initial admin setup).
-        const { mcp_server_id, ...restConfig } = extraConfig;
-
-        if (mcp_server_id) {
-          const mcpServerConnectionRes =
-            await MCPServerConnectionResource.findByMCPServer({
-              auth,
-              mcpServerId: mcp_server_id,
-              connectionType: "workspace",
-            });
-
-          if (mcpServerConnectionRes.isErr()) {
-            return null;
-          }
-
-          const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-          const connectionRes = await oauthApi.getAccessToken({
-            connectionId: mcpServerConnectionRes.value.connectionId,
-          });
-          if (connectionRes.isErr()) {
-            return null;
-          }
-          const connection = connectionRes.value.connection;
-          const connectionId = connection.connection_id;
-
-          return {
-            credential: {
-              content: {
-                from_connection_id: connectionId,
-              },
-              metadata: { workspace_id: workspaceId, user_id: userId },
-            },
-            cleanedConfig: {
-              client_id: connection.metadata.client_id as string,
-              ...restConfig,
-            },
-          };
-        }
-      }
-
-      const { client_secret, ...restConfig } = extraConfig;
-      // Keep client_id in metadata in clear text.
-      return {
-        credential: {
-          content: {
-            client_secret,
-            client_id: extraConfig.client_id,
-          },
-          metadata: { workspace_id: workspaceId, user_id: userId },
-        },
-        cleanedConfig: restConfig,
-      };
-    },
-  },
-  hubspot: {
-    setupUri: ({ connection }) => {
-      // For platform_actions, we need to request all scopes needed by the agent.
-      // For data_source_sync, we only need the scopes to read the data.
-      // TODO(MCP): Check if we can get more granular scopes for data_source_sync.
-      const scopes = [
-        "oauth",
-        "crm.objects.contacts.read",
-        "crm.objects.contacts.write",
-        "crm.schemas.contacts.read",
-        "crm.objects.companies.read",
-        "crm.objects.companies.write",
-        "crm.schemas.companies.read",
-        "crm.objects.deals.read",
-        "crm.objects.deals.write",
-        "crm.schemas.deals.read",
-        "tickets", // For tickets (covers read, write, schemas)
-        "crm.objects.owners.read", // For owners
-        "crm.schemas.custom.read", // For reading schemas of custom objects, and potentially useful for standard object properties
-        "crm.objects.custom.read", // For reading custom object data
-        "files", // For files (replaces files.read)
-        "sales-email-read", // For reading engagement details (especially emails, meetings, calls)
-        "timeline", // For timeline events, potentially associations
-        "crm.lists.read", // For addContactToList and future list operations
-        "crm.lists.write", // For addContactToList and future list operations
-        "automation", // For enrollContactInWorkflow and future automation operations
-      ];
-      return (
-        `https://app.hubspot.com/oauth/authorize` +
-        `?client_id=${config.getOAuthHubspotClientId()}` +
-        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("hubspot"))}` +
-        `&scope=${encodeURIComponent(scopes.join(" "))}` +
-        `&state=${connection.connection_id}`
-      );
-    },
-    codeFromQuery: (query) => {
-      return getStringFromQuery(query, "code");
-    },
-    connectionIdFromQuery: (query) => {
-      return getStringFromQuery(query, "state");
-    },
-    isExtraConfigValid: (extraConfig) => {
-      return Object.keys(extraConfig).length === 0;
-    },
-  },
+  confluence: new ConfluenceOAuthProvider(),
+  github: new GithubOAuthProvider(),
+  gmail: new GmailOAuthProvider(),
+  gong: new GongOAuthProvider(),
+  google_drive: new GoogleDriveOAuthProvider(),
+  hubspot: new HubspotOAuthProvider(),
+  intercom: new IntercomOAuthProvider(),
+  mcp: new MCPOAuthProvider(),
+  microsoft: new MicrosoftOAuthProvider(),
+  notion: new NotionOAuthProvider(),
+  salesforce: new SalesforceOAuthProvider(),
+  slack: new SlackOAuthProvider(),
+  zendesk: new ZendeskOAuthProvider(),
 };
 
 export async function createConnectionAndGetSetupUrl(
   auth: Authenticator,
   provider: OAuthProvider,
   useCase: OAuthUseCase,
-  extraConfig: Record<string, string>
+  extraConfig: ExtraConfigType
 ): Promise<Result<string, OAuthError>> {
   const api = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
@@ -742,9 +103,9 @@ export async function createConnectionAndGetSetupUrl(
     }
   }
 
-  const clientId: string | undefined = extraConfig.client_id;
+  const clientId: string | undefined = extraConfig.client_id as string;
 
-  const metadata: Record<string, string> = {
+  const metadata: Record<string, unknown> = {
     use_case: useCase,
     workspace_id: auth.getNonNullableWorkspace().sId,
     user_id: auth.getNonNullableUser().sId,

--- a/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
+++ b/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
@@ -19,7 +19,7 @@ export interface BaseOAuthStrategyProvider {
     clientId?: string;
     forceLabelsScope?: boolean;
     relatedCredential?: {
-      content: Record<string, unknown>;
+      content: Record<string, string>;
       metadata: { workspace_id: string; user_id: string };
     };
     extraConfig?: ExtraConfigType;
@@ -34,6 +34,7 @@ export interface BaseOAuthStrategyProvider {
     useCase: OAuthUseCase
   ) => boolean;
 
+  // If the provider has a method for getting the related credential, it must return a cleaned config.
   getRelatedCredential?: (
     auth: Authenticator,
     extraConfig: ExtraConfigType,
@@ -42,9 +43,14 @@ export interface BaseOAuthStrategyProvider {
     useCase: OAuthUseCase
   ) => Promise<{
     credential: {
-      content: Record<string, unknown>;
+      content: Record<string, string>;
       metadata: { workspace_id: string; user_id: string };
     };
     cleanedConfig: ExtraConfigType;
   } | null>;
+
+  isExtraConfigValidPostRelatedCredential?: (
+    extraConfig: ExtraConfigType,
+    useCase: OAuthUseCase
+  ) => boolean;
 }

--- a/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
+++ b/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
@@ -1,0 +1,50 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import type { Authenticator } from "@app/lib/auth";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType } from "@app/types/oauth/lib";
+import type { OAuthUseCase } from "@app/types/oauth/lib";
+
+export interface BaseOAuthStrategyProvider {
+  setupUri: ({
+    connection,
+    useCase,
+    clientId,
+    forceLabelsScope,
+    relatedCredential,
+    extraConfig,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+    clientId?: string;
+    forceLabelsScope?: boolean;
+    relatedCredential?: {
+      content: Record<string, unknown>;
+      metadata: { workspace_id: string; user_id: string };
+    };
+    extraConfig?: ExtraConfigType;
+  }) => string;
+
+  codeFromQuery: (query: ParsedUrlQuery) => string | null;
+
+  connectionIdFromQuery: (query: ParsedUrlQuery) => string | null;
+
+  isExtraConfigValid: (
+    extraConfig: ExtraConfigType,
+    useCase: OAuthUseCase
+  ) => boolean;
+
+  getRelatedCredential?: (
+    auth: Authenticator,
+    extraConfig: ExtraConfigType,
+    workspaceId: string,
+    userId: string,
+    useCase: OAuthUseCase
+  ) => Promise<{
+    credential: {
+      content: Record<string, unknown>;
+      metadata: { workspace_id: string; user_id: string };
+    };
+    cleanedConfig: ExtraConfigType;
+  } | null>;
+}

--- a/front/lib/api/oauth/providers/confluence.ts
+++ b/front/lib/api/oauth/providers/confluence.ts
@@ -1,0 +1,54 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class ConfluenceOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    const scopes = [
+      "read:confluence-space.summary",
+      "read:confluence-content.all",
+      "read:confluence-user",
+      "search:confluence",
+      "read:space:confluence",
+      "read:page:confluence",
+      "read:confluence-props",
+      "read:confluence-content.summary",
+      "report:personal-data",
+      "read:me",
+      "read:label:confluence",
+      "offline_access",
+    ];
+    return (
+      `https://auth.atlassian.com/authorize?audience=api.atlassian.com` +
+      `&client_id=${config.getOAuthConfluenceClientId()}` +
+      `&scope=${encodeURIComponent(scopes.join(" "))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("confluence"))}` +
+      `&state=${connection.connection_id}` +
+      `&response_type=code&prompt=consent`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/lib/api/oauth/providers/github.ts
+++ b/front/lib/api/oauth/providers/github.ts
@@ -1,0 +1,44 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import { getStringFromQuery } from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class GithubOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+    useCase,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    const app =
+      useCase === "platform_actions"
+        ? config.getOAuthGithubAppPlatformActions()
+        : config.getOAuthGithubApp();
+    // Only the `installations/new` URL supports state passing.
+    return (
+      `https://github.com/apps/${app}/installations/new` +
+      `?state=${connection.connection_id}`
+    );
+  }
+  // {
+  //   installation_id: '52689080',
+  //   setup_action: 'update',
+  //   state: 'con_...-...',
+  //   provider: 'github'
+  // }
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "installation_id");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -34,7 +34,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
       client_id: clientId,
       state: connection.connection_id,
       redirect_uri: finalizeUriForProvider("gmail"),
-      scope: extraConfig.scope as string,
+      scope: extraConfig.scope,
       access_type: "offline",
       prompt: "consent",
     });
@@ -67,7 +67,13 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
     workspaceId: string,
     userId: string,
     useCase: OAuthUseCase
-  ) {
+  ): Promise<{
+    credential: {
+      content: Record<string, string>;
+      metadata: { workspace_id: string; user_id: string };
+    };
+    cleanedConfig: ExtraConfigType;
+  } | null> {
     if (useCase === "personal_actions") {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
@@ -78,7 +84,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
         const mcpServerConnectionRes =
           await MCPServerConnectionResource.findByMCPServer({
             auth,
-            mcpServerId: mcp_server_id as string,
+            mcpServerId: mcp_server_id,
             connectionType: "workspace",
           });
 
@@ -104,7 +110,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
             metadata: { workspace_id: workspaceId, user_id: userId },
           },
           cleanedConfig: {
-            client_id: connection.metadata.client_id as string,
+            client_id: connection.metadata.client_id,
             ...restConfig,
           },
         };
@@ -116,7 +122,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
     return {
       credential: {
         content: {
-          client_secret,
+          client_secret: client_secret,
           client_id: extraConfig.client_id,
         },
         metadata: { workspace_id: workspaceId, user_id: userId },

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -1,0 +1,127 @@
+import type { ParsedUrlQuery } from "querystring";
+import querystring from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import { OAuthAPI } from "@app/types";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+    clientId,
+    extraConfig,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+    clientId?: string;
+    extraConfig?: ExtraConfigType;
+  }) {
+    if (!extraConfig || !extraConfig.scope) {
+      throw new Error("Missing authorization scope");
+    }
+
+    const qs = querystring.stringify({
+      response_type: "code",
+      client_id: clientId,
+      state: connection.connection_id,
+      redirect_uri: finalizeUriForProvider("gmail"),
+      scope: extraConfig.scope as string,
+      access_type: "offline",
+      prompt: "consent",
+    });
+    return `https://accounts.google.com/o/oauth2/auth?${qs}`;
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions") {
+      // If we have an mcp_server_id it means the admin already setup the connection and we have
+      // everything we need, otherwise we'll need the client_id and client_secret.
+      if (extraConfig.mcp_server_id) {
+        return true;
+      }
+      return !!(extraConfig.client_id && extraConfig.client_secret);
+    }
+    return Object.keys(extraConfig).length === 0;
+  }
+
+  async getRelatedCredential(
+    auth: Authenticator,
+    extraConfig: ExtraConfigType,
+    workspaceId: string,
+    userId: string,
+    useCase: OAuthUseCase
+  ) {
+    if (useCase === "personal_actions") {
+      // For personal actions we reuse the existing connection credential id from the existing
+      // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
+      // we have client_secret (initial admin setup).
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const mcpServerConnectionRes =
+          await MCPServerConnectionResource.findByMCPServer({
+            auth,
+            mcpServerId: mcp_server_id as string,
+            connectionType: "workspace",
+          });
+
+        if (mcpServerConnectionRes.isErr()) {
+          return null;
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getAccessToken({
+          connectionId: mcpServerConnectionRes.value.connectionId,
+        });
+        if (connectionRes.isErr()) {
+          return null;
+        }
+        const connection = connectionRes.value.connection;
+        const connectionId = connection.connection_id;
+
+        return {
+          credential: {
+            content: {
+              from_connection_id: connectionId,
+            },
+            metadata: { workspace_id: workspaceId, user_id: userId },
+          },
+          cleanedConfig: {
+            client_id: connection.metadata.client_id as string,
+            ...restConfig,
+          },
+        };
+      }
+    }
+
+    const { client_secret, ...restConfig } = extraConfig;
+    // Keep client_id in metadata in clear text.
+    return {
+      credential: {
+        content: {
+          client_secret,
+          client_id: extraConfig.client_id,
+        },
+        metadata: { workspace_id: workspaceId, user_id: userId },
+      },
+      cleanedConfig: restConfig,
+    };
+  }
+}

--- a/front/lib/api/oauth/providers/gong.ts
+++ b/front/lib/api/oauth/providers/gong.ts
@@ -1,0 +1,46 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class GongOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    const scopes = [
+      "api:calls:read:transcript",
+      "api:calls:read:extensive",
+      "api:calls:read:basic",
+      "api:users:read",
+    ];
+    return (
+      `https://app.gong.io/oauth2/authorize?` +
+      `client_id=${config.getOAuthGongClientId()}` +
+      `&scope=${encodeURIComponent(scopes.join(" "))}` +
+      `&response_type=code` +
+      `&state=${connection.connection_id}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("gong"))}`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/lib/api/oauth/providers/google_drive.ts
+++ b/front/lib/api/oauth/providers/google_drive.ts
@@ -1,0 +1,59 @@
+import type { ParsedUrlQuery } from "querystring";
+import querystring from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class GoogleDriveOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+    useCase,
+    forceLabelsScope,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+    forceLabelsScope?: boolean;
+  }) {
+    const scopes =
+      useCase === "labs_transcripts"
+        ? ["https://www.googleapis.com/auth/drive.meet.readonly"]
+        : [
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.readonly",
+          ];
+
+    if (forceLabelsScope) {
+      scopes.push("https://www.googleapis.com/auth/drive.labels.readonly");
+    }
+
+    const qs = querystring.stringify({
+      response_type: "code",
+      client_id: config.getOAuthGoogleDriveClientId(),
+      state: connection.connection_id,
+      redirect_uri: finalizeUriForProvider("google_drive"),
+      scope: scopes.join(" "),
+      access_type: "offline",
+      prompt: "consent",
+    });
+
+    return `https://accounts.google.com/o/oauth2/auth?${qs}`;
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -1,0 +1,61 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    const scopes = [
+      "oauth",
+      "crm.objects.contacts.read",
+      "crm.objects.contacts.write",
+      "crm.schemas.contacts.read",
+      "crm.objects.companies.read",
+      "crm.objects.companies.write",
+      "crm.schemas.companies.read",
+      "crm.objects.deals.read",
+      "crm.objects.deals.write",
+      "crm.schemas.deals.read",
+      "tickets",
+      "crm.objects.owners.read",
+      "crm.schemas.custom.read",
+      "crm.objects.custom.read",
+      "files",
+      "sales-email-read",
+      "timeline",
+      "crm.lists.read",
+      "crm.lists.write",
+      "automation",
+    ];
+    return (
+      `https://app.hubspot.com/oauth/authorize` +
+      `?client_id=${config.getOAuthHubspotClientId()}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("hubspot"))}` +
+      `&scope=${encodeURIComponent(scopes.join(" "))}` +
+      `&state=${connection.connection_id}`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/lib/api/oauth/providers/intercom.ts
+++ b/front/lib/api/oauth/providers/intercom.ts
@@ -1,0 +1,38 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class IntercomOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    return (
+      `https://app.intercom.com/oauth` +
+      `?client_id=${config.getOAuthIntercomClientId()}` +
+      `&state=${connection.connection_id}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("intercom"))}`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -1,0 +1,113 @@
+import type { ParsedUrlQuery } from "querystring";
+import { z } from "zod";
+
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { getPKCEConfig } from "@app/lib/utils/pkce";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export const MCPOAuthExtraConfigSchema = z.object({
+  client_id: z.string(),
+  client_secret: z.string(),
+  token_endpoint: z.string(),
+  authorization_endpoint: z.string(),
+  response_types_supported: z.array(z.string()),
+  grant_types_supported: z.array(z.string()).optional(),
+  code_challenge_methods_supported: z.array(z.string()).optional(),
+  code_verifier: z.string().optional(),
+  code_challenge: z.string().optional(),
+});
+
+export type MCPOAuthExtraConfig = z.infer<typeof MCPOAuthExtraConfigSchema>;
+
+export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    const responseType = "code";
+    const codeChallengeMethod = "S256";
+
+    const metadata = connection.metadata as MCPOAuthExtraConfig;
+    const authUrl = new URL(metadata.authorization_endpoint);
+
+    if (!metadata.response_types_supported.includes(responseType)) {
+      throw new Error(
+        `Incompatible auth server: does not support response type ${responseType}`
+      );
+    }
+
+    if (
+      !metadata.code_challenge_methods_supported ||
+      !metadata.code_challenge_methods_supported.includes(codeChallengeMethod)
+    ) {
+      throw new Error(
+        `Incompatible auth server: does not support code challenge method ${codeChallengeMethod}`
+      );
+    }
+
+    if (!metadata.code_challenge) {
+      throw new Error("Missing code challenge");
+    }
+
+    authUrl.searchParams.set("response_type", responseType);
+    authUrl.searchParams.set("client_id", metadata.client_id);
+    authUrl.searchParams.set("code_challenge", metadata.code_challenge);
+    authUrl.searchParams.set("code_challenge_method", codeChallengeMethod);
+    authUrl.searchParams.set("redirect_uri", finalizeUriForProvider("mcp"));
+    authUrl.searchParams.set("state", connection.connection_id);
+
+    return authUrl.toString();
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(
+    extraConfig: ExtraConfigType
+  ): extraConfig is MCPOAuthExtraConfig {
+    return MCPOAuthExtraConfigSchema.safeParse(extraConfig).success;
+  }
+
+  async getRelatedCredential(
+    auth: Authenticator,
+    extraConfig: ExtraConfigType,
+    workspaceId: string,
+    userId: string
+  ) {
+    if (!this.isExtraConfigValid(extraConfig)) {
+      return null;
+    }
+
+    const { client_secret, ...restConfig } = extraConfig;
+
+    const { code_verifier, code_challenge } = await getPKCEConfig();
+
+    return {
+      credential: {
+        content: {
+          client_secret,
+          client_id: extraConfig.client_id,
+        },
+        metadata: { workspace_id: workspaceId, user_id: userId },
+      },
+      cleanedConfig: {
+        ...restConfig,
+        code_verifier,
+        code_challenge,
+      },
+    };
+  }
+}

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -1,0 +1,90 @@
+import type { ParsedUrlQuery } from "querystring";
+import querystring from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+    relatedCredential,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+    relatedCredential?: {
+      content: Record<string, unknown>;
+      metadata: { workspace_id: string; user_id: string };
+    };
+  }) {
+    const scopes = [
+      "User.Read",
+      "Sites.Read.All",
+      "Directory.Read.All",
+      "Files.Read.All",
+      "Team.ReadBasic.All",
+      "ChannelSettings.Read.All",
+      "ChannelMessage.Read.All",
+      "offline_access",
+    ];
+    if (relatedCredential) {
+      return `${config.getClientFacingUrl()}/oauth/microsoft/finalize?provider=microsoft&code=client&state=${connection.connection_id}`;
+    } else {
+      const qs = querystring.stringify({
+        response_type: "code",
+        client_id: config.getOAuthMicrosoftClientId(),
+        state: connection.connection_id,
+        redirect_uri: finalizeUriForProvider("microsoft"),
+        scope: scopes.join(" "),
+      });
+      return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${qs}`;
+    }
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return (
+      Object.keys(extraConfig).length === 0 ||
+      !!(
+        extraConfig.client_id &&
+        extraConfig.client_secret &&
+        extraConfig.tenant_id
+      )
+    );
+  }
+
+  async getRelatedCredential(
+    auth: Authenticator,
+    extraConfig: ExtraConfigType,
+    workspaceId: string,
+    userId: string
+  ) {
+    const { client_id, client_secret, ...restConfig } = extraConfig;
+    if (!client_id || !client_secret) {
+      return null;
+    }
+    return {
+      credential: {
+        content: {
+          client_id,
+          client_secret,
+        },
+        metadata: { workspace_id: workspaceId, user_id: userId },
+      },
+      cleanedConfig: restConfig,
+    };
+  }
+}

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -19,7 +19,7 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
     connection: OAuthConnectionType;
     useCase: OAuthUseCase;
     relatedCredential?: {
-      content: Record<string, unknown>;
+      content: Record<string, string>;
       metadata: { workspace_id: string; user_id: string };
     };
   }) {

--- a/front/lib/api/oauth/providers/notion.ts
+++ b/front/lib/api/oauth/providers/notion.ts
@@ -1,0 +1,44 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class NotionOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+    useCase,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    const clientId =
+      useCase === "platform_actions"
+        ? config.getOAuthNotionPlatformActionsClientId()
+        : config.getOAuthNotionClientId();
+    return (
+      `https://api.notion.com/v1/oauth/authorize?owner=user` +
+      `&response_type=code` +
+      `&client_id=${clientId}` +
+      `&state=${connection.connection_id}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("notion"))}`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -81,7 +81,13 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
     workspaceId: string,
     userId: string,
     useCase: OAuthUseCase
-  ) {
+  ): Promise<{
+    credential: {
+      content: Record<string, string>;
+      metadata: { workspace_id: string; user_id: string };
+    };
+    cleanedConfig: ExtraConfigType;
+  } | null> {
     // SALESFORCE CONNECTION TO BE DEPRECATED.
     if (useCase === "salesforce_personal") {
       // For personal connection, we reuse the existing connection credential id
@@ -128,8 +134,8 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
           metadata: { workspace_id: workspaceId, user_id: userId },
         },
         cleanedConfig: {
-          client_id: connection.metadata.client_id as string,
-          instance_url: connection.metadata.instance_url as string,
+          client_id: connection.metadata.client_id,
+          instance_url: connection.metadata.instance_url,
           ...extraConfig,
         },
       };
@@ -145,7 +151,7 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
         const mcpServerConnectionRes =
           await MCPServerConnectionResource.findByMCPServer({
             auth,
-            mcpServerId: mcp_server_id as string,
+            mcpServerId: mcp_server_id,
             connectionType: "workspace",
           });
 
@@ -171,8 +177,8 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
             metadata: { workspace_id: workspaceId, user_id: userId },
           },
           cleanedConfig: {
-            client_id: connection.metadata.client_id as string,
-            instance_url: connection.metadata.instance_url as string,
+            client_id: connection.metadata.client_id,
+            instance_url: connection.metadata.instance_url,
             ...restConfig,
           },
         };

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -1,0 +1,195 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { isManaged } from "@app/lib/data_sources";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import { ConnectorsAPI, isValidSalesforceDomain, OAuthAPI } from "@app/types";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+    clientId,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+    clientId?: string;
+  }) {
+    if (!connection.metadata.instance_url) {
+      throw new Error("Missing Salesforce instance URL");
+    }
+    if (
+      !connection.metadata.code_verifier ||
+      !connection.metadata.code_challenge
+    ) {
+      throw new Error("Missing PKCE code verifier or challenge");
+    }
+
+    if (!clientId) {
+      throw new Error("Missing Salesforce client ID");
+    }
+    return (
+      `${connection.metadata.instance_url}/services/oauth2/authorize` +
+      `?response_type=code` +
+      `&client_id=${clientId}` +
+      `&state=${connection.connection_id}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("salesforce"))}` +
+      `&code_challenge=${connection.metadata.code_challenge}` +
+      `&code_challenge_method=S256`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions") {
+      // If we have an mcp_server_id it means the admin already setup the connection and we have
+      // everything we need, otherwise we'll need the instance_url and client_id.
+      if (extraConfig.mcp_server_id) {
+        return true;
+      }
+    }
+
+    if (useCase === "salesforce_personal") {
+      return true;
+    }
+
+    if (!extraConfig.instance_url || !extraConfig.client_id) {
+      return false;
+    }
+    return isValidSalesforceDomain(extraConfig.instance_url);
+  }
+
+  async getRelatedCredential(
+    auth: Authenticator,
+    extraConfig: ExtraConfigType,
+    workspaceId: string,
+    userId: string,
+    useCase: OAuthUseCase
+  ) {
+    // SALESFORCE CONNECTION TO BE DEPRECATED.
+    if (useCase === "salesforce_personal") {
+      // For personal connection, we reuse the existing connection credential id
+      // from the existing data source, if it exists.
+      const dataSources = await DataSourceResource.listByConnectorProvider(
+        auth,
+        "salesforce"
+      );
+      if (dataSources.length !== 1) {
+        return null;
+      }
+      const dataSource = dataSources[0].toJSON();
+      if (!isManaged(dataSource)) {
+        return null;
+      }
+
+      const connectorsAPI = new ConnectorsAPI(
+        config.getConnectorsAPIConfig(),
+        logger
+      );
+      const connectorRes =
+        await connectorsAPI.getConnectorFromDataSource(dataSource);
+      if (connectorRes.isErr()) {
+        return null;
+      }
+
+      const connector = connectorRes.value;
+
+      const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+      const connectionRes = await oauthApi.getAccessToken({
+        connectionId: connector.connectionId,
+      });
+      if (connectionRes.isErr()) {
+        return null;
+      }
+      const connection = connectionRes.value.connection;
+      const connectionId = connection.connection_id;
+
+      return {
+        credential: {
+          content: {
+            from_connection_id: connectionId,
+          },
+          metadata: { workspace_id: workspaceId, user_id: userId },
+        },
+        cleanedConfig: {
+          client_id: connection.metadata.client_id as string,
+          instance_url: connection.metadata.instance_url as string,
+          ...extraConfig,
+        },
+      };
+    }
+
+    if (useCase === "personal_actions") {
+      // For personal actions we reuse the existing connection credential id from the existing
+      // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
+      // we have client_secret and instance_url (initial admin setup).
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const mcpServerConnectionRes =
+          await MCPServerConnectionResource.findByMCPServer({
+            auth,
+            mcpServerId: mcp_server_id as string,
+            connectionType: "workspace",
+          });
+
+        if (mcpServerConnectionRes.isErr()) {
+          return null;
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getConnectionMetadata({
+          connectionId: mcpServerConnectionRes.value.connectionId,
+        });
+        if (connectionRes.isErr()) {
+          return null;
+        }
+        const connection = connectionRes.value.connection;
+        const connectionId = connection.connection_id;
+
+        return {
+          credential: {
+            content: {
+              from_connection_id: connectionId,
+            },
+            metadata: { workspace_id: workspaceId, user_id: userId },
+          },
+          cleanedConfig: {
+            client_id: connection.metadata.client_id as string,
+            instance_url: connection.metadata.instance_url as string,
+            ...restConfig,
+          },
+        };
+      }
+    }
+
+    const { client_secret, ...restConfig } = extraConfig;
+    // Keep client_id in metadata in clear text.
+    return {
+      credential: {
+        content: {
+          client_secret,
+          client_id: extraConfig.client_id,
+        },
+        metadata: { workspace_id: workspaceId, user_id: userId },
+      },
+      cleanedConfig: restConfig,
+    };
+  }
+}

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -1,0 +1,57 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    const scopes = [
+      "app_mentions:read",
+      "channels:history",
+      "channels:join",
+      "channels:read",
+      "chat:write",
+      "groups:history",
+      "groups:read",
+      "im:history",
+      "metadata.message:read",
+      "mpim:read",
+      "team:read",
+      "users:read",
+      "users:read.email",
+      "im:read",
+      "mpim:history",
+      "files:read",
+    ];
+    return (
+      `https://slack.com/oauth/v2/authorize?` +
+      `client_id=${config.getOAuthSlackClientId()}` +
+      `&scope=${encodeURIComponent(scopes.join(" "))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("slack"))}` +
+      `&state=${connection.connection_id}`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/lib/api/oauth/providers/zendesk.ts
+++ b/front/lib/api/oauth/providers/zendesk.ts
@@ -1,0 +1,48 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import { isValidZendeskSubdomain } from "@app/types";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    const scopes = ["read"];
+    if (!isValidZendeskSubdomain(connection.metadata.zendesk_subdomain)) {
+      throw "Invalid Zendesk subdomain";
+    }
+    return (
+      `https://${connection.metadata.zendesk_subdomain}.zendesk.com/oauth/authorizations/new?` +
+      `client_id=${config.getOAuthZendeskClientId()}` +
+      `&scope=${encodeURIComponent(scopes.join(" "))}` +
+      `&response_type=code` +
+      `&state=${connection.connection_id}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("zendesk"))}`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
+    if (Object.keys(extraConfig).length !== 1) {
+      return false;
+    }
+    return isValidZendeskSubdomain(extraConfig.zendesk_subdomain);
+  }
+}

--- a/front/lib/api/oauth/utils.ts
+++ b/front/lib/api/oauth/utils.ts
@@ -1,0 +1,19 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { OAuthProvider } from "@app/types";
+
+export function finalizeUriForProvider(provider: OAuthProvider): string {
+  return config.getClientFacingUrl() + `/oauth/${provider}/finalize`;
+}
+
+export function getStringFromQuery(
+  query: ParsedUrlQuery,
+  key: string
+): string | null {
+  const value = query[key];
+  if (typeof value != "string") {
+    return null;
+  }
+  return value;
+}

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -15,6 +15,7 @@ import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { RemoteAllowedIconType } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnection } from "@app/lib/models/assistant/actions/mcp_server_connection";
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
 import { destroyMCPServerViewDependencies } from "@app/lib/models/assistant/actions/mcp_server_view_helper";
 import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_mcp_server";
@@ -67,6 +68,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         description: blob.cachedDescription || DEFAULT_MCP_ACTION_DESCRIPTION,
         sharedSecret: blob.sharedSecret,
         lastSyncAt: new Date(),
+        authorization: blob.authorization,
       },
       { transaction }
     );
@@ -192,6 +194,13 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     auth: Authenticator
   ): Promise<Result<undefined | number, Error>> {
     const mcpServerViews = await MCPServerViewModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        remoteMCPServerId: this.id,
+      },
+    });
+
+    await MCPServerConnection.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         remoteMCPServerId: this.id,

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -75,7 +75,12 @@ export function makeSId(
     return cached;
   }
 
-  const sId = `${RESOURCES_PREFIX[resourceName]}_${sqids.encode(idsToEncode)}`;
+  const prefix = RESOURCES_PREFIX[resourceName];
+  if (!prefix) {
+    throw new Error(`Invalid resource name: ${resourceName}`);
+  }
+
+  const sId = `${prefix}_${sqids.encode(idsToEncode)}`;
   sIdCache.set(key, sId);
   return sId;
 }

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -48,7 +48,7 @@ const getOptimisticDataForCreate = (
   space: SpaceType
 ) => {
   if (!data) {
-    return { servers: [], success: true };
+    return { servers: [], success: true as const };
   }
   const mcpServerWithViews = data.servers.find((s) => s.sId === server.sId);
 
@@ -84,7 +84,7 @@ const getOptimisticDataForRemove = (
   serverView: MCPServerViewType
 ) => {
   if (!data) {
-    return { servers: [], success: true };
+    return { servers: [], success: true as const };
   }
 
   const mcpServerWithViews = data.servers.find(

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -3,8 +3,11 @@ import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
-import { mcpServersSortingFn } from "@app/lib/actions/mcp_helper";
-import type { MCPServerTypeWithViews } from "@app/lib/api/mcp";
+import {
+  getMcpServerDisplayName,
+  mcpServersSortingFn,
+} from "@app/lib/actions/mcp_helper";
+import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
 import type {
   MCPServerConnectionConnectionType,
   MCPServerConnectionType,
@@ -22,6 +25,7 @@ import type {
 import type { SyncMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/sync";
 import type { GetMCPServerToolsPermissionsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools";
 import type { PatchMCPServerToolsPermissionsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]";
+import type { CheckOAuthResponseBody } from "@app/pages/api/w/[wId]/mcp/check_oauth";
 import type {
   GetConnectionsResponseBody,
   PostConnectionResponseBody,
@@ -30,9 +34,10 @@ import type {
   LightWorkspaceType,
   OAuthProvider,
   OAuthUseCase,
+  Result,
   SpaceType,
 } from "@app/types";
-import { setupOAuthConnection } from "@app/types";
+import { Err, Ok, setupOAuthConnection } from "@app/types";
 import { getProviderAdditionalClientSideAuthCredentials } from "@app/types/oauth/lib";
 
 /**
@@ -195,6 +200,34 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
 }
 
 /**
+ * Hook to check if an OAuth connection is required for a remote MCP server.
+ */
+export function useCheckOAuthConnection(owner: LightWorkspaceType) {
+  const checkOAuthConnection = async (
+    url: string
+  ): Promise<Result<CheckOAuthResponseBody, Error>> => {
+    const response = await fetch(`/api/w/${owner.sId}/mcp/check_oauth`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      return new Err(
+        new Error(
+          error.api_error?.message || "Failed to check OAuth connection"
+        )
+      );
+    }
+
+    return new Ok(await response.json());
+  };
+
+  return { checkOAuthConnection };
+}
+
+/**
  * Hook to create a new MCP server from a URL
  */
 export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
@@ -203,15 +236,30 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
     owner,
   });
 
-  const createWithUrlSync = useCallback(
-    async (
-      url: string,
-      includeGlobal: boolean,
-      sharedSecret?: string
-    ): Promise<CreateMCPServerResponseBody> => {
+  const { mutateConnections } = useMCPServerConnections({
+    disabled: true,
+    connectionType: "workspace",
+    owner,
+  });
+
+  const createWithURL = useCallback(
+    async ({
+      url,
+      includeGlobal,
+      sharedSecret,
+      connectionId,
+    }: {
+      url: string;
+      includeGlobal: boolean;
+      sharedSecret?: string;
+      connectionId?: string;
+    }): Promise<Result<CreateMCPServerResponseBody, Error>> => {
       const body: any = { url, serverType: "remote", includeGlobal };
       if (sharedSecret) {
         body.sharedSecret = sharedSecret;
+      }
+      if (connectionId) {
+        body.connectionId = connectionId;
       }
       const response = await fetch(`/api/w/${owner.sId}/mcp`, {
         method: "POST",
@@ -221,16 +269,22 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
 
       if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error?.message || "Failed to synchronize server");
+        return new Err(
+          new Error(error.error?.message || "Failed to create server")
+        );
       }
 
       await mutateMCPServers();
-      return response.json();
+      if (connectionId) {
+        await mutateConnections();
+      }
+      const r = await response.json();
+      return new Ok(r);
     },
-    [mutateMCPServers, owner.sId]
+    [mutateMCPServers, mutateConnections, owner.sId]
   );
 
-  return { createWithUrlSync };
+  return { createWithURL };
 }
 
 /**
@@ -345,11 +399,11 @@ export function useCreateMCPServerConnection({
   const sendNotification = useSendNotification();
   const createMCPServerConnection = async ({
     connectionId,
-    mcpServerId,
+    mcpServer,
     provider,
   }: {
     connectionId: string;
-    mcpServerId: string;
+    mcpServer: MCPServerType;
     provider: OAuthProvider;
   }): Promise<PostConnectionResponseBody | null> => {
     const response = await fetch(
@@ -361,7 +415,7 @@ export function useCreateMCPServerConnection({
         },
         body: JSON.stringify({
           connectionId,
-          mcpServerId,
+          mcpServerId: mcpServer.sId,
           provider,
         }),
       }
@@ -369,16 +423,16 @@ export function useCreateMCPServerConnection({
     if (response.ok) {
       sendNotification({
         type: "success",
-        title: "Provider connected",
-        description: `Successfully connected to provider ${provider}.`,
+        title: `${getMcpServerDisplayName(mcpServer)} connected`,
+        description: `Successfully connected to ${getMcpServerDisplayName(mcpServer)}.`,
       });
       void mutateConnections();
       return response.json();
     } else {
       sendNotification({
         type: "error",
-        title: "Failed to connect provider",
-        description: "Could not connect to your provider. Please try again.",
+        title: `Failed to connect ${getMcpServerDisplayName(mcpServer)}`,
+        description: `Could not connect to ${getMcpServerDisplayName(mcpServer)}. Please try again.`,
       });
       return null;
     }
@@ -411,8 +465,10 @@ export function useDeleteMCPServerConnection({
   const deleteMCPServerConnection = useCallback(
     async ({
       connection,
+      mcpServer,
     }: {
       connection: MCPServerConnectionType;
+      mcpServer: MCPServerType;
     }): Promise<{ success: boolean }> => {
       const response = await fetch(
         `/api/w/${owner.sId}/mcp/connections/${connection.connectionType}/${connection.sId}`,
@@ -426,9 +482,8 @@ export function useDeleteMCPServerConnection({
       if (response.ok) {
         sendNotification({
           type: "success",
-          title: "Provider disconnected",
-          description:
-            "Your capability provider has been disconnected successfully.",
+          title: `${getMcpServerDisplayName(mcpServer)} disconnected`,
+          description: `Successfully disconnected from ${getMcpServerDisplayName(mcpServer)}.`,
         });
         if (connection.connectionType === "workspace") {
           void mutateWorkspaceConnections();
@@ -438,9 +493,8 @@ export function useDeleteMCPServerConnection({
       } else {
         sendNotification({
           type: "error",
-          title: "Failed to disconnect provider",
-          description:
-            "Could not disconnect to your provider. Please try again.",
+          title: `Failed to disconnect ${getMcpServerDisplayName(mcpServer)}`,
+          description: `Could not disconnect from ${getMcpServerDisplayName(mcpServer)}. Please try again.`,
         });
       }
 
@@ -543,14 +597,14 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
   const sendNotification = useSendNotification();
 
   const createPersonalConnection = async (
-    mcpServerId: string,
+    mcpServer: MCPServerType,
     provider: OAuthProvider,
     useCase: OAuthUseCase,
     scope?: string
   ): Promise<boolean> => {
     try {
       const extraConfig: Record<string, string> = {
-        mcp_server_id: mcpServerId,
+        mcp_server_id: mcpServer.sId,
       };
 
       const additionalCredentials =
@@ -588,7 +642,7 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
 
       const result = await createMCPServerConnection({
         connectionId: cRes.value.connection_id,
-        mcpServerId,
+        mcpServer,
         provider,
       });
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -25,11 +25,11 @@ import type {
 import type { SyncMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/sync";
 import type { GetMCPServerToolsPermissionsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools";
 import type { PatchMCPServerToolsPermissionsResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]";
-import type { CheckOAuthResponseBody } from "@app/pages/api/w/[wId]/mcp/check_oauth";
 import type {
   GetConnectionsResponseBody,
   PostConnectionResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/connections/[connectionType]";
+import type { DiscoverOAuthMetadataResponseBody } from "@app/pages/api/w/[wId]/mcp/discover_oauth_metadata";
 import type {
   LightWorkspaceType,
   OAuthProvider,
@@ -200,17 +200,25 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
 }
 
 /**
- * Hook to check if an OAuth connection is required for a remote MCP server.
+ * Hook to discover the OAuth metadata for a remote MCP server.
+ * It is used to check if the server requires OAuth authentication.
+ * If it does, it returns the OAuth connection metadata with the oauthRequired set to true.
+ * If it does not, it returns the oauthRequired set to false.
+ *
+ * Note: this hook should not be called too frequently, as it is likely rate limited by the mcp server provider.
  */
-export function useCheckOAuthConnection(owner: LightWorkspaceType) {
-  const checkOAuthConnection = async (
+export function useDiscoverOAuthMetadata(owner: LightWorkspaceType) {
+  const discoverOAuthMetadata = async (
     url: string
-  ): Promise<Result<CheckOAuthResponseBody, Error>> => {
-    const response = await fetch(`/api/w/${owner.sId}/mcp/check_oauth`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ url }),
-    });
+  ): Promise<Result<DiscoverOAuthMetadataResponseBody, Error>> => {
+    const response = await fetch(
+      `/api/w/${owner.sId}/mcp/discover_oauth_metadata`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+      }
+    );
 
     if (!response.ok) {
       const error = await response.json();
@@ -224,7 +232,7 @@ export function useCheckOAuthConnection(owner: LightWorkspaceType) {
     return new Ok(await response.json());
   };
 
-  return { checkOAuthConnection };
+  return { discoverOAuthMetadata };
 }
 
 /**

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -14,7 +14,7 @@
         "@hookform/resolvers": "^3.3.4",
         "@hubspot/api-client": "^12.0.1",
         "@mendable/firecrawl-js": "^1.24.0",
-        "@modelcontextprotocol/sdk": "^1.11.1",
+        "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
         "@notionhq/client": "^2.3.0",
         "@octokit/core": "^6.1.5",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -2967,13 +2967,14 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.1.tgz",
-      "integrity": "sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==",
+      "version": "1.12.1",
+      "resolved": "git+ssh://git@github.com/dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
+      "integrity": "sha512-tuIhHhinqMIeTTuxl6gQIJujLNUiNcjiTu0wWEOVbKhQDDQgXyeg6KvZpFdRqIRMMF67uuA/RNRrK/KSraepIQ==",
       "dependencies": {
+        "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
@@ -2985,6 +2986,26 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/pkce-challenge": {
       "version": "5.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -31,7 +31,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@hubspot/api-client": "^12.0.1",
     "@mendable/firecrawl-js": "^1.24.0",
-    "@modelcontextprotocol/sdk": "^1.11.1",
+    "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
     "@notionhq/client": "^2.3.0",
     "@octokit/core": "^6.1.5",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/front/pages/api/w/[wId]/mcp/check_oauth.ts
+++ b/front/pages/api/w/[wId]/mcp/check_oauth.ts
@@ -1,0 +1,77 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
+import { MCPOAuthRequiredError } from "@app/lib/actions/mcp_oauth_error";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { MCPOAuthExtraConfig } from "@app/lib/api/oauth/providers/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type CheckOAuthResponseBody =
+  | {
+      oauthRequired: true;
+      extraConfig: MCPOAuthExtraConfig;
+    }
+  | {
+      oauthRequired: false;
+    };
+
+const PostQueryParamsSchema = t.type({
+  url: t.string,
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<CheckOAuthResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { method } = req;
+
+  switch (method) {
+    case "POST": {
+      const r = PostQueryParamsSchema.decode(req.body);
+
+      if (isLeft(r)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid request body",
+          },
+        });
+      }
+
+      const { url } = r.right;
+
+      const r2 = await fetchRemoteServerMetaDataByURL(auth, url);
+      if (r2.isErr()) {
+        if (r2.error instanceof MCPOAuthRequiredError) {
+          return res.status(200).json({
+            oauthRequired: true,
+            // Return the oauth extraConfig to the client to allow them to handle the oauth flow.
+            extraConfig: r2.error.extraConfig,
+          });
+        }
+      }
+      return res.status(200).json({
+        oauthRequired: false,
+      });
+    }
+
+    default: {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/mcp/check_oauth.ts
+++ b/front/pages/api/w/[wId]/mcp/check_oauth.ts
@@ -5,7 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import { MCPOAuthRequiredError } from "@app/lib/actions/mcp_oauth_error";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPOAuthExtraConfig } from "@app/lib/api/oauth/providers/mcp";
+import type { MCPOAuthConnectionMetadataType } from "@app/lib/api/oauth/providers/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -13,7 +13,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 export type CheckOAuthResponseBody =
   | {
       oauthRequired: true;
-      extraConfig: MCPOAuthExtraConfig;
+      connectionMetadata: MCPOAuthConnectionMetadataType;
     }
   | {
       oauthRequired: false;
@@ -51,8 +51,8 @@ async function handler(
         if (r2.error instanceof MCPOAuthRequiredError) {
           return res.status(200).json({
             oauthRequired: true,
-            // Return the oauth extraConfig to the client to allow them to handle the oauth flow.
-            extraConfig: r2.error.extraConfig,
+            // Return the oauth connectionMetadata to the client to allow them to handle the oauth flow.
+            connectionMetadata: r2.error.connectionMetadata,
           });
         }
       }

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -8,25 +8,30 @@ import {
   isRemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import apiConfig from "@app/lib/api/config";
 import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
 
 export type GetMCPServersResponseBody = {
-  success: boolean;
+  success: true;
   servers: MCPServerTypeWithViews[];
 };
 
 export type CreateMCPServerResponseBody = {
-  success: boolean;
+  success: true;
   server: MCPServerType;
 };
 
@@ -36,6 +41,7 @@ const PostQueryParamsSchema = t.union([
     url: t.string,
     includeGlobal: t.union([t.boolean, t.undefined]),
     sharedSecret: t.union([t.string, t.undefined]),
+    connectionId: t.union([t.string, t.undefined]),
   }),
   t.type({
     serverType: t.literal("internal"),
@@ -124,12 +130,41 @@ async function handler(
           });
         }
 
+        // Default to the shared secret if it exists.
+        let bearerToken = sharedSecret || null;
+        let authorization: AuthorizationInfo | null = null;
+
+        // If a connectionId is provided, we use it to fetch the access token that must have been created by the admin.
+        if (body.connectionId) {
+          const token = await getOAuthConnectionAccessToken({
+            config: apiConfig.getOAuthAPIConfig(),
+            logger,
+            connectionId: body.connectionId,
+          });
+          if (token.isOk()) {
+            bearerToken = token.value.access_token;
+            authorization = {
+              provider: "mcp",
+              use_case: "platform_actions", // TODO (mcp): handle correctly the personal connections.
+            };
+          } else {
+            // We fail early if the connectionId is provided but the access token cannot be fetched.
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Error fetching OAuth connection access token",
+              },
+            });
+          }
+        }
+
         const r = await fetchRemoteServerMetaDataByURL(
           auth,
           url,
-          sharedSecret
+          bearerToken
             ? {
-                Authorization: `Bearer ${sharedSecret}`,
+                Authorization: `Bearer ${bearerToken}`,
               }
             : undefined
         );
@@ -138,8 +173,7 @@ async function handler(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message:
-                "Error fetching remote server metadata, URL may be invalid.",
+              message: `Error fetching remote server metadata: ${r.error.message}`,
             },
           });
         }
@@ -157,7 +191,20 @@ async function handler(
             : DEFAULT_MCP_SERVER_ICON,
           version: metadata.version,
           sharedSecret: sharedSecret || null,
+          authorization,
         });
+
+        if (body.connectionId) {
+          // We create a connection to the remote MCP server to allow the user to use the MCP server in the future.
+          // The connexion is of type "workspace" because it is created by the admin.
+          // If the server can use personal connections, we rely on this "workspace" connection to get the related credentials.
+          await MCPServerConnectionResource.makeNew(auth, {
+            connectionId: body.connectionId,
+            connectionType: "workspace",
+            serverType: "remote",
+            remoteMCPServerId: newRemoteMCPServer.id,
+          });
+        }
 
         if (body.includeGlobal) {
           const globalSpace =

--- a/front/pages/w/[wId]/oauth/[provider]/setup.tsx
+++ b/front/pages/w/[wId]/oauth/[provider]/setup.tsx
@@ -5,7 +5,7 @@ import { createConnectionAndGetSetupUrl } from "@app/lib/api/oauth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isOAuthProvider, isOAuthUseCase, safeParseJSON } from "@app/types";
 
-export const ExtraConfigTypeSchema = t.record(t.string, t.unknown);
+export const ExtraConfigTypeSchema = t.record(t.string, t.string);
 export type ExtraConfigType = t.TypeOf<typeof ExtraConfigTypeSchema>;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<object>(

--- a/front/pages/w/[wId]/oauth/[provider]/setup.tsx
+++ b/front/pages/w/[wId]/oauth/[provider]/setup.tsx
@@ -5,7 +5,7 @@ import { createConnectionAndGetSetupUrl } from "@app/lib/api/oauth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isOAuthProvider, isOAuthUseCase, safeParseJSON } from "@app/types";
 
-export const ExtraConfigTypeSchema = t.record(t.string, t.string);
+export const ExtraConfigTypeSchema = t.record(t.string, t.unknown);
 export type ExtraConfigType = t.TypeOf<typeof ExtraConfigTypeSchema>;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<object>(
@@ -29,7 +29,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<object>(
       };
     }
 
-    let parsedExtraConfig: Record<string, string> = {};
+    let parsedExtraConfig: ExtraConfigType = {};
     const parseRes = safeParseJSON(extraConfig as string);
     if (parseRes.isErr()) {
       return {

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -1,5 +1,3 @@
-import type { MCPOAuthExtraConfig } from "@app/lib/api/oauth/providers/mcp";
-
 import type {
   OAuthConnectionType,
   OAuthCredentials,
@@ -22,7 +20,7 @@ export async function setupOAuthConnection({
   owner: LightWorkspaceType;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
-  extraConfig: OAuthCredentials | MCPOAuthExtraConfig;
+  extraConfig: OAuthCredentials;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
     let url = `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}`;

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -1,3 +1,5 @@
+import type { MCPOAuthExtraConfig } from "@app/lib/api/oauth/providers/mcp";
+
 import type {
   OAuthConnectionType,
   OAuthCredentials,
@@ -20,7 +22,7 @@ export async function setupOAuthConnection({
   owner: LightWorkspaceType;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
-  extraConfig: OAuthCredentials;
+  extraConfig: OAuthCredentials | MCPOAuthExtraConfig;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
     let url = `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}`;

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -32,6 +32,7 @@ export const OAUTH_PROVIDERS = [
   "zendesk",
   "salesforce",
   "hubspot",
+  "mcp", // MCP is a special provider for MCP servers
 ] as const;
 
 export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
@@ -47,6 +48,7 @@ export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
   zendesk: "Zendesk",
   salesforce: "Salesforce",
   hubspot: "Hubspot",
+  mcp: "MCP",
 };
 
 export const getProviderAdditionalClientSideAuthCredentials = async (
@@ -62,6 +64,7 @@ export const getProviderAdditionalClientSideAuthCredentials = async (
         return getPKCEConfig();
       }
       return null;
+    case "mcp":
     case "hubspot":
     case "zendesk":
     case "slack":
@@ -193,6 +196,7 @@ export const getProviderRequiredOAuthCredentialInputs = async (
     case "github":
     case "google_drive":
     case "intercom":
+    case "mcp":
       if (!additionalCredentials) {
         return null;
       }

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -225,7 +225,7 @@ export function isValidScope(obj: unknown): obj is string | undefined {
 export type OAuthConnectionType = {
   connection_id: string;
   created: number;
-  metadata: Record<string, unknown>;
+  metadata: Record<string, string>;
   provider: OAuthProvider;
   status: "pending" | "finalized";
 };

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -129,8 +129,7 @@ export function asDisplayName(name?: string | null) {
     return "";
   }
 
-  return name
-    .toLowerCase()
+  return slugify(name)
     .replace(/_/g, " ")
     .replace(
       SPECIAL_CASES_PATTERN,


### PR DESCRIPTION
## Description

Add support for the new Oauth flow when connecting RemoteMCPServer as `workspace` connection.

Note:
- this PR do not allow picking between personal / workspace connection, it will be implemented in a subsequent PR.
- I forked the official lib to add a callback to get the discovered oauth server metadata (will try to get it merged upstream)

### New code
- MCP provider in oauth service & front
- New `MCPOAuthProvider` to handle the oauth callback from the MCP client (more about it below)
- Endpoint to check if a remote MCP server requires oauth.

### Refactored
- Improved notification and error message to use the server name instead of "MCP Server" when possible, show more detailed errors.
- Split the big front oauth `PROVIDER_STRATEGIES` to use file per provider (similar to what we do in `oauth`).
- Modals to create and connect an MCP server to support the new oauth flow.

### How it works

The official MCP sdk can do most of the flow and requires a class implementing `OAuthClientProvider` ([source](https://github.com/dust-tt/typescript-sdk/blob/bca26e405d6db2cf71fd7211234a72ecc46d0215/src/client/auth.ts#L13)) with callbacks to retrieve / save the information & tokens.

However, we want the flow to be handled by our own oauth service so it works naturally with everything else.

I didn't want to re-implement the [discovery of the metadata](https://github.com/dust-tt/typescript-sdk/blob/bca26e405d6db2cf71fd7211234a72ecc46d0215/src/client/auth.ts#L109) because it quite intricated with the MCP specificities and I prefer to get any fix they do there (such as [this one 2 weeks ago](https://github.com/modelcontextprotocol/typescript-sdk/pull/416)) for "free".

So what I did is that in our implementation of `OAuthClientProvider`:
- if we have a existing MCP server passed in : I try to fetch the token (either by sharedSecret or via an oauth connection) in the "tokens()" callback => then the MCP client will simply use them in the headers and stop the flow.
- if we don't have one (creation of remote mcp server or reconnection), I let the sdk do all the discovery until it reach "saveClientInformation()" where I raise a specific error with all the metadata we need.

In the front code, I use the new endpoint to check if an mcp server (via it's url) requires oauth and if so, get the said metadata. Then It's similar to other providers except all metadata of the oauth server (tokens endpoint, auth endpoint..) are passed via the connection's metdata.


## Tests

A lot of local test with unprotected mcp servers, api token protected mcp server (stripe), multilple oauth protected mcp servers (atlassian, linear, intercom, a nice list is [here](https://github.com/jaw9c/awesome-remote-mcp-servers)) as well as checking that gmail & salesforce were still working.

## Risk

Medium, with the refactoring of the provider in front, I could have broke something (but I double-checked that the code was exactly the same).

## Deploy Plan

Deploy `oauth` and `front`