### PR TITLE
Attempt to improve SQLite worker heartbeat logic

### DIFF
--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -108,12 +108,9 @@ impl WorkerState {
             // Run cleanup in background if enough time has passed.
             if last_cleanup.elapsed() >= DATABASE_CLEANUP_INTERVAL {
                 let registry = self.registry.clone();
-                tokio::task::spawn_blocking(move || {
-                    let rt = tokio::runtime::Handle::current();
-                    rt.block_on(async move {
-                        registry.lock().await.retain(|_, entry| {
-                            entry.last_accessed.elapsed() < DATABASE_TIMEOUT_DURATION
-                        });
+                tokio::task::spawn(async move {
+                    registry.lock().await.retain(|_, entry| {
+                        entry.last_accessed.elapsed() < DATABASE_TIMEOUT_DURATION
                     });
                 });
                 last_cleanup = Instant::now();

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -108,7 +108,7 @@ impl WorkerState {
             // Run cleanup in background if enough time has passed.
             if last_cleanup.elapsed() >= CLEANUP_INTERVAL {
                 let registry = self.registry.clone();
-                tokio::task::spawn(async move {
+                tokio::task::spawn_blocking(async move {
                     registry.lock().await.retain(|_, entry| {
                         entry.last_accessed.elapsed() < DATABASE_TIMEOUT_DURATION
                     });

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -108,9 +108,12 @@ impl WorkerState {
             // Run cleanup in background if enough time has passed.
             if last_cleanup.elapsed() >= DATABASE_CLEANUP_INTERVAL {
                 let registry = self.registry.clone();
-                tokio::task::spawn(async move {
-                    registry.lock().await.retain(|_, entry| {
-                        entry.last_accessed.elapsed() < DATABASE_TIMEOUT_DURATION
+                tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Handle::current();
+                    rt.block_on(async move {
+                        registry.lock().await.retain(|_, entry| {
+                            entry.last_accessed.elapsed() < DATABASE_TIMEOUT_DURATION
+                        });
                     });
                 });
                 last_cleanup = Instant::now();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We suspect that `cleanup_inactive_databases()` is taking more than 2 seconds, preventing heartbeats from running on their expected 3-second schedule.

Solution: Move database cleanup to a background task so it doesn't block the heartbeat loop. Cleanup now runs every 30 seconds in parallel, ensuring consistent heartbeat timing.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
