### PR TITLE
[connectors] enh(Slack): increase timeouts

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -28,8 +28,8 @@ const {
 
 const { deleteChannel, syncThread, syncChannel, syncNonThreaded } =
   proxyActivities<typeof activities>({
-    heartbeatTimeout: "10 minutes",
-    startToCloseTimeout: "60 minutes",
+    heartbeatTimeout: "15 minutes",
+    startToCloseTimeout: "90 minutes",
   });
 
 /**


### PR DESCRIPTION
## Description

- This PR follows up on https://github.com/dust-tt/dust/pull/13258, https://github.com/dust-tt/dust/pull/11788 and https://github.com/dust-tt/dust/pull/13265.
- We are still observing timeouts on `syncNonThreaded` specifically.
- We are suspecting rate limits to affect the speed of the sync (we have observed rate limits for the same connector).
- This PR increases the `heartbeatTimeout` and `startToCloseTimeout` on this activity, keeping them aligned with the other similar activities.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
