### PR TITLE
Salesforce connectors: synced queries scafolding

### DIFF
--- a/connectors/migrations/db/migration_77.sql
+++ b/connectors/migrations/db/migration_77.sql
@@ -1,4 +1,4 @@
 -- Migration created on Jun 09, 2025
-CREATE TABLE IF NOT EXISTS "salesforce_synced_queries" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "rootNodeName" TEXT NOT NULL, "soql" TEXT NOT NULL, "titleTemplate" TEXT NOT NULL, "contentTemplate" TEXT NOT NULL, "tagsTemplate" TEXT, "lastSeenUpdatedAt" TIMESTAMP WITH TIME ZONE, "connectorId" BIGINT NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
+CREATE TABLE IF NOT EXISTS "salesforce_synced_queries" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "rootNodeName" TEXT NOT NULL, "soql" TEXT NOT NULL, "titleTemplate" TEXT NOT NULL, "contentTemplate" TEXT NOT NULL, "tagsTemplate" TEXT, "lastSeenModifiedDate" TIMESTAMP WITH TIME ZONE, "connectorId" BIGINT NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
 
 CREATE INDEX "salesforce_synced_queries_connector_id" ON "salesforce_synced_queries" ("connectorId");

--- a/connectors/migrations/db/migration_77.sql
+++ b/connectors/migrations/db/migration_77.sql
@@ -1,6 +1,4 @@
 -- Migration created on Jun 09, 2025
-SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'salesforce_synced_queries';
-CREATE TABLE IF NOT EXISTS "salesforce_synced_queries" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "rootNodeName" VARCHAR(255) NOT NULL, "soql" TEXT NOT NULL, "titleTemplate" TEXT NOT NULL, "contentTemplate" TEXT NOT NULL, "tagsTemplate" TEXT, "lastSeenUpdatedAt" TIMESTAMP WITH TIME ZONE, "connectorId" BIGINT NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
-SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND t.relkind = 'r' and t.relname = 'salesforce_synced_queries' GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;
+CREATE TABLE IF NOT EXISTS "salesforce_synced_queries" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "rootNodeName" TEXT NOT NULL, "soql" TEXT NOT NULL, "titleTemplate" TEXT NOT NULL, "contentTemplate" TEXT NOT NULL, "tagsTemplate" TEXT, "lastSeenUpdatedAt" TIMESTAMP WITH TIME ZONE, "connectorId" BIGINT NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
+
 CREATE INDEX "salesforce_synced_queries_connector_id" ON "salesforce_synced_queries" ("connectorId");
-[17:07:53.549] INFO (4039748): Done;

--- a/connectors/migrations/db/migration_77.sql
+++ b/connectors/migrations/db/migration_77.sql
@@ -1,0 +1,6 @@
+-- Migration created on Jun 09, 2025
+SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'salesforce_synced_queries';
+CREATE TABLE IF NOT EXISTS "salesforce_synced_queries" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "rootNodeName" VARCHAR(255) NOT NULL, "soql" TEXT NOT NULL, "titleTemplate" TEXT NOT NULL, "contentTemplate" TEXT NOT NULL, "tagsTemplate" TEXT, "lastSeenUpdatedAt" TIMESTAMP WITH TIME ZONE, "connectorId" BIGINT NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
+SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND t.relkind = 'r' and t.relname = 'salesforce_synced_queries' GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;
+CREATE INDEX "salesforce_synced_queries_connector_id" ON "salesforce_synced_queries" ("connectorId");
+[17:07:53.549] INFO (4039748): Done;

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -52,7 +52,10 @@ import {
   RemoteSchemaModel,
   RemoteTableModel,
 } from "@connectors/lib/models/remote_databases";
