### PR TITLE
[front] Update action state initialization

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -125,6 +125,7 @@ export default function AssistantBuilder({
   defaultIsEdited,
   baseUrl,
   defaultTemplate,
+  isAgentDuplication = false,
 }: AssistantBuilderLightProps) {
   const router = useRouter();
   const sendNotification = useSendNotification();
@@ -178,10 +179,7 @@ export default function AssistantBuilder({
 
     // In case of duplicating an agent, we set initial action state from the original agent.
     // We should not override it with the actions we fetched from the client side (= empty actions).
-    if (
-      initialBuilderState?.actions &&
-      initialBuilderState.actions.length === 0
-    ) {
+    if (!isAgentDuplication) {
       setBuilderState((prevState) => ({
         ...prevState,
         actions: [
@@ -195,7 +193,7 @@ export default function AssistantBuilder({
         ],
       }));
     }
-  }, [actions, error, sendNotification, initialBuilderState?.actions]);
+  }, [actions, error, sendNotification, isAgentDuplication]);
 
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(() =>
     getDefaultBuilderState(initialBuilderState, defaultScope, plan)

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -91,8 +91,6 @@ function getDefaultBuilderState(
       duplicatedActions.push(getDataVisualizationActionConfiguration());
     }
 
-    console.log("initialBuilderState", initialBuilderState);
-
     return {
       ...initialBuilderState,
       generationSettings: initialBuilderState.generationSettings ?? {

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -31,6 +31,7 @@ import SettingsScreen, {
 } from "@app/components/assistant_builder/SettingsScreen";
 import { submitAssistantBuilderForm } from "@app/components/assistant_builder/submitAssistantBuilderForm";
 import type {
+  AssistantBuilderInitialState,
   AssistantBuilderLightProps,
   AssistantBuilderPendingAction,
   AssistantBuilderSetActionType,
@@ -58,6 +59,7 @@ import { useAssistantConfigurationActions } from "@app/lib/swr/actions";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
 import { useUser } from "@app/lib/swr/user";
+import type { AgentConfigurationScope, PlanType } from "@app/types";
 import {
   assertNever,
   CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG,
@@ -69,6 +71,50 @@ import {
 
 function isValidTab(tab: string): tab is BuilderScreen {
   return BUILDER_SCREENS.includes(tab as BuilderScreen);
+}
+
+function getDefaultBuilderState(
+  initialBuilderState: AssistantBuilderInitialState | null,
+  defaultScope: Exclude<AgentConfigurationScope, "global">,
+  plan: PlanType
+) {
+  if (initialBuilderState) {
+    // We fetch actions on the client side, but in case of duplicating an agent,
+    // we need to use the actions from the original agent.
+    const duplicatedActions = initialBuilderState.actions.map((action) => ({
+      id: uniqueId(),
+      ...action,
+    }));
+
+    // We need to add data viz as a fake action if it's enabled.
+    if (initialBuilderState.visualizationEnabled) {
+      duplicatedActions.push(getDataVisualizationActionConfiguration());
+    }
+
+    console.log("initialBuilderState", initialBuilderState);
+
+    return {
+      ...initialBuilderState,
+      generationSettings: initialBuilderState.generationSettings ?? {
+        ...getDefaultAssistantState().generationSettings,
+      },
+      actions: duplicatedActions,
+      maxStepsPerRun:
+        initialBuilderState.maxStepsPerRun ??
+        getDefaultAssistantState().maxStepsPerRun,
+    };
+  }
+
+  return {
+    ...getDefaultAssistantState(),
+    scope: defaultScope,
+    generationSettings: {
+      ...getDefaultAssistantState().generationSettings,
+      modelSettings: !isUpgraded(plan)
+        ? GPT_4_1_MINI_MODEL_CONFIG
+        : CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG,
+    },
+  };
 }
 
 export default function AssistantBuilder({
@@ -132,9 +178,12 @@ export default function AssistantBuilder({
       return;
     }
 
-    // In case of duplicating an agent, we should not override the original actions from
-    // the fetched actions (= empty actions).
-    if (actions.length > 0) {
+    // In case of duplicating an agent, we set initial action state from the original agent.
+    // We should not override it with the actions we fetched from the client side (= empty actions).
+    if (
+      initialBuilderState?.actions &&
+      initialBuilderState.actions.length === 0
+    ) {
       setBuilderState((prevState) => ({
         ...prevState,
         actions: [
@@ -148,43 +197,10 @@ export default function AssistantBuilder({
         ],
       }));
     }
-  }, [actions, error, sendNotification]);
+  }, [actions, error, sendNotification, initialBuilderState?.actions]);
 
-  const [builderState, setBuilderState] = useState<AssistantBuilderState>(
-    initialBuilderState
-      ? {
-          handle: initialBuilderState.handle,
-          description: initialBuilderState.description,
-          scope: initialBuilderState.scope,
-          instructions: initialBuilderState.instructions,
-          avatarUrl: initialBuilderState.avatarUrl,
-          generationSettings: initialBuilderState.generationSettings ?? {
-            ...getDefaultAssistantState().generationSettings,
-          },
-          // We fetch actions on the client side, but in case of duplicating an agent,
-          // we need to use the actions from the original agent.
-          actions: initialBuilderState.actions.map((action) => ({
-            id: uniqueId(),
-            ...action,
-          })),
-          maxStepsPerRun:
-            initialBuilderState.maxStepsPerRun ??
-            getDefaultAssistantState().maxStepsPerRun,
-          visualizationEnabled: initialBuilderState.visualizationEnabled,
-          templateId: initialBuilderState.templateId,
-          tags: initialBuilderState.tags,
-          editors: initialBuilderState.editors,
-        }
-      : {
-          ...getDefaultAssistantState(),
-          scope: defaultScope,
-          generationSettings: {
-            ...getDefaultAssistantState().generationSettings,
-            modelSettings: !isUpgraded(plan)
-              ? GPT_4_1_MINI_MODEL_CONFIG
-              : CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG,
-          },
-        }
+  const [builderState, setBuilderState] = useState<AssistantBuilderState>(() =>
+    getDefaultBuilderState(initialBuilderState, defaultScope, plan)
   );
 
   const [pendingAction, setPendingAction] =

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -526,6 +526,7 @@ type AssistantBuilderPropsBase<T> = {
   owner: WorkspaceType;
   plan: PlanType;
   subscription: SubscriptionType;
+  isAgentDuplication?: boolean;
 };
 
 export type AssistantBuilderProps =

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -180,6 +180,7 @@ export default function CreateAssistant({
         subscription={subscription}
         plan={plan}
         flow={flow}
+        isAgentDuplication={!!agentConfiguration}
         initialBuilderState={
           agentConfiguration
             ? {


### PR DESCRIPTION
## Description
Another follow up PR of https://github.com/dust-tt/dust/pull/13377. In the end I was not completely stupid but was sleepy enough to forget about the issues I found 🤦‍♀️ 

- It's probably very rare but in case agents have no real actions but  `data_visualization` was enabled, we didn't add it as a fake action and show no action message
- When you duplicate an agent we don't add data visualization as a fake action.

Things to test:
- when you duplicate an agent, it should not lose the actions of original agent
- when you open an existing agent with no action but data viz is enabled, you should see data viz as an action


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
