### PR TITLE
Add coding rule for MCP tool output types

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -352,6 +352,14 @@ name of the server. If having only one file is not possible, they should be plac
 that contains a file `server.ts` from where the `createServer` function that creates the server
 will be exported.
 
+### [MCP3] Tool output typing
+
+If a tool in an internal MCP server outputs a custom resource, a `zod` schema that describes the
+output must be defined in `lib/actions/mcp_internal_actions/output_schemas.ts`. This way, when
+processing the tool output, a typeguard that checks the output against the schema
+can be used to identify this output type. In the code of the internal server the type inferred
+from the `zod` schema should be used to type the tool output.
+
 ## TESTING
 
 ### [TEST1] Functionally test endpoints

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
@@ -51,19 +51,3 @@ export const logAndReturnError = ({
     error.response?.body?.message ?? error.message ?? message
   );
 };
-
-export const returnJSONStringifiedSuccess = ({
-  message,
-  result,
-}: {
-  message: string;
-  result: any;
-}): CallToolResult => {
-  return {
-    isError: false,
-    content: [
-      { type: "text", text: message },
-      { type: "text", text: JSON.stringify(result, null, 2) },
-    ],
-  };
-};

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -1,6 +1,6 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { trim } from "lodash";
 import { z } from "zod";
@@ -91,7 +91,15 @@ function createServer(
     dataSources: DataSourcesToolConfigurationType;
     tagsIn?: string[];
     tagsNot?: string[];
-  }): Promise<CallToolResult> => {
+  }): Promise<{
+    isError: boolean;
+    content:
+      | TextContent[]
+      | {
+          type: "resource";
+          resource: IncludeResultResourceType | IncludeQueryResourceType;
+        }[];
+  }> => {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     const credentials = dustManagedCredentials();
 

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -242,7 +242,7 @@ const FallbackBlock = z
   })
   .passthrough();
 
-export const NotionBlockSchema: z.ZodType<any> = z.union([
+export const NotionBlockSchema: z.ZodType = z.union([
   ParagraphBlock,
   Heading1Block,
   Heading2Block,

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -1,6 +1,6 @@
 import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import type { ZodRawShape } from "zod";
 import { z } from "zod";
 
@@ -15,6 +15,7 @@ import type {
   ServerSideMCPServerConfigurationType,
   ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
+import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -126,8 +127,8 @@ async function processDustFileOutput(
   sanitizedOutput: DustFileOutput,
   conversation: any,
   appName: string
-): Promise<CallToolResult["content"]> {
-  const content: CallToolResult["content"] = [];
+): Promise<{ type: "resource"; resource: ToolGeneratedFileType }[]> {
+  const content: { type: "resource"; resource: ToolGeneratedFileType }[] = [];
 
   const containsValidStructuredOutput = (
     output: DustFileOutput
@@ -322,7 +323,10 @@ export default async function createServer(
       app.description,
       convertDatasetSchemaToZodRawShape(schema),
       async (params) => {
-        const content: CallToolResult["content"] = [];
+        const content: (
+          | TextContent
+          | { type: "resource"; resource: ToolGeneratedFileType }
+        )[] = [];
 
         params = await prepareParamsWithHistory(
           params,

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/schema.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/schema.ts
@@ -1,15 +1,20 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
+import type {
+  DatabaseSchemaResourceType,
+  ExampleRowsResourceType,
+  QueryWritingInstructionsResourceType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   DUST_SQLITE_INSTRUCTIONS,
   getGenericDialectInstructions,
   SALESFORCE_INSTRUCTIONS,
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/dialect_instructions";
 
-export function getSchemaContent(
-  schemas: { dbml: string }[]
-): CallToolResult["content"] {
+export function getSchemaContent(schemas: { dbml: string }[]): {
+  type: "resource";
+  resource: DatabaseSchemaResourceType;
+}[] {
   return [
     {
       type: "resource",
@@ -24,7 +29,7 @@ export function getSchemaContent(
 
 export function getQueryWritingInstructionsContent(
   dialect: string
-): CallToolResult["content"] {
+): { type: "resource"; resource: QueryWritingInstructionsResourceType }[] {
   const instructions = (() => {
     if (dialect === "dust_sqlite") {
       return DUST_SQLITE_INSTRUCTIONS;
@@ -52,7 +57,10 @@ export function getDatabaseExampleRowsContent(
     dbml: string;
     head?: Array<Record<string, any>>;
   }[]
-): CallToolResult["content"] {
+): {
+  type: "resource";
+  resource: ExampleRowsResourceType;
+}[] {
   const heads = schemas
     .map((item) => {
       const h = item.head;

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -1,6 +1,5 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
 import {
@@ -9,6 +8,11 @@ import {
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type {
+  SqlQueryOutputType,
+  ThinkingOutputType,
+  ToolGeneratedFileType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   getDatabaseExampleRowsContent,
   getQueryWritingInstructionsContent,
@@ -28,6 +32,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
+
+// Types for the resources that are output by the tools of this server.
+type TablesQueryOutputResources =
+  | ThinkingOutputType
+  | SqlQueryOutputType
+  | ToolGeneratedFileType;
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "query_tables_v2",
@@ -188,7 +198,10 @@ function createServer(
         );
       }
 
-      const content: CallToolResult["content"] = [];
+      const content: {
+        type: "resource";
+        resource: TablesQueryOutputResources;
+      }[] = [];
 
       const results: CSVRecord[] = queryResult.value.results
         .map((r) => r.value)


### PR DESCRIPTION
## Description

- This PR adds a coding rule for typing MCP tool outputs.
- This PR also adapts the existing server to follow as best as possible the added rule.

## Tests

- `tsc`.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
