### PR TITLE
Lower connection pool in connectors Sequelize

### DIFF
--- a/connectors/src/resources/storage/index.ts
+++ b/connectors/src/resources/storage/index.ts
@@ -44,7 +44,7 @@ export const sequelizeConnection = new Sequelize(
   {
     pool: {
       // Default is 5.
-      max: isDevelopment() ? 5 : 10,
+      max: isDevelopment() ? 5 : 8,
     },
     logging: isDevelopment() && DB_LOGGING_ENABLED ? sequelizeLogger : false,
     hooks: {


### PR DESCRIPTION
## Description

- We have observed issues with having too many clients connected at once ([logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZdF94fm2HVtsQAAABhBWmRGOTVIekFBQ2tock5oR2M2azNBQUoAAAAkMDE5NzQ1ZjctZjY4ZS00OGM3LWEwNmYtYjI0YjcxNDZlMWEwAAACqw&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1749225252000&to_ts=1749225552000&live=false)).
- Looking [here](https://console.cloud.google.com/sql/instances/dust-api-db/system-insights?inv=1&invt=AbzZ-w&project=or1g1n-186209) we peak at 850 connections.
- This PR reduces the connection pool in production in connectors from 10 to 8 (default value in Sequelize is 5).

## Tests

## Risk

- May slow down the activity if we account for the time it takes to take a connection.

## Deploy Plan

- Deploy connectors.
