### PR TITLE
Refactor handling of api error to use the wrapper

### DIFF
--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -206,7 +206,12 @@ export async function createRegularSpaceAndGroup(
       }
     | { name: string; isRestricted: false },
   { ignoreWorkspaceLimit = false }: { ignoreWorkspaceLimit?: boolean } = {}
-): Promise<Result<SpaceResource, DustError | Error>> {
+): Promise<
+  Result<
+    SpaceResource,
+    DustError<"limit_reached" | "space_already_exists" | "internal_error">
+  >
+> {
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
 
@@ -285,7 +290,9 @@ export async function createRegularSpaceAndGroup(
           "The space cannot be created - group members could not be added"
         );
 
-        return new Err(new Error("The space cannot be created."));
+        return new Err(
+          new DustError("internal_error", "The space cannot be created.")
+        );
       }
     }
 
@@ -303,7 +310,9 @@ export async function createRegularSpaceAndGroup(
           },
           "The space cannot be created - failed to fetch groups"
         );
-        return new Err(new Error("The space cannot be created."));
+        return new Err(
+          new DustError("internal_error", "The space cannot be created.")
+        );
       }
 
       const selectedGroups = selectedGroupsResult.value;

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -3,7 +3,7 @@ export type DustErrorCode =
   | "internal_error"
   | "invalid_id"
   | "limit_reached"
-  | "resource_not_found"
+  | "connection_not_found"
   | "file_not_found"
   | "unauthorized"
   // Data source
@@ -34,6 +34,7 @@ export type DustErrorCode =
   // MCP Server errors
   | "remote_server_not_found"
   | "internal_server_not_found"
