### PR TITLE
Use getChannels() to leverage cache if possible

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -19,6 +19,7 @@ import { newWebhookSignal, syncChannelSignal } from "./signals";
 
 const {
   getChannel,
+  getChannels,
   fetchUsers,
   saveSuccessSyncActivity,
   syncChannelMetadata,
@@ -163,7 +164,14 @@ export async function syncOneThreadDebounced(
       debounceCount++;
       continue;
     }
-    const channel = await getChannel(connectorId, channelId);
+
+    // We first try to get the channel from the cache of all channels, if it's not found, we fetch it from the API.
+    let channel = (await getChannels(connectorId, false)).find(
+      (c) => c.id === channelId
+    );
+    if (!channel) {
+      channel = await getChannel(connectorId, channelId);
+    }
     if (!channel.name) {
       throw new Error(`Could not find channel name for channel ${channelId}`);
     }
@@ -206,7 +214,13 @@ export async function syncOneMessageDebounced(
     }
     console.log(`Talked to slack after debouncing ${debounceCount} time(s)`);
 
-    const channel = await getChannel(connectorId, channelId);
+    // We first try to get the channel from the cache of all channels, if it's not found, we fetch it from the API.
+    let channel = (await getChannels(connectorId, false)).find(
+      (c) => c.id === channelId
+    );
+    if (!channel) {
+      channel = await getChannel(connectorId, channelId);
+    }
     if (!channel.name) {
       throw new Error(`Could not find channel name for channel ${channelId}`);
     }


### PR DESCRIPTION
## Description

Use getChannels the workflow that sync a thread / message in slack to leverage the cache, fallback to the live call if missing.

## Risk

Medium but easy to revert

## Deploy Plan

Deploy front