### PR TITLE
Add mcp tool for google cal availability check

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -224,6 +224,7 @@ export const INTERNAL_MCP_SERVERS: Record<
       create_event: "low",
       update_event: "low",
       delete_event: "low",
+      check_availability: "never_ask",
     },
   },
 

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -55,14 +55,14 @@ export const makeMCPToolJSONSuccess = ({
   message,
   result,
 }: {
-  message: string;
+  message?: string;
   result: object | string;
 }): CallToolResult => {
   return {
     isError: false,
     content: [
-      { type: "text", text: message },
-      { type: "text", text: JSON.stringify(result, null, 2) },
+      ...(message ? [{ type: "text" as const, text: message }] : []),
+      { type: "text" as const, text: JSON.stringify(result, null, 2) },
     ],
   };
 };


### PR DESCRIPTION
## Description

* Adding tool to existing MCP server to check calendar availablity

## Tests

```
Frank Aloia
Frank Aloia
@GoogleCalendar [frank@dust.tt](mailto:frank@dust.tt)
@GoogleCalendar

Tools inspection
In EST, you have the following busy slots today:
8:30 AM to 9:30 AM
11:30 AM to 12:30 PM
1:15 PM to 3:00 PM
6:15 PM to 7:00 PM
The rest of the day is available.
```

## Risk

* minimal - behind FF

## Deploy Plan

* deploy front