### PR TITLE
[.github] - fix(sparkle): use Github App

### DIFF
--- a/.github/workflows/publish-sparkle-new.yml
+++ b/.github/workflows/publish-sparkle-new.yml
@@ -46,11 +46,19 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SPARKLE_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.SPARKLE_RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
       - uses: actions/setup-node@v3
@@ -60,8 +68,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
+          git config --global user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
 
       - name: Version bump and commit
         run: |


### PR DESCRIPTION
## Description

This PR aims at fixing the new sparkle deployment workflow to use a Github App `sparkle-release-bot` which has bypass permission such that it can push to main and fix the original error we had [here](https://github.com/dust-tt/dust/actions/runs/15163136645/job/42634015586).

## Risk

Low

## Deploy Plan

- Test new workflow and if successful deprecate previous one