### PR TITLE
Check tables validity before upserting

### DIFF
--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -263,13 +263,15 @@ const upsertExcelToDatasource: ProcessingFunction = async (
       },
     });
 
-    tableIds.push(tableId);
-
-    await upsertTableToDatasource(auth, {
+    const res = await upsertTableToDatasource(auth, {
       file: worksheetFile,
       dataSource,
       upsertArgs: upsertTableArgs,
     });
+
+    if (res.isOk()) {
+      tableIds.push(tableId);
+    }
   };
 
   const content = await getFileContent(auth, file);

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -256,8 +256,6 @@ export async function upsertTableFromCsv({
         );
       }
       return new Err(errorDetails);
-    } else {
-      const table = csvRes.value;
     }
   }
 

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -154,6 +154,21 @@ export async function upsertTableFromCsv({
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
+  if (file) {
+    const schemaRes = await coreAPI.tableValidateCSVContent({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
+      bucket: file.getBucketForVersion("processed").name,
+      bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+    });
+    if (schemaRes.isErr() || schemaRes.value.schema.length === 0) {
+      return new Err({
+        type: "invalid_request_error",
+        message: "Invalid CSV content, skipping",
+      });
+    }
+  }
+
   const tableRes = await coreAPI.upsertTable({
     projectId: dataSource.dustAPIProjectId,
     dataSourceId: dataSource.dustAPIDataSourceId,
@@ -241,6 +256,8 @@ export async function upsertTableFromCsv({
         );
       }
       return new Err(errorDetails);
+    } else {
+      const table = csvRes.value;
     }
   }
 


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/3034

## Description

This add a check before upserting a table, verifying that the schema is valid. This prevent having an invalid sheet automatically added in JIT table query.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
