### PR TITLE
[front] chore: fix type error in build

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -248,7 +248,7 @@ export const WarningResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.WARNING),
   warningTitle: z.string(),
   text: z.string(),
-  warningData: z.record(z.unknown()).optional(),
+  warningData: z.record(z.string(), z.unknown()).optional(),
   uri: z.literal(""),
 });
 

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -98,7 +98,10 @@ function createServer(
       | TextContent[]
       | {
           type: "resource";
-          resource: IncludeResultResourceType | IncludeQueryResourceType;
+          resource:
+            | IncludeResultResourceType
+            | IncludeQueryResourceType
+            | WarningResourceType;
         }[];
   }> => {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);


### PR DESCRIPTION
## Description

- This PR fixes a type error in the output type of the `includeFunction` used in the include MCP server.

## Tests

## Risk


## Deploy Plan

- Deploy front.
