### PR TITLE
Salesforce synced query: bump to 512

### DIFF
--- a/connectors/src/connectors/salesforce/lib/cli.ts
+++ b/connectors/src/connectors/salesforce/lib/cli.ts
@@ -78,7 +78,7 @@ export const salesforce = async ({
         credentials: connCredRes.value.credentials,
         limit: args.limit,
         offset: args.offset,
-        lastModifiedDateOrder: "DESC",
+        lastModifiedDateOrder: args.lastModifiedDateOrder,
       });
       if (res.isErr()) {
         throw res.error;

--- a/connectors/src/connectors/salesforce/temporal/workflows.ts
+++ b/connectors/src/connectors/salesforce/temporal/workflows.ts
@@ -103,7 +103,7 @@ export async function salesforceSyncWorkflow({
 //   await syncSalesforceConnection(connectorId);
 // }
 
-const SALESFORCE_SYNC_QUERY_PAGE_LIMIT = 128;
+const SALESFORCE_SYNC_QUERY_PAGE_LIMIT = 512;
 
 export function makeSalesforceSyncQueryWorkflowId(
   connectorId: ModelId,

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -626,6 +626,11 @@ export const SalesforceCommandSchema = t.type({
     dsId: t.union([t.string, t.undefined]),
     soql: t.union([t.string, t.undefined]),
     limit: t.union([t.number, t.undefined]),
+    lastModifiedDateOrder: t.union([
+      t.literal("ASC"),
+      t.literal("DESC"),
+      t.undefined,
+    ]),
     offset: t.union([t.number, t.undefined]),
     rootNodeName: t.union([t.string, t.undefined]),
     titleTemplate: t.union([t.string, t.undefined]),


### PR DESCRIPTION
## Description

Bump page size to 512 to limit risk of rate limiting (tested in prod against a real account and 512 is gladly accepted)

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `connectors`