### PR TITLE
[front] Fix link in Google Calendar auth info

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -22,7 +22,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
       "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events" as const,
   },
   icon: "GcalLogo",
-  documentationUrl: "https://docs.dust.tt/docs/google-calendar",
+  documentationUrl: "https://docs.dust.tt/docs/gmail",
 };
 
 const createServer = (): McpServer => {


### PR DESCRIPTION
## Description

Reported [here](https://dust4ai.slack.com/archives/C07KY510DH7/p1749735644189829), the link to setup google calendar doesn't exist, but judging from the screenshot we want to redirect to gmail setup page? 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
