### PR TITLE
Improve Slack Rate Limit Handling

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -601,7 +601,10 @@ const _webhookSlackAPIHandler = async (
             return res.status(200).send();
           }
 
-          const slackClient = await getSlackClient(slackConfig.connectorId);
+          const slackClient = await getSlackClient(slackConfig.connectorId, {
+            // Do not reject rate limited calls in webhook handler.
+            rejectRateLimitedCalls: false,
+          });
 
           const channelInfo = await slackClient.conversations.info({
             channel: event.channel,

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -46,7 +46,10 @@ export async function autoReadChannel(
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
-  const slackClient = await getSlackClient(connectorId);
+  const slackClient = await getSlackClient(connectorId, {
+    // Do not reject rate limited calls in auto read channel. Mostly calls from webhooks.
+    rejectRateLimitedCalls: false,
+  });
   const remoteChannel = await slackClient.conversations.info({
     channel: slackChannelId,
   });

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -135,7 +135,10 @@ export async function botAnswerMessage(
       // This means that the message has been deleted, so we don't need to send an error message.
       return new Ok(undefined);
     }
-    const slackClient = await getSlackClient(connector.id);
+    const slackClient = await getSlackClient(connector.id, {
+      // Do not reject rate limited calls in bot answer message.
+      rejectRateLimitedCalls: false,
+    });
     try {
       await slackClient.chat.postMessage({
         channel: slackChannel,
@@ -196,7 +199,10 @@ export async function botReplaceMention(
       },
       "Unexpected exception updating mention on Chat Bot message"
     );
-    const slackClient = await getSlackClient(connector.id);
+    const slackClient = await getSlackClient(connector.id, {
+      // Do not reject rate limited calls in bot replace mention.
+      rejectRateLimitedCalls: false,
+    });
     await slackClient.chat.postMessage({
       channel: slackChannel,
       text: "An unexpected error occurred. Our team has been notified.",
@@ -284,7 +290,10 @@ export async function botValidateToolExecution(
         );
       }
     }
-    const slackClient = await getSlackClient(connector.id);
+    const slackClient = await getSlackClient(connector.id, {
+      // Do not reject rate limited calls in bot validate tool execution.
+      rejectRateLimitedCalls: false,
+    });
     await slackClient.chat.postEphemeral({
       channel: slackChannel,
       user: slackChatBotMessage.slackUserId,
@@ -302,7 +311,10 @@ export async function botValidateToolExecution(
       },
       "Unexpected exception validating tool execution"
     );
-    const slackClient = await getSlackClient(connector.id);
+    const slackClient = await getSlackClient(connector.id, {
+      // Do not reject rate limited calls in bot validate tool execution.
+      rejectRateLimitedCalls: false,
+    });
     await slackClient.chat.postMessage({
       channel: slackChannel,
       text: "An unexpected error occurred while sending the validation. Our team has been notified.",
@@ -344,7 +356,10 @@ async function processErrorResult(
       slackChatBotMessage?.conversationId
     );
 
-    const slackClient = await getSlackClient(connector.id);
+    const slackClient = await getSlackClient(connector.id, {
+      // Do not reject rate limited calls in process error result.
+      rejectRateLimitedCalls: false,
+    });
 
     const errorPost = makeErrorBlock(
       conversationUrl,
@@ -404,7 +419,10 @@ async function answerMessage(
   }
 
   // We start by retrieving the slack user info.
-  const slackClient = await getSlackClient(connector.id);
+  const slackClient = await getSlackClient(connector.id, {
+    // Do not reject rate limited calls in answer message.
+    rejectRateLimitedCalls: false,
+  });
 
   let slackUserInfo: SlackUserInfo | null = null;
 

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -127,7 +127,10 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
     if (connectionId) {
       const accessToken = await getSlackAccessToken(connectionId);
-      const slackClient = await getSlackClient(accessToken);
+      const slackClient = await getSlackClient(accessToken, {
+        // Do not reject rate limited calls in update connector. Called from the API.
+        rejectRateLimitedCalls: false,
+      });
       const teamInfoRes = await slackClient.team.info();
       if (!teamInfoRes.ok || !teamInfoRes.team?.id) {
         throw new Error("Can't get the Slack team information.");
@@ -754,7 +757,10 @@ export async function uninstallSlack(connectionId: string) {
 
   try {
     const slackAccessToken = await getSlackAccessToken(connectionId);
-    const slackClient = await getSlackClient(slackAccessToken);
+    const slackClient = await getSlackClient(slackAccessToken, {
+      // Do not reject rate limited calls in uninstall slack. Called from the API.
+      rejectRateLimitedCalls: false,
+    });
     await slackClient.auth.test();
     const deleteRes = await slackClient.apps.uninstall({
       client_id: SLACK_CLIENT_ID,

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -153,7 +153,10 @@ export async function joinChannel(
     throw new Error(`Connector ${connectorId} not found`);
   }
 
-  const client = await getSlackClient(connector.id);
+  const client = await getSlackClient(connector.id, {
+    // Do not reject rate limited calls in join channel.
+    rejectRateLimitedCalls: false,
+  });
   try {
     const channelInfo = await client.conversations.info({ channel: channelId });
     if (!channelInfo.ok || !channelInfo.channel?.name) {

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -18,12 +18,19 @@ import type { ModelId } from "@connectors/types";
 // Timeout in ms for all network requests;
 const SLACK_NETWORK_TIMEOUT_MS = 30000;
 
-export async function getSlackClient(connectorId: ModelId): Promise<WebClient>;
 export async function getSlackClient(
-  slackAccessToken: string
+  connectorId: ModelId,
+  options?: { rejectRateLimitedCalls?: boolean }
 ): Promise<WebClient>;
 export async function getSlackClient(
-  connectorIdOrAccessToken: string | ModelId
+  slackAccessToken: string,
+  options?: { rejectRateLimitedCalls?: boolean }
+): Promise<WebClient>;
+export async function getSlackClient(
+  connectorIdOrAccessToken: string | ModelId,
+  options: { rejectRateLimitedCalls?: boolean } = {
+    rejectRateLimitedCalls: true,
+  }
 ): Promise<WebClient> {
   let slackAccessToken: string | undefined = undefined;
   if (typeof connectorIdOrAccessToken === "number") {
@@ -39,8 +46,7 @@ export async function getSlackClient(
   }
   const slackClient = new WebClient(slackAccessToken, {
     timeout: SLACK_NETWORK_TIMEOUT_MS,
-    // Do not let Slack client retry rate limited calls.
-    rejectRateLimitedCalls: true,
+    rejectRateLimitedCalls: options.rejectRateLimitedCalls ?? true,
     retryConfig: {
       retries: 1,
       factor: 1,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/13462.

This PR actually keep the Slack client rate limit handling for all customers-facing interactions (think webhooks, connector update, ...) and only disable it for Temporal activities.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Will create non-determinism error as we change existing activity. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
