### PR TITLE
Jgr142/disable non builders

### DIFF
--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -21,8 +21,9 @@ import { DeleteAssistantDialog } from "@app/components/assistant/DeleteAssistant
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
-import { isAdmin } from "@app/types";
+import { isAdmin, isBuilder } from "@app/types";
 
 interface AssistantDetailsButtonBarProps {
   agentConfiguration: LightAgentConfigurationType;
@@ -43,6 +44,14 @@ export function AssistantDetailsButtonBar({
   const [showDeletionModal, setShowDeletionModal] = useState(false);
   const { onOpenChange: onOpenChangeAssistantModal } =
     useURLSheet("assistantDetails");
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+
+  const isRestrictedFromAgentCreation =
+    featureFlags.includes("disallow_agent_creation_to_users") &&
+    !isBuilder(owner);
 
   const router = useRouter();
 
@@ -159,21 +168,22 @@ export function AssistantDetailsButtonBar({
         />
       </Link>
 
-      {agentConfiguration.scope !== "global" && (
-        <Link
-          onClick={(e) => !canEditAssistant && e.preventDefault()}
-          href={`/w/${owner.sId}/builder/assistants/${
-            agentConfiguration.sId
-          }?flow=workspace_assistants`}
-        >
-          <Button
-            size="sm"
-            disabled={!canEditAssistant}
-            variant="outline"
-            icon={PencilSquareIcon}
-          />
-        </Link>
-      )}
+      {agentConfiguration.scope !== "global" &&
+        !isRestrictedFromAgentCreation && (
+          <Link
+            onClick={(e) => !canEditAssistant && e.preventDefault()}
+            href={`/w/${owner.sId}/builder/assistants/${
+              agentConfiguration.sId
+            }?flow=workspace_assistants`}
+          >
+            <Button
+              size="sm"
+              disabled={!canEditAssistant}
+              variant="outline"
+              icon={PencilSquareIcon}
+            />
+          </Link>
+        )}
 
       {agentConfiguration.scope !== "global" && (
         <AssistantDetailsDropdownMenu />

--- a/front/components/assistant/WelcomeTourGuide.tsx
+++ b/front/components/assistant/WelcomeTourGuide.tsx
@@ -17,13 +17,9 @@ import { useMemo, useRef } from "react";
 import { useState } from "react";
 
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import {
-  isBuilder,
-  type ConnectorProvider,
-  type UserType,
-  type WorkspaceType,
-} from "@app/types";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { ConnectorProvider, UserType, WorkspaceType } from "@app/types";
+import { isBuilder } from "@app/types";
 
 // We want exactly 12 connections in the tour guide to have a clean grid layout.
 const CONNECTIONS_IN_TOUR_GUIDE: ConnectorProvider[] = [

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -33,6 +33,7 @@ import {
   useConversations,
   useDeleteConversation,
 } from "@app/lib/swr/conversations";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { removeDiacritics, subFilter } from "@app/lib/utils";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
@@ -62,6 +63,14 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
     ConversationWithoutContentType[]
   >([]);
   const doDelete = useDeleteConversation(owner);
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+
+  const isRestrictedFromAgentCreation =
+    featureFlags.includes("disallow_agent_creation_to_users") &&
+    !isBuilder(owner);
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null
@@ -243,14 +252,18 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                     <Button size="sm" icon={MoreIcon} variant="outline" />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent>
-                    <DropdownMenuLabel>Agent</DropdownMenuLabel>
-                    <DropdownMenuItem
-                      href={`/w/${owner.sId}/builder/assistants/create`}
-                      icon={PlusIcon}
-                      label="Create new agent"
-                      data-gtm-label="assistantCreationButton"
-                      data-gtm-location="sidebarMenu"
-                    />
+                    {!isRestrictedFromAgentCreation && (
+                      <>
+                        <DropdownMenuLabel>Agent</DropdownMenuLabel>
+                        <DropdownMenuItem
+                          href={`/w/${owner.sId}/builder/assistants/create`}
+                          icon={PlusIcon}
+                          label="Create new agent"
+                          data-gtm-label="assistantCreationButton"
+                          data-gtm-location="sidebarMenu"
+                        />
+                      </>
+                    )}
                     {isBuilder(owner) && (
                       <DropdownMenuItem
                         href={`/w/${owner.sId}/builder/assistants`}

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1098,3 +1098,16 @@ export const getFeatureFlags = memoizer.sync({
 
   itemMaxAge: () => 3000,
 });
+
+export async function isRestrictedFromAgentCreation(
+  owner: LightWorkspaceType,
+  auth: Authenticator
+): Promise<boolean> {
+  const featureFlags = await getFeatureFlags(owner);
+
+  return (
+    featureFlags.includes("restrict_agent_creation_to_higher_users") &&
+    !auth.isBuilder() &&
+    !auth.isAdmin()
+  );
+}

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1106,7 +1106,7 @@ export async function isRestrictedFromAgentCreation(
   const featureFlags = await getFeatureFlags(owner);
 
   return (
-    featureFlags.includes("restrict_agent_creation_to_higher_users") &&
+    featureFlags.includes("disallow_agent_creation_to_users") &&
     !auth.isBuilder() &&
     !auth.isAdmin()
   );

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1100,14 +1100,12 @@ export const getFeatureFlags = memoizer.sync({
 });
 
 export async function isRestrictedFromAgentCreation(
-  owner: LightWorkspaceType,
-  auth: Authenticator
+  owner: LightWorkspaceType
 ): Promise<boolean> {
   const featureFlags = await getFeatureFlags(owner);
 
   return (
     featureFlags.includes("disallow_agent_creation_to_users") &&
-    !auth.isBuilder() &&
-    !auth.isAdmin()
+    !isBuilder(owner)
   );
 }

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -18,7 +18,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { generateMockAgentConfigurationFromTemplate } from "@app/lib/api/assistant/templates";
 import config from "@app/lib/api/config";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { getFeatureFlags } from "@app/lib/auth";
+import { getFeatureFlags, isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
 import type {
@@ -75,11 +75,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  if (
-    featureFlags.includes("restrict_agent_creation_to_higher_users") &&
-    !auth.isBuilder() &&
-    !auth.isAdmin()
-  ) {
+  if (await isRestrictedFromAgentCreation(owner, auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -75,6 +75,16 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  if (
+    featureFlags.includes("restrict_agent_creation_to_higher_users") &&
+    !auth.isBuilder() &&
+    !auth.isAdmin()
+  ) {
+    return {
+      notFound: true,
+    };
+  }
+
   const { spaces, dataSourceViews, dustApps, mcpServerViews } =
     await getAccessibleSourcesAndApps(auth);
 

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -75,7 +75,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  if (await isRestrictedFromAgentCreation(owner, auth)) {
+  if (await isRestrictedFromAgentCreation(owner)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -22,6 +22,7 @@ import AppContentLayout, {
 } from "@app/components/sparkle/AppContentLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
 import type {
@@ -42,6 +43,18 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const plan = auth.plan();
   const subscription = auth.subscription();
   if (!owner || !plan || !auth.isUser() || !subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const featureFlags = await getFeatureFlags(owner);
+
+  if (
+    featureFlags.includes("restrict_agent_creation_to_higher_users") &&
+    !auth.isBuilder() &&
+    !auth.isAdmin()
+  ) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -22,7 +22,7 @@ import AppContentLayout, {
 } from "@app/components/sparkle/AppContentLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { getFeatureFlags } from "@app/lib/auth";
+import { isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
 import type {
@@ -48,13 +48,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const featureFlags = await getFeatureFlags(owner);
-
-  if (
-    featureFlags.includes("restrict_agent_creation_to_higher_users") &&
-    !auth.isBuilder() &&
-    !auth.isAdmin()
-  ) {
+  if (await isRestrictedFromAgentCreation(owner, auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -48,7 +48,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  if (await isRestrictedFromAgentCreation(owner, auth)) {
+  if (await isRestrictedFromAgentCreation(owner)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -15,6 +15,7 @@ import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -40,6 +41,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const subscription = auth.subscription();
 
   if (!owner || !auth.isBuilder() || !subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  if (await isRestrictedFromAgentCreation(owner)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -29,6 +29,7 @@ import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
@@ -93,6 +94,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const subscription = auth.subscription();
 
   if (!owner || !subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  if (await isRestrictedFromAgentCreation(owner)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -68,7 +68,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  if (await isRestrictedFromAgentCreation(owner, auth)) {
+  if (await isRestrictedFromAgentCreation(owner)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -18,7 +18,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { generateMockAgentConfigurationFromTemplate } from "@app/lib/api/assistant/templates";
 import config from "@app/lib/api/config";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { getFeatureFlags } from "@app/lib/auth";
+import { isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
 import type {
@@ -68,13 +68,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const featureFlags = await getFeatureFlags(owner);
-
-  if (
-    featureFlags.includes("restrict_agent_creation_to_higher_users") &&
-    !auth.isBuilder() &&
-    !auth.isAdmin()
-  ) {
+  if (await isRestrictedFromAgentCreation(owner, auth)) {
     return {
       notFound: true,
     };

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -33,6 +33,10 @@ export const WHITELISTABLE_FEATURES = [
   "gmail_tool",
   "agent_builder_v2",
   "restrict_agent_creation_to_higher_users",
+  "document_tracker",
+  "agent_discovery",
+  "search_knowledge_builder",
+  "snowflake_connector_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -32,6 +32,7 @@ export const WHITELISTABLE_FEATURES = [
   "salesforce_tool",
   "gmail_tool",
   "agent_builder_v2",
+  "restrict_agent_creation_to_higher_users",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -32,7 +32,7 @@ export const WHITELISTABLE_FEATURES = [
   "salesforce_tool",
   "gmail_tool",
   "agent_builder_v2",
-  "restrict_agent_creation_to_higher_users",
+  "disallow_agent_creation_to_users",
   "document_tracker",
   "agent_discovery",
   "search_knowledge_builder",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -836,7 +836,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "gmail_tool"
   | "agent_builder_v2"
-  | "restrict_agent_creation_to_higher_users"
+  | "disallow_agent_creation_to_users"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -836,6 +836,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "gmail_tool"
   | "agent_builder_v2"
+  | "restrict_agent_creation_to_higher_users"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds new feature flag that allows us, through poke, to only allows builders and admins to create agents/assistants.

## Tests

Manually tested: As agent, builder and user.

## Risk

Could block everyone, but likely won't since I tested

## Deploy Plan

No change
