### PR TITLE
feat(CLI): slash commands

### DIFF
--- a/cli/src/ui/commands/types.ts
+++ b/cli/src/ui/commands/types.ts
@@ -1,0 +1,15 @@
+export interface Command {
+  name: string;
+  description: string;
+  execute: () => void | Promise<void>;
+}
+
+export const AVAILABLE_COMMANDS: Command[] = [
+  {
+    name: "exit",
+    description: "Exit the chat",
+    execute: () => {
+      process.exit(0);
+    },
+  },
+];

--- a/cli/src/ui/components/CommandSelector.tsx
+++ b/cli/src/ui/components/CommandSelector.tsx
@@ -1,0 +1,53 @@
+import { Box, Text } from "ink";
+import React from "react";
+
+import type { Command } from "../commands/types.js";
+import { AVAILABLE_COMMANDS } from "../commands/types.js";
+
+interface CommandSelectorProps {
+  query: string;
+  selectedIndex: number;
+  onSelect: (command: Command) => void;
+}
+
+export function CommandSelector({ query, selectedIndex }: CommandSelectorProps) {
+  // Filter commands based on the query
+  const filteredCommands = AVAILABLE_COMMANDS.filter((command) =>
+    command.name.toLowerCase().startsWith(query.toLowerCase())
+  );
+
+  if (filteredCommands.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Box paddingX={1}>
+          <Text dimColor>No commands found</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box paddingX={1} flexDirection="column">
+        {filteredCommands.map((command, index) => {
+          const isSelected = index === selectedIndex;
+          return (
+            <Box key={command.name} flexDirection="row">
+              <Box width={15}>
+                <Text
+                  color={isSelected ? "blue" : undefined}
+                  bold={isSelected}
+                >
+                  /{command.name}
+                </Text>
+              </Box>
+              <Text dimColor={!isSelected} color={isSelected ? undefined : undefined}>
+                {command.description}
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/cli/src/ui/components/Conversation.tsx
+++ b/cli/src/ui/components/Conversation.tsx
@@ -13,6 +13,7 @@ import React, {
 
 import { useTerminalSize } from "../../utils/hooks/use_terminal_size.js";
 import { clearTerminal } from "../../utils/terminal.js";
+import { CommandSelector } from "./CommandSelector.js";
 import { InputBox } from "./InputBox.js";
 
 export type ConversationItem = { key: string } & (
@@ -58,6 +59,10 @@ interface ConversationProps {
   mentionPrefix: string;
   conversationId: string | null;
   stdout: NodeJS.WriteStream | null;
+  showCommandSelector: boolean;
+  commandQuery: string;
+  selectedCommandIndex: number;
+  commandCursorPosition: number;
 }
 
 const _Conversation: FC<ConversationProps> = ({
@@ -68,6 +73,10 @@ const _Conversation: FC<ConversationProps> = ({
   mentionPrefix,
   conversationId,
   stdout,
+  showCommandSelector,
+  commandQuery,
+  selectedCommandIndex,
+  commandCursorPosition,
 }: ConversationProps) => {
   return (
     <Box flexDirection="column" height="100%">
@@ -92,17 +101,26 @@ const _Conversation: FC<ConversationProps> = ({
       )}
 
       <InputBox
-        userInput={userInput}
-        cursorPosition={cursorPosition}
+        userInput={showCommandSelector ? `/${commandQuery}` : userInput}
+        cursorPosition={showCommandSelector ? commandCursorPosition + 1 : cursorPosition}
         isProcessingQuestion={isProcessingQuestion}
         mentionPrefix={mentionPrefix}
       />
-      <Box marginTop={0}>
-        <Text dimColor>
-          ↵ to send · \↵ for new line · ESC to clear
-          {conversationId && "· Ctrl+G to open in browser"}
-        </Text>
-      </Box>
+      {showCommandSelector && (
+        <CommandSelector
+          query={commandQuery}
+          selectedIndex={selectedCommandIndex}
+          onSelect={() => {}}
+        />
+      )}
+      {!showCommandSelector && (
+        <Box marginTop={0} paddingLeft={1}>
+          <Text dimColor>
+            ↵ to send · \↵ for new line · ESC to clear
+            {conversationId && " · Ctrl+G to open in browser"}
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Description

Adds a `/command` selector to the CLI.

For now there's a single `exit` command that exits the CLI, to keep the PR small. The goal is to add `/switch` to allow switching to a different agent without leaving the CLI.
We'll also be able to use this to resume previous conversations.

<img width="972" alt="Screenshot 2025-06-10 at 23 49 27" src="https://github.com/user-attachments/assets/3b8cc302-58a9-4d73-9504-411dc6e5d6df" />


## Tests

Extensive locally

## Risk

N/A (not bumping or publishing the CLI yet)

## Deploy Plan

N/A