### PR TITLE
[front] - fix(MentionDropdown): adjust positioning of MentionDropdown

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -44,9 +44,9 @@ export const MentionDropdown = ({
       setVirtualTriggerStyle({
         position: "fixed",
         left: triggerRect.left,
-        top: triggerRect.bottom,
+        top: triggerRect.top,
         width: 1,
-        height: 1,
+        height: triggerRect.height || 1,
         pointerEvents: "none",
         zIndex: -1,
       });


### PR DESCRIPTION
## Description

This PR applies the following changes:
 - Correct the vertical positioning by setting the dropdown top to the trigger's top rather than its bottom
 - Ensure the correct dropdown height by using the trigger's height if available or default to 1

## Risk

Medium

## Deploy Plan

Deploy front