### PR TITLE
[.github] - fix(danger.js): monitor package files

### DIFF
--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -33,6 +33,8 @@ jobs:
             'connectors/src/resources/storage/models/'
             'front/pages/api/v1/'
             'sdks/js/'
+            'front/package.json'
+            'extension/package.json'
           )
 
           PATHS_STRING="${MONITORED_PATHS[*]}"


### PR DESCRIPTION
## Description

This PR adds 'front/package.json' and 'extension/package.json' to the list of files monitored by DangerJS workflow.

## Risk

Low

## Deploy Plan

N/A