### PR TITLE
[front] - feat(feedback): add conversation url

### DIFF
--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -219,6 +219,20 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
           model: AgentMessageModel,
           attributes: ["id"],
           as: "agentMessage",
+          include: [
+            {
+              model: Message,
+              as: "message",
+              attributes: ["id", "sId"],
+              include: [
+                {
+                  model: ConversationModel,
+                  as: "conversation",
+                  attributes: ["id", "sId"],
+                },
+              ],
+            },
+          ],
         },
         {
           model: UserResource.model,
@@ -238,6 +252,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
           feedback.get(),
           {
             user: feedback.user,
+            conversationId: feedback.agentMessage?.message?.conversation?.sId,
           }
         );
       });

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -551,10 +551,7 @@ function reconstructConversationUrl(
   workspace: WorkspaceType,
   conversationId: string
 ) {
-  if (workspace.sId && conversationId) {
-    return `${config.getClientFacingUrl()}/w/${workspace.sId}/assistant/${conversationId}`;
-  }
-  return null;
+  return `${config.getClientFacingUrl()}/w/${workspace.sId}/assistant/${conversationId}`;
 }
 
 function generateCsvFromQueryResult(


### PR DESCRIPTION
## Description

This PR aims at adding the conversation url to feedbacks when exporting the detailed activity report. We only share conversation urls for shared conversations.

**References:**
- [User ask](https://dustcommunity.slack.com/archives/C07FXL42MT2/p1749105579999039)

## Risk

Moderated, could potentially leak unwanted conversation urls.

## Deploy Plan

- Deploy front
