### PR TITLE
Global agent mcp search

### DIFF
--- a/front/components/assistant/details/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/AssistantKnowledgeSection.tsx
@@ -51,7 +51,7 @@ import type {
   LightWorkspaceType,
   TagsFilter,
 } from "@app/types";
-import { DocumentViewRawContentKey, GLOBAL_AGENTS_SID } from "@app/types";
+import { DocumentViewRawContentKey } from "@app/types";
 
 interface AssistantKnowledgeSectionProps {
   agentConfiguration: AgentConfigurationType;
@@ -75,16 +75,8 @@ export function AssistantKnowledgeSection({
       queryTables: [] as { tables: TableDataSourceConfiguration[] }[],
     };
 
-    const isDustGlobalAgent = agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST;
-
     return agentConfiguration.actions.reduce((acc, action) => {
-      // Since Dust is configured with one search for all, plus individual searches for each managed data source,
-      // we hide these additional searches from the user in the UI to avoid displaying the same data source twice.
-      // We use the `hidden_dust_search_` prefix to identify these additional searches.
-      if (
-        isRetrievalConfiguration(action) &&
-        (!isDustGlobalAgent || !action.name.startsWith("hidden_dust_search_"))
-      ) {
+      if (isRetrievalConfiguration(action)) {
         acc.retrieval.push(action);
       } else if (isTablesQueryConfiguration(action)) {
         acc.queryTables.push(action);

--- a/front/components/assistant/details/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/AssistantKnowledgeSection.tsx
@@ -91,7 +91,7 @@ export function AssistantKnowledgeSection({
       }
       return acc;
     }, initial);
-  }, [agentConfiguration.actions, agentConfiguration.sId]);
+  }, [agentConfiguration.actions]);
 
   const retrievalByDataSources = useMemo(() => {
     const acc: Record<string, DataSourceConfiguration> = {};

--- a/front/components/assistant/details/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/AssistantToolsSection.tsx
@@ -30,12 +30,28 @@ import {
 import type { MCPServerTypeWithViews } from "@app/lib/api/mcp";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
-import { assertNever, removeNulls, SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import {
+  assertNever,
+  GLOBAL_AGENTS_SID,
+  removeNulls,
+  SUPPORTED_MODEL_CONFIGS,
+} from "@app/types";
 
 interface AssistantToolsSectionProps {
   agentConfiguration: AgentConfigurationType;
   owner: LightWorkspaceType;
 }
+
+// Since Dust is configured with one search for all, plus individual searches for each managed data source,
+// we hide these additional searches from the user in the UI to avoid displaying the same data source twice.
+// We use the `hidden_dust_search_` prefix to identify these additional searches.
+const isHiddenDustAction = (
+  agentConfiguration: AgentConfigurationType,
+  action: AgentActionConfigurationType
+) => {
+  const isDustGlobalAgent = agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST;
+  return isDustGlobalAgent && action.name.startsWith("hidden_dust_search_");
+};
 
 export function AssistantToolsSection({
   agentConfiguration,
@@ -45,9 +61,9 @@ export function AssistantToolsSection({
   const { mcpServers } = useMCPServers({ owner });
 
   const actions = removeNulls(
-    agentConfiguration.actions.map((action) =>
-      renderOtherAction(action, mcpServers)
-    )
+    agentConfiguration.actions
+      .filter((action) => !isHiddenDustAction(agentConfiguration, action))
+      .map((action) => renderOtherAction(action, mcpServers))
   );
   if (agentConfiguration.visualizationEnabled) {
     actions.push({

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -18,10 +18,6 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import {
-  getResourceNameAndIdFromSId,
-  makeSId,
-} from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationStatus,
@@ -249,13 +245,7 @@ function _getHelperGlobalAgent({
 
   const actions: AgentActionConfigurationType[] = [];
 
-  const helperDatasourceViewId = config.getDustAppsHelperDatasourceViewId();
-  const helperDatasourceView = getResourceNameAndIdFromSId(
-    helperDatasourceViewId
-  );
-  const helperDatasourceViewModelId = helperDatasourceView?.resourceModelId;
-
-  if (searchMCPServerView && helperDatasourceViewModelId) {
+  if (searchMCPServerView) {
     actions.push({
       id: -1,
       sId: GLOBAL_AGENTS_SID.HELPER + "-search-action",
@@ -266,11 +256,7 @@ function _getHelperGlobalAgent({
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
       dataSources: [
         {
-          sId: makeSId("data_source_configuration", {
-            id: helperDatasourceViewModelId, // Wrong: here it should be agentDataSourceConfiguration.id
-            workspaceId: owner.id,
-          }),
-          dataSourceViewId: helperDatasourceViewId,
+          dataSourceViewId: config.getDustAppsHelperDatasourceViewId(),
           workspaceId: config.getDustAppsWorkspaceId(),
           filter: { parents: null, tags: null },
         },
@@ -1251,11 +1237,6 @@ function _getManagedDataSourceAgent(
       mcpServerViewId: searchMCPServerView.sId,
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
       dataSources: filteredDataSourceViews.map((dsView) => ({
-        sId: makeSId("data_source_configuration", {
-          id: dsView.id, // Wrong: here it should be agentDataSourceConfiguration.id
-          workspaceId: owner.id,
-        }),
-        dataSourceId: dsView.dataSource.sId,
         dataSourceViewId: dsView.sId,
         workspaceId: preFetchedDataSources.workspaceId,
         filter: { tags: null, parents: null },
@@ -1547,11 +1528,6 @@ The agent always respects the mardown format and generates spaces to nest conten
       mcpServerViewId: searchMCPServerView.sId,
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
       dataSources: dataSourceViews.map((dsView) => ({
-        sId: makeSId("data_source_configuration", {
-          id: dsView.id, // Wrong: here it should be agentDataSourceConfiguration.id
-          workspaceId: owner.id,
-        }),
-        dataSourceId: dsView.dataSource.sId,
         dataSourceViewId: dsView.sId,
         workspaceId: preFetchedDataSources.workspaceId,
         filter: { parents: null, tags: null },
@@ -1590,10 +1566,6 @@ The agent always respects the mardown format and generates spaces to nest conten
           internalMCPServerId: searchMCPServerView.internalMCPServerId,
           dataSources: [
             {
-              sId: makeSId("data_source_configuration", {
-                id: dsView.id,
-                workspaceId: auth.getNonNullableWorkspace().id,
-              }),
               workspaceId: preFetchedDataSources.workspaceId,
               dataSourceViewId: dsView.sId,
               filter: { parents: null, tags: null },

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -18,6 +18,10 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import {
+  getResourceNameAndIdFromSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationStatus,
@@ -245,7 +249,13 @@ function _getHelperGlobalAgent({
 
   const actions: AgentActionConfigurationType[] = [];
 
-  if (searchMCPServerView) {
+  const helperDatasourceViewId = config.getDustAppsHelperDatasourceViewId();
+  const helperDatasourceView = getResourceNameAndIdFromSId(
+    helperDatasourceViewId
+  );
+  const helperDatasourceViewModelId = helperDatasourceView?.resourceModelId;
+
+  if (searchMCPServerView && helperDatasourceViewModelId) {
     actions.push({
       id: -1,
       sId: GLOBAL_AGENTS_SID.HELPER + "-search-action",
@@ -256,7 +266,11 @@ function _getHelperGlobalAgent({
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
       dataSources: [
         {
-          dataSourceViewId: config.getDustAppsHelperDatasourceViewId(),
+          sId: makeSId("data_source_configuration", {
+            id: helperDatasourceViewModelId, // Wrong: here it should be agentDataSourceConfiguration.id
+            workspaceId: owner.id,
+          }),
+          dataSourceViewId: helperDatasourceViewId,
           workspaceId: config.getDustAppsWorkspaceId(),
           filter: { parents: null, tags: null },
         },
@@ -1237,6 +1251,10 @@ function _getManagedDataSourceAgent(
       mcpServerViewId: searchMCPServerView.sId,
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
       dataSources: filteredDataSourceViews.map((dsView) => ({
+        sId: makeSId("data_source_configuration", {
+          id: dsView.id, // Wrong: here it should be agentDataSourceConfiguration.id
+          workspaceId: owner.id,
+        }),
         dataSourceId: dsView.dataSource.sId,
         dataSourceViewId: dsView.sId,
         workspaceId: preFetchedDataSources.workspaceId,
@@ -1529,6 +1547,10 @@ The agent always respects the mardown format and generates spaces to nest conten
       mcpServerViewId: searchMCPServerView.sId,
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
       dataSources: dataSourceViews.map((dsView) => ({
+        sId: makeSId("data_source_configuration", {
+          id: dsView.id, // Wrong: here it should be agentDataSourceConfiguration.id
+          workspaceId: owner.id,
+        }),
         dataSourceId: dsView.dataSource.sId,
         dataSourceViewId: dsView.sId,
         workspaceId: preFetchedDataSources.workspaceId,
@@ -1568,6 +1590,10 @@ The agent always respects the mardown format and generates spaces to nest conten
           internalMCPServerId: searchMCPServerView.internalMCPServerId,
           dataSources: [
             {
+              sId: makeSId("data_source_configuration", {
+                id: dsView.id,
+                workspaceId: auth.getNonNullableWorkspace().id,
+              }),
               workspaceId: preFetchedDataSources.workspaceId,
               dataSourceViewId: dsView.sId,
               filter: { parents: null, tags: null },


### PR DESCRIPTION
## Description

Refactor global agent retrieval actions to use the search mcp tool. 

## Tests

Locally. 
On front edge. 

## Risk

Break retrieval of global agent, or mess with the filters and allow for more search than we want. 

Can be rolled back. 

## Deploy Plan

Deploy front.