### PR TITLE
Salesforce synced query: optimization

### DIFF
--- a/connectors/src/connectors/salesforce/lib/utils.ts
+++ b/connectors/src/connectors/salesforce/lib/utils.ts
@@ -49,7 +49,6 @@ export function syncQueryTemplateInterpolate(
       throw new Error(`Key ${key} not found in record`);
     }
     const value = record[key];
-    console.log(value);
     return value?.toString() || "";
   });
 }

--- a/connectors/src/connectors/salesforce/temporal/activities.ts
+++ b/connectors/src/connectors/salesforce/temporal/activities.ts
@@ -9,6 +9,7 @@ import {
   syncQueryTemplateInterpolate,
 } from "@connectors/connectors/salesforce/lib/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   renderDocumentTitleAndContent,
   upsertDataSourceDocument,
@@ -21,8 +22,6 @@ import logger from "@connectors/logger/logger";
 import { SalesforceSyncedQueryResource } from "@connectors/resources/salesforce_resources";
 import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import PQueue from "p-queue";
-import { concurrentExecutor } from "@connectors/lib/async_utils";
 
 export async function syncSalesforceConnection(connectorId: ModelId) {
   const connAndCredsRes = await getConnectorAndCredentials(connectorId);

--- a/connectors/src/connectors/salesforce/temporal/workflows.ts
+++ b/connectors/src/connectors/salesforce/temporal/workflows.ts
@@ -103,7 +103,7 @@ export async function salesforceSyncWorkflow({
 //   await syncSalesforceConnection(connectorId);
 // }
 
-const SALESFORCE_SYNC_QUERY_PAGE_LIMIT = 512;
+const SALESFORCE_SYNC_QUERY_PAGE_LIMIT = 256;
 
 export function makeSalesforceSyncQueryWorkflowId(
   connectorId: ModelId,


### PR DESCRIPTION
## Description

Optimize with async: true and concurrentExecutor use (concurrency 8)
Reduce page to 256 to avoid chances of sporadic errors

## Tests

Tested locally with pageSize 1 to have multiple acitvities and offset logic tested

## Risk

None

## Deploy Plan

- deploy `connectors`