### PR TITLE
enh: use untrusted egress proxy for slackbot downloads

### DIFF
--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -3,40 +3,17 @@ import { Err, Ok } from "@dust-tt/client";
 import { hash as blake3 } from "blake3";
 import { NonRetryableError } from "crawlee";
 import dns from "dns";
-import type {
-  RequestInfo as UndiciRequestInfo,
-  RequestInit as UndiciRequestInit,
-} from "undici";
-import { fetch as undiciFetch, ProxyAgent } from "undici";
 
-import { apiConfig } from "@connectors/lib/api/config";
 import type {
   WebCrawlerFolder,
   WebCrawlerPage,
 } from "@connectors/lib/models/webcrawler";
+import { createProxyAwareFetch } from "@connectors/lib/proxy";
 import type { ContentNodeType } from "@connectors/types";
 import { WEBCRAWLER_MAX_DEPTH } from "@connectors/types";
 
 const MAX_REDIRECTS = 20;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-
-// Create a fetch function with proxy support if configured
-function createProxyAwareFetch() {
-  const proxyHost = apiConfig.getUntrustedEgressProxyHost();
-  const proxyPort = apiConfig.getUntrustedEgressProxyPort();
-
-  if (proxyHost && proxyPort) {
-    const proxyUrl = `http://${proxyHost}:${proxyPort}`;
-    const dispatcher = new ProxyAgent(proxyUrl);
-
-    return (input: UndiciRequestInfo, init?: UndiciRequestInit) => {
-      return undiciFetch(input, { ...init, dispatcher });
-    };
-  }
-
-  // If no proxy configured, use standard fetch
-  return fetch;
-}
 
 export type WebCrawlerErrorName =
   | "PRIVATE_IP"

--- a/connectors/src/lib/proxy.ts
+++ b/connectors/src/lib/proxy.ts
@@ -1,0 +1,30 @@
+import type {
+  RequestInfo as UndiciRequestInfo,
+  RequestInit as UndiciRequestInit,
+} from "undici";
+import { fetch as undiciFetch, ProxyAgent } from "undici";
+
+import { apiConfig } from "@connectors/lib/api/config";
+
+/**
+ * Creates a fetch function with proxy support if configured.
+ * If UNTRUSTED_EGRESS_PROXY_HOST and UNTRUSTED_EGRESS_PROXY_PORT are set,
+ * returns undici's fetch with proxy configuration.
+ * Otherwise, returns the standard global fetch.
+ */
+export function createProxyAwareFetch() {
+  const proxyHost = apiConfig.getUntrustedEgressProxyHost();
+  const proxyPort = apiConfig.getUntrustedEgressProxyPort();
+
+  if (proxyHost && proxyPort) {
+    const proxyUrl = `http://${proxyHost}:${proxyPort}`;
+    const dispatcher = new ProxyAgent(proxyUrl);
+
+    return (input: UndiciRequestInfo, init?: UndiciRequestInit) => {
+      return undiciFetch(input, { ...init, dispatcher });
+    };
+  }
+
+  // If no proxy configured, use standard fetch
+  return fetch;
+}


### PR DESCRIPTION
## Description

Since we don't control those URLs, it's technically safer to go through the squid proxy for those.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
