### PR TITLE
[Keyword Search] Search by URL in knowledge

### DIFF
--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -22,12 +22,18 @@ import { SpacePageHeader } from "@app/components/spaces/SpacePageHeaders";
 import { useCursorPaginationForDataTable } from "@app/hooks/useCursorPaginationForDataTable";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useQueryParams } from "@app/hooks/useQueryParams";
+import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
+import {
+  isNodeCandidate,
+  isUrlCandidate,
+  nodeCandidateFromUrl,
+} from "@app/lib/connectors";
 import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
 import { useDataSourceViews } from "@app/lib/swr/data_source_views";
-import { useSpaces, useSpaceSearch } from "@app/lib/swr/spaces";
+import { useSpacesSearch } from "@app/lib/swr/spaces";
 import type {
   APIError,
   ContentNodesViewType,
@@ -168,6 +174,9 @@ function BackendSearch({
   const [effectiveContentNode, setEffectiveContentNode] =
     React.useState<LightContentNode | null>(null);
   const effectiveDataSourceView = dataSourceView || searchResultDataSourceView;
+  const [nodeOrUrlCandidate, setNodeOrUrlCandidate] = React.useState<
+    UrlCandidate | NodeCandidate | null
+  >(null);
 
   const handleOpenDocument = React.useCallback(
     (node: DataSourceViewContentNode) => {
@@ -197,12 +206,23 @@ function BackendSearch({
   const handleClearSearch = React.useCallback(() => {
     searchParam.setParam(undefined);
     setSearchValue("");
+    setNodeOrUrlCandidate(null);
   }, [searchParam, setSearchValue]);
 
   const handleSearchChange = (value: string) => {
     searchParam.setParam(value);
     setSearchValue(value);
   };
+
+  // Check if the search term is a URL
+  React.useEffect(() => {
+    if (debouncedSearch.length >= MIN_SEARCH_QUERY_SIZE) {
+      const candidate = nodeCandidateFromUrl(debouncedSearch.trim());
+      setNodeOrUrlCandidate(candidate);
+    } else {
+      setNodeOrUrlCandidate(null);
+    }
+  }, [debouncedSearch]);
 
   const shouldShowSearchResults = debouncedSearch.length > 0;
 
@@ -222,35 +242,65 @@ function BackendSearch({
     resetPagination();
   }, [debouncedSearch, resetPagination]);
 
-  // Use the space search hook for backend search
+  // Use the spaces search hook for backend search with URL/node support
   const {
     isSearchLoading,
     isSearchValidating,
     searchResultNodes,
-    total: totalNodesCount,
     nextPageCursor,
-  } = useSpaceSearch({
-    dataSourceViews: targetDataSourceViews,
-    disabled: !debouncedSearch,
-    includeDataSources: true,
-    pagination: { cursor: cursorPagination.cursor, limit: PAGE_SIZE },
-    owner,
-    search: debouncedSearch,
-    space,
-    viewType,
-  });
+  } = useSpacesSearch(
+    isNodeCandidate(nodeOrUrlCandidate)
+      ? {
+          // NodeIdSearchParams
+          nodeIds: nodeOrUrlCandidate.node ? [nodeOrUrlCandidate.node] : [],
+          includeDataSources: false,
+          owner,
+          viewType,
+          disabled: !nodeOrUrlCandidate.node && !debouncedSearch,
+          spaceIds: [space.sId],
+          pagination: { cursor: cursorPagination.cursor, limit: PAGE_SIZE },
+        }
+      : {
+          // TextSearchParams
+          search: debouncedSearch,
+          searchSourceUrls: isUrlCandidate(nodeOrUrlCandidate),
+          includeDataSources: true,
+          owner,
+          viewType,
+          disabled: !debouncedSearch,
+          spaceIds: [space.sId],
+          pagination: { cursor: cursorPagination.cursor, limit: PAGE_SIZE },
+        }
+  );
 
   const isLoading = isDebouncing || isSearchLoading || isSearchValidating;
 
   React.useEffect(() => {
+    // Process search results to convert them to DataSourceViewContentNode format
+    const processedResults = searchResultNodes.flatMap((node) => {
+      const { dataSourceViews, ...rest } = node;
+      return dataSourceViews.map((view) => ({
+        ...rest,
+        dataSourceView: view,
+      }));
+    });
+
+    // Filter results based on URL match if we have a URL candidate
+    const filteredResults =
+      nodeOrUrlCandidate && !isNodeCandidate(nodeOrUrlCandidate)
+        ? processedResults.filter(
+            (node) => node.sourceUrl === nodeOrUrlCandidate.url
+          )
+        : processedResults;
+
     if (tablePagination.pageIndex === 0) {
       // Replace results on new search (first page)
-      setSearchResults(searchResultNodes);
-    } else if (searchResultNodes.length > 0) {
+      setSearchResults(filteredResults);
+    } else if (filteredResults.length > 0) {
       // Append results for subsequent pages
-      setSearchResults((prev) => [...prev, ...searchResultNodes]);
+      setSearchResults((prev) => [...prev, ...filteredResults]);
     }
-  }, [searchResultNodes, tablePagination.pageIndex]);
+  }, [searchResultNodes, tablePagination.pageIndex, nodeOrUrlCandidate]);
 
   const handleLoadMore = React.useCallback(() => {
     if (nextPageCursor && !isSearchValidating) {
@@ -284,10 +334,10 @@ function BackendSearch({
   }, [shouldShowSearchResults, showSearch]);
 
   React.useEffect(() => {
-    if (totalNodesCount !== undefined && !isSearchValidating && !isLoading) {
-      setSearchHitCount(totalNodesCount);
+    if (!isSearchValidating && !isLoading) {
+      setSearchHitCount(searchResults.length);
     }
-  }, [isLoading, isSearchValidating, totalNodesCount]);
+  }, [isLoading, isSearchValidating, searchResults]);
   return (
     <SpaceSearchContext.Provider value={searchContextValue}>
       <SearchInput

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -33,7 +33,7 @@ import {
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
 import { useDataSourceViews } from "@app/lib/swr/data_source_views";
-import { useSpacesSearch } from "@app/lib/swr/spaces";
+import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import type {
   APIError,
   ContentNodesViewType,

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -242,6 +242,16 @@ function BackendSearch({
     resetPagination();
   }, [debouncedSearch, resetPagination]);
 
+  const commonSearchParams = {
+    owner,
+    viewType,
+    spaceIds: [space.sId],
+    pagination: { cursor: cursorPagination.cursor, limit: PAGE_SIZE },
+    // Required by search API to allow admins to search the system space
+    allowAdminSearch: true,
+    disabled: !debouncedSearch,
+  };
+
   // Use the spaces search hook for backend search with URL/node support
   const {
     isSearchLoading,
@@ -249,27 +259,17 @@ function BackendSearch({
     searchResultNodes,
     nextPageCursor,
   } = useSpacesSearch(
-    isNodeCandidate(nodeOrUrlCandidate)
+    isNodeCandidate(nodeOrUrlCandidate) && nodeOrUrlCandidate.node
       ? {
-          // NodeIdSearchParams
-          nodeIds: nodeOrUrlCandidate.node ? [nodeOrUrlCandidate.node] : [],
+          ...commonSearchParams,
+          nodeIds: [nodeOrUrlCandidate.node],
           includeDataSources: false,
-          owner,
-          viewType,
-          disabled: !nodeOrUrlCandidate.node && !debouncedSearch,
-          spaceIds: [space.sId],
-          pagination: { cursor: cursorPagination.cursor, limit: PAGE_SIZE },
         }
       : {
-          // TextSearchParams
+          ...commonSearchParams,
           search: debouncedSearch,
           searchSourceUrls: isUrlCandidate(nodeOrUrlCandidate),
           includeDataSources: true,
-          owner,
-          viewType,
-          disabled: !debouncedSearch,
-          spaceIds: [space.sId],
-          pagination: { cursor: cursorPagination.cursor, limit: PAGE_SIZE },
         }
   );
 

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -688,6 +688,7 @@ type BaseSearchParams = {
   spaceIds?: string[];
   viewType: ContentNodesViewType;
   pagination?: CursorPaginationParams;
+  allowAdminSearch?: boolean;
 };
 
 // Text search variant
@@ -716,6 +717,7 @@ export function useSpacesSearch({
   viewType,
   pagination,
   searchSourceUrls = false,
+  allowAdminSearch = false,
 }: SpacesSearchParams): {
   isSearchLoading: boolean;
   isSearchError: boolean;
@@ -741,6 +743,7 @@ export function useSpacesSearch({
     searchSourceUrls,
     spaceIds,
     viewType,
+    allowAdminSearch,
   };
 
   // Only perform a query if we have a valid search
@@ -787,6 +790,7 @@ export function useSpacesSearchWithInfiniteScroll({
   spaceIds,
   viewType,
   pageSize = 25,
+  allowAdminSearch = false,
 }: SpacesSearchParams & { pageSize?: number }): {
   isSearchLoading: boolean;
   isSearchError: boolean;
@@ -802,6 +806,7 @@ export function useSpacesSearchWithInfiniteScroll({
     spaceIds,
     includeDataSources,
     limit: pageSize,
+    allowAdminSearch,
   };
 
   // Only perform a query if we have a valid search


### PR DESCRIPTION
Description
---
Fixes issue from [this thread](https://dust4ai.slack.com/archives/C066R3PMUAU/p1742573825442299)

When an URL is detected as pasted in knowledge, search returns the document with said URL if it exists.

This is achieved by:
- during search debounce in the Knowledge search bar (from `front/components/spaces/SpaceSearchLayout.tsx`), check if a valid URL is typed;
- reuse `nodeCandidateUrl` from `front/lib/connectors.ts` to see if there's an URL match for our sources;
- adapt the state of `BackendSearch` and the `useSpaceSearch` call of `front/components/spaces/SpaceSearchLayout.tsx` so that when there is a `nodeOrUrlCandidate`, the search call returns the appropriate result---with inspiration from the similar `useSpaceSearch` call of  `front/components/assistant/conversation/input_bar/InputBarContainer.tsx`.

A follow-up PR will implement a similar behaviour for the builder search. We can also delete the useSpaceSearch (no s) hook then.

## Tests
local

## Risk
standard. introduces a new permission for useSpacesSearch, to double check

## Deploy Plan
front
