### PR TITLE
fix(include): strip null bytes from output chunks

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -33,6 +33,7 @@ import {
   CoreAPI,
   dustManagedCredentials,
   removeNulls,
+  stripNullBytes,
   timeFrameFromNow,
 } from "@app/types";
 
@@ -234,7 +235,7 @@ function createServer(
           },
           tags: doc.tags,
           ref: refs.shift() as string,
-          chunks: doc.chunks.map((chunk) => chunk.text),
+          chunks: doc.chunks.map((chunk) => stripNullBytes(chunk.text)),
         };
       });
 


### PR DESCRIPTION
## Description

- We have observed issues in production where chunks contain null characters, causing the db insert in `agent_mcp_actions_output_items` to fail ([log](https://app.datadoghq.eu/logs?query=%22Error%20Posting%20message%22%20service%3Afront%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZdTcYyE8T8CUwAAABhBWmRUY1plSkFBQUttSERpSzlZNWxRQUkAAAAkMDE5NzUzN2EtOWFlOC00ZTMyLTlkNDktNDBmM2ZmMmNmMzYyAAUorg&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1749451063000&to_ts=1749451663000&live=false)).
- This PR aligns the `include` action with the `search` action and strips them from the chunks output by the tool.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
