### PR TITLE
[FS-like tools] Find / search handle data source root node ids

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -259,9 +259,7 @@ const createServer = (
         viewFilter = viewFilter.filter(
           (view) => view.data_source_id === dataSourceNodeId
         );
-      }
-
-      if (rootNodeId) {
+      } else if (rootNodeId) {
         viewFilter = viewFilter.map((view) => ({
           ...view,
           view_filter: [rootNodeId],

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -253,26 +253,20 @@ const createServer = (
       // are searched. It is not straightforward to guess which data source it
       // belongs to, this is why irrelevant data sources are not directly
       // filtered out.
-      const viewFilter = (() => {
-        const viewFilter = makeDataSourceViewFilter(
-          agentDataSourceConfigurations
+      let viewFilter = makeDataSourceViewFilter(agentDataSourceConfigurations);
+
+      if (dataSourceNodeId) {
+        viewFilter = viewFilter.filter(
+          (view) => view.data_source_id === dataSourceNodeId
         );
+      }
 
-        if (!rootNodeId) {
-          return viewFilter;
-        }
-
-        if (dataSourceNodeId) {
-          return viewFilter.filter(
-            (view) => view.data_source_id === dataSourceNodeId
-          );
-        }
-
-        return viewFilter.map((view) => ({
+      if (rootNodeId) {
+        viewFilter = viewFilter.map((view) => ({
           ...view,
           view_filter: [rootNodeId],
         }));
-      })();
+      }
 
       const searchResult = await coreAPI.searchNodes({
         query,


### PR DESCRIPTION
Description
---

Following #13162, model can now access a whole datasource via a constructed "data source" node id.

This PR makes find & search able to use those node ids. Additionally, it acts on the `rootNodeId` for find, which was previously ignored.

Risks
---
low (gated)

Deploy
---
front