### PR TITLE
Add `mimeType` filter in core's `/search/nodes` endpoint

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -99,6 +99,7 @@ fn default_search_scope() -> SearchScopeType {
 pub struct NodesSearchFilter {
     data_source_views: Vec<DatasourceViewFilter>,
     excluded_node_mime_types: Option<Vec<String>>,
+    mime_types: Option<Vec<String>>,
     node_ids: Option<Vec<String>>,
     node_types: Option<Vec<NodeType>>,
     parent_id: Option<String>,
@@ -842,6 +843,11 @@ impl ElasticsearchSearchStore {
                 .collect();
             counter.add(1);
             bool_query = bool_query.filter(Query::terms("node_type", terms));
+        }
+
+        if let Some(mime_types) = &filter.mime_types {
+            counter.add(1);
+            bool_query = bool_query.filter(Query::terms("mime_type", mime_types));
         }
 
         if let Some(parent_id) = &filter.parent_id {

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -12,7 +12,7 @@ use elasticsearch_dsl::{
     Aggregation, BoolQuery, FieldSort, Operator, Query, Script, ScriptSort, ScriptSortType, Search,
     Sort, SortOrder,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{error, info};
 use url::Url;
@@ -64,6 +64,14 @@ pub enum SearchScopeType {
     Both,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MimeTypeFilter {
+    #[serde(rename = "in")]
+    pub is_in: Option<Vec<String>>,
+    #[serde(rename = "not")]
+    pub is_not: Option<Vec<String>>,
+}
+
 #[derive(serde::Deserialize, Debug)]
 pub struct SortSpec {
     pub field: String,
@@ -98,8 +106,9 @@ fn default_search_scope() -> SearchScopeType {
 #[derive(serde::Deserialize, Debug)]
 pub struct NodesSearchFilter {
     data_source_views: Vec<DatasourceViewFilter>,
+    // TODO(2025-06-05 aubin): replace the excluded_node_mime_types with mime_types.not.
     excluded_node_mime_types: Option<Vec<String>>,
-    mime_types: Option<Vec<String>>,
+    mime_types: Option<MimeTypeFilter>,
     node_ids: Option<Vec<String>>,
     node_types: Option<Vec<NodeType>>,
     parent_id: Option<String>,
@@ -845,9 +854,26 @@ impl ElasticsearchSearchStore {
             bool_query = bool_query.filter(Query::terms("node_type", terms));
         }
 
-        if let Some(mime_types) = &filter.mime_types {
-            counter.add(1);
-            bool_query = bool_query.filter(Query::terms("mime_type", mime_types));
+        match &filter.mime_types {
+            Some(mime_type_filter) => {
+                match &mime_type_filter.is_in {
+                    Some(included_mime_types) => {
+                        counter.add(1);
+                        bool_query =
+                            bool_query.filter(Query::terms("mime_type", included_mime_types))
+                    }
+                    None => (),
+                }
+                match &mime_type_filter.is_not {
+                    Some(excluded_mime_types) => {
+                        counter.add(1);
+                        bool_query =
+                            bool_query.must_not(Query::terms("mime_type", excluded_mime_types))
+                    }
+                    None => (),
+                }
+            }
+            None => (),
         }
 
         if let Some(parent_id) = &filter.parent_id {

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -854,26 +854,15 @@ impl ElasticsearchSearchStore {
             bool_query = bool_query.filter(Query::terms("node_type", terms));
         }
 
-        match &filter.mime_types {
-            Some(mime_type_filter) => {
-                match &mime_type_filter.is_in {
-                    Some(included_mime_types) => {
-                        counter.add(1);
-                        bool_query =
-                            bool_query.filter(Query::terms("mime_type", included_mime_types))
-                    }
-                    None => (),
-                }
-                match &mime_type_filter.is_not {
-                    Some(excluded_mime_types) => {
-                        counter.add(1);
-                        bool_query =
-                            bool_query.must_not(Query::terms("mime_type", excluded_mime_types))
-                    }
-                    None => (),
-                }
+        if let Some(mime_type_filter) = &filter.mime_types {
+            if let Some(included_mime_types) = &mime_type_filter.is_in {
+                counter.add(1);
+                bool_query = bool_query.filter(Query::terms("mime_type", included_mime_types))
             }
-            None => (),
+            if let Some(excluded_mime_types) = &mime_type_filter.is_not {
+                counter.add(1);
+                bool_query = bool_query.must_not(Query::terms("mime_type", excluded_mime_types))
+            }
         }
 
         if let Some(parent_id) = &filter.parent_id {

--- a/front/lib/search.ts
+++ b/front/lib/search.ts
@@ -2,6 +2,7 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type {
   ContentNodesViewType,
+  CoreAPINodesSearchFilter,
   CoreAPISearchScope,
   LightWorkspaceType,
 } from "@app/types";
@@ -63,7 +64,7 @@ export function getSearchFilterFromDataSourceViews(
     nodeIds?: string[];
     parentId?: string;
   }
-) {
+): CoreAPINodesSearchFilter {
   const groupedPerDataSource = dataSourceViews.reduce(
     (acc, dsv) => {
       const dataSourceId = dsv.dataSource.dustAPIDataSourceId;
@@ -112,7 +113,7 @@ export function getSearchFilterFromDataSourceViews(
         isSingleDataSource: entries.length === 1,
       }),
     })),
-    excluded_node_mime_types: excludedNodeMimeTypes,
+    mime_types: { not: excludedNodeMimeTypes },
     node_types: getCoreViewTypeFilter(viewType),
     node_ids: nodeIds,
     ...(parentId && { parent_id: parentId }),

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -285,6 +285,7 @@ export const CoreAPINodesSearchFilterSchema = t.intersection([
     node_types: t.array(t.string),
     parent_id: t.string,
     query: t.string,
+    mime_types: t.array(t.string),
   }),
 ]);
 

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -280,18 +280,21 @@ export const CoreAPINodesSearchFilterSchema = t.intersection([
     data_source_views: t.array(CoreAPIDatasourceViewFilterSchema),
   }),
   t.partial({
-    excluded_node_mime_types: t.readonlyArray(t.string),
     node_ids: t.array(t.string),
     node_types: t.array(t.string),
     parent_id: t.string,
     query: t.string,
-    mime_types: t.array(t.string),
+    mime_types: t.partial({
+      in: t.union([t.readonlyArray(t.string), t.null]),
+      not: t.union([t.readonlyArray(t.string), t.null]),
+    }),
   }),
 ]);
 
 export type CoreAPINodesSearchFilter = t.TypeOf<
   typeof CoreAPINodesSearchFilterSchema
 >;
+
 export interface CoreAPIDataSourceStatsResponse {
   data_source: {
     data_source_id: string;

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -280,7 +280,7 @@ export const CoreAPINodesSearchFilterSchema = t.intersection([
     data_source_views: t.array(CoreAPIDatasourceViewFilterSchema),
   }),
   t.partial({
-    excluded_node_mime_types: t.union([t.readonlyArray(t.string), t.undefined]),
+    excluded_node_mime_types: t.readonlyArray(t.string),
     node_ids: t.array(t.string),
     node_types: t.array(t.string),
     parent_id: t.string,


### PR DESCRIPTION
## Description

- This PR adds a `mimeType` filter in the `/search/nodes` endpoint in core.
- This filter allows specifying included `mimeTypes`: if specified the mime type must be in the list, and excluded `mimeTypes`: if specified the mime type must not be in the list.
- The `excluded_mime_types` field is not removed from core to maintain retro-compatibility, it will be removed in a follow up PR.

## Tests

- Tested through the search bar (attach from knowledge).

## Risk

- N/A.

## Deploy Plan

- Deploy core.
- Deploy front after core is done.
