### PR TITLE
[Observability]Enable APM for Rust

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -488,6 +488,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd3e188039e0e9e3dce1ad873358fd6bab72e6496e18b898bc36d72c07af4b26"
+dependencies = [
+ "axum 0.8.4",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1357,7 @@ dependencies = [
  "async-trait",
  "axum 0.8.4",
  "axum-test",
+ "axum-tracing-opentelemetry",
  "base64 0.22.1",
  "bb8",
  "bb8-postgres",
@@ -1362,10 +1381,15 @@ dependencies = [
  "http 1.3.1",
  "humantime",
  "hyper 1.6.0",
+ "init-tracing-opentelemetry",
  "itertools 0.10.5",
  "jsonwebtoken 9.3.1",
  "lazy_static",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "parking_lot",
  "pest",
  "pest_derive",
@@ -1398,6 +1422,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-bunyan-formatter",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "unicode-normalization",
  "url",
@@ -1738,7 +1763,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "tonic-build",
  "url",
  "yup-oauth2",
@@ -2388,6 +2413,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "init-tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c85d27bf4663b776538013d3b71ac46c1b2b66bc14e8fbd2f1ceaff32ff088d"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "thiserror 2.0.12",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,6 +2953,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68f63eca5fad47e570e00e893094fc17be959c80c79a7d6ec1abdd5ae6ffc16"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest 0.12.20",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
+ "reqwest 0.12.20",
+ "thiserror 2.0.12",
+ "tokio",
+ "tonic 0.13.1",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
+ "tonic 0.13.1",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.1",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,7 +3565,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -3744,6 +3880,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.10",
@@ -3762,6 +3899,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.28",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4974,6 +5112,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5015,9 +5179,12 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.9.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5155,6 +5322,36 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dda3080d8657b99ddd303a4bda25ebd3479820abbd5a67af70a9dafd06b1713"
+dependencies = [
+ "http 1.3.1",
+ "opentelemetry",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -106,6 +106,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 axum = "0.8.4"
 axum-test = "17.3.0"
+axum-tracing-opentelemetry = "0.29.0"
 base64 = "0.22"
 bb8 = "0.8"
 bb8-postgres = "0.8"
@@ -129,10 +130,15 @@ gcp-bigquery-client = "0.25.1"
 http = "1.1.0"
 humantime = "2.2.0"
 hyper = { version = "1.3.1", features = ["full"] }
+init-tracing-opentelemetry =  { version = "0.29.0", features = ["tracing_subscriber_ext"] }
 itertools = "0.10"
 jsonwebtoken = "9.3.0"
 lazy_static = "1.4"
 once_cell = "1.18"
+opentelemetry = "0.30.0"
+opentelemetry-appender-tracing = { version = "0.30.1", features = ["experimental_use_tracing_span_context"] }
+opentelemetry-otlp = "0.30.0"
+opentelemetry_sdk = "0.30.0"
 parking_lot = "0.12"
 pest = "2.7"
 pest_derive = "2.7"
@@ -165,6 +171,7 @@ tokio-util = { version = "0.7", features = ["compat"] }
 tower-http = {version = "0.5", features = ["full"]}
 tracing = "0.1"
 tracing-bunyan-formatter = "0.3.9"
+tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 unicode-normalization = "0.1.24"
 url = "2.5"

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -4345,7 +4345,7 @@ fn main() {
         .route("/tokenize", post(tokenize))
         .route("/tokenize/batch", post(tokenize_batch))
         .layer(OtelInResponseLayer::default())
-        //start OpenTelemetry trace on incoming request
+        // Start OpenTelemetry trace on incoming request.
         .layer(OtelAxumLayer::default())
         // Extensions
         .layer(DefaultBodyLimit::disable())

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -1,12 +1,11 @@
 use dust::oauth::app;
+use dust::open_telemetry::init_subscribers;
 use tokio::{
     net::TcpListener,
     signal::unix::{signal, SignalKind},
 };
 
 use tracing::{error, info};
-use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
-use tracing_subscriber::prelude::*;
 
 fn main() {
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -15,15 +14,7 @@ fn main() {
         .unwrap();
 
     let r = rt.block_on(async {
-        tracing_subscriber::registry()
-            .with(JsonStorageLayer)
-            .with(
-                BunyanFormattingLayer::new("oauth".into(), std::io::stdout)
-                    .skip_fields(vec!["file", "line", "target"].into_iter())
-                    .unwrap(),
-            )
-            .with(tracing_subscriber::EnvFilter::new("info"))
-            .init();
+        let _guard = init_subscribers()?;
 
         let app = app::create_app().await?;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -162,3 +162,5 @@ pub mod oauth {
 }
 
 pub mod api_keys;
+
+pub mod open_telemetry;

--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -449,7 +449,7 @@ pub async fn create_app() -> Result<Router> {
         .route("/credentials/{credential_id}", delete(credentials_delete))
         // Extensions
         .layer(OtelInResponseLayer::default())
-        //start OpenTelemetry trace on incoming request
+        // Start OpenTelemetry trace on incoming request.
         .layer(OtelAxumLayer::default())
         .layer(from_fn(validate_api_key))
         .with_state(state.clone());

--- a/core/src/open_telemetry.rs
+++ b/core/src/open_telemetry.rs
@@ -27,7 +27,6 @@ where
         Box::new(
             tracing_subscriber::fmt::layer()
                 .json()
-                //.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .with_timer(tracing_subscriber::fmt::time::uptime()),
         )
     }
@@ -69,11 +68,7 @@ pub fn build_otel_layer<S>() -> Result<(OpenTelemetryLayer<S, Tracer>, TracingGu
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    use init_tracing_opentelemetry::{
-        init_propagator, //stdio,
-        otlp,
-        resource::DetectResource,
-    };
+    use init_tracing_opentelemetry::{init_propagator, otlp, resource::DetectResource};
     use opentelemetry::global;
     let otel_rsrc = DetectResource::default().build();
     let tracer_provider = otlp::init_tracerprovider(otel_rsrc, otlp::identity)?;

--- a/core/src/open_telemetry.rs
+++ b/core/src/open_telemetry.rs
@@ -1,0 +1,168 @@
+use init_tracing_opentelemetry::Error;
+use opentelemetry::trace::TracerProvider;
+use opentelemetry_appender_tracing::layer;
+use opentelemetry_otlp::LogExporter;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::trace::{SdkTracerProvider, Tracer};
+use tracing::{info, level_filters::LevelFilter, Subscriber};
+use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::{filter::EnvFilter, layer::SubscriberExt, registry::LookupSpan, Layer};
+
+fn build_logger_text<S>() -> Box<dyn Layer<S> + Send + Sync + 'static>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    use tracing_subscriber::fmt::format::FmtSpan;
+    if cfg!(debug_assertions) {
+        Box::new(
+            tracing_subscriber::fmt::layer()
+                .pretty()
+                .with_line_number(true)
+                .with_thread_names(true)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                .with_timer(tracing_subscriber::fmt::time::uptime()),
+        )
+    } else {
+        Box::new(
+            tracing_subscriber::fmt::layer()
+                .json()
+                //.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                .with_timer(tracing_subscriber::fmt::time::uptime()),
+        )
+    }
+}
+
+/// Read the configuration from (first non empty used, priority top to bottom):
+///
+/// - from parameter `directives`
+/// - from environment variable `RUST_LOG`
+/// - from environment variable `OTEL_LOG_LEVEL`
+/// - default to `Level::INFO`
+///
+/// And add directive to:
+///
+/// - `otel::tracing` should be a level info to emit opentelemetry trace & span
+///
+/// You can customize parameter "directives", by adding:
+///
+/// - `otel::setup=debug` set to debug to log detected resources, configuration read (optional)
+///
+/// see [Directives syntax](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives)
+pub fn build_level_filter_layer(log_directives: &str) -> Result<EnvFilter, Error> {
+    let dirs = if log_directives.is_empty() {
+        std::env::var("RUST_LOG")
+            .or_else(|_| std::env::var("OTEL_LOG_LEVEL"))
+            .unwrap_or_else(|_| "info".to_string())
+    } else {
+        log_directives.to_string()
+    };
+    let directive_to_allow_otel_trace = "otel::tracing=trace".parse()?;
+
+    Ok(EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .parse_lossy(dirs)
+        .add_directive(directive_to_allow_otel_trace))
+}
+
+pub fn build_otel_layer<S>() -> Result<(OpenTelemetryLayer<S, Tracer>, TracingGuard), Error>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    use init_tracing_opentelemetry::{
+        init_propagator, //stdio,
+        otlp,
+        resource::DetectResource,
+    };
+    use opentelemetry::global;
+    let otel_rsrc = DetectResource::default().build();
+    let tracer_provider = otlp::init_tracerprovider(otel_rsrc, otlp::identity)?;
+    init_propagator()?;
+    let layer = tracing_opentelemetry::layer()
+        .with_error_records_to_exceptions(true)
+        .with_tracer(tracer_provider.tracer("Dust OTLP tracer"));
+    global::set_tracer_provider(tracer_provider.clone());
+    Ok((layer, TracingGuard { tracer_provider }))
+}
+
+/// On Drop of the `TracingGuard` instance,
+/// the wrapped Tracer Provider is force to flush and to shutdown (ignoring error).
+#[must_use = "Recommend holding with 'let _guard = ' pattern to ensure final traces are sent to the server"]
+pub struct TracingGuard {
+    tracer_provider: SdkTracerProvider,
+}
+
+impl TracingGuard {
+    /// the wrapped Tracer Provider
+    #[must_use]
+    pub fn tracer_provider(&self) -> &impl TracerProvider {
+        &self.tracer_provider
+    }
+}
+
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        #[allow(unused_must_use)]
+        let _ = self.tracer_provider.force_flush();
+        let _ = self.tracer_provider.shutdown();
+    }
+}
+
+pub fn init_subscribers() -> Result<TracingGuard, Error> {
+    init_subscribers_and_loglevel("")
+}
+
+/// see [`build_level_filter_layer`] for the syntax of `log_directives`
+pub fn init_subscribers_and_loglevel(log_directives: &str) -> Result<TracingGuard, Error> {
+    //setup a temporary subscriber to log output during setup
+    let subscriber = tracing_subscriber::registry()
+        .with(build_level_filter_layer(log_directives)?)
+        .with(build_logger_text());
+    let _guard = tracing::subscriber::set_default(subscriber);
+    info!("init logging & tracing");
+
+    let (layer, guard) = build_otel_layer()?;
+
+    let exporter = LogExporter::builder()
+        .with_tonic()
+        .build()
+        .expect("failed to install logging");
+    let provider: SdkLoggerProvider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+
+    // To prevent a telemetry-induced-telemetry loop, OpenTelemetry's own internal
+    // logging is properly suppressed. However, logs emitted by external components
+    // (such as reqwest, tonic, etc.) are not suppressed as they do not propagate
+    // OpenTelemetry context. Until this issue is addressed
+    // (https://github.com/open-telemetry/opentelemetry-rust/issues/2877),
+    // filtering like this is the best way to suppress such logs.
+    //
+    // The filter levels are set as follows:
+    // - Allow `info` level and above by default.
+    // - Completely restrict logs from `hyper`, `tonic`, `h2`, and `reqwest`.
+    //
+    // Note: This filtering will also drop logs from these components even when
+    // they are used outside of the OTLP Exporter.
+    let filter_otel = EnvFilter::new("info")
+        .add_directive("hyper=off".parse().unwrap())
+        .add_directive("tonic=off".parse().unwrap())
+        .add_directive("h2=off".parse().unwrap())
+        .add_directive("reqwest=off".parse().unwrap());
+    let otel_layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(filter_otel);
+
+    let subscriber = tracing_subscriber::registry()
+        .with(JsonStorageLayer)
+        .with(
+            BunyanFormattingLayer::new("dust_api".into(), std::io::stdout)
+                .skip_fields(vec!["file", "line", "target"].into_iter())
+                .unwrap(),
+        )
+        .with(otel_layer)
+        .with(layer)
+        .with(build_level_filter_layer(log_directives)?)
+        .with(build_logger_text());
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    Ok(guard)
+}


### PR DESCRIPTION
## Description

In Rust, we are using the `tracing` library to produce 2 types of logs:

 - traditional log messages (see [here](https://app.datadoghq.eu/logs?query=service%3A%28core%20OR%20oauth%20OR%20core-sqlite-worker%29%20-%40request_span_id%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1750082601339&to_ts=1750083501339&live=true))
 - spans i.e. logs bound with a span id (see [here](https://app.datadoghq.eu/logs?query=service%3A%28core%20OR%20oauth%20OR%20core-sqlite-worker%29%20%40request_span_id%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1750082601339&to_ts=1750083501339&live=true))

As of now, both traditional logs and spans are sent to Datadog via Kubernetes log collection (more specifically [autodiscovery annotation](https://docs.datadoghq.com/containers/kubernetes/log/?tab=helm#autodiscovery-annotations)).

This PR makes Rust apps:

 - send traditional log messages to Datadog log management
 - send spans to Datadog APM
 
 It does so by sending Open Telemetry data directly to the Datadog agent (which requires enabling OTEL in the agent, see https://github.com/dust-tt/dust-infra/pull/339)

Using APM for spans make the data a richer and less verbose. The trade off is that the spans are going to be sampled and won't be exhaustive as previously.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

It's been tested locally on `Oauth` and `Core` apps.

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

👉 We are touching the observability configuration of our Rust app, as such the risk is to break it momentarily

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

In order to mitigate the risk, we'll start by enabling OTEL everywhere and once it's confirmed to be working as expected we'll remove the Kubernetes log collections for Rust.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
