### PR TITLE
cleanup: remove unused document_tracker feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -32,7 +32,6 @@ export const WHITELISTABLE_FEATURES = [
   "google_calendar_tool",
   "agent_builder_v2",
   "disallow_agent_creation_to_users",
-  "document_tracker",
   "agent_discovery",
   "search_knowledge_builder",
   "snowflake_connector_feature",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -809,7 +809,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "deepseek_r1_global_agent_feature"
   | "dev_mcp_actions"
   | "disable_run_logs"
-  | "document_tracker"
   | "force_gdrive_labels_scope"
   | "google_ai_studio_experimental_models_feature"
   | "index_private_slack_channel"


### PR DESCRIPTION
## Description

This PR removes the `document_tracker` feature flag from the codebase as it is no longer used in the front application. The flag has been removed from:
- `front/types/shared/feature_flags.ts` - removed from the `WHITELISTABLE_FEATURES` array
- `sdks/js/src/types.ts` - removed from the `WhitelistableFeaturesSchema`


## Tests


## Risk

Low risk - this only removes an unused feature flag from the whitelist. No functional code is affected.

## Deploy Plan
