### PR TITLE
enh: use untrusted egress proxy legacy webcrawler

### DIFF
--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -21,4 +21,14 @@ export const apiConfig = {
       apiKey: EnvironmentConfig.getEnvVariable("FIRECRAWL_API_KEY"),
     };
   },
+  getUntrustedEgressProxyHost: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "UNTRUSTED_EGRESS_PROXY_HOST"
+    );
+  },
+  getUntrustedEgressProxyPort: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "UNTRUSTED_EGRESS_PROXY_PORT"
+    );
+  },
 };


### PR DESCRIPTION
## Description

The legacy cheerio-based webcrawler makes requests to arbitrary user-controlled URLs.
As part of our safer egress effort, we want to route such requests through our squid proxy deployment which has enhanced SSRF protections

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

secrets on connectors + deploy connectors