### PR TITLE
[connectors] enh(Slack): align heartbeats and timeouts values

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -26,16 +26,11 @@ const {
   startToCloseTimeout: "10 minutes",
 });
 
-const { deleteChannel, syncThread, syncChannel } = proxyActivities<
-  typeof activities
->({
-  heartbeatTimeout: "10 minutes",
-  startToCloseTimeout: "60 minutes",
-});
-
-const { syncNonThreaded } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "50 minutes",
-});
+const { deleteChannel, syncThread, syncChannel, syncNonThreaded } =
+  proxyActivities<typeof activities>({
+    heartbeatTimeout: "10 minutes",
+    startToCloseTimeout: "60 minutes",
+  });
 
 /**
  * This workflow is in charge of synchronizing all the content of the Slack channels selected by the user.


### PR DESCRIPTION
## Description

- This PR follows up on https://github.com/dust-tt/dust/pull/13258 and https://github.com/dust-tt/dust/pull/11788.
- We are still observing heartbeat timeouts on `syncNonThreaded` specifically.
- This PR increases the `heartbeatTimeout` and `startToCloseTimeout` on this activity, aligning them with the other activities.

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
