### PR TITLE
enh(Confluence): Sort spaces by title in Connection admin

### DIFF
--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -227,11 +227,13 @@ export async function retrieveHierarchyForParent(
     },
   });
 
-  const allSpaces = syncedSpaces.map((space) =>
-    createContentNodeFromSpace(space, confluenceConfig.url, "read", {
-      isExpandable: true,
-    })
-  );
+  const allSpaces = syncedSpaces
+    .map((space) =>
+      createContentNodeFromSpace(space, confluenceConfig.url, "read", {
+        isExpandable: true,
+      })
+    )
+    .sort((a, b) => a.title.localeCompare(b.title));
 
   return new Ok(allSpaces);
 }
@@ -254,15 +256,17 @@ export async function retrieveAvailableSpaces(
   }
 
   return new Ok(
-    spacesRes.value.map((space) => {
-      const isSynced = syncedSpaces.some((ss) => ss.spaceId === space.id);
+    spacesRes.value
+      .map((space) => {
+        const isSynced = syncedSpaces.some((ss) => ss.spaceId === space.id);
 
-      return createContentNodeFromSpace(
-        space,
-        confluenceConfig.url,
-        isSynced ? "read" : "none",
-        { isExpandable: false }
-      );
-    })
+        return createContentNodeFromSpace(
+          space,
+          confluenceConfig.url,
+          isSynced ? "read" : "none",
+          { isExpandable: false }
+        );
+      })
+      .sort((a, b) => a.title.localeCompare(b.title))
   );
 }


### PR DESCRIPTION
## Description

- Stems from [this thread](https://dust4ai.slack.com/archives/C06N6P4M9F1/p1747837870840899).
- The customer could not find their space because they expected them to be sorted alphabetically + the first few spaces are actually sorted.
- The order we get from the API does not seem to have any visible logic for the end user.
- This PR sorts the spaces by title.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
