### PR TITLE
[front] Remove workspaceHasDomain on cutover

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -83,15 +83,11 @@ export async function getWorkspaceVerifiedDomain(
 export async function removeAllWorkspaceDomains(
   workspace: LightWorkspaceType
 ): Promise<void> {
-  const workspaceDomains = await WorkspaceHasDomainModel.findAll({
+  await WorkspaceHasDomainModel.destroy({
     where: {
       workspaceId: workspace.id,
     },
   });
-
-  for (const domain of workspaceDomains) {
-    await domain.destroy();
-  }
 }
 
 export async function getWorkspaceCreationDate(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -80,6 +80,20 @@ export async function getWorkspaceVerifiedDomain(
   return null;
 }
 
+export async function removeAllWorkspaceDomains(
+  workspace: LightWorkspaceType
+): Promise<void> {
+  const workspaceDomains = await WorkspaceHasDomainModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+
+  for (const domain of workspaceDomains) {
+    await domain.destroy();
+  }
+}
+
 export async function getWorkspaceCreationDate(
   workspaceId: string
 ): Promise<Date> {

--- a/front/scripts/relocation/relocate_workspace.ts
+++ b/front/scripts/relocation/relocate_workspace.ts
@@ -13,6 +13,7 @@ import {
 import {
   deleteWorkspace,
   isWorkspaceRelocationDone,
+  removeAllWorkspaceDomains,
   setWorkspaceRelocated,
   setWorkspaceRelocating,
   updateWorkspaceMetadata,
@@ -151,6 +152,8 @@ makeScript(
             );
             return;
           }
+
+          await removeAllWorkspaceDomains(owner);
 
           // 3) Update all users' region metadata.
           const updateUsersRegionToDestRes =


### PR DESCRIPTION
## Description

Remove workspaceHasDomain immediately on cutover - otherwise new users logging in US while the workspace has not been deleted yet will be associated with us region.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

none, relocation script
