### PR TITLE
[front] Store cookie after refresh

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -978,7 +978,9 @@ export async function getSession(
   res: NextApiResponse | GetServerSidePropsContext["res"]
 ): Promise<SessionWithUser | null> {
   return (
-    (await getWorkOSSession(req)) || (await getAuth0Session(req, res)) || null
+    (await getWorkOSSession(req, res)) ||
+    (await getAuth0Session(req, res)) ||
+    null
   );
 }
 


### PR DESCRIPTION
## Description

New cookie with new access token need to be stored after refresh . Avoid being unlogged after 5min (token expiration).

## Tests


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
