### PR TITLE
Add: Support for workspace/personal connections for remote MCP servers

### DIFF
--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -95,7 +95,7 @@ export function ConnectMCPServerDialog({
               provider: "mcp",
               // During setup, the use case is always "platform_actions".
               use_case: "platform_actions",
-              supported_use_cases: ["platform_actions"], // TODO(mcp): Add personal_actions option.
+              supported_use_cases: ["platform_actions", "personal_actions"],
             });
             setAuthCredentials({
               ...discoverOAuthMetadataRes.value.connectionMetadata,

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -118,7 +118,7 @@ export function CreateMCPServerDialog({
             setAuthorization({
               provider: "mcp",
               use_case: "platform_actions",
-              supported_use_cases: ["platform_actions"], // TODO(mcp): Add personal_actions option.
+              supported_use_cases: ["platform_actions", "personal_actions"],
             });
 
             setAuthCredentials(

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -85,7 +85,7 @@ export function MCPServerOAuthConnexion({
       };
       void fetchCredentialInputs();
     }
-  }, [authorization, setAuthCredentials, useCase]);
+  }, [authorization.provider, setAuthCredentials, useCase]);
 
   // We check if the form is valid.
   useEffect(() => {

--- a/front/components/spaces/SystemSpaceActionsList.tsx
+++ b/front/components/spaces/SystemSpaceActionsList.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { AdminActionsList } from "@app/components/actions/mcp/AdminActionsList";
 import { MCPServerDetails } from "@app/components/actions/mcp/MCPServerDetails";
@@ -27,12 +27,17 @@ export const SystemSpaceActionsList = ({
     space,
   });
 
-  const mcpServerView = serverViews.find(
-    (view) => view.server.sId === mcpServerToShow?.sId
+  const mcpServerView = useMemo(
+    () => serverViews.find((view) => view.server.sId === mcpServerToShow?.sId),
+    [serverViews, mcpServerToShow?.sId]
   );
 
   const { q: searchParam } = useQueryParams(["q"]);
   const searchTerm = searchParam.value || "";
+
+  const handleClose = useCallback(() => {
+    setMcpServerToShow(null);
+  }, []);
 
   if (!isAdmin) {
     return null;
@@ -44,9 +49,7 @@ export const SystemSpaceActionsList = ({
         <MCPServerDetails
           owner={owner}
           mcpServerView={mcpServerView ?? null}
-          onClose={() => {
-            setMcpServerToShow(null);
-          }}
+          onClose={handleClose}
           isOpen={!!mcpServerToShow}
         />
       )}
@@ -54,9 +57,7 @@ export const SystemSpaceActionsList = ({
         owner={owner}
         filter={searchTerm}
         systemSpace={space}
-        setMcpServerToShow={(mcpServer) => {
-          setMcpServerToShow(mcpServer);
-        }}
+        setMcpServerToShow={setMcpServerToShow}
       />
     </>
   );

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -4,6 +4,7 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { Implementation, Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { ProxyAgent } from "undici";
@@ -41,13 +42,7 @@ import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_r
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase, OAuthProvider, Result } from "@app/types";
-import {
-  assertNever,
-  Err,
-  isOAuthProvider,
-  isOAuthUseCase,
-  Ok,
-} from "@app/types";
+import { assertNever, Err, isOAuthProvider, Ok } from "@app/types";
 
 export type AuthorizationInfo = {
   provider: OAuthProvider;
@@ -63,8 +58,7 @@ export function isAuthorizationInfo(a: unknown): a is AuthorizationInfo {
     a !== null &&
     "provider" in a &&
     isOAuthProvider(a.provider) &&
-    "use_case" in a &&
-    isOAuthUseCase(a.use_case)
+    "supported_use_cases" in a
   );
 }
 
@@ -172,13 +166,13 @@ export const connectToMCPServer = async (
 
           await mcpClient.connect(client);
 
-          // The server might requires authentication for tools.
-          // To avoid any unnecessary work, we only fetch the token if we are try to run a tool.
-          // If we are just listing tools, we don't need to fetch the token.
+          // For internal servers, to avoid any unnecessary work, we only try to fetch the token if we are trying to run a tool.
           if (agentLoopContext?.runContext) {
             const metadata = await extractMetadataFromServerVersion(
               mcpClient.getServerVersion()
             );
+
+            // The server requires authentication.
             if (metadata.authorization) {
               if (!params.oAuthUseCase) {
                 throw new Error(
@@ -243,13 +237,54 @@ export const connectToMCPServer = async (
 
           const url = new URL(remoteMCPServer.url);
 
+          let token: OAuthTokens | undefined;
+          // The server requires authentication.
+          if (remoteMCPServer.authorization) {
+            // We only fetch the personal token if we are running a tool.
+            // Otherwise, for listing tools etc.., we use the workspace token.
+            const connectionType =
+              params.oAuthUseCase === "personal_actions" &&
+              agentLoopContext?.runContext
+                ? "personal"
+                : "workspace";
+
+            const c = await getConnectionForMCPServer(auth, {
+              mcpServerId: params.mcpServerId,
+              connectionType: connectionType,
+            });
+            if (c) {
+              token = {
+                access_token: c.access_token,
+                token_type: "bearer",
+                expires_in: c.access_token_expiry ?? undefined,
+                scope: c.connection.metadata.scope,
+              };
+            } else {
+              if (
+                params.oAuthUseCase === "personal_actions" &&
+                connectionType === "personal"
+              ) {
+                return new Err(
+                  new MCPServerPersonalAuthenticationRequiredError(
+                    params.mcpServerId,
+                    remoteMCPServer.authorization.provider,
+                    params.oAuthUseCase
+                  )
+                );
+              } else {
+                // TODO(mcp): We return an result to display a message to the user saying that the server requires the admin to setup the connection.
+                // For now, keeping iso.
+              }
+            }
+          }
+
           try {
             const req = {
               requestInit: {
                 headers: undefined,
                 dispatcher: createMCPDispatcher(),
               },
-              authProvider: new MCPOAuthProvider(auth, remoteMCPServer),
+              authProvider: new MCPOAuthProvider(auth, token),
             };
 
             await connectToRemoteMCPServer(mcpClient, url, req);

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -1,14 +1,18 @@
 import type { ParsedUrlQuery } from "querystring";
 import { z } from "zod";
 
+import config from "@app/lib/api/config";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { getPKCEConfig } from "@app/lib/utils/pkce";
+import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import { OAuthAPI } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 
 export const MCP_OAUTH_RESPONSE_TYPE = "code";
@@ -80,8 +84,17 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
   }
 
   isExtraConfigValid(
-    extraConfig: ExtraConfigType
+    extraConfig: ExtraConfigType,
+    useCase: OAuthUseCase
   ): extraConfig is MCPOAuthConnectionMetadataType {
+    if (useCase === "personal_actions") {
+      // If we have an mcp_server_id it means the admin already setup the connection and we have
+      // everything we need, otherwise we'll need the instance_url and client_id.
+      if (extraConfig.mcp_server_id) {
+        return true;
+      }
+    }
+
     return MCPOAuthConnectionMetadataSchema.safeParse(extraConfig).success;
   }
 
@@ -89,31 +102,82 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
     auth: Authenticator,
     extraConfig: ExtraConfigType,
     workspaceId: string,
-    userId: string
-  ) {
-    // Check that we have everything we need to make an oauth flow.
-    if (!this.isExtraConfigValid(extraConfig)) {
-      throw new Error("Invalid extraConfig before getting related credential");
-    }
-
-    const { client_secret, ...restConfig } = extraConfig;
-
-    const { code_verifier, code_challenge } = await getPKCEConfig();
-
-    return {
-      credential: {
-        content: {
-          client_secret,
-          client_id: extraConfig.client_id,
-        },
-        metadata: { workspace_id: workspaceId, user_id: userId },
-      },
-      cleanedConfig: {
-        ...restConfig,
-        code_challenge,
-        code_verifier,
-      },
+    userId: string,
+    useCase: OAuthUseCase
+  ): Promise<{
+    credential: {
+      content: Record<string, string>;
+      metadata: { workspace_id: string; user_id: string };
     };
+    cleanedConfig: ExtraConfigType;
+  } | null> {
+    if (useCase === "personal_actions") {
+      // For personal actions we reuse the existing connection credential id from the existing
+      // workspace connection (setup by admin) if we have it.
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const mcpServerConnectionRes =
+          await MCPServerConnectionResource.findByMCPServer({
+            auth,
+            mcpServerId: mcp_server_id,
+            connectionType: "workspace",
+          });
+
+        if (mcpServerConnectionRes.isErr()) {
+          return null;
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getConnectionMetadata({
+          connectionId: mcpServerConnectionRes.value.connectionId,
+        });
+        if (connectionRes.isErr()) {
+          return null;
+        }
+        const connection = connectionRes.value.connection;
+        const connectionId = connection.connection_id;
+
+        const { code_verifier, code_challenge } = await getPKCEConfig();
+
+        return {
+          credential: {
+            content: {
+              from_connection_id: connectionId,
+            },
+            metadata: { workspace_id: workspaceId, user_id: userId },
+          },
+          cleanedConfig: {
+            client_id: connection.metadata.client_id,
+            token_endpoint: connection.metadata.token_endpoint,
+            authorization_endpoint: connection.metadata.authorization_endpoint,
+            code_verifier,
+            code_challenge,
+            ...restConfig,
+          },
+        };
+      }
+    } else if (useCase === "platform_actions") {
+      const { client_secret, ...restConfig } = extraConfig;
+
+      const { code_verifier, code_challenge } = await getPKCEConfig();
+
+      return {
+        credential: {
+          content: {
+            client_secret,
+            client_id: extraConfig.client_id,
+          },
+          metadata: { workspace_id: workspaceId, user_id: userId },
+        },
+        cleanedConfig: {
+          ...restConfig,
+          code_challenge,
+          code_verifier,
+        },
+      };
+    }
+    throw new Error("MCP oauth provider does not support use case: " + useCase);
   }
 
   isExtraConfigValidPostRelatedCredential(

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -223,29 +223,32 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
  * Note: this hook should not be called too frequently, as it is likely rate limited by the mcp server provider.
  */
 export function useDiscoverOAuthMetadata(owner: LightWorkspaceType) {
-  const discoverOAuthMetadata = async (
-    url: string
-  ): Promise<Result<DiscoverOAuthMetadataResponseBody, Error>> => {
-    const response = await fetch(
-      `/api/w/${owner.sId}/mcp/discover_oauth_metadata`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url }),
-      }
-    );
-
-    if (!response.ok) {
-      const error = await response.json();
-      return new Err(
-        new Error(
-          error.api_error?.message || "Failed to check OAuth connection"
-        )
+  const discoverOAuthMetadata = useCallback(
+    async (
+      url: string
+    ): Promise<Result<DiscoverOAuthMetadataResponseBody, Error>> => {
+      const response = await fetch(
+        `/api/w/${owner.sId}/mcp/discover_oauth_metadata`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ url }),
+        }
       );
-    }
 
-    return new Ok(await response.json());
-  };
+      if (!response.ok) {
+        const error = await response.json();
+        return new Err(
+          new Error(
+            error.api_error?.message || "Failed to check OAuth connection"
+          )
+        );
+      }
+
+      return new Ok(await response.json());
+    },
+    [owner.sId]
+  );
 
   return { discoverOAuthMetadata };
 }

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -157,7 +157,7 @@ async function handler(
             authorization = {
               provider: "mcp",
               supported_use_cases: ["platform_actions", "personal_actions"],
-              use_case: "platform_actions", // TODO (mcp): handle correctly the personal connections.
+              use_case: "platform_actions",
             };
           } else {
             // We fail early if the connectionId is provided but the access token cannot be fetched.

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -249,10 +249,6 @@ const TOOL_MIME_TYPES = {
       "WARNING",
     ],
   }),
-  TOOL_ERROR: generateToolMimeTypes({
-    category: "TOOL_ERROR",
-    resourceTypes: ["PERSONAL_AUTHENTICATION_REQUIRED"],
-  }),
 };
 
 export const INTERNAL_MIME_TYPES = {


### PR DESCRIPTION
## Description

Allow remote MCP server to use personal connections.

## Tests

Locally with intercom.

## Risk

Medium.

## Deploy Plan

Deploy front, run backfill once again and then remove use_case from authentication.