### PR TITLE
enh(Zendesk): add `shouldSyncTicket` to `fetch-ticket` command

### DIFF
--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -593,6 +593,7 @@ export type ZendeskCountTicketsResponseType = t.TypeOf<
 
 export const ZendeskFetchTicketResponseSchema = t.type({
   ticket: t.union([t.UnknownRecord, t.null]), // Zendesk type, can't be iots'd,
+  shouldSyncTicket: t.boolean,
   isTicketOnDb: t.boolean,
 });
 export type ZendeskFetchTicketResponseType = t.TypeOf<

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -1129,24 +1129,28 @@ function ZendeskTicketCheck({
                   />
                 }
               />
-              <Tooltip
-                label={
-                  ticketDetails.shouldSyncTicket
-                    ? "Looking at its state, the ticket should be synced with Dust."
-                    : "Looking at its state, the ticket should not be synced with Dust."
-                }
-                className="max-w-md"
-                trigger={
-                  <Chip
-                    label={
-                      ticketDetails.shouldSyncTicket
-                        ? "Should be synced"
-                        : "Should not be synced"
-                    }
-                    color={ticketDetails.shouldSyncTicket ? "success" : "info"}
-                  />
-                }
-              />
+              {ticketDetails.ticket && (
+                <Tooltip
+                  label={
+                    ticketDetails.shouldSyncTicket
+                      ? "Looking at its state, the ticket should be synced with Dust."
+                      : "Looking at its state, the ticket should not be synced with Dust."
+                  }
+                  className="max-w-md"
+                  trigger={
+                    <Chip
+                      label={
+                        ticketDetails.shouldSyncTicket
+                          ? "Should be synced"
+                          : "Should not be synced"
+                      }
+                      color={
+                        ticketDetails.shouldSyncTicket ? "success" : "info"
+                      }
+                    />
+                  }
+                />
+              )}
             </div>
             {ticketDetails.ticket && (
               <div className="ml-4 pt-2 text-xs text-muted-foreground">

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -1129,6 +1129,24 @@ function ZendeskTicketCheck({
                   />
                 }
               />
+              <Tooltip
+                label={
+                  ticketDetails.shouldSyncTicket
+                    ? "Looking at its state, the ticket should be synced with Dust."
+                    : "Looking at its state, the ticket should not be synced with Dust."
+                }
+                className="max-w-md"
+                trigger={
+                  <Chip
+                    label={
+                      ticketDetails.shouldSyncTicket
+                        ? "Should be synced"
+                        : "Should not be synced"
+                    }
+                    color={ticketDetails.shouldSyncTicket ? "success" : "info"}
+                  />
+                }
+              />
             </div>
             {ticketDetails.ticket && (
               <div className="ml-4 pt-2 text-xs text-muted-foreground">

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -588,6 +588,7 @@ export type ZendeskCountTicketsResponseType = t.TypeOf<
 
 export const ZendeskFetchTicketResponseSchema = t.type({
   ticket: t.union([t.UnknownRecord, t.null]), // Zendesk type, can't be iots'd,
+  shouldSyncTicket: t.boolean,
   isTicketOnDb: t.boolean,
 });
 export type ZendeskFetchTicketResponseType = t.TypeOf<


### PR DESCRIPTION
## Description

- This PR adds a field `shouldSyncTicket` to the output of the `fetch-ticket`.
- This additional field is used to add a Chip in the Zendesk check ticket poke view, indicating whether a ticket should be synced.

<img width="525" alt="Screenshot 2025-06-16 at 11 45 54 AM" src="https://github.com/user-attachments/assets/3587d821-38f8-4548-ae84-d8d08cba2dea" />

## Tests

- Tested locally.

## Risk

- Low (admin-level action).
- Will temporarily make the Check ticket button in Poke not available (< 5 min).

## Deploy Plan

- Deploy connectors.
- Deploy front.
