### PR TITLE
salesforce_synced_queries feature flag to show it in search tools

### DIFF
--- a/front/components/assistant_builder/actions/configuration/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/actions/configuration/AssistantBuilderDataSourceModal.tsx
@@ -23,6 +23,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { assertNever } from "@app/types";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface AssistantBuilderDataSourceModalProps {
   initialDataSourceConfigurations: DataSourceViewSelectionConfigurations;
@@ -50,6 +51,10 @@ export default function AssistantBuilderDataSourceModal({
     useState<DataSourceViewSelectionConfigurations>(
       initialDataSourceConfigurations
     );
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
 
   useEffect(() => {
     if (isOpen) {
@@ -82,12 +87,12 @@ export default function AssistantBuilderDataSourceModal({
         );
       case "document":
         return dataSourceViews.filter((dsv) =>
-          supportsDocumentsData(dsv.dataSource)
+          supportsDocumentsData(dsv.dataSource, featureFlags)
         );
       default:
         assertNever(viewType);
     }
-  }, [dataSourceViews, viewType]);
+  }, [dataSourceViews, viewType, featureFlags]);
 
   const selectedTableCount = useMemo(() => {
     if (viewType !== "table") {

--- a/front/components/assistant_builder/actions/configuration/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/actions/configuration/AssistantBuilderDataSourceModal.tsx
@@ -16,6 +16,7 @@ import {
   supportsDocumentsData,
   supportsStructuredData,
 } from "@app/lib/data_sources";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   ContentNodesViewType,
   DataSourceViewSelectionConfigurations,
@@ -23,7 +24,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { assertNever } from "@app/types";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface AssistantBuilderDataSourceModalProps {
   initialDataSourceConfigurations: DataSourceViewSelectionConfigurations;

--- a/front/components/trackers/TrackerBuilderDataSourceModal.tsx
+++ b/front/components/trackers/TrackerBuilderDataSourceModal.tsx
@@ -16,6 +16,7 @@ import {
   supportsDocumentsData,
   supportsStructuredData,
 } from "@app/lib/data_sources";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   ContentNodesViewType,
   DataSourceViewSelectionConfigurations,
@@ -56,6 +57,10 @@ export default function TrackerBuilderDataSourceModal({
     [setSelectionConfigurations]
   );
 
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+
   const supportedDataSourceViewsForViewType = useMemo(() => {
     switch (viewType) {
       case "all":
@@ -66,12 +71,12 @@ export default function TrackerBuilderDataSourceModal({
         );
       case "document":
         return dataSourceViews.filter((dsv) =>
-          supportsDocumentsData(dsv.dataSource)
+          supportsDocumentsData(dsv.dataSource, featureFlags)
         );
       default:
         assertNever(viewType);
     }
-  }, [dataSourceViews, viewType]);
+  }, [dataSourceViews, viewType, featureFlags]);
 
   return (
     <Sheet>

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -5,6 +5,7 @@ import type {
   CoreAPIDocument,
   DataSourceType,
   DataSourceViewType,
+  WhitelistableFeature,
   WithConnector,
 } from "@app/types";
 
@@ -92,8 +93,15 @@ const STRUCTURED_DATA_SOURCES: ConnectorProvider[] = [
   "salesforce",
 ];
 
-export function supportsDocumentsData(ds: DataSource): boolean {
-  return !isRemoteDatabase(ds);
+export function supportsDocumentsData(
+  ds: DataSource,
+  featureFlags: WhitelistableFeature[]
+): boolean {
+  return (
+    !isRemoteDatabase(ds) ||
+    (ds.connectorProvider === "salesforce" &&
+      featureFlags.includes("salesforce_synced_queries"))
+  );
 }
 
 export function supportsStructuredData(ds: DataSource): boolean {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -22,6 +22,7 @@ export const WHITELISTABLE_FEATURES = [
   "xai_feature",
   "salesforce_feature",
   "pro_plan_salesforce_connector",
+  "salesforce_synced_queries",
   "show_debug_tools",
   "usage_data_api",
   "custom_webcrawler",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -824,6 +824,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "xai_feature"
   | "pro_plan_salesforce_connector"
   | "salesforce_feature"
+  | "salesforce_synced_queries"
   | "search_knowledge_builder"
   | "show_debug_tools"
   | "snowflake_connector_feature"


### PR DESCRIPTION
## Description

Feature flag to control showing Salesforce as a data source that supports documents

Runbook updated: https://www.notion.so/dust-tt/Runbook-Salesforce-connector-20e28599d94180d7beceeb8b526b38c6

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`