### PR TITLE
Fix: re-connection case

### DIFF
--- a/front/components/actions/MCPActionHeader.tsx
+++ b/front/components/actions/MCPActionHeader.tsx
@@ -4,10 +4,11 @@ import type { AssistantBuilderActionConfiguration } from "@app/components/assist
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
+import type { MCPOAuthUseCase } from "@app/types";
 
 interface MCPActionHeaderProps {
   mcpServer: MCPServerType;
-  isAuthorized: boolean;
+  oAuthUseCase: MCPOAuthUseCase | null;
   isConnected: boolean;
   isConnectionsLoading: boolean;
   action?: AssistantBuilderActionConfiguration;
@@ -15,13 +16,13 @@ interface MCPActionHeaderProps {
 
 export function MCPActionHeader({
   mcpServer,
-  isAuthorized,
+  oAuthUseCase,
   isConnected,
   isConnectionsLoading,
   action,
 }: MCPActionHeaderProps) {
   return (
-    <div className="flex flex-col items-center gap-3 sm:flex-row">
+    <div className="items-top flex flex-col gap-3 sm:flex-row">
       {getAvatar(mcpServer, "md")}
       <div className="flex grow flex-col gap-0 pr-9">
         <h2 className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
@@ -30,13 +31,23 @@ export function MCPActionHeader({
         <div className="line-clamp-1 overflow-hidden text-sm text-muted-foreground dark:text-muted-foreground-night">
           {mcpServer.description}
         </div>
-        {isAuthorized && !isConnected && !isConnectionsLoading && (
-          <div>
-            <Chip color="warning" size="xs">
-              Requires authentication
-            </Chip>
-          </div>
-        )}
+        {oAuthUseCase &&
+          !isConnectionsLoading &&
+          (isConnected ? (
+            <div className="pt-2">
+              <Chip color="success" size="xs">
+                Uses{" "}
+                {oAuthUseCase === "personal_actions" ? "personal" : "workspace"}{" "}
+                credentials
+              </Chip>
+            </div>
+          ) : (
+            <div className="pt-2">
+              <Chip color="warning" size="xs">
+                Requires authentication
+              </Chip>
+            </div>
+          ))}
       </div>
     </div>
   );

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -20,6 +20,7 @@ import type { MCPServerType } from "@app/lib/api/mcp";
 import {
   useCreateMCPServerConnection,
   useDiscoverOAuthMetadata,
+  useUpdateMCPServer,
 } from "@app/lib/swr/mcp_servers";
 import type {
   MCPOAuthUseCase,
@@ -61,6 +62,7 @@ export function ConnectMCPServerDialog({
     connectionType: "workspace",
   });
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
+  const { updateServer } = useUpdateMCPServer(owner, mcpServer?.sId ?? "");
 
   const serverType = useMemo(
     () =>
@@ -162,11 +164,16 @@ export function ConnectMCPServerDialog({
     }
 
     setExternalIsLoading(true);
-    // Then associate connection
+    // Then associate connection.
     await createMCPServerConnection({
       connectionId: cRes.value.connection_id,
       mcpServer: mcpServer,
       provider: authorization.provider,
+    });
+
+    // And update the oAuthUseCase for the MCP server.
+    await updateServer({
+      oAuthUseCase: useCase,
     });
 
     setExternalIsLoading(false);

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -122,24 +122,26 @@ export function MCPServerOAuthConnexion({
           {inputs ? (
             <>
               <Chip color="warning">
-                {remoteMCPServerUrl
-                  ? `${remoteMCPServerUrl} requires authentication with `
-                  : "These tools require authentication with "}
-                {OAUTH_PROVIDER_NAMES[authorization.provider]}
-                {documentationUrl && (
-                  <>
-                    . Please follow{" "}
-                    <a
-                      href={documentationUrl}
-                      className="text-highlight-600"
-                      target="_blank"
-                    >
-                      this guide
-                    </a>{" "}
-                    to learn how to set it up
-                  </>
-                )}
-                .
+                <span>
+                  {remoteMCPServerUrl
+                    ? `${remoteMCPServerUrl} requires authentication with `
+                    : "These tools require authentication with "}
+                  {OAUTH_PROVIDER_NAMES[authorization.provider]}
+                  {documentationUrl && (
+                    <>
+                      . Follow{" "}
+                      <a
+                        href={documentationUrl}
+                        className="text-highlight-600"
+                        target="_blank"
+                      >
+                        this guide
+                      </a>{" "}
+                      to set it up
+                    </>
+                  )}
+                  .
+                </span>
               </Chip>
               {Object.entries(inputs).map(([key, inputData]) => {
                 if (inputData.value) {

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -26,7 +26,7 @@ import type { RemoteMCPServerType } from "@app/lib/api/mcp";
 import {
   useMCPServers,
   useSyncRemoteMCPServer,
-  useUpdateRemoteMCPServer,
+  useUpdateMCPServer,
 } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types";
 import { normalizeError } from "@app/types";
@@ -69,7 +69,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
   });
 
   // Use the serverId from state for the hooks
-  const { updateServer } = useUpdateRemoteMCPServer(owner, mcpServer.sId);
+  const { updateServer } = useUpdateMCPServer(owner, mcpServer.sId);
   const { syncServer } = useSyncRemoteMCPServer(owner, mcpServer.sId);
 
   const onSubmit = useCallback(

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -96,7 +96,7 @@ export function ToolsList({
                       {asDisplayName(tool.name)}
                     </h4>
                     {tool.description && (
-                      <p className="text-base text-muted-foreground dark:text-muted-foreground-night">
+                      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                         {tool.description}
                       </p>
                     )}

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -988,7 +988,7 @@ function ActionEditor({
     disabled: !selectedMCPServerView?.server.authorization,
   });
 
-  const isConnected = connections.some(
+  const connection = connections.find(
     (c) =>
       c.internalMCPServerId === selectedMCPServerView?.server.sId ||
       c.remoteMCPServerId === selectedMCPServerView?.server.sId
@@ -1027,8 +1027,8 @@ function ActionEditor({
           {action.type === "MCP" && selectedMCPServerView ? (
             <MCPActionHeader
               mcpServer={selectedMCPServerView.server}
-              isAuthorized={Boolean(selectedMCPServerView.server.authorization)}
-              isConnected={isConnected}
+              oAuthUseCase={selectedMCPServerView.oAuthUseCase}
+              isConnected={Boolean(connection)}
               isConnectionsLoading={isConnectionsLoading}
               action={action}
             />

--- a/front/components/spaces/SystemSpaceActionsList.tsx
+++ b/front/components/spaces/SystemSpaceActionsList.tsx
@@ -5,6 +5,7 @@ import { AdminActionsList } from "@app/components/actions/mcp/AdminActionsList";
 import { MCPServerDetails } from "@app/components/actions/mcp/MCPServerDetails";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { MCPServerType } from "@app/lib/api/mcp";
+import { useMCPServerViews } from "@app/lib/swr/mcp_server_views";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 interface SpaceActionsListProps {
@@ -21,6 +22,14 @@ export const SystemSpaceActionsList = ({
   const [mcpServerToShow, setMcpServerToShow] = useState<MCPServerType | null>(
     null
   );
+  const { serverViews } = useMCPServerViews({
+    owner,
+    space,
+  });
+
+  const mcpServerView = serverViews.find(
+    (view) => view.server.sId === mcpServerToShow?.sId
+  );
 
   const { q: searchParam } = useQueryParams(["q"]);
   const searchTerm = searchParam.value || "";
@@ -34,7 +43,7 @@ export const SystemSpaceActionsList = ({
       {mcpServerToShow && (
         <MCPServerDetails
           owner={owner}
-          mcpServer={mcpServerToShow}
+          mcpServerView={mcpServerView ?? null}
           onClose={() => {
             setMcpServerToShow(null);
           }}

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -9,7 +9,7 @@ import type {
 } from "@app/lib/actions/constants";
 import type { DustAppRunConfigurationType } from "@app/lib/actions/dust_app_run";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
-import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_internal_actions/authentication";
+import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   augmentInputsWithConfiguration,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -23,8 +23,8 @@ import type {
   ServerSideMCPServerConfigurationType,
   ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
+import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_internal_actions/authentication";
 import {
   getInternalMCPServerAvailability,
   getInternalMCPServerNameAndWorkspaceId,

--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -10,9 +10,9 @@ import type {
 } from "@app/types";
 import { getOAuthConnectionAccessToken } from "@app/types";
 
-// Dedicated function to get the connection details for a given provider for internal MCP servers.
+// Dedicated function to get the connection details for an MCP server.
 // Not using the one from mcp_metadata.ts to avoid circular dependency.
-export async function getConnectionForInternalMCPServer(
+export async function getConnectionForMCPServer(
   auth: Authenticator,
   {
     mcpServerId,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -13,6 +13,10 @@ import {
   DEFAULT_MCP_ACTION_NAME,
   DEFAULT_MCP_ACTION_VERSION,
 } from "@app/lib/actions/constants";
+import {
+  getConnectionForMCPServer,
+  MCPServerPersonalAuthenticationRequiredError,
+} from "@app/lib/actions/mcp_authentication";
 import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
@@ -20,8 +24,6 @@ import {
   isInternalAllowedIcon,
 } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
-import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_internal_actions/authentication";
-import { getConnectionForInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/authentication";
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { MCPOAuthRequiredError } from "@app/lib/actions/mcp_oauth_error";
 import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
@@ -184,7 +186,7 @@ export const connectToMCPServer = async (
                 );
               }
 
-              const c = await getConnectionForInternalMCPServer(auth, {
+              const c = await getConnectionForMCPServer(auth, {
                 mcpServerId: params.mcpServerId,
                 connectionType:
                   params.oAuthUseCase === "personal_actions"

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -39,7 +39,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { ModelId, Result } from "@app/types";
+import type { MCPOAuthUseCase, ModelId, Result } from "@app/types";
 import {
   assertNever,
   Err,
@@ -398,6 +398,20 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       });
       return views[0] ?? null;
     }
+  }
+
+  public async updateOAuthUseCase(
+    auth: Authenticator,
+    oAuthUseCase: MCPOAuthUseCase
+  ): Promise<Result<number, Error>> {
+    if (!this.canAdministrate(auth)) {
+      return new Err(
+        new DustError("unauthorized", "Not allowed to update OAuth use case.")
+      );
+    }
+
+    const [affectedCount] = await this.update({ oAuthUseCase });
+    return new Ok(affectedCount);
   }
 
   // Deletion.

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -346,9 +346,9 @@ export function useSyncRemoteMCPServer(
 }
 
 /**
- * Hook to update a remote MCP server
+ * Hook to update an MCP server
  */
-export function useUpdateRemoteMCPServer(
+export function useUpdateMCPServer(
   owner: LightWorkspaceType,
   serverId: string
 ) {
@@ -358,12 +358,18 @@ export function useUpdateRemoteMCPServer(
     serverId,
   });
 
-  const updateServer = async (data: {
-    name: string;
-    icon: string;
-    description: string;
-    sharedSecret?: string;
-  }): Promise<PatchMCPServerResponseBody> => {
+  const updateServer = async (
+    data:
+      | {
+          name: string;
+          icon: string;
+          description: string;
+          sharedSecret?: string;
+        }
+      | {
+          oAuthUseCase: MCPOAuthUseCase;
+        }
+  ): Promise<PatchMCPServerResponseBody> => {
     const response = await fetch(`/api/w/${owner.sId}/mcp/${serverId}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },

--- a/front/tests/lib/resources/conversation_resource.test.ts
+++ b/front/tests/lib/resources/conversation_resource.test.ts
@@ -8,6 +8,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -136,44 +137,56 @@ describe("ConversationResource", () => {
       });
     });
 
-    it("should return only conversations with all messages before cutoff date: 90 days ago", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate({
-        auth,
-        cutoffDate: dateFromDaysAgo(90),
-      });
-      expect(oldConversations.length).toBe(2);
-      const oldConversationIds = oldConversations.map((c) => c.sId);
-      expect(oldConversationIds).toContain(convo3Id);
-      expect(oldConversationIds).toContain(convo4Id);
-    });
+    itInTransaction(
+      "should return only conversations with all messages before cutoff date: 90 days ago",
+      async () => {
+        const oldConversations = await ConversationResource.listAllBeforeDate({
+          auth,
+          cutoffDate: dateFromDaysAgo(90),
+        });
+        expect(oldConversations.length).toBe(2);
+        const oldConversationIds = oldConversations.map((c) => c.sId);
+        expect(oldConversationIds).toContain(convo3Id);
+        expect(oldConversationIds).toContain(convo4Id);
+      }
+    );
 
-    it("should return only conversations with all messages before cutoff date: 200 days ago", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate({
-        auth,
-        cutoffDate: dateFromDaysAgo(200),
-      });
-      expect(oldConversations.length).toBe(0);
-    });
+    itInTransaction(
+      "should return only conversations with all messages before cutoff date: 200 days ago",
+      async () => {
+        const oldConversations = await ConversationResource.listAllBeforeDate({
+          auth,
+          cutoffDate: dateFromDaysAgo(200),
+        });
+        expect(oldConversations.length).toBe(0);
+      }
+    );
 
-    it("should return only conversations with all messages before cutoff date: 5 days ago", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate({
-        auth,
-        cutoffDate: dateFromDaysAgo(5),
-      });
-      expect(oldConversations.length).toBe(3);
-      const oldConversationIds = oldConversations.map((c) => c.sId);
-      expect(oldConversationIds).toContain(convo1Id);
-      expect(oldConversationIds).toContain(convo3Id);
-      expect(oldConversationIds).toContain(convo4Id);
-    });
+    itInTransaction(
+      "should return only conversations with all messages before cutoff date: 5 days ago",
+      async () => {
+        const oldConversations = await ConversationResource.listAllBeforeDate({
+          auth,
+          cutoffDate: dateFromDaysAgo(5),
+        });
+        expect(oldConversations.length).toBe(3);
+        const oldConversationIds = oldConversations.map((c) => c.sId);
+        expect(oldConversationIds).toContain(convo1Id);
+        expect(oldConversationIds).toContain(convo3Id);
+        expect(oldConversationIds).toContain(convo4Id);
+      }
+    );
 
-    it("should return all old conversations no matter the batch size", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate({
-        auth,
-        cutoffDate: dateFromDaysAgo(1),
-        batchSize: 1,
-      });
-      expect(oldConversations.length).toBe(4);
-    });
+    itInTransaction(
+      "should return all old conversations no matter the batch size",
+      async () => {
+        const oldConversations = await ConversationResource.listAllBeforeDate({
+          auth,
+          cutoffDate: dateFromDaysAgo(1),
+          batchSize: 1,
+        });
+        expect(oldConversations.length).toBe(4);
+      }
+    );
   });
 });

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -117,6 +117,7 @@ const API_ERROR_TYPES = [
   // MCP:
   "mcp_auth_error",
   "invalid_mcp_server_id",
+  "mcp_server_not_found",
   // Workos:
   "workos_organization_not_found",
   "workos_server_error",


### PR DESCRIPTION
## Description

- Fix the re-connection flow of an MCP server: it was not taking into account the need to change the oAuthUseCase on the views.
- Added what kind of credentials an MCP server is using (and led me to fix that we would always show "workspace").
- Added support for updating oAuthUseCase for an MCP server in the PATCH endpoint.

## Tests

Added more tests to the PATCH endpoint to make sure the changes are correctly applied.
<img width="576" alt="image" src="https://github.com/user-attachments/assets/173bc7c1-a81f-41c9-8ab5-cc67de64c62e" />

## Risk

Low

## Deploy Plan

Deploy front