### PR TITLE
[Search] Prevent searching nodes index when using "data_sources_name" search scope

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -1088,6 +1088,10 @@ impl ElasticsearchSearchStore {
                 .unmapped_type("keyword"),
         ));
 
+        base_sort.push(Sort::FieldSort(
+            FieldSort::new("data_source_internal_id").order(SortOrder::Asc),
+        ));
+
         Ok(base_sort)
     }
 

--- a/core/src/search_stores/search_types.rs
+++ b/core/src/search_stores/search_types.rs
@@ -21,7 +21,7 @@ impl SearchItem {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing _index"))?;
 
-        // /!\ Very important, must be keep that way since both indices start with the same prefix.
+        // /!\ Very important, must be kept that way since both indices start with the same prefix.
         if index.starts_with(DATA_SOURCE_NODE_INDEX_NAME) {
             Ok(SearchItem::Node(NodeESDocument::from(source.clone())))
         } else {


### PR DESCRIPTION
Description
---
Calling `core.searchNodes` with data source view filters all set to "data_sources_name" search scope would actually search the elasticsearch `data_sources_nodes` index with no restriction.

This is a rare case but could happen e.g. on spaces that would only have 1 website and no other source.

Not an issue at the time since all calls to `core.searchNodes` either have a strict node filter, filter out nodes out of user space after, or explicitly use a different search scope. But better be fixed for future uses.

Risks
---
standard

Deploy
---
front
