### PR TITLE
[MCP Extract] Release extract MCP action (GA)  & migrate from legacy action for all workspaces

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1201,7 +1201,10 @@ function AddKnowledgeDropdown({
             return r.isOk() && r.value.name === "query_tables";
           });
         case "PROCESS":
-          return false;
+          return mcpServerViewsWithKnowledge.some((v) => {
+            const r = getInternalMCPServerNameAndWorkspaceId(v.server.sId);
+            return r.isOk() && r.value.name === "extract_data";
+          });
         default:
           assertNever(key);
       }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -177,9 +177,6 @@ export const INTERNAL_MCP_SERVERS: Record<
   extract_data: {
     id: 12,
     availability: "auto",
-    isRestricted: (plan, featureFlags) => {
-      return featureFlags.includes("dev_mcp_actions");
-    },
   },
   missing_action_catcher: {
     id: 13,

--- a/front/lib/actions/mcp_internal_actions/servers/process.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process.ts
@@ -9,10 +9,7 @@ import {
   generateJSONFileAndSnippet,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
-import {
-  DEFAULT_PROCESS_ACTION_NAME,
-  PROCESS_ACTION_TOP_K,
-} from "@app/lib/actions/constants";
+import { PROCESS_ACTION_TOP_K } from "@app/lib/actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import {
   ConfigurableToolInputSchemas,
@@ -52,7 +49,7 @@ import type {
 import { isUserMessageType, timeFrameFromNow } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: DEFAULT_PROCESS_ACTION_NAME,
+  name: "extract_data",
   version: "1.0.0",
   description: "Structured extraction",
   icon: "ActionScanIcon",

--- a/front/lib/actions/mcp_internal_actions/servers/process.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process.ts
@@ -9,7 +9,10 @@ import {
   generateJSONFileAndSnippet,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
-import { PROCESS_ACTION_TOP_K } from "@app/lib/actions/constants";
+import {
+  DEFAULT_PROCESS_ACTION_NAME,
+  PROCESS_ACTION_TOP_K,
+} from "@app/lib/actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import {
   ConfigurableToolInputSchemas,
@@ -49,9 +52,9 @@ import type {
 import { isUserMessageType, timeFrameFromNow } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "extract_data",
+  name: DEFAULT_PROCESS_ACTION_NAME,
   version: "1.0.0",
-  description: "Structured extraction (mcp)",
+  description: "Structured extraction",
   icon: "ActionScanIcon",
   authorization: null,
 };


### PR DESCRIPTION
Description
---
As per title: legacy extract action disappears from builder, MCP extract action appears, for all workspaces (ungated). All legacy actions are migrated to MCP.

Legacy action code is not completely removed, as for other actions (still used in global agents, JIT actions, etc.). Removing it should be done in a later PR when there are no more dependencies.

Key changes:
- Removes the `dev_mcp_actions` feature flag restriction from the `extract_data` MCP server
- Hides the legacy PROCESS action in the assistant builder when the `extract_data` MCP server is available

Risks
---
Migration can be rolled back, either as a whole or per-workspace. Rollback tested, see below.

Tests
---
Local tests:

+ create 2 extract-based agents in 2 different workspaces
+ run them both, check they work
+ migrate all workspaces
+ check new agents work
+ rollback workspace per workspace
+ check agents rolled back works

Deploy plan
---
- deploy front
- run `npx tsx migrations/20250526_migrate_extract_to_mcp.ts --execute` in US and EU
- save sql rollback files and monitor

