### PR TITLE
`run_agent` origin and participation skip

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -210,7 +210,7 @@ export default async function createServer(
             fullName: `@${mainAgent.name}`,
             email: null,
             profilePictureUrl: mainAgent.pictureUrl,
-            origin: "mcp",
+            origin: "run_agent",
           },
         },
         contentFragment: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -186,11 +186,11 @@ export default async function createServer(
         config.getDustAPIConfig(),
         {
           ...prodCredentials,
-          // We use a system API key here meaning that we can impersonate the user or the groups we
-          // have access to.
           extraHeaders: {
-            // We have to use the user override here as the sub-agent may rely on personal actions
-            // that have to be operated in the name of the user initiating the interaction.
+            // We use a system API key to override the user here (not groups and role) so that the
+            // sub-agent can access the same spaces as the user but also as the sub-agent may rely
+            // on personal actions that have to be operated in the name of the user initiating the
+            // interaction.
             ...getHeaderFromUserEmail(user?.email),
           },
         },
@@ -210,6 +210,7 @@ export default async function createServer(
             fullName: `@${mainAgent.name}`,
             email: null,
             profilePictureUrl: mainAgent.pictureUrl,
+            // `run_agent` origin will skip adding the conversation to the user history.
             origin: "run_agent",
           },
         },

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -646,7 +646,15 @@ export async function* postUserMessage(
       },
       variant: "light",
     }),
-    ConversationResource.upsertParticipation(auth, conversation),
+    (() => {
+      // If the origin of the user message is "run_agent", we do not want to update the
+      // participation of the user so that the conversation does not appear in the user's history.
+      if (context.origin === "run_agent") {
+        return;
+      }
+
+      return ConversationResource.upsertParticipation(auth, conversation);
+    })(),
   ]);
 
   const agentConfigurations = removeNulls(results[0]);

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -87,13 +87,13 @@ export type UserMessageOrigin =
   | "github-copilot-chat"
   | "gsheet"
   | "make"
-  | "mcp"
   | "n8n"
   | "raycast"
   | "slack"
   | "web"
   | "zapier"
-  | "zendesk";
+  | "zendesk"
+  | "run_agent";
 
 export type UserMessageContext = {
   username: string;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -257,7 +257,6 @@ const UserMessageOriginSchema = FlexibleEnumSchema<
   | "github-copilot-chat"
   | "gsheet"
   | "make"
-  | "mcp"
   | "n8n"
   | "raycast"
   | "slack"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -264,6 +264,7 @@ const UserMessageOriginSchema = FlexibleEnumSchema<
   | "web"
   | "zapier"
   | "zendesk"
+  | "run_agent"
 >()
   .or(z.null())
   .or(z.undefined());


### PR DESCRIPTION
## Description

Removes `mcp` origin in favor of `run_agent`.
Skips upserting participation for user when user message origin is `run_agent`

Fixes https://github.com/dust-tt/tasks/issues/3105

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`