### PR TITLE
[front] Open configuration panel on reasoning select

### DIFF
--- a/front/components/assistant_builder/AddToolsDropdown.tsx
+++ b/front/components/assistant_builder/AddToolsDropdown.tsx
@@ -152,7 +152,7 @@ export function AddToolsDropdown({
           ) ?? reasoningModels[0];
 
         setAction({
-          type: "insert",
+          type: "pending",
           action: {
             id: uniqueId(),
             ...action,

--- a/front/components/assistant_builder/actions/configuration/ReasoningModelConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ReasoningModelConfigurationSection.tsx
@@ -139,60 +139,65 @@ export function ReasoningModelConfigurationSection({
           </div>
         </Card>
       ) : (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              size="sm"
-              label={selectedReasoningModelConfig.displayName}
-              variant="outline"
-              isSelect
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            {performingModels.length > 0 && (
-              <>
-                <DropdownMenuLabel>
-                  Best performing reasoning models
-                </DropdownMenuLabel>
-                {performingModels.map((model) => (
-                  <ReasoningModelDropdownMenuItem
-                    key={`${model.modelId}-${model.reasoningEffort ?? ""}`}
-                    model={model}
-                    onClick={onModelSelect}
-                    isDark={isDark}
-                  />
-                ))}
-                <DropdownMenuLabel>Other models</DropdownMenuLabel>
-              </>
-            )}
-            {[...modelsGroupedByProvider.entries()].map(
-              ([providerId, models]) => {
-                return (
-                  <DropdownMenuGroup key={providerId}>
-                    <DropdownMenuSub>
-                      <DropdownMenuSubTrigger
-                        label={`${getProviderDisplayName(providerId)} models`}
-                        icon={getModelProviderLogo(providerId, isDark)}
-                      />
-                      <DropdownMenuPortal>
-                        <DropdownMenuSubContent>
-                          {models.map((model) => (
-                            <ReasoningModelDropdownMenuItem
-                              key={`${model.modelId}-${model.reasoningEffort ?? ""}`}
-                              model={model}
-                              onClick={onModelSelect}
-                              isDark={isDark}
-                            />
-                          ))}
-                        </DropdownMenuSubContent>
-                      </DropdownMenuPortal>
-                    </DropdownMenuSub>
-                  </DropdownMenuGroup>
-                );
-              }
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="sm"
+                label={selectedReasoningModelConfig.displayName}
+                variant="outline"
+                isSelect
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              {performingModels.length > 0 && (
+                <>
+                  <DropdownMenuLabel>
+                    Best performing reasoning models
+                  </DropdownMenuLabel>
+                  {performingModels.map((model) => (
+                    <ReasoningModelDropdownMenuItem
+                      key={`${model.modelId}-${model.reasoningEffort ?? ""}`}
+                      model={model}
+                      onClick={onModelSelect}
+                      isDark={isDark}
+                    />
+                  ))}
+                  <DropdownMenuLabel>Other models</DropdownMenuLabel>
+                </>
+              )}
+              {[...modelsGroupedByProvider.entries()].map(
+                ([providerId, models]) => {
+                  return (
+                    <DropdownMenuGroup key={providerId}>
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger
+                          label={`${getProviderDisplayName(providerId)} models`}
+                          icon={getModelProviderLogo(providerId, isDark)}
+                        />
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent>
+                            {models.map((model) => (
+                              <ReasoningModelDropdownMenuItem
+                                key={`${model.modelId}-${model.reasoningEffort ?? ""}`}
+                                model={model}
+                                onClick={onModelSelect}
+                                isDark={isDark}
+                              />
+                            ))}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+                    </DropdownMenuGroup>
+                  );
+                }
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <p className="mt-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {selectedReasoningModelConfig.description}
+          </p>
+        </>
       )}
     </ConfigurationSectionContainer>
   );


### PR DESCRIPTION
## Description
After merging https://github.com/dust-tt/dust/pull/13185, I realised you cannot select reasoning option more than once, because we always select the default model and don't open the configuration panel. So in this PR, we still select the default model for you but open a configuration panel so users can change it. I also forgot to add a description underneath so I squashed that in too. 

<img width="564" alt="Screenshot 2025-06-11 at 14 39 43" src="https://github.com/user-attachments/assets/be5e969b-f014-4297-9ced-726990b6cd1d" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
