### PR TITLE
Fix run_agent attribution

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -51,7 +51,7 @@ export function UserMessage({
     <div className="flex flex-grow flex-col">
       <div className="max-w-full self-end">
         <ConversationMessage
-          pictureUrl={message.user?.image || message.context.profilePictureUrl}
+          pictureUrl={message.context.profilePictureUrl || message.user?.image}
           name={message.context.fullName ?? undefined}
           renderName={(name) => <div className="heading-base">{name}</div>}
           type="user"

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -121,7 +121,10 @@ export default async function createServer(
     childAgentId = agentLoopContext.runContext.actionConfiguration.childAgentId;
   }
 
-  let childAgentBlob: { name: string; description: string } | null = null;
+  let childAgentBlob: {
+    name: string;
+    description: string;
+  } | null = null;
 
   if (childAgentId) {
     childAgentBlob = await leakyGetAgentNameAndDescriptionForChildAgent(
@@ -211,10 +214,10 @@ export default async function createServer(
           mentions: [{ configurationId: childAgentId }],
           context: {
             timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            username: user?.username ?? "unknown",
-            fullName: user?.fullName(),
-            email: user?.email,
-            profilePictureUrl: user?.imageUrl,
+            username: mainAgent.name,
+            fullName: `@${mainAgent.name}`,
+            email: null,
+            profilePictureUrl: mainAgent.pictureUrl,
             origin: "mcp",
           },
         },

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -187,7 +187,6 @@ export default async function createServer(
       const childAgentId = childAgentIdRes.value;
 
       const user = auth.user();
-      const requestedGroupIds = auth.groups().map((g) => g.sId);
 
       const prodCredentials = await prodAPICredentialsForOwner(owner);
       const api = new DustAPI(
@@ -197,8 +196,8 @@ export default async function createServer(
           // We use a system API key here meaning that we can impersonate the user or the groups we
           // have access to.
           extraHeaders: {
-            ...getHeaderFromGroupIds(requestedGroupIds),
-            ...getHeaderFromRole(auth.role()),
+            // We have to use the user override here as the sub-agent may rely on personal actions
+            // that have to be operated in the name of the user initiating the interaction.
             ...getHeaderFromUserEmail(user?.email),
           },
         },

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -22,14 +22,7 @@ import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import {
-  Err,
-  getHeaderFromGroupIds,
-  getHeaderFromRole,
-  getHeaderFromUserEmail,
-  normalizeError,
-  Ok,
-} from "@app/types";
+import { Err, getHeaderFromUserEmail, normalizeError, Ok } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
   name: "run_agent",


### PR DESCRIPTION
## Description

Also adds a comment to make sure we impersonate the user for personal tools use in sub-agents.

![image](https://github.com/user-attachments/assets/3d58710c-7c35-461d-8879-2d629ef10871)

Next PR: add a conversation use case (run_agent) and skip participation addition when used.

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`