### PR TITLE
[front] Autojoin switch use legacy domains table, enforce sso

### DIFF
--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -81,9 +81,8 @@ export default function RootLayout({
               isAPIErrorResponse(error) &&
               error.error.type === "not_authenticated"
             ) {
-              console.log("not_authenticated", error);
               // Redirect to login page.
-              // await router.push("/api/auth/login");
+              await router.push("/api/auth/login");
             }
           },
         }}

--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -81,8 +81,9 @@ export default function RootLayout({
               isAPIErrorResponse(error) &&
               error.error.type === "not_authenticated"
             ) {
+              console.log("not_authenticated", error);
               // Redirect to login page.
-              await router.push("/api/auth/login");
+              // await router.push("/api/auth/login");
             }
           },
         }}

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -15,12 +15,12 @@ import type {
 
 export function WorkspaceInfoTable({
   owner,
-  workspaceVerifiedDomain,
+  workspaceVerifiedDomains,
   worspaceCreationDay,
   extensionConfig,
 }: {
   owner: WorkspaceType;
-  workspaceVerifiedDomain: WorkspaceDomain | null;
+  workspaceVerifiedDomains: WorkspaceDomain[];
   worspaceCreationDay: string;
   extensionConfig: ExtensionConfigurationType | null;
 }) {
@@ -63,9 +63,17 @@ export function WorkspaceInfoTable({
             <PokeTableRow>
               <PokeTableCell>Auto Join</PokeTableCell>
               <PokeTableCell>
-                {workspaceVerifiedDomain?.domainAutoJoinEnabled ? "✅" : "❌"}
+                {workspaceVerifiedDomains.every((d) => d.domainAutoJoinEnabled)
+                  ? "✅"
+                  : workspaceVerifiedDomains.some(
+                        (d) => d.domainAutoJoinEnabled
+                      )
+                    ? "⚠️"
+                    : "❌"}
               </PokeTableCell>
-              <PokeTableCell>{workspaceVerifiedDomain?.domain}</PokeTableCell>
+              <PokeTableCell>
+                {workspaceVerifiedDomains.map((d) => d.domain).join(", ")}
+              </PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell className="max-w-48">

--- a/front/components/workspace/SSOConnection.tsx
+++ b/front/components/workspace/SSOConnection.tsx
@@ -1,10 +1,9 @@
 import type { Organization } from "@workos-inc/node";
 
 import Auth0SSOConnection from "@app/components/workspace/sso/Auth0SSOConnection";
-import { AutoJoinToggle } from "@app/components/workspace/sso/AutoJoinToggle";
 import WorkOSSSOConnection from "@app/components/workspace/sso/WorkOSSSOConnection";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { PlanType, WorkspaceDomain, WorkspaceType } from "@app/types";
+import type { PlanType, WorkspaceType } from "@app/types";
 
 export interface EnterpriseConnectionStrategyDetails {
   callbackUrl: string;

--- a/front/components/workspace/SSOConnection.tsx
+++ b/front/components/workspace/SSOConnection.tsx
@@ -1,9 +1,10 @@
 import type { Organization } from "@workos-inc/node";
 
 import Auth0SSOConnection from "@app/components/workspace/sso/Auth0SSOConnection";
+import { AutoJoinToggle } from "@app/components/workspace/sso/AutoJoinToggle";
 import WorkOSSSOConnection from "@app/components/workspace/sso/WorkOSSSOConnection";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { PlanType, WorkspaceType } from "@app/types";
+import type { PlanType, WorkspaceDomain, WorkspaceType } from "@app/types";
 
 export interface EnterpriseConnectionStrategyDetails {
   callbackUrl: string;
@@ -39,16 +40,14 @@ export default function SSOConnection({
     return null;
   }
 
-  if (!hasWorkOSSSOFeatureFlag) {
-    return (
-      <Auth0SSOConnection
-        domains={domains}
-        owner={owner}
-        plan={plan}
-        strategyDetails={strategyDetails}
-      />
-    );
-  }
-
-  return <WorkOSSSOConnection domains={domains} owner={owner} plan={plan} />;
+  return !hasWorkOSSSOFeatureFlag ? (
+    <Auth0SSOConnection
+      domains={domains}
+      owner={owner}
+      plan={plan}
+      strategyDetails={strategyDetails}
+    />
+  ) : (
+    <WorkOSSSOConnection domains={domains} owner={owner} plan={plan} />
+  );
 }

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -9,11 +9,13 @@ import {
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import type { CellContext } from "@tanstack/react-table";
 import type { Organization } from "@workos-inc/node";
 import React from "react";
 
 import { ConfirmContext } from "@app/components/Confirm";
 import UserProvisioning from "@app/components/workspace/DirectorySync";
+import { AutoJoinToggle } from "@app/components/workspace/sso/AutoJoinToggle";
 import type { EnterpriseConnectionStrategyDetails } from "@app/components/workspace/SSOConnection";
 import SSOConnection from "@app/components/workspace/SSOConnection";
 import {
@@ -21,16 +23,18 @@ import {
   useWorkspaceDomains,
 } from "@app/lib/swr/workos";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { LightWorkspaceType, PlanType } from "@app/types";
+import type { LightWorkspaceType, PlanType, WorkspaceDomain } from "@app/types";
 
 interface WorkspaceAccessPanelProps {
   enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails;
+  workspaceVerifiedDomains: WorkspaceDomain[];
   owner: LightWorkspaceType;
   plan: PlanType;
 }
 
 export default function WorkspaceAccessPanel({
   enterpriseConnectionStrategyDetails,
+  workspaceVerifiedDomains,
   owner,
   plan,
 }: WorkspaceAccessPanelProps) {
@@ -48,15 +52,22 @@ export default function WorkspaceAccessPanel({
       <DomainVerification
         addDomainLink={addDomainLink}
         domains={domains}
+        workspaceVerifiedDomains={workspaceVerifiedDomains}
         isDomainsLoading={isDomainsLoading}
         owner={owner}
       />
       <Separator />
       <SSOConnection
         domains={domains}
-        owner={owner}
         plan={plan}
         strategyDetails={enterpriseConnectionStrategyDetails}
+        owner={owner}
+      />
+      <AutoJoinToggle
+        domains={domains}
+        workspaceVerifiedDomains={workspaceVerifiedDomains}
+        owner={owner}
+        plan={plan}
       />
       {hasWorkOSUserProvisioningFeature && <Separator />}
       {hasWorkOSUserProvisioningFeature && (
@@ -69,6 +80,7 @@ export default function WorkspaceAccessPanel({
 interface DomainVerificationProps {
   addDomainLink?: string;
   domains: Organization["domains"];
+  workspaceVerifiedDomains: WorkspaceDomain[];
   isDomainsLoading: boolean;
   owner: LightWorkspaceType;
 }
@@ -76,6 +88,7 @@ interface DomainVerificationProps {
 function DomainVerification({
   addDomainLink,
   domains,
+  workspaceVerifiedDomains,
   isDomainsLoading,
   owner,
 }: DomainVerificationProps) {
@@ -96,6 +109,7 @@ function DomainVerification({
           addDomainLink={addDomainLink}
           domains={domains}
           owner={owner}
+          workspaceVerifiedDomains={workspaceVerifiedDomains}
         />
       )}
     </div>
@@ -105,6 +119,7 @@ function DomainVerification({
 interface DomainVerificationTableProps {
   addDomainLink?: string;
   domains: Organization["domains"];
+  workspaceVerifiedDomains: WorkspaceDomain[];
   owner: LightWorkspaceType;
 }
 
@@ -114,15 +129,16 @@ interface DomainRowData {
   status: string;
   onClick?: () => void;
   moreMenuItems?: any[];
+  workspaceVerifiedDomain?: WorkspaceDomain;
 }
 
 function DomainVerificationTable({
   addDomainLink,
   domains,
+  workspaceVerifiedDomains,
   owner,
 }: DomainVerificationTableProps) {
   const confirm = React.useContext(ConfirmContext);
-
   const { doRemoveWorkspaceDomain } = useRemoveWorkspaceDomain({ owner });
 
   const handleDeleteDomain = React.useCallback(
@@ -154,33 +170,34 @@ function DomainVerificationTable({
         header: "Domain",
         accessorKey: "domain",
         classname: "text-xs font-medium",
-        cell: ({ row }: { row: { original: DomainRowData } }) => {
+        cell: ({ row }: CellContext<DomainRowData, string>) => {
           return `@${row.original.domain}`;
         },
       },
       {
         header: "Status",
         accessorKey: "status",
-        cell: ({ getValue }: { getValue: () => string }) => {
+        cell: ({ getValue, row }: CellContext<DomainRowData, string>) => {
           const status = getValue();
+          const workspaceVerifiedDomain = row.original.workspaceVerifiedDomain;
           let chipColor: "success" | "info" | "rose" = "info";
-
-          if (status === "verified" || status === "legacy_verified") {
+          let label: string = "Pending";
+          if (workspaceVerifiedDomain && status === "verified") {
             chipColor = "success";
+            label = "Verified";
           } else if (status === "failed") {
             chipColor = "rose";
-          } else if (status === "pending") {
-            chipColor = "info";
+            label = "Failed";
           }
 
-          return <Chip color={chipColor} label={status} size="xs" />;
+          return <Chip color={chipColor} label={label} size="xs" />;
         },
       },
       {
         header: "",
         accessorKey: "actions",
         meta: { className: "w-14" },
-        cell: ({ row }: { row: { original: DomainRowData } }) => {
+        cell: ({ row }: CellContext<DomainRowData, string>) => {
           return (
             <IconButton
               icon={XMarkIcon}
@@ -200,20 +217,25 @@ function DomainVerificationTable({
     return domains.map((domain) => ({
       domain: domain.domain,
       status: domain.state,
+      workspaceVerifiedDomain: workspaceVerifiedDomains.find(
+        (d) => d.domain === domain.domain
+      ),
     }));
-  }, [domains]);
+  }, [domains, workspaceVerifiedDomains]);
 
   return (
     <div className="flex w-auto flex-col gap-6">
       <DataTable className="pt-6" columns={columns} data={data} />
       {addDomainLink && (
-        <Button
-          label="Add Domain"
-          variant="primary"
-          href={addDomainLink}
-          target="_blank"
-          icon={PlusIcon}
-        />
+        <div>
+          <Button
+            label="Add Domain"
+            variant="primary"
+            href={addDomainLink}
+            target="_blank"
+            icon={PlusIcon}
+          />
+        </div>
       )}
     </div>
   );

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -108,8 +108,8 @@ function DomainVerification({
         <DomainVerificationTable
           addDomainLink={addDomainLink}
           domains={domains}
-          owner={owner}
           workspaceVerifiedDomains={workspaceVerifiedDomains}
+          owner={owner}
         />
       )}
     </div>
@@ -126,10 +126,10 @@ interface DomainVerificationTableProps {
 // Define the row data type that extends TBaseData
 interface DomainRowData {
   domain: string;
+  workspaceVerifiedDomain?: WorkspaceDomain;
   status: string;
   onClick?: () => void;
   moreMenuItems?: any[];
-  workspaceVerifiedDomain?: WorkspaceDomain;
 }
 
 function DomainVerificationTable({

--- a/front/components/workspace/sso/Auth0SSOConnection.tsx
+++ b/front/components/workspace/sso/Auth0SSOConnection.tsx
@@ -26,6 +26,7 @@ import {
 import type { Organization } from "@workos-inc/node";
 import React from "react";
 
+import { ToggleEnforceEnterpriseConnectionModal } from "@app/components/workspace/sso/Toggle";
 import type { EnterpriseConnectionStrategyDetails } from "@app/components/workspace/SSOConnection";
 import { UpgradePlanDialog } from "@app/components/workspace/UpgradePlanDialog";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
@@ -757,94 +758,6 @@ function CreateEnterpriseConnectionModal({
         </SheetContainer>
       </SheetContent>
     </Sheet>
-  );
-}
-
-function ToggleEnforceEnterpriseConnectionModal({
-  isOpen,
-  onClose,
-  owner,
-}: {
-  isOpen: boolean;
-  onClose: (updated: boolean) => void;
-  owner: WorkspaceType;
-}) {
-  const sendNotification = useSendNotification();
-
-  const titleAndContent = {
-    enforce: {
-      title: "Enable Single Sign On Enforcement",
-      content: `
-        By enforcing SSO, access through social media logins will be discontinued.
-        Instead, you'll be directed to sign in via the SSO portal.
-        Please note, this change will require all users to sign out and reconnect using SSO.
-      `,
-      validateLabel: "Enforce Single Sign On",
-    },
-    remove: {
-      title: "Disable Single Sign On Enforcement",
-      content: `By disabling SSO enforcement, users will have the flexibility to login with social media.`,
-      validateLabel: "Disable Single Sign-On Enforcement",
-    },
-  };
-
-  const handleToggleSsoEnforced = React.useCallback(
-    async (ssoEnforced: boolean) => {
-      const res = await fetch(`/api/w/${owner.sId}`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          ssoEnforced,
-        }),
-      });
-
-      if (!res.ok) {
-        sendNotification({
-          type: "error",
-          title: "Update failed",
-          description: `Failed to enforce sso on workspace.`,
-        });
-      } else {
-        onClose(true);
-      }
-    },
-    [owner, sendNotification, onClose]
-  );
-
-  const dialog = titleAndContent[owner.ssoEnforced ? "remove" : "enforce"];
-
-  return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose(false);
-        }
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{dialog.title}</DialogTitle>
-        </DialogHeader>
-        <DialogContainer>{dialog.content}</DialogContainer>
-        <DialogFooter
-          leftButtonProps={{
-            label: "Cancel",
-            variant: "outline",
-            onClick: () => onClose(false),
-          }}
-          rightButtonProps={{
-            label: dialog.validateLabel,
-            variant: "warning",
-            onClick: async () => {
-              await handleToggleSsoEnforced(!owner.ssoEnforced);
-            },
-          }}
-        />
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/front/components/workspace/sso/AutoJoinToggle.tsx
+++ b/front/components/workspace/sso/AutoJoinToggle.tsx
@@ -16,19 +16,21 @@ import { UpgradePlanDialog } from "@app/components/workspace/UpgradePlanDialog";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import type { PlanType, WorkspaceDomain, WorkspaceType } from "@app/types";
 
+type DomainAutoJoinModalProps = {
+  domains: Organization["domains"];
+  domainAutoJoinEnabled: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+  owner: WorkspaceType;
+};
+
 function DomainAutoJoinModal({
   domains,
   domainAutoJoinEnabled,
   isOpen,
   onClose,
   owner,
-}: {
-  domains: Organization["domains"];
-  domainAutoJoinEnabled: boolean;
-  isOpen: boolean;
-  onClose: () => void;
-  owner: WorkspaceType;
-}) {
+}: DomainAutoJoinModalProps) {
   const sendNotification = useSendNotification();
   const title = domainAutoJoinEnabled
     ? "De-activate Auto-join"

--- a/front/components/workspace/sso/AutoJoinToggle.tsx
+++ b/front/components/workspace/sso/AutoJoinToggle.tsx
@@ -1,0 +1,196 @@
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Page,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import type { Organization } from "@workos-inc/node";
+import { useState } from "react";
+
+import { UpgradePlanDialog } from "@app/components/workspace/UpgradePlanDialog";
+import { isUpgraded } from "@app/lib/plans/plan_codes";
+import type { PlanType, WorkspaceDomain, WorkspaceType } from "@app/types";
+
+function DomainAutoJoinModal({
+  domains,
+  domainAutoJoinEnabled,
+  isOpen,
+  onClose,
+  owner,
+}: {
+  domains: Organization["domains"];
+  domainAutoJoinEnabled: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+  owner: WorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const title = domainAutoJoinEnabled
+    ? "De-activate Auto-join"
+    : "Activate Auto-join";
+  const validateLabel = domainAutoJoinEnabled ? "De-activate" : "Activate";
+  const validateVariant = domainAutoJoinEnabled ? "warning" : "primary";
+  const description = domainAutoJoinEnabled ? (
+    "New members will need to be invited in order to gain access to your Dust Workspace."
+  ) : (
+    <span>
+      Anyone with Google{" "}
+      <span className="font-bold">
+        {domains.map((d) => `"@${d.domain}"`).join(", ")}
+      </span>{" "}
+      account will have access to your Dust Workspace.
+    </span>
+  );
+
+  async function handleUpdateWorkspace(): Promise<void> {
+    const res = await fetch(`/api/w/${owner.sId}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        domainAutoJoinEnabled: !domainAutoJoinEnabled,
+      }),
+    });
+
+    if (!res.ok) {
+      sendNotification({
+        type: "error",
+        title: "Update failed",
+        description: `Failed to enable auto-add for whitelisted domain.`,
+      });
+    } else {
+      // We perform a full refresh so that the Workspace name updates and we get a fresh owner
+      // object so that the formValidation logic keeps working.
+      window.location.reload();
+    }
+  }
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md" isAlertDialog>
+        <DialogHeader hideButton>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>{description}</DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: validateLabel,
+            variant: validateVariant,
+            onClick: async () => {
+              await handleUpdateWorkspace();
+              onClose();
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type AutoJoinToggleProps = {
+  domains: Organization["domains"];
+  workspaceVerifiedDomains: WorkspaceDomain[];
+  owner: WorkspaceType;
+  plan: PlanType;
+};
+
+export function AutoJoinToggle({
+  domains,
+  workspaceVerifiedDomains,
+  owner,
+  plan,
+}: AutoJoinToggleProps) {
+  const [showUpgradePlanDialog, setShowUpgradePlanDialog] = useState(false);
+  const [isActivateAutoJoinOpened, setIsActivateAutoJoinOpened] =
+    useState(false);
+  const domainAutoJoinEnabled = workspaceVerifiedDomains.every(
+    (d) => d.domainAutoJoinEnabled
+  );
+
+  return (
+    <>
+      <DomainAutoJoinModal
+        domainAutoJoinEnabled={domainAutoJoinEnabled}
+        isOpen={isActivateAutoJoinOpened}
+        onClose={() => {
+          setIsActivateAutoJoinOpened(false);
+        }}
+        domains={domains}
+        owner={owner}
+      />
+      <UpgradePlanDialog
+        isOpen={showUpgradePlanDialog}
+        onClose={() => setShowUpgradePlanDialog(false)}
+        workspaceId={owner.sId}
+        title="Free plan"
+        description="You cannot enable auto-join with the free plan. Upgrade your plan to invite other members."
+      />
+      <Page.Vertical>
+        <div className="flex w-full flex-row items-center gap-2">
+          <div className="flex-1">
+            <div className="flex flex-row items-center gap-2">
+              <Page.H variant="h5">Auto-join Workspace</Page.H>
+            </div>
+            <Page.P variant="secondary">
+              Allow your team members to access your Dust workspace when they
+              authenticate with a{" "}
+              {domains.map((d) => `"@${d.domain}"`).join(", ")} accounts.
+            </Page.P>
+          </div>
+          <div className="flex justify-end">
+            {domainAutoJoinEnabled ? (
+              <Button
+                label="De-activate Auto-join"
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  if (isUpgraded(plan)) {
+                    setIsActivateAutoJoinOpened(true);
+                  } else {
+                    setShowUpgradePlanDialog(true);
+                  }
+                }}
+              />
+            ) : (
+              <Button
+                label="Activate Auto-join"
+                size="sm"
+                variant="primary"
+                tooltip={
+                  domains.length === 0
+                    ? "Add a domain to enable Auto-join"
+                    : undefined
+                }
+                disabled={!domains.length}
+                onClick={() => {
+                  if (isUpgraded(plan)) {
+                    setIsActivateAutoJoinOpened(true);
+                  } else {
+                    setShowUpgradePlanDialog(true);
+                  }
+                }}
+              />
+            )}
+          </div>
+        </div>
+      </Page.Vertical>
+    </>
+  );
+}

--- a/front/components/workspace/sso/Toggle.tsx
+++ b/front/components/workspace/sso/Toggle.tsx
@@ -1,0 +1,100 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+import type { WorkspaceType } from "@app/types";
+
+export function ToggleEnforceEnterpriseConnectionModal({
+  isOpen,
+  onClose,
+  owner,
+}: {
+  isOpen: boolean;
+  onClose: (updated: boolean) => void;
+  owner: WorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  const titleAndContent = {
+    enforce: {
+      title: "Enable Single Sign On Enforcement",
+      content: `
+          By enforcing SSO, access through social media logins will be discontinued.
+          Instead, you'll be directed to sign in via the SSO portal.
+          Please note, this change will require all users to sign out and reconnect using SSO.
+        `,
+      validateLabel: "Enforce Single Sign On",
+    },
+    remove: {
+      title: "Disable Single Sign On Enforcement",
+      content: `By disabling SSO enforcement, users will have the flexibility to login with social media.`,
+      validateLabel: "Disable Single Sign-On Enforcement",
+    },
+  };
+
+  const handleToggleSsoEnforced = React.useCallback(
+    async (ssoEnforced: boolean) => {
+      const res = await fetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ssoEnforced,
+        }),
+      });
+
+      if (!res.ok) {
+        sendNotification({
+          type: "error",
+          title: "Update failed",
+          description: `Failed to enforce sso on workspace.`,
+        });
+      } else {
+        onClose(true);
+      }
+    },
+    [owner, sendNotification, onClose]
+  );
+
+  const dialog = titleAndContent[owner.ssoEnforced ? "remove" : "enforce"];
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose(false);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{dialog.title}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>{dialog.content}</DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: () => onClose(false),
+          }}
+          rightButtonProps={{
+            label: dialog.validateLabel,
+            variant: "warning",
+            onClick: async () => {
+              await handleToggleSsoEnforced(!owner.ssoEnforced);
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/workspace/sso/WorkOSSSOConnection.tsx
+++ b/front/components/workspace/sso/WorkOSSSOConnection.tsx
@@ -110,6 +110,7 @@ export default function WorkOSSSOConnection({
           </div>
         )}
       </div>
+      {/* TODO(workos): Remove this once we have a clear way to enforce SSO with workos */}
       {isSSOConfigured ? (
         <div className="w-full space-y-4">
           <div className="flex flex-col space-y-4">

--- a/front/components/workspace/sso/WorkOSSSOConnection.tsx
+++ b/front/components/workspace/sso/WorkOSSSOConnection.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Checkbox,
   Chip,
   Dialog,
   DialogContainer,
@@ -7,12 +8,14 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Label,
   Page,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { Organization } from "@workos-inc/node";
 import React from "react";
 
+import { ToggleEnforceEnterpriseConnectionModal } from "@app/components/workspace/sso/Toggle";
 import { UpgradePlanDialog } from "@app/components/workspace/UpgradePlanDialog";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import {
@@ -38,6 +41,10 @@ export default function WorkOSSSOConnection({
   const [
     showDisableWorkOSSSOConnectionModal,
     setShowDisableWorkOSSSOConnectionModal,
+  ] = React.useState(false);
+  const [
+    isToggleEnforceEnterpriseConnectionModalOpened,
+    setIsToggleEnforceEnterpriseConnectionModalOpened,
   ] = React.useState(false);
 
   const { ssoStatus, isLoading: isLoadingSSO } = useWorkOSSSOStatus({ owner });
@@ -103,6 +110,29 @@ export default function WorkOSSSOConnection({
           </div>
         )}
       </div>
+      {isSSOConfigured ? (
+        <div className="w-full space-y-4">
+          <div className="flex flex-col space-y-4">
+            <div className="flex flex-row items-center space-x-2">
+              <Checkbox
+                id="sso-enforced"
+                checked={owner.ssoEnforced}
+                onClick={async () => {
+                  setIsToggleEnforceEnterpriseConnectionModalOpened(true);
+                }}
+              />
+              <Label htmlFor="sso-enforced" className="text-md font-normal">
+                Enforce SSO login
+              </Label>
+            </div>
+            <Page.P variant="secondary">
+              When SSO is enforced, users will no longer be able to use social
+              logins and will be redirected to the SSO portal.
+            </Page.P>
+          </div>
+        </div>
+      ) : null}
+
       <UpgradePlanDialog
         isOpen={showUpgradePlanDialog}
         onClose={() => setShowUpgradePlanDialog(false)}
@@ -110,6 +140,20 @@ export default function WorkOSSSOConnection({
         title="Free plan"
         description="You cannot enable SSO with the free plan. Upgrade your plan to access SSO features."
       />
+      <ToggleEnforceEnterpriseConnectionModal
+        isOpen={isToggleEnforceEnterpriseConnectionModalOpened}
+        onClose={async (updated: boolean) => {
+          setIsToggleEnforceEnterpriseConnectionModalOpened(false);
+
+          if (updated) {
+            // We perform a full refresh so that the Workspace name updates and we get a fresh owner
+            // object so that the formValidation logic keeps working.
+            window.location.reload();
+          }
+        }}
+        owner={owner}
+      />
+
       <DisableWorkOSSSOConnectionModal
         isOpen={showDisableWorkOSSSOConnectionModal}
         onClose={() => setShowDisableWorkOSSSOConnectionModal(false)}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -58,26 +58,24 @@ export async function getWorkspaceInfos(
   return renderLightWorkspaceType({ workspace });
 }
 
-export async function getWorkspaceVerifiedDomain(
+export async function getWorkspaceVerifiedDomains(
   workspace: LightWorkspaceType
-): Promise<WorkspaceDomain | null> {
-  const workspaceDomain = await WorkspaceHasDomainModel.findOne({
+): Promise<WorkspaceDomain[]> {
+  const workspaceDomains = await WorkspaceHasDomainModel.findAll({
     attributes: ["domain", "domainAutoJoinEnabled"],
     where: {
       workspaceId: workspace.id,
     },
-    // For now, one workspace can only have one domain.
-    limit: 1,
   });
 
-  if (workspaceDomain) {
-    return {
-      domain: workspaceDomain.domain,
-      domainAutoJoinEnabled: workspaceDomain.domainAutoJoinEnabled,
-    };
+  if (workspaceDomains) {
+    return workspaceDomains.map((domain) => ({
+      domain: domain.domain,
+      domainAutoJoinEnabled: domain.domainAutoJoinEnabled,
+    }));
   }
 
-  return null;
+  return [];
 }
 
 export async function removeAllWorkspaceDomains(

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -3,7 +3,7 @@ import type { FindOptions, Order, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -39,7 +39,7 @@ export type PokeWorkspaceType = LightWorkspaceType & {
   adminEmail: string | null;
   membersCount: number;
   dataSourcesCount: number;
-  workspaceDomain: WorkspaceDomain | null;
+  workspaceDomains: WorkspaceDomain[];
 };
 
 export type GetPokeWorkspacesResponseBody = {
@@ -314,8 +314,8 @@ async function handler(
                 activeOnly: true,
               });
 
-            const verifiedDomain =
-              await getWorkspaceVerifiedDomain(lightWorkspace);
+            const verifiedDomains =
+              await getWorkspaceVerifiedDomains(lightWorkspace);
 
             return {
               ...lightWorkspace,
@@ -324,7 +324,7 @@ async function handler(
               adminEmail: firstAdmin?.email ?? null,
               membersCount,
               dataSourcesCount,
-              workspaceDomain: verifiedDomain,
+              workspaceDomains: verifiedDomains,
             };
           })
         ),

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -2,7 +2,7 @@ import type { GetWorkspaceVerifiedDomainsResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -31,13 +31,11 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const verifiedDomain = await getWorkspaceVerifiedDomain(
+      const verifiedDomains = await getWorkspaceVerifiedDomains(
         auth.getNonNullableWorkspace()
       );
 
-      return res
-        .status(200)
-        .json({ verified_domains: verifiedDomain ? [verifiedDomain] : [] });
+      return res.status(200).json({ verified_domains: verifiedDomains });
 
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/enterprise-connection.ts
+++ b/front/pages/api/w/[wId]/enterprise-connection.ts
@@ -142,6 +142,7 @@ async function handler(
       }
       const { right: body } = bodyValidation;
 
+      //TODO(workos): handle multiple domains
       const workspaceWithVerifiedDomain = await WorkspaceHasDomainModel.findOne(
         {
           where: {

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -25,7 +25,7 @@ const WorkspaceSsoEnforceUpdateBodySchema = t.type({
 });
 
 const WorkspaceAllowedDomainUpdateBodySchema = t.type({
-  domain: t.string,
+  domain: t.union([t.string, t.undefined]),
   domainAutoJoinEnabled: t.boolean,
 });
 
@@ -127,7 +127,7 @@ async function handler(
           {
             where: {
               workspaceId: w.id,
-              domain,
+              ...(domain ? { domain } : {}),
             },
           }
         );

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -32,7 +32,7 @@ import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
 import config from "@app/lib/api/config";
 import {
   getWorkspaceCreationDate,
-  getWorkspaceVerifiedDomain,
+  getWorkspaceVerifiedDomains,
 } from "@app/lib/api/workspace";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
@@ -59,7 +59,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   registry: ActionRegistry;
   subscriptions: SubscriptionType[];
   whitelistableFeatures: WhitelistableFeature[];
-  workspaceVerifiedDomain: WorkspaceDomain | null;
+  workspaceVerifiedDomains: WorkspaceDomain[];
   worspaceCreationDay: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -91,7 +91,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     })
   );
 
-  const workspaceVerifiedDomain = await getWorkspaceVerifiedDomain(owner);
+  const workspaceVerifiedDomains = await getWorkspaceVerifiedDomains(owner);
   const worspaceCreationDate = await getWorkspaceCreationDate(owner.sId);
 
   const extensionConfig =
@@ -105,7 +105,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       whitelistableFeatures:
         WHITELISTABLE_FEATURES as unknown as WhitelistableFeature[],
       registry: getDustProdActionRegistry(),
-      workspaceVerifiedDomain,
+      workspaceVerifiedDomains,
       worspaceCreationDay: format(worspaceCreationDate, "yyyy-MM-dd"),
       extensionConfig: extensionConfig?.toJSON() ?? null,
       baseUrl: config.getClientFacingUrl(),
@@ -119,7 +119,7 @@ const WorkspacePage = ({
   subscriptions,
   whitelistableFeatures,
   registry,
-  workspaceVerifiedDomain,
+  workspaceVerifiedDomains,
   worspaceCreationDay,
   extensionConfig,
   baseUrl,
@@ -200,7 +200,7 @@ const WorkspacePage = ({
             <div className="mt-4 flex flex-col space-x-3 lg:flex-row">
               <WorkspaceInfoTable
                 owner={owner}
-                workspaceVerifiedDomain={workspaceVerifiedDomain}
+                workspaceVerifiedDomains={workspaceVerifiedDomains}
                 worspaceCreationDay={worspaceCreationDay}
                 extensionConfig={extensionConfig}
               />

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -55,8 +55,10 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
                 <PokeTableRow>
                   <PokeTableCell className="max-w-[200px] overflow-hidden text-ellipsis">
                     {ws.adminEmail}{" "}
-                    {ws.workspaceDomain && (
-                      <label>({ws.workspaceDomain.domain})</label>
+                    {ws.workspaceDomains && (
+                      <label>
+                        ({ws.workspaceDomains.map((d) => d.domain).join(", ")})
+                      </label>
                     )}
                   </PokeTableCell>
                   <PokeTableCell align="center">

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -11,7 +11,7 @@ import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import config from "@app/lib/api/config";
 import {
   getWorkspaceInfos,
-  getWorkspaceVerifiedDomain,
+  getWorkspaceVerifiedDomains,
 } from "@app/lib/api/workspace";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
@@ -65,7 +65,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
     };
   }
 
-  const workspaceDomain = await getWorkspaceVerifiedDomain(workspace);
+  const workspaceDomains = await getWorkspaceVerifiedDomains(workspace);
 
   const cId = typeof context.query.cId === "string" ? context.query.cId : null;
   const token = typeof context.query.t === "string" ? context.query.t : null;
@@ -81,7 +81,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 
   // Redirect to 404 if in a flow where we need a verified domain and there is none.
   if (
-    !workspaceDomain?.domainAutoJoinEnabled &&
+    !workspaceDomains.some((d) => d.domainAutoJoinEnabled) &&
     ["domain_conversation_link", "domain_invite_link"].includes(onboardingType)
   ) {
     return {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@app/lib/api/enterprise_connection";
 import {
   checkWorkspaceSeatAvailabilityUsingAuth,
-  getWorkspaceVerifiedDomain,
+  getWorkspaceVerifiedDomains,
 } from "@app/lib/api/workspace";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
@@ -46,7 +46,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails;
   plan: PlanType;
   workspaceHasAvailableSeats: boolean;
-  workspaceVerifiedDomain: WorkspaceDomain | null;
+  workspaceVerifiedDomains: WorkspaceDomain[];
 }>(async (context, auth) => {
   const plan = auth.plan();
   const owner = auth.workspace();
@@ -60,7 +60,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   // TODO(workos 2025-06-09): Remove this once fully migrated to WorkOS.
-  const workspaceVerifiedDomain = await getWorkspaceVerifiedDomain(owner);
+  const workspaceVerifiedDomains = await getWorkspaceVerifiedDomains(owner);
   const workspaceHasAvailableSeats =
     await checkWorkspaceSeatAvailabilityUsingAuth(auth);
 
@@ -88,7 +88,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       enterpriseConnectionStrategyDetails,
       plan,
       workspaceHasAvailableSeats,
-      workspaceVerifiedDomain,
+      workspaceVerifiedDomains,
     },
   };
 });
@@ -101,6 +101,7 @@ export default function WorkspaceAdmin({
   enterpriseConnectionStrategyDetails,
   plan,
   workspaceHasAvailableSeats,
+  workspaceVerifiedDomains,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [searchTerm, setSearchTerm] = useState("");
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
@@ -151,6 +152,7 @@ export default function WorkspaceAdmin({
           enterpriseConnectionStrategyDetails={
             enterpriseConnectionStrategyDetails
           }
+          workspaceVerifiedDomains={workspaceVerifiedDomains}
           owner={owner}
           plan={plan}
         />


### PR DESCRIPTION
## Description

- Adds back auto-join button based on internal workspace_has_domain models, until we can rely on workos
- Domains table check that workspace_has_domain is synchronized , otherwise shows "pending"
- Update UI to support multiple domains
- Enforce SSO button , needed for testing enforced sso flow, until we can handle it with workos policies ( https://github.com/dust-tt/tasks/issues/3130 )

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
