### PR TITLE
Fix: duplicate would lose the tools from the original agent

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -131,19 +131,21 @@ export default function AssistantBuilder({
       });
       return;
     }
-
-    setBuilderState((prevState) => ({
-      ...prevState,
-      actions: [
-        ...actions.map((action) => ({
-          id: uniqueId(),
-          ...action,
-        })),
-        ...(prevState.visualizationEnabled
-          ? [getDataVisualizationActionConfiguration()]
-          : []),
-      ],
-    }));
+    // Do not override the actions if they are already set.
+    if (actions.length > 0) {
+      setBuilderState((prevState) => ({
+        ...prevState,
+        actions: [
+          ...actions.map((action) => ({
+            id: uniqueId(),
+            ...action,
+          })),
+          ...(prevState.visualizationEnabled
+            ? [getDataVisualizationActionConfiguration()]
+            : []),
+        ],
+      }));
+    }
   }, [actions, error, sendNotification]);
 
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(
@@ -157,7 +159,10 @@ export default function AssistantBuilder({
           generationSettings: initialBuilderState.generationSettings ?? {
             ...getDefaultAssistantState().generationSettings,
           },
-          actions: [], // Actions will be populated later from the client
+          actions: initialBuilderState.actions.map((action) => ({
+            id: uniqueId(),
+            ...action,
+          })),
           maxStepsPerRun:
             initialBuilderState.maxStepsPerRun ??
             getDefaultAssistantState().maxStepsPerRun,


### PR DESCRIPTION
## Description

Bug reported by customer: when we duplicate an agent, we would lose the actions from the original one.
Fixed by making sure we use the actions passed in the initial state, if any.
Also, only override actions from the async load if there aren't any yet.

## Tests

Locally before/after.

## Risk

Medium, agents stuff.

## Deploy Plan

Deploy front