### PR TITLE
Add: oAuthUseCase to MCPServerView to support connectionType choice

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -25,10 +25,7 @@ export const serverInfo: InternalMCPServerDefinitionType = {
   description:
     "Agent can search (Google) and retrieve information from specific websites.",
   icon: "ActionGlobeAltIcon",
-  authorization: {
-    provider,
-    use_case: "connection" as const,
-  },
+  authorization: null,
 };
 
 const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -46,7 +46,7 @@ import { createSSRFInterceptor } from "@app/types/shared/utils/ssrf";
 
 export type AuthorizationInfo = {
   provider: OAuthProvider;
-  use_case: OAuthUseCase;
+  use_case: Extract<OAuthUseCase, "platform_actions" | "personal_actions">;
   scope?: string;
 };
 

--- a/front/lib/models/assistant/actions/mcp_server_view.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view.ts
@@ -1,6 +1,7 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -25,6 +26,8 @@ export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServ
   declare editedByUser: NonAttribute<UserModel>;
   declare space: NonAttribute<SpaceModel>;
   declare remoteMCPServer: NonAttribute<RemoteMCPServerModel>;
+
+  declare oAuthUseCase: AuthorizationInfo["use_case"] | null;
 }
 MCPServerViewModel.init(
   {
@@ -33,6 +36,7 @@ MCPServerViewModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+
     deletedAt: {
       type: DataTypes.DATE,
     },
@@ -63,6 +67,13 @@ MCPServerViewModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    oAuthUseCase: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      validate: {
+        isIn: [["platform_actions", "personal_actions"]],
+      },
     },
   },
   {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -143,6 +143,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         editedByUserId: editedByUser?.id ?? null,
         editedAt: new Date(),
         vaultId: space.id,
+        // TODO(mcp): add the use case to the create function
       },
       { transaction }
     );
@@ -160,15 +161,22 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   public static async create(
     auth: Authenticator,
     {
-      mcpServerId,
+      systemView,
       space,
       transaction,
     }: {
-      mcpServerId: string;
+      systemView: MCPServerViewResource;
       space: SpaceResource;
       transaction?: Transaction;
     }
   ) {
+    if (systemView.space.kind !== "system") {
+      throw new Error(
+        "You must pass the system view to create a new MCP server view"
+      );
+    }
+
+    const mcpServerId = systemView.mcpServerId;
     const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
 
     if (space.kind === "global") {
@@ -186,6 +194,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         serverType,
         internalMCPServerId: serverType === "internal" ? mcpServerId : null,
         remoteMCPServerId: serverType === "remote" ? id : null,
+        // For consistency and ease of use later, always copy the oAuthUseCase from the system view.
+        oAuthUseCase: systemView.oAuthUseCase,
       },
       space,
       auth.user() ?? undefined,
@@ -361,6 +371,33 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     );
 
     return views.find((view) => view.space.kind === "global") ?? null;
+  }
+
+  static async getMCPServerViewForSystemSpace(
+    auth: Authenticator,
+    mcpServerId: string
+  ): Promise<MCPServerViewResource | null> {
+    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+    const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
+    if (serverType === "internal") {
+      const views = await this.baseFetch(auth, {
+        where: {
+          serverType: "internal",
+          internalMCPServerId: mcpServerId,
+          vaultId: systemSpace.id,
+        },
+      });
+      return views[0] ?? null;
+    } else {
+      const views = await this.baseFetch(auth, {
+        where: {
+          serverType: "remote",
+          remoteMCPServerId: id,
+          vaultId: systemSpace.id,
+        },
+      });
+      return views[0] ?? null;
+    }
   }
 
   // Deletion.
