### PR TITLE
Do not let Slack Client retries rate limit requests

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -39,6 +39,8 @@ export async function getSlackClient(
   }
   const slackClient = new WebClient(slackAccessToken, {
     timeout: SLACK_NETWORK_TIMEOUT_MS,
+    // Do not let Slack client retry rate limited calls.
+    rejectRateLimitedCalls: true,
     retryConfig: {
       retries: 1,
       factor: 1,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We discovered with @Fraggle 👯 that a lot of activities where in a pending state on `connectors-worker-deployment`. Zooming a bit more Slack client does handle the rate limit by itself, with a default `tenRetriesInAboutThirtyMinutes` which basically lock one worker for 30 minutes preventing other tasks from being run.

This PR shuts down the Slack client self handling of rate limit so it can be bubbled up in our Temporal queue. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
