### PR TITLE
[front] fix agent mention not shown after navigation 

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -59,6 +59,11 @@ export const MentionDropdown = ({
     updateTriggerPosition();
   }, [triggerRect, updateTriggerPosition]);
 
+  // Only render the dropdown if we have a valid trigger
+  if (!triggerRect) {
+    return null;
+  }
+
   return (
     <DropdownMenu open={isOpen} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>

--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -59,7 +59,7 @@ export const MentionDropdown = ({
     updateTriggerPosition();
   }, [triggerRect, updateTriggerPosition]);
 
-  // Only render the dropdown if we have a valid trigger
+  // Only render the dropdown if we have a valid trigger.
   if (!triggerRect) {
     return null;
   }


### PR DESCRIPTION
## Description
This PR is to fix the issue when you open an agent list in one conversation, goes to another conversation and then try to open an agent list, it doesn't open and fails with the following error: 

```
[Error] aria-hidden (4)
<div data-side="bottom" data-align="start" role="menu" aria-orientation="vertical" data-state="open" data-radix-menu-content dir="ltr"…>...</div>
"in not contained inside"
<body style data-scroll-locked="1">…</body>
". Doing nothing"  
```

I'm not quite sure how it works, but my guess is we try to open the menu while we don't have valid the trigger (like pointing to the old DOM and hence the error)? I cannot reproduce this error on desktop but I can on my phone and it's fixed the issue there. But I'm not sure if this is the correct fix, does it make sense? If you can help me to understand how it works tomorrow that would be great 🙏

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
