### PR TITLE
[connectors] fix(Slack): fix error handling in `syncNonThreaded`

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -512,12 +512,12 @@ export async function syncNonThreaded(
       throw e;
     }
 
-    if (c.error) {
+    if (c?.error) {
       throw new Error(
         `Failed getting messages for channel ${channelId}: ${c.error}`
       );
     }
-    if (c.messages === undefined) {
+    if (c?.messages === undefined) {
       throw new Error(
         `Failed getting messages for channel ${channelId}: messages is undefined`
       );


### PR DESCRIPTION
## Description

- We have observed errors in production where in one specific line of the `syncNonThreaded` activity we read a property from an undefined, causing the activity to fail ([logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZdQ20TAFIkCgwAAABhBWmRRMjB1N0FBQUttSERpSzRKYzN3QTQAAAAkMDE5NzUwZGMtM2JkOS00MTQwLTg0NGUtYTNiMWFlYmU3ZWUyAAAGRQ&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1749407338000&to_ts=1749408238000&live=false)).
- This PR prevents the erroring code path from happening.

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
