### PR TITLE
[front] feat(FS tools): add mime type filtering

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -45,7 +45,6 @@ import {
   stripNullBytes,
   timeFrameFromNow,
 } from "@app/types";
-import { CONTENT_NODE_MIME_TYPES } from "../../../../../sdks/js/src";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "data_sources_file_system",

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -221,11 +221,12 @@ const createServer = (
             "has children (hasChildren: true), it means that it can be passed as a rootNodeId."
         ),
       mimeTypes: z
-        .string()
+        .array(z.string())
         .optional()
         .describe(
-          "The mime type to search for. If provided, only nodes with this mime type will be " +
-            "returned. If not provided, all mime types will be returned."
+          "The mime types to search for. If provided, only nodes with one of these mime types " +
+            "will be returned. If not provided, no filter will be applied. The mime types passed " +
+            "here must be one of the mime types found in the 'mimeType' field."
         ),
       dataSources:
         ConfigurableToolInputSchemas[
@@ -278,7 +279,7 @@ const createServer = (
         query,
         filter: {
           data_source_views: viewFilter,
-          mime_types: mimeTypes ? { in: [mimeTypes], not: null } : undefined,
+          mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
         },
         options: {
           cursor: nextPageCursor,
@@ -317,11 +318,12 @@ const createServer = (
             "If not provided, the content at the root of the filesystem will be shown."
         ),
       mimeTypes: z
-        .string()
+        .array(z.string())
         .optional()
         .describe(
-          "The mime type to search for. If provided, only nodes with this mime type will be " +
-            "returned. If not provided, all mime types will be returned."
+          "The mime types to search for. If provided, only nodes with one of these mime types " +
+            "will be returned. If not provided, no filter will be applied. The mime types passed " +
+            "here must be one of the mime types found in the 'mimeType' field."
         ),
       dataSources:
         ConfigurableToolInputSchemas[
@@ -367,7 +369,7 @@ const createServer = (
         searchResult = await coreAPI.searchNodes({
           filter: {
             data_source_views: dataSourceViewFilter,
-            mime_types: mimeTypes ? { in: [mimeTypes], not: null } : undefined,
+            mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
           },
           options,
         });
@@ -393,7 +395,7 @@ const createServer = (
             data_source_views: makeDataSourceViewFilter([dataSourceConfig]),
             node_ids: dataSourceConfig.parentsIn ?? undefined,
             parent_id: dataSourceConfig.parentsIn ? undefined : ROOT_PARENT_ID,
-            mime_types: mimeTypes ? { in: [mimeTypes], not: null } : undefined,
+            mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
           },
           options,
         });
@@ -407,7 +409,7 @@ const createServer = (
           filter: {
             data_source_views: dataSourceViewFilter,
             parent_id: nodeId,
-            mime_types: mimeTypes ? { in: [mimeTypes], not: null } : undefined,
+            mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
           },
           options,
         });

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -220,7 +220,13 @@ const createServer = (
             "and descendant of a specific node. If a node output by this tool or the list tool" +
             "has children (hasChildren: true), it means that it can be passed as a rootNodeId."
         ),
-      // TODO(2025-06-03 aubin): add search by mime type (not supported in the backend currently).
+      mimeTypes: z
+        .string()
+        .optional()
+        .describe(
+          "The mime type to search for. If provided, only nodes with this mime type will be " +
+            "returned. If not provided, all mime types will be returned."
+        ),
       dataSources:
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
@@ -234,6 +240,7 @@ const createServer = (
       sortBy,
       nextPageCursor,
       rootNodeId,
+      mimeTypes,
     }) => {
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
@@ -271,6 +278,7 @@ const createServer = (
         query,
         filter: {
           data_source_views: viewFilter,
+          mime_types: mimeTypes ? { in: [mimeTypes], not: null } : undefined,
         },
         options: {
           cursor: nextPageCursor,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -217,7 +217,8 @@ const createServer = (
           "The node ID of the node to start the search from. If not provided, the search will " +
             "start from the root of the filesystem. This ID can be found from previous search " +
             "results in the 'nodeId' field. This parameter restricts the search to the children " +
-            "and descendant of a specific node."
+            "and descendant of a specific node. If a node output by this tool or the list tool" +
+            "has children (hasChildren: true), it means that it can be passed as a rootNodeId."
         ),
       // TODO(2025-06-03 aubin): add search by mime type (not supported in the backend currently).
       dataSources:


### PR DESCRIPTION
## Description

- This PR adds mimeType-based filtering to the `find` and `search` tools.

Two things worth testing as a next step:
- Technically we could break it down in two arguments `includedMimeTypes` and `excludedMimeTypes` to allow excluding certain mime types, not seeing the use case for it so not doing it for now.
- We could also pass the existing mime types as an enum to help with discovery, I fear it may cause a too eager discovery though.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
