### PR TITLE
feat: start storing agent step contents

### DIFF
--- a/core/src/providers/chat_messages.rs
+++ b/core/src/providers/chat_messages.rs
@@ -71,7 +71,7 @@ pub struct SystemChatMessage {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ReasoningContent {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub displayable_text: Option<String>,
+    pub reasoning: Option<String>,
     pub metadata: String,
 }
 

--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -226,7 +226,7 @@ fn responses_api_input_from_chat_messages(
                                     encrypted_content: value.metadata.clone(),
                                     summary: vec![OpenAIResponseSummaryItem {
                                         r#type: "summary_text".to_string(),
-                                        text: value.displayable_text.clone().unwrap_or_default(),
+                                        text: value.reasoning.clone().unwrap_or_default(),
                                     }],
                                 });
                             }
@@ -305,14 +305,14 @@ fn assistant_chat_message_from_responses_api_output(
                 encrypted_content,
                 summary,
             } => {
-                let displayable_text = summary
+                let reasoning = summary
                     .as_ref()
                     .and_then(|s| s.first())
                     .map(|s| s.text.clone());
 
                 contents.push(AssistantContentItem::Reasoning {
                     value: ReasoningContent {
-                        displayable_text,
+                        reasoning,
                         metadata: encrypted_content.unwrap_or_default(),
                     },
                 });

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -1,5 +1,6 @@
 import type { DustAppConfigType, DustAppType } from "@dust-tt/client";
 import { DustAPI } from "@dust-tt/client";
+import { z } from "zod";
 
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -34,6 +35,41 @@ const logActionError = (
     },
     "Action run error"
   );
+};
+
+const DustAppChatBlockFunctionCallSchema = z.object({
+  arguments: z.string(),
+  id: z.string(),
+  name: z.string(),
+});
+
+// Define Zod schema for DustAppChatBlock
+const DustAppChatBlockSchema = z.object({
+  message: z.object({
+    content: z.string().optional(),
+    function_calls: z.array(DustAppChatBlockFunctionCallSchema).optional(),
+    role: z.string(),
+    contents: z.array(
+      z.union([
+        z.object({
+          type: z.literal("text_content"),
+          value: z.string(),
+        }),
+        z.object({
+          type: z.literal("function_call"),
+          value: DustAppChatBlockFunctionCallSchema,
+        }),
+      ])
+    ),
+  }),
+});
+
+export type DustAppChatBlockType = z.infer<typeof DustAppChatBlockSchema>;
+
+export const isDustAppChatBlockType = (
+  block: unknown
+): block is DustAppChatBlockType => {
+  return DustAppChatBlockSchema.safeParse(block).success;
 };
 
 /**

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -43,7 +43,6 @@ const DustAppChatBlockFunctionCallSchema = z.object({
   name: z.string(),
 });
 
-// Define Zod schema for DustAppChatBlock
 const DustAppChatBlockSchema = z.object({
   message: z.object({
     content: z.string().optional(),
@@ -58,6 +57,13 @@ const DustAppChatBlockSchema = z.object({
         z.object({
           type: z.literal("function_call"),
           value: DustAppChatBlockFunctionCallSchema,
+        }),
+        z.object({
+          type: z.literal("reasoning"),
+          value: z.object({
+            reasoning: z.string().optional(),
+            metadata: z.string(),
+          }),
         }),
       ])
     ),

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -3,6 +3,11 @@ import type {
   AgentActionConfigurationType,
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
+import type {
+  ReasoningContentType,
+  TextContentType,
+} from "@app/types/assistant/agent_message_content";
+import type { FunctionCallContentType } from "@app/types/assistant/agent_message_content";
 import type { TagType } from "@app/types/tag";
 import type { UserType } from "@app/types/user";
 
@@ -270,6 +275,8 @@ export type AgentChainOfThoughtEvent = {
   chainOfThought: string;
 };
 
+// Deprecated
+// TODO(agent-step-content): Remove this event
 export type AgentContentEvent = {
   type: "agent_message_content";
   created: number;
@@ -277,4 +284,13 @@ export type AgentContentEvent = {
   messageId: string;
   content: string;
   processedContent: string;
+};
+
+export type AgentStepContentEvent = {
+  type: "agent_step_content";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  index: number;
+  content: TextContentType | FunctionCallContentType | ReasoningContentType;
 };


### PR DESCRIPTION
## Description

We have a new `AgentStepContent` table that is meant to store the raw "content" items from modern LLM provider APIs.
This array is now being "JIT-backfilled" in `core`

This PR starts storing data in this table.

## Tests

Extensive locally.

## Risk

Critical path of conversation with agents

## Deploy Plan

Deploy `rust` then `front`