### PR TITLE
[extension] - fix(MentionDropdown): editorREf

### DIFF
--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -94,6 +94,10 @@ export const InputBarContainer = ({
     suggestionHandler: mentionDropdown.getSuggestionHandler(),
   });
 
+  useEffect(() => {
+    editorRef.current = editor;
+  }, [editor]);
+
   const sendNotification = useSendNotification();
 
   useUrlHandler(editor, selectedNode, nodeOrUrlCandidate, handleUrlReplaced);


### PR DESCRIPTION
## Description

This PR update the `editorRef` to always point to the current instance of the editor when it changes

## Risk

Low

## Deploy Plan

N/A