### PR TITLE
[front] fix(extract): prevent stream drop on validation

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -38,7 +38,7 @@ const JsonPropertySchema = z.object({
       z.string(),
       z.object({
         type: JsonTypeSchema,
-        description: z.string(),
+        description: z.string().optional(),
         properties: z.record(z.string(), z.any()).optional(),
         required: z.array(z.string()).optional(),
       })


### PR DESCRIPTION
## Description

- The extract tool currently performs a validation of the JSONSchema used in `generateConfiguredInput`.
- We have observed occurrences of `Invalid jsonSchema configuration for mimeType JSON_SCHEMA` in production, all due to the description missing on a property, which is the only thing we do enforce.
- As a quick fix, this PR removes this constraint, making the description optional. This constraint does not seem to exist on the non-MCP version.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
