### PR TITLE
enh(Confluence): add sync status to global sync

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -112,7 +112,7 @@ export async function confluenceSyncWorkflow({
       // Report progress before processing each space
       await reportInitialSyncProgress(
         connectorId,
-        `Processing ${processedSpaces + 1} out of ${totalSpaces} spaces`
+        `${processedSpaces + 1}/${totalSpaces} spaces`
       );
 
       // Async operation yielding control to the Temporal runtime.

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -100,10 +100,10 @@ export async function confluenceSyncWorkflow({
     memo,
   } = workflowInfo();
 
-  // Async operations allow Temporal's event loop to process signals.
-  // If a signal arrives during an async operation, it will update the set before the next iteration.
   let processedSpaces = 0;
 
+  // Async operations allow Temporal's event loop to process signals.
+  // If a signal arrives during an async operation, it will update the set before the next iteration.
   while (spaceIdsMap.size > 0) {
     // Create a copy of the map to iterate over, to avoid issues with concurrent modification.
     const spaceIdsToProcess = new Map(spaceIdsMap);

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -109,7 +109,7 @@ export async function confluenceSyncWorkflow({
     // Create a copy of the map to iterate over, to avoid issues with concurrent modification.
     const spaceIdsToProcess = new Map(spaceIdsMap);
     for (const [spaceId, opts] of spaceIdsToProcess) {
-      // Report progress before processing each space
+      // Report progress before processing each space.
       await reportInitialSyncProgress(
         connectorId,
         `${processedSpaces + 1}/${totalSpaces} spaces`

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -102,7 +102,6 @@ export async function confluenceSyncWorkflow({
 
   // Async operations allow Temporal's event loop to process signals.
   // If a signal arrives during an async operation, it will update the set before the next iteration.
-  const totalSpaces = spaceIdsMap.size;
   let processedSpaces = 0;
 
   while (spaceIdsMap.size > 0) {
@@ -112,7 +111,10 @@ export async function confluenceSyncWorkflow({
       // Report progress before processing each space.
       await reportInitialSyncProgress(
         connectorId,
-        `${processedSpaces + 1}/${totalSpaces} spaces`
+        // At this point, the map was cleared from the processed spaces so we have to do
+        // processedSpaces + spaceIdsMap.size to get the actual total, updated when we
+        // get a signal.
+        `${processedSpaces + 1}/${spaceIdsMap.size + processedSpaces} spaces`
       );
 
       // Async operation yielding control to the Temporal runtime.


### PR DESCRIPTION
## Description

- This PR adds a sync status to the sync to detail the number of spaces processed / total number of spaces.
- This information is visible with a Chip in the Connections screen.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Stop all Confluence workflows.
- Deploy connectors.
- Resume all Confluence workflows.
