### PR TITLE
Salesforce tool availability based on plan requirements

### DIFF
--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -113,7 +113,7 @@ export function getMcpServerDisplayName(
   let displayName = asDisplayName(server.name);
 
   if (res.isOk()) {
-    if (INTERNAL_MCP_SERVERS[res.value.name].flag != null) {
+    if (INTERNAL_MCP_SERVERS[res.value.name].isPreview) {
       displayName += " (Preview)";
     }
     // Will append Dust App name.

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -113,7 +113,9 @@ export function getMcpServerDisplayName(
   let displayName = asDisplayName(server.name);
 
   if (res.isOk()) {
-    if (INTERNAL_MCP_SERVERS[res.value.name].isPreview) {
+    const serverConfig = INTERNAL_MCP_SERVERS[res.value.name];
+
+    if (serverConfig.isRestricted !== undefined) {
       displayName += " (Preview)";
     }
     // Will append Dust App name.

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,6 +1,11 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
-import type { ModelId, Result, WhitelistableFeature } from "@app/types";
+import type {
+  ModelId,
+  PlanType,
+  Result,
+  WhitelistableFeature,
+} from "@app/types";
 import { Err, Ok } from "@app/types";
 
 export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
@@ -47,6 +52,10 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: number;
     availability: MCPServerAvailability;
     flag: WhitelistableFeature | null;
+    restriction?: (
+      plan: PlanType,
+      featureFlags: WhitelistableFeature[]
+    ) => boolean;
     tools_stakes?: Record<string, MCPToolStakeLevelType>;
   }
 > = {
@@ -181,7 +190,15 @@ export const INTERNAL_MCP_SERVERS: Record<
   salesforce: {
     id: 14,
     availability: "manual",
-    flag: "salesforce_tool",
+    flag: null,
+    restriction: (plan, featureFlags) => {
+      if (featureFlags.includes("salesforce_tool")) {
+        return true;
+      }
+      // Below to be replaced by: return plan.limits.connections.isSalesforceAllowed; when we are ready to release the feature.
+      void plan;
+      return false;
+    },
     tools_stakes: {
       execute_read_query: "low",
       list_objects: "low",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -51,11 +51,11 @@ export const INTERNAL_MCP_SERVERS: Record<
   {
     id: number;
     availability: MCPServerAvailability;
-    flag: WhitelistableFeature | null;
-    restriction?: (
+    isRestricted?: (
       plan: PlanType,
       featureFlags: WhitelistableFeature[]
     ) => boolean;
+    isPreview?: boolean;
     tools_stakes?: Record<string, MCPToolStakeLevelType>;
   }
 > = {
@@ -68,7 +68,6 @@ export const INTERNAL_MCP_SERVERS: Record<
   github: {
     id: 1,
     availability: "manual",
-    flag: null,
     tools_stakes: {
       create_issue: "low",
       add_issue_to_project: "low",
@@ -81,32 +80,29 @@ export const INTERNAL_MCP_SERVERS: Record<
   image_generation: {
     id: 2,
     availability: "auto",
-    flag: null,
   },
   file_generation: {
     id: 3,
     availability: "auto",
-    flag: null,
   },
   query_tables: {
     id: 4,
     availability: "auto",
-    flag: null,
   },
   "web_search_&_browse": {
     id: 5,
     availability: "auto",
-    flag: null,
   },
   think: {
     id: 6,
     availability: "auto",
-    flag: "dev_mcp_actions",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("dev_mcp_actions");
+    },
   },
   hubspot: {
     id: 7,
     availability: "manual",
-    flag: null,
     tools_stakes: {
       // Get operations.
       get_object_properties: "never_ask",
@@ -138,22 +134,24 @@ export const INTERNAL_MCP_SERVERS: Record<
   agent_router: {
     id: 8,
     availability: "auto_hidden_builder",
-    flag: "dev_mcp_actions",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("dev_mcp_actions");
+    },
   },
   include_data: {
     id: 9,
     availability: "auto",
-    flag: null,
   },
   run_dust_app: {
     id: 10,
     availability: "auto",
-    flag: "dev_mcp_actions",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("dev_mcp_actions");
+    },
   },
   notion: {
     id: 11,
     availability: "manual",
-    flag: null,
     tools_stakes: {
       search: "never_ask",
       retrieve_page: "never_ask",
@@ -180,18 +178,18 @@ export const INTERNAL_MCP_SERVERS: Record<
   extract_data: {
     id: 12,
     availability: "auto",
-    flag: "dev_mcp_actions",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("dev_mcp_actions");
+    },
   },
   missing_action_catcher: {
     id: 13,
     availability: "auto_hidden_builder",
-    flag: null,
   },
   salesforce: {
     id: 14,
     availability: "manual",
-    flag: null,
-    restriction: (plan, featureFlags) => {
+    isRestricted: (plan, featureFlags) => {
       if (featureFlags.includes("salesforce_tool")) {
         return true;
       }
@@ -208,7 +206,10 @@ export const INTERNAL_MCP_SERVERS: Record<
   gmail: {
     id: 15,
     availability: "manual",
-    flag: "gmail_tool",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("gmail_tool");
+    },
+    isPreview: true,
     tools_stakes: {
       get_drafts: "never_ask",
       create_draft: "low",
@@ -217,7 +218,10 @@ export const INTERNAL_MCP_SERVERS: Record<
   google_calendar: {
     id: 16,
     availability: "manual",
-    flag: "google_calendar_tool",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("google_calendar_tool");
+    },
+    isPreview: true,
     tools_stakes: {
       list_calendars: "never_ask",
       list_events: "never_ask",
@@ -232,33 +236,45 @@ export const INTERNAL_MCP_SERVERS: Record<
   primitive_types_debugger: {
     id: 1004,
     availability: "manual",
-    flag: "dev_mcp_actions",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("dev_mcp_actions");
+    },
   },
   search: {
     id: 1006,
     availability: "auto",
-    flag: null,
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("dev_mcp_actions");
+    },
+    isPreview: true,
   },
   reasoning: {
     id: 1007,
     availability: "auto",
-    flag: null,
   },
   run_agent: {
     id: 1008,
     availability: "auto",
-    flag: "dev_mcp_actions",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("dev_mcp_actions");
+    },
+    isPreview: true,
   },
   query_tables_v2: {
     id: 1009,
     availability: "auto",
     // We'll eventually switch everyone to this new tables query toolset.
-    flag: "exploded_tables_query",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("exploded_tables_query");
+    },
+    isPreview: true,
   },
   data_sources_file_system: {
     id: 1010,
     availability: "auto",
-    flag: "dev_mcp_actions",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("dev_mcp_actions");
+    },
   },
 };
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -189,12 +189,9 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 14,
     availability: "manual",
     isRestricted: (plan, featureFlags) => {
-      if (featureFlags.includes("salesforce_tool")) {
-        return true;
-      }
-      // Below to be replaced by: return plan.limits.connections.isSalesforceAllowed; when we are ready to release the feature.
-      void plan;
-      return false;
+      // When we are ready to release the feature, the condition will be:
+      // return featureFlags.includes("salesforce_tool") || plan.limits.connections.isSalesforceAllowed;
+      return featureFlags.includes("salesforce_tool");
     },
     tools_stakes: {
       execute_read_query: "low",
@@ -240,9 +237,6 @@ export const INTERNAL_MCP_SERVERS: Record<
   search: {
     id: 1006,
     availability: "auto",
-    isRestricted: (plan, featureFlags) => {
-      return featureFlags.includes("dev_mcp_actions");
-    },
   },
   reasoning: {
     id: 1007,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -55,7 +55,6 @@ export const INTERNAL_MCP_SERVERS: Record<
       plan: PlanType,
       featureFlags: WhitelistableFeature[]
     ) => boolean;
-    isPreview?: boolean;
     tools_stakes?: Record<string, MCPToolStakeLevelType>;
   }
 > = {
@@ -209,7 +208,6 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: (plan, featureFlags) => {
       return featureFlags.includes("gmail_tool");
     },
-    isPreview: true,
     tools_stakes: {
       get_drafts: "never_ask",
       create_draft: "low",
@@ -221,7 +219,6 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: (plan, featureFlags) => {
       return featureFlags.includes("google_calendar_tool");
     },
-    isPreview: true,
     tools_stakes: {
       list_calendars: "never_ask",
       list_events: "never_ask",
@@ -246,7 +243,6 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: (plan, featureFlags) => {
       return featureFlags.includes("dev_mcp_actions");
     },
-    isPreview: true,
   },
   reasoning: {
     id: 1007,
@@ -258,7 +254,6 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: (plan, featureFlags) => {
       return featureFlags.includes("dev_mcp_actions");
     },
-    isPreview: true,
   },
   query_tables_v2: {
     id: 1009,
@@ -267,7 +262,6 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: (plan, featureFlags) => {
       return featureFlags.includes("exploded_tables_query");
     },
-    isPreview: true,
   },
   data_sources_file_system: {
     id: 1010,

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -17,17 +17,12 @@ export const isEnabledForWorkspace = async (
   name: InternalMCPServerNameType
 ): Promise<boolean> => {
   const mcpServer = INTERNAL_MCP_SERVERS[name];
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-
-  // If the server has a required feature flag, check if it is enabled.
-  if (mcpServer.flag) {
-    return featureFlags.includes(mcpServer.flag);
-  }
 
   // If the server has a restriction, check if the restrictions are met.
-  if (mcpServer.restriction) {
+  if (mcpServer.isRestricted) {
+    const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
     const plan = auth.getNonNullablePlan();
-    return mcpServer.restriction(plan, featureFlags);
+    return mcpServer.isRestricted(plan, featureFlags);
   }
 
   // If the server has no restriction, it is available by default.

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -13,7 +13,6 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import type { WhitelistableFeature } from "@app/types";
 
 describe("MCPServerViewResource", () => {
   describe("listByWorkspace", () => {
@@ -32,15 +31,8 @@ describe("MCPServerViewResource", () => {
 
         // Create internals servers for each workspace
 
-        await FeatureFlagFactory.basic(
-          INTERNAL_MCP_SERVERS["think"].flag as WhitelistableFeature,
-          workspace1
-        );
-
-        await FeatureFlagFactory.basic(
-          INTERNAL_MCP_SERVERS["think"].flag as WhitelistableFeature,
-          workspace2
-        );
+        await FeatureFlagFactory.basic("dev_mcp_actions", workspace1);
+        await FeatureFlagFactory.basic("dev_mcp_actions", workspace2);
 
         expect(INTERNAL_MCP_SERVERS["think"].availability).toBe("auto");
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect } from "vitest";
 
-import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -11,7 +10,6 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import type { WhitelistableFeature } from "@app/types";
 
 import handler from "./available";
 
@@ -32,11 +30,7 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     // Create some servers
-    await FeatureFlagFactory.basic(
-      INTERNAL_MCP_SERVERS["primitive_types_debugger"]
-        .flag as WhitelistableFeature,
-      workspace
-    );
+    await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
 
     // Internal server in the right workspace
     const internalServer = await InternalMCPServerInMemoryResource.makeNew(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -2,7 +2,6 @@ import type { RequestMethod } from "node-mocks-http";
 import { describe, expect } from "vitest";
 
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
-import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -12,7 +11,6 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
-import type { WhitelistableFeature } from "@app/types";
 
 import handler from "./index";
 
@@ -43,11 +41,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
 
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    await FeatureFlagFactory.basic(
-      INTERNAL_MCP_SERVERS["primitive_types_debugger"]
-        .flag as WhitelistableFeature,
-      workspace
-    );
+    await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
 
     const internalServer = await InternalMCPServerInMemoryResource.makeNew(
       auth,
@@ -93,11 +87,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
         transaction: t,
       });
 
-      await FeatureFlagFactory.basic(
-        INTERNAL_MCP_SERVERS["primitive_types_debugger"]
-          .flag as WhitelistableFeature,
-        workspace
-      );
+      await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
 
       const internalServer = await InternalMCPServerInMemoryResource.makeNew(
         auth,
@@ -152,11 +142,7 @@ describe("Method Support /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => 
   itInTransaction("only supports DELETE method", async (t) => {
     const { req, res, workspace, space } = await setupTest(t, "admin", "GET");
 
-    await FeatureFlagFactory.basic(
-      INTERNAL_MCP_SERVERS["primitive_types_debugger"]
-        .flag as WhitelistableFeature,
-      workspace
-    );
+    await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
 
     const mcpServerId = internalMCPServerNameToSId({
       name: "primitive_types_debugger",


### PR DESCRIPTION
## Description

Salesforce tool won't be available to anyone once we are ready to roll out. 
We want it to be available on certain plans as we do for Connections. And for salesforce it's a bit more complex as we also want to have a feature flag on top of the plan restriction. 

This is a proposal on how to handle that. 
Since we are not ready yet to release I have commented out the real line of code, but this is to give an idea of what we could have. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 