### PR TITLE
[JIT Search] Migrate legacy retrieval JIT actions to new search JIT server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -27,7 +27,7 @@ function getDataSourceURI(config: DataSourceConfiguration): string {
     return `data_source_configuration://dust/w/${workspaceId}/data_source_configurations/sId/${sId}`;
   }
   const encodedFilter = encodeURIComponent(JSON.stringify(filter));
-  return `data_source_configuration://dust/w/${workspaceId}/data_source_configurations/viewId/${dataSourceViewId}/filter/${encodedFilter}`;
+  return `data_source_configuration://dust/w/${workspaceId}/data_source_views/${dataSourceViewId}/filter/${encodedFilter}`;
 }
 
 /**

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -6,12 +6,10 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import {
-  DATA_SOURCE_CONFIGURATION_URI_PATTERN,
-  validateConfiguredJsonSchema,
-} from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputJSONSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import {
   areSchemasEqual,
@@ -22,7 +20,6 @@ import {
 } from "@app/lib/utils/json_schemas";
 import type { WorkspaceType } from "@app/types";
 import { assertNever } from "@app/types";
-import { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 
 function getDataSourceURI(config: DataSourceConfiguration): string {
   const { workspaceId, sId, dataSourceViewId, filter } = config;

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -6,7 +6,10 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import {
+  DATA_SOURCE_CONFIGURATION_URI_PATTERN,
+  validateConfiguredJsonSchema,
+} from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputJSONSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
@@ -19,6 +22,16 @@ import {
 } from "@app/lib/utils/json_schemas";
 import type { WorkspaceType } from "@app/types";
 import { assertNever } from "@app/types";
+import { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
+
+function getDataSourceURI(config: DataSourceConfiguration): string {
+  const { workspaceId, sId, dataSourceViewId, filter } = config;
+  if (sId) {
+    return `data_source_configuration://dust/w/${workspaceId}/data_source_configurations/sId/${sId}`;
+  }
+  const encodedFilter = encodeURIComponent(JSON.stringify(filter));
+  return `data_source_configuration://dust/w/${workspaceId}/data_source_configurations/viewId/${dataSourceViewId}/filter/${encodedFilter}`;
+}
 
 /**
  * Defines how we fill the actual inputs of the tool for each mime type.
@@ -44,7 +57,7 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE: {
       return (
         actionConfiguration.dataSources?.map((config) => ({
-          uri: `data_source_configuration://dust/w/${owner.sId}/data_source_configurations/${config.sId}`,
+          uri: getDataSourceURI(config),
           mimeType,
         })) || []
       );

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -24,7 +24,7 @@ import { assertNever } from "@app/types";
 function getDataSourceURI(config: DataSourceConfiguration): string {
   const { workspaceId, sId, dataSourceViewId, filter } = config;
   if (sId) {
-    return `data_source_configuration://dust/w/${workspaceId}/data_source_configurations/sId/${sId}`;
+    return `data_source_configuration://dust/w/${workspaceId}/data_source_configurations/${sId}`;
   }
   const encodedFilter = encodeURIComponent(JSON.stringify(filter));
   return `data_source_configuration://dust/w/${workspaceId}/data_source_views/${dataSourceViewId}/filter/${encodedFilter}`;

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -14,7 +14,7 @@ import { Err, Ok } from "@app/types";
  * or a viewId and a filter, representing the configuration directly.
  */
 export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
-  /^data_source_configuration:\/\/dust\/w\/(\w+)\/data_source_configurations\/(?:sId\/(\w+)|viewId\/(\w+)\/filter\/(.+))$/;
+  /^data_source_configuration:\/\/dust\/w\/(\w+)\/(?:data_source_configurations\/sId\/(\w+)|data_source_views\/(\w+)\/filter\/(.+))$/;
 
 export const TABLE_CONFIGURATION_URI_PATTERN =
   /^table_configuration:\/\/dust\/w\/(\w+)\/table_configurations\/(\w+)$/;

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -8,8 +8,13 @@ import type { Result } from "@app/types";
 import { normalizeError } from "@app/types";
 import { Err, Ok } from "@app/types";
 
+/**
+ * URI pattern for configuring the data source to use within an action.
+ * Either an sId pointing to a configuration in the database,
+ * or a viewId and a filter, representing the configuration directly.
+ */
 export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
-  /^data_source_configuration:\/\/dust\/w\/(\w+)\/data_source_configurations\/(\w+)$/;
+  /^data_source_configuration:\/\/dust\/w\/(\w+)\/data_source_configurations\/(?:sId\/(\w+)|viewId\/(\w+)\/filter\/(.+))$/;
 
 export const TABLE_CONFIGURATION_URI_PATTERN =
   /^table_configuration:\/\/dust\/w\/(\w+)\/table_configurations\/(\w+)$/;

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -14,7 +14,7 @@ import { Err, Ok } from "@app/types";
  * or a viewId and a filter, representing the configuration directly.
  */
 export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
