### PR TITLE
Ignore draft configurations when computing agentsEditionsCount

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -385,6 +385,9 @@ export async function getBuildersUsageData(
             [Op.gt]: startDate,
             [Op.lt]: endDate,
           },
+          status: {
+            [Op.not]: "draft",
+          },
         },
         include: [
           {


### PR DESCRIPTION
## Description

Fix wrong agentsEditionsCount in the workspace usage query by excluding draft configurations.

## Tests

Local, before / after.

## Risk

Low

## Deploy Plan

Deploy front