### PR TITLE
[front] Add organizationId if available to avoid switcher

### DIFF
--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -37,14 +37,18 @@ export default async function handler(
 async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
   try {
     const { organizationId } = req.query;
-    let connectionId: string | undefined = undefined;
+    let enterpriseParams: { organizationId?: string; connectionId?: string } =
+      {};
     if (organizationId && typeof organizationId === "string") {
       // TODO(workos): We will want to cache this data
       const connections = await getWorkOS().sso.listConnections({
         organizationId,
       });
-      connectionId =
-        connections.data.length > 0 ? connections.data[0]?.id : undefined;
+      enterpriseParams = {
+        organizationId,
+        connectionId:
+          connections.data.length > 0 ? connections.data[0]?.id : undefined,
+      };
     }
 
     const authorizationUrl = getWorkOS().userManagement.getAuthorizationUrl({
@@ -52,7 +56,7 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       provider: "authkit",
       redirectUri: `${config.getClientFacingUrl()}/api/workos/callback`,
       clientId: config.getWorkOSClientId(),
-      connectionId,
+      ...enterpriseParams,
     });
 
     res.redirect(authorizationUrl);


### PR DESCRIPTION
## Description

If the domain is tied to multiple organization, we receive an error from authorize endpoint :

organization_selection_required
The user must choose an organization to finish their authentication.

Forcing organization id to avoid this

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
