### PR TITLE
Fix documentationURL nullable type

### DIFF
--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -202,7 +202,7 @@ export function ConnectMCPServerDialog({
               authCredentials={authCredentials}
               setAuthCredentials={setAuthCredentials}
               setIsFormValid={setIsFormValid}
-              documentationUrl={mcpServer?.documentationUrl}
+              documentationUrl={mcpServer?.documentationUrl ?? null}
             />
           )}
         </DialogContainer>

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -300,7 +300,7 @@ export function CreateMCPServerDialog({
               setUseCase={setUseCase}
               setAuthCredentials={setAuthCredentials}
               setIsFormValid={setIsOAuthFormValid}
-              documentationUrl={internalMCPServer?.documentationUrl}
+              documentationUrl={internalMCPServer?.documentationUrl ?? null}
             />
           )}
         </DialogContainer>

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -37,7 +37,7 @@ type MCPServerOauthConnexionProps = {
   setUseCase: (useCase: MCPOAuthUseCase) => void;
   setAuthCredentials: (authCredentials: OAuthCredentials) => void;
   setIsFormValid: (isFormValid: boolean) => void;
-  documentationUrl?: string;
+  documentationUrl: string | null;
 };
 
 export function MCPServerOAuthConnexion({

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -321,7 +321,7 @@ export function extractMetadataFromServerVersion(
       icon: isInternalMCPServerDefinition(r) ? r.icon : DEFAULT_MCP_SERVER_ICON,
       documentationUrl: isInternalMCPServerDefinition(r)
         ? r.documentationUrl
-        : undefined,
+        : null,
     };
   }
 
@@ -331,6 +331,7 @@ export function extractMetadataFromServerVersion(
     description: DEFAULT_MCP_ACTION_DESCRIPTION,
     icon: DEFAULT_MCP_SERVER_ICON,
     authorization: null,
+    documentationUrl: null,
   };
 }
 

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -48,7 +48,7 @@ export type MCPServerType = {
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   availability: MCPServerAvailability;
-  documentationUrl?: string;
+  documentationUrl: string | null;
 };
 
 export type RemoteMCPServerType = MCPServerType & {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See Slack thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1749578520252919).

Returning `undefined` in a `getServerSideProps` is not valid, as `undefined` can't be serialized, nullable values should be represented with `null` in this case. This `documentationUrl` nullable type currently breaks the assistant builder.

I'll add a linter rule tomorrow to prevent this from happening again.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
