### PR TITLE
[Nodes search] Prevent both `nodeIds` and `includeDataSources` in filter

### DIFF
--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -159,16 +159,21 @@ export async function getContentFragmentBlob(
         timestamp: dsView.dataSource.createdAt.getTime(),
       };
     } else {
-      const searchFilter = getSearchFilterFromDataSourceViews(
-        auth.getNonNullableWorkspace(),
-        [dsView],
-        {
-          excludedNodeMimeTypes: [],
-          includeDataSources: true,
-          viewType: "all",
-          nodeIds: [cf.nodeId],
-        }
-      );
+      const searchFilterRes = getSearchFilterFromDataSourceViews([dsView], {
+        excludedNodeMimeTypes: [],
+        includeDataSources: false,
+        viewType: "all",
+        nodeIds: [cf.nodeId],
+      });
+      if (searchFilterRes.isErr()) {
+        return new Err(
+          new Error(
+            `Content node not found for content fragment node id: ${cf.nodeId}`
+          )
+        );
+      }
+
+      const searchFilter = searchFilterRes.value;
 
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const searchRes = await coreAPI.searchNodes({

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -133,8 +133,7 @@ export async function handleSearch(
   const excludedNodeMimeTypes =
     nodeIds || searchSourceUrls ? [] : NON_SEARCHABLE_NODES_MIME_TYPES;
 
-  const searchFilter = getSearchFilterFromDataSourceViews(
-    auth.getNonNullableWorkspace(),
+  const searchFilterRes = getSearchFilterFromDataSourceViews(
     allDatasourceViews,
     {
       excludedNodeMimeTypes,
@@ -143,6 +142,17 @@ export async function handleSearch(
       nodeIds,
     }
   );
+  if (searchFilterRes.isErr()) {
+    return new Err({
+      status: 400,
+      error: {
+        type: "invalid_request_error",
+        message: `Invalid search filter parameters: ${searchFilterRes.error.message}`,
+      },
+    });
+  }
+
+  const searchFilter = searchFilterRes.value;
 
   const paginationRes = getCursorPaginationParams(req);
   if (paginationRes.isErr()) {

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -317,16 +317,23 @@ export async function searchContenNodesInSpace(
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-  const searchFilter = getSearchFilterFromDataSourceViews(
-    auth.getNonNullableWorkspace(),
-    dataSourceViews,
-    {
-      excludedNodeMimeTypes,
-      includeDataSources,
-      viewType,
-      parentId,
-    }
-  );
+  const searchFilterRes = getSearchFilterFromDataSourceViews(dataSourceViews, {
+    excludedNodeMimeTypes,
+    includeDataSources,
+    viewType,
+    parentId,
+  });
+
+  if (searchFilterRes.isErr()) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        `Invalid search filter parameters: ${searchFilterRes.error.message}`
+      )
+    );
+  }
+
+  const searchFilter = searchFilterRes.value;
 
   const searchRes = await coreAPI.searchNodes({
     query,

--- a/front/lib/search.ts
+++ b/front/lib/search.ts
@@ -4,7 +4,6 @@ import type {
   ContentNodesViewType,
   CoreAPINodesSearchFilter,
   CoreAPISearchScope,
-  LightWorkspaceType,
   Result,
 } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";


### PR DESCRIPTION


## Description

Both fields set do not make sense. It was fixed in core by #13287 

One call in front did set both filters and is fixed in that PR. The PR also now errs early in front in case both filters are used together.

## Risk
low

## Deploy Plan
front
