### PR TITLE
[connectors] fix: add missing migration script

### DIFF
--- a/connectors/migrations/db/migration_76.sql
+++ b/connectors/migrations/db/migration_76.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jan 08, 2025
+ALTER TABLE "public"."github_code_repositories" ADD COLUMN "skipReason" VARCHAR(255);


### PR DESCRIPTION
## Description

- I forgot to push the migration script in https://github.com/dust-tt/dust/pull/13238.
- This PR adds it.

## Tests

## Risk

## Deploy Plan

- No deploy.