@@ -543,15 +580,25 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         // Create the missing views
         for (const id of autoInternalMCPServerIds) {
           // Check if exists in system space.
-          const isInSystemSpace = views.some(
+          let systemViewModel = views.find(
             (v) => v.internalMCPServerId === id && v.vaultId === systemSpace.id
           );
-          if (!isInSystemSpace) {
-            await MCPServerViewResource.create(auth, {
-              mcpServerId: id,
-              space: systemSpace,
+          if (!systemViewModel) {
+            systemViewModel = await MCPServerViewModel.create({
+              workspaceId: auth.getNonNullableWorkspace().id,
+              serverType: "internal",
+              internalMCPServerId: id,
+              vaultId: systemSpace.id,
+              editedAt: new Date(),
+              editedByUserId: auth.user()?.id,
+              oAuthUseCase: null,
             });
           }
+          const systemView = new this(
+            MCPServerViewModel,
+            systemViewModel.get(),
+            systemSpace
+          );
 
           // Check if exists in global space.
           const isInGlobalSpace = views.some(
@@ -559,7 +606,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           );
           if (!isInGlobalSpace) {
             await MCPServerViewResource.create(auth, {
-              mcpServerId: id,
+              systemView,
               space: globalSpace,
             });
           }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -143,7 +143,6 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         editedByUserId: editedByUser?.id ?? null,
         editedAt: new Date(),
         vaultId: space.id,
-        // TODO(mcp): add the use case to the create function
       },
       { transaction }
     );
@@ -194,7 +193,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         serverType,
         internalMCPServerId: serverType === "internal" ? mcpServerId : null,
         remoteMCPServerId: serverType === "remote" ? id : null,
-        // For consistency and ease of use later, always copy the oAuthUseCase from the system view.
+        // Always copy the oAuthUseCase from the system view to the custom view.
+        // This way, it's always available on the MCP server view without having to fetch the system view.
         oAuthUseCase: systemView.oAuthUseCase,
       },
       space,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -82,7 +82,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         vaultId: systemSpace.id,
         editedAt: new Date(),
         editedByUserId: auth.user()?.id,
-        // TODO(mcp): add the use case to the create function
+        oAuthUseCase: blob.authorization?.use_case ?? null,
       },
       {
         transaction,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -82,6 +82,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         vaultId: systemSpace.id,
         editedAt: new Date(),
         editedByUserId: auth.user()?.id,
+        // TODO(mcp): add the use case to the create function
       },
       {
         transaction,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -618,6 +618,7 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
       const additionalCredentials =
         await getProviderAdditionalClientSideAuthCredentials({
           provider,
+          // @ts-expect-error useCase is too broad here but will fixed when we remove salesforce labs integration.
           use_case: useCase,
         });
       if (additionalCredentials) {

--- a/front/migrations/db/migration_276.sql
+++ b/front/migrations/db/migration_276.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jun 06, 2025
+ALTER TABLE "public"."mcp_server_views"
+ADD COLUMN "oAuthUseCase" VARCHAR(255);

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -207,11 +207,28 @@ async function handler(
         }
 
         if (body.includeGlobal) {
+          const systemView =
+            await MCPServerViewResource.getMCPServerViewForSystemSpace(
+              auth,
+              newRemoteMCPServer.sId
+            );
+
+          if (!systemView) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "Missing system view for remote MCP server, it should have been created when creating the remote server.",
+              },
+            });
+          }
+
           const globalSpace =
             await SpaceResource.fetchWorkspaceGlobalSpace(auth);
 
           await MCPServerViewResource.create(auth, {
-            mcpServerId: newRemoteMCPServer.sId,
+            systemView,
             space: globalSpace,
           });
         }
@@ -261,8 +278,25 @@ async function handler(
           const globalSpace =
             await SpaceResource.fetchWorkspaceGlobalSpace(auth);
 
+          const systemView =
+            await MCPServerViewResource.getMCPServerViewForSystemSpace(
+              auth,
+              newInternalMCPServer.id
+            );
+
+          if (!systemView) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "Missing system view for internal MCP server, it should have been created when creating the internal server.",
+              },
+            });
+          }
+
           await MCPServerViewResource.create(auth, {
-            mcpServerId: newInternalMCPServer.id,
+            systemView,
             space: globalSpace,
           });
         }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -89,8 +89,25 @@ async function handler(
         });
       }
 
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          auth,
+          mcpServerId
+        );
+
+      if (!systemView) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Missing system view for MCP server, it should have been created when adding the tool.",
+          },
+        });
+      }
+
       const mcpServerView = await MCPServerViewResource.create(auth, {
-        mcpServerId,
+        systemView,
         space,
       });
 

--- a/front/tests/utils/MCPServerViewFactory.ts
+++ b/front/tests/utils/MCPServerViewFactory.ts
@@ -1,3 +1,5 @@
+import type { Transaction } from "sequelize";
+
 import { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -7,13 +9,26 @@ export class MCPServerViewFactory {
   static async create(
     workspace: LightWorkspaceType,
     mcpServerId: string,
-    space: SpaceResource
+    space: SpaceResource,
+    transaction?: Transaction
   ): Promise<MCPServerViewResource> {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        mcpServerId
+      );
+
+    if (!systemView) {
+      throw new Error(
+        "System view not found, make sure you created it in your test."
+      );
+    }
 
     const serverView = await MCPServerViewResource.create(auth, {
-      mcpServerId,
+      systemView,
       space,
+      transaction,
     });
 
     return serverView;


### PR DESCRIPTION
## Description

Add a new column to store the type of oauth use case that the mcp server will use to allow picking between personal and workspace connections.
For now, we replicate the value from the system's view to the space's views, ultimately we could have a different behavior per space.

## Tests

Locally

## Risk

Low, it's not used for now.

## Deploy Plan

Apply migration and then deploy