### PR TITLE
run_agent: structured query/result

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -381,6 +381,54 @@ export const isBrowseResultResourceType = (
   );
 };
 
+// RunAgent results.
+
+export const RunAgentQueryResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.RUN_AGENT_QUERY),
+  text: z.string(),
+  childAgentId: z.string(),
+  uri: z.literal(""),
+});
+
+export type RunAgentQueryResourceType = z.infer<
+  typeof RunAgentQueryResourceSchema
+>;
+
+export const isRunAgentQueryResourceType = (
+  outputBlock: MCPToolResultContentType
+): outputBlock is {
+  type: "resource";
+  resource: RunAgentQueryResourceType;
+} => {
+  return (
+    outputBlock.type === "resource" &&
+    RunAgentQueryResourceSchema.safeParse(outputBlock.resource).success
+  );
+};
+
+export const RunAgentResultResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.RUN_AGENT_RESULT),
+  conversationId: z.string(),
+  text: z.string(),
+  uri: z.string(),
+});
+
+export type RunAgentResultResourceType = z.infer<
+  typeof RunAgentResultResourceSchema
+>;
+
+export const isRunAgentResultResourceType = (
+  outputBlock: MCPToolResultContentType
+): outputBlock is {
+  type: "resource";
+  resource: RunAgentResultResourceType;
+} => {
+  return (
+    outputBlock.type === "resource" &&
+    RunAgentResultResourceSchema.safeParse(outputBlock.resource).success
+  );
+};
+
 // Personal authentication required error.
 
 export const PersonalAuthenticationRequiredErrorResourceSchema = z.object({
@@ -460,6 +508,8 @@ const EmbeddedResourceSchema = z.object({
     TextResourceContentsSchema,
     ThinkingOutputSchema,
     ToolGeneratedFileSchema,
+    RunAgentQueryResourceSchema,
+    RunAgentResultResourceSchema,
     PersonalAuthenticationRequiredErrorResourceSchema,
   ]),
 });

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -14,7 +14,7 @@ import {
   isServerSideMCPServerConfiguration,
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
-import apiConfig from "@app/lib/api/config";
+import config from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
@@ -177,7 +177,7 @@ export default async function createServer(
       const prodCredentials = await prodAPICredentialsForOwner(owner);
       const requestedGroupIds = auth.groups().map((g) => g.sId);
       const api = new DustAPI(
-        apiConfig.getDustAPIConfig(),
+        config.getDustAPIConfig(),
         {
           ...prodCredentials,
           extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
@@ -250,8 +250,31 @@ export default async function createServer(
         }`;
         return makeMCPToolTextError(errorMessage);
       }
+      finalContent.trim();
 
-      return { content: [{ type: "text", text: finalContent.trim() }] };
+      return {
+        isError: false,
+        content: [
+          {
+            type: "resource",
+            resource: {
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.RUN_AGENT_QUERY,
+              text: query,
+              childAgentId: childAgentId,
+              uri: "",
+            },
+          },
+          {
+            type: "resource",
+            resource: {
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.RUN_AGENT_RESULT,
+              conversationId: conversation.sId,
+              text: finalContent.trim(),
+              uri: `${config.getClientFacingUrl()}/w/${auth.getNonNullableWorkspace().sId}/assistant/${conversation.sId}`,
+            },
+          },
+        ],
+      };
     }
   );
 

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -244,6 +244,8 @@ const TOOL_MIME_TYPES = {
       "EXAMPLE_ROWS",
       "WEBSEARCH_QUERY",
       "WEBSEARCH_RESULT",
+      "RUN_AGENT_RESULT",
+      "RUN_AGENT_QUERY",
     ],
   }),
   TOOL_ERROR: generateToolMimeTypes({


### PR DESCRIPTION
## Description

Introduce structure in the run_agent output (query and result) to build better UI.
This will be extensible with a host of new things in the future (citations, produced files, even potentially log of what happened in the conversation....)

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`