### PR TITLE
[JIT Search] Migrate legacy table query JIT actions to JIT server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -17,7 +17,7 @@ export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
   /^data_source_configuration:\/\/dust\/w\/(\w+)\/(?:data_source_configurations\/(\w+)|data_source_views\/(\w+)\/filter\/(.+))$/;
 
 export const TABLE_CONFIGURATION_URI_PATTERN =
-  /^table_configuration:\/\/dust\/w\/(\w+)\/table_configurations\/(\w+)$/;
+  /^table_configuration:\/\/dust\/w\/(\w+)\/(?:table_configurations\/(\w+)|data_source_views\/(\w+)\/tables\/(.+))$/;
 
 // URI pattern for configuring the agent to use within an action.
 export const AGENT_CONFIGURATION_URI_PATTERN =


### PR DESCRIPTION
## Description
Part of https://github.com/dust-tt/tasks/issues/2968

PR #13443 migrated legacy retrieval JIT actions to new search JIT server. This PR does the same for table query, filling `jitServers` instead of `jitActions` in `jit_actions.ts`, and changing TABLE_CONFIGURATION_URI_PATTERN accordingly.

Following the pattern established in PR #13443 for retrieval actions, this PR migrates table query actions from jitActions to jitServers. 

Key changes:
- Update TABLE_CONFIGURATION_URI_PATTERN to support dynamic configurations (similar to DATA_SOURCE_CONFIGURATION_URI_PATTERN)
- Add parseTableConfigurationURI and update fetchAgentTableConfigurations to handle both database-backed and dynamic table configurations
- Migrate table queries from TablesQueryConfigurationType actions to MCP server configurations using the "query_tables" server view

This allows JIT table configurations to be created dynamically without database storage, while maintaining backward compatibility with existing database-backed configurations.

## Risks
standard

## Deploy Plan
- Deploy front service