### PR TITLE
[JIT Search] Migrate legacy table query JIT actions to JIT server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -8,6 +8,7 @@ import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputJSONSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
 import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
@@ -28,6 +29,15 @@ function getDataSourceURI(config: DataSourceConfiguration): string {
   }
   const encodedFilter = encodeURIComponent(JSON.stringify(filter));
   return `data_source_configuration://dust/w/${workspaceId}/data_source_views/${dataSourceViewId}/filter/${encodedFilter}`;
+}
+
+function getTableURI(config: TableDataSourceConfiguration): string {
+  const { workspaceId, sId, dataSourceViewId, tableId } = config;
+  if (sId) {
+    return `table_configuration://dust/w/${workspaceId}/table_configurations/${sId}`;
+  }
+  const encodedTableId = encodeURIComponent(tableId);
+  return `table_configuration://dust/w/${workspaceId}/data_source_views/${dataSourceViewId}/tables/${encodedTableId}`;
 }
 
 /**
@@ -63,7 +73,7 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE: {
       return (
         actionConfiguration.tables?.map((config) => ({
-          uri: `table_configuration://dust/w/${owner.sId}/table_configurations/${config.sId}`,
+          uri: getTableURI(config),
           mimeType,
         })) || []
       );

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -36,8 +36,7 @@ function getTableURI(config: TableDataSourceConfiguration): string {
   if (sId) {
     return `table_configuration://dust/w/${workspaceId}/table_configurations/${sId}`;
   }
-  const encodedTableId = encodeURIComponent(tableId);
-  return `table_configuration://dust/w/${workspaceId}/data_source_views/${dataSourceViewId}/tables/${encodedTableId}`;
+  return `table_configuration://dust/w/${workspaceId}/data_source_views/${dataSourceViewId}/tables/${tableId}`;
 }
 
 /**

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -17,7 +17,7 @@ export const DATA_SOURCE_CONFIGURATION_URI_PATTERN =
   /^data_source_configuration:\/\/dust\/w\/(\w+)\/(?:data_source_configurations\/(\w+)|data_source_views\/(\w+)\/filter\/(.+))$/;
 
 export const TABLE_CONFIGURATION_URI_PATTERN =
-  /^table_configuration:\/\/dust\/w\/(\w+)\/table_configurations\/(\w+)$/;
+  /^table_configuration:\/\/dust\/w\/(\w+)\/(?:table_configurations\/(\w+)|data_source_views\/(\w+)\/tables\/(.+))$/;
 
 // URI pattern for configuring the agent to use within an action.
 export const AGENT_CONFIGURATION_URI_PATTERN =

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -13,7 +13,7 @@ import type {
   ThinkingOutputType,
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { fetchAgentTableConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { fetchTableDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { runActionStreamed } from "@app/lib/actions/server";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -112,7 +112,7 @@ function createServer(
         getDustProdAction("assistant-v2-query-tables").config
       );
 
-      const tableConfigurationsRes = await fetchAgentTableConfigurations(
+      const tableConfigurationsRes = await fetchTableDataSourceConfigurations(
         auth,
         tables
       );
@@ -123,15 +123,16 @@ function createServer(
       }
 
       const tableConfigurations = tableConfigurationsRes.value;
-      const dataSourceViews = await DataSourceViewResource.fetchByIds(auth, [
-        ...new Set(tableConfigurations.map((t) => t.dataSourceViewId)),
-      ]);
 
       const personalConnectionIds: Record<string, string> = {};
 
       // This is for Salesforce personal connections.
       const flags = await getFeatureFlags(owner);
       if (flags.includes("labs_salesforce_personal_connections")) {
+        const dataSourceViews = await DataSourceViewResource.fetchByIds(auth, [
+          ...new Set(tableConfigurations.map((t) => t.dataSourceViewId)),
+        ]);
+
         for (const dataSourceView of dataSourceViews) {
           if (dataSourceView.dataSource.connectorProvider === "salesforce") {
             const personalConnection =

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -24,7 +24,7 @@ import {
   getSectionColumnsPrefix,
   TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH,
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
-import { fetchAgentTableConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { fetchTableDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -69,7 +69,7 @@ function createServer(
     },
     async ({ tables }) => {
       // Fetch table configurations
-      const tableConfigurationsRes = await fetchAgentTableConfigurations(
+      const tableConfigurationsRes = await fetchTableDataSourceConfigurations(
         auth,
         tables
       );
@@ -165,7 +165,7 @@ function createServer(
         const agentLoopRunContext = agentLoopContext.runContext;
 
         // Fetch table configurations
-        const tableConfigurationsRes = await fetchAgentTableConfigurations(
+        const tableConfigurationsRes = await fetchTableDataSourceConfigurations(
           auth,
           tables
         );

--- a/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
@@ -153,10 +153,35 @@ describe("MCP Internal Actions Server Utils", () => {
         expect(result.isOk()).toBe(true);
         if (result.isOk()) {
           expect(result.value).toHaveLength(1);
-          expect(result.value[0].id).toBe(tableConfig.id);
+          expect(result.value[0].tableId).toBe(tableConfig.tableId);
+          expect(result.value[0].workspaceId).toBe(workspace.sId);
         }
       }
     );
+
+    itInTransaction("should handle dynamic table configurations", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const tablesConfiguration = [
+        {
+          uri: `table_configuration://dust/w/${workspace.sId}/data_source_views/dsv_12345/tables/table%20name`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
+        },
+      ];
+
+      const result = await fetchAgentTableConfigurations(
+        auth,
+        tablesConfiguration
+      );
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(1);
+        expect(result.value[0].tableId).toBe("table name");
+        expect(result.value[0].workspaceId).toBe(workspace.sId);
+        expect(result.value[0].dataSourceViewId).toBe("dsv_12345");
+      }
+    });
   });
 
   describe("getCoreSearchArgs", () => {

--- a/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
@@ -11,7 +11,7 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 
-import { fetchAgentTableConfigurations, getCoreSearchArgs } from "./utils";
+import { fetchTableDataSourceConfigurations, getCoreSearchArgs } from "./utils";
 
 describe("MCP Internal Actions Server Utils", () => {
   describe("fetchAgentTableConfigurations", () => {
@@ -53,7 +53,7 @@ describe("MCP Internal Actions Server Utils", () => {
           },
         ];
 
-        const result = await fetchAgentTableConfigurations(
+        const result = await fetchTableDataSourceConfigurations(
           auth,
           tablesConfiguration
         );
@@ -81,7 +81,7 @@ describe("MCP Internal Actions Server Utils", () => {
           },
         ];
 
-        const result = await fetchAgentTableConfigurations(
+        const result = await fetchTableDataSourceConfigurations(
           auth,
           tablesConfiguration
         );
@@ -146,7 +146,7 @@ describe("MCP Internal Actions Server Utils", () => {
           },
         ];
 
-        const result = await fetchAgentTableConfigurations(
+        const result = await fetchTableDataSourceConfigurations(
           auth,
           tablesConfiguration
         );
@@ -170,7 +170,7 @@ describe("MCP Internal Actions Server Utils", () => {
         },
       ];
 
-      const result = await fetchAgentTableConfigurations(
+      const result = await fetchTableDataSourceConfigurations(
         auth,
         tablesConfiguration
       );

--- a/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
@@ -165,7 +165,7 @@ describe("MCP Internal Actions Server Utils", () => {
 
       const tablesConfiguration = [
         {
-          uri: `table_configuration://dust/w/${workspace.sId}/data_source_views/dsv_12345/tables/table%20name`,
+          uri: `table_configuration://dust/w/${workspace.sId}/data_source_views/dsv_12345/tables/table_name`,
           mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
         },
       ];
@@ -177,7 +177,7 @@ describe("MCP Internal Actions Server Utils", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         expect(result.value).toHaveLength(1);
-        expect(result.value[0].tableId).toBe("table name");
+        expect(result.value[0].tableId).toBe("table_name");
         expect(result.value[0].workspaceId).toBe(workspace.sId);
         expect(result.value[0].dataSourceViewId).toBe("dsv_12345");
       }

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -151,7 +151,7 @@ export async function fetchTableDataSourceConfigurations(
       results.push({
         workspaceId,
         dataSourceViewId: viewId,
-        tableId: decodeURIComponent(tableId),
+        tableId,
       });
     } else {
       return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -74,7 +74,7 @@ export async function fetchAgentDataSourceConfiguration(
   return new Ok(agentDataSourceConfiguration);
 }
 
-export async function fetchAgentTableConfigurations(
+export async function fetchTableDataSourceConfigurations(
   auth: Authenticator,
   tablesConfiguration: TablesConfigurationToolType
 ): Promise<Result<TableDataSourceConfiguration[], Error>> {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -22,7 +22,7 @@ import type {
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { ProcessConfigurationType } from "@app/lib/actions/process";
-import type { TablesQueryConfigurationType } from "@app/lib/actions/tables_query";
+import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
 import type {
   ActionConfigurationType,
   AgentActionConfigurationType,
@@ -193,15 +193,20 @@ async function getJITActions(
   );
 
   if (filesUsableAsTableQuery.length > 0) {
-    const action: TablesQueryConfigurationType = {
-      // The description here is the description of the data, a meta description of the action
-      // is prepended automatically.
-      description: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION,
-      type: "tables_query_configuration",
-      id: -1,
-      name: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
-      sId: generateRandomModelSId(),
-      tables: filesUsableAsTableQuery.flatMap((f) => {
+    // Get the query_tables MCP server view
+    const queryTablesView =
+      await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+        auth,
+        "query_tables"
+      );
+
+    assert(
+      queryTablesView,
+      "MCP server view not found for query_tables. Ensure auto tools are created."
+    );
+
+    const tables: TableDataSourceConfiguration[] =
+      filesUsableAsTableQuery.flatMap((f) => {
         if (isConversationFileType(f)) {
           assert(
             conversationDataSourceView,
@@ -220,9 +225,26 @@ async function getJITActions(
           }));
         }
         assertNever(f);
-      }),
+      });
+
+    const tablesServer: ServerSideMCPServerConfigurationType = {
+      id: -1,
+      sId: generateRandomModelSId(),
+      type: "mcp_server_configuration",
+      name: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
+      description: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION,
+      dataSources: null,
+      tables,
+      childAgentId: null,
+      reasoningModel: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: queryTablesView.sId,
+      dustAppConfiguration: null,
+      internalMCPServerId: queryTablesView.mcpServerId,
     };
-    actions.push(action);
+    jitServers.push(tablesServer);
   }
 
   // Get the retrieval view once - we'll need it for search functionality

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -139,7 +139,7 @@ describe("JSON Schema Utilities", () => {
                           uri: {
                             type: "string",
                             pattern:
-                              "^table_configuration:\\/\\/dust\\/w\\/(\\w+)\\/table_configurations\\/(\\w+)$",
+                              "^table_configuration:\\/\\/dust\\/w\\/(\\w+)\\/(?:table_configurations\\/(\\w+)|data_source_views\\/(\\w+)\\/tables\\/(.+))$",
                           },
                           mimeType: {
                             type: "string",


### PR DESCRIPTION
Part of https://github.com/dust-tt/tasks/issues/2968

## Description
PR #13443 migrated legacy retrieval JIT actions to new search JIT server. This PR does the same for table query, filling `jitServers` instead of `jitActions` in `jit_actions.ts`, and changing TABLE_CONFIGURATION_URI_PATTERN accordingly.

However, it takes a different approach than PR #13443. Instead of parsing URIs at call sites, we keep the original `fetchAgentTableConfigurations` function signature but change its return type from `AgentTablesQueryConfigurationTable[]` to `TableDataSourceConfiguration[]`. The URL parsing logic is moved inside the function to minimize code changes in callers.

Key changes:
- Update TABLE_CONFIGURATION_URI_PATTERN to support dynamic configurations (similar to DATA_SOURCE_CONFIGURATION_URI_PATTERN)
- Keep fetchAgentTableConfigurations with same arguments but return TableDataSourceConfiguration[]
- Move URL parsing logic inside fetchAgentTableConfigurations to minimize caller changes
- Migrate table queries from TablesQueryConfigurationType actions to MCP server configurations using the "query_tables" server view
- Update all call sites to work with the new return type

This allows JIT table configurations to be created dynamically without database storage, while maintaining backward compatibility with existing database-backed configurations.

## Risks

Standard

## Deploy Plan

- Deploy front service
