### PR TITLE
Implement WorkOS Webhooks

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -204,6 +204,12 @@ const config = {
   getWorkOSCookiePassword: (): string => {
     return EnvironmentConfig.getEnvVariable("WORKOS_COOKIE_PASSWORD");
   },
+  getWorkOSWebhookSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("WORKOS_WEBHOOK_SECRET");
+  },
+  getWorkOSWebhookSigningSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("WORKOS_WEBHOOK_SIGNING_SECRET");
+  },
 
   // Profiler.
   getProfilerSecret: (): string | undefined => {

--- a/front/lib/api/workos/webhook_helpers.ts
+++ b/front/lib/api/workos/webhook_helpers.ts
@@ -1,0 +1,38 @@
+import type { Event } from "@workos-inc/node";
+
+import config from "@app/lib/api/config";
+import { getWorkOS } from "@app/lib/api/workos/client";
+import type { Result } from "@app/types";
+import { Ok } from "@app/types";
+
+// WorkOS sends webhooks from a fixed set of IP addresses.
+const workosIpAddresses = [
+  "3.217.146.166",
+  "23.21.184.92",
+  "34.204.154.149",
+  "44.213.245.178",
+  "44.215.236.82",
+  "50.16.203.9",
+  "52.1.251.34",
+  "52.21.49.187",
+  "174.129.36.47",
+];
+
+export function isWorkOSIpAddress(ipAddress: string) {
+  return workosIpAddresses.includes(ipAddress);
+}
+
+export async function validateWorkOSWebhookEvent(
+  payload: unknown,
+  { signatureHeader }: { signatureHeader: string }
+): Promise<Result<Event, Error>> {
+  const workOS = getWorkOS();
+
+  const verifiedEvent = await workOS.webhooks.constructEvent({
+    payload,
+    sigHeader: signatureHeader,
+    secret: config.getWorkOSWebhookSigningSecret(),
+  });
+
+  return new Ok(verifiedEvent);
+}

--- a/front/lib/api/workos/webhook_helpers.ts
+++ b/front/lib/api/workos/webhook_helpers.ts
@@ -3,7 +3,7 @@ import type { Event } from "@workos-inc/node";
 import config from "@app/lib/api/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import type { Result } from "@app/types";
-import { Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 // WorkOS sends webhooks from a fixed set of IP addresses.
 const workosIpAddresses = [
@@ -28,11 +28,15 @@ export async function validateWorkOSWebhookEvent(
 ): Promise<Result<Event, Error>> {
   const workOS = getWorkOS();
 
-  const verifiedEvent = await workOS.webhooks.constructEvent({
-    payload,
-    sigHeader: signatureHeader,
-    secret: config.getWorkOSWebhookSigningSecret(),
-  });
+  try {
+    const verifiedEvent = await workOS.webhooks.constructEvent({
+      payload,
+      sigHeader: signatureHeader,
+      secret: config.getWorkOSWebhookSigningSecret(),
+    });
 
-  return new Ok(verifiedEvent);
+    return new Ok(verifiedEvent);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -684,3 +684,17 @@ export async function getWorkspaceAdministrationVersionLock(
     "[WORKSPACE_TRACE] Advisory lock acquired"
   );
 }
+
+export async function findWorkspaceByWorkOSOrganizationId(
+  workOSOrganizationId: string
+): Promise<LightWorkspaceType | null> {
+  const workspace = await Workspace.findOne({
+    where: { workOSOrganizationId },
+  });
+
+  if (!workspace) {
+    return null;
+  }
+
+  return renderLightWorkspaceType({ workspace });
+}

--- a/front/lib/api/workspace_domains.ts
+++ b/front/lib/api/workspace_domains.ts
@@ -1,0 +1,62 @@
+import { Workspace } from "@app/lib/models/workspace";
+import { WorkspaceHasDomainModel } from "@app/lib/models/workspace_has_domain";
+import type { LightWorkspaceType, Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export async function updateWorkspaceDomain(
+  workspace: LightWorkspaceType,
+  { domain }: { domain: string }
+): Promise<Result<WorkspaceHasDomainModel, Error>> {
+  const existingDomain = await WorkspaceHasDomainModel.findOne({
+    where: { domain },
+    include: [
+      {
+        model: Workspace,
+        as: "workspace",
+        required: true,
+      },
+    ],
+  });
+
+  if (existingDomain && existingDomain.workspace.id === workspace.id) {
+    return new Ok(existingDomain);
+  }
+
+  if (existingDomain) {
+    return new Err(
+      new Error(
+        `Domain ${domain} already exists in workspace ${existingDomain.workspace.id}`
+      )
+    );
+  }
+
+  const d = await WorkspaceHasDomainModel.create({
+    domain,
+    domainAutoJoinEnabled: false,
+    workspaceId: workspace.id,
+  });
+
+  return new Ok(d);
+}
+
+export async function deleteWorkspaceDomain(
+  workspace: LightWorkspaceType,
+  { domain }: { domain: string }
+): Promise<Result<void, Error>> {
+  const existingDomain = await WorkspaceHasDomainModel.findOne({
+    where: {
+      domain,
+      workspaceId: workspace.id,
+    },
+  });
+
+  if (!existingDomain) {
+    return new Err(
+      new Error(`Domain ${domain} not found for workspace ${workspace.sId}`)
+    );
+  }
+
+  await existingDomain.destroy();
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/workspace_domains.ts
+++ b/front/lib/api/workspace_domains.ts
@@ -3,7 +3,7 @@ import { WorkspaceHasDomainModel } from "@app/lib/models/workspace_has_domain";
 import type { LightWorkspaceType, Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
-export async function updateWorkspaceDomain(
+export async function upsertWorkspaceDomain(
   workspace: LightWorkspaceType,
   { domain }: { domain: string }
 ): Promise<Result<WorkspaceHasDomainModel, Error>> {

--- a/front/pages/api/workos/webhooks/[webhookSecret].ts
+++ b/front/pages/api/workos/webhooks/[webhookSecret].ts
@@ -47,7 +47,7 @@ async function handler(
   }
 
   // Validate the client IP address.
-  const { remoteAddress: clientIp } = req.socket;
+  const clientIp = req.headers["x-forwarded-for"] || req.socket.remoteAddress;
   if (typeof clientIp !== "string") {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/workos/webhooks/[webhookSecret].ts
+++ b/front/pages/api/workos/webhooks/[webhookSecret].ts
@@ -5,6 +5,7 @@ import {
   isWorkOSIpAddress,
   validateWorkOSWebhookEvent,
 } from "@app/lib/api/workos/webhook_helpers";
+import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchWorkOSEventsWorkflow } from "@app/temporal/workos_events_queue/client";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -83,8 +84,14 @@ async function handler(
   const result = await validateWorkOSWebhookEvent(payload, {
     signatureHeader: sigHeader,
   });
-
   if (result.isErr()) {
+    logger.error(
+      {
+        error: result.error,
+      },
+      "Invalid WorkOS webhook event"
+    );
+
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/workos/webhooks/[webhookSecret].ts
+++ b/front/pages/api/workos/webhooks/[webhookSecret].ts
@@ -1,0 +1,77 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import config from "@app/lib/api/config";
+import { validateWorkOSWebhookEvent } from "@app/lib/api/workos/webhook_helpers";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import { launchWorkOSEventsWorkflow } from "@app/temporal/workos_events_queue/client";
+import type { WithAPIErrorResponse } from "@app/types";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<void>>
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const { webhookSecret } = req.query;
+  if (typeof webhookSecret !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The webhookSecret query parameter is required.",
+      },
+    });
+  }
+
+  if (webhookSecret !== config.getWorkOSWebhookSecret()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "not_authenticated",
+        message: "The webhookSecret query parameter is invalid.",
+      },
+    });
+  }
+
+  const { body: payload } = req;
+  const sigHeader = req.headers["workos-signature"];
+  if (typeof sigHeader !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The workos-signature header is required.",
+      },
+    });
+  }
+
+  const result = await validateWorkOSWebhookEvent(payload, {
+    signatureHeader: sigHeader,
+  });
+
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: result.error.message,
+      },
+    });
+  }
+
+  await launchWorkOSEventsWorkflow({
+    eventPayload: result.value,
+  });
+
+  res.status(200).send();
+}
+
+export default withLogging(handler);

