### PR TITLE
[front] - feat(AB v2): add instructions tips

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -11,6 +11,7 @@ export function AgentBuilderInstructionsBlock() {
 
   return (
     <div className="flex h-full flex-col gap-4">
+      <Page.H>Instructions</Page.H>
       <div className="flex flex-col items-center justify-between sm:flex-row">
         <Page.P>
           <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -10,8 +10,7 @@ export function AgentBuilderInstructionsBlock() {
     useAgentBuilderInstructionsContext();
 
   return (
-    <div className="flex flex-col gap-4">
-      <Page.H>Instructions</Page.H>
+    <div className="flex h-full flex-col gap-4">
       <div className="flex flex-col items-center justify-between sm:flex-row">
         <Page.P>
           <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -10,7 +10,7 @@ export function AgentBuilderInstructionsBlock() {
     useAgentBuilderInstructionsContext();
 
   return (
-    <div className="flex h-full flex-col gap-4">
+    <div className="flex flex-col gap-4">
       <Page.H>Instructions</Page.H>
       <div className="flex flex-col items-center justify-between sm:flex-row">
         <Page.P>

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -25,7 +25,6 @@ const extensions = [
     limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
   }),
 ];
-
 const editorVariants = cva(
   [
     "overflow-auto min-h-60 h-full border rounded-xl p-2",

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@dust-tt/sparkle";
 import { CharacterCount } from "@tiptap/extension-character-count";
 import Document from "@tiptap/extension-document";
 import { History } from "@tiptap/extension-history";
@@ -6,13 +7,14 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { cva } from "class-variance-authority";
 import React, { useEffect } from "react";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { useAgentBuilderInstructionsContext } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
+import { InstructionTipsPopover } from "@app/components/agent_builder/instructions/InstructionsTipsPopover";
 import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
 import {
   plainTextFromTipTapContent,
   tipTapContentFromPlainText,
 } from "@app/lib/client/assistant_builder/instructions";
-import { classNames } from "@app/lib/utils";
 
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
@@ -55,6 +57,7 @@ const editorVariants = cva(
 );
 
 export function AgentBuilderInstructionsEditor() {
+  const { owner } = useAgentBuilderContext();
   const { instructions, setInstructions } =
     useAgentBuilderInstructionsContext();
 
@@ -102,6 +105,9 @@ export function AgentBuilderInstructionsEditor() {
     <div className="flex h-full flex-col gap-1">
       <div className="relative h-full min-h-60 grow p-px">
         <EditorContent editor={editor} className="absolute inset-0" />
+        <div className="absolute bottom-2 right-2">
+          <InstructionTipsPopover owner={owner} instructions={instructions} />
+        </div>
       </div>
       {editor && (
         <CharacterCountDisplay
@@ -130,7 +136,7 @@ const CharacterCountDisplay = ({
 
   return (
     <span
-      className={classNames(
+      className={cn(
         "text-end text-xs",
         isOverLimit
           ? "text-warning"

--- a/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
+++ b/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
@@ -20,7 +20,7 @@ import { Err, Ok } from "@app/types";
 
 const STATIC_TIPS = [
   "Break down your instructions into steps to leverage the model's reasoning capabilities.",
-  "Give context on how you'd like the agent to act, e.g. 'Act like a senior analyst'.",
+  "Give context on how you’d like the agent to act, e.g. 'Act like a senior analyst'.",
   "Add instructions on the format of the answer: tone of voice, answer in bullet points, in code blocks, etc...",
 ];
 

--- a/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
+++ b/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
@@ -1,0 +1,152 @@
+import {
+  ContentMessage,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { LightbulbIcon } from "@dust-tt/sparkle";
+import { Button } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+import React from "react";
+
+import type {
+  APIError,
+  BuilderSuggestionsType,
+  Result,
+  WorkspaceType,
+} from "@app/types";
+import { Err, Ok } from "@app/types";
+
+const STATIC_TIPS = [
+  "Break down your instructions into steps to leverage the model's reasoning capabilities.",
+  "Give context on how you'd like the agent to act, e.g. 'Act like a senior analyst'.",
+  "Add instructions on the format of the answer: tone of voice, answer in bullet points, in code blocks, etc...",
+];
+
+type TipStatus = "loading" | "loaded" | "error";
+
+interface InstructionTipsPopoverProps {
+  owner: WorkspaceType;
+  instructions: string;
+}
+
+export function InstructionTipsPopover({
+  owner,
+  instructions,
+}: InstructionTipsPopoverProps) {
+  const [tips, setTips] = useState<string[]>(STATIC_TIPS);
+  const [status, setStatus] = useState<TipStatus>("loaded");
+  const [error, setError] = useState<APIError | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || !instructions.trim()) {
+      return;
+    }
+
+    const fetchTips = async () => {
+      setStatus("loading");
+      setError(null);
+
+      const result = await getRankedSuggestions({
+        owner,
+        currentInstructions: instructions,
+        formerSuggestions: [],
+      });
+
+      if (result.isErr()) {
+        setError(result.error);
+        setStatus("error");
+        return;
+      }
+
+      if (result.value.status === "ok" && result.value.suggestions?.length) {
+        // Take first 3 suggestions
+        setTips(result.value.suggestions.slice(0, 3));
+      } else {
+        // Fallback to static tips
+        setTips(STATIC_TIPS);
+      }
+
+      setStatus("loaded");
+    };
+
+    void fetchTips();
+  }, [isOpen, instructions, owner]);
+
+  return (
+    <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          icon={LightbulbIcon}
+          aria-label="View instruction tips"
+        />
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-4" side="bottom" align="start">
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <span className="heading-base text-muted-foreground dark:text-muted-foreground-night">
+              Tips
+            </span>
+            {status === "loading" && <Spinner size="xs" />}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {status === "error" && error ? (
+              <ContentMessage size="sm" variant="warning" className="w-full">
+                Error loading tips: {error.message}
+              </ContentMessage>
+            ) : (
+              tips.map((tip, index) => (
+                <ContentMessage
+                  key={index}
+                  size="sm"
+                  variant="highlight"
+                  className="w-full"
+                >
+                  {tip}
+                </ContentMessage>
+              ))
+            )}
+          </div>
+        </div>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}
+
+async function getRankedSuggestions({
+  owner,
+  currentInstructions,
+  formerSuggestions,
+}: {
+  owner: WorkspaceType;
+  currentInstructions: string;
+  formerSuggestions: string[];
+}): Promise<Result<BuilderSuggestionsType, APIError>> {
+  const res = await fetch(`/api/w/${owner.sId}/assistant/builder/suggestions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      type: "instructions",
+      inputs: {
+        current_instructions: currentInstructions,
+        former_suggestions: formerSuggestions,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    return new Err({
+      type: "internal_server_error",
+      message: "Failed to get suggestions",
+    });
+  }
+
+  return new Ok(await res.json());
+}

--- a/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
+++ b/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
@@ -19,7 +19,7 @@ import type {
 import { Err, Ok } from "@app/types";
 
 const STATIC_TIPS = [
-  "Break down your instructions into steps to leverage the model's reasoning capabilities.",
+  "Break down your instructions into steps to leverage the model’s reasoning capabilities.",
   "Give context on how you’d like the agent to act, e.g. 'Act like a senior analyst'.",
   "Add instructions on the format of the answer: tone of voice, answer in bullet points, in code blocks, etc...",
 ];


### PR DESCRIPTION
## Description

This PR enhances the agent builder instructions experience by adding a tips popover that provides contextual suggestions for writing better instructions. The tips are dynamically fetched from an API based on the current instructions content and displayed in a popover menu accessible via a lightbulb icon.

![Screenshot 2025-06-24 at 16 43 13](https://github.com/user-attachments/assets/0fdda212-0076-4e6a-9b5f-d1323cc5cc78)

**References:**
- https://github.com/dust-tt/tasks/issues/2961

## Risk

Low, behind FF

## Deploy Plan

Deploy front