### PR TITLE
fix: Add global agents to run_agent selection dropdown

### DIFF
--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -12,7 +12,6 @@ import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { ConfigurationSectionContainer } from "@app/components/assistant_builder/actions/configuration/ConfigurationSectionContainer";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import type { LightWorkspaceType } from "@app/types";
-import { isGlobalAgentId } from "@app/types";
 
 interface ChildAgentSelectorProps {
   owner: LightWorkspaceType;
@@ -108,8 +107,7 @@ export function ChildAgentConfigurationSection({
               <AssistantPicker
                 owner={owner}
                 assistants={agentConfigurations.filter(
-                  (agent) =>
-                    agent.sId !== selectedAgentId && !isGlobalAgentId(agent.sId)
+                  (agent) => agent.sId !== selectedAgentId
                 )}
                 onItemClick={(agent) => {
                   onAgentSelect(agent.sId);
@@ -132,9 +130,7 @@ export function ChildAgentConfigurationSection({
           <div className="flex h-full w-full items-center justify-center">
             <AssistantPicker
               owner={owner}
-              assistants={agentConfigurations.filter(
-                (agent) => !isGlobalAgentId(agent.sId)
-              )}
+              assistants={agentConfigurations}
               onItemClick={(agent) => {
                 onAgentSelect(agent.sId);
               }}


### PR DESCRIPTION
Resolves #13432

## Summary

This PR adds support for selecting global agents (like dust, claude-4-sonnet, etc.) in the run_agent agent builder configuration.

## Changes
- Removed global agent filtering in `ChildAgentConfigurationSection.tsx`
- Global agents now appear alongside custom agents in the selection dropdown
- Removed unused `isGlobalAgentId` import

## Testing
- TypeScript checks pass
- Code formatting verified

Generated with [Claude Code](https://claude.ai/code)