--- a/front/pages/api/workos/webhooks/[webhookSecret].ts
+++ b/front/pages/api/workos/webhooks/[webhookSecret].ts
@@ -19,7 +19,7 @@ async function handler(
       status_code: 405,
       api_error: {
         type: "method_not_supported_error",
-        message: "The method passed is not supported, GET is expected.",
+        message: "The method passed is not supported, POST is expected.",
       },
     });
   }
@@ -47,7 +47,7 @@ async function handler(
   }
 
   // Validate the client IP address.
-  const clientIp = req.headers["x-forwarded-for"] || req.socket.remoteAddress;
+  const { remoteAddress: clientIp } = req.socket;
   if (typeof clientIp !== "string") {
     return apiError(req, res, {
       status_code: 400,
@@ -60,6 +60,13 @@ async function handler(
 
   const isWorkOSIp = isWorkOSIpAddress(clientIp);
   if (!isWorkOSIp) {
+    logger.error(
+      {
+        clientIp,
+      },
+      "Request not from WorkOS IP range"
+    );
+
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -21,16 +21,18 @@ import {
 import { runUpsertQueueWorker } from "@app/temporal/upsert_queue/worker";
 import { runUpsertTableQueueWorker } from "@app/temporal/upsert_tables/worker";
 import { runUpdateWorkspaceUsageWorker } from "@app/temporal/usage_queue/worker";
+import { runWorkOSEventsWorker } from "@app/temporal/workos_events_queue/worker";
 import { setupGlobalErrorHandler } from "@app/types/shared/utils/global_error_handler";
 
 setupGlobalErrorHandler(logger);
 
 type WorkerName =
+  | "agent_loop"
   | "data_retention"
   | "document_tracker"
   | "hard_delete"
-  | "labs"
   | "labs_connections"
+  | "labs"
   | "mentions_count"
   | "permissions_queue"
   | "poke"
@@ -42,14 +44,15 @@ type WorkerName =
   | "update_workspace_usage"
   | "upsert_queue"
   | "upsert_table_queue"
-  | "agent_loop";
+  | "workos_events_queue";
 
 const workerFunctions: Record<WorkerName, () => Promise<void>> = {
+  agent_loop: runAgentLoopWorker,
   data_retention: runDataRetentionWorker,
   document_tracker: runTrackerWorker,
   hard_delete: runHardDeleteWorker,
-  labs: runLabsTranscriptsWorker,
   labs_connections: runLabsConnectionsWorker,
+  labs: runLabsTranscriptsWorker,
   mentions_count: runMentionsCountWorker,
   permissions_queue: runPermissionsWorker,
   poke: runPokeWorker,
@@ -61,7 +64,7 @@ const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   update_workspace_usage: runUpdateWorkspaceUsageWorker,
   upsert_queue: runUpsertQueueWorker,
   upsert_table_queue: runUpsertTableQueueWorker,
-  agent_loop: runAgentLoopWorker,
+  workos_events_queue: runWorkOSEventsWorker,
 };
 
 const ALL_WORKERS = Object.keys(workerFunctions);

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -4,7 +4,7 @@ import assert from "assert";
 import { findWorkspaceByWorkOSOrganizationId } from "@app/lib/api/workspace";
 import {
   deleteWorkspaceDomain,
-  updateWorkspaceDomain,
+  upsertWorkspaceDomain,
 } from "@app/lib/api/workspace_domains";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
@@ -28,7 +28,7 @@ async function handleOrganizationDomainEvent(
 
   let domainResult: Result<any, Error>;
   if (expectedState === "verified") {
-    domainResult = await updateWorkspaceDomain(workspace, { domain });
+    domainResult = await upsertWorkspaceDomain(workspace, { domain });
   } else {
     domainResult = await deleteWorkspaceDomain(workspace, { domain });
   }

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -1,0 +1,81 @@
+import type { Event, OrganizationDomain } from "@workos-inc/node";
+import assert from "assert";
+
+import { findWorkspaceByWorkOSOrganizationId } from "@app/lib/api/workspace";
+import {
+  deleteWorkspaceDomain,
+  updateWorkspaceDomain,
+} from "@app/lib/api/workspace_domains";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+
+async function handleOrganizationDomainEvent(
+  eventData: OrganizationDomain,
+  expectedState: "verified" | "failed"
+) {
+  const { domain, organizationId, state } = eventData;
+
+  assert(
+    state === expectedState,
+    `Domain state is not ${expectedState} -- expected ${expectedState} but got ${state}`
+  );
+
+  const workspace = await findWorkspaceByWorkOSOrganizationId(organizationId);
+  if (!workspace) {
+    logger.info({ organizationId }, "Workspace not found for organization");
+    throw new Error(`Workspace not found for organization ${organizationId}`);
+  }
+
+  let domainResult: Result<any, Error>;
+  if (expectedState === "verified") {
+    domainResult = await updateWorkspaceDomain(workspace, { domain });
+  } else {
+    domainResult = await deleteWorkspaceDomain(workspace, { domain });
+  }
+
+  if (domainResult.isErr()) {
+    logger.error(
+      { error: domainResult.error },
+      "Error updating/deleting domain"
+    );
+    throw domainResult.error;
+  }
+
+  logger.info({ domain }, "Domain updated/deleted");
+}
+
+// WorkOS webhooks do not guarantee event ordering. Events can arrive out of sequence.
+// We rely on Temporal's retry strategies and the idempotency of these activities
+// to correctly process events even if they are received in a non-chronological order.
+export async function processWorkOSEventActivity({
+  eventPayload,
+}: {
+  eventPayload: Event;
+}) {
+  switch (eventPayload.event) {
+    case "organization_domain.verified":
+      await handleOrganizationDomainVerified(eventPayload.data);
+      break;
+
+    case "organization_domain.verification_failed":
+      await handleOrganizationDomainVerificationFailed(eventPayload.data);
+      break;
+
+    default:
+      logger.info(
+        { eventType: eventPayload.event },
+        "Unhandled workOS event type -- skipping"
+      );
+      break;
+  }
+}
+
+async function handleOrganizationDomainVerified(eventData: OrganizationDomain) {
+  await handleOrganizationDomainEvent(eventData, "verified");
+}
+
+async function handleOrganizationDomainVerificationFailed(
+  eventData: OrganizationDomain
+) {
+  await handleOrganizationDomainEvent(eventData, "failed");
+}

--- a/front/temporal/workos_events_queue/client.ts
+++ b/front/temporal/workos_events_queue/client.ts
@@ -1,0 +1,33 @@
+import type { Event } from "@workos-inc/node";
+
+import { getTemporalClient } from "@app/lib/temporal";
+import { QUEUE_NAME } from "@app/temporal/workos_events_queue/config";
+import { workosEventsWorkflow } from "@app/temporal/workos_events_queue/workflows";
+import type { Result } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
+
+export async function launchWorkOSEventsWorkflow({
+  eventPayload,
+}: {
+  eventPayload: Event;
+}): Promise<Result<string, Error>> {
+  const client = await getTemporalClient();
+
+  const { event: eventType } = eventPayload;
+  const workflowId = `workos-events-${eventType}-${Date.now()}`;
+
+  try {
+    await client.workflow.start(workosEventsWorkflow, {
+      args: [{ eventPayload }],
+      memo: {
+        eventType,
+      },
+      taskQueue: QUEUE_NAME,
+      workflowId,
+    });
+
+    return new Ok(workflowId);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/temporal/workos_events_queue/config.ts
+++ b/front/temporal/workos_events_queue/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `workos-events-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/workos_events_queue/worker.ts
+++ b/front/temporal/workos_events_queue/worker.ts
@@ -1,0 +1,30 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { getTemporalWorkerConnection } from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/workos_events_queue/activities";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runWorkOSEventsWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxConcurrentActivityTaskExecutions: 32,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/workos_events_queue/workflows.ts
+++ b/front/temporal/workos_events_queue/workflows.ts
@@ -1,0 +1,16 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type { Event } from "@workos-inc/node";
+
+import type * as activities from "@app/temporal/workos_events_queue/activities";
+
+const { processWorkOSEventActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
+export async function workosEventsWorkflow({
+  eventPayload,
+}: {
+  eventPayload: Event;
+}) {
+  await processWorkOSEventActivity({ eventPayload });
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR implements WorkOS webhooks, this first PR is limited to foundational work for robust webhook handling alongside organisation domain verification.

There are a few known constraints from WorkOS that motivated the design implementation:
1. Events can be out-of-order, meaning we can get `dsync.group.user_added` before we get `dsync.user.created`
2. We want to do the minimum work and store event's payload to return 2xx to WorkOS and process downstream the actual payload
3. They have a pretty solid retry policy but we still want to have a safety net on our side.

This PR introduces a dedicated endpoint for WorkOS, this endpoint bundles several security points:
- Query must origin from a valid IP for WorkOS
- Custom secrets in the webhook endpoint
- Event payload must be signed with the right secret. Each event is verified.

If all the security points above are met, then the event will be enqueued in our Temporal worker to be process later on. Given that events can be out-of-order, we rely on Temporal's retry mechanism to retry all failed events. Events failing more than 10 times will trigger a monitor.

Only two events regarding organisation's domains are handled in this PR, the goal is to use WorkOS as a source of truth and replicate it in our `workspace_has_domains` table. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [x] Add `WORKOS_WEBHOOK_SECRET` secret in `front-secrets-v2`
- [x] Add `WORKOS_WEBHOOK_SIGNING_SECRET` secret in `front-secrets-v2`
