### PR TITLE
feat(connectors): Increase the max minutes of running for the webcrawler

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -18,6 +18,7 @@ import {
   WebCrawlerError,
 } from "@connectors/connectors/webcrawler/lib/utils";
 import {
+  FIRECRAWL_REQ_TIMEOUT,
   MAX_BLOCKED_RATIO,
   MAX_PAGES_TOO_LARGE_RATIO,
   MAX_TIME_TO_CRAWL_MINUTES,
@@ -188,6 +189,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
             onlyMainContent: true,
             formats: ["markdown", "links"],
             headers: customHeaders,
+            timeout: FIRECRAWL_REQ_TIMEOUT,
           });
 
           if (!crawlerResponse.success) {

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -9,6 +9,7 @@ import {
 
 import type * as activities from "@connectors/connectors/webcrawler/temporal/activities";
 import type { ModelId } from "@connectors/types";
+import { WEBCRAWLER_MAX_PAGES } from "@connectors/types";
 
 // timeout for crawling a single url = timeout for upserting (5 minutes) + 2mn
 // leeway to crawl on slow websites
@@ -17,7 +18,9 @@ export const REQUEST_HANDLING_TIMEOUT = 420;
 // them 20mn to hearbeat.
 export const HEARTBEAT_TIMEOUT = 1200;
 
-export const MAX_TIME_TO_CRAWL_MINUTES = 240;
+export const FIRECRAWL_REQ_TIMEOUT = 30_000; // millisecond
+export const MAX_TIME_TO_CRAWL_MINUTES =
+  (WEBCRAWLER_MAX_PAGES * FIRECRAWL_REQ_TIMEOUT) / 1000 / 60; // X millisecond timeout per page, and we have a hardcoded limit of Y pages
 export const MIN_EXTRACTED_TEXT_LENGTH = 1024;
 export const MAX_BLOCKED_RATIO = 0.9;
 export const MAX_PAGES_TOO_LARGE_RATIO = 0.9;


### PR DESCRIPTION
## Description
Now that we've outsourced scraping to firecrawl:
- we have a default timeout of 30s on their requests
- and we've also increase the max pages to be crawled
So increasing the max minute of the crawler running can make sense, now `MAX_TIME_TO_CRAWL_MINUTES` is dependant on existing `WEBCRAWLER_MAX_PAGES` and a new `FIRECRAWL_REQ_TIMEOUT`, so in case we change one of them allowed running time a webcrawler is up to date.

- Added some extra heartbeat to have more context when a job get stuck.
- Fix extra `/` in the URL in the mardown by using `path.join`

Should reduce the number of event related to webcrawler taking too long and still keeping it in check.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Having too long running jobs

## Deploy Plan
- Deploy connectors
