### PR TITLE
Add: UI ready to handle choice between personal and workspace connect…

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@dust-tt/client": "^1.0.54",
-    "@dust-tt/sparkle": "0.2.524",
+    "@dust-tt/sparkle": "^0.2.526",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -121,7 +121,10 @@ export const AdminActionsList = ({
       setIsCreateOpen(true);
     } else {
       setIsLoading(true);
-      await createInternalMCPServer(mcpServer.name, true);
+      await createInternalMCPServer({
+        name: mcpServer.name,
+        includeGlobal: true,
+      });
       setIsLoading(false);
     }
   };

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -7,19 +7,25 @@ import {
   DialogTitle,
   useSendNotification,
 } from "@dust-tt/sparkle";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { MCPServerOAuthConnexion } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
 import {
   getMcpServerDisplayName,
+  getServerTypeAndIdFromSId,
   isRemoteMCPServerType,
 } from "@app/lib/actions/mcp_helper";
+import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import {
   useCreateMCPServerConnection,
   useDiscoverOAuthMetadata,
 } from "@app/lib/swr/mcp_servers";
-import type { OAuthCredentials, WorkspaceType } from "@app/types";
+import type {
+  MCPOAuthUseCase,
+  OAuthCredentials,
+  WorkspaceType,
+} from "@app/types";
 import { OAUTH_PROVIDER_NAMES, setupOAuthConnection } from "@app/types";
 
 type ConnectMCPServerDialogProps = {
@@ -33,83 +39,139 @@ type ConnectMCPServerDialogProps = {
 export function ConnectMCPServerDialog({
   owner,
   mcpServer,
-  setIsLoading,
+  setIsLoading: setExternalIsLoading,
   isOpen = false,
   setIsOpen,
 }: ConnectMCPServerDialogProps) {
   const sendNotification = useSendNotification();
+  const [isLoading, setIsLoading] = useState(false);
+  const [useCase, setUseCase] = useState<MCPOAuthUseCase | null>(null);
   const [authCredentials, setAuthCredentials] =
     useState<OAuthCredentials | null>(null);
+  const [
+    remoteMCPServerOAuthDiscoveryDone,
+    setRemoteMCPServerOAuthDiscoveryDone,
+  ] = useState(false);
+  const [authorization, setAuthorization] = useState<AuthorizationInfo | null>(
+    null
+  );
   const [isFormValid, setIsFormValid] = useState(true);
-
   const { createMCPServerConnection } = useCreateMCPServerConnection({
     owner,
     connectionType: "workspace",
   });
-
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
 
+  const serverType = useMemo(
+    () =>
+      mcpServer
+        ? getServerTypeAndIdFromSId(mcpServer.sId).serverType
+        : "internal",
+    [mcpServer]
+  );
+
+  useEffect(() => {
+    const discoverOAuth = async () => {
+      if (isOpen && mcpServer) {
+        if (serverType === "internal") {
+          setAuthorization(mcpServer.authorization);
+        } else if (
+          isRemoteMCPServerType(mcpServer) &&
+          mcpServer.url &&
+          !remoteMCPServerOAuthDiscoveryDone
+        ) {
+          setIsLoading(true);
+          const discoverOAuthMetadataRes = await discoverOAuthMetadata(
+            mcpServer.url
+          );
+
+          if (
+            discoverOAuthMetadataRes.isOk() &&
+            discoverOAuthMetadataRes.value.oauthRequired
+          ) {
+            setAuthorization({
+              provider: "mcp",
+              // During setup, the use case is always "platform_actions".
+              use_case: "platform_actions",
+              supported_use_cases: ["platform_actions"], // TODO(mcp): Add personal_actions option.
+            });
+            setAuthCredentials({
+              ...discoverOAuthMetadataRes.value.connectionMetadata,
+            });
+            setRemoteMCPServerOAuthDiscoveryDone(true);
+          }
+        }
+        setIsLoading(false);
+      } else {
+        setAuthorization(null);
+      }
+    };
+
+    void discoverOAuth();
+  }, [
+    mcpServer,
+    isOpen,
+    serverType,
+    remoteMCPServerOAuthDiscoveryDone,
+    discoverOAuthMetadata,
+  ]);
+
   const resetState = useCallback(() => {
-    setIsLoading(false);
+    setExternalIsLoading(false);
     setAuthCredentials(null);
-  }, [setIsLoading]);
+    setIsLoading(false);
+    setRemoteMCPServerOAuthDiscoveryDone(false);
+    setAuthorization(null);
+    setUseCase(null);
+  }, [setExternalIsLoading]);
 
   const handleSave = async () => {
-    if (!mcpServer?.authorization) {
-      throw new Error(
-        "MCP server has no authorization while trying to connect"
-      );
+    if (!mcpServer) {
+      throw new Error("MCP server is null while trying to connect");
     }
 
-    setIsLoading(true);
+    if (!authorization) {
+      throw new Error("Authorization is null while trying to connect");
+    }
 
-    let extraConfig: OAuthCredentials = authCredentials ?? {};
-
-    if (isRemoteMCPServerType(mcpServer) && mcpServer.url) {
-      const discoverOAuthMetadataRes = await discoverOAuthMetadata(
-        mcpServer.url
-      );
-      if (
-        discoverOAuthMetadataRes.isOk() &&
-        discoverOAuthMetadataRes.value.oauthRequired
-      ) {
-        extraConfig = {
-          ...extraConfig,
-          ...discoverOAuthMetadataRes.value.connectionMetadata,
-        };
-      }
+    if (!useCase) {
+      throw new Error("Use case is null while trying to connect");
     }
 
     // First setup connection
+    setIsLoading(true);
     const cRes = await setupOAuthConnection({
       dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
       owner,
-      provider: mcpServer.authorization.provider,
-      useCase: mcpServer.authorization.use_case,
+      provider: authorization.provider,
+      // During setup, the use case is always "platform_actions".
+      useCase: "platform_actions",
       extraConfig: {
-        ...extraConfig,
-        ...(mcpServer.authorization.scope
-          ? { scope: mcpServer.authorization.scope }
-          : {}),
+        ...(authCredentials ?? {}),
+        ...(authorization.scope ? { scope: authorization.scope } : {}),
       },
     });
     if (cRes.isErr()) {
       sendNotification({
         type: "error",
-        title: `Failed to connect ${OAUTH_PROVIDER_NAMES[mcpServer.authorization.provider]}`,
+        title: `Failed to connect ${OAUTH_PROVIDER_NAMES[authorization.provider]}`,
         description: cRes.error.message,
       });
+      setIsLoading(false);
       return;
     }
 
+    setExternalIsLoading(true);
     // Then associate connection
     await createMCPServerConnection({
       connectionId: cRes.value.connection_id,
       mcpServer: mcpServer,
-      provider: mcpServer.authorization.provider,
+      provider: authorization.provider,
     });
 
+    setExternalIsLoading(false);
     setIsLoading(false);
+    setIsOpen(false);
   };
 
   return (
@@ -127,13 +189,22 @@ export function ConnectMCPServerDialog({
           </DialogTitle>
         </DialogHeader>
         <DialogContainer>
-          <MCPServerOAuthConnexion
-            authorization={mcpServer?.authorization ?? null}
-            authCredentials={authCredentials}
-            setAuthCredentials={setAuthCredentials}
-            setIsFormValid={setIsFormValid}
-            documentationUrl={mcpServer?.documentationUrl}
-          />
+          {authorization && (
+            <MCPServerOAuthConnexion
+              remoteMCPServerUrl={
+                mcpServer && isRemoteMCPServerType(mcpServer)
+                  ? mcpServer.url
+                  : undefined
+              }
+              useCase={useCase}
+              setUseCase={setUseCase}
+              authorization={authorization}
+              authCredentials={authCredentials}
+              setAuthCredentials={setAuthCredentials}
+              setIsFormValid={setIsFormValid}
+              documentationUrl={mcpServer?.documentationUrl}
+            />
+          )}
         </DialogContainer>
         <DialogFooter
           leftButtonProps={{
@@ -142,17 +213,17 @@ export function ConnectMCPServerDialog({
             onClick: resetState,
           }}
           rightButtonProps={{
-            label: mcpServer?.authorization ? "Save and connect" : "Save",
+            isLoading: isLoading,
+            label: authorization ? "Save & Connect" : "",
             variant: "primary",
             onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
               e.preventDefault();
               e.stopPropagation();
               if (isFormValid) {
                 void handleSave();
-                setIsOpen(false);
               }
             },
-            disabled: !isFormValid,
+            disabled: !isFormValid || (authorization && !useCase) || isLoading,
           }}
         />
       </DialogContent>

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
   Input,
   Label,
+  SliderToggle,
   useSendNotification,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
@@ -15,13 +16,17 @@ import { MCPServerOAuthConnexion } from "@app/components/actions/mcp/MCPServerOA
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { MCPServerType } from "@app/lib/api/mcp";
+import type { MCPConnectionType } from "@app/lib/swr/mcp_servers";
 import {
   useCreateInternalMCPServer,
-  useCreateMCPServerConnection,
   useCreateRemoteMCPServer,
   useDiscoverOAuthMetadata,
 } from "@app/lib/swr/mcp_servers";
-import type { OAuthCredentials, WorkspaceType } from "@app/types";
+import type {
+  MCPOAuthUseCase,
+  OAuthCredentials,
+  WorkspaceType,
+} from "@app/types";
 import {
   OAUTH_PROVIDER_NAMES,
   setupOAuthConnection,
@@ -41,96 +46,58 @@ export function CreateMCPServerDialog({
   owner,
   internalMCPServer,
   setMCPServerToShow,
-  setIsLoading,
+  setIsLoading: setExternalIsLoading,
   isOpen = false,
   setIsOpen,
 }: RemoteMCPServerDetailsProps) {
   const sendNotification = useSendNotification();
+  const [
+    remoteMCPServerOAuthDiscoveryDone,
+    setRemoteMCPServerOAuthDiscoveryDone,
+  ] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [remoteServerUrl, setRemoteServerUrl] = useState("");
   const [sharedSecret, setSharedSecret] = useState<string | undefined>(
     undefined
   );
+  const [useCase, setUseCase] = useState<MCPOAuthUseCase | null>(null);
   const [authCredentials, setAuthCredentials] =
     useState<OAuthCredentials | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [isFormValid, setIsFormValid] = useState(true);
+  const [isOAuthFormValid, setIsOAuthFormValid] = useState(true);
   const [authorization, setAuthorization] = useState<AuthorizationInfo | null>(
     null
   );
+  const [requiresBearerToken, setRequiresBearerToken] = useState(false);
 
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
   const { createWithURL } = useCreateRemoteMCPServer(owner);
-  const { createMCPServerConnection } = useCreateMCPServerConnection({
-    owner,
-    connectionType: "workspace",
-  });
   const { createInternalMCPServer } = useCreateInternalMCPServer(owner);
 
   useEffect(() => {
-    if (internalMCPServer) {
+    if (internalMCPServer && isOpen) {
       setAuthorization(internalMCPServer.authorization);
+    } else {
+      setAuthorization(null);
     }
-  }, [internalMCPServer]);
+  }, [internalMCPServer, isOpen]);
 
   const resetState = useCallback(() => {
     setIsLoading(false);
+    setExternalIsLoading(false);
     setError(null);
     setRemoteServerUrl("");
+    setRemoteMCPServerOAuthDiscoveryDone(false);
     setSharedSecret(undefined);
+    setUseCase(null);
     setAuthCredentials(null);
+    setRequiresBearerToken(false);
+    setIsOAuthFormValid(true);
     setAuthorization(null);
-  }, [setIsLoading]);
+  }, [setExternalIsLoading]);
 
   const handleSave = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (internalMCPServer) {
-      setIsLoading(true);
-
-      if (authorization) {
-        // First setup connection
-        const cRes = await setupOAuthConnection({
-          dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
-          owner,
-          provider: authorization.provider,
-          useCase: authorization.use_case,
-          extraConfig: {
-            ...(authCredentials ?? {}),
-            ...(authorization.scope ? { scope: authorization.scope } : {}),
-          },
-        });
-        if (cRes.isErr()) {
-          sendNotification({
-            type: "error",
-            title: `Failed to connect ${OAUTH_PROVIDER_NAMES[authorization.provider]}`,
-            description: cRes.error.message,
-          });
-          return;
-        }
-
-        // If ok, create server
-        const createServerRes = await createInternalMCPServer(
-          internalMCPServer.name,
-          true
-        );
-
-        // Then associate connection
-        if (createServerRes.success) {
-          await createMCPServerConnection({
-            connectionId: cRes.value.connection_id,
-            mcpServer: createServerRes.server,
-            provider: authorization.provider,
-          });
-        } else {
-          sendNotification({
-            type: "error",
-            title: "Failed to create MCP server",
-          });
-        }
-      } else {
-        await createInternalMCPServer(internalMCPServer.name, true);
-      }
-      setIsLoading(false);
-      return;
-    } else {
+    if (remoteServerUrl) {
       const urlValidation = validateUrl(remoteServerUrl);
 
       if (!urlValidation.valid) {
@@ -141,66 +108,122 @@ export function CreateMCPServerDialog({
         return;
       }
 
-      try {
-        setIsLoading(true);
+      setIsLoading(true);
 
-        let connectionId: string | undefined;
+      if (!remoteMCPServerOAuthDiscoveryDone) {
         const discoverOAuthMetadataRes =
           await discoverOAuthMetadata(remoteServerUrl);
-        if (
-          discoverOAuthMetadataRes.isOk() &&
-          discoverOAuthMetadataRes.value.oauthRequired
-        ) {
-          sendNotification({
-            title: "Authorization required",
-            type: "info",
-            description:
-              "You must authorize the MCP server to access your data.",
-          });
-          const cRes = await setupOAuthConnection({
-            dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
-            owner,
-            provider: "mcp",
-            useCase: "platform_actions",
-            extraConfig: discoverOAuthMetadataRes.value.connectionMetadata,
-          });
-          if (cRes.isOk()) {
-            connectionId = cRes.value.connection_id;
+        if (discoverOAuthMetadataRes.isOk()) {
+          if (discoverOAuthMetadataRes.value.oauthRequired) {
+            setAuthorization({
+              provider: "mcp",
+              use_case: "platform_actions",
+              supported_use_cases: ["platform_actions"], // TODO(mcp): Add personal_actions option.
+            });
+
+            setAuthCredentials(
+              discoverOAuthMetadataRes.value.connectionMetadata
+            );
           }
+          setRemoteMCPServerOAuthDiscoveryDone(true);
         }
-
-        const createRes = await createWithURL({
-          url: remoteServerUrl,
-          includeGlobal: true,
-          sharedSecret,
-          connectionId,
-        });
-
-        if (createRes.isOk()) {
-          sendNotification({
-            title: "Success",
-            type: "success",
-            description: `${getMcpServerDisplayName(createRes.value.server)} added successfully.`,
-          });
-          setMCPServerToShow(createRes.value.server);
-        } else {
-          sendNotification({
-            title: "Error creating MCP server",
-            type: "error",
-            description: createRes.error.message,
-          });
-        }
-      } catch (error) {
-        sendNotification({
-          title: "Error creating MCP server",
-          type: "error",
-          description:
-            error instanceof Error ? error.message : "An error occurred",
-        });
-      } finally {
-        resetState();
+        setIsLoading(false);
+        return;
       }
     }
+
+    if (authorization && !useCase) {
+      // Should not happen as the button should be disabled if the use case is not selected.
+      sendNotification({
+        type: "error",
+        title: "Missing use case",
+        description: "Please select a use case",
+      });
+      setIsLoading(false);
+      return;
+    }
+
+    // If the authorization is set, we need to setup the OAuth connection.
+    let oauthConnection: MCPConnectionType | undefined;
+    if (authorization) {
+      const cRes = await setupOAuthConnection({
+        dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
+        owner,
+        provider: authorization.provider,
+        // During setup, the use case is always "platform_actions".
+        useCase: "platform_actions",
+        extraConfig: {
+          ...(authCredentials ?? {}),
+          ...(authorization.scope ? { scope: authorization.scope } : {}),
+        },
+      });
+      if (cRes.isErr()) {
+        sendNotification({
+          type: "error",
+          title: `Failed to connect ${OAUTH_PROVIDER_NAMES[authorization.provider]}`,
+          description: cRes.error.message,
+        });
+        return;
+      }
+      oauthConnection = {
+        useCase: useCase!,
+        connectionId: cRes.value.connection_id,
+      };
+    }
+
+    // Then, create the server, either internal or remote.
+    setExternalIsLoading(true);
+    let server: MCPServerType | undefined;
+    if (internalMCPServer) {
+      const createRes = await createInternalMCPServer({
+        name: internalMCPServer.name,
+        oauthConnection,
+        includeGlobal: true,
+      });
+
+      if (createRes.isErr()) {
+        sendNotification({
+          type: "error",
+          title: "Failed to create MCP server",
+          description: createRes.error.message,
+        });
+        setExternalIsLoading(false);
+        setIsLoading(false);
+        return;
+      }
+      server = createRes.value.server;
+    }
+
+    if (remoteServerUrl) {
+      const createRes = await createWithURL({
+        url: remoteServerUrl,
+        includeGlobal: true,
+        sharedSecret: requiresBearerToken ? sharedSecret : undefined,
+        oauthConnection,
+      });
+
+      if (createRes.isErr()) {
+        sendNotification({
+          type: "error",
+          title: "Failed to create MCP server",
+          description: createRes.error.message,
+        });
+        setExternalIsLoading(false);
+        setIsLoading(false);
+        return;
+      }
+      server = createRes.value.server;
+    }
+
+    sendNotification({
+      title: "Success",
+      type: "success",
+      description: `${getMcpServerDisplayName(server!)} added successfully.`,
+    });
+    setMCPServerToShow(server!);
+    setExternalIsLoading(false);
+    setIsLoading(false);
+    setIsOpen(false);
   };
 
   return (
@@ -220,7 +243,7 @@ export function CreateMCPServerDialog({
           </DialogTitle>
         </DialogHeader>
         <DialogContainer>
-          {!internalMCPServer && (
+          {!internalMCPServer && !authorization && (
             <>
               <div className="space-y-2">
                 <Label htmlFor="url">URL</Label>
@@ -239,14 +262,27 @@ export function CreateMCPServerDialog({
                 </div>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="sharedSecret">
-                  Bearer Token (if the server requires authentication)
+                <Label htmlFor="requiresBearerToken">
+                  Requires Bearer Token
                 </Label>
-                <div className="flex space-x-2">
+                <div className="flex items-center space-x-2">
+                  <div>
+                    <SliderToggle
+                      disabled={false}
+                      selected={requiresBearerToken}
+                      onClick={() =>
+                        setRequiresBearerToken(!requiresBearerToken)
+                      }
+                    />
+                  </div>
+
                   <div className="flex-grow">
                     <Input
                       id="sharedSecret"
-                      placeholder="Paste the Bearer Token here (optional)"
+                      placeholder={
+                        requiresBearerToken ? "Paste the Bearer Token here" : ""
+                      }
+                      disabled={!requiresBearerToken}
                       value={sharedSecret}
                       onChange={(e) => setSharedSecret(e.target.value)}
                     />
@@ -255,32 +291,35 @@ export function CreateMCPServerDialog({
               </div>
             </>
           )}
-          <MCPServerOAuthConnexion
-            authorization={authorization}
-            authCredentials={authCredentials}
-            setAuthCredentials={setAuthCredentials}
-            setIsFormValid={setIsFormValid}
-            documentationUrl={internalMCPServer?.documentationUrl}
-          />
+          {authorization && (
+            <MCPServerOAuthConnexion
+              remoteMCPServerUrl={remoteServerUrl}
+              authorization={authorization}
+              authCredentials={authCredentials}
+              useCase={useCase}
+              setUseCase={setUseCase}
+              setAuthCredentials={setAuthCredentials}
+              setIsFormValid={setIsOAuthFormValid}
+              documentationUrl={internalMCPServer?.documentationUrl}
+            />
+          )}
         </DialogContainer>
         <DialogFooter
           leftButtonProps={{
             label: "Cancel",
             variant: "ghost",
-            onClick: resetState,
           }}
           rightButtonProps={{
-            label: authorization ? "Save and connect" : "Save",
+            isLoading,
+            label: authorization ? "Save & Connect" : "Save",
             variant: "primary",
             onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
               e.preventDefault();
               e.stopPropagation();
-              if (isFormValid) {
-                void handleSave(e);
-                setIsOpen(false);
-              }
+              void handleSave(e);
             },
-            disabled: !isFormValid,
+            disabled:
+              !isOAuthFormValid || (authorization && !useCase) || isLoading,
           }}
         />
       </DialogContent>

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   ContentMessage,
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -53,8 +54,8 @@ export function MCPServerOAuthConnexion({
   const [inputs, setInputs] = useState<OAuthCredentialInputs | null>(null);
 
   useEffect(() => {
-    // If there is only one use case, set it, otherwise leave it to the user to choose.
-    if (authorization.supported_use_cases.length === 1) {
+    // Pick first choice by default.
+    if (authorization.supported_use_cases.length > 0) {
       setUseCase(authorization.supported_use_cases[0]);
     }
   }, [authorization, setUseCase]);
@@ -120,7 +121,7 @@ export function MCPServerOAuthConnexion({
         <>
           {inputs ? (
             <>
-              <span className="text-500 w-full font-normal">
+              <Chip color="warning">
                 {remoteMCPServerUrl
                   ? `${remoteMCPServerUrl} requires authentication with `
                   : "These tools require authentication with "}
@@ -139,7 +140,7 @@ export function MCPServerOAuthConnexion({
                   </>
                 )}
                 .
-              </span>
+              </Chip>
               {Object.entries(inputs).map(([key, inputData]) => {
                 if (inputData.value) {
                   // If the credential is already set, we don't need to ask the user for it.
@@ -176,48 +177,51 @@ export function MCPServerOAuthConnexion({
               })}
             </>
           ) : (
-            <Label className="self-start font-normal">
+            <Chip color="warning">
               {remoteMCPServerUrl ? <b>{remoteMCPServerUrl}</b> : "These tools"}{" "}
               requires authentication.
-            </Label>
+            </Chip>
           )}
           {authorization.supported_use_cases.length > 1 && containerRef && (
-            <div className="flex flex-col items-center gap-2 pt-4">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    isSelect
-                    variant="outline"
-                    label={
-                      useCase
-                        ? OAUTH_USE_CASE_TO_LABEL[useCase]
-                        : "Select credentials type"
-                    }
-                    size="sm"
-                  />
-                </DropdownMenuTrigger>
+            <div className="w-full">
+              <Label>Credentials Type</Label>
+              <div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      isSelect
+                      variant="outline"
+                      label={
+                        useCase
+                          ? OAUTH_USE_CASE_TO_LABEL[useCase]
+                          : "Select credentials type"
+                      }
+                      size="sm"
+                    />
+                  </DropdownMenuTrigger>
 
-                <DropdownMenuContent mountPortalContainer={containerRef}>
-                  {authorization.supported_use_cases.map(
-                    (selectableUseCase) => (
-                      <DropdownMenuCheckboxItem
-                        key={selectableUseCase}
-                        checked={selectableUseCase === useCase}
-                        onCheckedChange={() => setUseCase(selectableUseCase)}
-                      >
-                        {OAUTH_USE_CASE_TO_LABEL[selectableUseCase]}
-                      </DropdownMenuCheckboxItem>
-                    )
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                  <DropdownMenuContent mountPortalContainer={containerRef}>
+                    {authorization.supported_use_cases.map(
+                      (selectableUseCase) => (
+                        <DropdownMenuCheckboxItem
+                          key={selectableUseCase}
+                          checked={selectableUseCase === useCase}
+                          onCheckedChange={() => setUseCase(selectableUseCase)}
+                        >
+                          {OAUTH_USE_CASE_TO_LABEL[selectableUseCase]}
+                        </DropdownMenuCheckboxItem>
+                      )
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             </div>
           )}
-          <div className="w-full pt-4">
+          <div className="w-full">
             {useCase === "platform_actions" && (
               <ContentMessage
-                size="md"
-                variant="warning"
+                size="lg"
+                variant="golden"
                 title="Workspace level credentials."
                 icon={InformationCircleIcon}
               >
@@ -227,7 +231,7 @@ export function MCPServerOAuthConnexion({
             )}
             {useCase === "personal_actions" && (
               <ContentMessage
-                size="md"
+                size="lg"
                 variant="highlight"
                 title="Personal level credentials."
                 icon={InformationCircleIcon}

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -1,5 +1,10 @@
 import {
+  Button,
   ContentMessage,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
   InformationCircleIcon,
   Input,
   Label,
@@ -7,49 +12,79 @@ import {
 import { useEffect, useState } from "react";
 
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
-import type { OAuthCredentialInputs, OAuthCredentials } from "@app/types";
+import type {
+  MCPOAuthUseCase,
+  OAuthCredentialInputs,
+  OAuthCredentials,
+} from "@app/types";
 import {
   getProviderRequiredOAuthCredentialInputs,
   isSupportedOAuthCredential,
   OAUTH_PROVIDER_NAMES,
 } from "@app/types";
 
+const OAUTH_USE_CASE_TO_LABEL: Record<MCPOAuthUseCase, string> = {
+  platform_actions: "Workspace",
+  personal_actions: "Personal",
+};
+
 type MCPServerOauthConnexionProps = {
-  authorization: AuthorizationInfo | null;
+  remoteMCPServerUrl?: string;
+  authorization: AuthorizationInfo;
   authCredentials: OAuthCredentials | null;
+  useCase: MCPOAuthUseCase | null;
+  setUseCase: (useCase: MCPOAuthUseCase) => void;
   setAuthCredentials: (authCredentials: OAuthCredentials) => void;
   setIsFormValid: (isFormValid: boolean) => void;
   documentationUrl?: string;
 };
 
 export function MCPServerOAuthConnexion({
+  remoteMCPServerUrl,
   authorization,
   authCredentials,
+  useCase,
+  setUseCase,
   setAuthCredentials,
   setIsFormValid,
   documentationUrl,
 }: MCPServerOauthConnexionProps) {
+  const [containerRef, setContainerRef] = useState<HTMLDivElement | null>(null);
   const [inputs, setInputs] = useState<OAuthCredentialInputs | null>(null);
 
-  // We fetch the credential inputs for this provider and use case.
   useEffect(() => {
-    const fetchCredentialInputs = async () => {
-      const credentialInputs =
-        await getProviderRequiredOAuthCredentialInputs(authorization);
-      setInputs(credentialInputs);
-      // Set the auth credentials to the values in the credentials object
-      // that already have a value as we will not ask the user for these values.
-      if (credentialInputs) {
-        setAuthCredentials(
-          Object.entries(credentialInputs).reduce(
-            (acc, [key, { value }]) => ({ ...acc, [key]: value }),
-            {}
-          )
+    // If there is only one use case, set it, otherwise leave it to the user to choose.
+    if (authorization.supported_use_cases.length === 1) {
+      setUseCase(authorization.supported_use_cases[0]);
+    }
+  }, [authorization, setUseCase]);
+
+  useEffect(() => {
+    if (useCase) {
+      // We fetch the credential inputs for this provider and use case.
+      const fetchCredentialInputs = async () => {
+        const credentialInputs = await getProviderRequiredOAuthCredentialInputs(
+          {
+            provider: authorization.provider,
+            useCase: useCase,
+          }
         );
-      }
-    };
-    void fetchCredentialInputs();
-  }, [authorization, setAuthCredentials]);
+        setInputs(credentialInputs);
+
+        // Set the auth credentials to the values in the credentials object
+        // that already have a value as we will not ask the user for these values.
+        if (credentialInputs) {
+          setAuthCredentials(
+            Object.entries(credentialInputs).reduce(
+              (acc, [key, { value }]) => ({ ...acc, [key]: value }),
+              {}
+            )
+          );
+        }
+      };
+      void fetchCredentialInputs();
+    }
+  }, [authorization, setAuthCredentials, useCase]);
 
   // We check if the form is valid.
   useEffect(() => {
@@ -70,101 +105,140 @@ export function MCPServerOAuthConnexion({
           break;
         }
       }
-      setIsFormValid(isFormValid);
+
+      setIsFormValid(isFormValid && !!useCase);
     }
-  }, [authCredentials, inputs, setIsFormValid]);
+  }, [authCredentials, inputs, setIsFormValid, useCase]);
 
   return (
-    authorization && (
-      <div className="flex flex-col items-center gap-2">
-        {inputs ? (
-          <>
-            <span className="text-500 w-full font-semibold">
-              These tools require admin authentication with{" "}
-              {OAUTH_PROVIDER_NAMES[authorization.provider]}
-              {documentationUrl && (
-                <>
-                  . Please follow{" "}
-                  <a
-                    href={documentationUrl}
-                    className="text-highlight-600"
-                    target="_blank"
-                  >
-                    this guide
-                  </a>{" "}
-                  to learn how to set it up
-                </>
-              )}
-              .
-            </span>
-            {Object.entries(inputs).map(([key, inputData]) => {
-              if (inputData.value) {
-                // If the credential is already set, we don't need to ask the user for it.
-                return null;
-              }
-              if (!isSupportedOAuthCredential(key)) {
-                // Can't happen but to make typescript happy.
-                return null;
-              }
-              const value = authCredentials?.[key] ?? "";
-              return (
-                <div key={key} className="w-full">
-                  <Label htmlFor={key}>{inputData.label}</Label>
-                  <Input
-                    id={key}
-                    value={value}
-                    onChange={(e) =>
-                      setAuthCredentials({
-                        ...authCredentials,
-                        [key]: e.target.value,
-                      })
+    <div
+      className="flex flex-col items-center gap-2"
+      id="mcp-server-oauth-connexion-container"
+      ref={setContainerRef}
+    >
+      {authorization && (
+        <>
+          {inputs ? (
+            <>
+              <span className="text-500 w-full font-normal">
+                {remoteMCPServerUrl
+                  ? `${remoteMCPServerUrl} requires authentication with `
+                  : "These tools require authentication with "}
+                {OAUTH_PROVIDER_NAMES[authorization.provider]}
+                {documentationUrl && (
+                  <>
+                    . Please follow{" "}
+                    <a
+                      href={documentationUrl}
+                      className="text-highlight-600"
+                      target="_blank"
+                    >
+                      this guide
+                    </a>{" "}
+                    to learn how to set it up
+                  </>
+                )}
+                .
+              </span>
+              {Object.entries(inputs).map(([key, inputData]) => {
+                if (inputData.value) {
+                  // If the credential is already set, we don't need to ask the user for it.
+                  return null;
+                }
+                if (!isSupportedOAuthCredential(key)) {
+                  // Can't happen but to make typescript happy.
+                  return null;
+                }
+                const value = authCredentials?.[key] ?? "";
+                return (
+                  <div key={key} className="w-full">
+                    <Label htmlFor={key}>{inputData.label}</Label>
+                    <Input
+                      id={key}
+                      value={value}
+                      onChange={(e) =>
+                        setAuthCredentials({
+                          ...authCredentials,
+                          [key]: e.target.value,
+                        })
+                      }
+                      message={inputData.helpMessage}
+                      messageStatus={
+                        value.length > 0 &&
+                        inputData.validator &&
+                        !inputData.validator(value)
+                          ? "error"
+                          : undefined
+                      }
+                    />
+                  </div>
+                );
+              })}
+            </>
+          ) : (
+            <Label className="self-start font-normal">
+              {remoteMCPServerUrl ? <b>{remoteMCPServerUrl}</b> : "These tools"}{" "}
+              requires authentication.
+            </Label>
+          )}
+          {authorization.supported_use_cases.length > 1 && containerRef && (
+            <div className="flex flex-col items-center gap-2 pt-4">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    isSelect
+                    variant="outline"
+                    label={
+                      useCase
+                        ? OAUTH_USE_CASE_TO_LABEL[useCase]
+                        : "Select credentials type"
                     }
-                    message={inputData.helpMessage}
-                    messageStatus={
-                      value.length > 0 &&
-                      inputData.validator &&
-                      !inputData.validator(value)
-                        ? "error"
-                        : undefined
-                    }
+                    size="sm"
                   />
-                </div>
-              );
-            })}
-          </>
-        ) : (
-          <Label className="self-start">
-            These tools require authentication with{" "}
-            {OAUTH_PROVIDER_NAMES[authorization.provider]}.
-          </Label>
-        )}
+                </DropdownMenuTrigger>
 
-        <div className="w-full pt-4">
-          {authorization.use_case === "platform_actions" && (
-            <ContentMessage
-              size="md"
-              variant="warning"
-              title="These tools are using workspace level credentials."
-              icon={InformationCircleIcon}
-            >
-              Authentication credentials will be shared by all users of this
-              workspace when they use these tools.
-            </ContentMessage>
+                <DropdownMenuContent mountPortalContainer={containerRef}>
+                  {authorization.supported_use_cases.map(
+                    (selectableUseCase) => (
+                      <DropdownMenuCheckboxItem
+                        key={selectableUseCase}
+                        checked={selectableUseCase === useCase}
+                        onCheckedChange={() => setUseCase(selectableUseCase)}
+                      >
+                        {OAUTH_USE_CASE_TO_LABEL[selectableUseCase]}
+                      </DropdownMenuCheckboxItem>
+                    )
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           )}
-          {authorization.use_case === "personal_actions" && (
-            <ContentMessage
-              size="md"
-              variant="highlight"
-              title="These tools are using personal level credentials."
-              icon={InformationCircleIcon}
-            >
-              Once setup for the workspace, each user will have to connect their
-              own {OAUTH_PROVIDER_NAMES[authorization.provider]} credentials to
-              interact with these tools.
-            </ContentMessage>
-          )}
-        </div>
-      </div>
-    )
+          <div className="w-full pt-4">
+            {useCase === "platform_actions" && (
+              <ContentMessage
+                size="md"
+                variant="warning"
+                title="Workspace level credentials."
+                icon={InformationCircleIcon}
+              >
+                The authentication credentials you provide during setup will be
+                shared by all users in this workspace when using these tools.
+              </ContentMessage>
+            )}
+            {useCase === "personal_actions" && (
+              <ContentMessage
+                size="md"
+                variant="highlight"
+                title="Personal level credentials."
+                icon={InformationCircleIcon}
+              >
+                Once setup for the workspace, each user will have to connect
+                their own credentials to interact with these tools.
+              </ContentMessage>
+            )}
+          </div>
+        </>
+      )}
+    </div>
   );
 }

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -20,6 +20,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "github" as const,
     use_case: "platform_actions" as const,
+    supported_use_cases: ["platform_actions"] as const,
   },
   icon: "GithubLogo",
 };

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -19,6 +19,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "gmail" as const,
     use_case: "personal_actions" as const,
+    supported_use_cases: ["personal_actions"] as const,
     scope:
       "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose" as const,
   },

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -19,7 +19,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "gmail",
     use_case: "personal_actions",
-    supported_use_cases: ["personal_actions", "platform_actions"] as const,
+    supported_use_cases: ["personal_actions"] as const,
     scope:
       "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events" as const,
   },

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -19,6 +19,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "gmail",
     use_case: "personal_actions",
+    supported_use_cases: ["personal_actions", "platform_actions"] as const,
     scope:
       "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events" as const,
   },

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -48,6 +48,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "hubspot" as const,
     use_case: "platform_actions" as const,
+    supported_use_cases: ["platform_actions"] as const,
   },
   icon: "HubspotLogo",
 };

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -24,6 +24,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "notion" as const,
     use_case: "platform_actions" as const,
+    supported_use_cases: ["platform_actions"] as const,
   },
   icon: "NotionLogo",
 };

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -20,6 +20,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "salesforce" as const,
     use_case: "personal_actions" as const,
+    supported_use_cases: ["personal_actions", "platform_actions"] as const,
   },
   icon: "SalesforceLogo",
 };

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -35,7 +35,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
-import type { OAuthProvider, OAuthUseCase, Result } from "@app/types";
+import type { MCPOAuthUseCase, OAuthProvider, Result } from "@app/types";
 import {
   assertNever,
   Err,
@@ -46,7 +46,9 @@ import {
 
 export type AuthorizationInfo = {
   provider: OAuthProvider;
-  use_case: Extract<OAuthUseCase, "platform_actions" | "personal_actions">;
+  // TODO(mcp): remove use_case once the code has been updated to use the view.
+  use_case: MCPOAuthUseCase;
+  supported_use_cases: MCPOAuthUseCase[];
   scope?: string;
 };
 

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -10,7 +10,7 @@ import type {
   MCPServerAvailability,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
-import type { EditedByUser, ModelId } from "@app/types";
+import type { EditedByUser, MCPOAuthUseCase, ModelId } from "@app/types";
 
 export type MCPToolType = {
   name: string;
@@ -69,6 +69,7 @@ export interface MCPServerViewType {
   spaceId: string;
   serverType: "remote" | "internal";
   server: MCPServerType;
+  oAuthUseCase: MCPOAuthUseCase | null;
   editedByUser: EditedByUser | null;
 }
 

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -56,6 +56,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
       if (extraConfig.mcp_server_id) {
         return true;
       }
+    } else if (useCase === "platform_actions") {
       return !!(extraConfig.client_id && extraConfig.client_secret);
     }
     return Object.keys(extraConfig).length === 0;

--- a/front/lib/models/assistant/actions/mcp_server_view.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view.ts
@@ -1,12 +1,12 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { MCPOAuthUseCase } from "@app/types";
 import { assertNever } from "@app/types";
 
 export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServerViewModel> {
@@ -27,7 +27,7 @@ export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServ
   declare space: NonAttribute<SpaceModel>;
   declare remoteMCPServer: NonAttribute<RemoteMCPServerModel>;
 
-  declare oAuthUseCase: AuthorizationInfo["use_case"] | null;
+  declare oAuthUseCase: MCPOAuthUseCase | null;
 }
 MCPServerViewModel.init(
   {

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -68,13 +68,19 @@ describe("MCPServerViewResource", () => {
         // Internal server in the right workspace
         const internalServer1 = await InternalMCPServerInMemoryResource.makeNew(
           auth1,
-          "think",
+          {
+            name: "think",
+            useCase: null,
+          },
           t
         );
 
         const internalServer2 = await InternalMCPServerInMemoryResource.makeNew(
           auth2,
-          "think",
+          {
+            name: "think",
+            useCase: null,
+          },
           t
         );
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -665,6 +665,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         this.serverType === "remote"
           ? this.getRemoteMCPServerResource().toJSON()
           : this.getInternalMCPServerResource().toJSON(),
+      oAuthUseCase: this.oAuthUseCase,
       editedByUser: this.makeEditedBy(
         this.editedByUser,
         this.remoteMCPServer ? this.remoteMCPServer.updatedAt : this.updatedAt

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -26,7 +26,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { Result } from "@app/types";
+import type { MCPOAuthUseCase, Result } from "@app/types";
 import { Ok, redactString, removeNulls } from "@app/types";
 
 const SECRET_REDACTION_COOLDOWN_IN_MINUTES = 10;
@@ -51,7 +51,9 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     blob: Omit<
       CreationAttributes<RemoteMCPServerModel>,
       "name" | "description" | "spaceId" | "sId" | "lastSyncAt"
-    >,
+    > & {
+      oAuthUseCase: MCPOAuthUseCase | null;
+    },
     transaction?: Transaction
   ) {
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
@@ -82,7 +84,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         vaultId: systemSpace.id,
         editedAt: new Date(),
         editedByUserId: auth.user()?.id,
-        oAuthUseCase: blob.authorization?.use_case ?? null,
+        oAuthUseCase: blob.oAuthUseCase,
       },
       {
         transaction,

--- a/front/lib/swr/mcp_server_views.ts
+++ b/front/lib/swr/mcp_server_views.ts
@@ -70,6 +70,7 @@ const getOptimisticDataForCreate = (
               server,
               editedByUser: null,
               spaceId: space.sId,
+              oAuthUseCase: null,
             },
           ],
         },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.524",
+        "@dust-tt/sparkle": "^0.2.525",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1103,9 +1103,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.524",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.524.tgz",
-      "integrity": "sha512-UpJht5dyVxq3++CMJWlR6ZCdpLwMDrKS5GmSySSUNNKINVDINQente3YmKhySafudz78+WsBl4Xtdg8XuH0imA==",
+      "version": "0.2.526",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.526.tgz",
+      "integrity": "sha512-udey/Rmqooia5DrQmbsGMCFseio85875cIDluhyROOerOrGx9InvAKMyekSg4SnjaCIl1U6/oFqRAJjwpLJSlg==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.524",
+    "@dust-tt/sparkle": "^0.2.526",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -57,7 +57,10 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
     // Internal server in the right workspace
     const internalServer = await InternalMCPServerInMemoryResource.makeNew(
       auth,
-      "primitive_types_debugger",
+      {
+        name: "primitive_types_debugger",
+        useCase: null,
+      },
       t
     );
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -45,7 +45,10 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
 
     const internalServer = await InternalMCPServerInMemoryResource.makeNew(
       auth,
-      "primitive_types_debugger",
+      {
+        name: "primitive_types_debugger",
+        useCase: null,
+      },
       t
     );
 
@@ -91,7 +94,10 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
 
       const internalServer = await InternalMCPServerInMemoryResource.makeNew(
         auth,
-        "primitive_types_debugger",
+        {
+          name: "primitive_types_debugger",
+          useCase: null,
+        },
         t
       );
 
@@ -150,7 +156,10 @@ describe("Method Support /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => 
 
     const mcpServer = await InternalMCPServerInMemoryResource.makeNew(
       authenticator,
-      "primitive_types_debugger",
+      {
+        name: "primitive_types_debugger",
+        useCase: null,
+      },
       t
     );
 

--- a/front/tests/utils/RemoteMCPServerFactory.ts
+++ b/front/tests/utils/RemoteMCPServerFactory.ts
@@ -34,6 +34,7 @@ export class RemoteMCPServerFactory {
       icon: DEFAULT_MCP_SERVER_ICON,
       version: DEFAULT_MCP_ACTION_VERSION,
       authorization: null,
+      oAuthUseCase: null,
     });
   }
 }


### PR DESCRIPTION
## Description

Update Creation and Connect dialog to allow the users to pick between personal and workspace credentials (if there is more than one choice).
In this PR, I only allow the one and only one choice from current as we don't handle retrieving the choice yet from the view.
In the next PR, I'll expand choices when appropriate and refactor to retrieve from view.

## Tests

Local (for illustration purpose, I did the video with choices for salesforce)


https://github.com/user-attachments/assets/60927ed0-78d1-42f3-b6e1-96c124233368

https://github.com/user-attachments/assets/29b06235-6704-4d4f-bee2-8b91d14c4d50



## Risk

Medium, could break the setup flow (but tested a lot).

## Deploy Plan

Deploy front, then do another PR.