### PR TITLE
[front] - feat(AB v2): add instructions editor block

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -2,22 +2,22 @@ import { Page } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AdvancedSettings } from "@app/components/agent_builder/instructions/AdvancedSettings";
-import {
-  useAgentBuilderInstructionsContext,
-} from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
+import { useAgentBuilderInstructionsContext } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
+import { AgentBuilderInstructionsEditor } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
 
 export function AgentBuilderInstructionsBlock() {
   const { generationSettings, setGenerationSettings, models } =
     useAgentBuilderInstructionsContext();
 
   return (
-    <div className="flex flex-col gap-4">
-      <Page.H>Instructions</Page.H>
+    <div className="flex h-full flex-col gap-4">
       <div className="flex flex-col items-center justify-between sm:flex-row">
-        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Command or guideline you provide to your agent to direct its
-          responses.
-        </span>
+        <Page.P>
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Command or guideline you provide to your agent to direct its
+            responses.
+          </span>
+        </Page.P>
         <div className="flex w-full flex-col gap-2 sm:w-auto">
           <div className="flex items-center gap-2">
             <AdvancedSettings
@@ -28,6 +28,7 @@ export function AgentBuilderInstructionsBlock() {
           </div>
         </div>
       </div>
+      <AgentBuilderInstructionsEditor />
     </div>
   );
 }

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -11,6 +11,7 @@ export function AgentBuilderInstructionsBlock() {
 
   return (
     <div className="flex h-full flex-col gap-4">
+      <Page.H>Instructions</Page.H>
       <div className="flex flex-col items-center justify-between sm:flex-row">
         <Page.P>
           <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -1,7 +1,10 @@
+import { Page } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AdvancedSettings } from "@app/components/agent_builder/instructions/AdvancedSettings";
-import { useAgentBuilderInstructionsContext } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
+import {
+  useAgentBuilderInstructionsContext,
+} from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
 
 export function AgentBuilderInstructionsBlock() {
   const { generationSettings, setGenerationSettings, models } =
@@ -9,6 +12,7 @@ export function AgentBuilderInstructionsBlock() {
 
   return (
     <div className="flex flex-col gap-4">
+      <Page.H>Instructions</Page.H>
       <div className="flex flex-col items-center justify-between sm:flex-row">
         <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
           Command or guideline you provide to your agent to direct its

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
@@ -11,6 +11,8 @@ interface AgentBuilderInstructionsContextType {
   generationSettings: GenerationSettingsType;
   setGenerationSettings: (settings: GenerationSettingsType) => void;
   models: ModelConfigurationType[];
+  instructions: string;
+  setInstructions: (instructions: string) => void;
 }
 
 const AgentBuilderInstructionsContext = createContext<
@@ -36,6 +38,8 @@ export function AgentBuilderInstructionsProvider({
       temperature: 0.7,
     });
 
+  const [instructions, setInstructions] = useState<string>("");
+
   const handleSetGenerationSettings = useCallback(
     (settings: GenerationSettingsType) => {
       const processedSettings = {
@@ -56,8 +60,10 @@ export function AgentBuilderInstructionsProvider({
       generationSettings,
       setGenerationSettings: handleSetGenerationSettings,
       models,
+      instructions,
+      setInstructions,
     }),
-    [generationSettings, handleSetGenerationSettings, models]
+    [generationSettings, handleSetGenerationSettings, models, instructions]
   );
 
   return (

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -4,7 +4,7 @@ import { History } from "@tiptap/extension-history";
 import Text from "@tiptap/extension-text";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { cva } from "class-variance-authority";
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect } from "react";
 
 import { useAgentBuilderInstructionsContext } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
 import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
@@ -15,6 +15,16 @@ import {
 import { classNames } from "@app/lib/utils";
 
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
+
+const extensions = [
+  Document,
+  Text,
+  ParagraphExtension,
+  History,
+  CharacterCount.configure({
+    limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
+  }),
+];
 
 const editorVariants = cva(
   [
@@ -48,19 +58,6 @@ const editorVariants = cva(
 export function AgentBuilderInstructionsEditor() {
   const { instructions, setInstructions } =
     useAgentBuilderInstructionsContext();
-
-  const extensions = useMemo(
-    () => [
-      Document,
-      Text,
-      ParagraphExtension,
-      History,
-      CharacterCount.configure({
-        limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
-      }),
-    ],
-    []
-  );
 
   const editor = useEditor({
     extensions,

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -1,0 +1,147 @@
+import { CharacterCount } from "@tiptap/extension-character-count";
+import Document from "@tiptap/extension-document";
+import { History } from "@tiptap/extension-history";
+import Text from "@tiptap/extension-text";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { cva } from "class-variance-authority";
+import React, { useEffect, useMemo } from "react";
+
+import { useAgentBuilderInstructionsContext } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
+import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
+import {
+  plainTextFromTipTapContent,
+  tipTapContentFromPlainText,
+} from "@app/lib/client/assistant_builder/instructions";
+import { classNames } from "@app/lib/utils";
+
+export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
+
+const editorVariants = cva(
+  [
+    "overflow-auto min-h-60 h-full border rounded-xl p-2",
+    "transition-all duration-200",
+    "bg-muted-background dark:bg-muted-background-night",
+  ],
+  {
+    variants: {
+      error: {
+        true: [
+          "border-warning-500 dark:border-warning-500-night",
+          "focus:ring-warning-500 dark:focus:ring-warning-500-night",
+          "focus:outline-warning-500 dark:focus:outline-warning-500-night",
+          "focus:border-warning-500 dark:focus:border-warning-500-night",
+        ],
+        false: [
+          "border-border dark:border-border-night",
+          "focus:ring-highlight-300 dark:focus:ring-highlight-300-night",
+          "focus:outline-highlight-200 dark:focus:outline-highlight-200-night",
+          "focus:border-highlight-300 dark:focus:border-highlight-300-night",
+        ],
+      },
+    },
+    defaultVariants: {
+      error: false,
+    },
+  }
+);
+
+export function AgentBuilderInstructionsEditor() {
+  const { instructions, setInstructions } =
+    useAgentBuilderInstructionsContext();
+
+  const extensions = useMemo(
+    () => [
+      Document,
+      Text,
+      ParagraphExtension,
+      History,
+      CharacterCount.configure({
+        limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
+      }),
+    ],
+    []
+  );
+
+  const editor = useEditor({
+    extensions,
+    content: tipTapContentFromPlainText(instructions),
+    onUpdate: ({ editor }) => {
+      const json = editor.getJSON();
+      const plainText = plainTextFromTipTapContent(json);
+      setInstructions(plainText);
+    },
+  });
+
+  const currentCharacterCount =
+    editor?.storage.characterCount.characters() || 0;
+  const displayError =
+    currentCharacterCount >= INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT;
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.setOptions({
+      editorProps: {
+        attributes: {
+          class: editorVariants({ error: displayError }),
+        },
+      },
+    });
+  }, [editor, displayError]);
+
+  useEffect(() => {
+    if (!editor || instructions === undefined) {
+      return;
+    }
+
+    const currentContent = plainTextFromTipTapContent(editor.getJSON());
+    if (currentContent !== instructions) {
+      editor.commands.setContent(tipTapContentFromPlainText(instructions));
+    }
+  }, [editor, instructions]);
+
+  return (
+    <div className="flex h-full flex-col gap-1">
+      <div className="relative h-full min-h-60 grow p-px">
+        <EditorContent editor={editor} className="absolute inset-0" />
+      </div>
+      {editor && (
+        <CharacterCountDisplay
+          count={currentCharacterCount}
+          maxCount={INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT}
+        />
+      )}
+    </div>
+  );
+}
+
+interface CharacterCountDisplayProps {
+  count: number;
+  maxCount: number;
+}
+
+const CharacterCountDisplay = ({
+  count,
+  maxCount,
+}: CharacterCountDisplayProps) => {
+  if (count <= maxCount / 2) {
+    return null;
+  }
+
+  const isOverLimit = count >= maxCount;
+
+  return (
+    <span
+      className={classNames(
+        "text-end text-xs",
+        isOverLimit
+          ? "text-warning"
+          : "text-muted-foreground dark:text-muted-foreground-night"
+      )}
+    >
+      {count} / {maxCount} characters
+    </span>
+  );
+};

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -25,20 +25,18 @@ interface ModelSelectionSubmenuProps {
 
 interface ModelRadioItemProps {
   modelConfig: ModelConfigurationType;
-  currentModelKey: string;
   isDark: boolean;
   onModelSelection: (modelConfig: ModelConfigurationType) => void;
 }
 
 function ModelRadioItem({
   modelConfig,
-  currentModelKey,
   isDark,
   onModelSelection,
 }: ModelRadioItemProps) {
   return (
     <DropdownMenuRadioItem
-      value={currentModelKey}
+      value={`${modelConfig.modelId}${modelConfig.reasoningEffort ? `-${modelConfig.reasoningEffort}` : ""}`}
       icon={getModelProviderLogo(modelConfig.providerId, isDark)}
       description={modelConfig.shortDescription}
       label={modelConfig.displayName}
@@ -75,28 +73,30 @@ export function ModelSelectionSubmenu({
       <DropdownMenuSubContent className="w-80">
         <DropdownMenuLabel label="Best performing models" />
         <DropdownMenuRadioGroup value={currentModelKey}>
-          {bestPerformingModelConfigs.map((modelConfig) => (
-            <ModelRadioItem
-              key={getModelKey(modelConfig)}
-              modelConfig={modelConfig}
-              currentModelKey={currentModelKey}
-              isDark={isDark}
-              onModelSelection={handleModelSelection}
-            />
-          ))}
+          {bestPerformingModelConfigs.map((modelConfig) => {
+            return (
+              <ModelRadioItem
+                key={getModelKey(modelConfig)}
+                modelConfig={modelConfig}
+                isDark={isDark}
+                onModelSelection={handleModelSelection}
+              />
+            );
+          })}
         </DropdownMenuRadioGroup>
 
         <DropdownMenuLabel label="Other models" />
         <DropdownMenuRadioGroup value={currentModelKey}>
-          {otherModelConfigs.map((modelConfig) => (
-            <ModelRadioItem
-              key={getModelKey(modelConfig)}
-              modelConfig={modelConfig}
-              currentModelKey={currentModelKey}
-              isDark={isDark}
-              onModelSelection={handleModelSelection}
-            />
-          ))}
+          {otherModelConfigs.map((modelConfig) => {
+            return (
+              <ModelRadioItem
+                key={getModelKey(modelConfig)}
+                modelConfig={modelConfig}
+                isDark={isDark}
+                onModelSelection={handleModelSelection}
+              />
+            );
+          })}
         </DropdownMenuRadioGroup>
       </DropdownMenuSubContent>
     </DropdownMenuSub>


### PR DESCRIPTION
## Description

This PR adds the instruction editor block to the new agent builder layout.

**References:**
- https://github.com/dust-tt/tasks/issues/2960

## Risk

Low, behind FF

## Deploy Plan

Deploy front