### PR TITLE
Fix: error when syncing remote mcp servers

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -350,7 +350,7 @@ export async function fetchRemoteServerMetaDataByURL(
   auth: Authenticator,
   url: string,
   headers?: Record<string, string>
-): Promise<Result<Omit<MCPServerType, "sId">, Error>> {
+): ReturnType<typeof fetchRemoteServerMetaData> {
   const r = await connectToMCPServer(auth, {
     params: {
       type: "remoteMCPServerUrl",
@@ -360,18 +360,62 @@ export async function fetchRemoteServerMetaDataByURL(
   });
 
   if (r.isErr()) {
+    return r;
+  }
+  try {
+    return await fetchRemoteServerMetaData(auth, r.value);
+  } catch (e: unknown) {
     logger.error(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,
-        error: r.error,
+        error: e,
       },
-      "Error connecting to remote MCP server"
+      "Error fetching metadata from remote MCP server"
     );
-    return new Err(r.error);
+    return new Err(
+      new Error("Error getting metadata from the remote MCP server.")
+    );
+  } finally {
+    await r.value.close();
   }
+}
 
-  const mcpClient = r.value;
+export async function fetchRemoteServerMetaDataByServerId(
+  auth: Authenticator,
+  serverId: string
+): ReturnType<typeof fetchRemoteServerMetaData> {
+  const r = await connectToMCPServer(auth, {
+    params: {
+      type: "mcpServerId",
+      mcpServerId: serverId,
+    },
+  });
 
+  if (r.isErr()) {
+    return r;
+  }
+  try {
+    return await fetchRemoteServerMetaData(auth, r.value);
+  } catch (e: unknown) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        error: e,
+      },
+      "Error fetching metadata from remote MCP server"
+    );
+    return new Err(
+      new Error("Error getting metadata from the remote MCP server.")
+    );
+  } finally {
+    await r.value.close();
+  }
+}
+
+async function fetchRemoteServerMetaData(
+  auth: Authenticator,
+  mcpClient: Client
+): Promise<Result<Omit<MCPServerType, "sId">, Error>> {
   try {
     const serverVersion = mcpClient.getServerVersion();
     const metadata = extractMetadataFromServerVersion(serverVersion);
@@ -395,7 +439,5 @@ export async function fetchRemoteServerMetaDataByURL(
     return new Err(
       new Error("Error getting metadata from the remote MCP server.")
     );
-  } finally {
-    await mcpClient.close();
   }
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -362,22 +362,10 @@ export async function fetchRemoteServerMetaDataByURL(
   if (r.isErr()) {
     return r;
   }
-  try {
-    return await fetchRemoteServerMetaData(auth, r.value);
-  } catch (e: unknown) {
-    logger.error(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        error: e,
-      },
-      "Error fetching metadata from remote MCP server"
-    );
-    return new Err(
-      new Error("Error getting metadata from the remote MCP server.")
-    );
-  } finally {
-    await r.value.close();
-  }
+
+  const result = await fetchRemoteServerMetaData(auth, r.value);
+  await r.value.close();
+  return result;
 }
 
 export async function fetchRemoteServerMetaDataByServerId(
@@ -394,22 +382,10 @@ export async function fetchRemoteServerMetaDataByServerId(
   if (r.isErr()) {
     return r;
   }
-  try {
-    return await fetchRemoteServerMetaData(auth, r.value);
-  } catch (e: unknown) {
-    logger.error(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        error: e,
-      },
-      "Error fetching metadata from remote MCP server"
-    );
-    return new Err(
-      new Error("Error getting metadata from the remote MCP server.")
-    );
-  } finally {
-    await r.value.close();
-  }
+
+  const result = await fetchRemoteServerMetaData(auth, r.value);
+  await r.value.close();
+  return result;
 }
 
 async function fetchRemoteServerMetaData(

--- a/front/pages/api/w/[wId]/mcp/[serverId]/sync.test.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/sync.test.ts
@@ -31,7 +31,7 @@ vi.mock(import("@app/lib/actions/mcp_actions"), async (importOriginal) => {
   const mod = await importOriginal();
   return {
     ...mod,
-    fetchRemoteServerMetaDataByURL: vi.fn().mockResolvedValue({
+    fetchRemoteServerMetaData: vi.fn().mockResolvedValue({
       name: "Updated Server Name",
       description: "Updated server description",
       tools: [

--- a/front/pages/api/w/[wId]/mcp/[serverId]/sync.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/sync.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
+import { fetchRemoteServerMetaDataByServerId } from "@app/lib/actions/mcp_metadata";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -65,15 +65,7 @@ async function handler(
     });
   }
 
-  const r = await fetchRemoteServerMetaDataByURL(
-    auth,
-    server.url,
-    server.sharedSecret
-      ? {
-          Authorization: `Bearer ${server.sharedSecret}`,
-        }
-      : undefined
-  );
+  const r = await fetchRemoteServerMetaDataByServerId(auth, server.sId);
   if (r.isErr()) {
     await server.markAsErrored(auth, {
       lastError: r.error.message,

--- a/front/temporal/remote_tools/activities.ts
+++ b/front/temporal/remote_tools/activities.ts
@@ -1,4 +1,4 @@
-import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
+import { fetchRemoteServerMetaDataByServerId } from "@app/lib/actions/mcp_metadata";
 import { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { getWorkspaceByModelId } from "@app/lib/workspace";
@@ -33,15 +33,7 @@ export async function syncRemoteMCPServers(ids: number[]): Promise<void> {
       const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
       // Fetch the remote server metadata
-      const r = await fetchRemoteServerMetaDataByURL(
-        auth,
-        server.url,
-        server.sharedSecret
-          ? {
-              Authorization: `Bearer ${server.sharedSecret}`,
-            }
-          : undefined
-      );
+      const r = await fetchRemoteServerMetaDataByServerId(auth, server.sId);
 
       if (r.isErr()) {
         logger.error(


### PR DESCRIPTION
## Description

Syncing was failing in the activity and when done manually because both path were using URL and headers and did not take into account the potential oauth connection.
Fixed by exposing a way to do it via the remote mcp server id and therefor leverage correctly the auth system.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front` and `front-worker`