### PR TITLE
Add Dust labs page for MCP action observability

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -169,7 +169,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
         ? actualActions[actualActions.length - 1].createdAt.toISOString()
         : null;
 
-      const actionsData: MCPActionData[] = actualActions.map((action) => {
+      const actionsData: MCPAction[] = actualActions.map((action) => {
         const agentMessage = action.agent_message;
         return {
           sId: MCPActionType.modelIdToSId({
@@ -205,7 +205,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
   }
 }
 
-export type MCPActionData = {
+export type MCPAction = {
   sId: string;
   createdAt: string;
   functionCallName: string | null;
@@ -217,7 +217,7 @@ export type MCPActionData = {
 };
 
 export type GetMCPActionsResult = {
-  actions: MCPActionData[];
+  actions: MCPAction[];
   nextCursor: string | null;
   totalCount: number;
 };

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1,0 +1,229 @@
+import type { Attributes, ModelStatic } from "sequelize";
+import { Op } from "sequelize";
+
+import { MCPActionType } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import {
+  ConversationModel,
+  Message,
+} from "@app/lib/models/assistant/conversation";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+type AgentMCPActionWithConversation = AgentMCPAction & {
+  agent_message: AgentMessage & {
+    message: Message & {
+      conversation: ConversationModel;
+    };
+  };
+};
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
+export interface AgentMCPActionResource
+  extends ReadonlyAttributesType<AgentMCPAction> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
+  static model: ModelStatic<AgentMCPAction> = AgentMCPAction;
+
+  constructor(
+    model: ModelStatic<AgentMCPAction>,
+    blob: Attributes<AgentMCPAction>
+  ) {
+    super(AgentMCPAction, blob);
+  }
+
+  async delete(): Promise<Result<undefined, Error>> {
+    return new Err(
+      new Error("Direct deletion of MCP actions is not supported")
+    );
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: number;
+    workspaceId: number;
+  }): string {
+    return MCPActionType.modelIdToSId({ id, workspaceId });
+  }
+
+  get sId(): string {
+    return AgentMCPActionResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  toJSON() {
+    return {
+      sId: this.sId,
+      createdAt: this.createdAt.toISOString(),
+      functionCallName: this.functionCallName,
+      params: this.params,
+      executionState: this.executionState,
+      isError: this.isError,
+    };
+  }
+
+  static async getMCPActionsForAgent(
+    auth: Authenticator,
+    { agentConfigurationId, limit, cursor }: GetMCPActionsOptions
+  ): Promise<Result<GetMCPActionsResult, Error>> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const whereClause: any = {
+      workspaceId: owner.id,
+    };
+
+    if (cursor) {
+      const cursorDate = new Date(cursor);
+      if (isNaN(cursorDate.getTime())) {
+        return new Err(new Error("Invalid cursor format"));
+      }
+      whereClause.createdAt = {
+        [Op.lt]: cursorDate,
+      };
+    }
+
+    try {
+      // Get total count for pagination
+      const totalCount = await AgentMCPAction.count({
+        include: [
+          {
+            model: AgentMessage,
+            as: "agent_message",
+            required: true,
+            where: {
+              agentConfigurationId: agentConfigurationId,
+            },
+            include: [
+              {
+                model: Message,
+                as: "message",
+                required: true,
+                include: [
+                  {
+                    model: ConversationModel,
+                    as: "conversation",
+                    required: true,
+                    where: {
+                      visibility: { [Op.ne]: "deleted" },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        where: {
+          workspaceId: owner.id,
+        },
+      });
+
+      // Get all MCP actions for the specific agent with conversation info and limit
+      const mcpActions = (await AgentMCPAction.findAll({
+        include: [
+          {
+            model: AgentMessage,
+            as: "agent_message",
+            required: true,
+            where: {
+              agentConfigurationId: agentConfigurationId,
+            },
+            include: [
+              {
+                model: Message,
+                as: "message",
+                required: true,
+                include: [
+                  {
+                    model: ConversationModel,
+                    as: "conversation",
+                    required: true,
+                    where: {
+                      visibility: { [Op.ne]: "deleted" },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        where: whereClause,
+        order: [["createdAt", "DESC"]],
+        limit: limit + 1, // Fetch one extra to determine if there are more results
+      })) as AgentMCPActionWithConversation[];
+
+      // Determine if there are more results and get the actual results
+      const hasMore = mcpActions.length > limit;
+      const actualActions = hasMore ? mcpActions.slice(0, limit) : mcpActions;
+      const nextCursor = hasMore
+        ? actualActions[actualActions.length - 1].createdAt.toISOString()
+        : null;
+
+      const actionsData: MCPActionData[] = actualActions.map((action) => {
+        const agentMessage = action.agent_message;
+        return {
+          sId: MCPActionType.modelIdToSId({
+            id: action.id,
+            workspaceId: owner.id,
+          }),
+          createdAt: action.createdAt.toISOString(),
+          functionCallName: action.functionCallName,
+          params: action.params,
+          executionState: action.executionState,
+          isError: action.isError,
+          conversationId: agentMessage.message.conversation.sId,
+          messageId: agentMessage.message.sId,
+        };
+      });
+
+      return new Ok({
+        actions: actionsData,
+        nextCursor,
+        totalCount,
+      });
+    } catch (error) {
+      logger.error(
+        {
+          workspaceId: owner.id,
+          agentConfigurationId,
+          error,
+        },
+        "Failed to fetch MCP actions from database"
+      );
+      return new Err(new Error("Failed to fetch MCP actions from database"));
+    }
+  }
+}
+
+export type MCPActionData = {
+  sId: string;
+  createdAt: string;
+  functionCallName: string | null;
+  params: Record<string, unknown>;
+  executionState: string;
+  isError: boolean;
+  conversationId: string;
+  messageId: string;
+};
+
+export type GetMCPActionsResult = {
+  actions: MCPActionData[];
+  nextCursor: string | null;
+  totalCount: number;
+};
+
+export type GetMCPActionsOptions = {
+  agentConfigurationId: string;
+  limit: number;
+  cursor?: string;
+};

--- a/front/lib/swr/mcp_actions.ts
+++ b/front/lib/swr/mcp_actions.ts
@@ -49,10 +49,10 @@ export function useMCPActions({
   const handleSetPage = useCallback(
     (page: number) => {
       setCurrentPage(page);
-      
+
       // If we're going to a page we haven't fetched yet, add the cursor
       if (data?.nextCursor && page === cursors.length) {
-        setCursors(prev => [...prev, data.nextCursor]);
+        setCursors((prev) => [...prev, data.nextCursor]);
       }
     },
     [data?.nextCursor, cursors.length]
@@ -70,7 +70,9 @@ export function useMCPActions({
     }
   }, [currentPage]);
 
-  const totalPages = data?.totalCount ? Math.ceil(data.totalCount / pageSize) : 0;
+  const totalPages = data?.totalCount
+    ? Math.ceil(data.totalCount / pageSize)
+    : 0;
   const canGoNext = Boolean(data?.nextCursor);
   const canGoPrevious = currentPage > 0;
 
@@ -88,4 +90,4 @@ export function useMCPActions({
     canGoPrevious,
     mutate,
   };
-} 
+}

--- a/front/lib/swr/mcp_actions.ts
+++ b/front/lib/swr/mcp_actions.ts
@@ -1,0 +1,91 @@
+import { useCallback, useState } from "react";
+import type { Fetcher } from "swr";
+
+import type { MCPAction } from "@app/lib/resources/agent_mcp_action_resource";
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetMCPActionsResponseBody } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UseMCPActionsProps {
+  owner: LightWorkspaceType;
+  agentId: string;
+  pageSize?: number;
+}
+
+interface UseMCPActionsReturn {
+  actions: MCPAction[];
+  totalCount: number;
+  currentPage: number;
+  totalPages: number;
+  isLoading: boolean;
+  isError: boolean;
+  setPage: (page: number) => void;
+  nextPage: () => void;
+  previousPage: () => void;
+  canGoNext: boolean;
+  canGoPrevious: boolean;
+  mutate: () => void;
+}
+
+export function useMCPActions({
+  owner,
+  agentId,
+  pageSize = 25,
+}: UseMCPActionsProps): UseMCPActionsReturn {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [cursors, setCursors] = useState<(string | null)[]>([null]);
+
+  const mcpActionsFetcher: Fetcher<GetMCPActionsResponseBody> = fetcher;
+
+  // For the current page, we need the cursor from our cache
+  const cursor = cursors[currentPage] || null;
+  const url = cursor
+    ? `/api/w/${owner.sId}/labs/mcp_actions/${agentId}?limit=${pageSize}&cursor=${cursor}`
+    : `/api/w/${owner.sId}/labs/mcp_actions/${agentId}?limit=${pageSize}`;
+
+  const { data, error, mutate } = useSWRWithDefaults(url, mcpActionsFetcher);
+
+  // Update cursors when we get new data
+  const handleSetPage = useCallback(
+    (page: number) => {
+      setCurrentPage(page);
+      
+      // If we're going to a page we haven't fetched yet, add the cursor
+      if (data?.nextCursor && page === cursors.length) {
+        setCursors(prev => [...prev, data.nextCursor]);
+      }
+    },
+    [data?.nextCursor, cursors.length]
+  );
+
+  const nextPage = useCallback(() => {
+    if (data?.nextCursor) {
+      handleSetPage(currentPage + 1);
+    }
+  }, [currentPage, data?.nextCursor, handleSetPage]);
+
+  const previousPage = useCallback(() => {
+    if (currentPage > 0) {
+      setCurrentPage(currentPage - 1);
+    }
+  }, [currentPage]);
+
+  const totalPages = data?.totalCount ? Math.ceil(data.totalCount / pageSize) : 0;
+  const canGoNext = Boolean(data?.nextCursor);
+  const canGoPrevious = currentPage > 0;
+
+  return {
+    actions: data?.actions || [],
+    totalCount: data?.totalCount || 0,
+    currentPage,
+    totalPages,
+    isLoading: !error && !data,
+    isError: !!error,
+    setPage: handleSetPage,
+    nextPage,
+    previousPage,
+    canGoNext,
+    canGoPrevious,
+    mutate,
+  };
+} 

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -1,0 +1,267 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import { NumberFromString, withFallback } from "io-ts-types";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Op } from "sequelize";
+
+import { MCPActionType } from "@app/lib/actions/mcp";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import {
+  ConversationModel,
+  Message,
+} from "@app/lib/models/assistant/conversation";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const GetMCPActionsQuerySchema = t.type({
+  agentId: t.string,
+  limit: withFallback(
+    t.refinement(
+      NumberFromString,
+      (n): n is number => n >= 1 && n <= 100,
+      `LimitWithRange`
+    ),
+    25
+  ),
+  cursor: t.union([t.string, t.undefined]),
+});
+
+export type GetMCPActionsResponseBody = {
+  actions: Array<{
+    sId: string;
+    createdAt: string;
+    functionCallName: string | null;
+    params: Record<string, unknown>;
+    executionState: string;
+    isError: boolean;
+    conversationId: string;
+    messageId: string;
+  }>;
+  nextCursor: string | null;
+  totalCount: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMCPActionsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET":
+      const queryValidation = GetMCPActionsQuerySchema.decode({
+        ...req.query,
+        limit: req.query.limit
+          ? parseInt(req.query.limit as string, 10)
+          : undefined,
+      });
+
+      if (isLeft(queryValidation)) {
+        const pathError = reporter.formatValidationErrors(queryValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${pathError}`,
+          },
+        });
+      }
+
+      const { agentId, limit, cursor } = queryValidation.right;
+
+      const owner = auth.getNonNullableWorkspace();
+      const flags = await getFeatureFlags(owner);
+      if (!flags.includes("labs_mcp_actions_dashboard")) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "feature_flag_not_found",
+            message: "MCP Actions dashboard is not available.",
+          },
+        });
+      }
+
+      // Only admins can access the MCP Actions Dashboard
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "Only workspace admins can access the MCP Actions Dashboard.",
+          },
+        });
+      }
+
+      // Verify the agent exists and user has access
+      const agentConfiguration = await getAgentConfiguration(
+        auth,
+        agentId,
+        "light"
+      );
+      if (!agentConfiguration) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "agent_configuration_not_found",
+            message: "The agent you're trying to access was not found.",
+          },
+        });
+      }
+
+      const whereClause: any = {
+        workspaceId: owner.id,
+      };
+
+      if (cursor) {
+        const cursorDate = new Date(cursor);
+        if (isNaN(cursorDate.getTime())) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Invalid cursor format.",
+            },
+          });
+        }
+        whereClause.createdAt = {
+          [Op.lt]: cursorDate,
+        };
+      }
+
+      let mcpActions;
+      let totalCount;
+      try {
+        // Get total count for pagination
+        totalCount = await AgentMCPAction.count({
+          include: [
+            {
+              model: AgentMessage,
+              as: "agent_message",
+              required: true,
+              where: {
+                agentConfigurationId: agentConfiguration.sId,
+              },
+              include: [
+                {
+                  model: Message,
+                  as: "message",
+                  required: true,
+                  include: [
+                    {
+                      model: ConversationModel,
+                      as: "conversation",
+                      required: true,
+                      where: {
+                        visibility: { [Op.ne]: "deleted" },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          where: {
+            workspaceId: owner.id,
+          },
+        });
+
+        // Get all MCP actions for the specific agent with conversation info and limit
+        mcpActions = await AgentMCPAction.findAll({
+          include: [
+            {
+              model: AgentMessage,
+              as: "agent_message",
+              required: true,
+              where: {
+                agentConfigurationId: agentConfiguration.sId,
+              },
+              include: [
+                {
+                  model: Message,
+                  as: "message",
+                  required: true,
+                  include: [
+                    {
+                      model: ConversationModel,
+                      as: "conversation",
+                      required: true,
+                      where: {
+                        visibility: { [Op.ne]: "deleted" },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          where: whereClause,
+          order: [["createdAt", "DESC"]],
+          limit: limit + 1, // Fetch one extra to determine if there are more results
+        });
+      } catch (error) {
+        logger.error(
+          {
+            workspaceId: owner.id,
+            agentId,
+            error,
+          },
+          "Failed to fetch MCP actions from database"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to fetch MCP actions from database.",
+          },
+        });
+      }
+
+      // Determine if there are more results and get the actual results
+      const hasMore = mcpActions.length > limit;
+      const actualActions = hasMore ? mcpActions.slice(0, limit) : mcpActions;
+      const nextCursor = hasMore
+        ? actualActions[actualActions.length - 1].createdAt.toISOString()
+        : null;
+
+      const actionsData = actualActions.map((action) => {
+        const agentMessage = (action as any).agent_message;
+        return {
+          sId: MCPActionType.modelIdToSId({
+            id: action.id,
+            workspaceId: owner.id,
+          }),
+          createdAt: action.createdAt.toISOString(),
+          functionCallName: action.functionCallName,
+          params: action.params,
+          executionState: action.executionState,
+          isError: action.isError,
+          conversationId: agentMessage?.message?.conversation?.sId || "",
+          messageId: agentMessage?.message?.sId || "",
+        };
+      });
+
+      return res.status(200).json({
+        actions: actionsData,
+        nextCursor,
+        totalCount,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -8,7 +8,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type { MCPActionData } from "@app/lib/resources/agent_mcp_action_resource";
+import type { MCPAction } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -27,7 +27,7 @@ const GetMCPActionsQuerySchema = t.type({
 });
 
 export type GetMCPActionsResponseBody = {
-  actions: MCPActionData[];
+  actions: MCPAction[];
   nextCursor: string | null;
   totalCount: number;
 };

--- a/front/pages/w/[wId]/labs/index.tsx
+++ b/front/pages/w/[wId]/labs/index.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionCodeBoxIcon,
   BookOpenIcon,
   ContextItem,
   EyeIcon,
@@ -42,6 +43,16 @@ const LABS_FEATURES: LabsFeatureItemType[] = [
     description:
       "Document monitoring made simple - receive alerts when documents are out of date.",
     onlyAdminCanManage: false,
+  },
+  {
+    id: "mcp_actions",
+    label: "MCP Actions Dashboard",
+    featureFlag: "labs_mcp_actions_dashboard",
+    visibleWithoutAccess: true,
+    icon: ActionCodeBoxIcon,
+    description:
+      "Monitor and track MCP (Model Context Protocol) actions executed by your agents.",
+    onlyAdminCanManage: true,
   },
   {
     id: "salesforce_personal_connections",

--- a/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
@@ -1,0 +1,369 @@
+import {
+  ActionCodeBoxIcon,
+  Avatar,
+  Breadcrumbs,
+  Button,
+  Chip,
+  ContextItem,
+  ExternalLinkIcon,
+  Icon,
+  Page,
+  Pagination,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import { useCallback, useEffect, useState } from "react";
+
+import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
+import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import AppContentLayout from "@app/components/sparkle/AppContentLayout";
+import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { getFeatureFlags } from "@app/lib/auth";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import type { GetMCPActionsResponseBody } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
+import type {
+  LightAgentConfigurationType,
+  SubscriptionType,
+  WorkspaceType,
+} from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  agent: LightAgentConfigurationType;
+  agentId: string;
+}>(async (_context, auth) => {
+  const owner = auth.workspace();
+  const subscription = auth.subscription();
+  const user = auth.user();
+  const agentId = _context.params?.agentId as string;
+
+  if (!owner || !subscription || !user || !agentId) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const flags = await getFeatureFlags(owner);
+  if (!flags.includes("labs_mcp_actions_dashboard")) {
+    return {
+      notFound: true,
+    };
+  }
+
+  if (!auth.isAdmin()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const agent = await getAgentConfiguration(auth, agentId, "light");
+  if (!agent) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+      subscription,
+      agent,
+      agentId,
+    },
+  };
+});
+
+export default function AgentMCPActions({
+  owner,
+  subscription,
+  agent,
+  agentId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [allActions, setAllActions] = useState<
+    Array<{
+      sId: string;
+      createdAt: string;
+      functionCallName: string | null;
+      params: Record<string, unknown>;
+      executionState: string;
+      isError: boolean;
+      conversationId: string;
+      messageId: string;
+    }>
+  >([]);
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: 25,
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [totalCount, setTotalCount] = useState(0);
+  const [cursors, setCursors] = useState<(string | null)[]>([null]);
+
+  const startIndex = pagination.pageIndex * pagination.pageSize;
+  const endIndex = startIndex + pagination.pageSize;
+  const currentPageActions = allActions.slice(startIndex, endIndex);
+
+  // Check if we need to fetch more data
+  const needsMoreData =
+    pagination.pageIndex >=
+      Math.floor(allActions.length / pagination.pageSize) &&
+    cursors[cursors.length - 1] !== null;
+
+  const fetchData = useCallback(async () => {
+    if (isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const targetPageIndex = Math.floor(
+        allActions.length / pagination.pageSize
+      );
+      const cursor = cursors[targetPageIndex] || null;
+      const url = cursor
+        ? `/api/w/${owner.sId}/labs/mcp_actions/${agentId}?limit=${pagination.pageSize}&cursor=${cursor}`
+        : `/api/w/${owner.sId}/labs/mcp_actions/${agentId}?limit=${pagination.pageSize}`;
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error("Failed to fetch MCP actions");
+      }
+      const data: GetMCPActionsResponseBody = await response.json();
+
+      setAllActions((prev) => [...prev, ...data.actions]);
+      setCursors((prev) => [...prev, data.nextCursor]);
+
+      // Use the actual total count from the API
+      setTotalCount(data.totalCount);
+    } catch (error) {
+      console.error("Failed to fetch data:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    owner.sId,
+    agentId,
+    pagination.pageSize,
+    allActions.length,
+    cursors,
+    isLoading,
+  ]);
+
+  useEffect(() => {
+    if (needsMoreData) {
+      void fetchData();
+    }
+  }, [needsMoreData, fetchData]);
+
+  useEffect(() => {
+    if (allActions.length === 0 && !isLoading) {
+      void fetchData();
+    }
+  }, [allActions.length, isLoading, fetchData]);
+
+  const items = [
+    {
+      label: "Exploratory features",
+      href: `/w/${owner.sId}/labs`,
+    },
+    {
+      label: "MCP Actions Dashboard",
+      href: `/w/${owner.sId}/labs/mcp_actions`,
+    },
+    {
+      label: agent.name,
+      href: `/w/${owner.sId}/labs/mcp_actions/${agentId}`,
+    },
+  ];
+
+  const formatParams = (params: Record<string, unknown>): string => {
+    try {
+      return JSON.stringify(params, null, 2);
+    } catch {
+      return String(params);
+    }
+  };
+
+  const getExecutionStateColor = (state: string) => {
+    switch (state) {
+      case "allowed_explicitly":
+      case "allowed_implicitly":
+        return "success";
+      case "denied":
+        return "warning";
+      case "pending":
+        return "info";
+      case "timeout":
+        return "warning";
+      default:
+        return "primary";
+    }
+  };
+
+  const handleConversationLink = (
+    conversationId: string,
+    messageId: string
+  ) => {
+    if (conversationId && messageId) {
+      window.open(`/w/${owner.sId}/assistant/${conversationId}`, "_blank");
+    }
+  };
+
+  return (
+    <ConversationsNavigationProvider>
+      <AppContentLayout
+        subscription={subscription}
+        owner={owner}
+        pageTitle={`Dust - MCP Actions for ${agent.name}`}
+        navChildren={<AssistantSidebarMenu owner={owner} />}
+      >
+        <div className="mb-4">
+          <Breadcrumbs items={items} />
+        </div>
+
+        <Page>
+          <Page.Header
+            title={`MCP Actions for ${agent.name}`}
+            icon={ActionCodeBoxIcon}
+            description={`View all MCP actions executed by the ${agent.name} agent.`}
+          />
+
+          {/* Agent info section */}
+          <div className="mb-6 border-b border-gray-200 pb-4">
+            <div className="flex items-center gap-3">
+              <Avatar size="md" name={agent.name} visual={agent.pictureUrl} />
+              <div className="flex flex-col">
+                <h3 className="text-lg font-medium text-foreground dark:text-foreground-night">
+                  {agent.name}
+                </h3>
+                <div className="flex items-center gap-2">
+                  <Chip
+                    color={agent.scope === "global" ? "primary" : "green"}
+                    size="xs"
+                  >
+                    {agent.scope === "global"
+                      ? "Default Agent"
+                      : "Custom Agent"}
+                  </Chip>
+                  <Chip
+                    color={agent.status === "active" ? "success" : "warning"}
+                    size="xs"
+                  >
+                    {agent.status}
+                  </Chip>
+                </div>
+                {agent.description && (
+                  <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    {agent.description}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <Page.Layout direction="vertical">
+            {isLoading && allActions.length === 0 ? (
+              <div className="flex justify-center py-8">
+                <Spinner />
+              </div>
+            ) : (
+              <>
+                <ContextItem.List>
+                  <ContextItem.SectionHeader
+                    title="Action History"
+                    description={`${totalCount} MCP action${totalCount !== 1 ? "s" : ""} executed by this agent`}
+                  />
+
+                  {currentPageActions.length > 0 ? (
+                    <>
+                      {currentPageActions.map((action) => (
+                        <ContextItem
+                          key={action.sId}
+                          title={action.functionCallName || "Unknown Action"}
+                          visual={<Icon visual={ActionCodeBoxIcon} />}
+                          action={
+                            <div className="flex items-center gap-2">
+                              <Chip
+                                color={
+                                  action.isError
+                                    ? "warning"
+                                    : getExecutionStateColor(
+                                        action.executionState
+                                      )
+                                }
+                                size="xs"
+                              >
+                                {action.isError
+                                  ? "Error"
+                                  : action.executionState.replace("_", " ")}
+                              </Chip>
+                              {action.conversationId && (
+                                <Button
+                                  size="xs"
+                                  variant="outline"
+                                  icon={ExternalLinkIcon}
+                                  onClick={() =>
+                                    handleConversationLink(
+                                      action.conversationId,
+                                      action.messageId
+                                    )
+                                  }
+                                >
+                                  View Conversation
+                                </Button>
+                              )}
+                            </div>
+                          }
+                        >
+                          <div className="space-y-2">
+                            <ContextItem.Description
+                              description={`Executed on ${new Date(action.createdAt).toLocaleString()}`}
+                            />
+                            {Object.keys(action.params).length > 0 && (
+                              <div className="rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
+                                <h4 className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">
+                                  Input Parameters:
+                                </h4>
+                                <pre className="max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground dark:text-muted-foreground-night">
+                                  {formatParams(action.params)}
+                                </pre>
+                              </div>
+                            )}
+                          </div>
+                        </ContextItem>
+                      ))}
+                    </>
+                  ) : (
+                    <ContextItem
+                      title="No Actions Found"
+                      visual={<Icon visual={ActionCodeBoxIcon} />}
+                    >
+                      <ContextItem.Description description="No MCP actions have been executed by this agent yet." />
+                    </ContextItem>
+                  )}
+                </ContextItem.List>
+
+                {totalCount > pagination.pageSize && (
+                  <div className="mt-4">
+                    <Pagination
+                      rowCount={totalCount}
+                      pagination={pagination}
+                      setPagination={setPagination}
+                      size="sm"
+                    />
+                  </div>
+                )}
+              </>
+            )}
+          </Page.Layout>
+        </Page>
+      </AppContentLayout>
+    </ConversationsNavigationProvider>
+  );
+}
+
+AgentMCPActions.getLayout = (page: React.ReactElement) => {
+  return <AppRootLayout>{page}</AppRootLayout>;
+};

--- a/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
@@ -81,17 +81,12 @@ export default function AgentMCPActions({
   agent,
   agentId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const {
-    actions,
-    totalCount,
-    currentPage,
-    isLoading,
-    setPage,
-  } = useMCPActions({
-    owner,
-    agentId,
-    pageSize: 25,
-  });
+  const { actions, totalCount, currentPage, isLoading, setPage } =
+    useMCPActions({
+      owner,
+      agentId,
+      pageSize: 25,
+    });
 
   const pagination = {
     pageIndex: currentPage,

--- a/front/pages/w/[wId]/labs/mcp_actions/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/index.tsx
@@ -1,0 +1,182 @@
+import {
+  ActionCodeBoxIcon,
+  Avatar,
+  Breadcrumbs,
+  Button,
+  Chip,
+  ContextItem,
+  ExternalLinkIcon,
+  Icon,
+  Page,
+  RobotIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
+
+import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
+import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import AppContentLayout from "@app/components/sparkle/AppContentLayout";
+import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { getFeatureFlags } from "@app/lib/auth";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import type { SubscriptionType, WorkspaceType } from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+}>(async (_context, auth) => {
+  const owner = auth.workspace();
+  const subscription = auth.subscription();
+  const user = auth.user();
+
+  if (!owner || !subscription || !user) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const flags = await getFeatureFlags(owner);
+  if (!flags.includes("labs_mcp_actions_dashboard")) {
+    return {
+      notFound: true,
+    };
+  }
+
+  // Only admins can access the MCP Actions Dashboard
+  if (!auth.isAdmin()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+      subscription,
+    },
+  };
+});
+
+export default function MCPActionsDashboard({
+  owner,
+  subscription,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+  const { agentConfigurations, isAgentConfigurationsLoading } =
+    useAgentConfigurations({
+      workspaceId: owner.sId,
+      agentsGetView: "list",
+      includes: [],
+    });
+
+  const items = [
+    {
+      label: "Exploratory features",
+      href: `/w/${owner.sId}/labs`,
+    },
+    {
+      label: "MCP Actions Dashboard",
+      href: `/w/${owner.sId}/labs/mcp_actions`,
+    },
+  ];
+
+  const handleAgentSelect = (agentId: string) => {
+    void router.push(`/w/${owner.sId}/labs/mcp_actions/${agentId}`);
+  };
+
+  const activeAgents =
+    agentConfigurations?.filter((agent) => agent.status === "active") || [];
+
+  return (
+    <ConversationsNavigationProvider>
+      <AppContentLayout
+        subscription={subscription}
+        owner={owner}
+        pageTitle="Dust - MCP Actions Dashboard"
+        navChildren={<AssistantSidebarMenu owner={owner} />}
+      >
+        <div className="mb-4">
+          <Breadcrumbs items={items} />
+        </div>
+
+        <Page>
+          <Page.Header
+            title="MCP Actions Dashboard"
+            icon={ActionCodeBoxIcon}
+            description="Monitor and track MCP (Model Context Protocol) actions executed by your agents."
+          />
+
+          <Page.Layout direction="vertical">
+            {isAgentConfigurationsLoading ? (
+              <div className="flex justify-center py-8">
+                <Spinner />
+              </div>
+            ) : (
+              <ContextItem.List>
+                <ContextItem.SectionHeader
+                  title="Active Agents"
+                  description={`${activeAgents.length} agent${activeAgents.length !== 1 ? "s" : ""} available for MCP action monitoring.`}
+                />
+
+                {activeAgents.length > 0 ? (
+                  activeAgents.map((agent) => (
+                    <ContextItem
+                      key={agent.sId}
+                      title={agent.name}
+                      visual={
+                        <Avatar
+                          size="sm"
+                          name={agent.name}
+                          visual={agent.pictureUrl}
+                        />
+                      }
+                      action={
+                        <div className="flex items-center gap-2">
+                          <Chip
+                            color={
+                              agent.scope === "global" ? "primary" : "green"
+                            }
+                            size="xs"
+                          >
+                            {agent.scope === "global" ? "Default" : "Custom"}
+                          </Chip>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            icon={ExternalLinkIcon}
+                            onClick={() => handleAgentSelect(agent.sId)}
+                          >
+                            View Actions
+                          </Button>
+                        </div>
+                      }
+                    >
+                      <ContextItem.Description
+                        description={
+                          agent.description || "No description available"
+                        }
+                      />
+                    </ContextItem>
+                  ))
+                ) : (
+                  <ContextItem
+                    title="No Active Agents Found"
+                    visual={<Icon visual={RobotIcon} />}
+                  >
+                    <ContextItem.Description description="No active agents found in this workspace. Agents must be active to execute MCP actions." />
+                  </ContextItem>
+                )}
+              </ContextItem.List>
+            )}
+          </Page.Layout>
+        </Page>
+      </AppContentLayout>
+    </ConversationsNavigationProvider>
+  );
+}
+
+MCPActionsDashboard.getLayout = (page: React.ReactElement) => {
+  return <AppRootLayout>{page}</AppRootLayout>;
+};

--- a/front/types/labs.ts
+++ b/front/types/labs.ts
@@ -13,6 +13,7 @@ export type LabsTranscriptsProviderType =
 export const labsFeatures = [
   "transcripts",
   "trackers",
+  "mcp_actions",
   "salesforce_personal_connections",
 ] as const;
 export type LabsFeatureType = (typeof labsFeatures)[number];

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -21,6 +21,7 @@ export const WHITELISTABLE_FEATURES = [
   "google_ai_studio_experimental_models_feature",
   "google_calendar_tool",
   "index_private_slack_channel",
+  "labs_mcp_actions_dashboard",
   "labs_salesforce_personal_connections",
   "labs_trackers",
   "labs_transcripts",
@@ -41,6 +42,7 @@ export const WHITELISTABLE_FEATURES = [
   "workos_user_provisioning",
   "workos",
   "xai_feature",
+  "labs_mcp_actions_dashboard",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -840,6 +840,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "workos_user_provisioning"
   | "workos"
   | "xai_feature"
+  | "labs_mcp_actions_dashboard"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

* Adding a dashboard behind a FF in Dust labs to view the history of MCP actions taken per agent. Only accessible for admin with the intention of providing the ability to audit actions taken asynchronously. API created in Labs to facilitate the data required for this dashboard. See screenshots below for experience

## Tests

<img width="1032" alt="Screenshot 2025-06-10 at 8 19 26 PM" src="https://github.com/user-attachments/assets/62d1645f-01ad-45b4-ac98-f838fa73ae3f" />
<img width="1056" alt="Screenshot 2025-06-10 at 8 19 42 PM" src="https://github.com/user-attachments/assets/acbfae96-1d09-46e0-ba4b-089f453139df" />

## Risk

* Behind FF

## Deploy Plan

* Deploy front