### PR TITLE
[front] fix(table-upserts): fix table schema validation flow

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1955,6 +1955,7 @@ export async function renderAndUpsertPageFromCache({
             sourceUrl:
               parentDb.notionUrl ??
               `https://www.notion.so/${parentDb.notionDatabaseId.replace(/-/g, "")}`,
+            allowEmptySchema: true,
           })
         );
       } else {
@@ -2683,6 +2684,7 @@ export async function upsertDatabaseStructuredDataFromCache({
       sourceUrl:
         dbModel.notionUrl ??
         `https://www.notion.so/${dbModel.notionDatabaseId.replace(/-/g, "")}`,
+      allowEmptySchema: true,
     })
   );
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -964,6 +964,7 @@ export async function upsertDataSourceTableFromCsv({
   mimeType,
   sourceUrl,
   tags,
+  allowEmptySchema,
 }: {
   dataSourceConfig: DataSourceConfig;
   tableId: string;
@@ -978,6 +979,7 @@ export async function upsertDataSourceTableFromCsv({
   mimeType: string;
   sourceUrl?: string;
   tags?: string[];
+  allowEmptySchema?: boolean;
 }) {
   const localLogger = logger.child({ ...loggerArgs, tableId, tableName });
   const statsDTags = [
@@ -1032,6 +1034,7 @@ export async function upsertDataSourceTableFromCsv({
     timestamp: null,
     tags: tags ?? null,
     sourceUrl: sourceUrl ?? null,
+    allowEmptySchema,
   };
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -626,6 +626,7 @@ export interface UpsertTableArgs {
   tags?: string[] | null;
   parentId?: string | null;
   parents?: string[] | null;
+  allowEmptySchema?: boolean;
 }
 
 export function isUpsertTableArgs(
@@ -783,7 +784,7 @@ export async function upsertTable({
         });
       }
     }
-    if (schemaRes.value.schema.length === 0) {
+    if (!params.allowEmptySchema && schemaRes.value.schema.length === 0) {
       return new Err({
         name: "dust_error",
         code: "invalid_csv_content",

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -783,6 +783,13 @@ export async function upsertTable({
         });
       }
     }
+    if (schemaRes.value.schema.length === 0) {
+      return new Err({
+        name: "dust_error",
+        code: "invalid_csv_content",
+        message: "Invalid CSV content, skipping",
+      });
+    }
   }
 
   if (async) {

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -741,51 +741,51 @@ export async function upsertTable({
 
   const title = params.title.trim() || name.trim() || UNTITLED_TITLE;
 
-  if (async) {
-    if (fileId) {
-      const file = await FileResource.fetchById(auth, fileId);
-      if (!file) {
-        return new Err<DustError>({
+  if (fileId) {
+    const file = await FileResource.fetchById(auth, fileId);
+    if (!file) {
+      return new Err<DustError>({
+        name: "dust_error",
+        code: "file_not_found",
+        message:
+          "The file associated with the fileId you provided was not found",
+      });
+    }
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+    const schemaRes = await coreAPI.tableValidateCSVContent({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
+      bucket: file.getBucketForVersion("processed").name,
+      bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+    });
+    if (schemaRes.isErr()) {
+      if (schemaRes.error.code === "invalid_csv_content") {
+        return new Err({
           name: "dust_error",
-          code: "file_not_found",
-          message:
-            "The file associated with the fileId you provided was not found",
+          code: "invalid_csv_content",
+          message: schemaRes.error.message,
+        });
+      } else {
+        logger.error(
+          {
+            bucket: file.getBucketForVersion("processed").name,
+            bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+            dataSourceId: dataSource.sId,
+            error: schemaRes.error,
+          },
+          "Error validating CSV content"
+        );
+        return new Err({
+          name: "dust_error",
+          code: "internal_error",
+          message: schemaRes.error.message,
         });
       }
-      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-
-      const schemaRes = await coreAPI.tableValidateCSVContent({
-        projectId: dataSource.dustAPIProjectId,
-        dataSourceId: dataSource.dustAPIDataSourceId,
-        bucket: file.getBucketForVersion("processed").name,
-        bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
-      });
-      if (schemaRes.isErr()) {
-        if (schemaRes.error.code === "invalid_csv_content") {
-          return new Err({
-            name: "dust_error",
-            code: "invalid_csv_content",
-            message: schemaRes.error.message,
-          });
-        } else {
-          logger.error(
-            {
-              bucket: file.getBucketForVersion("processed").name,
-              bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
-              dataSourceId: dataSource.sId,
-              error: schemaRes.error,
-            },
-            "Error validating CSV content"
-          );
-          return new Err({
-            name: "dust_error",
-            code: "internal_error",
-            message: schemaRes.error.message,
-          });
-        }
-      }
     }
+  }
 
+  if (async) {
     const enqueueRes = await enqueueUpsertTable({
       upsertTable: {
         workspaceId: owner.sId,

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -154,21 +154,6 @@ export async function upsertTableFromCsv({
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-  if (file) {
-    const schemaRes = await coreAPI.tableValidateCSVContent({
-      projectId: dataSource.dustAPIProjectId,
-      dataSourceId: dataSource.dustAPIDataSourceId,
-      bucket: file.getBucketForVersion("processed").name,
-      bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
-    });
-    if (schemaRes.isErr() || schemaRes.value.schema.length === 0) {
-      return new Err({
-        type: "invalid_request_error",
-        message: "Invalid CSV content, skipping",
-      });
-    }
-  }
-
   const tableRes = await coreAPI.upsertTable({
     projectId: dataSource.dustAPIProjectId,
     dataSourceId: dataSource.dustAPIDataSourceId,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -93,6 +93,11 @@ vi.mock("@app/lib/file_storage", () => ({
       createReadStream: () => Readable.from([mockFileContent.content]),
     }),
   })),
+  getPrivateUploadBucket: vi.fn(() => ({
+    file: () => ({
+      createReadStream: () => Readable.from([mockFileContent.content]),
+    }),
+  })),
 }));
 
 describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv", () => {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -96,7 +96,7 @@ vi.mock("@app/lib/file_storage", () => ({
 }));
 
 describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv", () => {
-  itInTransaction("succesfully upserts a CSV received as file", async (t) => {
+  itInTransaction("successfully upserts a CSV received as file", async (t) => {
     const { req, res, workspace, globalGroup } =
       await createPublicApiMockRequest({
         systemKey: true,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -222,6 +222,7 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
         description: "desc",
         fileId: file.sId,
         tableId: "fooTable-1",
+        allowEmptySchema: true,
       };
 
       await handler(req, res);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -129,6 +129,7 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
       description: "desc",
       fileId: file.sId,
       tableId: "fooTable-1",
+      allowEmptySchema: true,
     };
 
     // First fetch is to create the table

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -230,6 +230,17 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
         allowEmptySchema: true,
       };
 
+      global.fetch = vi.fn().mockImplementation(async (url: string) => {
+        if (url.endsWith("/validate_csv_content")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(CORE_VALIDATE_CSV_FAKE_RESPONSE), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            })
+          );
+        }
+      });
+
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(400);

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2428,6 +2428,7 @@ export const UpsertTableFromCsvRequestSchema = z.object({
   sourceUrl: z.string().nullable().optional(),
   tableId: z.string(),
   fileId: z.string(),
+  allowEmptySchema: z.boolean().optional(),
 });
 
 export type UpsertTableFromCsvRequestType = z.infer<


### PR DESCRIPTION
## Description

- This PR moves the CSV content validation check up in the upsert table flow.
- This does not change anything for regular upserts and prevents doing the check twice for connectors upserts (before enqueuing and when depiling the upsert queue).
- It adds a validation on empty schemas for connectors upserts, which is disabled for Notion since Notion has databases that have empty schemas that should still be upserted due to having children.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Then deploy connectors.