-import { SalesforceConfigurationModel } from "@connectors/lib/models/salesforce";
+import {
+  SalesforceConfigurationModel,
+  SalesforceSyncedQueryModel,
+} from "@connectors/lib/models/salesforce";
 import {
   SlackBotWhitelistModel,
   SlackChannel,
@@ -136,6 +139,7 @@ async function main(): Promise<void> {
   await ZendeskArticleModel.sync({ alter: true });
   await ZendeskTicketModel.sync({ alter: true });
   await SalesforceConfigurationModel.sync({ alter: true });
+  await SalesforceSyncedQueryModel.sync({ alter: true });
   await GongConfigurationModel.sync({ alter: true });
   await GongTranscriptModel.sync({ alter: true });
   await GongUserModel.sync({ alter: true });

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -31,10 +31,13 @@ import {
   RemoteSchemaModel,
   RemoteTableModel,
 } from "@connectors/lib/models/remote_databases";
-import { SalesforceConfigurationModel } from "@connectors/lib/models/salesforce";
 import { saveNodesFromPermissions } from "@connectors/lib/remote_databases/utils";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import {
+  SalesforceConfigurationResource,
+  SalesforceSyncedQueryResource,
+} from "@connectors/resources/salesforce_resources";
 import type { ConnectorPermission, ContentNode } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 
@@ -129,11 +132,8 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
       throw new Error(`Connector ${this.connectorId} not found`);
     }
 
-    await SalesforceConfigurationModel.destroy({
-      where: {
-        connectorId: connector.id,
-      },
-    });
+    await SalesforceConfigurationResource.deleteByConnectorId(connector.id);
+    await SalesforceSyncedQueryResource.deleteByConnectorId(connector.id);
 
     await RemoteTableModel.destroy({
       where: {

--- a/connectors/src/connectors/salesforce/lib/cli.ts
+++ b/connectors/src/connectors/salesforce/lib/cli.ts
@@ -119,6 +119,8 @@ export const salesforce = async ({
         };
       });
 
+      // TODO(spolu): --execute: true
+
       return { documents, created: false };
     }
   }

--- a/connectors/src/connectors/salesforce/lib/cli.ts
+++ b/connectors/src/connectors/salesforce/lib/cli.ts
@@ -1,0 +1,125 @@
+import { default as topLogger } from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type {
+  SalesforceCheckConnectionResponseType,
+  SalesforceCommandType,
+  SalesforceRunSoqlResponseType,
+  SalesforceSetupSyncedQueryResponseType,
+} from "@connectors/types";
+
+import { runSOQL, testSalesforceConnection } from "./salesforce_api";
+import { getConnectorAndCredentials } from "./utils";
+
+export const salesforce = async ({
+  command,
+  args,
+}: SalesforceCommandType): Promise<
+  | SalesforceCheckConnectionResponseType
+  | SalesforceRunSoqlResponseType
+  | SalesforceSetupSyncedQueryResponseType
+> => {
+  const logger = topLogger.child({ majorCommand: "salesforce", command, args });
+
+  if (!args.wId) {
+    throw new Error("Missing --wId argument");
+  }
+  if (!args.dsId) {
+    throw new Error("Missing --dsId argument");
+  }
+
+  const connector = await ConnectorResource.findByDataSource({
+    workspaceId: args.wId,
+    dataSourceId: args.dsId,
+  });
+  if (!connector) {
+    throw new Error(
+      `Connector not found for workspace ${args.wId} and data source ${args.dsId}.`
+    );
+  }
+
+  if (connector.type !== "salesforce") {
+    throw new Error(`Connector is not of type salesforce`);
+  }
+
+  const connCredRes = await getConnectorAndCredentials(connector.id);
+  if (connCredRes.isErr()) {
+    throw connCredRes.error;
+  }
+
+  switch (command) {
+    case "check-connection": {
+      const testRes = await testSalesforceConnection(
+        connCredRes.value.credentials
+      );
+      if (testRes.isErr()) {
+        throw testRes.error;
+      }
+
+      logger.info("Salesforce connection test successful");
+      return { ok: true };
+    }
+    case "run-soql": {
+      if (!args.soql) {
+        throw new Error("Missing --soql argument");
+      }
+
+      const res = await runSOQL({
+        soql: args.soql,
+        credentials: connCredRes.value.credentials,
+      });
+      if (res.isErr()) {
+        throw res.error;
+      }
+
+      return { records: res.value.records };
+    }
+    case "setup-synced-query": {
+      if (!args.soql) {
+        throw new Error("Missing --soql argument");
+      }
+      if (!args.titleTemplate) {
+        throw new Error("Missing --titleTemplate argument");
+      }
+      if (!args.contentTemplate) {
+        throw new Error("Missing --contentTemplate argument");
+      }
+      if (!args.rootNodeName) {
+        throw new Error("Missing --rootNodeName argument");
+      }
+
+      const res = await runSOQL({
+        soql: args.soql,
+        credentials: connCredRes.value.credentials,
+      });
+      if (res.isErr()) {
+        throw res.error;
+      }
+
+      const documents = res.value.records.map((record) => {
+        if (!record.Id || !record.LastModifiedDate) {
+          throw new Error(
+            "Record is missing required fields: Id or LastModifiedDate"
+          );
+        }
+        let tags: string[] = [];
+        if (args.tagsTemplate) {
+          const raw = eval("`" + args.tagsTemplate + "`") as string;
+          tags = raw
+            .split(",")
+            .map((tag) => tag.trim())
+            .filter((tag) => tag);
+        }
+
+        return {
+          id: record.Id,
+          lastUpdatedAt: new Date(record.LastModifiedDate).toISOString(),
+          title: eval("`" + args.titleTemplate + "`") as string,
+          content: eval("`" + args.contentTemplate + "`") as string,
+          tags,
+        };
+      });
+
+      return { documents, created: false };
+    }
+  }
+};

--- a/connectors/src/connectors/salesforce/lib/cli.ts
+++ b/connectors/src/connectors/salesforce/lib/cli.ts
@@ -112,7 +112,7 @@ export const salesforce = async ({
 
         return {
           id: record.Id,
-          lastUpdatedAt: new Date(record.LastModifiedDate).toISOString(),
+          lastModifiedDate: new Date(record.LastModifiedDate).toISOString(),
           title: eval("`" + args.titleTemplate + "`") as string,
           content: eval("`" + args.contentTemplate + "`") as string,
           tags,

--- a/connectors/src/connectors/salesforce/lib/salesforce_api.ts
+++ b/connectors/src/connectors/salesforce/lib/salesforce_api.ts
@@ -23,7 +23,6 @@ import { buildInternalId } from "@connectors/lib/remote_databases/utils";
 const SF_API_VERSION = "57.0";
 
 /**
-/**
  * Get a Salesforce connection for the given connection ID.
  */
 export const getSalesforceConnection = async (
@@ -75,14 +74,14 @@ export async function testSalesforceConnection(
  */
 export const fetchDatabases = (): RemoteDBDatabase[] => {
   // Salesforce do not have a concept of databases per say, the most similar concept is a project.
-  // Since credentials are always scoped to a project, we directly return a single database with the project name.
+  // Since credentials are always scoped to a project, we directly return a single database with the
+  // project name.
   return [{ name: INTERNAL_ID_DATABASE }];
 };
 
 /**
- * Fetch the schemas available in the Salesforce account.
- * In Salesforce, we have two types of objects: standard and custom.
- * We fetch them separately and return them as two different schemas.
+ * Fetch the schemas available in the Salesforce account. In Salesforce, we have two types of
+ * objects: standard and custom. We fetch them separately and return them as two different schemas.
  */
 export const fetchSchemas = (): RemoteDBSchema[] => {
   return [
@@ -98,8 +97,8 @@ export const fetchSchemas = (): RemoteDBSchema[] => {
 };
 
 /**
- * Fetch the tables available in the Salesforce account.
- * In Salesforce, objects are the equivalent of tables.
+ * Fetch the tables available in the Salesforce account. In Salesforce, objects are the equivalent
+ * of tables.
  */
 export async function fetchTables({
   credentials,
@@ -150,8 +149,8 @@ export const fetchTree = async ({
 }: {
   credentials: SalesforceAPICredentials;
 }): Promise<Result<RemoteDBTree, Error>> => {
-  const databases = await fetchDatabases();
-  const schemas = await fetchSchemas();
+  const databases = fetchDatabases();
+  const schemas = fetchSchemas();
   const tree = {
     databases: await Promise.all(
       databases.map(async (db) => {

--- a/connectors/src/connectors/salesforce/lib/utils.ts
+++ b/connectors/src/connectors/salesforce/lib/utils.ts
@@ -1,5 +1,6 @@
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
+import type { Record } from "jsforce";
 
 import { ConnectorManagerError } from "@connectors/connectors/interface";
 import type { SalesforceAPICredentials } from "@connectors/connectors/salesforce/lib/oauth";
@@ -36,3 +37,13 @@ export const getConnectorAndCredentials = async (
     credentials,
   });
 };
+
+export function syncQueryTemplateInterpolate(
+  template: string,
+  record: Record
+): string {
+  return template.replace(/\$\{([^}]+)\}/g, (_, key) => {
+    const value = record[key.split(".")[1]];
+    return value?.toString() || "";
+  });
+}

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -11,6 +11,7 @@ import { google_drive } from "@connectors/connectors/google_drive/lib/cli";
 import { intercom } from "@connectors/connectors/intercom/lib/cli";
 import { microsoft } from "@connectors/connectors/microsoft/lib/cli";
 import { notion } from "@connectors/connectors/notion/lib/cli";
+import { salesforce } from "@connectors/connectors/salesforce/lib/cli";
 import { slack } from "@connectors/connectors/slack/lib/cli";
 import { snowflake } from "@connectors/connectors/snowflake/lib/cli";
 import {
@@ -67,6 +68,8 @@ export async function runCommand(adminCommand: AdminCommandType) {
       return webcrawler(adminCommand);
     case "zendesk":
       return zendesk(adminCommand);
+    case "salesforce":
+      return salesforce(adminCommand);
     default:
       assertNever(adminCommand);
   }

--- a/connectors/src/lib/models/salesforce.ts
+++ b/connectors/src/lib/models/salesforce.ts
@@ -35,7 +35,7 @@ export class SalesforceSyncedQueryModel extends ConnectorBaseModel<SalesforceSyn
   declare updatedAt: CreationOptional<Date>;
   declare rootNodeName: string;
   declare soql: string;
-  declare lastSeenUpdatedAt: Date | null;
+  declare lastSeenModifiedDate: Date | null;
   declare titleTemplate: string;
   declare contentTemplate: string;
   declare tagsTemplate: string | null;
@@ -72,7 +72,7 @@ SalesforceSyncedQueryModel.init(
       type: DataTypes.TEXT,
       allowNull: true,
     },
-    lastSeenUpdatedAt: {
+    lastSeenModifiedDate: {
       type: DataTypes.DATE,
       allowNull: true,
     },

--- a/connectors/src/lib/models/salesforce.ts
+++ b/connectors/src/lib/models/salesforce.ts
@@ -53,7 +53,7 @@ SalesforceSyncedQueryModel.init(
       defaultValue: DataTypes.NOW,
     },
     rootNodeName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     soql: {

--- a/connectors/src/lib/models/salesforce.ts
+++ b/connectors/src/lib/models/salesforce.ts
@@ -29,3 +29,42 @@ SalesforceConfigurationModel.init(
     relationship: "hasOne",
   }
 );
+
+export class SalesforceSyncedQueryModel extends ConnectorBaseModel<SalesforceSyncedQueryModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare rootNodeName: string;
+  declare query: string;
+  declare lastSeenUpdatedAt: Date | null;
+}
+SalesforceSyncedQueryModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    rootNodeName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    query: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    lastSeenUpdatedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "salesforce_synced_queries",
+    indexes: [{ fields: ["connectorId"], unique: false }],
+  }
+);

--- a/connectors/src/lib/models/salesforce.ts
+++ b/connectors/src/lib/models/salesforce.ts
@@ -34,8 +34,11 @@ export class SalesforceSyncedQueryModel extends ConnectorBaseModel<SalesforceSyn
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare rootNodeName: string;
-  declare query: string;
+  declare soql: string;
   declare lastSeenUpdatedAt: Date | null;
+  declare titleTemplate: string;
+  declare contentTemplate: string;
+  declare tagsTemplate: string | null;
 }
 SalesforceSyncedQueryModel.init(
   {
@@ -53,9 +56,21 @@ SalesforceSyncedQueryModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    query: {
+    soql: {
       type: DataTypes.TEXT,
       allowNull: false,
+    },
+    titleTemplate: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    contentTemplate: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    tagsTemplate: {
+      type: DataTypes.TEXT,
+      allowNull: true,
     },
     lastSeenUpdatedAt: {
       type: DataTypes.DATE,

--- a/connectors/src/resources/salesforce_resources.ts
+++ b/connectors/src/resources/salesforce_resources.ts
@@ -1,0 +1,188 @@
+import type { Result } from "@dust-tt/client";
+import { Ok } from "@dust-tt/client";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
+
+import {
+  SalesforceConfigurationModel,
+  SalesforceSyncedQueryModel,
+} from "@connectors/lib/models/salesforce";
+import { BaseResource } from "@connectors/resources/base_resource";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ReadonlyAttributesType } from "@connectors/resources/storage/types"; // Attributes are marked as read-only to reflect the stateless nature of our Resource.
+import { ModelId } from "@connectors/types";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface SalesforceConfigurationResource
+  extends ReadonlyAttributesType<SalesforceConfigurationModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class SalesforceConfigurationResource extends BaseResource<SalesforceConfigurationModel> {
+  static model: ModelStatic<SalesforceConfigurationModel> =
+    SalesforceConfigurationModel;
+
+  constructor(
+    model: ModelStatic<SalesforceConfigurationModel>,
+    blob: Attributes<SalesforceConfigurationModel>
+  ) {
+    super(SalesforceConfigurationModel, blob);
+  }
+
+  static async makeNew({
+    blob,
+    transaction,
+  }: {
+    blob: CreationAttributes<SalesforceConfigurationModel>;
+    transaction?: Transaction;
+  }): Promise<SalesforceConfigurationResource> {
+    const configuration = await SalesforceConfigurationModel.create(
+      { ...blob },
+      transaction && { transaction }
+    );
+    return new this(this.model, configuration.get());
+  }
+
+  static async fetchByConnectorId(
+    connectorId: number
+  ): Promise<SalesforceConfigurationResource | null> {
+    const configuration = await SalesforceConfigurationModel.findOne({
+      where: { connectorId },
+    });
+    return configuration && new this(this.model, configuration.get());
+  }
+
+  static async fetchByConnectorIds(
+    connectorIds: ModelId[]
+  ): Promise<Record<ModelId, SalesforceConfigurationResource>> {
+    const blobs = await this.model.findAll({
+      where: {
+        connectorId: connectorIds,
+      },
+    });
+
+    return blobs.reduce(
+      (acc, blob) => {
+        acc[blob.connectorId] = new this(this.model, blob.get());
+        return acc;
+      },
+      {} as Record<ModelId, SalesforceConfigurationResource>
+    );
+  }
+
+  static async deleteByConnectorId(
+    connectorId: number,
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.model.destroy({ where: { connectorId }, transaction });
+  }
+
+  async postFetchHook(): Promise<void> {
+    return;
+  }
+
+  async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        connectorId: this.connectorId,
+      },
+      transaction,
+    });
+    return new Ok(undefined);
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      id: this.id,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+      connectorId: this.connectorId,
+    };
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface SalesforceSyncedQueryResource
+  extends ReadonlyAttributesType<SalesforceSyncedQueryModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class SalesforceSyncedQueryResource extends BaseResource<SalesforceSyncedQueryModel> {
+  static model: ModelStatic<SalesforceSyncedQueryModel> =
+    SalesforceSyncedQueryModel;
+
+  constructor(
+    model: ModelStatic<SalesforceSyncedQueryModel>,
+    blob: Attributes<SalesforceSyncedQueryModel>
+  ) {
+    super(SalesforceSyncedQueryModel, blob);
+  }
+
+  async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: { connectorId: this.connectorId, id: this.id },
+      transaction,
+    });
+    return new Ok(undefined);
+  }
+
+  static async deleteByConnectorId(
+    connectorId: ModelId,
+    transaction?: Transaction
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: { connectorId },
+      transaction,
+    });
+    return new Ok(undefined);
+  }
+
+  async postFetchHook(): Promise<void> {
+    return;
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      id: this.id,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+
+      rootNodeName: this.rootNodeName,
+      soql: this.soql,
+      lastSeenUpdatedAt: this.lastSeenUpdatedAt,
+      titleTemplate: this.titleTemplate,
+      contentTemplate: this.contentTemplate,
+      tagsTemplate: this.tagsTemplate,
+      connectorId: this.connectorId,
+    };
+  }
+
+  static async makeNew({
+    blob,
+    transaction,
+  }: {
+    blob: CreationAttributes<SalesforceSyncedQueryModel>;
+    transaction?: Transaction;
+  }): Promise<SalesforceSyncedQueryResource> {
+    const brand = await SalesforceSyncedQueryModel.create(
+      { ...blob },
+      transaction && { transaction }
+    );
+    return new this(this.model, brand.get());
+  }
+
+  static async fetchByConnector(
+    connector: ConnectorResource
+  ): Promise<SalesforceSyncedQueryResource[]> {
+    const syncedQueries = await SalesforceSyncedQueryModel.findAll({
+      where: { connectorId: connector.id },
+    });
+    return syncedQueries.map((brand) => new this(this.model, brand.get()));
+  }
+}

--- a/connectors/src/resources/salesforce_resources.ts
+++ b/connectors/src/resources/salesforce_resources.ts
@@ -14,7 +14,7 @@ import {
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types"; // Attributes are marked as read-only to reflect the stateless nature of our Resource.
-import { ModelId } from "@connectors/types";
+import type { ModelId } from "@connectors/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -155,7 +155,7 @@ export class SalesforceSyncedQueryResource extends BaseResource<SalesforceSynced
 
       rootNodeName: this.rootNodeName,
       soql: this.soql,
-      lastSeenUpdatedAt: this.lastSeenUpdatedAt,
+      lastSeenModifiedDate: this.lastSeenModifiedDate,
       titleTemplate: this.titleTemplate,
       contentTemplate: this.contentTemplate,
       tagsTemplate: this.tagsTemplate,

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -611,6 +611,62 @@ export type ZendeskFetchBrandResponseType = t.TypeOf<
  */
 
 /**
+ * <Salesforce>
+ */
+export const SalesforceCommandSchema = t.type({
+  majorCommand: t.literal("salesforce"),
+  command: t.union([
+    t.literal("check-connection"),
+    t.literal("run-soql"),
+    t.literal("setup-synced-query"),
+  ]),
+  args: t.type({
+    wId: t.union([t.string, t.undefined]),
+    dsId: t.union([t.string, t.undefined]),
+    soql: t.union([t.string, t.undefined]),
+    rootNodeName: t.union([t.string, t.undefined]),
+    titleTemplate: t.union([t.string, t.undefined]),
+    contentTemplate: t.union([t.string, t.undefined]),
+    tagsTemplate: t.union([t.string, t.undefined]),
+  }),
+});
+export type SalesforceCommandType = t.TypeOf<typeof SalesforceCommandSchema>;
+
+export const SalesforceCheckConnectionResponseSchema = t.type({
+  ok: t.boolean,
+});
+export type SalesforceCheckConnectionResponseType = t.TypeOf<
+  typeof SalesforceCheckConnectionResponseSchema
+>;
+
+export const SalesforceRunSoqlResponseSchema = t.type({
+  records: t.array(t.UnknownRecord), // Salesforce type, can't be iots'd
+});
+export type SalesforceRunSoqlResponseType = t.TypeOf<
+  typeof SalesforceRunSoqlResponseSchema
+>;
+
+export const SalesforceSetupSyncedQueryResponseSchema = t.type({
+  documents: t.array(
+    t.type({
+      id: t.string,
+      lastUpdatedAt: t.string,
+      title: t.string,
+      content: t.string,
+      tags: t.array(t.string),
+    })
+  ),
+  created: t.boolean,
+});
+export type SalesforceSetupSyncedQueryResponseType = t.TypeOf<
+  typeof SalesforceSetupSyncedQueryResponseSchema
+>;
+
+/**
+ * </Salesforce>
+ */
+
+/**
  * <Admin>
  */
 export const AdminCommandSchema = t.union([
@@ -628,6 +684,7 @@ export const AdminCommandSchema = t.union([
   TemporalCommandSchema,
   WebcrawlerCommandSchema,
   ZendeskCommandSchema,
+  SalesforceCommandSchema,
 ]);
 export type AdminCommandType = t.TypeOf<typeof AdminCommandSchema>;
 
@@ -667,6 +724,9 @@ export const AdminResponseSchema = t.union([
   ZendeskCountTicketsResponseSchema,
   ZendeskFetchBrandResponseSchema,
   ZendeskFetchTicketResponseSchema,
+  SalesforceCheckConnectionResponseSchema,
+  SalesforceRunSoqlResponseSchema,
+  SalesforceSetupSyncedQueryResponseSchema,
 ]);
 export type AdminResponseType = t.TypeOf<typeof AdminResponseSchema>;
 /**

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -650,7 +650,7 @@ export const SalesforceSetupSyncedQueryResponseSchema = t.type({
   documents: t.array(
     t.type({
       id: t.string,
-      lastUpdatedAt: t.string,
+      lastModifiedDate: t.string,
       title: t.string,
       content: t.string,
       tags: t.array(t.string),


### PR DESCRIPTION
## Description

- Introduces a new table `salesforce_synced_queries` which contains
  - soql query
  - root node name (the name of the root node underwhich we'll ingest the results of the query)
  - titleTemplate (template to compute title from a query `record` object)
  - contentTemplate (same for content)
  - tagsTeamplte (same for comma separated tags)
  - lastSeenModifiedDate this one will be used to know when to stop ingestion (SOQL typical terminology)
- Moves things to Resource.
- Introduce scafolding for cli to setup a synced query

## Tests

Tested locally. Connector creation and deletion + new cli commands.

## Risk

Low: new model + cli scafolding

## Deploy Plan

- lock `connectors`
- run migration
- deploy `connectors`