### PR TITLE
Automatically uses google drive instead of gmail as provider for a specific workspace

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -184,6 +184,17 @@ export const connectToMCPServer = async (
                 );
               }
 
+              // Temporary to do a video.
+              if (
+                auth.getNonNullableWorkspace().sId === "91o4vu0LzW" &&
+                metadata.authorization.provider === "gmail"
+              ) {
+                metadata.authorization = {
+                  ...metadata.authorization,
+                  provider: "google_drive",
+                };
+              }
+
               const c = await getConnectionForMCPServer(auth, {
                 mcpServerId: params.mcpServerId,
                 connectionType:

--- a/front/lib/api/oauth/providers/google_drive.ts
+++ b/front/lib/api/oauth/providers/google_drive.ts
@@ -15,10 +15,12 @@ export class GoogleDriveOAuthProvider implements BaseOAuthStrategyProvider {
     connection,
     useCase,
     forceLabelsScope,
+    extraConfig,
   }: {
     connection: OAuthConnectionType;
     useCase: OAuthUseCase;
     forceLabelsScope?: boolean;
+    extraConfig?: ExtraConfigType;
   }) {
     const scopes =
       useCase === "labs_transcripts"
@@ -37,7 +39,7 @@ export class GoogleDriveOAuthProvider implements BaseOAuthStrategyProvider {
       client_id: config.getOAuthGoogleDriveClientId(),
       state: connection.connection_id,
       redirect_uri: finalizeUriForProvider("google_drive"),
-      scope: scopes.join(" "),
+      scope: extraConfig?.scope ?? scopes.join(" "),
       access_type: "offline",
       prompt: "consent",
     });
@@ -53,7 +55,13 @@ export class GoogleDriveOAuthProvider implements BaseOAuthStrategyProvider {
     return getStringFromQuery(query, "state");
   }
 
-  isExtraConfigValid(extraConfig: ExtraConfigType) {
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions" || useCase === "platform_actions") {
+      if (extraConfig.scope) {
+        return true;
+      }
+    }
+
     return Object.keys(extraConfig).length === 0;
   }
 }

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -102,7 +102,21 @@ export class InternalMCPServerInMemoryResource {
       return null;
     }
 
-    server.metadata = cachedMetadata;
+    // Temporary to do a video.
+    if (
+      auth.getNonNullableWorkspace().sId === "91o4vu0LzW" &&
+      cachedMetadata.authorization?.provider === "gmail"
+    ) {
+      server.metadata = {
+        ...cachedMetadata,
+        authorization: {
+          ...cachedMetadata.authorization,
+          provider: "google_drive",
+        },
+      };
+    } else {
+      server.metadata = cachedMetadata;
+    }
 
     return server;
   }

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -41,7 +41,7 @@ export const OAUTH_PROVIDERS = [
 export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
   confluence: "Confluence",
   github: "GitHub",
-  google_drive: "Google Drive",
+  google_drive: "Google",
   gmail: "Gmail",
   intercom: "Intercom",
   notion: "Notion",


### PR DESCRIPTION
## Description

Goal is to be able to make a youtube video for google data access review team as well as let them test by themselves.
Basically rerouting "gmail" provider to our main google provider.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front