### PR TITLE
enh(cli): enable private agent access

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/dust-cli",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "@dust-tt/client": "^1.0.50",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",

--- a/cli/src/utils/hooks/use_agents.ts
+++ b/cli/src/utils/hooks/use_agents.ts
@@ -40,9 +40,7 @@ export function useAgents() {
         return;
       }
 
-      const agentsRes = await dustClient.getAgentConfigurations({
-        view: "all",
-      });
+      const agentsRes = await dustClient.getAgentConfigurations({});
 
       if (agentsRes.isErr()) {
         setError(`API Error fetching agents: ${agentsRes.error.message}`);


### PR DESCRIPTION
## Description
Remove hardcoded 'view: all' parameter from agent fetching in CLI to enable access to private agents. This brings the CLI to feature parity with the extension.

The CLI was explicitly requesting view='all' which only returns public agents, while the extension uses the default view which includes private agents for authenticated users.

## Tests
- Tested manually that CLI can now access private agents after authentication

## Risk
Low risk - removing a restrictive parameter to use API defaults. The authentication and permission checks remain unchanged.

## Deploy Plan
Publish CLI

