### PR TITLE
[front] fix mentions list display issue on iOS browsers

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -44,7 +44,9 @@ export const MentionDropdown = ({
       setVirtualTriggerStyle({
         position: "fixed",
         left: triggerRect.left,
-        top: triggerRect.top,
+        // On iOS based browsers, the position is not correct without adding the offsetTop.
+        // Something related to the position calculation when there is a scrollable area.
+        top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
         width: 1,
         height: triggerRect.height || 1,
         pointerEvents: "none",
@@ -60,11 +62,7 @@ export const MentionDropdown = ({
   return (
     <DropdownMenu open={isOpen} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
-        <div
-          ref={triggerRef}
-          style={virtualTriggerStyle}
-          className="absolute"
-        />
+        <div ref={triggerRef} style={virtualTriggerStyle} />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="w-72"


### PR DESCRIPTION
## Description
This PR is to fix the display issue of mention list on iOS based browser. I cannot wrap my head around fully, but seems like iOS calculates the position differently when position is fixed, and trigger is somehow placed a bit higher than it's supposed to be, and push down it by the size of viewport offset will place the cursor where we want. 

Jules confirmed that it's working on Android. I tested on iOS and desktop it works as expected.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
