### PR TITLE
[front] feat: update invitation flow to support WorkOS

### DIFF
--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -7,17 +7,17 @@ export function getSignUpUrl({
   invitationEmail?: string;
   workOSEnabled?: boolean;
 }) {
-  let signUpUrl;
   if (workOSEnabled) {
-    signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screenHint=sign-up`;
+    let signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screenHint=sign-up`;
     if (invitationEmail) {
       signUpUrl += `&loginHint=${encodeURIComponent(invitationEmail)}`;
     }
-  } else {
-    signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&prompt=login&screen_hint=signup`;
-    if (invitationEmail) {
-      signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
-    }
+    return signUpUrl;
+  }
+
+  let signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&prompt=login&screen_hint=signup`;
+  if (invitationEmail) {
+    signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
   }
 
   return signUpUrl;

--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -9,12 +9,15 @@ export function getSignUpUrl({
 }) {
   let signUpUrl;
   if (workOSEnabled) {
-    signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screen_hint=sign-up`;
+    signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screenHint=sign-up`;
+    if (invitationEmail) {
+      signUpUrl += `&loginHint=${encodeURIComponent(invitationEmail)}`;
+    }
   } else {
     signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&prompt=login&screen_hint=signup`;
-  }
-  if (invitationEmail) {
-    signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
+    if (invitationEmail) {
+      signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
+    }
   }
 
   return signUpUrl;

--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -5,7 +5,11 @@ export function getSignUpUrl({
   signupCallbackUrl: string;
   invitationEmail?: string;
 }) {
-  let signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&prompt=login&screen_hint=signup`;
+  // if (featureFlags.includes("workos") && workspace.workOSOrganizationId) {
+  //   return `api/workos/login?organizationId=${workspace.workOSOrganizationId}`;
+  // }
+
+  let signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screen_hint=sign-up`;
 
   if (invitationEmail) {
     signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;

--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -1,16 +1,18 @@
 export function getSignUpUrl({
   signupCallbackUrl,
   invitationEmail,
+  workOSEnabled,
 }: {
   signupCallbackUrl: string;
   invitationEmail?: string;
+  workOSEnabled?: boolean;
 }) {
-  // if (featureFlags.includes("workos") && workspace.workOSOrganizationId) {
-  //   return `api/workos/login?organizationId=${workspace.workOSOrganizationId}`;
-  // }
-
-  let signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screen_hint=sign-up`;
-
+  let signUpUrl;
+  if (workOSEnabled) {
+    signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screen_hint=sign-up`;
+  } else {
+    signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&prompt=login&screen_hint=signup`;
+  }
   if (invitationEmail) {
     signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
   }

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -209,7 +209,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
 
     if (isString(state)) {
       const stateObj = JSON.parse(
-        Buffer.from(state as string, "base64").toString("utf-8")
+        Buffer.from(state, "base64").toString("utf-8")
       );
       if (isString(stateObj.returnTo)) {
         res.redirect(stateObj.returnTo);

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -43,7 +43,7 @@ export default async function handler(
 
 async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const { organizationId, screen_hint, login_hint, returnTo } = req.query;
+    const { organizationId, screenHint, loginHint, returnTo } = req.query;
     let enterpriseParams: { organizationId?: string; connectionId?: string } =
       {};
     if (organizationId && typeof organizationId === "string") {
@@ -67,8 +67,8 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       state:
         returnTo &&
         Buffer.from(JSON.stringify({ returnTo })).toString("base64"),
-      ...(isValidScreenHint(screen_hint) ? { screenHint: screen_hint } : {}),
-      ...(isString(login_hint) ? { loginHint: login_hint } : {}),
+      ...(isValidScreenHint(screenHint) ? { screenHint } : {}),
+      ...(isString(loginHint) ? { loginHint } : {}),
     });
 
     res.redirect(authorizationUrl);

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -14,6 +14,13 @@ import { setRegionForUser } from "@app/lib/api/workos/user";
 import { getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
+import { isString } from "@app/types";
+
+function isValidScreenHint(
+  screenHint: string | string[] | undefined
+): screenHint is "sign-up" | "sign-in" {
+  return isString(screenHint) && ["sign-up", "sign-in"].includes(screenHint);
+}
 
 //TODO(workos): This file could be split in 3 route handlers.
 export default async function handler(
@@ -36,7 +43,7 @@ export default async function handler(
 
 async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const { organizationId } = req.query;
+    const { organizationId, screen_hint, login_hint, returnTo } = req.query;
     let enterpriseParams: { organizationId?: string; connectionId?: string } =
       {};
     if (organizationId && typeof organizationId === "string") {
@@ -57,6 +64,11 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       redirectUri: `${config.getClientFacingUrl()}/api/workos/callback`,
       clientId: config.getWorkOSClientId(),
       ...enterpriseParams,
+      state:
+        returnTo &&
+        Buffer.from(JSON.stringify({ returnTo })).toString("base64"),
+      ...(isValidScreenHint(screen_hint) ? { screenHint: screen_hint } : {}),
+      ...(isString(login_hint) ? { loginHint: login_hint } : {}),
     });
 
     res.redirect(authorizationUrl);
@@ -170,7 +182,9 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
 
       let returnTo = "/";
       try {
-        const stateObj = JSON.parse(state as string);
+        const stateObj = JSON.parse(
+          Buffer.from(state as string, "base64").toString("utf-8")
+        );
         if (stateObj.returnTo) {
           const url = new URL(stateObj.returnTo);
           returnTo = url.pathname + url.search;
@@ -192,6 +206,15 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
       `workos_session=${sealedCookie}; Path=/; HttpOnly; Secure;SameSite=Lax`,
       `sessionType=workos; Path=/; Secure;SameSite=Lax`,
     ]);
+
+    if (isString(state)) {
+      const stateObj = JSON.parse(
+        Buffer.from(state as string, "base64").toString("utf-8")
+      );
+      if (isString(stateObj.returnTo)) {
+        res.redirect(stateObj.returnTo);
+      }
+    }
 
     res.redirect("/api/login");
   } catch (error) {

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -65,6 +65,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
       notFound: true,
     };
   }
+
   const flags = await getFeatureFlags(workspace);
   const workOSEnabled =
     flags.includes("workos") && isString(workspace.workOSOrganizationId);


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2992.
- This PR handles the invitation flow when logging and signing up using WorkOS.
- API reference: https://workos.com/docs/reference/user-management/authentication/get-authorization-url.

## Tests

Local:
- In a non-SSO setup: invite a user by email, click on the link in the email, go through the signup flow and check that we end up in the correct workspace instead of creating one.

## Risk

- TBC

## Deploy Plan

- Deploy front.
