### PR TITLE
[front] provisioning: add authentication endpoints in api v1

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -17,6 +17,13 @@ const config = {
       "NEXT_PUBLIC_DUST_CLIENT_FACING_URL"
     );
   },
+  getOAuthProvider: (): "auth0" | "workos" => {
+    const provider = EnvironmentConfig.getOptionalEnvVariable("OAUTH_PROVIDER");
+    if (!provider || (provider !== "auth0" && provider !== "workos")) {
+      return "auth0"; // Default to auth0 if not set or invalid.
+    }
+    return provider;
+  },
   getAuth0TenantUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("AUTH0_TENANT_DOMAIN_URL");
   },

--- a/front/pages/api/v1/auth/[action].ts
+++ b/front/pages/api/v1/auth/[action].ts
@@ -1,0 +1,79 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import config from "@app/lib/api/config";
+
+type Provider = {
+  authorizeUri: string;
+  authenticateUri: string;
+  logoutUri: string;
+};
+
+const providers: Record<string, Provider> = {
+  workos: {
+    authorizeUri: "api.workos.com/user_management/authorize",
+    authenticateUri: "api.workos.com/user_management/authenticate",
+    logoutUri: "api/workos/com/user_management/sessions/logout",
+  },
+  auth0: {
+    authorizeUri: "dust-tt.us.auth0.com/authorize",
+    authenticateUri: "dust-tt.us.auth0.com/oauth/token",
+    logoutUri: "dust-tt.us.auth0.com/v2/logout",
+  },
+};
+
+function getProvider(): Provider {
+  const provider = config.getOAuthProvider();
+  return providers[provider];
+}
+
+/**
+ * @ignoreswagger
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { action } = req.query;
+
+  switch (action) {
+    case "authorize":
+      return handleAuthorize(req, res);
+    case "authenticate":
+      return handleAuthenticate(req, res);
+    case "logout":
+      return handleLogout(req, res);
+    default:
+      res.status(404).json({ error: "Action not found" });
+  }
+}
+
+async function handleAuthorize(req: NextApiRequest, res: NextApiResponse) {
+  const { query } = req;
+  const authorizeUrl = `https://${getProvider().authorizeUri}?${query}`;
+  res.redirect(authorizeUrl);
+}
+
+async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const response = await fetch(`https://${getProvider().authenticateUri}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Origin: req.headers.origin || "",
+      },
+      credentials: "include",
+      body: new URLSearchParams(req.body).toString(),
+    });
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (error) {
+    console.error("Error in authenticate proxy:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
+  const { query } = req;
+  const authorizeUrl = `https://${getProvider().logoutUri}?${query}`;
+  res.redirect(authorizeUrl);
+}

--- a/front/pages/api/v1/auth/[action].ts
+++ b/front/pages/api/v1/auth/[action].ts
@@ -6,6 +6,7 @@ type Provider = {
   authorizeUri: string;
   authenticateUri: string;
   logoutUri: string;
+  clientId: string;
 };
 
 const providers: Record<string, Provider> = {
@@ -13,11 +14,13 @@ const providers: Record<string, Provider> = {
     authorizeUri: "api.workos.com/user_management/authorize",
     authenticateUri: "api.workos.com/user_management/authenticate",
     logoutUri: "api/workos/com/user_management/sessions/logout",
+    clientId: config.getWorkOSClientId(),
   },
   auth0: {
     authorizeUri: "dust-tt.us.auth0.com/authorize",
     authenticateUri: "dust-tt.us.auth0.com/oauth/token",
     logoutUri: "dust-tt.us.auth0.com/v2/logout",
+    clientId: config.getAuth0WebApplicationId(),
   },
 };
 
@@ -49,7 +52,11 @@ export default async function handler(
 
 async function handleAuthorize(req: NextApiRequest, res: NextApiResponse) {
   const { query } = req;
-  const authorizeUrl = `https://${getProvider().authorizeUri}?${query}`;
+  const params = new URLSearchParams({
+    ...query,
+    client_id: getProvider().clientId,
+  }).toString();
+  const authorizeUrl = `https://${getProvider().authorizeUri}?${params}}`;
   res.redirect(authorizeUrl);
 }
 
@@ -74,6 +81,10 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
 
 async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
   const { query } = req;
-  const authorizeUrl = `https://${getProvider().logoutUri}?${query}`;
+  const params = new URLSearchParams({
+    ...query,
+    client_id: getProvider().clientId,
+  }).toString();
+  const authorizeUrl = `https://${getProvider().logoutUri}?${params}`;
   res.redirect(authorizeUrl);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

In the context of the WorkOS migration, we need to update all side-platforms authentication.
For the Front plugin, being hosted in an iframe, it needs a backend proxy to perform the calls. 
We use that problem to make it an opportunity to provide auth endpoints to authenticate to a Dust account through the v1 API.

The endpoint rely on an environment variable to redirect you to the right authentication providers. This also allows us to swap easily from auth0 to workos when time is right.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Not tested yet because not used. Really only is proxying the calls, should work. Will fix in the PRs implementing the use of it if needed.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, not used.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Add environment variable to prod.
Update runbook.
Deploy front.