### PR TITLE
Optimize Slack syncNonThreaded: Fix 90-minute timeouts with adaptive chunking

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -667,6 +667,9 @@ async function processAndUpsertNonThreadedMessages({
 
   const startDate = new Date(weekStartTsMs);
   const endDate = new Date(weekEndTsMs);
+
+  // IMPORTANT: Document ID generation relies on weekly start/end dates, not chunk boundaries.
+  // This ensures all chunks processing the same week contribute to the same document.
   const documentId =
     slackNonThreadedMessagesInternalIdFromSlackNonThreadedMessagesIdentifier({
       channelId,

--- a/front/lib/actions/mcp_internal_actions/servers/process.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process.ts
@@ -121,6 +121,7 @@ function createServer(
     ? {
         tagsIn: z
           .array(z.string())
+          .optional()
           .describe(
             "A list of labels (also called tags) to restrict the search based on the user request and past conversation context." +
               "If multiple labels are provided, the search will return documents that have at least one of the labels." +
@@ -129,6 +130,7 @@ function createServer(
           ),
         tagsNot: z
           .array(z.string())
+          .optional()
           .describe(
             "A list of labels (also called tags) to exclude from the search based on the user request and past conversation context." +
               "Any document having one of these labels will be excluded from the search."
@@ -176,14 +178,17 @@ function createServer(
             .nullable(),
       ...tagsInputSchema,
     },
-    async ({
-      dataSources,
-      objective,
-      jsonSchema,
-      timeFrame,
-      tagsIn,
-      tagsNot,
-    }) => {
+    async (params) => {
+      const { dataSources, objective, jsonSchema, timeFrame, ...rest } = params;
+
+      // Type-safe extraction of tags parameters
+      const tagsIn = isTagsModeConfigured
+        ? ((rest as any).tagsIn as string[] | undefined)
+        : undefined;
+      const tagsNot = isTagsModeConfigured
+        ? ((rest as any).tagsNot as string[] | undefined)
+        : undefined;
+
       // Unwrap and prepare variables.
       assert(
         agentLoopContext?.runContext,

--- a/front/lib/actions/mcp_internal_actions/servers/process.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process.ts
@@ -121,7 +121,6 @@ function createServer(
     ? {
         tagsIn: z
           .array(z.string())
-          .optional()
           .describe(
             "A list of labels (also called tags) to restrict the search based on the user request and past conversation context." +
               "If multiple labels are provided, the search will return documents that have at least one of the labels." +
@@ -130,7 +129,6 @@ function createServer(
           ),
         tagsNot: z
           .array(z.string())
-          .optional()
           .describe(
             "A list of labels (also called tags) to exclude from the search based on the user request and past conversation context." +
               "Any document having one of these labels will be excluded from the search."
@@ -178,17 +176,14 @@ function createServer(
             .nullable(),
       ...tagsInputSchema,
     },
-    async (params) => {
-      const { dataSources, objective, jsonSchema, timeFrame, ...rest } = params;
-
-      // Type-safe extraction of tags parameters
-      const tagsIn = isTagsModeConfigured
-        ? ((rest as any).tagsIn as string[] | undefined)
-        : undefined;
-      const tagsNot = isTagsModeConfigured
-        ? ((rest as any).tagsNot as string[] | undefined)
-        : undefined;
-
+    async ({
+      dataSources,
+      objective,
+      jsonSchema,
+      timeFrame,
+      tagsIn,
+      tagsNot,
+    }) => {
       // Unwrap and prepare variables.
       assert(
         agentLoopContext?.runContext,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
### The Problem

Our Slack connector's `syncNonThreaded` activity has been causing frequent monitors. The current 90-minute timeout far exceeds the recommended 5-10 minutes for activities, leading to multiple timeout.

#### Root Causes
1. Monolithic Activity Design

The original implementation processed entire weeks of messages in a single activity. Bot-heavy channels (Datadog, CI/CD integrations, etc.) can generate hundreds of messages per hour, causing activities to process thousands of messages and hit timeouts. This results in failed syncs, resource waste from activities killed during deployments, and many monitors.

2. Flawed Pagination Strategy ([doc](https://api.slack.com/methods/conversations.history))

The original code relied on timestamp-based pagination using Slack's oldest/latest parameters, but never used Slack's native cursor pagination. This approach had a critical flaw: Slack's timestamp filtering is not inclusive, potentially causing message loss when multiple messages share the same timestamp.

```
// OLD: Risky timestamp-based "pagination"
const result = await client.conversations.history({
  oldest: `${startTsSec}`,
  latest: `${latestTsSec}`,
  // No cursor used - could miss messages with same timestamp!
});
```

This PR implements an adaptive chunking approach, aiming to use short, resilient activities that can run within 5-10 minutes. The activity now returns the resume state that can be used in the subsequent activity to resume. Workflow now owns most of the logic to paginate over imports.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
- This creates breaking changes in the Temporal stack, this workflow is only triggered by webhooks, will make sure to restart the one that failed while deploying. 
- ⚠️ This increase the number of queries performed on the Slack API by 7x. Slack is currently doing some changes on their API tier, will monitor once out.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
