### PR TITLE
Fix WorkOS webhook IP Check

### DIFF
--- a/front/lib/api/workos/webhook_helpers.ts
+++ b/front/lib/api/workos/webhook_helpers.ts
@@ -22,6 +22,22 @@ export function isWorkOSIpAddress(ipAddress: string) {
   return workosIpAddresses.includes(ipAddress);
 }
 
+/**
+ * Extracts the client IP address from request headers.
+ * Handles x-forwarded-for header which can contain comma-separated IPs from proxy chains.
+ * Returns the first IP (original client) or null if no forwarded header exists.
+ */
+export function getClientIpFromHeaders(headers: {
+  [key: string]: string | string[] | undefined;
+}): string | null {
+  const forwardedFor = headers["x-forwarded-for"];
+  if (forwardedFor) {
+    const ip = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
+    return ip.split(",")[0].trim();
+  }
+  return null;
+}
+
 export async function validateWorkOSWebhookEvent(
   payload: unknown,
   { signatureHeader }: { signatureHeader: string }

--- a/front/pages/api/workos/webhooks/[webhookSecret].ts
+++ b/front/pages/api/workos/webhooks/[webhookSecret].ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import {
+  getClientIpFromHeaders,
   isWorkOSIpAddress,
   validateWorkOSWebhookEvent,
 } from "@app/lib/api/workos/webhook_helpers";
@@ -47,7 +48,8 @@ async function handler(
   }
 
   // Validate the client IP address.
-  const clientIp = req.headers["x-forwarded-for"] || req.socket.remoteAddress;
+  const clientIp =
+    getClientIpFromHeaders(req.headers) || req.socket.remoteAddress;
   if (typeof clientIp !== "string") {
     return apiError(req, res, {
       status_code: 400,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Recent WorkOS Webhook events have failed because we fail to validate that the IP belongs to WorkOS. Looks like most of those events were re-routed leading to several IPs in the `x-forwarded-for` header. This PR ensures we only take the original one.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
