### PR TITLE
enh: use untrusted egress proxy for oauth token endpoints

### DIFF
--- a/core/src/http/proxy_client.rs
+++ b/core/src/http/proxy_client.rs
@@ -1,0 +1,42 @@
+use lazy_static::lazy_static;
+use std::env;
+use tracing::{error, info};
+
+lazy_static! {
+    static ref UNTRUSTED_EGRESS_PROXY: Option<String> = {
+        match (
+            env::var("UNTRUSTED_EGRESS_PROXY_HOST"),
+            env::var("UNTRUSTED_EGRESS_PROXY_PORT"),
+        ) {
+            (Ok(host), Ok(port)) => {
+                let proxy_url = format!("http://{}:{}", host, port);
+                info!(
+                    proxy_url = proxy_url.as_str(),
+                    "Untrusted egress proxy configured"
+                );
+                Some(proxy_url)
+            }
+            _ => None,
+        }
+    };
+}
+
+/// Creates a reqwest client builder configured with the untrusted egress proxy if the
+/// environment variables UNTRUSTED_EGRESS_PROXY_HOST and UNTRUSTED_EGRESS_PROXY_PORT are set.
+/// The builder can be further customized before building the final client.
+pub fn create_untrusted_egress_client_builder() -> reqwest::ClientBuilder {
+    let mut builder = reqwest::Client::builder();
+
+    if let Some(proxy_url) = UNTRUSTED_EGRESS_PROXY.as_ref() {
+        match reqwest::Proxy::all(proxy_url) {
+            Ok(proxy) => {
+                builder = builder.proxy(proxy);
+            }
+            Err(e) => {
+                error!(error = ?e, proxy_url = proxy_url.as_str(), "Failed to configure untrusted egress proxy");
+            }
+        }
+    }
+
+    builder
+}

--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -3,22 +3,15 @@ use crate::utils;
 use crate::{cached_request::CachedRequest, project::Project};
 use anyhow::{anyhow, Result};
 use hyper::body::Buf;
-use lazy_static::lazy_static;
 use reqwest::redirect::Policy;
 use reqwest::{header, Method};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{env, io::prelude::*, str::FromStr};
+use std::{io::prelude::*, str::FromStr};
 use tracing::info;
 
 use super::network::NetworkUtils;
-
-lazy_static! {
-    static ref UNTRUSTED_EGRESS_PROXY_HOST: Option<String> =
-        env::var("UNTRUSTED_EGRESS_PROXY_HOST").ok();
-    static ref UNTRUSTED_EGRESS_PROXY_PORT: Option<String> =
-        env::var("UNTRUSTED_EGRESS_PROXY_PORT").ok();
-}
+use super::proxy_client::create_untrusted_egress_client_builder;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct HttpRequest {
@@ -87,38 +80,25 @@ impl HttpRequest {
         // First check the initial URL.
         NetworkUtils::check_url_for_private_ip(&self.url)?;
 
-        // First create the client with the custom redirect policy.
-        let mut client_builder = reqwest::Client::builder().redirect(Policy::custom(|attempt| {
-            // Log the redirect for debugging.
-            println!(
-                "Redirect attempt from: {:?} to: {}",
-                attempt.previous(),
-                attempt.url()
-            );
+        // Create the client with the untrusted egress proxy and custom redirect policy.
+        let client_builder =
+            create_untrusted_egress_client_builder().redirect(Policy::custom(|attempt| {
+                // Log the redirect for debugging.
+                println!(
+                    "Redirect attempt from: {:?} to: {}",
+                    attempt.previous(),
+                    attempt.url()
+                );
 
-            // Ensure the URL is not pointing to a private IP.
-            match NetworkUtils::check_url_for_private_ip(attempt.url().as_str()) {
-                Ok(_) => attempt.follow(),
-                Err(e) => {
-                    println!("Attempt to follow redirect to private IP: {}", e);
-                    attempt.error(e)
+                // Ensure the URL is not pointing to a private IP.
+                match NetworkUtils::check_url_for_private_ip(attempt.url().as_str()) {
+                    Ok(_) => attempt.follow(),
+                    Err(e) => {
+                        println!("Attempt to follow redirect to private IP: {}", e);
+                        attempt.error(e)
+                    }
                 }
-            }
-        }));
-
-        if let (Some(proxy_host), Some(proxy_port)) = (
-            UNTRUSTED_EGRESS_PROXY_HOST.as_ref(),
-            UNTRUSTED_EGRESS_PROXY_PORT.as_ref(),
-        ) {
-            let proxy_url = format!("http://{}:{}", proxy_host, proxy_port);
-            let proxy = reqwest::Proxy::all(&proxy_url)
-                .map_err(|e| anyhow!("Failed to configure proxy: {}", e))?;
-            client_builder = client_builder.proxy(proxy);
-            info!(
-                proxy_url = proxy_url.as_str(),
-                "Using proxy for HTTP request"
-            );
-        }
+            }));
 
         let client = client_builder
             .build()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -81,6 +81,7 @@ pub mod providers {
 }
 pub mod http {
     pub mod network;
+    pub mod proxy_client;
     pub mod request;
 }
 pub mod blocks {


### PR DESCRIPTION
## Description

Use untrusted egress proxy in `oauth` when making requests to `token_endpoint` URLs we don't control.

This affects:
- Salesforce
- MCP

Also DRY the proxied reqwest client building (affects CURL and BROWSE blocks)

## Tests

Locally

## Risk

Risk of breaking MCP and Salesforce oauth

## Deploy Plan

Deploy core and oauth (secret already live on `oauth`)