### PR TITLE
[.github] - fix(sparkle): ensure dependencies and build before npm publish

### DIFF
--- a/.github/workflows/publish-sparkle.yml
+++ b/.github/workflows/publish-sparkle.yml
@@ -88,6 +88,6 @@ jobs:
 
       - name: Publish
         working-directory: sparkle
-        run: npm publish
+        run: npm ci && npm run build && npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

This PR does the following:
 - Run `npm ci` to install clean versions of dependencies based on `package-lock.json`
 - Execute `npm run build` to create the production build before publishing to npm registry
 
While the install in front is not affected it seems like the extension requires the `dist/` folder to install sparkle

## Risk

Low

## Deploy Plan

N/A