### PR TITLE
feat: Add chain of thought configuration to Gemini 2.5 Pro

### DIFF
--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -874,8 +874,10 @@ export const GEMINI_2_5_PRO_PREVIEW_MODEL_CONFIG: ModelConfigurationType = {
   description: "Google's powerful large context model (1m context).",
   shortDescription: "Google's powerful model (preview).",
   isLegacy: false,
+  delimitersConfiguration: CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION,
   generationTokensCount: 2048,
   supportsVision: true,
+  toolUseMetaPrompt: CHAIN_OF_THOUGHT_META_PROMPT,
 };
 
 // DEPRECATED -- Replaced by GA model


### PR DESCRIPTION
## Description

- Added delimitersConfiguration with CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION
- Added toolUseMetaPrompt with CHAIN_OF_THOUGHT_META_PROMPT
- This enables structured reasoning with <thinking> and <response> tags for Gemini 2.5 Pro, matching the behavior of Claude models

## Tests

Local

## Risk

change of behavior on 2.5-pro based agents

## Deploy Plan

Deploy front