### PR TITLE
[front] fix: Fix type of column integer -> bigint

### DIFF
--- a/front/migrations/db/migration_275.sql
+++ b/front/migrations/db/migration_275.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jan 30, 2025
+ALTER TABLE "public"."remote_mcp_server_tool_metadata" 
+ALTER COLUMN "remoteMCPServerId" TYPE bigint;


### PR DESCRIPTION
## Description

The column `"remote_mcp_server_tool_metadata"."remoteMCPServerId"` is of type `INTEGER` instead of `BIGINT`, causing issues on inserts in production ([logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20region%3Aeurope-west1&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZdEPOcbuhbduwAAABhBWmRFUFBwUEFBREN1NFJ2WFJhTnh3QVgAAAAkMDE5NzQ0M2YtNGRhYi00MTIxLWFlYTEtYWZlNTk0ZDA3Njk1AAPLlg&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1749196260000&to_ts=1749196560000&live=false)).
The type in the code is already correct, this PR adds a migration script to change it in db.
In both US and EU dbs the type is incorrect.

```sql
SELECT *
    FROM information_schema.columns 
WHERE table_name = 'remote_mcp_server_tool_metadata'; 
```

## Tests

- Run locally.

## Risk

- N/A.

## Deploy Plan

- Run `migration_275.sql`.
