### PR TITLE
Fix Slack non-threaded message import

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -445,7 +445,8 @@ export async function syncNonThreadedChunk({
   connectorId,
   cursor,
   endTsMs,
-  ignoreApiCallLimit = false,
+  // Name is confusing, but kept to avoid breaking changes in Temporal activities.
+  ignoreMessageLimit = false,
   isBatchSync = false,
   maxTotalMessages = MAX_SYNC_NON_THREAD_MESSAGES,
   startTsMs,
@@ -457,7 +458,7 @@ export async function syncNonThreadedChunk({
   connectorId: ModelId;
   cursor?: string;
   endTsMs: number;
-  ignoreApiCallLimit?: boolean;
+  ignoreMessageLimit?: boolean;
   isBatchSync: boolean;
   maxTotalMessages?: number;
   startTsMs: number;
@@ -557,7 +558,7 @@ export async function syncNonThreadedChunk({
     nextCursor = c.response_metadata?.next_cursor;
 
     // Stop if we've made enough API calls for this chunk (unless ignoring limit).
-    if (!ignoreApiCallLimit && apiCallCount >= MAX_API_CALLS_PER_CHUNK) {
+    if (!ignoreMessageLimit && apiCallCount >= MAX_API_CALLS_PER_CHUNK) {
       logger.info(
         {
           apiCallCount,
@@ -774,7 +775,7 @@ export async function syncMultipleNonThreaded(
         connectorId,
         isBatchSync: true,
         // Ignore API call limit to process entire week as single chunk.
-        ignoreApiCallLimit: true,
+        ignoreMessageLimit: true,
         maxTotalMessages,
         weekStartTsMs: startTsMs,
         weekEndTsMs: weekEndTsMs,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes an actual issue around Slack non-threaded messages, the cursor was not properly passed following a refactoring in https://github.com/dust-tt/dust/pull/13354.

Also changed the logic of chunking to replace the message-based chunking with API call limits in Slack sync
- Change from MAX_MESSAGES_PER_CHUNK to MAX_API_CALLS_PER_CHUNK (20)
- More robust as Slack rate limit is pretty aggressive and previous chunking was being applied filtered messages which  reduce count but API calls remain high

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
