### PR TITLE
feat: start using agent step content for text contents

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -288,6 +288,10 @@ async function* runMultiActionsAgentLoop(
             type: event.content.type,
             value: event.content,
           });
+          agentMessage.contents.push({
+            step: i,
+            content: event.content,
+          });
           break;
 
         // Generation events

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -25,6 +25,7 @@ import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
+import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import {
   AgentMessage,
   Mention,
@@ -256,6 +257,11 @@ export async function getConversation(
           {
             model: AgentMessageContent,
             as: "agentMessageContents",
+            required: false,
+          },
+          {
+            model: AgentStepContentModel,
+            as: "agentStepContents",
             required: false,
           },
         ],
@@ -845,6 +851,7 @@ export async function* postUserMessage(
                   configuration,
                   rank: messageRow.rank,
                   skipToolsValidation: agentMessageRow.skipToolsValidation,
+                  contents: [],
                 } satisfies AgentMessageWithRankType,
               };
             })();
@@ -1360,6 +1367,7 @@ export async function* editUserMessage(
                 configuration,
                 rank: messageRow.rank,
                 skipToolsValidation: agentMessageRow.skipToolsValidation,
+                contents: [],
               } satisfies AgentMessageWithRankType,
             };
           })();
@@ -1611,6 +1619,7 @@ export async function* retryAgentMessage(
         configuration: message.configuration,
         rank: m.rank,
         skipToolsValidation: agentMessageRow.skipToolsValidation,
+        contents: [],
       };
 
       return {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -20,6 +20,7 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
+import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import {
   AgentMessage,
   Mention,
@@ -278,6 +279,13 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
             step: rc.step,
             content: rc.content,
           })) ?? [],
+        contents:
+          agentMessage.agentStepContents
+            ?.sort((a, b) => a.step - b.step || a.index - b.index)
+            .map((sc) => ({
+              step: sc.step,
+              content: sc.value,
+            })) ?? [],
         error,
         configuration: agentConfiguration,
         skipToolsValidation: agentMessage.skipToolsValidation,
@@ -413,6 +421,11 @@ async function fetchMessagesForPage(
           {
             model: AgentMessageContent,
             as: "agentMessageContents",
+            required: false,
+          },
+          {
+            model: AgentStepContentModel,
+            as: "agentStepContents",
             required: false,
           },
         ],

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -142,7 +142,7 @@ export async function renderConversationForModel(
         .map(([, step]) => step);
 
       if (excludeActions) {
-        // In Exclude Actions mode, we only render the last step that has content.
+        // In Exclude Actions mode, we only render the last step that has text content.
         const stepsWithContent = steps.filter((s) => s?.contents.length);
         if (stepsWithContent.length) {
           const lastStepWithContent =
@@ -151,6 +151,7 @@ export async function renderConversationForModel(
             role: "assistant",
             name: m.configuration.name,
             content: lastStepWithContent.contents.join("\n"),
+            contents: m.contents,
           } satisfies AssistantContentMessageTypeModel);
         }
       } else {
@@ -185,12 +186,14 @@ export async function renderConversationForModel(
               role: "assistant",
               function_calls: step.actions.map((s) => s.call),
               content: step.contents.join("\n"),
+              contents: m.contents,
             } satisfies AssistantFunctionCallMessageTypeModel);
           } else {
             messages.push({
               role: "assistant",
               content: step.contents.join("\n"),
               name: m.configuration.name,
+              contents: m.contents,
             } satisfies AssistantContentMessageTypeModel);
           }
 

