### PR TITLE
[front] - chore(AB v2): create instructions setup

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -4,17 +4,11 @@ import { AgentBuilderLayout } from "@app/components/agent_builder/AgentBuilderLa
 import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilderLeftPanel";
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
 import { AgentBuilderInstructionsProvider } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
-import type { WorkspaceType } from "@app/types";
 
-interface AgentBuilderProps {
-  owner: WorkspaceType;
-}
-
-export default function AgentBuilder({ owner }: AgentBuilderProps) {
+export default function AgentBuilder() {
   return (
-    <AgentBuilderInstructionsProvider owner={owner}>
+    <AgentBuilderInstructionsProvider>
       <AgentBuilderLayout
-        owner={owner}
         leftPanel={
           <AgentBuilderLeftPanel
             title="Create new agent"

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { AgentBuilderLayout } from "@app/components/agent_builder/AgentBuilderLayout";
 import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilderLeftPanel";
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
+import { AgentBuilderInstructionsProvider } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
 import type { WorkspaceType } from "@app/types";
 
 interface AgentBuilderProps {
@@ -11,16 +12,18 @@ interface AgentBuilderProps {
 
 export default function AgentBuilder({ owner }: AgentBuilderProps) {
   return (
-    <AgentBuilderLayout
-      owner={owner}
-      leftPanel={
-        <AgentBuilderLeftPanel
-          title="Create new agent"
-          onCancel={() => console.log("Cancel")}
-          onSave={() => console.log("Save")}
-        />
-      }
-      rightPanel={<AgentBuilderRightPanel />}
-    />
+    <AgentBuilderInstructionsProvider owner={owner}>
+      <AgentBuilderLayout
+        owner={owner}
+        leftPanel={
+          <AgentBuilderLeftPanel
+            title="Create new agent"
+            onCancel={() => console.log("Cancel")}
+            onSave={() => console.log("Save")}
+          />
+        }
+        rightPanel={<AgentBuilderRightPanel />}
+      />
+    </AgentBuilderInstructionsProvider>
   );
 }

--- a/front/components/agent_builder/AgentBuilderContext.tsx
+++ b/front/components/agent_builder/AgentBuilderContext.tsx
@@ -1,15 +1,21 @@
-import { createContext, useState } from "react";
+import { createContext, useContext, useState } from "react";
 import { useEffect } from "react";
 
 import { mcpServerViewSortingFn } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import type { AppType, DataSourceViewType, SpaceType } from "@app/types";
+import type {
+  AppType,
+  DataSourceViewType,
+  SpaceType,
+  WorkspaceType,
+} from "@app/types";
 
 type AgentBuilderContextType = {
   dustApps: AppType[];
   dataSourceViews: DataSourceViewType[];
   spaces: SpaceType[];
   mcpServerViews: MCPServerViewType[];
+  owner: WorkspaceType;
   isPreviewPanelOpen: boolean;
   setIsPreviewPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
@@ -19,6 +25,7 @@ export const AgentBuilderContext = createContext<AgentBuilderContextType>({
   dataSourceViews: [],
   spaces: [],
   mcpServerViews: [],
+  owner: {} as WorkspaceType,
   isPreviewPanelOpen: true,
   setIsPreviewPanelOpen: () => {},
 });
@@ -36,6 +43,7 @@ export function AgentBuilderProvider({
   dataSourceViews,
   spaces,
   mcpServerViews,
+  owner,
   children,
 }: AgentBuilderContextProps) {
   const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState(false);
@@ -61,6 +69,7 @@ export function AgentBuilderProvider({
         dataSourceViews,
         spaces,
         mcpServerViews: mcpServerViews.sort(mcpServerViewSortingFn),
+        owner,
         isPreviewPanelOpen,
         setIsPreviewPanelOpen,
       }}
@@ -68,4 +77,14 @@ export function AgentBuilderProvider({
       {children}
     </AgentBuilderContext.Provider>
   );
+}
+
+export function useAgentBuilderContext() {
+  const context = useContext(AgentBuilderContext);
+  if (!context) {
+    throw new Error(
+      "useAgentBuilderContext must be used within an AgentBuilderProvider"
+    );
+  }
+  return context;
 }

--- a/front/components/agent_builder/AgentBuilderContext.tsx
+++ b/front/components/agent_builder/AgentBuilderContext.tsx
@@ -23,18 +23,21 @@ export const AgentBuilderContext = createContext<AgentBuilderContextType>({
   setIsPreviewPanelOpen: () => {},
 });
 
+interface AgentBuilderContextProps
+  extends Omit<
+    AgentBuilderContextType,
+    "isPreviewPanelOpen" | "setIsPreviewPanelOpen"
+  > {
+  children: React.ReactNode;
+}
+
 export function AgentBuilderProvider({
   dustApps,
   dataSourceViews,
   spaces,
   mcpServerViews,
   children,
-}: Omit<
-  AgentBuilderContextType,
-  "isPreviewPanelOpen" | "setIsPreviewPanelOpen"
-> & {
-  children: React.ReactNode;
-}) {
+}: AgentBuilderContextProps) {
   const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState(false);
 
   useEffect(() => {

--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -10,7 +10,6 @@ import React from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 
 import { AgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import type { WorkspaceType } from "@app/types";
 
 const COLLAPSED_RIGHT_PANEL_SIZE = 3;
 const MIN_EXPANDED_RIGHT_PANEL_SIZE = 20;
@@ -19,15 +18,13 @@ const DEFAULT_RIGHT_PANEL_SIZE = 30;
 interface AgentBuilderLayoutProps {
   leftPanel: React.ReactNode;
   rightPanel: React.ReactNode;
-  owner: WorkspaceType;
 }
 
 export function AgentBuilderLayout({
   leftPanel,
   rightPanel,
-  owner,
 }: AgentBuilderLayoutProps) {
-  const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
+  const { owner, isPreviewPanelOpen, setIsPreviewPanelOpen } =
     useContext(AgentBuilderContext);
   const previewPanelRef = useRef<ImperativePanelHandle>(null);
   const [isResizing, setIsResizing] = useState(false);

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -30,7 +30,7 @@ export function AgentBuilderLeftPanel({
           />
         }
       />
-      <div className="flex-1 overflow-y-auto p-4">
+      <div className="flex-1 p-4">
         <AgentBuilderInstructionsBlock />
       </div>
     </div>

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -1,12 +1,13 @@
 import { BarHeader } from "@dust-tt/sparkle";
 import React from "react";
 
+import { AgentBuilderInstructionsBlock } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsBlock";
+
 interface AgentBuilderLeftPanelProps {
   title: string;
   onSave?: () => void;
   onCancel: () => void;
   isSaving?: boolean;
-  children?: React.ReactNode;
 }
 
 export function AgentBuilderLeftPanel({
@@ -14,7 +15,6 @@ export function AgentBuilderLeftPanel({
   onSave,
   onCancel,
   isSaving,
-  children,
 }: AgentBuilderLeftPanelProps) {
   return (
     <div className="flex h-full flex-col">
@@ -30,7 +30,9 @@ export function AgentBuilderLeftPanel({
           />
         }
       />
-      <div className="flex-1 overflow-y-auto">{children}</div>
+      <div className="flex-1 overflow-y-auto p-4">
+        <AgentBuilderInstructionsBlock />
+      </div>
     </div>
   );
 }

--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -1,0 +1,68 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+import { CreativityLevelSubmenu } from "@app/components/agent_builder/instructions/CreativityLevelSubmenu";
+import { ModelSelectionSubmenu } from "@app/components/agent_builder/instructions/ModelSelectionSubmenu";
+import { ResponseFormatSubmenu } from "@app/components/agent_builder/instructions/ResponseFormatSubmenu";
+import type { GenerationSettingsType } from "@app/components/agent_builder/types";
+import type { ModelConfigurationType } from "@app/types";
+import { isSupportingResponseFormat } from "@app/types";
+
+interface AdvancedSettingsProps {
+  generationSettings: GenerationSettingsType;
+  setGenerationSettings: (
+    generationSettingsSettings: GenerationSettingsType
+  ) => void;
+  models: ModelConfigurationType[];
+}
+
+export function AdvancedSettings({
+  generationSettings,
+  setGenerationSettings,
+  models,
+}: AdvancedSettingsProps) {
+  if (!models) {
+    return null;
+  }
+
+  const supportsResponseFormat = isSupportingResponseFormat(
+    generationSettings.modelSettings.modelId
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          label="Advanced settings"
+          variant="outline"
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <ModelSelectionSubmenu
+          generationSettings={generationSettings}
+          setGenerationSettings={setGenerationSettings}
+          models={models}
+        />
+
+        <CreativityLevelSubmenu
+          generationSettings={generationSettings}
+          setGenerationSettings={setGenerationSettings}
+        />
+
+        {supportsResponseFormat && (
+          <ResponseFormatSubmenu
+            generationSettings={generationSettings}
+            setGenerationSettings={setGenerationSettings}
+          />
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { AdvancedSettings } from "@app/components/agent_builder/instructions/AdvancedSettings";
+import { useAgentBuilderInstructions } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
+
+export function AgentBuilderInstructionsBlock() {
+  const { generationSettings, setGenerationSettings, models } =
+    useAgentBuilderInstructions();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col items-center justify-between sm:flex-row">
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Command or guideline you provide to your agent to direct its
+          responses.
+        </span>
+        <div className="flex w-full flex-col gap-2 sm:w-auto">
+          <div className="flex items-center gap-2">
+            <AdvancedSettings
+              generationSettings={generationSettings}
+              setGenerationSettings={setGenerationSettings}
+              models={models}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 import { AdvancedSettings } from "@app/components/agent_builder/instructions/AdvancedSettings";
-import { useAgentBuilderInstructions } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
+import { useAgentBuilderInstructionsContext } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
 
 export function AgentBuilderInstructionsBlock() {
   const { generationSettings, setGenerationSettings, models } =
-    useAgentBuilderInstructions();
+    useAgentBuilderInstructionsContext();
 
   return (
     <div className="flex flex-col gap-4">

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
@@ -1,0 +1,84 @@
+import React, { createContext, useContext, useMemo, useState } from "react";
+
+import type { GenerationSettingsType } from "@app/components/agent_builder/types";
+import { useModels } from "@app/lib/swr/models";
+import type { ModelConfigurationType, WorkspaceType } from "@app/types";
+import { GPT_4O_MODEL_ID, isSupportingResponseFormat } from "@app/types";
+
+interface AgentBuilderInstructionsContextType {
+  generationSettings: GenerationSettingsType;
+  setGenerationSettings: (settings: GenerationSettingsType) => void;
+  models: ModelConfigurationType[];
+}
+
+const AgentBuilderInstructionsContext = createContext<
+  AgentBuilderInstructionsContextType | undefined
+>(undefined);
+
+interface AgentBuilderInstructionsProviderProps {
+  children: React.ReactNode;
+  owner: WorkspaceType;
+}
+
+export function AgentBuilderInstructionsProvider({
+  children,
+  owner,
+}: AgentBuilderInstructionsProviderProps) {
+  const { models } = useModels({ owner });
+
+  const [generationSettings, setGenerationSettings] =
+    useState<GenerationSettingsType>({
+      modelSettings: {
+        modelId: GPT_4O_MODEL_ID,
+        providerId: "openai",
+      },
+      temperature: 0.7,
+    });
+
+  const contextValue = useMemo(
+    () => ({ generationSettings, setGenerationSettings, models }),
+    [generationSettings, models]
+  );
+
+  return (
+    <AgentBuilderInstructionsContext.Provider value={contextValue}>
+      {children}
+    </AgentBuilderInstructionsContext.Provider>
+  );
+}
+
+export function useAgentBuilderInstructionsContext() {
+  const context = useContext(AgentBuilderInstructionsContext);
+  if (context === undefined) {
+    throw new Error(
+      "useAgentBuilderInstructionsContext must be used within an AgentBuilderInstructionsProvider"
+    );
+  }
+  return context;
+}
+
+export function useAgentBuilderInstructions() {
+  const context = useAgentBuilderInstructionsContext();
+
+  const setGenerationSettings = useMemo(
+    () => (settings: GenerationSettingsType) => {
+      const processedSettings = {
+        ...settings,
+        responseFormat: isSupportingResponseFormat(
+          settings.modelSettings.modelId
+        )
+          ? settings.responseFormat
+          : undefined,
+      };
+
+      context.setGenerationSettings(processedSettings);
+    },
+    [context.setGenerationSettings]
+  );
+
+  return {
+    generationSettings: context.generationSettings,
+    setGenerationSettings,
+    models: context.models,
+  };
+}

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useMemo, useState } from "react";
+import { useCallback } from "react";
 
 import type { GenerationSettingsType } from "@app/components/agent_builder/types";
 import { useModels } from "@app/lib/swr/models";
@@ -35,9 +36,28 @@ export function AgentBuilderInstructionsProvider({
       temperature: 0.7,
     });
 
+  const handleSetGenerationSettings = useCallback(
+    (settings: GenerationSettingsType) => {
+      const processedSettings = {
+        ...settings,
+        responseFormat: isSupportingResponseFormat(
+          settings.modelSettings.modelId
+        )
+          ? settings.responseFormat
+          : undefined,
+      };
+      setGenerationSettings(processedSettings);
+    },
+    []
+  );
+
   const contextValue = useMemo(
-    () => ({ generationSettings, setGenerationSettings, models }),
-    [generationSettings, models]
+    () => ({
+      generationSettings,
+      setGenerationSettings: handleSetGenerationSettings,
+      models,
+    }),
+    [generationSettings, handleSetGenerationSettings, models]
   );
 
   return (
@@ -55,30 +75,4 @@ export function useAgentBuilderInstructionsContext() {
     );
   }
   return context;
-}
-
-export function useAgentBuilderInstructions() {
-  const context = useAgentBuilderInstructionsContext();
-
-  const setGenerationSettings = useMemo(
-    () => (settings: GenerationSettingsType) => {
-      const processedSettings = {
-        ...settings,
-        responseFormat: isSupportingResponseFormat(
-          settings.modelSettings.modelId
-        )
-          ? settings.responseFormat
-          : undefined,
-      };
-
-      context.setGenerationSettings(processedSettings);
-    },
-    [context]
-  );
-
-  return {
-    generationSettings: context.generationSettings,
-    setGenerationSettings,
-    models: context.models,
-  };
 }

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
@@ -73,7 +73,7 @@ export function useAgentBuilderInstructions() {
 
       context.setGenerationSettings(processedSettings);
     },
-    [context.setGenerationSettings]
+    [context]
   );
 
   return {

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
@@ -1,9 +1,10 @@
 import React, { createContext, useContext, useMemo, useState } from "react";
 import { useCallback } from "react";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { GenerationSettingsType } from "@app/components/agent_builder/types";
 import { useModels } from "@app/lib/swr/models";
-import type { ModelConfigurationType, WorkspaceType } from "@app/types";
+import type { ModelConfigurationType } from "@app/types";
 import { GPT_4O_MODEL_ID, isSupportingResponseFormat } from "@app/types";
 
 interface AgentBuilderInstructionsContextType {
@@ -18,13 +19,12 @@ const AgentBuilderInstructionsContext = createContext<
 
 interface AgentBuilderInstructionsProviderProps {
   children: React.ReactNode;
-  owner: WorkspaceType;
 }
 
 export function AgentBuilderInstructionsProvider({
   children,
-  owner,
 }: AgentBuilderInstructionsProviderProps) {
+  const { owner } = useAgentBuilderContext();
   const { models } = useModels({ owner });
 
   const [generationSettings, setGenerationSettings] =

--- a/front/components/agent_builder/instructions/CreativityLevelSubmenu.tsx
+++ b/front/components/agent_builder/instructions/CreativityLevelSubmenu.tsx
@@ -1,0 +1,48 @@
+import {
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+import { CREATIVITY_LEVELS } from "@app/components/agent_builder/instructions/utils";
+import type { GenerationSettingsType } from "@app/components/agent_builder/types";
+
+interface CreativityLevelSubmenuProps {
+  generationSettings: GenerationSettingsType;
+  setGenerationSettings: (generationSettings: GenerationSettingsType) => void;
+}
+
+export function CreativityLevelSubmenu({
+  generationSettings,
+  setGenerationSettings,
+}: CreativityLevelSubmenuProps) {
+  const handleCreativityChange = (temperature: number) => {
+    setGenerationSettings({
+      ...generationSettings,
+      temperature,
+    });
+  };
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger label="Creativity level" />
+      <DropdownMenuSubContent>
+        <DropdownMenuRadioGroup
+          value={generationSettings?.temperature.toString()}
+        >
+          {CREATIVITY_LEVELS.map(({ label, value }) => (
+            <DropdownMenuRadioItem
+              key={value}
+              value={value.toString()}
+              label={label}
+              onClick={() => handleCreativityChange(value)}
+            />
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -1,0 +1,82 @@
+import {
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+import {
+  categorizeModels,
+  getModelKey,
+} from "@app/components/agent_builder/instructions/utils";
+import type { GenerationSettingsType } from "@app/components/agent_builder/types";
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { ModelConfigurationType } from "@app/types";
+
+interface ModelSelectionSubmenuProps {
+  generationSettings: GenerationSettingsType;
+  setGenerationSettings: (generationSettings: GenerationSettingsType) => void;
+  models: ModelConfigurationType[];
+}
+
+export function ModelSelectionSubmenu({
+  generationSettings,
+  setGenerationSettings,
+  models,
+}: ModelSelectionSubmenuProps) {
+  const { isDark } = useTheme();
+  const { bestPerformingModelConfigs, otherModelConfigs } =
+    categorizeModels(models);
+
+  const currentModelKey = `${generationSettings.modelSettings.modelId}${generationSettings.modelSettings.reasoningEffort ? `-${generationSettings.modelSettings.reasoningEffort}` : ""}`;
+
+  const handleModelSelection = (modelConfig: ModelConfigurationType) => {
+    setGenerationSettings({
+      ...generationSettings,
+      modelSettings: {
+        modelId: modelConfig.modelId,
+        providerId: modelConfig.providerId,
+        reasoningEffort: modelConfig.reasoningEffort,
+      },
+    });
+  };
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger label="Model selection" />
+      <DropdownMenuSubContent className="w-80">
+        <DropdownMenuLabel label="Best performing models" />
+        <DropdownMenuRadioGroup value={currentModelKey}>
+          {bestPerformingModelConfigs.map((modelConfig) => (
+            <DropdownMenuRadioItem
+              key={getModelKey(modelConfig)}
+              value={getModelKey(modelConfig)}
+              icon={getModelProviderLogo(modelConfig.providerId, isDark)}
+              description={modelConfig.shortDescription}
+              label={modelConfig.displayName}
+              onClick={() => handleModelSelection(modelConfig)}
+            />
+          ))}
+        </DropdownMenuRadioGroup>
+
+        <DropdownMenuLabel label="Other models" />
+        <DropdownMenuRadioGroup value={currentModelKey}>
+          {otherModelConfigs.map((modelConfig) => (
+            <DropdownMenuRadioItem
+              key={getModelKey(modelConfig)}
+              value={getModelKey(modelConfig)}
+              icon={getModelProviderLogo(modelConfig.providerId, isDark)}
+              description={modelConfig.shortDescription}
+              label={modelConfig.displayName}
+              onClick={() => handleModelSelection(modelConfig)}
+            />
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -23,6 +23,30 @@ interface ModelSelectionSubmenuProps {
   models: ModelConfigurationType[];
 }
 
+interface ModelRadioItemProps {
+  modelConfig: ModelConfigurationType;
+  currentModelKey: string;
+  isDark: boolean;
+  onModelSelection: (modelConfig: ModelConfigurationType) => void;
+}
+
+function ModelRadioItem({
+  modelConfig,
+  currentModelKey,
+  isDark,
+  onModelSelection,
+}: ModelRadioItemProps) {
+  return (
+    <DropdownMenuRadioItem
+      value={currentModelKey}
+      icon={getModelProviderLogo(modelConfig.providerId, isDark)}
+      description={modelConfig.shortDescription}
+      label={modelConfig.displayName}
+      onClick={() => onModelSelection(modelConfig)}
+    />
+  );
+}
+
 export function ModelSelectionSubmenu({
   generationSettings,
   setGenerationSettings,
@@ -52,13 +76,12 @@ export function ModelSelectionSubmenu({
         <DropdownMenuLabel label="Best performing models" />
         <DropdownMenuRadioGroup value={currentModelKey}>
           {bestPerformingModelConfigs.map((modelConfig) => (
-            <DropdownMenuRadioItem
+            <ModelRadioItem
               key={getModelKey(modelConfig)}
-              value={getModelKey(modelConfig)}
-              icon={getModelProviderLogo(modelConfig.providerId, isDark)}
-              description={modelConfig.shortDescription}
-              label={modelConfig.displayName}
-              onClick={() => handleModelSelection(modelConfig)}
+              modelConfig={modelConfig}
+              currentModelKey={currentModelKey}
+              isDark={isDark}
+              onModelSelection={handleModelSelection}
             />
           ))}
         </DropdownMenuRadioGroup>
@@ -66,13 +89,12 @@ export function ModelSelectionSubmenu({
         <DropdownMenuLabel label="Other models" />
         <DropdownMenuRadioGroup value={currentModelKey}>
           {otherModelConfigs.map((modelConfig) => (
-            <DropdownMenuRadioItem
+            <ModelRadioItem
               key={getModelKey(modelConfig)}
-              value={getModelKey(modelConfig)}
-              icon={getModelProviderLogo(modelConfig.providerId, isDark)}
-              description={modelConfig.shortDescription}
-              label={modelConfig.displayName}
-              onClick={() => handleModelSelection(modelConfig)}
+              modelConfig={modelConfig}
+              currentModelKey={currentModelKey}
+              isDark={isDark}
+              onModelSelection={handleModelSelection}
             />
           ))}
         </DropdownMenuRadioGroup>

--- a/front/components/agent_builder/instructions/ResponseFormatSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ResponseFormatSubmenu.tsx
@@ -1,0 +1,85 @@
+import {
+  cn,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@dust-tt/sparkle";
+import dynamic from "next/dynamic";
+import React from "react";
+
+import type { GenerationSettingsType } from "@app/components/agent_builder/types";
+import { isInvalidJson } from "@app/components/agent_builder/utils";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+
+const CodeEditor = dynamic(
+  () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),
+  { ssr: false }
+);
+
+const RESPONSE_FORMAT_PLACEHOLDER =
+  "Example:\n\n" +
+  "{\n" +
+  '  "type": "json_schema",\n' +
+  '  "json_schema": {\n' +
+  '    "name": "YourSchemaName",\n' +
+  '    "strict": true,\n' +
+  '    "schema": {\n' +
+  '      "type": "object",\n' +
+  '      "properties": {\n' +
+  '        "property1":\n' +
+  '          { "type":"string" }\n' +
+  "      },\n" +
+  '      "required": ["property1"],\n' +
+  '      "additionalProperties": false\n' +
+  "    }\n" +
+  "  }\n" +
+  "}";
+
+interface ResponseFormatSubmenuProps {
+  generationSettings: GenerationSettingsType;
+  setGenerationSettings: (generationSettings: GenerationSettingsType) => void;
+}
+
+export function ResponseFormatSubmenu({
+  generationSettings,
+  setGenerationSettings,
+}: ResponseFormatSubmenuProps) {
+  const { isDark } = useTheme();
+
+  const handleResponseFormatChange = (value: string) => {
+    setGenerationSettings({
+      ...generationSettings,
+      responseFormat: value,
+    });
+  };
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger label="Structured Response Format" />
+      <DropdownMenuSubContent className="w-96">
+        <CodeEditor
+          data-color-mode={isDark ? "dark" : "light"}
+          value={generationSettings?.responseFormat ?? ""}
+          placeholder={RESPONSE_FORMAT_PLACEHOLDER}
+          name="responseFormat"
+          onChange={(e) => handleResponseFormatChange(e.target.value)}
+          minHeight={380}
+          className={cn(
+            "rounded-lg",
+            isInvalidJson(generationSettings?.responseFormat)
+              ? "border-2 border-red-500 bg-slate-100 dark:bg-slate-100-night"
+              : "bg-slate-100 dark:bg-slate-100-night"
+          )}
+          style={{
+            fontSize: 13,
+            fontFamily:
+              "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+            overflowY: "auto",
+            height: "400px",
+          }}
+          language="json"
+        />
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}

--- a/front/components/agent_builder/instructions/utils.ts
+++ b/front/components/agent_builder/instructions/utils.ts
@@ -1,0 +1,50 @@
+import type { ModelConfigurationType, ModelIdType } from "@app/types";
+import {
+  CLAUDE_3_5_SONNET_20241022_MODEL_ID,
+  GPT_4O_MODEL_ID,
+  MISTRAL_LARGE_MODEL_ID,
+} from "@app/types";
+import {
+  AGENT_CREATIVITY_LEVEL_TEMPERATURES,
+  AGENT_CREATIVITY_LEVEL_DISPLAY_NAMES,
+} from "@app/components/agent_builder/types";
+import type { AgentCreativityLevel } from "@app/components/agent_builder/types";
+
+export const BEST_PERFORMING_MODELS_ID: ModelIdType[] = [
+  GPT_4O_MODEL_ID,
+  CLAUDE_3_5_SONNET_20241022_MODEL_ID,
+  MISTRAL_LARGE_MODEL_ID,
+] as const;
+
+export const CREATIVITY_LEVELS = Object.entries(
+  AGENT_CREATIVITY_LEVEL_TEMPERATURES
+).map(([k, v]) => ({
+  label: AGENT_CREATIVITY_LEVEL_DISPLAY_NAMES[k as AgentCreativityLevel],
+  value: v,
+}));
+
+export function isBestPerformingModel(modelId: ModelIdType): boolean {
+  return BEST_PERFORMING_MODELS_ID.includes(modelId);
+}
+
+export function categorizeModels(models: ModelConfigurationType[]): {
+  bestPerformingModelConfigs: ModelConfigurationType[];
+  otherModelConfigs: ModelConfigurationType[];
+} {
+  const bestPerformingModelConfigs: ModelConfigurationType[] = [];
+  const otherModelConfigs: ModelConfigurationType[] = [];
+
+  for (const modelConfig of models) {
+    if (isBestPerformingModel(modelConfig.modelId)) {
+      bestPerformingModelConfigs.push(modelConfig);
+    } else {
+      otherModelConfigs.push(modelConfig);
+    }
+  }
+
+  return { bestPerformingModelConfigs, otherModelConfigs };
+}
+
+export function getModelKey(modelConfig: ModelConfigurationType): string {
+  return `${modelConfig.modelId}${modelConfig.reasoningEffort ? `-${modelConfig.reasoningEffort}` : ""}`;
+}

--- a/front/components/agent_builder/instructions/utils.ts
+++ b/front/components/agent_builder/instructions/utils.ts
@@ -1,14 +1,14 @@
+import type { AgentCreativityLevel } from "@app/components/agent_builder/types";
+import {
+  AGENT_CREATIVITY_LEVEL_DISPLAY_NAMES,
+  AGENT_CREATIVITY_LEVEL_TEMPERATURES,
+} from "@app/components/agent_builder/types";
 import type { ModelConfigurationType, ModelIdType } from "@app/types";
 import {
   CLAUDE_3_5_SONNET_20241022_MODEL_ID,
   GPT_4O_MODEL_ID,
   MISTRAL_LARGE_MODEL_ID,
 } from "@app/types";
-import {
-  AGENT_CREATIVITY_LEVEL_TEMPERATURES,
-  AGENT_CREATIVITY_LEVEL_DISPLAY_NAMES,
-} from "@app/components/agent_builder/types";
-import type { AgentCreativityLevel } from "@app/components/agent_builder/types";
 
 export const BEST_PERFORMING_MODELS_ID: ModelIdType[] = [
   GPT_4O_MODEL_ID,

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -1,0 +1,35 @@
+import type { SupportedModel } from "@app/types";
+import { ioTsEnum } from "@app/types";
+
+export const AGENT_CREATIVITY_LEVELS = [
+  "deterministic",
+  "factual",
+  "balanced",
+  "creative",
+] as const;
+export type AgentCreativityLevel = (typeof AGENT_CREATIVITY_LEVELS)[number];
+export const AgentCreativityLevelCodec = ioTsEnum<AgentCreativityLevel>(
+  AGENT_CREATIVITY_LEVELS,
+  "AgentCreativityLevel"
+);
+export const AGENT_CREATIVITY_LEVEL_DISPLAY_NAMES = {
+  deterministic: "Deterministic",
+  factual: "Factual",
+  balanced: "Balanced",
+  creative: "Creative",
+} as const;
+export const AGENT_CREATIVITY_LEVEL_TEMPERATURES: Record<
+  AgentCreativityLevel,
+  number
+> = {
+  deterministic: 0.0,
+  factual: 0.2,
+  balanced: 0.7,
+  creative: 1.0,
+};
+
+export type GenerationSettingsType = {
+  modelSettings: SupportedModel;
+  temperature: number;
+  responseFormat?: string;
+};

--- a/front/components/agent_builder/utils.ts
+++ b/front/components/agent_builder/utils.ts
@@ -1,0 +1,11 @@
+export const isInvalidJson = (value: string | null | undefined): boolean => {
+  if (!value) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return !parsed || typeof parsed !== "object";
+  } catch {
+    return true;
+  }
+};

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -170,8 +170,9 @@ export default function CreateAgent({
       dustApps={dustApps}
       dataSourceViews={dataSourceViews}
       mcpServerViews={mcpServerViews}
+      owner={owner}
     >
-      <AgentBuilder owner={owner} />
+      <AgentBuilder />
     </AgentBuilderProvider>
   );
 }


### PR DESCRIPTION
## Description

This PR creates the foundational instructions setup UI for Agent Builder v2, introducing a modular context-based architecture to manage agent generation settings. It implements an "Advanced Settings" dropdown that allows users to configure model selection, creativity levels, and structured response formats. 

The implementation establishes the scaffolding for the new agent builder while maintaining clean separation of concerns through dedicated context providers.

## Risk

Low, behind FF

## Deploy Plan

- Deploy front
