### PR TITLE
[front] fix(extract): fix validation errors at tool execution time

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -32,7 +32,7 @@ const JsonTypeSchema = z.union([
 
 const JsonPropertySchema = z.object({
   type: JsonTypeSchema,
-  description: z.string(),
+  description: z.string().optional(),
   properties: z
     .record(
       z.string(),


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/13338.
- We currently have stream dropping errors due to an overly restrictive validation on the JSONSchema ([logs](https://app.datadoghq.eu/logs?query=%22Error%20Posting%20message%22%20service%3Afront%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZdeNx8RdNQuTgAAABhBWmRlTnl2T0FBQjRCdWI0b0VqR2RnQU4AAAAkMDE5NzVlMzctMmFjYy00NTk4LWEyODYtY2YyZjhhYTJiZjA3AAAQrg&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1749631783000&to_ts=1749632383000&live=false)).
- This PR fixes that.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