--- a/front/lib/models/assistant/agent_step_content.ts
+++ b/front/lib/models/assistant/agent_step_content.ts
@@ -4,7 +4,7 @@ import { DataTypes } from "sequelize";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { AssistantContentItemType } from "@app/types/assistant/agent_message_content";
+import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 
 export class AgentStepContentModel extends WorkspaceAwareModel<AgentStepContentModel> {
   declare createdAt: CreationOptional<Date>;
@@ -13,8 +13,8 @@ export class AgentStepContentModel extends WorkspaceAwareModel<AgentStepContentM
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
   declare step: number;
   declare index: number;
-  declare type: AssistantContentItemType["type"];
-  declare value: AssistantContentItemType;
+  declare type: AgentContentItemType["type"];
+  declare value: AgentContentItemType;
 
   declare agentMessage?: NonAttribute<AgentMessage>;
 }

--- a/front/migrations/20250113_migrate_agent_message_contents_to_step_contents.ts
+++ b/front/migrations/20250113_migrate_agent_message_contents_to_step_contents.ts
@@ -1,0 +1,225 @@
+import { Op } from "sequelize";
+
+import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
+import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types";
+import type { TextContentType } from "@app/types/assistant/agent_message_content";
+
+async function migrateAgentMessageContentsToStepContents(
+  workspace: LightWorkspaceType,
+  { execute, logger }: { execute: boolean; logger: Logger }
+) {
+  let lastSeenAgentMessageId = 0;
+  const batchSize = 100; // Process 100 agent messages at a time
+  let totalMessagesProcessed = 0;
+  let totalContentsProcessed = 0;
+  let totalContentsCreated = 0;
+  let totalMessagesSkipped = 0;
+
+  logger.info({ workspaceId: workspace.sId }, "Starting migration");
+
+  for (;;) {
+    // Fetch agent messages that have content to migrate
+    const agentMessagesWithContent = await AgentMessage.findAll({
+      where: {
+        id: { [Op.gt]: lastSeenAgentMessageId },
+        workspaceId: workspace.id,
+      },
+      include: [
+        {
+          model: AgentMessageContent,
+          as: "agentMessageContents",
+          required: true, // Only get agent messages that have content
+          where: {
+            workspaceId: workspace.id,
+          },
+        },
+      ],
+      order: [["id", "ASC"]],
+      limit: batchSize,
+    });
+
+    if (agentMessagesWithContent.length === 0) {
+      break;
+    }
+
+    const agentMessageIds = agentMessagesWithContent.map((am) => am.id);
+
+    // Check which agent messages already have step contents
+    const existingStepContents = await AgentStepContentModel.findAll({
+      where: {
+        agentMessageId: { [Op.in]: agentMessageIds },
+        workspaceId: workspace.id,
+      },
+      attributes: ["agentMessageId"],
+      group: ["agentMessageId"],
+    });
+
+    // Create a set of agent message IDs that already have step contents
+    const agentMessagesWithStepContents = new Set(
+      existingStepContents.map((sc) => sc.agentMessageId)
+    );
+
+    // Process each agent message
+    for (const agentMessage of agentMessagesWithContent) {
+      totalMessagesProcessed++;
+
+      // Skip if this agent message already has step contents
+      if (agentMessagesWithStepContents.has(agentMessage.id)) {
+        totalMessagesSkipped++;
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            agentMessageId: agentMessage.id,
+            contentCount: agentMessage.agentMessageContents?.length || 0,
+          },
+          "Skipping agent message - already has step contents"
+        );
+        continue;
+      }
+
+      const messageContents = agentMessage.agentMessageContents || [];
+      totalContentsProcessed += messageContents.length;
+
+      if (messageContents.length > 0) {
+        // Sort contents by ID to ensure consistent ordering
+        const sortedContents = messageContents.sort((a, b) => a.id - b.id);
+
+        // Group contents by step to assign proper indices
+        const contentsByStep = new Map<number, AgentMessageContent[]>();
+        for (const content of sortedContents) {
+          const stepContents = contentsByStep.get(content.step) || [];
+          stepContents.push(content);
+          contentsByStep.set(content.step, stepContents);
+        }
+
+        // Prepare all step contents for this agent message
+        const stepContentsToCreate: Array<{
+          agentMessageId: number;
+          step: number;
+          index: number;
+          type: "text_content";
+          value: TextContentType;
+          workspaceId: number;
+          createdAt: Date;
+          updatedAt: Date;
+        }> = [];
+        for (const [, contents] of contentsByStep) {
+          // Sort contents within each step by ID and assign indices
+          const sortedStepContents = contents.sort((a, b) => a.id - b.id);
+
+          for (let index = 0; index < sortedStepContents.length; index++) {
+            const amc = sortedStepContents[index];
+            const textContent: TextContentType = {
+              type: "text_content",
+              value: amc.content,
+            };
+
+            stepContentsToCreate.push({
+              agentMessageId: amc.agentMessageId,
+              step: amc.step,
+              index, // Index based on order within the step
+              type: "text_content" as const,
+              value: textContent,
+              workspaceId: workspace.id,
+              createdAt: amc.createdAt,
+              updatedAt: amc.updatedAt,
+            });
+          }
+        }
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            agentMessageId: agentMessage.id,
+            toCreate: stepContentsToCreate.length,
+            execute,
+          },
+          "Step contents to create for agent message"
+        );
+
+        if (execute) {
+          // Bulk create all step contents for this agent message.
+          await AgentStepContentModel.bulkCreate(stepContentsToCreate);
+
+          totalContentsCreated += stepContentsToCreate.length;
+
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              agentMessageId: agentMessage.id,
+              created: stepContentsToCreate.length,
+            },
+            "Created step contents for agent message"
+          );
+        }
+      }
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        messagesInBatch: agentMessagesWithContent.length,
+        totalMessagesProcessed,
+        totalMessagesSkipped,
+        totalContentsProcessed,
+        totalContentsCreated,
+      },
+      "Completed batch"
+    );
+
+    lastSeenAgentMessageId =
+      agentMessagesWithContent[agentMessagesWithContent.length - 1].id;
+  }
+
+  return {
+    totalMessagesProcessed,
+    totalMessagesSkipped,
+    totalContentsProcessed,
+    totalContentsCreated,
+  };
+}
+
+async function migrateForWorkspace(
+  workspace: LightWorkspaceType,
+  { execute, logger }: { execute: boolean; logger: Logger }
+) {
+  logger.info(
+    { workspaceId: workspace.sId, execute },
+    "Starting workspace migration"
+  );
+
+  const {
+    totalMessagesProcessed,
+    totalMessagesSkipped,
+    totalContentsProcessed,
+    totalContentsCreated,
+  } = await migrateAgentMessageContentsToStepContents(workspace, {
+    execute,
+    logger,
+  });
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      totalMessagesProcessed,
+      totalMessagesSkipped,
+      totalContentsProcessed,
+      totalContentsCreated,
+    },
+    "Completed workspace migration"
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(
+    async (workspace) => {
+      await migrateForWorkspace(workspace, { execute, logger });
+    },
+    { concurrency: 5 }
+  );
+});

