### PR TITLE
[workos] feat: Handle webhooks in the temporal activities

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -14,7 +14,7 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
-import type { ActiveRoleType, Result } from "@app/types";
+import type { ActiveRoleType, LightWorkspaceType, Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 export async function createAndLogMembership({
@@ -23,18 +23,22 @@ export async function createAndLogMembership({
   role,
 }: {
   user: UserResource;
-  workspace: Workspace;
+  workspace: Workspace | LightWorkspaceType;
   role: ActiveRoleType;
 }) {
+  const w =
+    workspace instanceof Workspace
+      ? renderLightWorkspaceType({ workspace })
+      : workspace;
   const m = await MembershipResource.createMembership({
     role,
     user,
-    workspace: renderLightWorkspaceType({ workspace }),
+    workspace: w,
   });
 
   void ServerSideTracking.trackCreateMembership({
     user: user.toJSON(),
-    workspace: renderLightWorkspaceType({ workspace }),
+    workspace: w,
     role: m.role,
     startAt: m.startAt,
   });

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -9,6 +9,7 @@ import config from "@app/lib/api/config";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import type { SessionWithUser } from "@app/lib/iam/provider";
+import type { LightWorkspaceType } from "@app/types";
 
 export type SessionCookie = {
   sessionData: string;
@@ -90,4 +91,27 @@ export async function updateUserFromAuth0(
       },
     });
   }
+}
+
+export async function fetchWorkOSUserWithEmail(
+  workspace: LightWorkspaceType,
+  email?: string | null
+) {
+  if (email == null) {
+    throw new Error("Missing email");
+  }
+
+  const workOSUserResponse = await getWorkOS().userManagement.listUsers({
+    organizationId: workspace.workOSOrganizationId ?? undefined,
+    email,
+  });
+
+  const [workOSUser] = workOSUserResponse.data;
+  if (!workOSUser) {
+    throw new Error(
+      `User not found with email "${email}" in workOS for workspace "${workspace.sId}"`
+    );
+  }
+
+  return workOSUser;
 }

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -9,7 +9,8 @@ import config from "@app/lib/api/config";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import type { LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType, Result } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 export type SessionCookie = {
   sessionData: string;
@@ -96,9 +97,9 @@ export async function updateUserFromAuth0(
 export async function fetchWorkOSUserWithEmail(
   workspace: LightWorkspaceType,
   email?: string | null
-) {
+): Promise<Result<WorkOSUser, Error>> {
   if (email == null) {
-    throw new Error("Missing email");
+    return new Err(new Error("Missing email"));
   }
 
   const workOSUserResponse = await getWorkOS().userManagement.listUsers({
@@ -108,10 +109,12 @@ export async function fetchWorkOSUserWithEmail(
 
   const [workOSUser] = workOSUserResponse.data;
   if (!workOSUser) {
-    throw new Error(
-      `User not found with email "${email}" in workOS for workspace "${workspace.sId}"`
+    return new Err(
+      new Error(
+        `User not found with email "${email}" in workOS for workspace "${workspace.sId}"`
+      )
     );
   }
 
-  return workOSUser;
+  return new Ok(workOSUser);
 }

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -201,6 +201,7 @@ export async function createOrUpdateUser({
       name: externalUser.name,
       firstName,
       lastName,
+      imageUrl: externalUser.picture,
     });
 
     if (existingWorkOSUser) {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -540,12 +540,12 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async upsertByWorkOSGroupId(
     auth: Authenticator,
-    workspace: LightWorkspaceType,
     directoryGroup: DirectoryGroup
   ) {
+    const owner = auth.getNonNullableWorkspace();
     const group = await this.model.findOne({
       where: {
-        workspaceId: workspace.id,
+        workspaceId: owner.id,
         workOSGroupId: directoryGroup.directoryId,
       },
     });
@@ -561,19 +561,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       workOSGroupId: directoryGroup.directoryId,
       updatedAt: new Date(),
       kind: "provisioned",
-      workspaceId: workspace.id,
-    });
-  }
-
-  static async deleteByWorkOSGroupId(
-    workspace: LightWorkspaceType,
-    directoryGroup: DirectoryGroup
-  ) {
-    await this.model.destroy({
-      where: {
-        workspaceId: workspace.id,
-        workOSGroupId: directoryGroup.directoryId,
-      },
+      workspaceId: owner.id,
     });
   }
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -539,6 +539,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   static async upsertByWorkOSGroupId(
+    auth: Authenticator,
     workspace: LightWorkspaceType,
     directoryGroup: DirectoryGroup
   ) {
@@ -550,9 +551,9 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
 
     if (group) {
-      group.name = directoryGroup.name;
-      await group.save();
-      return new this(this.model, group.get());
+      const groupResource = new this(this.model, group.get());
+      await groupResource.updateName(auth, directoryGroup.name);
+      return groupResource;
     }
 
     return this.makeNew({

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -241,7 +241,7 @@ export class UserResource extends BaseResource<UserModel> {
 
   async delete(
     auth: Authenticator,
-    { transaction }: { transaction?: Transaction }
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
     await this.deleteAllMetadata();
 

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -102,7 +102,7 @@ async function fetchWorkOSUserWithEmail(
   email?: string | null
 ) {
   if (email == null) {
-    throw new Error(`Missing email`);
+    throw new Error("Missing email");
   }
 
   const workOSUserResponse = await workOS.userManagement.listUsers({

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -8,6 +8,7 @@ import type {
 } from "@workos-inc/node";
 import assert from "assert";
 
+import { createAndLogMembership } from "@app/lib/api/signup";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import {
   fetchWorkOSUserWithEmail,
@@ -30,8 +31,6 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import mainLogger from "@app/logger/logger";
 import type { LightWorkspaceType, Result } from "@app/types";
-
-import { launchUpdateUsageWorkflow } from "../usage_queue/client";
 
 const logger = mainLogger.child(
   {},
@@ -307,18 +306,12 @@ async function handleCreateOrUpdateWorkOSUser(
     user,
     externalUser,
   });
-  const membership = await MembershipResource.createMembership({
+
+  await createAndLogMembership({
     user: createdOrUpdatedUser,
     workspace,
     role: "user",
   });
-  void ServerSideTracking.trackCreateMembership({
-    user: createdOrUpdatedUser.toJSON(),
-    workspace,
-    role: membership.role,
-    startAt: membership.startAt,
-  });
-  await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
 }
 
 async function handleDeleteWorkOSUser(

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -129,7 +129,7 @@ export async function processWorkOSEventActivity({
       await verifyWorkOSWorkspace(
         eventPayload.data.organizationId,
         eventPayload.data,
-        GroupResource.deleteByWorkOSGroupId
+        handleGroupDelete
       );
       break;
 
@@ -217,7 +217,7 @@ async function handleGroupUpsert(
   event: DirectoryGroup
 ) {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  await GroupResource.upsertByWorkOSGroupId(auth, workspace, event);
+  await GroupResource.upsertByWorkOSGroupId(auth, event);
 }
 
 async function handleUserAddedToGroup(
@@ -348,4 +348,21 @@ async function handleDeleteWorkOSUser(
     workspace,
     ...membershipRevokeResult.value,
   });
+}
+
+async function handleGroupDelete(
+  workspace: LightWorkspaceType,
+  event: DirectoryGroup
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const group = await GroupResource.fetchByWorkOSGroupId(
+    auth,
+    event.directoryId
+  );
+
+  if (!group) {
+    throw new Error("Group to delete not found");
+  }
+
+  await group.delete(auth);
 }

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -228,10 +228,14 @@ async function handleUserAddedToGroup(
     return;
   }
 
-  const workOSUser = await fetchWorkOSUserWithEmail(
+  const workOSUserRes = await fetchWorkOSUserWithEmail(
     workspace,
     event.user.email
   );
+  if (workOSUserRes.isErr()) {
+    throw workOSUserRes.error;
+  }
+  const workOSUser = workOSUserRes.value;
 
   const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
   if (!user) {
@@ -261,10 +265,14 @@ async function handleUserRemovedFromGroup(
     return;
   }
 
-  const workOSUser = await fetchWorkOSUserWithEmail(
+  const workOSUserRes = await fetchWorkOSUserWithEmail(
     workspace,
     event.user.email
   );
+  if (workOSUserRes.isErr()) {
+    throw workOSUserRes.error;
+  }
+  const workOSUser = workOSUserRes.value;
 
   const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
   if (!user) {
@@ -289,7 +297,11 @@ async function handleCreateOrUpdateWorkOSUser(
   workspace: LightWorkspaceType,
   event: DirectoryUser
 ) {
-  const workOSUser = await fetchWorkOSUserWithEmail(workspace, event.email);
+  const workOSUserRes = await fetchWorkOSUserWithEmail(workspace, event.email);
+  if (workOSUserRes.isErr()) {
+    throw workOSUserRes.error;
+  }
+  const workOSUser = workOSUserRes.value;
 
   const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
   const externalUser: ExternalUser = {
@@ -318,7 +330,11 @@ async function handleDeleteWorkOSUser(
   workspace: LightWorkspaceType,
   event: DirectoryUser
 ) {
-  const workOSUser = await fetchWorkOSUserWithEmail(workspace, event.email);
+  const workOSUserRes = await fetchWorkOSUserWithEmail(workspace, event.email);
+  if (workOSUserRes.isErr()) {
+    throw workOSUserRes.error;
+  }
+  const workOSUser = workOSUserRes.value;
 
   const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
   if (!user) {

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -26,6 +26,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import mainLogger from "@app/logger/logger";
 import type { LightWorkspaceType, Result } from "@app/types";
+import { normalizeError } from "@app/types";
 
 const workOS = getWorkOS();
 
@@ -258,7 +259,10 @@ async function handleUserAddedToGroup(
     );
   }
 
-  await group.addMember(auth, user.toJSON());
+  const res = await group.addMember(auth, user.toJSON());
+  if (res.isErr()) {
+    logger.error(normalizeError(res.error));
+  }
 }
 
 async function handleUserRemovedFromGroup(
@@ -288,7 +292,10 @@ async function handleUserRemovedFromGroup(
     );
   }
 
-  await group.removeMember(auth, user.toJSON());
+  const res = await group.removeMember(auth, user.toJSON());
+  if (res.isErr()) {
+    logger.error(normalizeError(res.error));
+  }
 }
 
 async function handleCreateOrUpdateWorkOSUser(

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -110,7 +110,7 @@ async function fetchWorkOSUserWithEmail(
     email,
   });
 
-  const workOSUser = _.first(workOSUserResponse.data);
+  const [workOSUser] = workOSUserResponse.data;
   if (!workOSUser) {
     throw new Error(
       `User not found with email "${email}" in workOS for workspace "${workspace.sId}"`


### PR DESCRIPTION
## Description
- [#12844](https://github.com/dust-tt/dust/issues/12844)
- Handle the following events coming from WorkOS:
  - `dsync.group.created`
  - `dsync.group.updated`
  - `dsync.group.deleted`
  - `dsync.group.user_added`
  - `dsync.group.user_removed`
  - `dsync.user.created`
  - `dsync.user.updated`
  - `dsync.user.deleted`
- Throw error if a model or resource is missing, in case the event was received in the wrong order, so it can be retried later with updated informations.

## Tests
- Haven't tried locally

## Risk
- If handled incorrectly, could create/update/remove group or users.

## Deploy Plan
- Deploy front