-  /^data_source_configuration:\/\/dust\/w\/(\w+)\/(?:data_source_configurations\/sId\/(\w+)|data_source_views\/(\w+)\/filter\/(.+))$/;
+  /^data_source_configuration:\/\/dust\/w\/(\w+)\/(?:data_source_configurations\/(\w+)|data_source_views\/(\w+)\/filter\/(.+))$/;
 
 export const TABLE_CONFIGURATION_URI_PATTERN =
   /^table_configuration:\/\/dust\/w\/(\w+)\/table_configurations\/(\w+)$/;

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -13,6 +13,7 @@ import type {
 import {
   fetchAgentDataSourceConfiguration,
   getCoreSearchArgs,
+  parseDataSourceConfigurationURI,
   renderRelativeTimeFrameForToolOutput,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import {
@@ -23,6 +24,7 @@ import {
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
@@ -31,7 +33,7 @@ import {
   getDataSourceNameFromView,
   getDisplayNameForDocument,
 } from "@app/lib/data_sources";
-import type { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -432,8 +434,10 @@ const createServer = (
         searchResult = await coreAPI.searchNodes({
           filter: {
             data_source_views: makeDataSourceViewFilter([dataSourceConfig]),
-            node_ids: dataSourceConfig.parentsIn ?? undefined,
-            parent_id: dataSourceConfig.parentsIn ? undefined : ROOT_PARENT_ID,
+            node_ids: dataSourceConfig.filter.parents?.in ?? undefined,
+            parent_id: dataSourceConfig.filter.parents?.in
+              ? undefined
+              : ROOT_PARENT_ID,
             mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
           },
           options,
@@ -844,35 +848,125 @@ const createServer = (
   return server;
 };
 
+// Type to represent data source configuration with resolved data source model
+type ResolvedDataSourceConfiguration = DataSourceConfiguration & {
+  dataSource: {
+    dustAPIProjectId: string;
+    dustAPIDataSourceId: string;
+    connectorProvider: ConnectorProvider | null;
+    name: string;
+  };
+};
+
 async function getAgentDataSourceConfigurations(
   dataSources: DataSourcesToolConfigurationType
-): Promise<Result<AgentDataSourceConfiguration[], Error>> {
-  const agentDataSourceConfigurationsResults = await concurrentExecutor(
+): Promise<Result<ResolvedDataSourceConfiguration[], Error>> {
+  const configResults = await concurrentExecutor(
     dataSources,
-    async (dataSourceConfiguration) =>
-      fetchAgentDataSourceConfiguration(dataSourceConfiguration),
+    async (dataSourceConfiguration) => {
+      const configInfoRes = parseDataSourceConfigurationURI(
+        dataSourceConfiguration.uri
+      );
+
+      if (configInfoRes.isErr()) {
+        return configInfoRes;
+      }
+
+      const configInfo = configInfoRes.value;
+
+      if (configInfo.type === "database") {
+        // Database configuration
+        const r = await fetchAgentDataSourceConfiguration(configInfo.sId);
+        if (r.isErr()) {
+          return r;
+        }
+        const agentConfig = r.value;
+        const dataSourceViewSId = DataSourceViewResource.modelIdToSId({
+          id: agentConfig.dataSourceView.id,
+          workspaceId: agentConfig.dataSourceView.workspaceId,
+        });
+        const resolved: ResolvedDataSourceConfiguration = {
+          workspaceId: agentConfig.dataSourceView.workspace.sId,
+          dataSourceViewId: dataSourceViewSId,
+          filter: {
+            parents:
+              agentConfig.parentsIn || agentConfig.parentsNotIn
+                ? {
+                    in: agentConfig.parentsIn || [],
+                    not: agentConfig.parentsNotIn || [],
+                  }
+                : null,
+            tags:
+              agentConfig.tagsIn || agentConfig.tagsNotIn
+                ? {
+                    in: agentConfig.tagsIn || [],
+                    not: agentConfig.tagsNotIn || [],
+                    mode: agentConfig.tagsMode || "custom",
+                  }
+                : undefined,
+          },
+          dataSource: {
+            dustAPIProjectId: agentConfig.dataSource.dustAPIProjectId,
+            dustAPIDataSourceId: agentConfig.dataSource.dustAPIDataSourceId,
+            connectorProvider: agentConfig.dataSource.connectorProvider,
+            name: agentConfig.dataSource.name,
+          },
+        };
+        return new Ok(resolved);
+      } else {
+        // Dynamic configuration
+        const { Authenticator } = await import("@app/lib/auth");
+        const auth = await Authenticator.internalAdminForWorkspace(
+          configInfo.configuration.workspaceId
+        );
+
+        // Fetch the data source view
+        const dataSourceViews =
+          await DataSourceViewResource.listByWorkspace(auth);
+        const dataSourceView = dataSourceViews.find(
+          (dsv) => dsv.sId === configInfo.configuration.dataSourceViewId
+        );
+
+        if (!dataSourceView) {
+          return new Err(
+            new Error(
+              `Data source view not found: ${configInfo.configuration.dataSourceViewId}`
+            )
+          );
+        }
+
+        const dataSource = dataSourceView.dataSource;
+
+        const resolved: ResolvedDataSourceConfiguration = {
+          ...configInfo.configuration,
+          dataSource: {
+            dustAPIProjectId: dataSource.dustAPIProjectId,
+            dustAPIDataSourceId: dataSource.dustAPIDataSourceId,
+            connectorProvider: dataSource.connectorProvider,
+            name: dataSource.name,
+          },
+        };
+        return new Ok(resolved);
+      }
+    },
     { concurrency: 10 }
   );
 
-  if (agentDataSourceConfigurationsResults.some((res) => res.isErr())) {
+  if (configResults.some((res) => res.isErr())) {
     return new Err(new Error("Failed to fetch data source configurations."));
   }
 
   return new Ok(
-    removeNulls(
-      agentDataSourceConfigurationsResults.map((res) =>
-        res.isOk() ? res.value : null
-      )
-    )
+    removeNulls(configResults.map((res) => (res.isOk() ? res.value : null)))
   );
 }
 
 function makeDataSourceViewFilter(
-  agentDataSourceConfigurations: AgentDataSourceConfiguration[]
+  agentDataSourceConfigurations: ResolvedDataSourceConfiguration[]
 ) {
-  return agentDataSourceConfigurations.map(({ dataSource, parentsIn }) => ({
+  return agentDataSourceConfigurations.map(({ dataSource, filter }) => ({
     data_source_id: dataSource.dustAPIDataSourceId,
-    view_filter: parentsIn ?? [],
+    view_filter: filter.parents?.in ?? [],
   }));
 }
 
@@ -965,7 +1059,7 @@ function renderNode(
  */
 function renderSearchResults(
   response: CoreAPISearchNodesResponse,
-  agentDataSourceConfigurations: AgentDataSourceConfiguration[]
+  agentDataSourceConfigurations: ResolvedDataSourceConfiguration[]
 ): DataSourceNodeListType {
   const dataSourceIdToConnectorMap = new Map<
     string,

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -32,31 +32,18 @@ import type {
 import { Err, Ok } from "@app/types";
 
 export async function fetchAgentDataSourceConfiguration(
-  dataSourceConfiguration: DataSourcesToolConfigurationType[number]
+  dataSourceConfigSId: string
 ): Promise<Result<AgentDataSourceConfiguration, Error>> {
-  const match = dataSourceConfiguration.uri.match(
-    DATA_SOURCE_CONFIGURATION_URI_PATTERN
-  );
-  if (!match) {
-    return new Err(
-      new Error(
-        `Invalid URI for a data source configuration: ${dataSourceConfiguration.uri}`
-      )
-    );
-  }
-
-  // It's safe to do this because the inputs are already checked against the zod schema here.
-  const [, , dataSourceConfigId] = match;
-  const sIdParts = getResourceNameAndIdFromSId(dataSourceConfigId);
+  const sIdParts = getResourceNameAndIdFromSId(dataSourceConfigSId);
   if (!sIdParts) {
     return new Err(
-      new Error(`Invalid data source configuration ID: ${dataSourceConfigId}`)
+      new Error(`Invalid data source configuration ID: ${dataSourceConfigSId}`)
     );
   }
   if (sIdParts.resourceName !== "data_source_configuration") {
     return new Err(
       new Error(
-        `ID is not a data source configuration ID: ${dataSourceConfigId}`
+        `ID is not a data source configuration ID: ${dataSourceConfigSId}`
       )
     );
   }
@@ -81,7 +68,7 @@ export async function fetchAgentDataSourceConfiguration(
 
   if (!agentDataSourceConfiguration) {
     return new Err(
-      new Error(`Data source configuration ${dataSourceConfigId} not found`)
+      new Error(`Data source configuration ${dataSourceConfigSId} not found`)
     );
   }
 
@@ -154,61 +141,165 @@ type CoreSearchArgs = {
   dataSourceView: DataSourceViewType;
 };
 
+type DataSourceConfigInfo =
+  | {
+      type: "database";
+      sId: string;
+    }
+  | {
+      type: "dynamic";
+      configuration: DataSourceConfiguration;
+    };
+
+export function parseDataSourceConfigurationURI(
+  uri: string
+): Result<DataSourceConfigInfo, Error> {
+  const match = uri.match(DATA_SOURCE_CONFIGURATION_URI_PATTERN);
+  if (!match) {
+    return new Err(
+      new Error(`Invalid URI for a data source configuration: ${uri}`)
+    );
+  }
+
+  const [, workspaceId, sId, viewId, filterStr] = match;
+
+  if (sId) {
+    // Database configuration
+    return new Ok({
+      type: "database",
+      sId,
+    });
+  } else if (viewId && filterStr) {
+    // Dynamic configuration
+    try {
+      const filter = JSON.parse(decodeURIComponent(filterStr));
+      return new Ok({
+        type: "dynamic",
+        configuration: {
+          workspaceId,
+          dataSourceViewId: viewId,
+          filter,
+        },
+      });
+    } catch (e) {
+      return new Err(new Error(`Failed to parse filter from URI: ${e}`));
+    }
+  } else {
+    return new Err(new Error(`Invalid URI format: ${uri}`));
+  }
+}
+
 export async function getDataSourceConfiguration(
   dataSourceToolConfiguration: DataSourcesToolConfigurationType[number]
 ): Promise<Result<DataSourceConfiguration, Error>> {
-  const r = await fetchAgentDataSourceConfiguration(
-    dataSourceToolConfiguration
+  const configInfoRes = parseDataSourceConfigurationURI(
+    dataSourceToolConfiguration.uri
   );
 
-  if (r.isErr()) {
-    return r;
+  if (configInfoRes.isErr()) {
+    return configInfoRes;
   }
 
-  const agentDataSourceConfiguration = r.value;
+  const configInfo = configInfoRes.value;
 
-  return new Ok(renderDataSourceConfiguration(agentDataSourceConfiguration));
+  if (configInfo.type === "database") {
+    const r = await fetchAgentDataSourceConfiguration(configInfo.sId);
+    if (r.isErr()) {
+      return r;
+    }
+    const agentDataSourceConfiguration = r.value;
+    return new Ok(renderDataSourceConfiguration(agentDataSourceConfiguration));
+  } else {
+    // Dynamic configuration - return directly
+    return new Ok(configInfo.configuration);
+  }
 }
 
 export async function getCoreSearchArgs(
   auth: Authenticator,
   dataSourceConfiguration: DataSourcesToolConfigurationType[number]
 ): Promise<Result<CoreSearchArgs, Error>> {
-  const r = await fetchAgentDataSourceConfiguration(dataSourceConfiguration);
+  const configInfoRes = parseDataSourceConfigurationURI(
+    dataSourceConfiguration.uri
+  );
 
-  if (r.isErr()) {
-    return r;
+  if (configInfoRes.isErr()) {
+    return configInfoRes;
   }
 
-  const agentDataSourceConfiguration = r.value;
-  const dataSource = agentDataSourceConfiguration.dataSource;
+  const configInfo = configInfoRes.value;
 
-  const dataSourceViews = await DataSourceViewResource.fetchByModelIds(auth, [
-    agentDataSourceConfiguration.dataSourceViewId,
-  ]);
-  if (dataSourceViews.length !== 1) {
-    return new Err(
-      new Error(`Expected 1 data source view, got ${dataSourceViews.length}`)
+  if (configInfo.type === "database") {
+    const r = await fetchAgentDataSourceConfiguration(configInfo.sId);
+
+    if (r.isErr()) {
+      return r;
+    }
+
+    const agentDataSourceConfiguration = r.value;
+    const dataSource = agentDataSourceConfiguration.dataSource;
+
+    const dataSourceViews = await DataSourceViewResource.fetchByModelIds(auth, [
+      agentDataSourceConfiguration.dataSourceViewId,
+    ]);
+    if (dataSourceViews.length !== 1) {
+      return new Err(
+        new Error(`Expected 1 data source view, got ${dataSourceViews.length}`)
+      );
+    }
+    const dataSourceView = dataSourceViews[0];
+
+    return new Ok({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
+      filter: {
+        tags: {
+          in: agentDataSourceConfiguration.tagsIn,
+          not: agentDataSourceConfiguration.tagsNotIn,
+        },
+        parents: {
+          in: agentDataSourceConfiguration.parentsIn,
+          not: agentDataSourceConfiguration.parentsNotIn,
+        },
+      },
+      view_filter: dataSourceView.toViewFilter(),
+      dataSourceView: dataSourceView.toJSON(),
+    });
+  } else {
+    // Dynamic configuration
+    const config = configInfo.configuration;
+
+    // Fetch the data source view
+    const dataSourceViews = await DataSourceViewResource.listByWorkspace(auth);
+    const dataSourceView = dataSourceViews.find(
+      (dsv) => dsv.sId === config.dataSourceViewId
     );
-  }
-  const dataSourceView = dataSourceViews[0];
 
-  return new Ok({
-    projectId: dataSource.dustAPIProjectId,
-    dataSourceId: dataSource.dustAPIDataSourceId,
-    filter: {
-      tags: {
-        in: agentDataSourceConfiguration.tagsIn,
-        not: agentDataSourceConfiguration.tagsNotIn,
+    if (!dataSourceView) {
+      return new Err(
+        new Error(`Data source view not found: ${config.dataSourceViewId}`)
+      );
+    }
+
+    const dataSource = dataSourceView.dataSource;
+
+    return new Ok({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
+      filter: {
+        tags: {
+          in: config.filter.tags?.in || null,
+          not: config.filter.tags?.not || null,
+        },
+        parents: {
+          in: config.filter.parents?.in || null,
+          not: config.filter.parents?.not || null,
+        },
       },
-      parents: {
-        in: agentDataSourceConfiguration.parentsIn,
-        not: agentDataSourceConfiguration.parentsNotIn,
-      },
-    },
-    view_filter: dataSourceView.toViewFilter(),
-    dataSourceView: dataSourceView.toJSON(),
-  });
+      view_filter: dataSourceView.toViewFilter(),
+      dataSourceView: dataSourceView.toJSON(),
+    });
+  }
 }
 
 export function shouldAutoGenerateTags(

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -107,18 +107,55 @@ async function getJITActions(
     conversation: ConversationType;
     files: ConversationAttachmentType[];
   }
-): Promise<ActionConfigurationType[]> {
+): Promise<{
+  jitActions: ActionConfigurationType[];
+  jitServers: MCPServerConfigurationType[];
+}> {
   const actions: ActionConfigurationType[] = [];
 
   // Get supporting actions from available actions.
   const supportingActions = getSupportingActions(agentActions);
 
+  const jitServers: MCPServerConfigurationType[] = [];
+
   // Add supporting actions first.
   actions.push(...supportingActions);
 
   if (files.length === 0) {
-    return actions;
+    return { jitActions: actions, jitServers: [] };
   }
+
+  // Add conversation_files MCP server if there are conversation files
+  const conversationFilesView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "conversation_files"
+    );
+
+  assert(
+    conversationFilesView,
+    "MCP server view not found for conversation_files. Ensure auto tools are created."
+  );
+
+  const conversationFilesServer: ServerSideMCPServerConfigurationType = {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: "conversation_files",
+    description: "Access and include files from the conversation",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    reasoningModel: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: conversationFilesView.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: conversationFilesView.mcpServerId,
+  };
+
+  jitServers.push(conversationFilesServer);
 
   // Check tables for the table query action.
   const filesUsableAsTableQuery = files.filter((f) => f.isQueryable);
@@ -130,193 +167,195 @@ async function getJITActions(
   const filesUsableForExtracting = files.filter((f) => f.isExtractable);
 
   if (
-    filesUsableAsTableQuery.length > 0 ||
-    filesUsableAsRetrievalQuery.length > 0 ||
-    filesUsableForExtracting.length > 0
+    filesUsableAsTableQuery.length === 0 &&
+    filesUsableAsRetrievalQuery.length === 0 &&
+    filesUsableForExtracting.length === 0
   ) {
-    // Get the datasource view for the conversation.
-    const conversationDataSourceView =
-      await DataSourceViewResource.fetchByConversation(auth, conversation);
-
-    // Assign tables to multi-sheet spreadsheets.
-    await concurrentExecutor(
-      filesUsableAsTableQuery.filter((f) =>
-        isMultiSheetSpreadsheetContentType(f.contentType)
-      ),
-      async (f) => {
-        assert(
-          isConversationContentNodeType(f),
-          "Unreachable: file should be a content node"
-        );
-        f.generatedTables = await getTablesFromMultiSheetSpreadsheet(auth, f);
-      },
-      {
-        concurrency: 10,
-      }
-    );
-
-    if (filesUsableAsTableQuery.length > 0) {
-      const action: TablesQueryConfigurationType = {
-        // The description here is the description of the data, a meta description of the action
-        // is prepended automatically.
-        description: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION,
-        type: "tables_query_configuration",
-        id: -1,
-        name: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
-        sId: generateRandomModelSId(),
-        tables: filesUsableAsTableQuery.flatMap((f) => {
-          if (isConversationFileType(f)) {
-            assert(
-              conversationDataSourceView,
-              "No conversation datasource view found for table when trying to get JIT actions"
-            );
-            return f.generatedTables.map((tableId) => ({
-              workspaceId: auth.getNonNullableWorkspace().sId,
-              dataSourceViewId: conversationDataSourceView.sId,
-              tableId,
-            }));
-          } else if (isConversationContentNodeType(f)) {
-            return f.generatedTables.map((tableId) => ({
-              workspaceId: auth.getNonNullableWorkspace().sId,
-              dataSourceViewId: f.nodeDataSourceViewId,
-              tableId,
-            }));
-          }
-          assertNever(f);
-        }),
-      };
-      actions.push(action);
-    }
-
-    if (filesUsableAsRetrievalQuery.length > 0) {
-      const dataSources: DataSourceConfiguration[] = filesUsableAsRetrievalQuery
-        // For each searchable content node, we add its datasourceview with itself as parent
-        // filter.
-        .filter((f) => isConversationContentNodeType(f))
-        .map((f) => ({
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          // Cast ok here because of the filter above.
-          dataSourceViewId: (f as ConversationContentNodeType)
-            .nodeDataSourceViewId,
-          filter: {
-            parents: {
-              in: [(f as ConversationContentNodeType).nodeId],
-              not: [],
-            },
-            tags: null,
-          },
-        }));
-      if (conversationDataSourceView) {
-        dataSources.push({
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          dataSourceViewId: conversationDataSourceView.sId,
-          filter: { parents: null, tags: null },
-        });
-      }
-      const action: RetrievalConfigurationType = {
-        description: DEFAULT_CONVERSATION_SEARCH_ACTION_DATA_DESCRIPTION,
-        type: "retrieval_configuration",
-        id: -1,
-        name: DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
-        sId: generateRandomModelSId(),
-        topK: "auto",
-        query: "auto",
-        relativeTimeFrame: "auto",
-        dataSources,
-      };
-      actions.push(action);
-    }
-
-    // Add process action for processable files
-    if (filesUsableForExtracting.length > 0) {
-      const dataSources: DataSourceConfiguration[] = filesUsableForExtracting
-        // For each extractable content node, we add its datasourceview with itself as parent filter.
-        .filter((f) => isConversationContentNodeType(f))
-        .map((f) => ({
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          // Cast ok here because of the filter above.
-          dataSourceViewId: (f as ConversationContentNodeType)
-            .nodeDataSourceViewId,
-          filter: {
-            parents: {
-              in: [(f as ConversationContentNodeType).nodeId],
-              not: [],
-            },
-            tags: null,
-          },
-        }));
-      if (conversationDataSourceView) {
-        dataSources.push({
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          dataSourceViewId: conversationDataSourceView.sId,
-          filter: { parents: null, tags: null },
-        });
-      }
-
-      const action: ProcessConfigurationType = {
-        description: DEFAULT_CONVERSATION_EXTRACT_ACTION_DATA_DESCRIPTION,
-        type: "process_configuration",
-        id: -1,
-        name: DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
-        sId: generateRandomModelSId(),
-        dataSources,
-        relativeTimeFrame: "auto",
-        jsonSchema: null,
-      };
-      actions.push(action);
-    }
-
-    for (const [i, f] of files
-      .filter((f) => isConversationContentNodeType(f) && isSearchableFolder(f))
-      .entries()) {
-      // This is valid because of the filter above.
-      const folder = f as ConversationContentNodeType;
-      const dataSources: DataSourceConfiguration[] = [
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          dataSourceViewId: folder.nodeDataSourceViewId,
-          filter: {
-            // Do not filter on parent if the folder is a data source node.
-            parents: isContentFragmentDataSourceNode(folder)
-              ? null
-              : {
-                  in: [folder.nodeId],
-                  not: [],
-                },
-            tags: null,
-          },
-        },
-      ];
-      // add retrieval action for the folder
-      const action: RetrievalConfigurationType = {
-        description: `Search content within the documents inside "${folder.title}"`,
-        type: "retrieval_configuration",
-        id: -1,
-        name: `search_folder_${i}`,
-        sId: generateRandomModelSId(),
-        topK: "auto",
-        query: "auto",
-        relativeTimeFrame: "auto",
-        dataSources,
-      };
-      actions.push(action);
-
-      // add process action for the folder
-      const processAction: ProcessConfigurationType = {
-        description: `Extract structured data from the documents inside "${folder.title}"`,
-        type: "process_configuration",
-        id: -1,
-        name: `extract_folder_${i}`,
-        sId: generateRandomModelSId(),
-        dataSources,
-        relativeTimeFrame: "auto",
-        jsonSchema: null,
-      };
-      actions.push(processAction);
-    }
+    return { jitActions: actions, jitServers };
   }
 
-  return actions;
+  // Get the datasource view for the conversation.
+  const conversationDataSourceView =
+    await DataSourceViewResource.fetchByConversation(auth, conversation);
+
+  // Assign tables to multi-sheet spreadsheets.
+  await concurrentExecutor(
+    filesUsableAsTableQuery.filter((f) =>
+      isMultiSheetSpreadsheetContentType(f.contentType)
+    ),
+    async (f) => {
+      assert(
+        isConversationContentNodeType(f),
+        "Unreachable: file should be a content node"
+      );
+      f.generatedTables = await getTablesFromMultiSheetSpreadsheet(auth, f);
+    },
+    {
+      concurrency: 10,
+    }
+  );
+
+  if (filesUsableAsTableQuery.length > 0) {
+    const action: TablesQueryConfigurationType = {
+      // The description here is the description of the data, a meta description of the action
+      // is prepended automatically.
+      description: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION,
+      type: "tables_query_configuration",
+      id: -1,
+      name: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
+      sId: generateRandomModelSId(),
+      tables: filesUsableAsTableQuery.flatMap((f) => {
+        if (isConversationFileType(f)) {
+          assert(
+            conversationDataSourceView,
+            "No conversation datasource view found for table when trying to get JIT actions"
+          );
+          return f.generatedTables.map((tableId) => ({
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            dataSourceViewId: conversationDataSourceView.sId,
+            tableId,
+          }));
+        } else if (isConversationContentNodeType(f)) {
+          return f.generatedTables.map((tableId) => ({
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            dataSourceViewId: f.nodeDataSourceViewId,
+            tableId,
+          }));
+        }
+        assertNever(f);
+      }),
+    };
+    actions.push(action);
+  }
+
+  if (filesUsableAsRetrievalQuery.length > 0) {
+    const dataSources: DataSourceConfiguration[] = filesUsableAsRetrievalQuery
+      // For each searchable content node, we add its datasourceview with itself as parent
+      // filter.
+      .filter((f) => isConversationContentNodeType(f))
+      .map((f) => ({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        // Cast ok here because of the filter above.
+        dataSourceViewId: (f as ConversationContentNodeType)
+          .nodeDataSourceViewId,
+        filter: {
+          parents: {
+            in: [(f as ConversationContentNodeType).nodeId],
+            not: [],
+          },
+          tags: null,
+        },
+      }));
+    if (conversationDataSourceView) {
+      dataSources.push({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        dataSourceViewId: conversationDataSourceView.sId,
+        filter: { parents: null, tags: null },
+      });
+    }
+    const action: RetrievalConfigurationType = {
+      description: DEFAULT_CONVERSATION_SEARCH_ACTION_DATA_DESCRIPTION,
+      type: "retrieval_configuration",
+      id: -1,
+      name: DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
+      sId: generateRandomModelSId(),
+      topK: "auto",
+      query: "auto",
+      relativeTimeFrame: "auto",
+      dataSources,
+    };
+    actions.push(action);
+  }
+
+  // Add process action for processable files
+  if (filesUsableForExtracting.length > 0) {
+    const dataSources: DataSourceConfiguration[] = filesUsableForExtracting
+      // For each extractable content node, we add its datasourceview with itself as parent filter.
+      .filter((f) => isConversationContentNodeType(f))
+      .map((f) => ({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        // Cast ok here because of the filter above.
+        dataSourceViewId: (f as ConversationContentNodeType)
+          .nodeDataSourceViewId,
+        filter: {
+          parents: {
+            in: [(f as ConversationContentNodeType).nodeId],
+            not: [],
+          },
+          tags: null,
+        },
+      }));
+    if (conversationDataSourceView) {
+      dataSources.push({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        dataSourceViewId: conversationDataSourceView.sId,
+        filter: { parents: null, tags: null },
+      });
+    }
+
+    const action: ProcessConfigurationType = {
+      description: DEFAULT_CONVERSATION_EXTRACT_ACTION_DATA_DESCRIPTION,
+      type: "process_configuration",
+      id: -1,
+      name: DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
+      sId: generateRandomModelSId(),
+      dataSources,
+      relativeTimeFrame: "auto",
+      jsonSchema: null,
+    };
+    actions.push(action);
+  }
+
+  for (const [i, f] of files
+    .filter((f) => isConversationContentNodeType(f) && isSearchableFolder(f))
+    .entries()) {
+    // This is valid because of the filter above.
+    const folder = f as ConversationContentNodeType;
+    const dataSources: DataSourceConfiguration[] = [
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        dataSourceViewId: folder.nodeDataSourceViewId,
+        filter: {
+          // Do not filter on parent if the folder is a data source node.
+          parents: isContentFragmentDataSourceNode(folder)
+            ? null
+            : {
+                in: [folder.nodeId],
+                not: [],
+              },
+          tags: null,
+        },
+      },
+    ];
+    // add retrieval action for the folder
+    const action: RetrievalConfigurationType = {
+      description: `Search content within the documents inside "${folder.title}"`,
+      type: "retrieval_configuration",
+      id: -1,
+      name: `search_folder_${i}`,
+      sId: generateRandomModelSId(),
+      topK: "auto",
+      query: "auto",
+      relativeTimeFrame: "auto",
+      dataSources,
+    };
+    actions.push(action);
+
+    // add process action for the folder
+    const processAction: ProcessConfigurationType = {
+      description: `Extract structured data from the documents inside "${folder.title}"`,
+      type: "process_configuration",
+      id: -1,
+      name: `extract_folder_${i}`,
+      sId: generateRandomModelSId(),
+      dataSources,
+      relativeTimeFrame: "auto",
+      jsonSchema: null,
+    };
+    actions.push(processAction);
+  }
+
+  return { jitActions: actions, jitServers };
 }
 
 export async function getEmulatedAndJITActions(
@@ -336,8 +375,6 @@ export async function getEmulatedAndJITActions(
   jitServers: MCPServerConfigurationType[];
 }> {
   const emulatedActions: AgentActionType[] = [];
-  let jitActions: ActionConfigurationType[] = [];
-  const jitServers: MCPServerConfigurationType[] = [];
 
   const files = listFiles(conversation);
   const a = makeConversationListFilesAction({
@@ -348,45 +385,11 @@ export async function getEmulatedAndJITActions(
     emulatedActions.push(a);
   }
 
-  jitActions = await getJITActions(auth, {
+  const { jitActions, jitServers } = await getJITActions(auth, {
     conversation,
     files,
     agentActions,
   });
-
-  // Add conversation_files MCP server if there are conversation files
-  if (files.length > 0) {
-    const conversationFilesView =
-      await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-        auth,
-        "conversation_files"
-      );
-
-    assert(
-      conversationFilesView,
-      "MCP server view not found for conversation_files. Ensure auto tools are created."
-    );
-
-    const conversationFilesServer: ServerSideMCPServerConfigurationType = {
-      id: -1,
-      sId: generateRandomModelSId(),
-      type: "mcp_server_configuration",
-      name: "conversation_files",
-      description: "Access and include files from the conversation",
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      reasoningModel: null,
-      timeFrame: null,
-      jsonSchema: null,
-      additionalConfiguration: {},
-      mcpServerViewId: conversationFilesView.sId,
-      dustAppConfiguration: null,
-      internalMCPServerId: conversationFilesView.mcpServerId,
-    };
-
-    jitServers.push(conversationFilesServer);
-  }
 
   // We ensure that all emulated actions are injected with step -1.
   assert(

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -229,6 +229,17 @@ async function getJITActions(
   }
 
   if (filesUsableAsRetrievalQuery.length > 0) {
+    const retrievalView =
+      await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+        auth,
+        "search"
+      );
+
+    assert(
+      retrievalView,
+      "MCP server view not found for search. Ensure auto tools are created."
+    );
+
     const dataSources: DataSourceConfiguration[] = filesUsableAsRetrievalQuery
       // For each searchable content node, we add its datasourceview with itself as parent
       // filter.
@@ -253,18 +264,25 @@ async function getJITActions(
         filter: { parents: null, tags: null },
       });
     }
-    const action: RetrievalConfigurationType = {
-      description: DEFAULT_CONVERSATION_SEARCH_ACTION_DATA_DESCRIPTION,
-      type: "retrieval_configuration",
+
+    const retrievalServer: ServerSideMCPServerConfigurationType = {
       id: -1,
-      name: DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
       sId: generateRandomModelSId(),
-      topK: "auto",
-      query: "auto",
-      relativeTimeFrame: "auto",
+      type: "mcp_server_configuration",
+      name: "conversation_search",
+      description: "Semantic search over all files from the conversation",
       dataSources,
+      tables: null,
+      childAgentId: null,
+      reasoningModel: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: retrievalView.sId,
+      dustAppConfiguration: null,
+      internalMCPServerId: retrievalView.mcpServerId,
     };
-    actions.push(action);
+    jitServers.push(retrievalServer);
   }
 
   // Add process action for processable files


### PR DESCRIPTION
Part of https://github.com/dust-tt/tasks/issues/2968

Description
---

Migrates legacy retrieval JIT actions to new search JIT server.
1. in getJITActions, servers are now also returned;
2. the conversation search legacy action is returned as a search server;
3. similarly, the `search_folder_${i}` search actions have been replaced with equivalent servers;

There was a challenge in creating appropriate `DataSourceConfiguration`s for the `dataSources` field of the search servers. These configurations are turned into URIs by `generateConfiguredInput` used in `augmentInputsWithConfiguration`. They used to require the `sId` field to be set, referring to an existing `AgentDataSourceConfiguration` model, stored in database. Here, since the actions are JIT, the configurations passed are not stored in database. Therefore, the `DATA_SOURCE_CONFIGURATION_URI_PATTERN` is revisited to allow either an `sId` as before ("database" configuration), or a representation of the configuration directly with viewId and filter ("dynamic" configuration)

The main caller of this pattern, `fetchAgentDataSourceConfiguration`, is adapted to take a data source config sid directly. Callers of `fetchAgentDataSourceConfiguration` now call a new function to check whether the configuration is database or dynamic, use `fetchAgentDataSourceConfiguration` only if it's a database configuration, and otherwise parse the configuration from the URL directly. 

Callers of `fetchAgentDataSourceConfiguration` expected a `AgentDataSourceConfiguration` model so adaptations were made to callers so they manage the case when the config is dynamic and as such maps to a `DataSourceConfiguration` with no `sId`

## Risks
low

## Tests

- [ ] Verify existing JIT actions continue to work with database configurations
- [ ] Test new dynamic configurations with conversation search
- [ ] Test folder search functionality with MCP servers
- [ ] Verify data source file system operations work with both configuration types

## Deploy Plan
- No database migrations required
- Deploy front service with the new code
- Monitor for any errors related to URI parsing or configuration fetching