### PR TITLE
Close feedback loop in Slack tool approval workflow

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1011,7 +1011,7 @@ async function makeContentFragments(
         continue;
       }
 
-      const fileContent = await response.blob();
+      const fileContent = await response.buffer();
 
       const fileName = f.name || f.title || "notitle";
 

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -1,9 +1,9 @@
 import type { LightAgentConfigurationType } from "@dust-tt/client";
 
+import type { RequestToolPermissionActionValueParsed } from "@connectors/api/webhooks/webhook_slack_interaction";
 import {
   APPROVE_TOOL_EXECUTION,
   REJECT_TOOL_EXECUTION,
-  RequestToolPermissionActionValueParsed,
   STATIC_AGENT_CONFIG,
 } from "@connectors/api/webhooks/webhook_slack_interaction";
 import type { SlackMessageFootnotes } from "@connectors/connectors/slack/chat/citations";

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -1,6 +1,11 @@
 import type { LightAgentConfigurationType } from "@dust-tt/client";
 
-import { STATIC_AGENT_CONFIG } from "@connectors/api/webhooks/webhook_slack_interaction";
+import {
+  APPROVE_TOOL_EXECUTION,
+  REJECT_TOOL_EXECUTION,
+  RequestToolPermissionActionValueParsed,
+  STATIC_AGENT_CONFIG,
+} from "@connectors/api/webhooks/webhook_slack_interaction";
 import type { SlackMessageFootnotes } from "@connectors/connectors/slack/chat/citations";
 import { makeDustAppUrl } from "@connectors/connectors/slack/chat/utils";
 import { truncate } from "@connectors/types";
@@ -257,7 +262,12 @@ export function makeToolValidationBlock({
             emoji: true,
           },
           style: "primary",
-          action_id: "approve_tool_execution",
+          value: JSON.stringify({
+            status: "approved",
+            agentName,
+            toolName,
+          } as RequestToolPermissionActionValueParsed),
+          action_id: APPROVE_TOOL_EXECUTION,
         },
         {
           type: "button",
@@ -267,7 +277,12 @@ export function makeToolValidationBlock({
             emoji: true,
           },
           style: "danger",
-          action_id: "reject_tool_execution",
+          value: JSON.stringify({
+            status: "rejected",
+            agentName,
+            toolName,
+          } as RequestToolPermissionActionValueParsed),
+          action_id: REJECT_TOOL_EXECUTION,
         },
       ],
     },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Fix https://github.com/dust-tt/tasks/issues/3025

- ✅ Updates the ephemeral message containing the Call To Action "Approve" or "Reject" with a feedback message
- 🤨 Also updates Bot's profile picture for the message which seems due to Slack's partial support for updating ephemeral
- Approving/Rejecting in Dust web interface doesn't provide any feedback to Slack, the ephemeral remains hanging

## Tests

Tested on casquedelumiere.slack.com (see 1password credentials)

### Before

#### Approve

https://github.com/user-attachments/assets/f699b9a8-ff7c-4671-86f2-ac7f982ae038

#### Reject

https://github.com/user-attachments/assets/7f90182f-c9e3-4819-b070-4f199832ef49

### After

#### Approve

https://github.com/user-attachments/assets/61ea634b-f4db-492d-8fd2-75b4f050bfee

#### Reject

https://github.com/user-attachments/assets/ed171f62-0245-4f3a-9bf0-8b01162a96be


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
