### PR TITLE
[sparkle] improve chip component

### DIFF
--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -161,7 +161,10 @@ type ChipLinkProps = ChipBaseProps &
 
 type ChipProps = ChipLinkProps | ChipButtonProps;
 
-// Since we can have a button inside a button, the top level element is a div
+// TODO(yuka: 1606): we should update this component so that you cannot have both
+// onClick and onRemove at the same time. We should use div when there is no onClick,
+// but use button when there is onClick.
+// Since we can have a button inside a button with current implementation, the top level element is a div
 // with a role="button", a tabIndex={0} to make it focusable, and onKeyDown handler.
 const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
   (

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -161,6 +161,8 @@ type ChipLinkProps = ChipBaseProps &
 
 type ChipProps = ChipLinkProps | ChipButtonProps;
 
+// Since we can have a button inside a button, the top level element is a div
+// with a role="button", a tabIndex={0} to make it focusable, and onKeyDown handler.
 const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
   (
     {

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -183,20 +183,28 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
         className={cn(
           chipVariants({ size, background: color, text: color }),
           className,
-          onRemove && "s-cursor-pointer"
+          onClick && "s-cursor-pointer"
         )}
         aria-label={label}
         ref={ref}
         onClick={onClick ? () => onClick() : undefined}
+        role={onClick ? "button" : undefined}
+        onKeyDown={(e) => {
+          if (
+            onClick &&
+            (e.key === "Enter" || e.key === " ") &&
+            e.target === e.currentTarget
+          ) {
+            onClick();
+          }
+        }}
+        tabIndex={onClick ? 0 : undefined}
       >
         {children}
         {icon && <Icon visual={icon} size={size as IconProps["size"]} />}
         {label && (
           <span
-            className={cn(
-              "s-pointer s-grow s-truncate",
-              onClick ? "s-cursor-pointer" : "s-cursor-default"
-            )}
+            className={cn("s-grow s-truncate", onClick && "s-cursor-pointer")}
           >
             {isBusy ? (
               <AnimatedText variant={color}>{label}</AnimatedText>
@@ -206,7 +214,12 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
           </span>
         )}
         {onRemove && (
-          <div onClick={onRemove ?? undefined}>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+          >
             <Icon
               visual={XMarkIcon}
               size={size}
@@ -215,7 +228,7 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
                 closeIconVariants[color || "primary"]
               )}
             />
-          </div>
+          </button>
         )}
       </div>
     );

--- a/sparkle/src/stories/Chip.stories.tsx
+++ b/sparkle/src/stories/Chip.stories.tsx
@@ -106,54 +106,63 @@ export const AllColors = () => (
         size="sm"
         color="primary"
         label="Primary"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
         color="highlight"
         label="Highlight"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
         color="success"
         label="Success"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
         color="warning"
         label="Warning"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
         color="info"
         label="Info"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
         color="green"
         label="Green"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
         color="blue"
         label="Blue"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
         color="rose"
         label="Rose"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
       <Chip
         size="sm"
         color="golden"
         label="Golden"
+        onClick={() => alert("Clicked")}
         onRemove={() => alert("Removed")}
       />
     </div>


### PR DESCRIPTION
## Description
This PR is to improve Chip component in Sparkle. I wanted to improve the action details button in conversation because clickable area was very narrow and we didn't show a pointer cursor even though it's clickable. I also took this opportunity to improve a11y. 

Related/not related:  I think it would be cool that if we show an icon or something when you can click the action details, right now it's not easy to tell if you can click it or not 🙏 @pinotalexandre 

<img width="241" alt="Screenshot 2025-06-13 at 17 32 41" src="https://github.com/user-attachments/assets/fd6a45ea-fa47-46f8-bd82-09a03aebbb2e" />



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
