### PR TITLE
enh(FS-tools): expose to the model `hasChildren`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -714,6 +714,7 @@ function renderNode(node: CoreAPIContentNode) {
     sourceUrl: node.source_url,
     // TODO(2025-06-02 aubin): see if we want a translation on these.
     mimeType: node.mime_type,
+    hasChildren: node.children_count > 0,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -296,7 +296,8 @@ const createServer = (
     "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
       "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
       "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
-      "the next step's nodeId.",
+      "the next step's nodeId. If in a list you find a node that has children (hasChildren: true)," +
+      " it means that you can use list again on it.",
     {
       nodeId: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -296,8 +296,8 @@ const createServer = (
     "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
       "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
       "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
-      "the next step's nodeId. If a node has children (hasChildren: true), it means that this tool " +
-      "can be used again on it.",
+      "the next step's nodeId. If a node output by this tool or the find tool has children " +
+      "(hasChildren: true), it means that this tool can be used again on it.",
     {
       nodeId: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -296,8 +296,8 @@ const createServer = (
     "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
       "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
       "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
-      "the next step's nodeId. If in a list you find a node that has children (hasChildren: true)," +
-      " it means that you can use list again on it.",
+      "the next step's nodeId. If a node has children (hasChildren: true), it means that this tool " +
+      "can be used again on it.",
     {
       nodeId: z
         .string()


### PR DESCRIPTION
## Description

- Expose to the model `hasChildren` information.
- Goal is to make it more obvious whether a node can be searched again.

## Tests

## Risk

## Deploy Plan

- Deploy `front`.
