### PR TITLE
[front] workos: backfill lastLoginAt with real data

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -239,9 +239,9 @@ export class UserResource extends BaseResource<UserModel> {
     });
   }
 
-  async recordLoginActivity() {
+  async recordLoginActivity(date?: Date) {
     return this.update({
-      lastLoginAt: new Date(),
+      lastLoginAt: date ?? new Date(),
     });
   }
 
@@ -370,6 +370,7 @@ export class UserResource extends BaseResource<UserModel> {
       lastName: this.lastName,
       fullName: this.fullName(),
       image: this.imageUrl,
+      lastLoginAt: this.lastLoginAt?.getTime(),
     };
   }
 

--- a/front/migrations/20250613_users_last_login_at.ts
+++ b/front/migrations/20250613_users_last_login_at.ts
@@ -1,0 +1,90 @@
+import { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import * as fs from "fs";
+import * as readline from "readline";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+
+interface LastLoginData {
+  user_id: string;
+  last_login: string;
+}
+
+const backfillLastLoginAt = async (execute: boolean, filePath: string) => {
+  const fileStream = fs.createReadStream(filePath);
+  const rl = readline.createInterface({
+    input: fileStream,
+    crlfDelay: Infinity,
+  });
+
+  const lastLoginMap = new Map<string, string>();
+  for await (const line of rl) {
+    const data: LastLoginData = JSON.parse(line);
+    lastLoginMap.set(data.user_id, data.last_login);
+  }
+
+  logger.info(
+    `Loaded ${lastLoginMap.size} last login records from ${filePath}`
+  );
+
+  // Process each auth0Sub
+  await concurrentExecutor(
+    Array.from(lastLoginMap.entries()),
+    async ([auth0Sub, lastLoginStr]) => {
+      if (!auth0Sub || !lastLoginStr) {
+        logger.warn(
+          `Skipping entry with missing auth0Sub or lastLogin: ${JSON.stringify({
+            auth0Sub,
+            lastLoginStr,
+          })}`
+        );
+        return;
+      }
+
+      const lastLogin = new Date(lastLoginStr);
+      if (isNaN(lastLogin.getTime())) {
+        logger.warn(
+          `Invalid lastLogin date for auth0Sub ${auth0Sub}: ${lastLoginStr}`
+        );
+        return;
+      }
+      const user = await UserResource.fetchByAuth0Sub(auth0Sub);
+      if (!user) {
+        logger.info({ auth0Sub }, "No user found for auth0Sub");
+        return;
+      }
+
+      if (
+        user.lastLoginAt &&
+        user.lastLoginAt.getTime() >= lastLogin.getTime()
+      ) {
+        logger.info(
+          `User ${user.auth0Sub} already has lastLoginAt set to ${user.lastLoginAt}, skipping`
+        );
+        return;
+      }
+
+      logger.info(
+        `Backfilling user ${user.id} (${auth0Sub}) with lastLoginAt=${lastLogin.toISOString()} [execute: ${execute}]`
+      );
+
+      if (execute) {
+        await user.recordLoginActivity(lastLogin);
+      }
+    },
+    { concurrency: 16 }
+  );
+};
+
+makeScript(
+  {
+    filePath: {
+      type: "string",
+      description: "Path to the JSONL file containing last login data",
+      required: true,
+    },
+  },
+  async ({ execute, filePath }) => {
+    await backfillLastLoginAt(execute, filePath);
+  }
+);

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -94,6 +94,7 @@ export type UserType = {
   lastName: string | null;
   fullName: string;
   image: string | null;
+  lastLoginAt?: number;
 };
 
 export type UserTypeWithWorkspaces = UserType & {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

In order to merge https://github.com/dust-tt/dust/pull/13389, we need to first backfill the lastLoginAt column.

This PR implements a backfill script for the lastLoginAt column, based on an Auth0 data export.
```
{"user_id":"google-oauth2|109752425456574996531","last_login":"2024-06-13T15:18:52.733Z"}
{"user_id":"78227fca-c720-44a1-bf94-8ba622840e93","last_login":"2024-06-13T15:18:52.733Z"}
{"user_id":"cc73b110-1278-4377-a464-660d553d8277"}
{"user_id":"google-oauth2|758943758943789543785","last_login":"2024-06-13T15:18:52.733Z"}
```
The export file is a .jsonl file on this format.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested locally, updates user with no date, does not update user that already have a lastLogin date.
If a line does not have a last_login, it's skipped.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks, only updates the lastLoginAt column.

## Deploy Plan

Upload the export to prodbox, run the backfill there on both regions.