### PR TITLE
[front] fix: expire content fragments on `dataSourceView` `hardDelete`

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -649,6 +649,9 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<number, Error>> {
+    // Mark all content fragments that reference this data source view as expired.
+    await this.expireContentFragments(auth, transaction);
+
     // Delete agent configurations elements pointing to this data source view.
     await AgentDataSourceConfiguration.destroy({
       where: {


### PR DESCRIPTION
## Description

- Hard deleting a data source view currently does not expire the content fragments (i.e. setting `nodeId` and `nodeDataSourceViewId` to `null`) whereas the soft delete does.
- This causes errors in production where the `hardDelete` fails on a FK constraint ([logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20region%3Aeurope-west1&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZdUjdn0rTY1hQAAABhBWmRVamVWUEFBQmZRRWV1MTdpejJBQUgAAAAkMDE5NzU0OGQtZmFlZC00NzVlLTllYTQtYmE5YjIyN2U3ZjhhAAAWrA&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1749469980000&to_ts=1749470280000&live=false)).

## Tests

## Risk

- Medium.

## Deploy Plan

- Deploy front.