+  | "mcp_server_view_not_found"
   // Space errors
   | "space_already_exists";
 

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -134,7 +134,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
     if (connections.length !== ids.length) {
       return new Err(
         new DustError(
-          "resource_not_found",
+          "connection_not_found",
           ids.length === 1
             ? "Connection not found"
             : "Some connections were not found"
@@ -174,7 +174,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
 
     return connections.length > 0
       ? new Ok(connections[0])
-      : new Err(new DustError("resource_not_found", "Connection not found"));
+      : new Err(new DustError("connection_not_found", "Connection not found"));
   }
 
   static async listByWorkspace({

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -435,7 +435,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       | { isRestricted: true; memberIds: string[]; managementMode: "manual" }
       | { isRestricted: true; groupIds: string[]; managementMode: "group" }
       | { isRestricted: false }
-  ): Promise<Result<undefined, DustError>> {
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "group_not_found"
+        | "user_not_found"
+        | "user_not_member"
+        | "user_already_member"
+        | "system_or_global_group"
+        | "invalid_id"
+      >
+    >
+  > {
     if (!this.canAdministrate(auth)) {
       return new Err(
         new DustError(
@@ -603,7 +616,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }: {
       userIds: string[];
     }
-  ): Promise<Result<UserResource[], DustError>> {
+  ): Promise<
+    Result<
+      UserResource[],
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_already_member"
+        | "system_or_global_group"
+      >
+    >
+  > {
     if (!this.canAdministrate(auth)) {
       return new Err(
         new DustError(
@@ -639,7 +662,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }: {
       userIds: string[];
     }
-  ): Promise<Result<UserResource[], DustError>> {
+  ): Promise<
+    Result<
+      UserResource[],
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "system_or_global_group"
+      >
+    >
+  > {
     if (!this.canAdministrate(auth)) {
       return new Err(
         new DustError(

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -2,7 +2,6 @@ import tracer from "dd-trace";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getSession } from "@app/lib/auth";
-import type { DustError } from "@app/lib/error";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import type {
   CustomGetServerSideProps,
@@ -12,13 +11,7 @@ import type {
   BaseResource,
   ResourceLogJSON,
 } from "@app/lib/resources/base_resource";
-import type {
-  APIErrorType,
-  APIErrorWithStatusCode,
-  Err,
-  WithAPIErrorResponse,
-} from "@app/types";
-import { assertNever } from "@app/types";
+import type { APIErrorWithStatusCode, WithAPIErrorResponse } from "@app/types";
 
 import logger from "./logger";
 import { statsDClient } from "./statsDClient";
@@ -166,76 +159,6 @@ export function withLogging<T>(
       "Processed request"
     );
   };
-}
-
-// TODO: add other error codes as we use this method in other places
-type SupportedDustErrorType = Omit<DustError, "code"> & {
-  code:
-    | "unauthorized"
-    | "internal_error"
-    | "user_not_found"
-    | "user_not_member"
-    | "user_already_member"
-    | "system_or_global_group"
-    | "group_not_found"
-    | "mcp_server_view_not_found"
-    | "limit_reached"
-    | "space_already_exists"
-    | "invalid_id";
-};
-
-export function dustErrorToApiErrorType(
-  r: Err<SupportedDustErrorType>
-): APIErrorType {
-  switch (r.error.code) {
-    case "unauthorized":
-      return "workspace_auth_error";
-    case "group_not_found":
-      return "group_not_found";
-    case "user_not_found":
-      return "user_not_found";
-    case "mcp_server_view_not_found":
-      return "mcp_server_view_not_found";
-    case "limit_reached":
-      return "plan_limit_error";
-    case "space_already_exists":
-      return "space_already_exists";
-    case "user_not_member":
-    case "user_already_member":
-    case "invalid_id":
-    case "system_or_global_group":
-      return "invalid_request_error";
-    case "internal_error":
-      return "internal_server_error";
-    default:
-      assertNever(r.error.code);
-  }
-}
-
-export function dustErrorToHttpStatusCode(
-  // TODO: add other error codes as we use this method in other places
-  r: Err<SupportedDustErrorType>
-) {
-  switch (r.error.code) {
-    case "unauthorized":
-      return 401;
-    case "group_not_found":
-    case "user_not_found":
-    case "mcp_server_view_not_found":
-      return 404;
-    case "limit_reached":
-      return 403;
-    case "space_already_exists":
-    case "user_not_member":
-    case "user_already_member":
-    case "invalid_id":
-    case "system_or_global_group":
-      return 400;
-    case "internal_error":
-      return 500;
-    default:
-      assertNever(r.error.code);
-  }
 }
 
 export function apiError<T>(

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -2,11 +2,14 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { apiError } from "@app/logger/withlogging";
+import {
+  apiError,
+  dustErrorToApiErrorType,
+  dustErrorToHttpStatusCode,
+} from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { isString } from "@app/types";
+import { assertNever, isString } from "@app/types";
 
 /**
  * @ignoreswagger
@@ -65,26 +68,42 @@ async function handler(
         userIds: [userId],
       });
       if (updateRes.isErr()) {
-        if (
-          updateRes.error instanceof DustError &&
-          updateRes.error.code === "unauthorized"
-        ) {
-          return apiError(req, res, {
-            status_code: 403,
-            api_error: {
-              type: "workspace_auth_error",
-              message:
-                "Only users that are `admins` can administrate space members.",
-            },
-          });
-        } else {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: updateRes.error.message,
-            },
-          });
+        switch (updateRes.error.code) {
+          case "unauthorized":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(updateRes),
+              api_error: {
+                type: dustErrorToApiErrorType(updateRes),
+                message: "You are not authorized to update the space.",
+              },
+            });
+          case "user_not_member":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(updateRes),
+              api_error: {
+                type: dustErrorToApiErrorType(updateRes),
+                message: "The user is not a member of the space.",
+              },
+            });
+          case "user_not_found":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(updateRes),
+              api_error: {
+                type: dustErrorToApiErrorType(updateRes),
+                message: "The user was not found in the workspace.",
+              },
+            });
+          case "system_or_global_group":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(updateRes),
+              api_error: {
+                type: dustErrorToApiErrorType(updateRes),
+                message:
+                  "Users cannot be removed from system or global groups.",
+              },
+            });
+          default:
+            assertNever(updateRes.error.code);
         }
       }
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -3,11 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import {
-  apiError,
-  dustErrorToApiErrorType,
-  dustErrorToHttpStatusCode,
-} from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { assertNever, isString } from "@app/types";
 
@@ -71,33 +67,33 @@ async function handler(
         switch (updateRes.error.code) {
           case "unauthorized":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 401,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "workspace_auth_error",
                 message: "You are not authorized to update the space.",
               },
             });
           case "user_not_member":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message: "The user is not a member of the space.",
               },
             });
           case "user_not_found":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 404,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "user_not_found",
                 message: "The user was not found in the workspace.",
               },
             });
           case "system_or_global_group":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message:
                   "Users cannot be removed from system or global groups.",
               },

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -4,11 +4,14 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { apiError } from "@app/logger/withlogging";
+import {
+  apiError,
+  dustErrorToApiErrorType,
+  dustErrorToHttpStatusCode,
+} from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { isString } from "@app/types";
+import { assertNever, isString } from "@app/types";
 
 /**
  * @ignoreswagger
@@ -73,26 +76,42 @@ async function handler(
         userIds: userIds,
       });
       if (updateRes.isErr()) {
-        if (
-          updateRes.error instanceof DustError &&
-          updateRes.error.code === "unauthorized"
-        ) {
-          return apiError(req, res, {
-            status_code: 403,
-            api_error: {
-              type: "workspace_auth_error",
-              message:
-                "Only users that are `admins` can administrate space members.",
-            },
-          });
-        } else {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: updateRes.error.message,
-            },
-          });
+        switch (updateRes.error.code) {
+          case "unauthorized":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(updateRes),
+              api_error: {
+                type: dustErrorToApiErrorType(updateRes),
+                message: "You are not authorized to update the space.",
+              },
+            });
+          case "user_already_member":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(updateRes),
+              api_error: {
+                type: dustErrorToApiErrorType(updateRes),
+                message: "The user is already a member of the space.",
+              },
+            });
+          case "user_not_found":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(updateRes),
+              api_error: {
+                type: dustErrorToApiErrorType(updateRes),
+                message: "The user was not found in the workspace.",
+              },
+            });
+          case "system_or_global_group":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(updateRes),
+              api_error: {
+                type: dustErrorToApiErrorType(updateRes),
+                message:
+                  "Users cannot be removed from system or global groups.",
+              },
+            });
+          default:
+            assertNever(updateRes.error.code);
         }
       }
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -5,11 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import {
-  apiError,
-  dustErrorToApiErrorType,
-  dustErrorToHttpStatusCode,
-} from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { assertNever, isString } from "@app/types";
 
@@ -79,33 +75,33 @@ async function handler(
         switch (updateRes.error.code) {
           case "unauthorized":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 401,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "workspace_auth_error",
                 message: "You are not authorized to update the space.",
               },
             });
           case "user_already_member":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 409,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message: "The user is already a member of the space.",
               },
             });
           case "user_not_found":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 404,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "user_not_found",
                 message: "The user was not found in the workspace.",
               },
             });
           case "system_or_global_group":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message:
                   "Users cannot be removed from system or global groups.",
               },

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -293,7 +293,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",
-        message: "Cannot add: user is already a member of the group",
+        message: "The user is already a member of the agent editors group.",
       },
     });
   });
@@ -314,7 +314,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",
-        message: "Cannot remove: user is not a member of the group",
+        message: "The user is not a member of the agent editors group.",
       },
     });
   });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -280,7 +280,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     });
   });
 
-  it("should return 400 when adding existing editor", async () => {
+  it("should return 409 when adding existing editor", async () => {
     const { req, res, agentOwner } = await setupTest({
       requestUserRole: "admin",
       method: "PATCH",
@@ -289,7 +289,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     req.body = { addEditorIds: [agentOwner.sId] }; // Try to re-add owner
 
     await handler(req, res);
-    expect(res._getStatusCode()).toBe(400);
+    expect(res._getStatusCode()).toBe(409);
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",
@@ -298,7 +298,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     });
   });
 
-  it("should return 400 when removing non-editor", async () => {
+  it("should return 409 when removing non-editor", async () => {
     const { req, res, workspace } = await setupTest({
       requestUserRole: "admin",
       method: "PATCH",
@@ -310,7 +310,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     req.body = { removeEditorIds: [nonEditor.sId] };
 
     await handler(req, res);
-    expect(res._getStatusCode()).toBe(400);
+    expect(res._getStatusCode()).toBe(409);
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -11,12 +11,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import {
-  apiError,
-  dustErrorToApiErrorType,
-  dustErrorToHttpStatusCode,
-  withLogging,
-} from "@app/logger/withlogging";
+import { apiError, withLogging } from "@app/logger/withlogging";
 import type { UserType, WithAPIErrorResponse } from "@app/types";
 import { assertNever } from "@app/types";
 
@@ -86,33 +81,33 @@ async function handler(
     switch (editorGroupRes.error.code) {
       case "unauthorized":
         return apiError(req, res, {
-          status_code: dustErrorToHttpStatusCode(editorGroupRes),
+          status_code: 401,
           api_error: {
-            type: dustErrorToApiErrorType(editorGroupRes),
+            type: "workspace_auth_error",
             message: "You are not authorized to update the agent editors.",
           },
         });
       case "invalid_id":
         return apiError(req, res, {
-          status_code: dustErrorToHttpStatusCode(editorGroupRes),
+          status_code: 400,
           api_error: {
-            type: dustErrorToApiErrorType(editorGroupRes),
+            type: "invalid_request_error",
             message: "Some of the passed ids are invalid.",
           },
         });
       case "group_not_found":
         return apiError(req, res, {
-          status_code: dustErrorToHttpStatusCode(editorGroupRes),
+          status_code: 404,
           api_error: {
-            type: dustErrorToApiErrorType(editorGroupRes),
+            type: "group_not_found",
             message: "Unable to find the editor group for the agent.",
           },
         });
       case "internal_error":
         return apiError(req, res, {
-          status_code: dustErrorToHttpStatusCode(editorGroupRes),
+          status_code: 500,
           api_error: {
-            type: dustErrorToApiErrorType(editorGroupRes),
+            type: "internal_server_error",
             message: editorGroupRes.error.message,
           },
         });
@@ -206,67 +201,67 @@ async function handler(
         switch (updateRes.error.code) {
           case "unauthorized":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 401,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "workspace_auth_error",
                 message: "You are not authorized to update the agent editors.",
               },
             });
           case "invalid_id":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message: "Some of the passed ids are invalid.",
               },
             });
           case "group_not_found":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 404,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "group_not_found",
                 message: "Unable to find the editor group for the agent.",
               },
             });
           case "user_not_found":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 404,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "user_not_found",
                 message: "The user was not found in the workspace.",
               },
             });
           case "user_not_member":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 403,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "workspace_auth_error",
                 message: "The user is not a member of the agent editors group.",
               },
             });
           case "system_or_global_group":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 403,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "workspace_auth_error",
                 message:
                   "Users cannot be removed from system or global groups.",
               },
             });
           case "user_already_member":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 409,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message:
                   "The user is already a member of the agent editors group.",
               },
             });
           case "internal_error":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 500,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "internal_server_error",
                 message: updateRes.error.message,
               },
             });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -233,9 +233,9 @@ async function handler(
             });
           case "user_not_member":
             return apiError(req, res, {
-              status_code: 403,
+              status_code: 409,
               api_error: {
-                type: "workspace_auth_error",
+                type: "invalid_request_error",
                 message: "The user is not a member of the agent editors group.",
               },
             });

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
@@ -115,7 +115,7 @@ async function handler(
           case "invalid_csv_content":
           case "invalid_csv_and_file":
           case "invalid_content_error":
-          case "resource_not_found":
+          case "connection_not_found":
           case "table_not_found":
           case "file_not_found":
             status_code = 400;

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -8,11 +8,7 @@ import { DustError } from "@app/lib/error";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
-import {
-  apiError,
-  dustErrorToApiErrorType,
-  dustErrorToHttpStatusCode,
-} from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import type { MCPOAuthUseCase, Result, WithAPIErrorResponse } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";
 
@@ -147,17 +143,17 @@ async function handler(
             switch (r.error.code) {
               case "unauthorized":
                 return apiError(req, res, {
-                  status_code: dustErrorToHttpStatusCode(r),
+                  status_code: 401,
                   api_error: {
-                    type: dustErrorToApiErrorType(r),
+                    type: "workspace_auth_error",
                     message: "You are not authorized to update the MCP server.",
                   },
                 });
               case "mcp_server_view_not_found":
                 return apiError(req, res, {
-                  status_code: dustErrorToHttpStatusCode(r),
+                  status_code: 404,
                   api_error: {
-                    type: dustErrorToApiErrorType(r),
+                    type: "mcp_server_view_not_found",
                     message: "Could not find the associated MCP server view.",
                   },
                 });
@@ -220,9 +216,9 @@ async function handler(
               switch (r.error.code) {
                 case "unauthorized":
                   return apiError(req, res, {
-                    status_code: dustErrorToHttpStatusCode(r),
+                    status_code: 401,
                     api_error: {
-                      type: dustErrorToApiErrorType(r),
+                      type: "workspace_auth_error",
                       message:
                         "You are not authorized to update the MCP server.",
                     },
@@ -242,18 +238,18 @@ async function handler(
               switch (r.error.code) {
                 case "unauthorized":
                   return apiError(req, res, {
-                    status_code: dustErrorToHttpStatusCode(r),
+                    status_code: 401,
                     api_error: {
-                      type: dustErrorToApiErrorType(r),
+                      type: "workspace_auth_error",
                       message:
                         "You are not authorized to update the MCP server.",
                     },
                   });
                 case "mcp_server_view_not_found":
                   return apiError(req, res, {
-                    status_code: dustErrorToHttpStatusCode(r),
+                    status_code: 404,
                     api_error: {
-                      type: dustErrorToApiErrorType(r),
+                      type: "mcp_server_view_not_found",
                       message: "Could not find the associated MCP server view.",
                     },
                   });
@@ -298,9 +294,9 @@ async function handler(
         switch (r.error.code) {
           case "unauthorized":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(r),
+              status_code: 401,
               api_error: {
-                type: dustErrorToApiErrorType(r),
+                type: "workspace_auth_error",
                 message: "You are not authorized to delete the MCP server.",
               },
             });

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -4,12 +4,17 @@ import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
-import { apiError, dustErrorToApiError } from "@app/logger/withlogging";
-import type { MCPOAuthUseCase, WithAPIErrorResponse } from "@app/types";
-import { assertNever, Ok } from "@app/types";
+import {
+  apiError,
+  dustErrorToApiErrorType,
+  dustErrorToHttpStatusCode,
+} from "@app/logger/withlogging";
+import type { MCPOAuthUseCase, Result, WithAPIErrorResponse } from "@app/types";
+import { assertNever, Err, Ok } from "@app/types";
 
 export type GetMCPServerResponseBody = {
   server: MCPServerType;
@@ -139,7 +144,26 @@ async function handler(
           });
 
           if (r.isErr()) {
-            return dustErrorToApiError(r, req, res);
+            switch (r.error.code) {
+              case "unauthorized":
+                return apiError(req, res, {
+                  status_code: dustErrorToHttpStatusCode(r),
+                  api_error: {
+                    type: dustErrorToApiErrorType(r),
+                    message: "You are not authorized to update the MCP server.",
+                  },
+                });
+              case "mcp_server_view_not_found":
+                return apiError(req, res, {
+                  status_code: dustErrorToHttpStatusCode(r),
+                  api_error: {
+                    type: dustErrorToApiErrorType(r),
+                    message: "Could not find the associated MCP server view.",
+                  },
+                });
+              default:
+                assertNever(r.error.code);
+            }
           }
 
           return res.status(200).json({
@@ -193,7 +217,19 @@ async function handler(
               lastSyncAt: new Date(),
             });
             if (r.isErr()) {
-              return dustErrorToApiError(r, req, res);
+              switch (r.error.code) {
+                case "unauthorized":
+                  return apiError(req, res, {
+                    status_code: dustErrorToHttpStatusCode(r),
+                    api_error: {
+                      type: dustErrorToApiErrorType(r),
+                      message:
+                        "You are not authorized to update the MCP server.",
+                    },
+                  });
+                default:
+                  assertNever(r.error.code);
+              }
             }
           }
 
@@ -203,7 +239,27 @@ async function handler(
               oAuthUseCase,
             });
             if (r.isErr()) {
-              return dustErrorToApiError(r, req, res);
+              switch (r.error.code) {
+                case "unauthorized":
+                  return apiError(req, res, {
+                    status_code: dustErrorToHttpStatusCode(r),
+                    api_error: {
+                      type: dustErrorToApiErrorType(r),
+                      message:
+                        "You are not authorized to update the MCP server.",
+                    },
+                  });
+                case "mcp_server_view_not_found":
+                  return apiError(req, res, {
+                    status_code: dustErrorToHttpStatusCode(r),
+                    api_error: {
+                      type: dustErrorToApiErrorType(r),
+                      message: "Could not find the associated MCP server view.",
+                    },
+                  });
+                default:
+                  assertNever(r.error.code);
+              }
             }
           }
 
@@ -239,7 +295,18 @@ async function handler(
       const r = await server.delete(auth);
 
       if (r.isErr()) {
-        return dustErrorToApiError(r, req, res);
+        switch (r.error.code) {
+          case "unauthorized":
+            return apiError(req, res, {
+              status_code: dustErrorToHttpStatusCode(r),
+              api_error: {
+                type: dustErrorToApiErrorType(r),
+                message: "You are not authorized to delete the MCP server.",
+              },
+            });
+          default:
+            assertNever(r.error.code);
+        }
       }
 
       return res.status(200).json({
@@ -269,8 +336,16 @@ async function updateOAuthUseCaseForMCPServer(
     mcpServerId: string;
     oAuthUseCase: MCPOAuthUseCase;
   }
-) {
+): Promise<
+  Result<undefined, DustError<"mcp_server_view_not_found" | "unauthorized">>
+> {
   const views = await MCPServerViewResource.listByMCPServer(auth, mcpServerId);
+
+  if (views.length === 0) {
+    return new Err(
+      new DustError("mcp_server_view_not_found", "MCP server view not found")
+    );
+  }
 
   for (const view of views) {
     const result = await view.updateOAuthUseCase(auth, oAuthUseCase);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -6,11 +6,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import {
-  apiError,
-  dustErrorToApiErrorType,
-  dustErrorToHttpStatusCode,
-} from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import type { SpaceType, WithAPIErrorResponse } from "@app/types";
 import { assertNever, PatchSpaceMembersRequestBodySchema } from "@app/types";
 
@@ -71,58 +67,58 @@ async function handler(
         switch (updateRes.error.code) {
           case "unauthorized":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 401,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "workspace_auth_error",
                 message:
                   "Only users that are `admins` can administrate space members.",
               },
             });
           case "user_not_found":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 404,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "user_not_found",
                 message: "The user was not found in the workspace.",
               },
             });
           case "user_not_member":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message: "The user is not a member of the workspace.",
               },
             });
           case "group_not_found":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 404,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "group_not_found",
                 message: "The group was not found in the workspace.",
               },
             });
           case "user_already_member":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message: "The user is already a member of the space.",
               },
             });
           case "invalid_id":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message: "Some of the passed ids are invalid.",
               },
             });
           case "system_or_global_group":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(updateRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(updateRes),
+                type: "invalid_request_error",
                 message:
                   "Users cannot be removed from system or global groups.",
               },

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -6,11 +6,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { createRegularSpaceAndGroup } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import {
-  apiError,
-  dustErrorToApiErrorType,
-  dustErrorToHttpStatusCode,
-} from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import type { SpaceType, WithAPIErrorResponse } from "@app/types";
 import { assertNever, PostSpaceRequestBodySchema } from "@app/types";
 
@@ -109,26 +105,26 @@ async function handler(
         switch (spaceRes.error.code) {
           case "limit_reached":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(spaceRes),
+              status_code: 403,
               api_error: {
-                type: dustErrorToApiErrorType(spaceRes),
+                type: "plan_limit_error",
                 message:
                   "Limit of spaces allowed for your plan reached. Contact support to upgrade.",
               },
             });
           case "space_already_exists":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(spaceRes),
+              status_code: 400,
               api_error: {
-                type: dustErrorToApiErrorType(spaceRes),
+                type: "space_already_exists",
                 message: "Space with that name already exists.",
               },
             });
           case "internal_error":
             return apiError(req, res, {
-              status_code: dustErrorToHttpStatusCode(spaceRes),
+              status_code: 500,
               api_error: {
-                type: dustErrorToApiErrorType(spaceRes),
+                type: "internal_server_error",
                 message: spaceRes.error.message,
               },
             });

--- a/front/types/shared/utils/error_utils.ts
+++ b/front/types/shared/utils/error_utils.ts
@@ -1,3 +1,5 @@
+import { DustError } from "@app/lib/error";
+
 export function errorToString(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -14,4 +16,14 @@ export function normalizeError(error: unknown): Error {
   }
 
   return new Error(errorToString(error));
+}
+
+export function normalizeAsInternalDustError(
+  error: unknown
+): DustError<"internal_error"> {
+  if (error instanceof DustError && error.code === "internal_error") {
+    return error;
+  }
+
+  return new DustError("internal_error", errorToString(error));
 }


### PR DESCRIPTION
## Description

Uses helpers to enforce consistency in code => status, error type but enforce a specific public message for each error code that can be returned by the internal api.

Typing of error is more precise. unless / until we create mapping for all error codes but ultimately, I think it would be better to refactor to have all our DustError typed to the codes each method can return and remove the default value for the type template on DustError.

## Tests

tsc.

## Risk

Low, I tried to make sure we map to the same error code / message as before.

## Deploy Plan

Deploy front