### PR TITLE
Stop logging Workos login failure

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -584,7 +584,8 @@ async function handleWorkOSAuth<T>(
       });
     }
 
-    logger.error(decoded.error, "Failed to verify WorkOS token");
+    // TODO(workos): Actively log errors when WorkOS is the sole login method.
+    // logger.error(decoded.error, "Failed to verify WorkOS token");
     return new Err({
       status_code: 401,
       api_error: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since https://github.com/dust-tt/dust/issues/13184 we first tries WorkOS auth, before doing a fallback on Auth0. This led to tons of logs in our Datadog instance. For now there is no need to log as WorkOS isn't the single login method.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
