### PR TITLE
[front] - chore(tools): run dust app migration script tweak

### DIFF
--- a/front/migrations/20250521_migrate_dust_app_mcp.ts
+++ b/front/migrations/20250521_migrate_dust_app_mcp.ts
@@ -204,7 +204,9 @@ makeScript(
     const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
 
     if (workspaceId && allWorkspaces) {
-      throw new Error("Cannot specify both workspaceId and allWorkspaces arguments.");
+      throw new Error(
+        "Cannot specify both workspaceId and allWorkspaces arguments."
+      );
     }
 
     let workspaces: Workspace[] = [];
@@ -227,7 +229,9 @@ makeScript(
         order: [["id", "ASC"]],
       });
     } else {
-      throw new Error("Must specify either workspaceId or allWorkspaces argument.");
+      throw new Error(
+        "Must specify either workspaceId or allWorkspaces argument."
+      );
     }
 
     const migrationDir = "migration_dust_app_run";

--- a/front/migrations/20250521_migrate_dust_app_mcp.ts
+++ b/front/migrations/20250521_migrate_dust_app_mcp.ts
@@ -194,9 +194,18 @@ makeScript(
       description: "Workspace SID to migrate",
       required: false,
     },
+    allWorkspaces: {
+      type: "boolean",
+      description: "Migrate all workspaces with dust app run configurations",
+      required: false,
+    },
   },
-  async ({ execute, workspaceId }, parentLogger) => {
+  async ({ execute, workspaceId, allWorkspaces }, parentLogger) => {
     const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
+
+    if (workspaceId && allWorkspaces) {
+      throw new Error("Cannot specify both workspaceId and allWorkspaces arguments.");
+    }
 
     let workspaces: Workspace[] = [];
     if (workspaceId) {
@@ -209,7 +218,7 @@ makeScript(
         throw new Error(`Workspace with SID ${workspaceId} not found.`);
       }
       workspaces = [workspace];
-    } else {
+    } else if (allWorkspaces) {
       const workspaceIds = await findWorkspacesWithDustAppRunConfigurations();
       workspaces = await Workspace.findAll({
         where: {
@@ -217,6 +226,8 @@ makeScript(
         },
         order: [["id", "ASC"]],
       });
+    } else {
+      throw new Error("Must specify either workspaceId or allWorkspaces argument.");
     }
 
     const migrationDir = "migration_dust_app_run";


### PR DESCRIPTION
## Description

This PR adds a new option to migrate all workspaces with dust app configurations in one command

## Risk

Low

## Deploy Plan

Apply migration to all workspaces in eu and us