--- a/front/migrations/20250113_migrate_agent_message_contents_to_step_contents.ts
+++ b/front/migrations/20250113_migrate_agent_message_contents_to_step_contents.ts
@@ -407,7 +407,7 @@ function createFunctionCallContent(
   }
 }
 
-async function migrateAgentMessageContentsToStepContents(
+async function migrateAgentMessageContentsAndActionsToStepContents(
   workspace: LightWorkspaceType,
   { execute, logger }: { execute: boolean; logger: Logger }
 ) {
@@ -679,7 +679,7 @@ async function migrateForWorkspace(
     totalActionsProcessed,
     totalActionsCreated,
     actionTypeCounts,
-  } = await migrateAgentMessageContentsToStepContents(workspace, {
+  } = await migrateAgentMessageContentsAndActionsToStepContents(workspace, {
     execute,
     logger,
   });

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -18,25 +18,25 @@ export type FunctionCallContentType = {
   value: FunctionCallType;
 };
 
-export type AssistantContentItemType =
+export type AgentContentItemType =
   | TextContentType
   | ReasoningContentType
   | FunctionCallContentType;
 
 export function isTextContent(
-  content: AssistantContentItemType
+  content: AgentContentItemType
 ): content is TextContentType {
   return content.type === "text_content";
 }
 
 export function isReasoningContent(
-  content: AssistantContentItemType
+  content: AgentContentItemType
 ): content is ReasoningContentType {
   return content.type === "reasoning";
 }
 
 export function isFunctionCallContent(
-  content: AssistantContentItemType
+  content: AgentContentItemType
 ): content is FunctionCallContentType {
   return content.type === "function_call";
 }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -21,7 +21,7 @@ import type {
   AgentConfigurationStatus,
   LightAgentConfigurationType,
 } from "./agent";
-import type { AssistantContentItemType } from "./agent_message_content";
+import type { AgentContentItemType } from "./agent_message_content";
 
 /**
  * Mentions
@@ -208,7 +208,7 @@ export type AgentMessageType = BaseAgentMessageType & {
     step: number;
     content: string;
   }>;
-  contents: Array<{ step: number; content: AssistantContentItemType }>;
+  contents: Array<{ step: number; content: AgentContentItemType }>;
 };
 
 export type LightAgentMessageType = BaseAgentMessageType & {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -189,7 +189,6 @@ export type BaseAgentMessageType = {
   status: AgentMessageStatus;
   content: string | null;
   chainOfThought: string | null;
-  contents?: AssistantContentItemType[];
   error: {
     code: string;
     message: string;
@@ -209,6 +208,7 @@ export type AgentMessageType = BaseAgentMessageType & {
     step: number;
     content: string;
   }>;
+  contents: Array<{ step: number; content: AssistantContentItemType }>;
 };
 
 export type LightAgentMessageType = BaseAgentMessageType & {

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -1,4 +1,4 @@
-import type { AssistantContentItemType } from "@app/types/assistant/agent_message_content";
+import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 
 /**
  * Model rendering of conversations.
@@ -60,14 +60,14 @@ export interface AssistantFunctionCallMessageTypeModel {
   role: "assistant";
   content?: string;
   function_calls: FunctionCallType[];
-  contents?: Array<{ step: number; content: AssistantContentItemType }>;
+  contents?: Array<{ step: number; content: AgentContentItemType }>;
 }
 
 export interface AssistantContentMessageTypeModel {
   role: "assistant";
   name: string;
   content: string;
-  contents?: Array<{ step: number; content: AssistantContentItemType }>;
+  contents?: Array<{ step: number; content: AgentContentItemType }>;
 }
 
 // This is the output of one function call

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -1,3 +1,5 @@
+import type { AssistantContentItemType } from "@app/types/assistant/agent_message_content";
+
 /**
  * Model rendering of conversations.
  */
@@ -58,12 +60,14 @@ export interface AssistantFunctionCallMessageTypeModel {
   role: "assistant";
   content?: string;
   function_calls: FunctionCallType[];
+  contents?: Array<{ step: number; content: AssistantContentItemType }>;
 }
 
 export interface AssistantContentMessageTypeModel {
   role: "assistant";
   name: string;
   content: string;
+  contents?: Array<{ step: number; content: AssistantContentItemType }>;
 }
 
 // This is the output of one function call


### PR DESCRIPTION
## Description

- When available, `renderConversationForModel` will start using the data from `AgentStepContent` instead of `AgentMessageContents` to render the text content
- When not available, it will continue using the legacy table and log that it's using the legacy table
- I added a migration to backfill the existing step contents:
    - text contents are migrated using `AgentMessageContents` as source
    - function call contents are migrated from the various action models
- `renderConversationForModel`'s output now includes the `contents` array for agent messages when available

Once deployed and migrated, we should be ready to remove the legacy table entirely

## Tests

Extensive manual tests

## Risk

On the critical path for conversations

## Deploy Plan

Deploy front + run migration script