### PR TITLE
Run Agent Action Details UI

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -59,6 +59,7 @@ export function GenericActionDetails({
   owner,
   action,
   defaultOpen,
+  lastNotification,
 }: ActionDetailsComponentBaseProps<MCPActionType>) {
   return (
     <ActionDetailsWrapper
@@ -66,6 +67,7 @@ export function GenericActionDetails({
       defaultOpen={defaultOpen}
       visual={ACTION_SPECIFICATIONS["MCP"].cardIcon}
     >
+      Notification: {JSON.stringify(lastNotification, undefined, 2)}
       <div className="flex flex-col gap-4 py-4 pl-6">
         <CollapsibleComponent
           rootProps={{ defaultOpen: !action.generatedFiles.length }}

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -15,12 +15,16 @@ import {
   isExtractResultResourceType,
   isIncludeResultResourceType,
   isReasoningSuccessOutput,
+  isRunAgentProgressOutput,
+  isRunAgentResultResourceType,
   isSearchResultResourceType,
   isSqlQueryOutput,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import { isSupportedImageContentType } from "@app/types";
+
+import { MCPRunAgentActionDetails } from "./MCPRunAgentActionDetails";
 
 export function MCPActionDetails(
   props: ActionDetailsComponentBaseProps<MCPActionType>
@@ -31,6 +35,9 @@ export function MCPActionDetails(
   const isBrowse = props.action.output?.some(isBrowseResultResourceType);
   const isTablesQuery = props.action.output?.some(isSqlQueryOutput);
   const isExtract = props.action.output?.some(isExtractResultResourceType);
+  const isRunAgent =
+    props.action.output?.some(isRunAgentResultResourceType) ||
+    isRunAgentProgressOutput(props.lastNotification?.data.output);
 
   // TODO(mcp): rationalize the display of results for MCP to remove the need for specific checks.
   // Hack to find out whether the output comes from the reasoning tool, links back to the TODO above.
@@ -50,6 +57,8 @@ export function MCPActionDetails(
     return <MCPReasoningActionDetails {...props} />;
   } else if (isExtract) {
     return <MCPExtractActionDetails {...props} />;
+  } else if (isRunAgent) {
+    return <MCPRunAgentActionDetails {...props} />;
   } else {
     return <GenericActionDetails {...props} />;
   }
@@ -59,7 +68,6 @@ export function GenericActionDetails({
   owner,
   action,
   defaultOpen,
-  lastNotification,
 }: ActionDetailsComponentBaseProps<MCPActionType>) {
   return (
     <ActionDetailsWrapper
@@ -67,7 +75,6 @@ export function GenericActionDetails({
       defaultOpen={defaultOpen}
       visual={ACTION_SPECIFICATIONS["MCP"].cardIcon}
     >
-      Notification: {JSON.stringify(lastNotification, undefined, 2)}
       <div className="flex flex-col gap-4 py-4 pl-6">
         <CollapsibleComponent
           rootProps={{ defaultOpen: !action.generatedFiles.length }}

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -5,6 +5,7 @@ import { MCPBrowseActionDetails } from "@app/components/actions/mcp/details/MCPB
 import { MCPExtractActionDetails } from "@app/components/actions/mcp/details/MCPExtractActionDetails";
 import { MCPIncludeActionDetails } from "@app/components/actions/mcp/details/MCPIncludeActionDetails";
 import { MCPReasoningActionDetails } from "@app/components/actions/mcp/details/MCPReasoningActionDetails";
+import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPSearchActionDetails } from "@app/components/actions/mcp/details/MCPSearchActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { MCPWebsearchActionDetails } from "@app/components/actions/mcp/details/MCPWebsearchActionDetails";
@@ -23,8 +24,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
 import { isSupportedImageContentType } from "@app/types";
-
-import { MCPRunAgentActionDetails } from "./MCPRunAgentActionDetails";
 
 export function MCPActionDetails(
   props: ActionDetailsComponentBaseProps<MCPActionType>

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -1,0 +1,123 @@
+import { Avatar, Button, RobotIcon } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
+import type { MCPActionType } from "@app/lib/actions/mcp";
+import {
+  isRunAgentProgressOutput,
+  isRunAgentQueryResourceType,
+  isRunAgentResultResourceType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { useAgentConfiguration } from "@app/lib/swr/assistants";
+
+export function MCPRunAgentActionDetails({
+  owner,
+  action,
+  lastNotification,
+  defaultOpen,
+}: ActionDetailsComponentBaseProps<MCPActionType>) {
+  const queryResource =
+    action.output?.find(isRunAgentQueryResourceType) || null;
+
+  const resultResource =
+    action.output?.find(isRunAgentResultResourceType) || null;
+
+  const childAgentId = useMemo(() => {
+    if (queryResource) {
+      return queryResource.resource.childAgentId;
+    }
+    if (lastNotification) {
+      if (isRunAgentProgressOutput(lastNotification.data.output)) {
+        return lastNotification.data.output.childAgentId;
+      }
+    }
+    return null;
+  }, [queryResource, lastNotification]);
+
+  const query = useMemo(() => {
+    if (queryResource) {
+      return queryResource.resource.text;
+    }
+    if (lastNotification) {
+      if (isRunAgentProgressOutput(lastNotification.data.output)) {
+        return lastNotification.data.output.query;
+      }
+    }
+    return null;
+  }, [queryResource, lastNotification]);
+
+  const response = useMemo(() => {
+    if (resultResource) {
+      return resultResource.resource.text;
+    }
+    return null;
+  }, [resultResource]);
+
+  const isBusy = useMemo(() => {
+    if (resultResource) {
+      return false;
+    }
+    return true;
+  }, [resultResource]);
+
+  const { agentConfiguration: childAgent } = useAgentConfiguration({
+    workspaceId: owner.sId,
+    agentConfigurationId: childAgentId,
+  });
+
+  return (
+    <ActionDetailsWrapper
+      actionName="Run agent"
+      defaultOpen={defaultOpen}
+      visual={RobotIcon}
+    >
+      <div className="flex flex-col gap-4 pl-6 pt-4">
+        <div className="flex flex-col gap-2">
+          {query && childAgent && (
+            <>
+              <div className="flex items-center gap-2">
+                <Avatar
+                  name={childAgent.name}
+                  visual={childAgent.pictureUrl}
+                  busy={isBusy}
+                  disabled={false}
+                  size="xs"
+                />
+                <div>
+                  <Button
+                    label="View conversation"
+                    variant="outline"
+                    onClick={() =>
+                      window.open(
+                        resultResource
+                          ? resultResource.resource.uri
+                          : `/w/${owner.sId}/asssistant/${childAgent.id}`,
+                        "_blank"
+                      )
+                    }
+                    size="xs"
+                    className="!p-1"
+                  />
+                </div>
+              </div>
+              <div className="text-sm font-normal text-foreground dark:text-foreground-night">
+                <span className="font-bold">Query: </span>{" "}
+                <span className="text-muted-foreground dark:text-muted-foreground-night">
+                  {query}
+                </span>
+              </div>
+            </>
+          )}
+          {response && childAgent && (
+            <>
+              <div className="text-sm font-normal text-foreground dark:text-foreground-night">
+                <span className="font-bold">Response: </span> {response}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </ActionDetailsWrapper>
+  );
+}

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -39,10 +39,8 @@ export function MCPRunAgentActionDetails({
     if (queryResource) {
       return queryResource.resource.text;
     }
-    if (lastNotification) {
-      if (isRunAgentProgressOutput(lastNotification.data.output)) {
-        return lastNotification.data.output.query;
-      }
+    if (isRunAgentProgressOutput(lastNotification?.data.output)) {
+      return lastNotification.data.output.query;
     }
     return null;
   }, [queryResource, lastNotification]);
@@ -60,6 +58,16 @@ export function MCPRunAgentActionDetails({
     }
     return true;
   }, [resultResource]);
+
+  const conversationUrl = useMemo(() => {
+    if (resultResource) {
+      return resultResource.resource.uri;
+    }
+    if (isRunAgentProgressOutput(lastNotification?.data.output)) {
+      return `/w/${owner.sId}/assistant/${lastNotification.data.output.conversationId}`;
+    }
+    return null;
+  }, [resultResource, lastNotification, owner.sId]);
 
   const { agentConfiguration: childAgent } = useAgentConfiguration({
     workspaceId: owner.sId,
@@ -85,20 +93,15 @@ export function MCPRunAgentActionDetails({
                   size="xs"
                 />
                 <div>
-                  <Button
-                    label="View conversation"
-                    variant="outline"
-                    onClick={() =>
-                      window.open(
-                        resultResource
-                          ? resultResource.resource.uri
-                          : `/w/${owner.sId}/asssistant/${childAgent.id}`,
-                        "_blank"
-                      )
-                    }
-                    size="xs"
-                    className="!p-1"
-                  />
+                  {conversationUrl && (
+                    <Button
+                      label="View conversation"
+                      variant="outline"
+                      onClick={() => window.open(conversationUrl, "_blank")}
+                      size="xs"
+                      className="!p-1"
+                    />
+                  )}
                 </div>
               </div>
               <div className="text-sm font-normal text-foreground dark:text-foreground-night">

--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -8,6 +8,7 @@ import { RetrievalActionDetails } from "@app/components/actions/retrieval/Retrie
 import { SearchLabelsActionDetails } from "@app/components/actions/SearchLabelsActionDetails";
 import { TablesQueryActionDetails } from "@app/components/actions/tables_query/TablesQueryActionDetails";
 import { WebsearchActionDetails } from "@app/components/actions/websearch/WebsearchActionDetails";
+import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentActionType, LightWorkspaceType } from "@app/types";
 import { ACTION_RUNNING_LABELS } from "@app/types";
 
@@ -16,6 +17,7 @@ export interface ActionDetailsComponentBaseProps<
 > {
   action: T;
   owner: LightWorkspaceType;
+  lastNotification: ProgressNotificationContentType | null;
   defaultOpen: boolean;
 }
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -565,6 +565,7 @@ export function AgentMessage({
             agentMessage={agentMessage}
             conversationId={conversationId}
             lastAgentStateClassification={messageStreamState.agentState}
+            actionProgress={messageStreamState.actionProgress}
             owner={owner}
           />
 

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -7,6 +7,7 @@ import type {
   BaseActionType,
   BaseAgentActionType,
 } from "@app/lib/actions/types";
+import type { ActionProgressState } from "@app/lib/assistant/state/messageReducer";
 import type { AgentStateClassification } from "@app/lib/assistant/state/messageReducer";
 import type { LightAgentMessageType, LightWorkspaceType } from "@app/types";
 import { assertNever } from "@app/types";
@@ -15,6 +16,7 @@ interface AgentMessageActionsProps {
   agentMessage: LightAgentMessageType;
   conversationId: string;
   lastAgentStateClassification: AgentStateClassification;
+  actionProgress: ActionProgressState;
   owner: LightWorkspaceType;
 }
 
@@ -22,6 +24,7 @@ export function AgentMessageActions({
   agentMessage,
   conversationId,
   lastAgentStateClassification,
+  actionProgress,
   owner,
 }: AgentMessageActionsProps) {
   const [chipLabel, setChipLabel] = useState<string | undefined>("Thinking");
@@ -58,6 +61,7 @@ export function AgentMessageActions({
         isOpened={isActionDrawerOpened}
         onClose={() => setIsActionDrawerOpened(false)}
         isActing={lastAgentStateClassification === "acting"}
+        actionProgress={actionProgress}
         owner={owner}
       />
       <ActionDetails

--- a/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
@@ -86,14 +86,15 @@ export function AgentMessageActionsDrawer({
                     const actionSpecification = getActionSpecification(
                       action.type
                     );
-                    const progress = actionProgress.get(action.id);
+                    const lastNotification =
+                      actionProgress.get(action.id)?.progress ?? null;
                     const ActionDetailsComponent =
                       actionSpecification.detailsComponent;
                     return (
                       <div key={`action-${action.id}`}>
                         <ActionDetailsComponent
                           action={action}
-                          lastNotification={progress?.progress ?? null}
+                          lastNotification={lastNotification}
                           defaultOpen={idx === 0 && step === "1"}
                           owner={owner}
                         />

--- a/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
@@ -8,6 +8,7 @@ import {
 } from "@dust-tt/sparkle";
 
 import { getActionSpecification } from "@app/components/actions/types";
+import type { ActionProgressState } from "@app/lib/assistant/state/messageReducer";
 import { useConversationMessage } from "@app/lib/swr/conversations";
 import type {
   AgentActionType,
@@ -18,6 +19,7 @@ import type {
 interface AgentMessageActionsDrawerProps {
   conversationId: string;
   message: LightAgentMessageType;
+  actionProgress: ActionProgressState;
   isOpened: boolean;
   isActing: boolean;
   onClose: () => void;
@@ -26,6 +28,7 @@ interface AgentMessageActionsDrawerProps {
 export function AgentMessageActionsDrawer({
   conversationId,
   message,
+  actionProgress,
   isOpened,
   isActing,
   onClose,
@@ -83,12 +86,14 @@ export function AgentMessageActionsDrawer({
                     const actionSpecification = getActionSpecification(
                       action.type
                     );
+                    const progress = actionProgress.get(action.id);
                     const ActionDetailsComponent =
                       actionSpecification.detailsComponent;
                     return (
                       <div key={`action-${action.id}`}>
                         <ActionDetailsComponent
                           action={action}
+                          lastNotification={progress?.progress ?? null}
                           defaultOpen={idx === 0 && step === "1"}
                           owner={owner}
                         />

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -511,9 +511,8 @@ const NotificationTextContentSchema = z.object({
 const NotificationRunAgentContentSchema = z.object({
   type: z.literal("run_agent"),
   childAgentId: z.string(),
-  childAgentName: z.string(),
-  childAgentDescription: z.string(),
   conversationId: z.string(),
+  query: z.string(),
 });
 
 export const ProgressNotificationOutputSchema = z

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -495,26 +495,38 @@ const NotificationImageContentSchema = z.object({
   mimeType: z.string(),
 });
 
+type ImageProgressOutput = z.infer<typeof NotificationImageContentSchema>;
+
 const NotificationTextContentSchema = z.object({
   type: z.literal("text"),
   text: z.string(),
 });
-
-type ImageProgressOutput = z.infer<typeof NotificationImageContentSchema>;
-
-export const ProgressNotificationOutputSchema = z
-  .union([NotificationImageContentSchema, NotificationTextContentSchema])
-  .optional();
-
-type ProgressNotificationOutput = z.infer<
-  typeof ProgressNotificationOutputSchema
->;
 
 export function isImageProgressOutput(
   output: ProgressNotificationOutput
 ): output is ImageProgressOutput {
   return output !== undefined && output.type === "image";
 }
+
+const NotificationRunAgentContentSchema = z.object({
+  type: z.literal("run_agent"),
+  childAgentId: z.string(),
+  childAgentName: z.string(),
+  childAgentDescription: z.string(),
+  conversationId: z.string(),
+});
+
+export const ProgressNotificationOutputSchema = z
+  .union([
+    NotificationImageContentSchema,
+    NotificationTextContentSchema,
+    NotificationRunAgentContentSchema,
+  ])
+  .optional();
+
+type ProgressNotificationOutput = z.infer<
+  typeof ProgressNotificationOutputSchema
+>;
 
 export const ProgressNotificationContentSchema = z.object({
   // Required for the MCP protocol.

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -497,16 +497,16 @@ const NotificationImageContentSchema = z.object({
 
 type ImageProgressOutput = z.infer<typeof NotificationImageContentSchema>;
 
-const NotificationTextContentSchema = z.object({
-  type: z.literal("text"),
-  text: z.string(),
-});
-
 export function isImageProgressOutput(
   output: ProgressNotificationOutput
 ): output is ImageProgressOutput {
   return output !== undefined && output.type === "image";
 }
+
+const NotificationTextContentSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
 
 const NotificationRunAgentContentSchema = z.object({
   type: z.literal("run_agent"),

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -515,6 +515,18 @@ const NotificationRunAgentContentSchema = z.object({
   query: z.string(),
 });
 
+type RunAgentProgressOutput = z.infer<typeof NotificationRunAgentContentSchema>;
+
+export function isRunAgentProgressOutput(
+  output: ProgressNotificationOutput
+): output is RunAgentProgressOutput {
+  return (
+    output !== undefined &&
+    output.type === "run_agent" &&
+    "childAgentId" in output
+  );
+}
+
 export const ProgressNotificationOutputSchema = z
   .union([
     NotificationImageContentSchema,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -242,9 +242,8 @@ export default async function createServer(
               label: `Running agent ${childAgentBlob.name}`,
               output: {
                 type: "run_agent",
+                query,
                 childAgentId: childAgentId,
-                childAgentName: childAgentBlob.name,
-                childAgentDescription: childAgentBlob.description,
                 conversationId: conversation.sId,
               },
             },

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -16,18 +16,20 @@ import type { LightAgentMessageType } from "@app/types/assistant/conversation";
 
 export type AgentStateClassification = "thinking" | "acting" | "done";
 
+export type ActionProgressState = Map<
+  BaseAction["id"],
+  {
+    action: AgentActionType;
+    progress?: ProgressNotificationContentType;
+  }
+>;
+
 export interface MessageTemporaryState {
   message: LightAgentMessageType;
   agentState: AgentStateClassification;
   isRetrying: boolean;
   lastUpdated: Date;
-  actionProgress: Map<
-    BaseAction["id"],
-    {
-      action: AgentActionType;
-      progress?: ProgressNotificationContentType;
-    }
-  >;
+  actionProgress: ActionProgressState;
 }
 
 export type AgentMessageStateEvent =

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1343,9 +1343,17 @@ const NotificationTextContentSchema = z.object({
   text: z.string(),
 });
 
+const NotificationRunAgentCotnentSchema = z.object({
+  type: z.literal("run_agent"),
+  childAgentId: z.string(),
+  conversationId: z.string(),
+  query: z.string(),
+});
+
 const NotificationContentSchema = z.union([
   NotificationImageContentSchema,
   NotificationTextContentSchema,
+  NotificationRunAgentCotnentSchema,
 ]);
 
 const ToolNotificationProgressSchema = z.object({


### PR DESCRIPTION
## Description

- Proposal for drilling "lastNotification" from AgentMessage to ActionDetails (lastNotification only for now as the reduce we use keeps only the last one but that can be revisited in the future)
- Proposal for detecting notifications in the MCPActionDetails component early
- Initial ugly implementation of the component

Design request made here: https://dust4ai.slack.com/archives/C07TCNSR0CS/p1749125412402179 but will merge without it as it's all experimental for now.

![Screenshot from 2025-06-05 14-23-48](https://github.com/user-attachments/assets/7f36b50d-b234-424e-b285-405bb7bab202)
![Screenshot from 2025-06-05 14-23-34](https://github.com/user-attachments/assets/670e4d89-4a46-47c6-acd2-017c6a35b5a6)

Note: we have a bug as we move from the processing agentMessage to the final state where it falls back to the default action details view and one has to close and reopen the drawer to see the updated results. Visible even on regular actions where the output does not show once the action finalize without closing/reopening. Can be investigated separately.

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`