### PR TITLE
enh(Slack): bump `startToCloseTimeout` for Slack `syncChannel`

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -24,7 +24,7 @@ const {
   attemptChannelJoinActivity,
   deleteChannelsFromConnectorDb,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minutes",
+  startToCloseTimeout: "20 minutes",
 });
 
 const { deleteChannel, syncThread } = proxyActivities<typeof activities>({

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -15,7 +15,6 @@ import { newWebhookSignal, syncChannelSignal } from "./signals";
 
 const {
   getChannel,
-  syncChannel,
   fetchUsers,
   saveSuccessSyncActivity,
   syncChannelMetadata,
@@ -24,10 +23,12 @@ const {
   attemptChannelJoinActivity,
   deleteChannelsFromConnectorDb,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "20 minutes",
+  startToCloseTimeout: "10 minutes",
 });
 
-const { deleteChannel, syncThread } = proxyActivities<typeof activities>({
+const { deleteChannel, syncThread, syncChannel } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "30 minutes",
 });
 


### PR DESCRIPTION
## Description

- This PR bumps the `startToCloseTimeout` for the activity `syncChannel` from 10 to 30 minutes.
- We've observed timeouts in production.
- It makes sense for this activity to have a higher or equal timeout than `syncThread` given that it does more work.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
