### PR TITLE
enh: enable HTTP egress proxy for core untrusted requests againw

### DIFF
--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -106,19 +106,19 @@ impl HttpRequest {
             }
         }));
 
-        // if let (Some(proxy_host), Some(proxy_port)) = (
-        //     UNTRUSTED_EGRESS_PROXY_HOST.as_ref(),
-        //     UNTRUSTED_EGRESS_PROXY_PORT.as_ref(),
-        // ) {
-        //     let proxy_url = format!("http://{}:{}", proxy_host, proxy_port);
-        //     let proxy = reqwest::Proxy::all(&proxy_url)
-        //         .map_err(|e| anyhow!("Failed to configure proxy: {}", e))?;
-        //     client_builder = client_builder.proxy(proxy);
-        //     info!(
-        //         proxy_url = proxy_url.as_str(),
-        //         "Using proxy for HTTP request"
-        //     );
-        // }
+        if let (Some(proxy_host), Some(proxy_port)) = (
+            UNTRUSTED_EGRESS_PROXY_HOST.as_ref(),
+            UNTRUSTED_EGRESS_PROXY_PORT.as_ref(),
+        ) {
+            let proxy_url = format!("http://{}:{}", proxy_host, proxy_port);
+            let proxy = reqwest::Proxy::all(&proxy_url)
+                .map_err(|e| anyhow!("Failed to configure proxy: {}", e))?;
+            client_builder = client_builder.proxy(proxy);
+            info!(
+                proxy_url = proxy_url.as_str(),
+                "Using proxy for HTTP request"
+            );
+        }
 
         let client = client_builder
             .build()


### PR DESCRIPTION
## Description

We now have the squid proxy with dynamic IP deployed in dust-kube.

Secrets have been updated. Switching to this for our untrusted egress on core

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
