### PR TITLE
[connectors] enh(Slack): increase `startToCloseTimeout` and heartbeat

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -701,6 +701,8 @@ export async function syncThreads(
         return;
       }
 
+      await heartbeat();
+
       return syncThread(
         channelId,
         channelName,

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -29,7 +29,8 @@ const {
 const { deleteChannel, syncThread, syncChannel } = proxyActivities<
   typeof activities
 >({
-  startToCloseTimeout: "30 minutes",
+  heartbeatTimeout: "10 minutes",
+  startToCloseTimeout: "60 minutes",
 });
 
 const { syncNonThreaded } = proxyActivities<typeof activities>({


### PR DESCRIPTION
## Description

- We have observed a Slack connector hitting rate limits repeatedly ([logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZdUYHlhNBC-EwAAABhBWmRVWUh4Z0FBQVV1U0c4OXVSazhnQUkAAAAkMDE5NzU0NjItMGQ2NC00ZjNhLThkMjItZTQ2NDFiNGFmNzBhAAAN6w&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1749466438000&to_ts=1749467338000&live=false)) and thus hitting the `startToCloseTimeout`.
- This PR increases the timeout and adds hearbeating in `syncThreads` in between each thread to maintain some form of timeout.

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
