### PR TITLE
[front] fix(workos): Fix webhooks directory sync

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -13,7 +13,7 @@ import type { RegionType } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import logger from "@app/logger/logger";
-import type { LightWorkspaceType, Result } from "@app/types";
+import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 export type SessionCookie = {
@@ -110,7 +110,6 @@ export async function updateUserFromAuth0(
 }
 
 export async function fetchWorkOSUserWithEmail(
-  workspace: LightWorkspaceType,
   email?: string | null
 ): Promise<Result<WorkOSUser, Error>> {
   if (email == null) {
@@ -118,17 +117,12 @@ export async function fetchWorkOSUserWithEmail(
   }
 
   const workOSUserResponse = await getWorkOS().userManagement.listUsers({
-    organizationId: workspace.workOSOrganizationId ?? undefined,
     email,
   });
 
   const [workOSUser] = workOSUserResponse.data;
   if (!workOSUser) {
-    return new Err(
-      new Error(
-        `User not found with email "${email}" in workOS for workspace "${workspace.sId}"`
-      )
-    );
+    return new Err(new Error(`User not found with email "${email}"`));
   }
 
   return new Ok(workOSUser);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -558,7 +558,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     return this.makeNew({
       name: directoryGroup.name,
-      workOSGroupId: directoryGroup.directoryId,
+      workOSGroupId: directoryGroup.id,
       updatedAt: new Date(),
       kind: "provisioned",
       workspaceId: owner.id,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -546,7 +546,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const group = await this.model.findOne({
       where: {
         workspaceId: owner.id,
-        workOSGroupId: directoryGroup.directoryId,
+        workOSGroupId: directoryGroup.id,
       },
     });
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -752,13 +752,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groups.map((group) => new this(GroupModel, group.get()));
   }
 
-  async isMember(auth: Authenticator): Promise<boolean> {
-    const owner = auth.getNonNullableWorkspace();
-
+  async isMember(user: UserResource): Promise<boolean> {
     if (this.isGlobal()) {
       return true;
     }
-
     if (this.isSystem()) {
       return false;
     }
@@ -766,10 +763,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     const membership = await GroupMembershipModel.findOne({
       where: {
         groupId: this.id,
-        workspaceId: owner.id,
+        workspaceId: this.workspaceId,
         startAt: { [Op.lte]: new Date() },
         [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-        userId: auth.getNonNullableUser().id,
+        userId: user.id,
       },
     });
 

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -247,6 +247,18 @@ async function handleUserAddedToGroup(
     );
   }
 
+  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  const isMember = await group.isMember(userAuth);
+  if (isMember) {
+    logger.info(
+      `User "${user.sId}" is already member of group "${group.sId}", skipping`
+    );
+    return;
+  }
+
   const res = await group.addMember(auth, user.toJSON());
   if (res.isErr()) {
     throw res.error;
@@ -312,6 +324,18 @@ async function handleCreateOrUpdateWorkOSUser(
     user,
     externalUser,
   });
+
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user: createdOrUpdatedUser,
+      workspace,
+    });
+  if (membership) {
+    logger.info(
+      `User ${createdOrUpdatedUser.sId} already have a membership associated to workspace "${workspace.sId}", skipping`
+    );
+    return;
+  }
 
   await createAndLogMembership({
     user: createdOrUpdatedUser,

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -228,10 +228,7 @@ async function handleUserAddedToGroup(
     return;
   }
 
-  const workOSUserRes = await fetchWorkOSUserWithEmail(
-    workspace,
-    event.user.email
-  );
+  const workOSUserRes = await fetchWorkOSUserWithEmail(event.user.email);
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
   }
@@ -265,10 +262,7 @@ async function handleUserRemovedFromGroup(
     return;
   }
 
-  const workOSUserRes = await fetchWorkOSUserWithEmail(
-    workspace,
-    event.user.email
-  );
+  const workOSUserRes = await fetchWorkOSUserWithEmail(event.user.email);
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
   }
@@ -297,7 +291,7 @@ async function handleCreateOrUpdateWorkOSUser(
   workspace: LightWorkspaceType,
   event: DirectoryUser
 ) {
-  const workOSUserRes = await fetchWorkOSUserWithEmail(workspace, event.email);
+  const workOSUserRes = await fetchWorkOSUserWithEmail(event.email);
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
   }
@@ -330,7 +324,7 @@ async function handleDeleteWorkOSUser(
   workspace: LightWorkspaceType,
   event: DirectoryUser
 ) {
-  const workOSUserRes = await fetchWorkOSUserWithEmail(workspace, event.email);
+  const workOSUserRes = await fetchWorkOSUserWithEmail(event.email);
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
   }

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -246,12 +246,7 @@ async function handleUserAddedToGroup(
       `Group not found for workOSId "${event.group.id}" in workspace "${workspace.sId}"`
     );
   }
-
-  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
-  const isMember = await group.isMember(userAuth);
+  const isMember = await group.isMember(user);
   if (isMember) {
     logger.info(
       `User "${user.sId}" is already member of group "${group.sId}", skipping`


### PR DESCRIPTION
## Description
- Fix not properly putting the `workOSGroupId`
- Remove the orgID when searching for a workOS user, users might not be linked to an organization.
- Handle user already existing when syncing
- Handle membership already existing when syncing
- Handle user already in group when syncing

## Tests
- Tested locally

## Risk
- No more than before

## Deploy Plan
- Deploy front
