### PR TITLE
[front] provisioning(billing): only include active users in per seat pricing

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -433,6 +433,17 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       where,
       distinct: true,
       col: "userId",
+      include: [
+        {
+          model: UserModel,
+          required: true,
+          where: {
+            lastLoginAt: {
+              [Op.ne]: null,
+            },
+          },
+        },
+      ],
       transaction,
     });
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

With the recent provisioning feature, we'll be creating users that are not active in workspaces that have directory sync activated. For the Per Seat pricing, we need to avoid counting those users in the billing.

Thus, we're modifying the compute fonction used in the `recordUsageActivity` workflow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Not tested.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

High-ish ? Risks to mess up the query and lose money (or risk to gain too much). 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front