### PR TITLE
[front] Don't look for datasources when searching for url

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -819,7 +819,7 @@ impl ElasticsearchSearchStore {
     ) -> Result<BoolQuery> {
         if let Some(_) = &filter.node_ids {
             return Err(anyhow::anyhow!(
-                "Node IDs are not supported on data sources"
+                "The `node_ids` filter should not be used in conjunction with search in the datasources index, since datasources do not have nodeIds. Use `nodes_title` search scope to avoid searching this index, or remove the `node_ids` filter."
             ));
         }
 

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -817,6 +817,12 @@ impl ElasticsearchSearchStore {
         filter: &NodesSearchFilter,
         counter: &mut QueryClauseCounter,
     ) -> Result<BoolQuery> {
+        if let Some(_) = &filter.node_ids {
+            return Err(anyhow::anyhow!(
+                "Node IDs are not supported on data sources"
+            ));
+        }
+
         let mut bool_query = Query::bool()
             // Data sources don't support parents.
             .filter(self.build_shared_permission_filter(filter, DATA_SOURCE_INDEX_NAME, counter));

--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -113,7 +113,7 @@ export const InputBarContainer = ({
       ? {
           // NodeIdSearchParams
           nodeIds: nodeOrUrlCandidate?.node ? [nodeOrUrlCandidate.node] : [],
-          includeDataSources: true,
+          includeDataSources: false,
           viewType: "all",
           disabled: isSpacesLoading || !nodeOrUrlCandidate,
           spaceIds: spaces.map((s) => s.sId),
@@ -122,7 +122,7 @@ export const InputBarContainer = ({
           // TextSearchParams
           search: nodeOrUrlCandidate?.url || "",
           searchSourceUrls: true,
-          includeDataSources: true,
+          includeDataSources: false,
           viewType: "all",
           disabled: isSpacesLoading || !nodeOrUrlCandidate,
           spaceIds: spaces.map((s) => s.sId),

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -135,7 +135,7 @@ const InputBarContainer = ({
       ? {
           // NodeIdSearchParams
           nodeIds: nodeOrUrlCandidate?.node ? [nodeOrUrlCandidate.node] : [],
-          includeDataSources: true,
+          includeDataSources: false,
           owner,
           viewType: "all",
           disabled: isSpacesLoading || !nodeOrUrlCandidate,
@@ -145,7 +145,7 @@ const InputBarContainer = ({
           // TextSearchParams
           search: nodeOrUrlCandidate?.url || "",
           searchSourceUrls: true,
-          includeDataSources: true,
+          includeDataSources: false,
           owner,
           viewType: "all",
           disabled: isSpacesLoading || !nodeOrUrlCandidate,


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/3092

## Description

When pasting a URL, we only want to search for nodes - not datasources. Issue is that when using a node_id and including datasources, , data sources are not filtered and all of them are returned. 
First fix is to not include datasources, as we will never paste a datasource url.
Looking how to fix the search


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
