### PR TITLE
Add support for organization_updated event in WorkOS webhook

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -27,7 +27,6 @@ import type {
   RoleType,
   SubscriptionType,
   UserTypeWithWorkspaces,
-  WorkspaceDomain,
   WorkspaceSegmentationType,
   WorkspaceType,
 } from "@app/types";

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -58,26 +58,6 @@ export async function getWorkspaceInfos(
   return renderLightWorkspaceType({ workspace });
 }
 
-export async function getWorkspaceVerifiedDomains(
-  workspace: LightWorkspaceType
-): Promise<WorkspaceDomain[]> {
-  const workspaceDomains = await WorkspaceHasDomainModel.findAll({
-    attributes: ["domain", "domainAutoJoinEnabled"],
-    where: {
-      workspaceId: workspace.id,
-    },
-  });
-
-  if (workspaceDomains) {
-    return workspaceDomains.map((domain) => ({
-      domain: domain.domain,
-      domainAutoJoinEnabled: domain.domainAutoJoinEnabled,
-    }));
-  }
-
-  return [];
-}
-
 export async function removeAllWorkspaceDomains(
   workspace: LightWorkspaceType
 ): Promise<void> {

--- a/front/lib/api/workspace_domains.ts
+++ b/front/lib/api/workspace_domains.ts
@@ -1,6 +1,6 @@
 import { Workspace } from "@app/lib/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/models/workspace_has_domain";
-import type { LightWorkspaceType, Result } from "@app/types";
+import type { LightWorkspaceType, Result, WorkspaceDomain } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 export async function upsertWorkspaceDomain(
@@ -59,4 +59,24 @@ export async function deleteWorkspaceDomain(
   await existingDomain.destroy();
 
   return new Ok(undefined);
+}
+
+export async function getWorkspaceVerifiedDomains(
+  workspace: LightWorkspaceType
+): Promise<WorkspaceDomain[]> {
+  const workspaceDomains = await WorkspaceHasDomainModel.findAll({
+    attributes: ["domain", "domainAutoJoinEnabled"],
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+
+  if (workspaceDomains) {
+    return workspaceDomains.map((domain) => ({
+      domain: domain.domain,
+      domainAutoJoinEnabled: domain.domainAutoJoinEnabled,
+    }));
+  }
+
+  return [];
 }

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -3,6 +3,7 @@ import type { FindOptions, Order, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -31,7 +32,6 @@ import type {
   WithAPIErrorResponse,
   WorkspaceDomain,
 } from "@app/types";
-import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 export type PokeWorkspaceType = LightWorkspaceType & {
   createdAt: string;

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -3,7 +3,6 @@ import type { FindOptions, Order, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -32,6 +31,7 @@ import type {
   WithAPIErrorResponse,
   WorkspaceDomain,
 } from "@app/types";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 export type PokeWorkspaceType = LightWorkspaceType & {
   createdAt: string;

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -2,10 +2,10 @@ import type { GetWorkspaceVerifiedDomainsResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 /**
  * @ignoreswagger

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -2,10 +2,10 @@ import type { GetWorkspaceVerifiedDomainsResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 /**
  * @ignoreswagger

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -31,6 +31,7 @@ import { TrackerDataTable } from "@app/components/poke/trackers/table";
 import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
 import config from "@app/lib/api/config";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -47,7 +48,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { WHITELISTABLE_FEATURES } from "@app/types";
-import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   activeSubscription: SubscriptionType;

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -30,10 +30,7 @@ import { ActiveSubscriptionTable } from "@app/components/poke/subscriptions/tabl
 import { TrackerDataTable } from "@app/components/poke/trackers/table";
 import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
 import config from "@app/lib/api/config";
-import {
-  getWorkspaceCreationDate,
-  getWorkspaceVerifiedDomains,
-} from "@app/lib/api/workspace";
+import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -50,6 +47,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { WHITELISTABLE_FEATURES } from "@app/types";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   activeSubscription: SubscriptionType;

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -9,14 +9,12 @@ import type { InferGetServerSidePropsType } from "next";
 
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import config from "@app/lib/api/config";
-import {
-  getWorkspaceInfos,
-  getWorkspaceVerifiedDomains,
-} from "@app/lib/api/workspace";
+import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { getSignUpUrl } from "@app/lib/signup";
 import type { LightWorkspaceType } from "@app/types";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 /**
  * 3 ways to end up here:

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -10,11 +10,11 @@ import type { InferGetServerSidePropsType } from "next";
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import config from "@app/lib/api/config";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { getSignUpUrl } from "@app/lib/signup";
 import type { LightWorkspaceType } from "@app/types";
-import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 /**
  * 3 ways to end up here:

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -31,10 +31,7 @@ import {
   makeEnterpriseConnectionInitiateLoginUrl,
   makeSamlAcsUrl,
 } from "@app/lib/api/enterprise_connection";
-import {
-  checkWorkspaceSeatAvailabilityUsingAuth,
-  getWorkspaceVerifiedDomains,
-} from "@app/lib/api/workspace";
+import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useGroups } from "@app/lib/swr/groups";
@@ -50,6 +47,7 @@ import type {
   WorkspaceDomain,
   WorkspaceType,
 } from "@app/types";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -32,6 +32,7 @@ import {
   makeSamlAcsUrl,
 } from "@app/lib/api/enterprise_connection";
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
+import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useGroups } from "@app/lib/swr/groups";
@@ -47,7 +48,6 @@ import type {
   WorkspaceDomain,
   WorkspaceType,
 } from "@app/types";
-import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR increase the existing coverage of WorkOS webhook. This PR adds handler for `organization_updated` event. For now domains interaction do not trigger this one yet, but this is actively worked on by the WorkOS team.

With this changes, all domains added through our Poke plugin directly in a verified state as well as domain removed should be sync with our internal `workspace_has_domains` model. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
