### PR TITLE
Upg: remove the 1... 1000 rule for internal servers id and add unit test

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { INTERNAL_MCP_SERVERS } from "./constants";
+
+describe("INTERNAL_MCP_SERVERS", () => {
+  it("should have unique IDs for all servers", () => {
+    const ids = Object.values(INTERNAL_MCP_SERVERS).map((server) => server.id);
+    const uniqueIds = new Set(ids);
+
+    expect(ids.length).toBe(uniqueIds.size);
+  });
+});

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -59,12 +59,9 @@ export const INTERNAL_MCP_SERVERS: Record<
     timeoutMs?: number;
   }
 > = {
-  // Notes:
-  // ids should be stable, do not change them for production internal servers as it would break existing agents.
-  // Let's start dev actions at 1000 to avoid conflicts with production actions.
-  // flag "dev_mcp_actions" for actions that are only used internally for dev and testing.
+  // Note:
+  // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
 
-  // Production
   github: {
     id: 1,
     availability: "manual",
@@ -222,7 +219,6 @@ export const INTERNAL_MCP_SERVERS: Record<
     },
   },
 
-  // Dev
   primitive_types_debugger: {
     id: 1004,
     availability: "manual",


### PR DESCRIPTION
## Description

Remove the 1.. 1000 rule for internal server id.

## Tests

Added unit-test.

## Risk

Low

## Deploy Plan

deploy front