### PR TITLE
Fix Poke workspace deletion

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -70,13 +70,13 @@ import {
   LabsTranscriptsConfigurationModel,
   LabsTranscriptsHistoryModel,
 } from "@app/lib/resources/storage/models/labs_transcripts";
+import { TagResource } from "@app/lib/resources/tags_resource";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { deleteAllConversations } from "@app/temporal/scrub_workspace/activities";
 import { CoreAPI } from "@app/types";
-import { TagResource } from "@app/lib/resources/tags_resource";
 
 const hardDeleteLogger = logger.child({ activity: "hard-delete" });
 
@@ -253,7 +253,7 @@ export async function deleteAgentsActivity({
     const mcpActions = await AgentMCPAction.findAll({
       where: {
         mcpServerConfigurationId: {
-          [Op.in]: mcpServerConfigurations.map((r) => r.id),
+          [Op.in]: mcpServerConfigurations.map((r) => `${r.id}`),
         },
       },
     });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes workspace deletion ([example](https://cloud.temporal.io/namespaces/dust-front-prod.gmnlm/workflows/poke-mfcoGcFfUx-delete-workspace/01975f4c-663b-7b36-a532-568c31e5809c/history)).

`AgentMCPAction` model stores `mcpServerConfigurationId` as string and not `ModelId`. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
