### PR TITLE
Fix SFDC connector deletion

### DIFF
--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -34,10 +34,6 @@ import {
 import { saveNodesFromPermissions } from "@connectors/lib/remote_databases/utils";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import {
-  SalesforceConfigurationResource,
-  SalesforceSyncedQueryResource,
-} from "@connectors/resources/salesforce_resources";
 import type { ConnectorPermission, ContentNode } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -132,9 +132,6 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
       throw new Error(`Connector ${this.connectorId} not found`);
     }
 
-    await SalesforceConfigurationResource.deleteByConnectorId(connector.id);
-    await SalesforceSyncedQueryResource.deleteByConnectorId(connector.id);
-
     await RemoteTableModel.destroy({
       where: {
         connectorId: connector.id,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
PR https://github.com/dust-tt/dust/pull/13273 changed the resources around SFDC. A regression was introduced that attempts to delete twice the configuration.

A first deletion occurs here:

https://github.com/dust-tt/dust/blob/fb1f638d233f6c4a55e3074e87b1364f7f0e1eba/connectors/src/connectors/salesforce/index.ts#L135-L136

Then we attempt to delete through the resource here:

https://github.com/dust-tt/dust/blob/fb1f638d233f6c4a55e3074e87b1364f7f0e1eba/connectors/src/connectors/salesforce/index.ts#L156

This leads to stuck activities ([thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1749804300953569)).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [ ] Deploy connectors
- [ ] Re-add already deleted `salesforce_configurations`
