### PR TITLE
feat: allow overriding tool timeouts

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -125,6 +125,7 @@ export type ServerSideMCPToolType = Omit<
   availability: MCPServerAvailability;
   permission: MCPToolStakeLevelType;
   toolServerId: string;
+  timeoutMs?: number;
 };
 
 export type ClientSideMCPToolType = Omit<
@@ -135,6 +136,7 @@ export type ClientSideMCPToolType = Omit<
   permission: MCPToolStakeLevelType;
   toolServerId: string;
   type: "mcp_configuration";
+  timeoutMs?: number;
 };
 
 type WithToolNameMetadata<T> = T & {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -56,6 +56,7 @@ export const INTERNAL_MCP_SERVERS: Record<
       featureFlags: WhitelistableFeature[]
     ) => boolean;
     tools_stakes?: Record<string, MCPToolStakeLevelType>;
+    timeoutMs?: number;
   }
 > = {
   // Notes:
@@ -248,6 +249,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: (plan, featureFlags) => {
       return featureFlags.includes("dev_mcp_actions");
     },
+    timeoutMs: 5 * 60 * 1000, // 5 minutes
   },
   query_tables_v2: {
     id: 1009,

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -29,6 +29,7 @@ export type WithStakeLevelType<T> = T & {
 export type ServerSideMCPToolTypeWithStakeLevel =
   WithStakeLevelType<MCPToolWithAvailabilityType> & {
     toolServerId: string;
+    timeoutMs?: number;
   };
 
 export type ClientSideMCPToolTypeWithStakeLevel =


### PR DESCRIPTION
## Description

I am frequently hitting the 2 minutes default timeout on `run_agent` for complex queries.
This PR adds the ability to override the default timeout at the server level.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
