### PR TITLE
[front] enh(monitoring): increase precision on tool execution time

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -32,7 +32,7 @@ export function withToolLogging<T>(
     ];
 
     statsDClient.increment("use_actions.count", 1, tags);
-    const now = new Date();
+    const startTime = performance.now();
 
     const result = await toolCallback(params);
 
@@ -57,7 +57,7 @@ export function withToolLogging<T>(
       return result;
     }
 
-    const elapsed = new Date().getTime() - now.getTime();
+    const elapsed = performance.now() - startTime;
     statsDClient.distribution(
       "run_action.duration.distribution",
       elapsed,


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/13305.
- This PR increases the precision on the reported execution time of actions monitored through the withToolLogging wrapper.
- It does so by using `performance.now` instead of `Date.getTime` ([link](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#performance.now_vs._date.now)).

## Tests

## Risk

- N/A

## Deploy Plan

- Deploy front.
