### PR TITLE
Fix: cannot edit uploaded table

### DIFF
--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -108,7 +108,7 @@ export const TableUploadOrEditModal = ({
           upsertRes = await doUpdate({
             name: table.name,
             description: table.description,
-            truncate: true,
+            truncate: false,
             title: table.name,
             mimeType: "text/csv",
             sourceUrl: null,


### PR DESCRIPTION
## Description

When editing an upload table metadata without replacing content, the truncate flag must be false otherwise it raise an error in the backend.

## Tests

Local

## Risk

None

## Deploy Plan

Deploy front