### PR TITLE
[front] - fix(danger.js): use `path` module for file paths in danger checks

### DIFF
--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -1,5 +1,6 @@
 import { danger, fail, warn } from "danger";
 import fs from "fs";
+import path from "path";
 
 const sdkAckLabel = "sdk-ack";
 const migrationAckLabel = "migration-ack";
@@ -127,21 +128,21 @@ function checkAppsRegistry() {
 }
 
 async function checkSparkleVersionConsistency() {
-  const frontPackageJsonContent =
+  const frontPackageJsonDiff =
     await danger.git.JSONDiffForFile("front/package.json");
-  const extensionPackageJsonContent = await danger.git.JSONDiffForFile(
+  const extensionPackageJsonDiff = await danger.git.JSONDiffForFile(
     "extension/package.json"
   );
 
-  if (!frontPackageJsonContent && !extensionPackageJsonContent) {
+  if (!frontPackageJsonDiff && !extensionPackageJsonDiff) {
     return;
   }
 
   const frontPackageJson = JSON.parse(
-    fs.readFileSync("front/package.json", "utf8")
+    fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
   );
   const extensionPackageJson = JSON.parse(
-    fs.readFileSync("extension/package.json", "utf8")
+    fs.readFileSync(path.join(__dirname, "../extension/package.json"), "utf8")
   );
 
   const frontVersion = frontPackageJson.dependencies?.["@dust-tt/sparkle"];


### PR DESCRIPTION
## Description

This PR aims at fixing the following error:
```
Error:  Error: ENOENT: no such file or directory, open 'front/package.json'
    at Object.readFileSync (node:fs:449:20)
    at dangerfile.ts:117:58
    at Generator.next (<anonymous>)
    at fulfilled (dangerfile.ts:5:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'front/package.json'
}
```

**References:**
- https://github.com/dust-tt/dust/pull/13272

## Risk

Breaking CI

## Deploy Plan

N/A