### PR TITLE
Refactor to have internal tools ready for personal OR workspace connection type.

### DIFF
--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -202,7 +202,7 @@ export function ConnectMCPServerDialog({
               authCredentials={authCredentials}
               setAuthCredentials={setAuthCredentials}
               setIsFormValid={setIsFormValid}
-              documentationUrl={mcpServer?.documentationUrl}
+              documentationUrl={mcpServer?.documentationUrl ?? undefined}
             />
           )}
         </DialogContainer>

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -300,7 +300,9 @@ export function CreateMCPServerDialog({
               setUseCase={setUseCase}
               setAuthCredentials={setAuthCredentials}
               setIsFormValid={setIsOAuthFormValid}
-              documentationUrl={internalMCPServer?.documentationUrl}
+              documentationUrl={
+                internalMCPServer?.documentationUrl ?? undefined
+              }
             />
           )}
         </DialogContainer>

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -513,6 +513,7 @@ async function getMCPClientConnectionParams(
     return new Ok({
       type: "mcpServerId",
       mcpServerId: mcpServerView.mcpServerId,
+      oAuthUseCase: mcpServerView.oAuthUseCase,
     });
   }
 
@@ -599,6 +600,7 @@ export async function tryListMCPTools(
             conversationId: agentLoopListToolsContext.conversation.sId,
             messageId: agentLoopListToolsContext.agentMessage.sId,
             error: toolsAndInstructionsRes.error,
+            mcpServerName: action.name,
           },
           `Error listing tools from MCP server: ${normalizeError(
             toolsAndInstructionsRes.error

--- a/front/lib/actions/mcp_internal_actions/authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/authentication.ts
@@ -1,6 +1,3 @@
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
@@ -12,27 +9,6 @@ import type {
   OAuthUseCase,
 } from "@app/types";
 import { getOAuthConnectionAccessToken } from "@app/types";
-
-import type { AuthorizationInfo } from "../mcp_metadata";
-
-// Dedicated function to get an access token for a given provider for internal MCP servers.
-// Not using the one from mcp_metadata.ts to avoid circular dependency.
-export async function getAccessTokenForInternalMCPServer(
-  auth: Authenticator,
-  {
-    mcpServerId,
-    connectionType,
-  }: {
-    mcpServerId: string;
-    connectionType: MCPServerConnectionConnectionType;
-  }
-): Promise<string | null> {
-  const connection = await getConnectionForInternalMCPServer(auth, {
-    mcpServerId,
-    connectionType,
-  });
-  return connection?.access_token ?? null;
-}
 
 // Dedicated function to get the connection details for a given provider for internal MCP servers.
 // Not using the one from mcp_metadata.ts to avoid circular dependency.
@@ -99,33 +75,4 @@ export class MCPServerPersonalAuthenticationRequiredError extends Error {
       "mcpServerId" in error
     );
   }
-}
-
-export function makeMCPToolPersonalAuthenticationRequiredError(
-  mcpServerId: string,
-  authorization: AuthorizationInfo
-): CallToolResult {
-  return {
-    isError: true,
-    content: [
-      {
-        type: "resource",
-        resource: {
-          mimeType:
-            INTERNAL_MIME_TYPES.TOOL_ERROR.PERSONAL_AUTHENTICATION_REQUIRED,
-          uri: "",
-          text: new MCPServerPersonalAuthenticationRequiredError(
-            mcpServerId,
-            authorization.provider,
-            authorization.use_case,
-            authorization.scope
-          ).message,
-          mcpServerId,
-          provider: authorization.provider,
-          useCase: authorization.use_case,
-          scope: authorization.scope,
-        },
-      },
-    ],
-  };
 }

--- a/front/lib/actions/mcp_internal_actions/in_memory_with_auth_transport.ts
+++ b/front/lib/actions/mcp_internal_actions/in_memory_with_auth_transport.ts
@@ -1,0 +1,86 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type {
+  JSONRPCMessage,
+  RequestId,
+} from "@modelcontextprotocol/sdk/types.js";
+
+interface QueuedMessage {
+  message: JSONRPCMessage;
+  extra?: { authInfo?: AuthInfo };
+}
+
+/**
+ * In-memory transport for creating clients and servers that talk to each other within the same process.
+ */
+export class InMemoryWithAuthTransport implements Transport {
+  private _otherTransport?: InMemoryWithAuthTransport;
+  private _messageQueue: QueuedMessage[] = [];
+  private _authInfo?: AuthInfo;
+
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (
+    message: JSONRPCMessage,
+    extra?: { authInfo?: AuthInfo }
+  ) => void;
+  sessionId?: string;
+
+  /**
+   * Creates a pair of linked in-memory transports that can communicate with each other. One should be passed to a Client and one to a Server.
+   */
+  static createLinkedPair(): [
+    InMemoryWithAuthTransport,
+    InMemoryWithAuthTransport,
+  ] {
+    const clientTransport = new InMemoryWithAuthTransport();
+    const serverTransport = new InMemoryWithAuthTransport();
+    clientTransport._otherTransport = serverTransport;
+    serverTransport._otherTransport = clientTransport;
+
+    return [clientTransport, serverTransport];
+  }
+
+  public setAuthInfo(authInfo: AuthInfo): void {
+    this._authInfo = authInfo;
+  }
+
+  async start(): Promise<void> {
+    // Process any messages that were queued before start was called
+    while (this._messageQueue.length > 0) {
+      const queuedMessage = this._messageQueue.shift()!;
+      this.onmessage?.(queuedMessage.message, queuedMessage.extra);
+    }
+  }
+
+  async close(): Promise<void> {
+    const other = this._otherTransport;
+    this._otherTransport = undefined;
+    await other?.close();
+    this.onclose?.();
+  }
+
+  /**
+   * Sends a message with optional auth info.
+   * This is useful for testing authentication scenarios.
+   */
+  async send(
+    message: JSONRPCMessage,
+    options?: { relatedRequestId?: RequestId; authInfo?: AuthInfo }
+  ): Promise<void> {
+    if (!this._otherTransport) {
+      throw new Error("Not connected");
+    }
+
+    if (this._otherTransport.onmessage) {
+      this._otherTransport.onmessage(message, {
+        authInfo: options?.authInfo ?? this._authInfo,
+      });
+    } else {
+      this._otherTransport._messageQueue.push({
+        message,
+        extra: { authInfo: options?.authInfo ?? this._authInfo },
+      });
+    }
+  }
+}

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -1,4 +1,3 @@
-import type { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
@@ -7,6 +6,7 @@ import {
   getInternalMCPServerNameAndWorkspaceId,
   INTERNAL_MCP_SERVERS,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { getInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/servers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
@@ -31,7 +31,7 @@ export const isEnabledForWorkspace = async (
 
 export const connectToInternalMCPServer = async (
   mcpServerId: string,
-  transport: InMemoryTransport,
+  transport: InMemoryWithAuthTransport,
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> => {
@@ -45,7 +45,6 @@ export const connectToInternalMCPServer = async (
     auth,
     {
       internalMCPServerName: res.value.name,
-      mcpServerId,
     },
     agentLoopContext
   );

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -17,6 +17,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Tools with access to the published agents of the workspace.",
   icon: "ActionRobotIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 const createServer = (auth: Authenticator): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -58,6 +58,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     "called a node, nodes are referenced by a nodeId.",
   authorization: null,
   icon: "ActionDocumentTextIcon",
+  documentationUrl: null,
 };
 
 const OPTION_PARAMETERS = {

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -19,6 +19,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Agent can generate and convert files.",
   authorization: null,
   icon: "ActionDocumentTextIcon",
+  documentationUrl: null,
 };
 
 const OUTPUT_FORMATS = [

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -2,13 +2,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Octokit } from "@octokit/core";
 import { z } from "zod";
 
-import { getAccessTokenForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
 import {
   makeMCPToolTextError,
   makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-import type { Authenticator } from "@app/lib/auth";
 import { normalizeError } from "@app/types";
 
 const GITHUB_GET_PULL_REQUEST_ACTION_MAX_COMMITS = 32;
@@ -23,9 +21,10 @@ const serverInfo: InternalMCPServerDefinitionType = {
     supported_use_cases: ["platform_actions"] as const,
   },
   icon: "GithubLogo",
+  documentationUrl: null,
 };
 
-const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
+const createServer = (): McpServer => {
   const server = new McpServer(serverInfo);
 
   server.tool(
@@ -49,11 +48,8 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Labels to associate with this issue."),
     },
-    async ({ owner, repo, title, body, assignees, labels }) => {
-      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "workspace",
-      });
+    async ({ owner, repo, title, body, assignees, labels }, { authInfo }) => {
+      const accessToken = authInfo?.token;
 
       const octokit = new Octokit({ auth: accessToken });
 
@@ -94,11 +90,8 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
       repo: z.string().describe("The name of the repository."),
       pullNumber: z.number().describe("The pull request number."),
     },
-    async ({ owner, repo, pullNumber }) => {
-      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "workspace",
-      });
+    async ({ owner, repo, pullNumber }, { authInfo }) => {
+      const accessToken = authInfo?.token;
 
       const octokit = new Octokit({ auth: accessToken });
 
@@ -402,11 +395,11 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .describe("File comments to leave as part of the review.")
         .optional(),
     },
-    async ({ owner, repo, pullNumber, body, event, comments = [] }) => {
-      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "workspace",
-      });
+    async (
+      { owner, repo, pullNumber, body, event, comments = [] },
+      { authInfo }
+    ) => {
+      const accessToken = authInfo?.token;
 
       const octokit = new Octokit({ auth: accessToken });
 
@@ -444,11 +437,8 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           "The owner of the repository (account or organization name)."
         ),
     },
-    async ({ owner }) => {
-      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "workspace",
-      });
+    async ({ owner }, { authInfo }) => {
+      const accessToken = authInfo?.token;
 
       const octokit = new Octokit({ auth: accessToken });
 
@@ -579,11 +569,8 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           "Optional field configuration with both fieldId and optionId required if provided."
         ),
     },
-    async ({ owner, repo, issueNumber, projectId, field }) => {
-      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "workspace",
-      });
+    async ({ owner, repo, issueNumber, projectId, field }, { authInfo }) => {
+      const accessToken = authInfo?.token;
 
       const octokit = new Octokit({ auth: accessToken });
 
@@ -686,11 +673,8 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .string()
         .describe("The contents of the comment (GitHub markdown)."),
     },
-    async ({ owner, repo, issueNumber, body }) => {
-      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "workspace",
-      });
+    async ({ owner, repo, issueNumber, body }, { authInfo }) => {
+      const accessToken = authInfo?.token;
 
       const octokit = new Octokit({ auth: accessToken });
 
@@ -728,11 +712,8 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
       repo: z.string().describe("The name of the repository."),
       issueNumber: z.number().describe("The issue number."),
     },
-    async ({ owner, repo, issueNumber }) => {
-      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "workspace",
-      });
+    async ({ owner, repo, issueNumber }, { authInfo }) => {
+      const accessToken = authInfo?.token;
 
       const octokit = new Octokit({ auth: accessToken });
 
@@ -879,19 +860,19 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Results per page. Defaults to 30, max 100."),
     },
-    async ({
-      owner,
-      repo,
-      state = "OPEN",
-      labels,
-      sort = "CREATED_AT",
-      direction = "DESC",
-      perPage = 30,
-    }) => {
-      const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "workspace",
-      });
+    async (
+      {
+        owner,
+        repo,
+        state = "OPEN",
+        labels,
+        sort = "CREATED_AT",
+        direction = "DESC",
+        perPage = 30,
+      },
+      { authInfo }
+    ) => {
+      const accessToken = authInfo?.token;
 
       const octokit = new Octokit({ auth: accessToken });
 

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -1,15 +1,14 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import assert from "assert";
 import { google } from "googleapis";
 import { z } from "zod";
 
-import { makeMCPToolPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_internal_actions/authentication";
-import { getConnectionForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
 import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-import type { Authenticator } from "@app/lib/auth";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const serverInfo: InternalMCPServerDefinitionType = {
@@ -27,18 +26,15 @@ const serverInfo: InternalMCPServerDefinitionType = {
   documentationUrl: "https://docs.dust.tt/docs/google-calendar",
 };
 
-const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
+const createServer = (): McpServer => {
   const server = new McpServer(serverInfo);
 
-  async function getCalendarClient() {
-    const connection = await getConnectionForInternalMCPServer(auth, {
-      mcpServerId,
-      connectionType: "personal",
-    });
-    const accessToken = connection?.access_token;
+  async function getCalendarClient(authInfo?: AuthInfo) {
+    const accessToken = authInfo?.token;
     if (!accessToken) {
       return null;
     }
+
     const oauth2Client = new google.auth.OAuth2();
     oauth2Client.setCredentials({ access_token: accessToken });
     return google.calendar({
@@ -57,14 +53,13 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Maximum number of calendars to return (max 250)."),
     },
-    async ({ pageToken, maxResults }) => {
-      const calendar = await getCalendarClient();
-      if (!calendar) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
+    async ({ pageToken, maxResults }, { authInfo }) => {
+      const calendar = await getCalendarClient(authInfo);
+      assert(
+        calendar,
+        "Calendar client could not be created - it should never happen"
+      );
+
       try {
         const res = await calendar.calendarList.list({
           pageToken,
@@ -108,21 +103,16 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .describe("Maximum number of events to return (max 2500)."),
       pageToken: z.string().optional().describe("Page token for pagination."),
     },
-    async ({
-      calendarId = "primary",
-      q,
-      timeMin,
-      timeMax,
-      maxResults,
-      pageToken,
-    }) => {
-      const calendar = await getCalendarClient();
-      if (!calendar) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
+    async (
+      { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
+      { authInfo }
+    ) => {
+      const calendar = await getCalendarClient(authInfo);
+      assert(
+        calendar,
+        "Calendar client could not be created - it should never happen"
+      );
+
       try {
         const res = await calendar.events.list({
           calendarId,
@@ -154,14 +144,13 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .describe("The calendar ID (default: 'primary')."),
       eventId: z.string().describe("The ID of the event to retrieve."),
     },
-    async ({ calendarId = "primary", eventId }) => {
-      const calendar = await getCalendarClient();
-      if (!calendar) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
+    async ({ calendarId = "primary", eventId }, { authInfo }) => {
+      const calendar = await getCalendarClient(authInfo);
+      assert(
+        calendar,
+        "Calendar client could not be created - it should never happen"
+      );
+
       try {
         const res = await calendar.events.get({
           calendarId,
@@ -202,23 +191,25 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
       location: z.string().optional().describe("Location of the event."),
       colorId: z.string().optional().describe("Color ID for the event."),
     },
-    async ({
-      calendarId = "primary",
-      summary,
-      description,
-      start,
-      end,
-      attendees,
-      location,
-      colorId,
-    }) => {
-      const calendar = await getCalendarClient();
-      if (!calendar) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
+    async (
+      {
+        calendarId = "primary",
+        summary,
+        description,
+        start,
+        end,
+        attendees,
+        location,
+        colorId,
+      },
+      { authInfo }
+    ) => {
+      const calendar = await getCalendarClient(authInfo);
+      assert(
+        calendar,
+        "Calendar client could not be created - it should never happen"
+      );
+
       try {
         const event: {
           summary: string;
@@ -285,24 +276,26 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
       location: z.string().optional().describe("Location of the event."),
       colorId: z.string().optional().describe("Color ID for the event."),
     },
-    async ({
-      calendarId = "primary",
-      eventId,
-      summary,
-      description,
-      start,
-      end,
-      attendees,
-      location,
-      colorId,
-    }) => {
-      const calendar = await getCalendarClient();
-      if (!calendar) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
+    async (
+      {
+        calendarId = "primary",
+        eventId,
+        summary,
+        description,
+        start,
+        end,
+        attendees,
+        location,
+        colorId,
+      },
+      { authInfo }
+    ) => {
+      const calendar = await getCalendarClient(authInfo);
+      assert(
+        calendar,
+        "Calendar client could not be created - it should never happen"
+      );
+
       try {
         const event: {
           summary?: string;
@@ -361,14 +354,13 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .describe("The calendar ID (default: 'primary')."),
       eventId: z.string().describe("The ID of the event to delete."),
     },
-    async ({ calendarId = "primary", eventId }) => {
-      const calendar = await getCalendarClient();
-      if (!calendar) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
+    async ({ calendarId = "primary", eventId }, { authInfo }) => {
+      const calendar = await getCalendarClient(authInfo);
+      assert(
+        calendar,
+        "Calendar client could not be created - it should never happen"
+      );
+
       try {
         await calendar.events.delete({
           calendarId,
@@ -406,14 +398,13 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
           "Time zone used in the response. Optional. The default is UTC."
         ),
     },
-    async ({ email, startTime, endTime, timeZone }) => {
-      const calendar = await getCalendarClient();
-      if (!calendar) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
+    async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
+      const calendar = await getCalendarClient(authInfo);
+      assert(
+        calendar,
+        "Calendar client could not be created - it should never happen"
+      );
+
       try {
         const res = await calendar.freebusy.query({
           requestBody: {

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hupspot_utils.ts
@@ -1,8 +1,7 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-import { getAccessTokenForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 
 export const ERROR_MESSAGES = {
@@ -11,16 +10,16 @@ export const ERROR_MESSAGES = {
   NO_OBJECTS_FOUND: "No objects found",
 } as const;
 
-export const withAuth = async (
-  auth: Authenticator,
-  mcpServerId: string,
-  action: (accessToken: string) => Promise<CallToolResult>,
-  params?: any
-): Promise<CallToolResult> => {
-  const accessToken = await getAccessTokenForInternalMCPServer(auth, {
-    mcpServerId,
-    connectionType: "workspace",
-  });
+export const withAuth = async ({
+  action,
+  params,
+  authInfo,
+}: {
+  action: (accessToken: string) => Promise<CallToolResult>;
+  params?: any;
+  authInfo?: AuthInfo;
+}): Promise<CallToolResult> => {
+  const accessToken = authInfo?.token;
   if (!accessToken) {
     return makeMCPToolTextError(ERROR_MESSAGES.NO_ACCESS_TOKEN);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -38,7 +38,6 @@ import {
   makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-import type { Authenticator } from "@app/lib/auth";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "hubspot",
@@ -51,9 +50,10 @@ const serverInfo: InternalMCPServerDefinitionType = {
     supported_use_cases: ["platform_actions"] as const,
   },
   icon: "HubspotLogo",
+  documentationUrl: null,
 };
 
-const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
+const createServer = (): McpServer => {
   const server = new McpServer(serverInfo);
 
   server.tool(
@@ -63,17 +63,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
       objectType: z.enum(ALL_OBJECTS),
       creatableOnly: z.boolean().optional(),
     },
-    async ({ objectType, creatableOnly = true }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await getObjectProperties({
-          accessToken,
-          objectType,
-          creatableOnly,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Operation completed successfully",
-          result,
-        });
+    async ({ objectType, creatableOnly = true }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await getObjectProperties({
+            accessToken,
+            objectType,
+            creatableOnly,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Operation completed successfully",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -95,17 +98,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Optional array of associations to create."),
     },
-    async ({ properties, associations }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createContact({
-          accessToken,
-          properties,
-          associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Contact created successfully.",
-          result,
-        });
+    async ({ properties, associations }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createContact({
+            accessToken,
+            properties,
+            associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Contact created successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -117,16 +123,19 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
       objectType: z.enum(ALL_OBJECTS),
       email: z.string().describe("The email address of the object."),
     },
-    async ({ objectType, email }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const object = await getObjectByEmail(accessToken, objectType, email);
-        if (!object) {
-          return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
-        }
-        return makeMCPToolJSONSuccess({
-          message: "Operation completed successfully",
-          result: object,
-        });
+    async ({ objectType, email }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const object = await getObjectByEmail(accessToken, objectType, email);
+          if (!object) {
+            return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Operation completed successfully",
+            result: object,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -159,25 +168,28 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         )
         .describe("Array of property filters to apply."),
     },
-    async ({ objectType, filters }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const count = await countObjectsByProperties(
-          accessToken,
-          objectType,
-          filters
-        );
-        if (!count) {
-          return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
-        }
-        if (count === MAX_COUNT_LIMIT) {
-          return makeMCPToolTextError(
-            `Can't retrieve the exact number of objects matching the filters (hit Hubspot API limit of max ${MAX_COUNT_LIMIT} total objects).`
+    async ({ objectType, filters }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const count = await countObjectsByProperties(
+            accessToken,
+            objectType,
+            filters
           );
-        }
-        return makeMCPToolTextSuccess({
-          message: "Operation completed successfully",
-          result: count.toString(),
-        });
+          if (!count) {
+            return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
+          }
+          if (count === MAX_COUNT_LIMIT) {
+            return makeMCPToolTextError(
+              `Can't retrieve the exact number of objects matching the filters (hit Hubspot API limit of max ${MAX_COUNT_LIMIT} total objects).`
+            );
+          }
+          return makeMCPToolTextSuccess({
+            message: "Operation completed successfully",
+            result: count.toString(),
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -189,16 +201,23 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
       objectType: z.enum(SIMPLE_OBJECTS),
       limit: z.number().optional(),
     },
-    async ({ objectType, limit = MAX_LIMIT }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const objects = await getLatestObjects(accessToken, objectType, limit);
-        if (!objects.length) {
-          return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
-        }
-        return makeMCPToolJSONSuccess({
-          message: "Operation completed successfully",
-          result: objects,
-        });
+    async ({ objectType, limit = MAX_LIMIT }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const objects = await getLatestObjects(
+            accessToken,
+            objectType,
+            limit
+          );
+          if (!objects.length) {
+            return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Operation completed successfully",
+            result: objects,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -220,17 +239,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Optional array of associations to create."),
     },
-    async ({ properties, associations }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createCompany({
-          accessToken,
-          properties,
-          associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Company created successfully.",
-          result,
-        });
+    async ({ properties, associations }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createCompany({
+            accessToken,
+            properties,
+            associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Company created successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -252,17 +274,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Optional array of associations to create."),
     },
-    async ({ properties, associations }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createDeal({
-          accessToken,
-          properties,
-          associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Deal created successfully.",
-          result,
-        });
+    async ({ properties, associations }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createDeal({
+            accessToken,
+            properties,
+            associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Deal created successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -286,17 +311,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Optional array of associations to create."),
     },
-    async ({ properties, associations }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createLead({
-          accessToken,
-          properties,
-          associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Lead (as Deal) created successfully.",
-          result,
-        });
+    async ({ properties, associations }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createLead({
+            accessToken,
+            properties,
+            associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Lead (as Deal) created successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -322,17 +350,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Optional array of associations to create."),
     },
-    async (input) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createTask({
-          accessToken,
-          properties: input.properties,
-          associations: input.associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Task created successfully.",
-          result,
-        });
+    async (input, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createTask({
+            accessToken,
+            properties: input.properties,
+            associations: input.associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Task created successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -354,17 +385,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Optional array of associations to create."),
     },
-    async (input) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createTicket({
-          accessToken,
-          properties: input.properties,
-          associations: input.associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Ticket created successfully.",
-          result,
-        });
+    async (input, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createTicket({
+            accessToken,
+            properties: input.properties,
+            associations: input.associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Ticket created successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -398,17 +432,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Direct IDs of objects to associate the note with."),
     },
-    async ({ properties, associations }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createNote({
-          accessToken,
-          properties,
-          associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Note created successfully.",
-          result,
-        });
+    async ({ properties, associations }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createNote({
+            accessToken,
+            properties,
+            associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Note created successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -432,17 +469,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Direct IDs of objects to associate the communication with."),
     },
-    async ({ properties, associations }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createCommunication({
-          accessToken,
-          properties,
-          associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: `Communication (channel: ${properties.hs_communication_channel_type || "unknown"}) created successfully.`,
-          result,
-        });
+    async ({ properties, associations }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createCommunication({
+            accessToken,
+            properties,
+            associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: `Communication (channel: ${properties.hs_communication_channel_type || "unknown"}) created successfully.`,
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -466,17 +506,20 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .optional()
         .describe("Direct IDs of objects to associate the meeting with."),
     },
-    async ({ properties, associations }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await createMeeting({
-          accessToken,
-          properties,
-          associations,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Meeting created successfully.",
-          result,
-        });
+    async ({ properties, associations }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await createMeeting({
+            accessToken,
+            properties,
+            associations,
+          });
+          return makeMCPToolJSONSuccess({
+            message: "Meeting created successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -488,16 +531,19 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     {
       contactId: z.string().describe("The ID of the contact to retrieve."),
     },
-    async ({ contactId }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await getContact(accessToken, contactId);
-        if (!result) {
-          return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
-        }
-        return makeMCPToolJSONSuccess({
-          message: "Contact retrieved successfully.",
-          result,
-        });
+    async ({ contactId }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await getContact(accessToken, contactId);
+          if (!result) {
+            return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Contact retrieved successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -509,16 +555,19 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     {
       companyId: z.string().describe("The ID of the company to retrieve."),
     },
-    async ({ companyId }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await getCompany(accessToken, companyId);
-        if (!result) {
-          return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
-        }
-        return makeMCPToolJSONSuccess({
-          message: "Company retrieved successfully.",
-          result,
-        });
+    async ({ companyId }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await getCompany(accessToken, companyId);
+          if (!result) {
+            return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Company retrieved successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -530,16 +579,19 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     {
       dealId: z.string().describe("The ID of the deal to retrieve."),
     },
-    async ({ dealId }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await getDeal(accessToken, dealId);
-        if (!result) {
-          return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
-        }
-        return makeMCPToolJSONSuccess({
-          message: "Deal retrieved successfully.",
-          result,
-        });
+    async ({ dealId }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await getDeal(accessToken, dealId);
+          if (!result) {
+            return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Deal retrieved successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -553,18 +605,21 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .string()
         .describe("The ID of the meeting (engagement) to retrieve."),
     },
-    async ({ meetingId }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await getMeeting(accessToken, meetingId);
-        if (!result) {
-          return makeMCPToolTextError(
-            ERROR_MESSAGES.OBJECT_NOT_FOUND + " Or it was not a meeting."
-          );
-        }
-        return makeMCPToolJSONSuccess({
-          message: "Meeting retrieved successfully.",
-          result,
-        });
+    async ({ meetingId }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await getMeeting(accessToken, meetingId);
+          if (!result) {
+            return makeMCPToolTextError(
+              ERROR_MESSAGES.OBJECT_NOT_FOUND + " Or it was not a meeting."
+            );
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Meeting retrieved successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -576,18 +631,21 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
     {
       fileId: z.string().describe("The ID of the file."),
     },
-    async ({ fileId }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await getFilePublicUrl(accessToken, fileId);
-        if (!result) {
-          return makeMCPToolTextError(
-            "File not found or public URL not available."
-          );
-        }
-        return makeMCPToolJSONSuccess({
-          message: "File public URL retrieved successfully.",
-          result: { url: result }, // Return as an object for consistency
-        });
+    async ({ fileId }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await getFilePublicUrl(accessToken, fileId);
+          if (!result) {
+            return makeMCPToolTextError(
+              "File not found or public URL not available."
+            );
+          }
+          return makeMCPToolJSONSuccess({
+            message: "File public URL retrieved successfully.",
+            result: { url: result }, // Return as an object for consistency
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -602,20 +660,25 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
         .describe("The type of the object (contacts, companies, or deals)."),
       fromObjectId: z.string().describe("The ID of the object."),
     },
-    async ({ fromObjectType, fromObjectId }) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await getAssociatedMeetings(
-          accessToken,
-          fromObjectType,
-          fromObjectId
-        );
-        if (result === null) {
-          return makeMCPToolTextError("Error retrieving associated meetings.");
-        }
-        return makeMCPToolJSONSuccess({
-          message: "Associated meetings retrieved successfully.",
-          result,
-        });
+    async ({ fromObjectType, fromObjectId }, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await getAssociatedMeetings(
+            accessToken,
+            fromObjectType,
+            fromObjectId
+          );
+          if (result === null) {
+            return makeMCPToolTextError(
+              "Error retrieving associated meetings."
+            );
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Associated meetings retrieved successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );
@@ -655,24 +718,29 @@ const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
       limit: z.number().optional().default(MAX_LIMIT),
       after: z.string().optional().describe("Pagination cursor."),
     },
-    async (input) => {
-      return withAuth(auth, mcpServerId, async (accessToken) => {
-        const result = await searchCrmObjects({
-          accessToken,
-          objectType: input.objectType,
-          filters: input.filters,
-          query: input.query,
-          propertiesToReturn: input.propertiesToReturn,
-          limit: input.limit,
-          after: input.after,
-        });
-        if (!result) {
-          return makeMCPToolTextError("Search failed or returned no results.");
-        }
-        return makeMCPToolJSONSuccess({
-          message: "CRM objects searched successfully.",
-          result,
-        });
+    async (input, { authInfo }) => {
+      return withAuth({
+        action: async (accessToken) => {
+          const result = await searchCrmObjects({
+            accessToken,
+            objectType: input.objectType,
+            filters: input.filters,
+            query: input.query,
+            propertiesToReturn: input.propertiesToReturn,
+            limit: input.limit,
+            after: input.after,
+          });
+          if (!result) {
+            return makeMCPToolTextError(
+              "Search failed or returned no results."
+            );
+          }
+          return makeMCPToolJSONSuccess({
+            message: "CRM objects searched successfully.",
+            result,
+          });
+        },
+        authInfo,
       });
     }
   );

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -23,6 +23,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Agent can generate images (GPT Image 1).",
   icon: "ActionImageIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 const createServer = (auth: Authenticator): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -45,6 +45,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Include data exhaustively (mcp)",
   icon: "ActionTimeIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 function createServer(

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -31,18 +31,16 @@ export async function getInternalMCPServer(
   auth: Authenticator,
   {
     internalMCPServerName,
-    mcpServerId,
   }: {
     internalMCPServerName: InternalMCPServerNameType;
-    mcpServerId: string;
   },
   agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":
-      return githubServer(auth, mcpServerId);
+      return githubServer();
     case "hubspot":
-      return hubspotServer(auth, mcpServerId);
+      return hubspotServer();
     case "image_generation":
       return imageGenerationDallEServer(auth);
     case "file_generation":
@@ -62,7 +60,7 @@ export async function getInternalMCPServer(
     case "missing_action_catcher":
       return missingActionCatcherServer(auth, agentLoopContext);
     case "notion":
-      return notionServer(auth, mcpServerId);
+      return notionServer();
     case "include_data":
       return includeDataServer(auth, agentLoopContext);
     case "run_agent":
@@ -76,11 +74,11 @@ export async function getInternalMCPServer(
     case "extract_data":
       return extractDataServer(auth, agentLoopContext);
     case "salesforce":
-      return salesforceServer(auth, mcpServerId);
+      return salesforceServer();
     case "gmail":
-      return gmailServer(auth, mcpServerId);
+      return gmailServer();
     case "google_calendar":
-      return calendarServer(auth, mcpServerId);
+      return calendarServer();
     case "data_sources_file_system":
       return dataSourcesFileSystemServer(auth, agentLoopContext);
     default:

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -10,6 +10,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "To be used to catch errors and avoid erroring.",
   authorization: null,
   icon: "ActionDocumentTextIcon",
+  documentationUrl: null,
 };
 
 const createServer = (

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -12,6 +12,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     "Demo server showing a basic interaction with various configurable blocks.",
   icon: "ActionEmotionLaughIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 function createServer(): McpServer {

--- a/front/lib/actions/mcp_internal_actions/servers/process.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process.ts
@@ -54,6 +54,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Structured extraction",
   icon: "ActionScanIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 const EXTRACT_TOOL_JSON_SCHEMA_ARGUMENT_DESCRIPTION =

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -21,6 +21,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     "Agent can decide to trigger a reasoning model for complex tasks.",
   icon: "ActionLightbulbIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 function createServer(

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -37,6 +37,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Run a child agent (agent as tool).",
   icon: "ActionRobotIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 function parseAgentConfigurationUri(uri: string): Result<string, Error> {

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -49,6 +49,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Run Dust Apps with specified parameters (mcp)",
   icon: "CommandLineIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 interface DustFileOutput {

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -3,15 +3,10 @@ import jsforce from "jsforce";
 import { z } from "zod";
 
 import {
-  getConnectionForInternalMCPServer,
-  makeMCPToolPersonalAuthenticationRequiredError,
-} from "@app/lib/actions/mcp_internal_actions/authentication";
-import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-import type { Authenticator } from "@app/lib/auth";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "salesforce",
@@ -23,11 +18,12 @@ const serverInfo: InternalMCPServerDefinitionType = {
     supported_use_cases: ["personal_actions", "platform_actions"] as const,
   },
   icon: "SalesforceLogo",
+  documentationUrl: null,
 };
 
 const SF_API_VERSION = "57.0";
 
-const createServer = (auth: Authenticator, mcpServerId: string): McpServer => {
+const createServer = (): McpServer => {
   const server = new McpServer(serverInfo, {
     instructions: `You have access to the following tools: execute_read_query, list_objects, and describe_object.
 
@@ -82,22 +78,9 @@ This is the most reliable way to discover the correct names for fields and relat
     {
       query: z.string().describe("The SOQL read query to execute"),
     },
-    async ({ query }) => {
-      const connection = await getConnectionForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "personal",
-      });
-      const accessToken = connection?.access_token;
-      const instanceUrl = connection?.connection.metadata.instance_url as
-        | string
-        | undefined;
-
-      if (!accessToken || !instanceUrl) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
+    async ({ query }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
 
       const conn = new jsforce.Connection({
         instanceUrl,
@@ -125,23 +108,10 @@ This is the most reliable way to discover the correct names for fields and relat
         .default("all")
         .describe("Filter objects by type: all, standard, or custom"),
     },
-    async ({ filter }) => {
-      const connection = await getConnectionForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "personal",
-      });
+    async ({ filter }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
 
-      const accessToken = connection?.access_token;
-      const instanceUrl = connection?.connection.metadata.instance_url as
-        | string
-        | undefined;
-
-      if (!accessToken || !instanceUrl) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
       const conn = new jsforce.Connection({
         instanceUrl,
         accessToken,
@@ -174,23 +144,10 @@ This is the most reliable way to discover the correct names for fields and relat
     {
       objectName: z.string().describe("The name of the object to describe"),
     },
-    async ({ objectName }) => {
-      const connection = await getConnectionForInternalMCPServer(auth, {
-        mcpServerId,
-        connectionType: "personal",
-      });
+    async ({ objectName }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
 
-      const accessToken = connection?.access_token;
-      const instanceUrl = connection?.connection.metadata.instance_url as
-        | string
-        | undefined;
-
-      if (!accessToken || !instanceUrl) {
-        return makeMCPToolPersonalAuthenticationRequiredError(
-          mcpServerId,
-          serverInfo.authorization!
-        );
-      }
       const conn = new jsforce.Connection({
         instanceUrl,
         accessToken,

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -45,6 +45,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Search through selected Data sources (mcp)",
   icon: "ActionMagnifyingGlassIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 function createServer(

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -49,6 +49,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Tables, Spreadsheets, Notion DBs (quantitative).",
   icon: "ActionTableIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 function createServer(

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -46,6 +46,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     "Tables, Spreadsheets, Notion DBs (quantitative) (mcp, exploded).",
   icon: "ActionTableIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 function createServer(

--- a/front/lib/actions/mcp_internal_actions/servers/think.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/think.ts
@@ -9,6 +9,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   description: "Expand thinking and reasoning capabilities.",
   icon: "ActionBrainIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 const createServer = (): McpServer => {

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -26,6 +26,7 @@ export const serverInfo: InternalMCPServerDefinitionType = {
     "Agent can search (Google) and retrieve information from specific websites.",
   icon: "ActionGlobeAltIcon",
   authorization: null,
+  documentationUrl: null,
 };
 
 const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -3,7 +3,7 @@ import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { Implementation, Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { ProxyAgent } from "undici";
@@ -20,6 +20,9 @@ import {
   isInternalAllowedIcon,
 } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
+import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_internal_actions/authentication";
+import { getConnectionForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
+import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { MCPOAuthRequiredError } from "@app/lib/actions/mcp_oauth_error";
 import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -81,6 +84,7 @@ export function isInternalMCPServerDefinition(
 interface ConnectViaMCPServerId {
   type: "mcpServerId";
   mcpServerId: string;
+  oAuthUseCase: MCPOAuthUseCase | null;
 }
 
 export const isConnectViaMCPServerId = (
@@ -139,7 +143,9 @@ export const connectToMCPServer = async (
     params: MCPConnectionParams;
     agentLoopContext?: AgentLoopContextType;
   }
-): Promise<Result<Client, Error>> => {
+): Promise<
+  Result<Client, Error | MCPServerPersonalAuthenticationRequiredError>
+> => {
   // This is where we route the MCP client to the right server.
   const mcpClient = new Client({
     name: "dust-mcp-client",
@@ -154,14 +160,71 @@ export const connectToMCPServer = async (
         case "internal":
           // Create a pair of linked in-memory transports
           // And connect the client to the server.
-          const [client, server] = InMemoryTransport.createLinkedPair();
+          const [client, server] = InMemoryWithAuthTransport.createLinkedPair();
           await connectToInternalMCPServer(
             params.mcpServerId,
             server,
             auth,
             agentLoopContext
           );
+
           await mcpClient.connect(client);
+
+          // The server might requires authentication for tools.
+          // To avoid any unnecessary work, we only fetch the token if we are try to run a tool.
+          // If we are just listing tools, we don't need to fetch the token.
+          if (agentLoopContext?.runContext) {
+            const metadata = await extractMetadataFromServerVersion(
+              mcpClient.getServerVersion()
+            );
+            if (metadata.authorization) {
+              if (!params.oAuthUseCase) {
+                throw new Error(
+                  "Internal server requires authentication but no use case was provided - Should never happen"
+                );
+              }
+
+              const c = await getConnectionForInternalMCPServer(auth, {
+                mcpServerId: params.mcpServerId,
+                connectionType:
+                  params.oAuthUseCase === "personal_actions"
+                    ? "personal"
+                    : "workspace",
+              });
+              if (c) {
+                const authInfo: AuthInfo = {
+                  token: c.access_token,
+                  expiresAt: c.access_token_expiry ?? undefined,
+                  clientId: "",
+                  scopes: [],
+                  extra: {
+                    ...c.connection.metadata,
+                    connectionType:
+                      params.oAuthUseCase === "personal_actions"
+                        ? "personal"
+                        : "workspace",
+                  },
+                };
+
+                client.setAuthInfo(authInfo);
+                server.setAuthInfo(authInfo);
+              } else {
+                if (params.oAuthUseCase === "personal_actions") {
+                  return new Err(
+                    new MCPServerPersonalAuthenticationRequiredError(
+                      params.mcpServerId,
+                      metadata.authorization.provider,
+                      params.oAuthUseCase,
+                      metadata.authorization.scope
+                    )
+                  );
+                } else {
+                  // TODO(mcp): We return an result to display a message to the user saying that the server requires the admin to setup the connection.
+                  // For now, keeping iso.
+                }
+              }
+            }
+          }
           break;
 
         case "remote":
@@ -321,7 +384,7 @@ export function extractMetadataFromServerVersion(
       icon: isInternalMCPServerDefinition(r) ? r.icon : DEFAULT_MCP_SERVER_ICON,
       documentationUrl: isInternalMCPServerDefinition(r)
         ? r.documentationUrl
-        : undefined,
+        : null,
     };
   }
 
@@ -331,6 +394,7 @@ export function extractMetadataFromServerVersion(
     description: DEFAULT_MCP_ACTION_DESCRIPTION,
     icon: DEFAULT_MCP_SERVER_ICON,
     authorization: null,
+    documentationUrl: null,
   };
 }
 
@@ -384,6 +448,7 @@ export async function fetchRemoteServerMetaDataByServerId(
     params: {
       type: "mcpServerId",
       mcpServerId: serverId,
+      oAuthUseCase: "platform_actions",
     },
   });
 

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -48,7 +48,7 @@ export type MCPServerType = {
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   availability: MCPServerAvailability;
-  documentationUrl?: string;
+  documentationUrl: string | null;
 };
 
 export type RemoteMCPServerType = MCPServerType & {

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -41,6 +41,7 @@ const getCachedMetadata = cacheWithRedis(
       params: {
         type: "mcpServerId",
         mcpServerId: id,
+        oAuthUseCase: null,
       },
     });
 

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -362,6 +362,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       lastSyncAt: this.lastSyncAt?.getTime() ?? null,
       lastError: this.lastError,
       sharedSecret: secret,
+      documentationUrl: null,
     };
   }
 }


### PR DESCRIPTION
## Description

Prepare internal servers to handle personal & workspace connection types:
- Create a custom in-memory transport with the authInfo.
- Move the token handling outside of the server and pass it via the transport (as a regular mcp server would do).
- Move the personal connection required error outside of the server.
- Fix the documentationUrl (undefined is not valid as getServerSideProps, it was breaking assistant builder)
- Remove dead code

## Tests

Local

## Risk

Medium but I tested all of them.

## Deploy Plan

Deploy front.