### PR TITLE
Dust/Helper agent router: Instructions to explain when to use those tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -137,9 +137,6 @@ export const INTERNAL_MCP_SERVERS: Record<
   agent_router: {
     id: 8,
     availability: "auto_hidden_builder",
-    isRestricted: (plan, featureFlags) => {
-      return featureFlags.includes("dev_mcp_actions");
-    },
   },
   include_data: {
     id: 9,

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -23,51 +23,19 @@ const serverInfo: InternalMCPServerDefinitionType = {
 export const LIST_ALL_AGENTS_TOOL_NAME = "list_all_published_agents";
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content";
 
-const SERVER_INSTRUCTIONS = `You have access to the following tools: ${LIST_ALL_AGENTS_TOOL_NAME}, ${SUGGEST_AGENTS_TOOL_NAME}.
+const SERVER_INSTRUCTIONS = `This toolset provides access to specialized agents available in the workspace.
+A good usage of these tools is:
+- when the user asks for a list of agents or when the user asks for suggestions for an agent.
+- when the agent is not able to handle the user's request and tries to suggest an agent that might be able to handle the request.
 
-# IMPORTANT: Check for specialized agents BEFORE attempting to answer
+# Agent Presentation Format
+Both tools return agents with a "mention" field containing a clickable format (e.g., \`:mention[AgentName]{sId=abc123}\`). This format allows users to directly select and interact with the suggested agents.
 
-**CRITICAL**: Before searching for data or attempting to answer any request, ALWAYS check if there's a specialized agent for the topic using suggest_agents. This is especially important for:
-
-- **Platform/Service-specific requests**: Salesforce, HubSpot, Slack, GitHub, Jira, Notion, Google Drive, etc.
-- **Domain-specific questions**: HR, Sales, Marketing, Legal, Finance, Engineering, etc.
-- **Tool-specific queries**: Any mention of specific software, platforms, or services
-
-# When to use these tools
-
-1. **ALWAYS as your FIRST action when**:
-   - The user mentions a specific platform or service name (e.g., "Salesforce accounts", "GitHub issues", "Slack messages")
-   - The request is about data from a specific system
-   - The query relates to a specific business function or domain
-
-2. **When explicitly asked**: If the user asks to see available agents, list agents, or find a suitable agent.
-
-3. **When the request seems specific**: Any request that appears to be about a specific domain, platform, or specialized task.
-
-# Example patterns that MUST trigger suggest_agents:
-- "What's the latest [anything] on [platform name]?" → Check for platform-specific agent
-- "Show me [data type] from [service]" → Check for service-specific agent
-- "[Platform name] [any request]" → Check for platform agent
-- Questions about specific business functions → Check for domain agents
-
-# ${LIST_ALL_AGENTS_TOOL_NAME}
-Lists all active published agents in the workspace. Use when the user wants to browse all available agents.
-
-# ${SUGGEST_AGENTS_TOOL_NAME}
-Suggests the most relevant agents based on the user's query. **USE THIS FIRST** before attempting to search or answer questions about specific platforms, services, or domains.
-
-**Workflow**:
-1. Receive user request
-2. If it mentions a platform/service/domain → Use suggest_agents IMMEDIATELY
-3. If specialized agents exist → Present them to the user using the mention directive
-4. Only proceed with general search if no specialized agents are found
-
-**CRITICAL: How to present agents to users**
-When you find relevant agents, you MUST use the mention directive format provided by the tools. This allows users to click on the agent name to select it. The tools return agents with a "mention" field that contains the clickable format - USE THIS FORMAT when presenting agents to users.
-
-Example: If the tool returns an agent with mention \`:mention[Salesforce]{sId=abc123}\`, present it exactly like that in your response so the user can click on it.
-
-Always inform the user about specialized agents and let them choose whether to use them.
+# Specialized Agent Examples
+The workspace may contain specialized agents for:
+- Platform integrations (Salesforce, Slack, GitHub, etc.)
+- Business domains (HR, Sales, Marketing, etc.)
+- Specific workflows or processes
 `;
 
 const createServer = (auth: Authenticator): McpServer => {
@@ -77,7 +45,7 @@ const createServer = (auth: Authenticator): McpServer => {
 
   server.tool(
     LIST_ALL_AGENTS_TOOL_NAME,
-    "List all active published agents in the workspace.",
+    "Returns a complete list of all published agents in the workspace. Each agent includes: name and description, and a clickable mention format for easy selection",
     {},
     async () => {
       const owner = auth.getNonNullableWorkspace();
@@ -139,7 +107,7 @@ const createServer = (auth: Authenticator): McpServer => {
 
   server.tool(
     SUGGEST_AGENTS_TOOL_NAME,
-    "Suggest agents for the current user's query.",
+    "Analyzes a user query and returns relevant specialized agents that might be better suited to handle specific requests. The tool uses semantic matching to find agents whose capabilities align with the query content.",
     {
       userMessage: z.string().describe("The user's message."),
       conversationId: z.string().describe("The conversation id."),

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -23,20 +23,9 @@ const serverInfo: InternalMCPServerDefinitionType = {
 export const LIST_ALL_AGENTS_TOOL_NAME = "list_all_published_agents";
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content";
 
-const SERVER_INSTRUCTIONS = `This toolset provides access to specialized agents available in the workspace.
-A good usage of these tools is:
-- when the user asks for a list of agents or when the user asks for suggestions for an agent.
-- when the agent is not able to handle the user's request and tries to suggest an agent that might be able to handle the request.
-
-# Agent Presentation Format
-Both tools return agents with a "mention" field containing a clickable format (e.g., \`:mention[AgentName]{sId=abc123}\`). This format allows users to directly select and interact with the suggested agents.
-
-# Specialized Agent Examples
-The workspace may contain specialized agents for:
-- Platform integrations (Salesforce, Slack, GitHub, etc.)
-- Business domains (HR, Sales, Marketing, etc.)
-- Specific workflows or processes
-`;
+const SERVER_INSTRUCTIONS = `These tools provide discoverability to published agents available in the workspace.
+The tools return agents with their "mention" markdown directive.
+The directive should be used to display a clickable version of the agent name in the response.`;
 
 const createServer = (auth: Authenticator): McpServer => {
   const server = new McpServer(serverInfo, {
@@ -45,7 +34,7 @@ const createServer = (auth: Authenticator): McpServer => {
 
   server.tool(
     LIST_ALL_AGENTS_TOOL_NAME,
-    "Returns a complete list of all published agents in the workspace. Each agent includes: name and description, and a clickable mention format for easy selection",
+    "Returns a complete list of all published agents in the workspace.",
     {},
     async () => {
       const owner = auth.getNonNullableWorkspace();

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -1383,13 +1383,33 @@ function _getDustGlobalAgent(
       }
     : dummyModelConfiguration;
 
-  const instructions = `The agent answers with precision and brevity. It produces short and straight to the point answers. The agent should not provide additional information or content that the user did not ask for. When possible, the agent should answer using a single sentence.
-    # When the user asks a questions to the agent, the agent should analyze the situation as follows.
-    1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the agent's own knowledge), the agent should search in the company's internal data sources to answer the question. Searching in all datasources is the default behavior unless the user has specified the location in which case it is better to search only on the specific data source. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-    2. If the users's question requires information that is recent and likely to be found on the public internet, the agent should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
-    3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the agent should both search the internal company data sources and the public internet before answering the user's question.
-    4. If the user's query require neither internal company data or recent public knowledge, the agent is allowed to answer without using any tool.
-    The agent always respects the mardown format and generates spaces to nest content.`;
+  const instructions = `The agent answers with precision and brevity. It produces short and straight to the point answers.
+The agent should not provide additional information or content that the user did not ask for.
+When possible, the agent should answer using a single sentence.
+
+# When the user asks a questions to the agent, the agent should analyze the situation as follows:
+
+1. If the user's question requires information that is likely private or internal to the company
+   (and therefore unlikely to be found on the public internet or within the agent's own knowledge),
+   the agent should search in the company's internal data sources to answer the question.
+   Searching in all datasources is the default behavior unless the user has specified the location
+   in which case it is better to search only on the specific data source.
+   It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
+   If no relevant information is found but the user's question seems to be internal to the company,
+   the agent should use the ${SUGGEST_AGENTS_TOOL_NAME} tool to suggest an agent that might be able to handle the request.
+
+2. If the users's question requires information that is recent and likely to be found on the public internet,
+   the agent should use the internet to answer the question.
+   That means performing a websearch and potentially browse some webpages.
+
+3. If it is not obvious whether the information would be included in the internal company data sources
+   or on the public internet, the agent should both search the internal company data sources
+   and the public internet before answering the user's question.
+
+4. If the user's query require neither internal company data or recent public knowledge,
+   the agent is allowed to answer without using any tool.
+
+The agent always respects the mardown format and generates spaces to nest content.`;
 
   const dustAgent = {
     id: -1,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -6,6 +6,10 @@ import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/actions/constants";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  LIST_ALL_AGENTS_TOOL_NAME,
+  SUGGEST_AGENTS_TOOL_NAME,
+} from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
 import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
 import config from "@app/lib/api/config";
@@ -158,7 +162,7 @@ function _getAgentRouterToolsConfiguration(
       id: -1,
       sId: agentId + "-agent-router-list-action",
       type: "mcp_server_configuration",
-      name: "list_agents",
+      name: LIST_ALL_AGENTS_TOOL_NAME,
       description: "List the published agents of the workspace.",
       mcpServerViewId: mcpServerView.sId,
       internalMCPServerId,
@@ -175,7 +179,7 @@ function _getAgentRouterToolsConfiguration(
       id: -1,
       sId: agentId + "-agent-router-suggest-agents",
       type: "mcp_server_configuration",
-      name: "suggest_agents",
+      name: SUGGEST_AGENTS_TOOL_NAME,
       description: "Suggest agents based on the user's query.",
       mcpServerViewId: mcpServerView.sId,
       internalMCPServerId,


### PR DESCRIPTION
## Description

Agent router tools are added by default to `@dust` and `@helper`. They cannot be added to another agent (availability=`auto_hidden_builder`). 

The goal is to help user discover specific agents. I did many tests and unless you ask specifically if there's a specific agent for this or that, it was never calling the tools. 

This is an attempt to make it better.

Exact use case I'm trying to solve: If you ask  `@dust` a question about Salesforce or Snowflake, it will most likely do a websearch cause it does not have access to Table Query or the tools. 

With the changes we have this: 
<img width="894" alt="Screenshot 2025-06-13 at 11 26 21" src="https://github.com/user-attachments/assets/53c51a32-25c3-464f-9b89-0b5757aab08b" />
Ideally it could directly call the sub agents but not possible at the moment!

If I ask for the wifi code it does do a retrieval it does not search for a wifi agent 😄 

## Tests

Tested locally but with very few data. 

## Risk

This tool is still under a feature flag (Dust only). I'd like to merge it and if no big regression I'd like to activate it for one client who expressed the need for the use case described earlier. 

Since it might significantly impact `@Dust` behavior, I think keeping it gated is the right thing to do. 

## Deploy Plan

Deploy front. 