### PR TITLE
[front] enh(monitoring): add tool wrapper for monitoring

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -16,6 +16,7 @@ import {
   getCoreSearchArgs,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
@@ -273,7 +274,7 @@ function createServer(
       "retrieve_recent_documents",
       "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
       commonInputsSchema,
-      includeFunction
+      withToolLogging(auth, "include", includeFunction)
     );
   } else {
     server.tool(
@@ -283,7 +284,7 @@ function createServer(
         ...commonInputsSchema,
         ...tagsInputSchema,
       },
-      includeFunction
+      withToolLogging(auth, "include", includeFunction)
     );
 
     server.tool(

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -15,6 +15,7 @@ import {
   getCoreSearchArgs,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
@@ -279,7 +280,7 @@ function createServer(
         " The search is based on semantic similarity between the query and chunks of information" +
         " from the data sources.",
       commonInputsSchema,
-      searchFunction
+      withToolLogging(auth, "semantic_search", searchFunction)
     );
   } else {
     server.tool(
@@ -291,7 +292,7 @@ function createServer(
         ...commonInputsSchema,
         ...tagsInputSchema,
       },
-      searchFunction
+      withToolLogging(auth, "semantic_search", searchFunction)
     );
 
     server.tool(

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -24,6 +24,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { fetchAgentTableConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
@@ -32,7 +33,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
-import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 
 // Types for the resources that are output by the tools of this server.
 type TablesQueryOutputResources =

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -32,6 +32,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 
 // Types for the resources that are output by the tools of this server.
 type TablesQueryOutputResources =
@@ -139,168 +140,175 @@ function createServer(
         .string()
         .describe("The name of the file to save the results to."),
     },
-    async ({ tables, query, fileName }) => {
-      // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
-      if (!agentLoopContext?.runContext) {
-        throw new Error("Unreachable: missing agentLoopContext.");
-      }
+    withToolLogging(
+      auth,
+      "tables_query",
+      async ({ tables, query, fileName }) => {
+        // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
+        if (!agentLoopContext?.runContext) {
+          throw new Error("Unreachable: missing agentLoopContext.");
+        }
 
-      const agentLoopRunContext = agentLoopContext.runContext;
+        const agentLoopRunContext = agentLoopContext.runContext;
 
-      // Fetch table configurations
-      const agentTableConfigurationsRes = await fetchAgentTableConfigurations(
-        auth,
-        tables
-      );
-      if (agentTableConfigurationsRes.isErr()) {
-        return makeMCPToolTextError(
-          `Error fetching table configurations: ${agentTableConfigurationsRes.error.message}`
-        );
-      }
-      const agentTableConfigurations = agentTableConfigurationsRes.value;
-      if (agentTableConfigurations.length === 0) {
-        return makeMCPToolTextError(
-          "The agent does not have access to any tables. Please edit the agent's Query Tables tool to add tables, or remove the tool."
-        );
-      }
-      const dataSourceViews = await DataSourceViewResource.fetchByModelIds(
-        auth,
-        [...new Set(agentTableConfigurations.map((t) => t.dataSourceViewId))]
-      );
-      const dataSourceViewsMap = new Map(
-        dataSourceViews.map((dsv) => [dsv.id, dsv])
-      );
-
-      // Call Core API's /query_database endpoint
-      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-      const queryResult = await coreAPI.queryDatabase({
-        tables: agentTableConfigurations.map((t) => {
-          const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
-          if (
-            !dataSourceView ||
-            !dataSourceView.dataSource.dustAPIDataSourceId
-          ) {
-            throw new Error(
-              `Missing data source ID for view ${t.dataSourceViewId}`
-            );
-          }
-          return {
-            project_id: parseInt(dataSourceView.dataSource.dustAPIProjectId),
-            data_source_id: dataSourceView.dataSource.dustAPIDataSourceId,
-            table_id: t.tableId,
-          };
-        }),
-        query,
-      });
-      if (queryResult.isErr()) {
-        return makeMCPToolTextError(
-          `Error executing database query: ${queryResult.error.message}`
-        );
-      }
-
-      const content: {
-        type: "resource";
-        resource: TablesQueryOutputResources;
-      }[] = [];
-
-      const results: CSVRecord[] = queryResult.value.results
-        .map((r) => r.value)
-        .filter(
-          (record) =>
-            record !== undefined &&
-            record !== null &&
-            typeof record === "object"
-        );
-
-      if (results.length > 0) {
-        // date in yyyy-mm-dd
-        const humanReadableDate = new Date().toISOString().split("T")[0];
-        const queryTitle = `${fileName} (${humanReadableDate})`;
-
-        // Generate the CSV file.
-        const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {
-          title: queryTitle,
-          conversationId: agentLoopRunContext.conversation.sId,
-          results,
-        });
-
-        // Upload the CSV file to the conversation data source.
-        await uploadFileToConversationDataSource({
+        // Fetch table configurations
+        const agentTableConfigurationsRes = await fetchAgentTableConfigurations(
           auth,
-          file: csvFile,
-        });
-
-        // Append the CSV file to the output of the tool as an agent-generated file.
-        content.push({
-          type: "resource",
-          resource: {
-            text: `Your query results were generated successfully.`,
-            uri: csvFile.getPublicUrl(auth),
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-            fileId: csvFile.sId,
-            title: queryTitle,
-            contentType: csvFile.contentType,
-            snippet: csvSnippet,
-          },
-        });
-
-        // Check if we should generate a section JSON file.
-        const shouldGenerateSectionFile = results.some((result) =>
-          Object.values(result).some(
-            (value) =>
-              typeof value === "string" &&
-              value.length > TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH
-          )
+          tables
+        );
+        if (agentTableConfigurationsRes.isErr()) {
+          return makeMCPToolTextError(
+            `Error fetching table configurations: ${agentTableConfigurationsRes.error.message}`
+          );
+        }
+        const agentTableConfigurations = agentTableConfigurationsRes.value;
+        if (agentTableConfigurations.length === 0) {
+          return makeMCPToolTextError(
+            "The agent does not have access to any tables. Please edit the agent's Query Tables tool to add tables, or remove the tool."
+          );
+        }
+        const dataSourceViews = await DataSourceViewResource.fetchByModelIds(
+          auth,
+          [...new Set(agentTableConfigurations.map((t) => t.dataSourceViewId))]
+        );
+        const dataSourceViewsMap = new Map(
+          dataSourceViews.map((dsv) => [dsv.id, dsv])
         );
 
-        if (shouldGenerateSectionFile) {
-          // First, we fetch the connector provider for the data source, cause the chunking
-          // strategy of the section file depends on it: Since all tables are from the same
-          // data source, we can just take the first table's data source view id.
-          const [dataSourceView] = await DataSourceViewResource.fetchByModelIds(
-            auth,
-            [agentTableConfigurations[0].dataSourceViewId]
+        // Call Core API's /query_database endpoint
+        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+        const queryResult = await coreAPI.queryDatabase({
+          tables: agentTableConfigurations.map((t) => {
+            const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
+            if (
+              !dataSourceView ||
+              !dataSourceView.dataSource.dustAPIDataSourceId
+            ) {
+              throw new Error(
+                `Missing data source ID for view ${t.dataSourceViewId}`
+              );
+            }
+            return {
+              project_id: parseInt(dataSourceView.dataSource.dustAPIProjectId),
+              data_source_id: dataSourceView.dataSource.dustAPIDataSourceId,
+              table_id: t.tableId,
+            };
+          }),
+          query,
+        });
+        if (queryResult.isErr()) {
+          return makeMCPToolTextError(
+            `Error executing database query: ${queryResult.error.message}`
           );
-          const connectorProvider =
-            dataSourceView?.dataSource?.connectorProvider ?? null;
-          const sectionColumnsPrefix =
-            getSectionColumnsPrefix(connectorProvider);
+        }
 
-          // Generate the section file.
-          const sectionFile = await generateSectionFile(auth, {
-            title: queryTitle,
-            conversationId: agentLoopRunContext.conversation.sId,
-            results,
-            sectionColumnsPrefix,
-          });
+        const content: {
+          type: "resource";
+          resource: TablesQueryOutputResources;
+        }[] = [];
 
-          // Upload the section file to the conversation data source.
+        const results: CSVRecord[] = queryResult.value.results
+          .map((r) => r.value)
+          .filter(
+            (record) =>
+              record !== undefined &&
+              record !== null &&
+              typeof record === "object"
+          );
+
+        if (results.length > 0) {
+          // date in yyyy-mm-dd
+          const humanReadableDate = new Date().toISOString().split("T")[0];
+          const queryTitle = `${fileName} (${humanReadableDate})`;
+
+          // Generate the CSV file.
+          const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(
+            auth,
+            {
+              title: queryTitle,
+              conversationId: agentLoopRunContext.conversation.sId,
+              results,
+            }
+          );
+
+          // Upload the CSV file to the conversation data source.
           await uploadFileToConversationDataSource({
             auth,
-            file: sectionFile,
+            file: csvFile,
           });
 
-          // Append the section file to the output of the tool as an agent-generated file.
+          // Append the CSV file to the output of the tool as an agent-generated file.
           content.push({
             type: "resource",
             resource: {
-              text: "Your query results were generated successfully.",
-              uri: sectionFile.getPublicUrl(auth),
+              text: `Your query results were generated successfully.`,
+              uri: csvFile.getPublicUrl(auth),
               mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-              fileId: sectionFile.sId,
-              title: `${queryTitle} (Rich Text)`,
-              contentType: sectionFile.contentType,
-              snippet: null,
+              fileId: csvFile.sId,
+              title: queryTitle,
+              contentType: csvFile.contentType,
+              snippet: csvSnippet,
             },
           });
-        }
-      }
 
-      return {
-        isError: false,
-        content,
-      };
-    }
+          // Check if we should generate a section JSON file.
+          const shouldGenerateSectionFile = results.some((result) =>
+            Object.values(result).some(
+              (value) =>
+                typeof value === "string" &&
+                value.length > TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH
+            )
+          );
+
+          if (shouldGenerateSectionFile) {
+            // First, we fetch the connector provider for the data source, cause the chunking
+            // strategy of the section file depends on it: Since all tables are from the same
+            // data source, we can just take the first table's data source view id.
+            const [dataSourceView] =
+              await DataSourceViewResource.fetchByModelIds(auth, [
+                agentTableConfigurations[0].dataSourceViewId,
+              ]);
+            const connectorProvider =
+              dataSourceView?.dataSource?.connectorProvider ?? null;
+            const sectionColumnsPrefix =
+              getSectionColumnsPrefix(connectorProvider);
+
+            // Generate the section file.
+            const sectionFile = await generateSectionFile(auth, {
+              title: queryTitle,
+              conversationId: agentLoopRunContext.conversation.sId,
+              results,
+              sectionColumnsPrefix,
+            });
+
+            // Upload the section file to the conversation data source.
+            await uploadFileToConversationDataSource({
+              auth,
+              file: sectionFile,
+            });
+
+            // Append the section file to the output of the tool as an agent-generated file.
+            content.push({
+              type: "resource",
+              resource: {
+                text: "Your query results were generated successfully.",
+                uri: sectionFile.getPublicUrl(auth),
+                mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+                fileId: sectionFile.sId,
+                title: `${queryTitle} (Rich Text)`,
+                contentType: sectionFile.contentType,
+                snippet: null,
+              },
+            });
+          }
+        }
+
+        return {
+          isError: false,
+          content,
+        };
+      }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -25,7 +25,7 @@ export function withToolLogging<T>(
     logger.info(loggerArgs, "Tool execution start");
 
     const tags = [
-      `tool:${toolName}`,
+      `action:${toolName}`,
       `workspace:${owner.sId}`,
       `workspace_name:${owner.name}`,
       `workspace_plan_code:${auth.plan()?.code || null}`,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -1,0 +1,69 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
+import { removeNulls } from "@app/types";
+
+export function withToolLogging<T>(
+  auth: Authenticator,
+  toolName: string,
+  toolCallback: (params: T) => Promise<CallToolResult>
+) {
+  return async (params: T) => {
+    const owner = auth.getNonNullableWorkspace();
+
+    const loggerArgs = {
+      workspace: {
+        sId: owner.sId,
+        name: owner.name,
+        plan_code: auth.plan()?.code || null,
+      },
+      toolName,
+    };
+
+    logger.info(loggerArgs, "Tool execution start");
+
+    const tags = [
+      `tool:${toolName}`,
+      `workspace:${owner.sId}`,
+      `workspace_name:${owner.name}`,
+      `workspace_plan_code:${auth.plan()?.code || null}`,
+    ];
+
+    statsDClient.increment("use_actions.count", 1, tags);
+    const now = new Date();
+
+    const result = await toolCallback(params);
+
+    if (result.isError) {
+      statsDClient.increment("use_actions_error.count", 1, [
+        "error_type:run_error",
+        ...tags,
+      ]);
+
+      // Only process text content, resources may be huge.
+      const error = removeNulls(
+        result.content.map((c) => (c.type === "text" ? c.text : null))
+      ).join("\n");
+
+      logger.error(
+        {
+          error,
+          ...loggerArgs,
+        },
+        "Tool execution error"
+      );
+      return result;
+    }
+
+    const elapsed = new Date().getTime() - now.getTime();
+    statsDClient.distribution(
+      "run_action.duration.distribution",
+      elapsed,
+      tags
+    );
+
+    return result;
+  };
+}


### PR DESCRIPTION
## Description

- As a consequence of the migration to MCP actions, some actions do not rely on a dust app anymore. For instance the semantic search now calls `core` directly instead of using the `assistant-v2-retrieval` dust app.
- This PR adds a wrapper `withToolLogging` that wraps a tool callback to increment/update the `use_actions`, `use_actions_error`  and `run_action` Datadog metrics + logs the start and the errors.
- Only the `semantic_search`, the exploded `tables_query and the `include` tools are wrapped, `reasoning` and `process` still rely on the Dust App so we have logging there.
- The name of the metrics and the tags remain the same for now, we'll have to do some cleanup and update the dashboards once all actions have been migrated: for now in terms of wording there is a mixup between "action" and "tool". 

## Tests

- Tested locally.

## Risk

High blast radius:
- Slightly increases the cardinality of the Datadog metric.
- Adds quite a lot of logs.

## Deploy Plan

- Deploy front.
