### PR TITLE
track signup event in googletagmanager

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -137,7 +137,8 @@ export default function LandingLayout({
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${gtmTrackingId}');
-              (function(){var urlParams = new URLSearchParams(window.location.search);var gclid = urlParams.get('gclid');if (gclid) {sessionStorage.setItem('gclid', gclid);}})();
+              // Store the gclid query parameter in sessionStorage if present.
+              (function(){var g=new URLSearchParams(window.location.search).get('gclid');g&&sessionStorage.setItem('gclid',g);})();
             `}
           </Script>
         )}

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -137,7 +137,6 @@ export default function LandingLayout({
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${gtmTrackingId}');
-              // Store the gclid query parameter in sessionStorage if present.
               (function(){var g=new URLSearchParams(window.location.search).get('gclid');g&&sessionStorage.setItem('gclid',g);})();
             `}
           </Script>

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -137,6 +137,7 @@ export default function LandingLayout({
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${gtmTrackingId}');
+              (function(){var urlParams = new URLSearchParams(window.location.search);var gclid = urlParams.get('gclid');if (gclid) {sessionStorage.setItem('gclid', gclid);}})();
             `}
           </Script>
         )}

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -99,6 +99,7 @@ export default function AppRootLayout({
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
+              (function(){var urlParams = new URLSearchParams(window.location.search);var gclid = urlParams.get('gclid');if (gclid) {sessionStorage.setItem('gclid', gclid);}})();
             `}
         </Script>
       </WelcomeTourGuideProvider>

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -99,8 +99,9 @@ export default function AppRootLayout({
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
-              (function(){var urlParams = new URLSearchParams(window.location.search);var gclid = urlParams.get('gclid');if (gclid) {sessionStorage.setItem('gclid', gclid);}})();
-            `}
+              // Store the gclid query parameter in sessionStorage if present.
+              (function(){var g=new URLSearchParams(window.location.search).get('gclid');g&&sessionStorage.setItem('gclid',g);})();
+          `}
         </Script>
       </WelcomeTourGuideProvider>
     </ThemeProvider>

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -99,7 +99,6 @@ export default function AppRootLayout({
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
-              // Store the gclid query parameter in sessionStorage if present.
               (function(){var g=new URLSearchParams(window.location.search).get('gclid');g&&sessionStorage.setItem('gclid',g);})();
           `}
         </Script>

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -83,7 +83,8 @@ export default function OnboardingLayout({
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
           })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
-          (function(){var urlParams = new URLSearchParams(window.location.search);var gclid = urlParams.get('gclid');if (gclid) {sessionStorage.setItem('gclid', gclid);}})();
+          // Store the gclid query parameter in sessionStorage if present.
+          (function(){var g=new URLSearchParams(window.location.search).get('gclid');g&&sessionStorage.setItem('gclid',g);})();
         `}
       </Script>
     </>

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -78,12 +78,13 @@ export default function OnboardingLayout({
 
       <Script id="google-tag-manager" strategy="afterInteractive">
         {`
-              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-              })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
-            `}
+          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
+          (function(){var urlParams = new URLSearchParams(window.location.search);var gclid = urlParams.get('gclid');if (gclid) {sessionStorage.setItem('gclid', gclid);}})();
+        `}
       </Script>
     </>
   );

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -83,7 +83,6 @@ export default function OnboardingLayout({
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
           })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
-          // Store the gclid query parameter in sessionStorage if present.
           (function(){var g=new URLSearchParams(window.location.search).get('gclid');g&&sessionStorage.setItem('gclid',g);})();
         `}
       </Script>

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -1,7 +1,14 @@
-interface DataLayer {
-  event: "userIdentified";
-  userId: string;
-}
+type DataLayer =
+  | {
+      event: "userIdentified";
+      userId: string;
+    }
+  | {
+      event: "signup_completed";
+      user_email: string;
+      company_name: string;
+      gclid: string | null;
+    };
 
 interface Signals {
   identify: (data: { email: string; name: string }) => void;

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -19,6 +19,17 @@ class MyDocument extends Document {
           )}
         </Head>
         <body>
+          {/* Google Tag Manager (noscript) */}
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            ></iframe>
+          </noscript>
+          {/* End Google Tag Manager (noscript) */}
+
           <Main />
           <NextScript />
         </body>

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -19,7 +19,6 @@ class MyDocument extends Document {
           )}
         </Head>
         <body>
-          {/* Google Tag Manager (noscript) */}
           <noscript>
             <iframe
               src={`https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}`}
@@ -28,8 +27,6 @@ class MyDocument extends Document {
               style={{ display: "none", visibility: "hidden" }}
             ></iframe>
           </noscript>
-          {/* End Google Tag Manager (noscript) */}
-
           <Main />
           <NextScript />
         </body>

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -84,7 +84,7 @@ export default function Welcome({
         gclid: sessionStorage.getItem("gclid") || null,
       });
     }
-  }, [user.sId, user.email, owner.name]);
+  }, [user.email, owner.name]);
 
   useEffect(() => {
     setIsFormValid(

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -73,6 +73,19 @@ export default function Welcome({
 
   const { patchUser } = usePatchUser();
 
+  // GTM signup event tracking
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "signup_completed",
+        user_email: user.email,
+        company_name: owner.name,
+        gclid: sessionStorage.getItem("gclid") || null,
+      });
+    }
+  }, [user.sId, user.email, owner.name]);
+
   useEffect(() => {
     setIsFormValid(
       firstName !== "" &&

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -73,19 +73,6 @@ export default function Welcome({
 
   const { patchUser } = usePatchUser();
 
-  // GTM signup event tracking
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      window.dataLayer = window.dataLayer || [];
-      window.dataLayer.push({
-        event: "signup_completed",
-        user_email: user.email,
-        company_name: owner.name,
-        gclid: sessionStorage.getItem("gclid") || null,
-      });
-    }
-  }, [user.email, owner.name]);
-
   useEffect(() => {
     setIsFormValid(
       firstName !== "" &&
@@ -96,6 +83,17 @@ export default function Welcome({
 
   const { submit, isSubmitting } = useSubmitFunction(async () => {
     await patchUser(firstName, lastName, false, jobType);
+
+    // GTM signup event tracking: only fire after successful submit
+    if (typeof window !== "undefined") {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "signup_completed",
+        user_email: user.email,
+        company_name: owner.name,
+        gclid: sessionStorage.getItem("gclid") || null,
+      });
+    }
 
     await router.push(
       `/w/${owner.sId}/assistant/new?welcome=true${


### PR DESCRIPTION
## Description
Implements https://github.com/dust-tt/tasks/issues/3121

Adds 
a basic googletagmanager setup
signup tracking through signup_completed event
gclid URL parameter capture


## Tests

Using GTM's preview mode https://tagmanager.google.com/#/container/accounts/6265819401/containers/204597125/workspaces/2/variables

## Risk

Slower loading times

