### PR TITLE
Ignore workspace not found in WorkOS webhook

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -56,7 +56,11 @@ async function verifyWorkOSWorkspace<E extends object, R>(
 
   const workspace = await findWorkspaceByWorkOSOrganizationId(organizationId);
   if (!workspace) {
-    throw new Error(`Workspace not found for workspace "${organizationId}"`);
+    // Skip processing if workspace not found - it likely belongs to another region.
+    // This is expected in a multi-region setup. DataDog monitors these warnings
+    // and will alert if they occur across all regions.
+    logger.warn({ organizationId }, "Workspace not found for organization");
+    return;
   }
 
   return handler(workspace, event);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We are a bit too assertive on WorkOS webhooks introduced in https://github.com/dust-tt/dust/pull/13313.

WorkOS sends webhook events to all regions, so it's expected that a workspace is not found there. This PR changes the behavior to log only. A monitor will be triggered if a log for the same organization id is found in all regions. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
