### PR TITLE
auth: tighten groups to requested + role when provided

### DIFF
--- a/front/lib/actions/dust_app_run.ts
+++ b/front/lib/actions/dust_app_run.ts
@@ -45,6 +45,7 @@ import type {
 import {
   Err,
   getHeaderFromGroupIds,
+  getHeaderFromRole,
   Ok,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
@@ -424,7 +425,10 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
       apiConfig,
       {
         ...prodCredentials,
-        extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+        extraHeaders: {
+          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...getHeaderFromRole(auth.role()),
+        },
       },
       logger,
       apiConfig.nodeEnv === "development" ? "http://localhost:3000" : null

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -11,7 +11,7 @@ import type { Action } from "@app/lib/registry";
 import { cloneBaseConfig } from "@app/lib/registry";
 import logger from "@app/logger/logger";
 import type { APIError, Result } from "@app/types";
-import { Err, getHeaderFromGroupIds, Ok } from "@app/types";
+import { Err, getHeaderFromGroupIds, getHeaderFromRole, Ok } from "@app/types";
 
 const ActionResponseBaseSchema = t.type({
   run_id: t.string,
@@ -87,7 +87,10 @@ export async function callAction<V extends t.Mixed>(
     apiConfig.getDustAPIConfig(),
     {
       ...prodCredentials,
-      extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+      extraHeaders: {
+        ...getHeaderFromGroupIds(requestedGroupIds),
+        ...getHeaderFromRole(auth.role()),
+      },
     },
     logger
   );

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -9,7 +9,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types";
-import { getHeaderFromGroupIds } from "@app/types/groups";
+import { getHeaderFromGroupIds, getHeaderFromRole } from "@app/types/groups";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "agent_router",
@@ -28,13 +28,17 @@ const createServer = (auth: Authenticator): McpServer => {
     {},
     async () => {
       const owner = auth.getNonNullableWorkspace();
-      const prodCredentials = await prodAPICredentialsForOwner(owner);
       const requestedGroupIds = auth.groups().map((g) => g.sId);
+
+      const prodCredentials = await prodAPICredentialsForOwner(owner);
       const api = new DustAPI(
         apiConfig.getDustAPIConfig(),
         {
           ...prodCredentials,
-          extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+          extraHeaders: {
+            ...getHeaderFromGroupIds(requestedGroupIds),
+            ...getHeaderFromRole(auth.role()),
+          },
         },
         logger
       );
@@ -89,13 +93,17 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     async ({ userMessage }) => {
       const owner = auth.getNonNullableWorkspace();
-      const prodCredentials = await prodAPICredentialsForOwner(owner);
       const requestedGroupIds = auth.groups().map((g) => g.sId);
+
+      const prodCredentials = await prodAPICredentialsForOwner(owner);
       const api = new DustAPI(
         apiConfig.getDustAPIConfig(),
         {
           ...prodCredentials,
-          extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+          extraHeaders: {
+            ...getHeaderFromGroupIds(requestedGroupIds),
+            ...getHeaderFromRole(auth.role()),
+          },
         },
         logger
       );

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -21,7 +21,13 @@ import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { Err, getHeaderFromGroupIds, normalizeError, Ok } from "@app/types";
+import {
+  Err,
+  getHeaderFromGroupIds,
+  getHeaderFromRole,
+  normalizeError,
+  Ok,
+} from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "run_agent",
@@ -174,13 +180,17 @@ export default async function createServer(
       }
       const childAgentId = childAgentIdRes.value;
 
-      const prodCredentials = await prodAPICredentialsForOwner(owner);
       const requestedGroupIds = auth.groups().map((g) => g.sId);
+
+      const prodCredentials = await prodAPICredentialsForOwner(owner);
       const api = new DustAPI(
         config.getDustAPIConfig(),
         {
           ...prodCredentials,
-          extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+          extraHeaders: {
+            ...getHeaderFromGroupIds(requestedGroupIds),
+            ...getHeaderFromRole(auth.role()),
+          },
         },
         logger
       );

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -33,7 +33,11 @@ import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type { DatasetSchema } from "@app/types";
 import type { SpecificationBlockType } from "@app/types";
-import { getHeaderFromGroupIds, SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import {
+  getHeaderFromGroupIds,
+  getHeaderFromRole,
+  SUPPORTED_MODEL_CONFIGS,
+} from "@app/types";
 
 import { ConfigurableToolInputSchemas } from "../input_schemas";
 
@@ -335,15 +339,18 @@ export default async function createServer(
           auth
         );
 
-        const prodCredentials = await prodAPICredentialsForOwner(owner);
         const requestedGroupIds = auth.groups().map((g) => g.sId);
-        const apiConfig = config.getDustAPIConfig();
 
+        const prodCredentials = await prodAPICredentialsForOwner(owner);
+        const apiConfig = config.getDustAPIConfig();
         const api = new DustAPI(
           apiConfig,
           {
             ...prodCredentials,
-            extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+            extraHeaders: {
+              ...getHeaderFromGroupIds(requestedGroupIds),
+              ...getHeaderFromRole(auth.role()),
+            },
           },
           logger,
           apiConfig.nodeEnv === "development" ? "http://localhost:3000" : null

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -8,7 +8,7 @@ import type { DustRegistryActionName } from "@app/lib/registry";
 import { getDustProdAction } from "@app/lib/registry";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
-import { Err, getHeaderFromGroupIds, Ok } from "@app/types";
+import { Err, getHeaderFromGroupIds, getHeaderFromRole, Ok } from "@app/types";
 
 // Record an event and a log for the action error.
 const logActionError = (
@@ -85,13 +85,17 @@ export async function runActionStreamed(
   statsDClient.increment("use_actions.count", 1, tags);
   const now = new Date();
 
-  const prodCredentials = await prodAPICredentialsForOwner(owner);
   const requestedGroupIds = auth.groups().map((g) => g.sId);
+
+  const prodCredentials = await prodAPICredentialsForOwner(owner);
   const api = new DustAPI(
     apiConfig.getDustAPIConfig(),
     {
       ...prodCredentials,
-      extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+      extraHeaders: {
+        ...getHeaderFromGroupIds(requestedGroupIds),
+        ...getHeaderFromRole(auth.role()),
+      },
     },
     logger
   );
@@ -201,13 +205,17 @@ export async function runAction(
   statsDClient.increment("use_actions.count", 1, tags);
   const now = new Date();
 
-  const prodCredentials = await prodAPICredentialsForOwner(owner);
   const requestedGroupIds = auth.groups().map((g) => g.sId);
+
+  const prodCredentials = await prodAPICredentialsForOwner(owner);
   const api = new DustAPI(
     apiConfig.getDustAPIConfig(),
     {
       ...prodCredentials,
-      extraHeaders: getHeaderFromGroupIds(requestedGroupIds),
+      extraHeaders: {
+        ...getHeaderFromGroupIds(requestedGroupIds),
+        ...getHeaderFromRole(auth.role()),
+      },
     },
     logger
   );

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -21,7 +21,11 @@ import logger from "@app/logger/logger";
 import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { UserTypeWithWorkspaces, WithAPIErrorResponse } from "@app/types";
-import { getGroupIdsFromHeaders, getUserEmailFromHeaders } from "@app/types";
+import {
+  getGroupIdsFromHeaders,
+  getRoleFromHeaders,
+  getUserEmailFromHeaders,
+} from "@app/types";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -339,7 +343,8 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
       const keyAndWorkspaceAuth = await Authenticator.fromKey(
         keyRes.value,
         wId,
-        getGroupIdsFromHeaders(req.headers)
+        getGroupIdsFromHeaders(req.headers),
+        getRoleFromHeaders(req.headers)
       );
       const { keyAuth } = keyAndWorkspaceAuth;
       let { workspaceAuth } = keyAndWorkspaceAuth;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -495,25 +495,13 @@ export class Authenticator {
     let keySubscription: SubscriptionResource | null = null;
 
     if (workspace) {
-      [keyGroups, requestedGroups, keySubscription, workspaceSubscription] =
-        await Promise.all([
-          // Key related attributes.
-          GroupResource.listWorkspaceGroupsFromKey(key),
-          requestedGroupIds
-            ? GroupResource.listGroupsWithSystemKey(key, requestedGroupIds)
-            : [],
-          getSubscriptionForWorkspace(keyWorkspace),
-          // Workspace related attributes.
-          getSubscriptionForWorkspace(workspace),
-        ]);
-    }
-
-    if (workspace) {
       if (requestedGroupIds && key.isSystem) {
         [requestedGroups, keySubscription, workspaceSubscription] =
           await Promise.all([
+            // Key related attributes.
             GroupResource.listGroupsWithSystemKey(key, requestedGroupIds),
             getSubscriptionForWorkspace(keyWorkspace),
+            // Workspace related attributes.
             getSubscriptionForWorkspace(workspace),
           ]);
       } else {
@@ -521,6 +509,7 @@ export class Authenticator {
           [
             GroupResource.listWorkspaceGroupsFromKey(key),
             getSubscriptionForWorkspace(keyWorkspace),
+            // Workspace related attributes.
             getSubscriptionForWorkspace(workspace),
           ]
         );

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -442,12 +442,15 @@ export class Authenticator {
    * @param wId the target workspaceId
    * @param requestedGroupIds optional groups to assign the auth in place of the key groups (only
    *                                   possible with a system key).
+   * @param requestedRole optional role to assign the auth in place of the key role (only possible
+   *                               with a system key).
    * @returns Promise<{ workspaceAuth: Authenticator, keyAuth: Authenticator }>
    */
   static async fromKey(
     key: KeyResource,
     wId: string,
-    requestedGroupIds?: string[]
+    requestedGroupIds?: string[],
+    requestedRole?: RoleType
   ): Promise<{
     workspaceAuth: Authenticator;
     keyAuth: Authenticator;
@@ -476,10 +479,11 @@ export class Authenticator {
     let role = "none" as RoleType;
     const isKeyWorkspace = keyWorkspace.id === workspace?.id;
     if (isKeyWorkspace) {
-      // System keys have admin role on their workspace.
       if (key.isSystem) {
-        role = "admin";
+        // System keys have admin role on their workspace unless requested otherwise.
+        role = requestedRole ?? "admin";
       } else {
+        // Regular keys have builder role on their workspace.
         role = "builder";
       }
     }

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -90,7 +90,7 @@ export function getRoleFromHeaders(
   let role = headers[DustRoleHeader.toLowerCase()];
   if (typeof role === "string") {
     role = role.trim();
-    if (role.trim().length > 0 && isRoleType(role)) {
+    if (role.length > 0 && isRoleType(role)) {
       return role;
     }
   }

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -1,4 +1,6 @@
 import type { ModelId } from "./shared/model_id";
+import type { RoleType } from "./user";
+import { isRoleType } from "./user";
 
 /**
  * system group: Accessible by no-one other than our system API keys. Has access
@@ -77,5 +79,29 @@ export function getHeaderFromGroupIds(groupIds: string[] | undefined) {
 
   return {
     [DustGroupIdsHeader]: groupIds.join(","),
+  };
+}
+
+const DustRoleHeader = "X-Dust-Role";
+
+export function getRoleFromHeaders(
+  headers: Record<string, string | string[] | undefined>
+): RoleType | undefined {
+  let role = headers[DustRoleHeader.toLowerCase()];
+  if (typeof role === "string") {
+    role = role.trim();
+    if (role.trim().length > 0 && isRoleType(role)) {
+      return role;
+    }
+  }
+  return undefined;
+}
+
+export function getHeaderFromRole(role: RoleType | undefined) {
+  if (!role) {
+    return undefined;
+  }
+  return {
+    [DustRoleHeader]: role,
   };
 }

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -24,6 +24,10 @@ export const RoleSchema = t.keyof(keyObject(ROLES));
 
 export type RoleType = t.TypeOf<typeof RoleSchema>;
 
+export function isRoleType(role: string): role is RoleType {
+  return ROLES.includes(role as RoleType);
+}
+
 export const ActiveRoleSchema = t.keyof(keyObject(ACTIVE_ROLES));
 
 export type ActiveRoleType = t.TypeOf<typeof ActiveRoleSchema>;


### PR DESCRIPTION
## Description

When using `requestedGroups` (dust app run, router, runActionStreamed) with a system API Key we would add the groups to the key groups but the key is a system API key so it has access to all groups already.

Instead pin on the requestedGroups also make sure we pin the role and don't upgrade to admin.

## Tests

Tested locally

## Risk

High, all re-entrant calls basically. Will test on front-edge.

## Deploy Plan

- test on front-edge
- deploy `front`