### PR TITLE
enh(run_agent): parse and display Chain Of Thought

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -116,7 +116,11 @@ export function MCPRunAgentActionDetails({
           )}
           {chainOfThought && childAgent && (
             <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-              <ContentMessage title="Agent thoughts" variant="primary" size="lg">
+              <ContentMessage
+                title="Agent thoughts"
+                variant="primary"
+                size="lg"
+              >
                 <Markdown
                   content={chainOfThought}
                   isStreaming={false}

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -59,6 +59,18 @@ export function MCPRunAgentActionDetails({
     return null;
   }, [resultResource]);
 
+  const chainOfThought = useMemo(() => {
+    if (resultResource) {
+      return resultResource.resource.chainOfThought || null;
+    }
+    return null;
+  }, [resultResource]);
+
+  const { agentConfiguration: childAgent } = useAgentConfiguration({
+    workspaceId: owner.sId,
+    agentConfigurationId: childAgentId,
+  });
+
   const isBusy = useMemo(() => {
     if (resultResource) {
       return false;
@@ -75,11 +87,6 @@ export function MCPRunAgentActionDetails({
     }
     return null;
   }, [resultResource, lastNotification, owner.sId]);
-
-  const { agentConfiguration: childAgent } = useAgentConfiguration({
-    workspaceId: owner.sId,
-    agentConfigurationId: childAgentId,
-  });
   return (
     <ActionDetailsWrapper
       actionName={childAgent?.name ? `Run @${childAgent.name}` : "Run Agent"}
@@ -96,9 +103,22 @@ export function MCPRunAgentActionDetails({
         <div className="flex flex-col gap-4">
           {query && childAgent && (
             <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-              <ContentMessage title="Query" variant="outline" size="lg">
+              <ContentMessage title="Query" variant="primary" size="lg">
                 <Markdown
                   content={query}
+                  isStreaming={false}
+                  forcedTextSize="text-sm"
+                  textColor="text-muted-foreground"
+                  isLastMessage={false}
+                />
+              </ContentMessage>
+            </div>
+          )}
+          {chainOfThought && childAgent && (
+            <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+              <ContentMessage title="Agent thoughts" variant="primary" size="lg">
+                <Markdown
+                  content={chainOfThought}
                   isStreaming={false}
                   forcedTextSize="text-sm"
                   textColor="text-muted-foreground"

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -404,6 +404,7 @@ export const RunAgentResultResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.RUN_AGENT_RESULT),
   conversationId: z.string(),
   text: z.string(),
+  chainOfThought: z.string().optional(),
   uri: z.string(),
 });
 

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -272,20 +272,17 @@ export default async function createServer(
         for await (const event of streamRes.value.eventStream) {
           if (event.type === "generation_tokens") {
             // Separate content based on classification
-            if ("classification" in event) {
-              if (event.classification === "chain_of_thought") {
-                chainOfThought += event.text;
-              } else if (event.classification === "tokens") {
-                finalContent += event.text;
-              }
-            } else {
-              // For delimiter events, we don't add the delimiter text itself
-              // but we might add newlines for chain of thought blocks
-              if (event.classification === "closing_delimiter" && 
-                  event.delimiterClassification === "chain_of_thought" &&
-                  chainOfThought.length > 0) {
-                chainOfThought += "\n";
-              }
+            if (event.classification === "chain_of_thought") {
+              chainOfThought += event.text;
+            } else if (event.classification === "tokens") {
+              finalContent += event.text;
+            } else if (
+              event.classification === "closing_delimiter" &&
+              event.delimiterClassification === "chain_of_thought" &&
+              chainOfThought.length > 0
+            ) {
+              // For closing chain of thought delimiters, add a newline
+              chainOfThought += "\n";
             }
           } else if (event.type === "agent_error") {
             const errorMessage = `Agent error: ${event.error.message}`;
@@ -353,7 +350,8 @@ export default async function createServer(
               mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.RUN_AGENT_RESULT,
               conversationId: conversation.sId,
               text: finalContent,
-              chainOfThought: chainOfThought.length > 0 ? chainOfThought : undefined,
+              chainOfThought:
+                chainOfThought.length > 0 ? chainOfThought : undefined,
               uri: `${config.getClientFacingUrl()}/w/${auth.getNonNullableWorkspace().sId}/assistant/${conversation.sId}`,
             },
           },


### PR DESCRIPTION
## Description

- Add optional `chainOfThought` field to `RunAgentResultResourceSchema`
- Update `run_agent` server to separate chain of thought from content during streaming
- Display chain of thought in separate 'Agent thoughts' section in UI


### before
<img width="783" alt="Screenshot 2025-06-10 at 13 30 57" src="https://github.com/user-attachments/assets/3d1ace5c-4421-4f54-869b-3b70c209145c" />

### after

<img width="770" alt="Screenshot 2025-06-10 at 13 30 05" src="https://github.com/user-attachments/assets/fcbd4226-f209-491a-ae5f-aa6bde3b39b4" />



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
