### PR TITLE
Fix Poke Plugin to Manage Domain in WorkOS

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/manage_authorized_domains.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_authorized_domains.ts
@@ -16,7 +16,7 @@ import { Err, Ok } from "@app/types";
 
 async function handleAddDomain(
   auth: Authenticator,
-  { domain, autoJoinEnabled }: { domain: string; autoJoinEnabled: boolean },
+  { domain }: { domain: string },
   existingDomain: WorkspaceHasDomainModel | null
 ): Promise<Result<PluginResponse, Error>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -67,9 +67,9 @@ async function handleAddDomain(
 
   return new Ok({
     display: "text",
-    value: `Domain ${domain} has been added to the workspace${
-      autoJoinEnabled ? " with auto-join enabled" : ""
-    }. Next webhook will add it to the workspace in the database.`,
+    value:
+      `Domain ${domain} has been added to the workspace. Next webhook will add it to ` +
+      "the workspace in the database.",
   });
 }
 
@@ -124,13 +124,6 @@ export const addAuthorizedDomain = createPlugin({
         description: "Select operation to perform",
         values: ["add", "remove"],
       },
-      autoJoinEnabled: {
-        type: "boolean",
-        label: "Auto Join Enabled",
-        description:
-          "Whether to automatically add users with this domain email",
-        default: false,
-      },
     },
   },
   execute: async (auth, _, args) => {
@@ -156,11 +149,7 @@ export const addAuthorizedDomain = createPlugin({
     });
 
     if (operation === "add") {
-      return handleAddDomain(
-        auth,
-        { domain, autoJoinEnabled: args.autoJoinEnabled },
-        existingDomain
-      );
+      return handleAddDomain(auth, { domain }, existingDomain);
     } else {
       return handleRemoveDomain(auth, { domain }, existingDomain);
     }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the Poke plugin to managed WorkOS Organisation's domains. It was not working properly when updating an existing organisation. This refactors preserve all the other domains and there states.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
