### PR TITLE
[front] enh(extract): enforce JSONSchema validation in Agent builder

### DIFF
--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -22,6 +22,7 @@ import type {
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { isDustAppRunConfiguration } from "@app/lib/actions/types/guards";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { LightWorkspaceType, SpaceType, TimeFrame } from "@app/types";
@@ -390,6 +391,17 @@ export function hasErrorActionMCP(
       !action.configuration.dustAppConfiguration
     ) {
       return "Please select a Dust App.";
+    }
+    if (
+      requirements.mayRequireJsonSchemaConfiguration &&
+      action.configuration._jsonSchemaString
+    ) {
+      const validationResult = validateConfiguredJsonSchema(
+        action.configuration._jsonSchemaString
+      );
+      if (validationResult.isErr()) {
+        return validationResult.error.message;
+      }
     }
 
     const missingFields = [];

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -37,7 +37,7 @@ export function hasErrorActionProcess(
       action.configuration._jsonSchemaString
     );
     if (validationResult.isErr()) {
-      return validationResult.error.message;
+      return `${errorMessage}. ${validationResult.error.message}`;
     }
   }
   if (Object.keys(action.configuration.dataSourceConfigurations).length === 0) {

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -19,7 +19,7 @@ import type {
   AssistantBuilderProcessConfiguration,
   AssistantBuilderTimeFrame,
 } from "@app/components/assistant_builder/types";
-import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import type { Result } from "@app/types";
 import type { SpaceType, WorkspaceType } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -32,13 +32,8 @@ export function hasErrorActionProcess(
   if (action.type !== "PROCESS") {
     return "Invalid action type.";
   }
-  if (action.configuration._jsonSchemaString) {
-    const validationResult = validateConfiguredJsonSchema(
-      action.configuration._jsonSchemaString
-    );
-    if (validationResult.isErr()) {
-      return `${errorMessage}. ${validationResult.error.message}`;
-    }
+  if (!validateJsonSchema(action.configuration._jsonSchemaString).isValid) {
+    return errorMessage;
   }
   if (Object.keys(action.configuration.dataSourceConfigurations).length === 0) {
     return errorMessage;

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -19,7 +19,7 @@ import type {
   AssistantBuilderProcessConfiguration,
   AssistantBuilderTimeFrame,
 } from "@app/components/assistant_builder/types";
-import { validateJsonSchema } from "@app/lib/utils/json_schemas";
+import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { Result } from "@app/types";
 import type { SpaceType, WorkspaceType } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -32,8 +32,13 @@ export function hasErrorActionProcess(
   if (action.type !== "PROCESS") {
     return "Invalid action type.";
   }
-  if (!validateJsonSchema(action.configuration._jsonSchemaString).isValid) {
-    return errorMessage;
+  if (action.configuration._jsonSchemaString) {
+    const validationResult = validateConfiguredJsonSchema(
+      action.configuration._jsonSchemaString
+    );
+    if (validationResult.isErr()) {
+      return validationResult.error.message;
+    }
   }
   if (Object.keys(action.configuration.dataSourceConfigurations).length === 0) {
     return errorMessage;

--- a/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
@@ -8,9 +8,8 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { useState } from "react";
 
 import { ConfigurationSectionContainer } from "@app/components/assistant_builder/actions/configuration/ConfigurationSectionContainer";
-import { validateJsonSchema } from "@app/lib/utils/json_schemas";
-import type { Result } from "@app/types";
 import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { Result } from "@app/types";
 
 interface JsonSchemaConfigurationSectionProps {
   // The agent's instructions and tool description, needed to generate the

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -3,17 +3,11 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { Ajv } from "ajv";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { ZodError } from "zod";
 
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
-import {
-  ConfigurableToolInputType,
-  validateConfiguredJsonSchema,
-} from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import {
-  ConfigurableToolInputJSONSchemas,
-  JsonSchemaSchema,
-} from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { ConfigurableToolInputJSONSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import {
@@ -493,7 +487,7 @@ export function getMCPServerRequirements(
 }
 
 /**
- * Checks if a JSON schema matches should be idenfied as being configurable for a specific mime type.
+ * Checks if a JSON schema should be identified as being configurable for a specific mime type.
  */
 function isSchemaConfigurable(
   schema: JSONSchema,
@@ -521,7 +515,8 @@ function isSchemaConfigurable(
 /**
  * Recursively finds all property keys and subschemas match a specific sub-schema.
  * This function handles nested objects and arrays.
- * @returns A record of property keys that match the schema comparison. Empty record if no matches found.
+ * @returns A record of property keys that match the schema comparison.
+ * Empty record if no matches are found.
  */
 export function findMatchingSubSchemas(
   inputSchema: JSONSchema,

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -1,8 +1,11 @@
 import type { InternalToolInputMimeType } from "@dust-tt/client";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
+import { z, ZodError } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
+
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
   /^data_source_configuration:\/\/dust\/w\/(\w+)\/data_source_configurations\/(\w+)$/;
@@ -17,7 +20,7 @@ export const AGENT_CONFIGURATION_URI_PATTERN =
   /^agent:\/\/dust\/w\/(\w+)\/agents\/([\w-]+)$/;
 
 // The full, recursive schema for a JSON schema is not yet supported by MCP call
-// tool, and anyways its full validation is not needed. Therefore, we describe 2
+// tool, and anyway its full validation is not needed. Therefore, we describe 2
 // levels of depth then use z.any(). As an added bonus, it is arguably better
 // for the tool call to generate a good argument.
 const JsonTypeSchema = z.union([
@@ -53,6 +56,32 @@ export const JsonSchemaSchema = z.object({
   required: z.array(z.string()).optional(),
   properties: z.record(z.string(), JsonPropertySchema).optional(),
 });
+
+/**
+ * Validates a JSONSchema for being used as a configured input in a tool with the mime type
+ * (INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA).
+ * More restrictive than validateJsonSchema, as it explicitly checks that the schema
+ * can be used as an arg of a tool that expects an INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA.
+ */
+export function validateConfiguredJsonSchema(
+  jsonSchema: JSONSchema
+): Result<z.infer<typeof JsonSchemaSchema>, Error> {
+  try {
+    const validated = JsonSchemaSchema.parse(jsonSchema);
+    return new Ok(validated);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return new Err(
+        new Error(
+          `Invalid jsonSchema configuration for mimeType JSON_SCHEMA: ${error.errors
+            .map((e) => `${e.path.join(".")}: ${e.message}`)
+            .join(", ")}`
+        )
+      );
+    }
+    throw error;
+  }
+}
 
 /**
  * Mapping between the mime types we used to identify a configurable resource and the Zod schema used to validate it.

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -5,6 +5,7 @@ import { z, ZodError } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 import type { Result } from "@app/types";
+import { normalizeError } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
@@ -81,7 +82,7 @@ export function validateConfiguredJsonSchema(
         )
       );
     }
-    throw error;
+    return new Err(normalizeError(error));
   }
 }
 

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -64,10 +64,12 @@ export const JsonSchemaSchema = z.object({
  * can be used as an arg of a tool that expects an INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA.
  */
 export function validateConfiguredJsonSchema(
-  jsonSchema: JSONSchema
+  jsonSchema: JSONSchema | string
 ): Result<z.infer<typeof JsonSchemaSchema>, Error> {
   try {
-    const validated = JsonSchemaSchema.parse(jsonSchema);
+    const validated = JsonSchemaSchema.parse(
+      typeof jsonSchema !== "object" ? JSON.parse(jsonSchema) : jsonSchema
+    );
     return new Ok(validated);
   } catch (error) {
     if (error instanceof ZodError) {

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -1,4 +1,3 @@
-import {} from "@dust-tt/client";
 import { Op } from "sequelize";
 
 import { renderDataSourceConfiguration } from "@app/lib/actions/configuration/helpers";

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -128,6 +128,10 @@ export function setValueAtPath(
   current[path[path.length - 1]] = value;
 }
 
+/**
+ * Validates a generic JSON schema as per the JSON schema specification.
+ * Less strict than the JsonSchemaSchema zod schema.
+ */
 export function validateJsonSchema(value: object | string | null | undefined): {
   isValid: boolean;
   error?: string;


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/13343.
- This PR enforces that the same validation is used when configuring the `process` tool in Agent Builder than when using it.
- This way, we can't have validation errors due to an invalid JSONSchema when running the tool.
- It separates the functions that validate that a JSONSchema is valid and that it is a valid input as a tool parameter with the mime type `INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA`, which are two different things.
- This PR also adds a missing validation in `hasErrorActionMCP`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
