### PR TITLE
Remove `workspace` visibility

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -307,7 +307,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const includedConversationVisibilities: ConversationVisibility[] = [
       "unlisted",
-      "workspace",
     ];
 
     if (options?.includeDeleted) {

--- a/front/migrations/db/migration_280.sql
+++ b/front/migrations/db/migration_280.sql
@@ -1,0 +1,1 @@
+UPDATE conversations SET visibility='unlisted' WHERE visibility='workspace';

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -77,13 +77,6 @@ const MAX_CONVERSATION_DEPTH = 4;
  *                 type: string
  *                 description: The title of the conversation
  *                 example: My conversation
- *               visibility:
- *                 type: string
- *                 description: The visibility of the conversation (The API only accepts `unlisted`)
- *                 enum:
- *                   - workspace
- *                   - unlisted
- *                 example: unlisted
  *               skipToolsValidation:
  *                 type: boolean
  *                 description: Whether to skip the tools validation of the agent messages triggered by this user message (optional, defaults to false)

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -562,7 +562,7 @@ export async function processTranscriptActivity(
 
     const initialConversation = await createConversation(auth, {
       title: transcriptTitle,
-      visibility: "workspace",
+      visibility: "unlisted",
     });
 
     const baseContext = {

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -180,7 +180,6 @@ export const InternalPostConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
   visibility: t.union([
     t.literal("unlisted"),
-    t.literal("workspace"),
     t.literal("deleted"),
     t.literal("test"),
   ]),

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -240,11 +240,7 @@ export function isAgentMessageType(arg: MessageType): arg is AgentMessageType {
  * when a user 'tests' an agent not in their list using the "test" button:
  * those conversations do not show in users' histories.
  */
-export type ConversationVisibility =
-  | "unlisted"
-  | "workspace"
-  | "deleted"
-  | "test";
+export type ConversationVisibility = "unlisted" | "deleted" | "test";
 
 /**
  * A lighter version of Conversation without the content (for menu display).

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2095,7 +2095,7 @@ export const PublicPostConversationsRequestBodySchema = z.intersection(
   z.object({
     title: z.string().nullable().optional(),
     visibility: z
-      .enum(["unlisted", "workspace", "deleted", "test"])
+      .enum(["unlisted", "deleted", "test"])
       .optional()
       .default("unlisted"),
     depth: z.number().optional(),


### PR DESCRIPTION
## Description

Unused. 

- Undocuments visibility parameter in the API
- Remove `workspace` visibility
- Migration to move conversations with it to `unlisted`

## Tests

Type checking + conversation creation is covered by tests

## Risk

High. Tested locally + covered by tests.

## Deploy Plan

- run migration
- update docs
- deploy `front`