### PR TITLE
[front] Enable SSO connection setupp flow for all SSO users

### DIFF
--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -95,7 +95,7 @@ export function CreateOrEditSpaceModal({
     workspaceId: owner.sId,
   });
 
-  const isWorkOSFeatureEnabled = hasFeature("workos");
+  const isWorkOSFeatureEnabled = hasFeature("workos_user_provisioning");
 
   useEffect(() => {
     if (!isWorkOSFeatureEnabled) {

--- a/front/components/workspace/SSOConnection.tsx
+++ b/front/components/workspace/SSOConnection.tsx
@@ -1,30 +1,19 @@
 import type { Organization } from "@workos-inc/node";
 
-import Auth0SSOConnection from "@app/components/workspace/sso/Auth0SSOConnection";
 import WorkOSSSOConnection from "@app/components/workspace/sso/WorkOSSSOConnection";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { PlanType, WorkspaceType } from "@app/types";
-
-export interface EnterpriseConnectionStrategyDetails {
-  callbackUrl: string;
-  initiateLoginUrl: string;
-  // SAML Specific.
-  audienceUri: string;
-  samlAcsUrl: string;
-}
 
 interface SSOConnectionProps {
   domains: Organization["domains"];
   owner: WorkspaceType;
   plan: PlanType;
-  strategyDetails: EnterpriseConnectionStrategyDetails;
 }
 
 export default function SSOConnection({
   domains,
   owner,
   plan,
-  strategyDetails,
 }: SSOConnectionProps) {
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
@@ -32,21 +21,10 @@ export default function SSOConnection({
 
   // Feature flag `okta_enterprise_connection` is required to use SSO.
   const hasSSOFeatureFlag = featureFlags.includes("okta_enterprise_connection");
-  // If the `workos` feature flag is also enabled, then we can use the WorkOS SSO connection.
-  const hasWorkOSSSOFeatureFlag = featureFlags.includes("workos");
 
   if (!hasSSOFeatureFlag) {
     return null;
   }
 
-  return !hasWorkOSSSOFeatureFlag ? (
-    <Auth0SSOConnection
-      domains={domains}
-      owner={owner}
-      plan={plan}
-      strategyDetails={strategyDetails}
-    />
-  ) : (
-    <WorkOSSSOConnection domains={domains} owner={owner} plan={plan} />
-  );
+  return <WorkOSSSOConnection domains={domains} owner={owner} plan={plan} />;
 }

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -41,9 +41,8 @@ export default function WorkspaceAccessPanel({
 
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   // Both workos and workos_user_provisioning are required to enable user provisioning.
-  const hasWorkOSUserProvisioningFeature = hasFeature(
-    "workos_user_provisioning"
-  );
+  const hasWorkOSUserProvisioningFeature =
+    hasFeature("workos") && hasFeature("workos_user_provisioning");
 
   return (
     <div className="flex flex-col gap-6">

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -16,7 +16,6 @@ import React from "react";
 import { ConfirmContext } from "@app/components/Confirm";
 import UserProvisioning from "@app/components/workspace/DirectorySync";
 import { AutoJoinToggle } from "@app/components/workspace/sso/AutoJoinToggle";
-import type { EnterpriseConnectionStrategyDetails } from "@app/components/workspace/SSOConnection";
 import SSOConnection from "@app/components/workspace/SSOConnection";
 import {
   useRemoveWorkspaceDomain,
@@ -26,14 +25,12 @@ import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LightWorkspaceType, PlanType, WorkspaceDomain } from "@app/types";
 
 interface WorkspaceAccessPanelProps {
-  enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails;
   workspaceVerifiedDomains: WorkspaceDomain[];
   owner: LightWorkspaceType;
   plan: PlanType;
 }
 
 export default function WorkspaceAccessPanel({
-  enterpriseConnectionStrategyDetails,
   workspaceVerifiedDomains,
   owner,
   plan,
@@ -44,8 +41,9 @@ export default function WorkspaceAccessPanel({
 
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   // Both workos and workos_user_provisioning are required to enable user provisioning.
-  const hasWorkOSUserProvisioningFeature =
-    hasFeature("workos") && hasFeature("workos_user_provisioning");
+  const hasWorkOSUserProvisioningFeature = hasFeature(
+    "workos_user_provisioning"
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -57,12 +55,7 @@ export default function WorkspaceAccessPanel({
         owner={owner}
       />
       <Separator />
-      <SSOConnection
-        domains={domains}
-        plan={plan}
-        strategyDetails={enterpriseConnectionStrategyDetails}
-        owner={owner}
-      />
+      <SSOConnection domains={domains} plan={plan} owner={owner} />
       <AutoJoinToggle
         domains={domains}
         workspaceVerifiedDomains={workspaceVerifiedDomains}

--- a/front/components/workspace/sso/Auth0SSOConnection.tsx
+++ b/front/components/workspace/sso/Auth0SSOConnection.tsx
@@ -27,7 +27,6 @@ import type { Organization } from "@workos-inc/node";
 import React from "react";
 
 import { ToggleEnforceEnterpriseConnectionModal } from "@app/components/workspace/sso/Toggle";
-import type { EnterpriseConnectionStrategyDetails } from "@app/components/workspace/SSOConnection";
 import { UpgradePlanDialog } from "@app/components/workspace/UpgradePlanDialog";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useWorkspaceEnterpriseConnection } from "@app/lib/swr/workspaces";
@@ -43,6 +42,14 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { connectionStrategyToHumanReadable } from "@app/types";
+
+export interface EnterpriseConnectionStrategyDetails {
+  callbackUrl: string;
+  initiateLoginUrl: string;
+  // SAML Specific.
+  audienceUri: string;
+  samlAcsUrl: string;
+}
 
 interface Auth0SSOConnectionProps {
   domains: Organization["domains"];

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -55,6 +55,7 @@ export function useWorkspaceAnalytics({
   };
 }
 
+// TODO(workos): Remove this once we have migrated to WorkOS.
 export function useWorkspaceEnterpriseConnection({
   owner,
   disabled,

--- a/front/pages/api/w/[wId]/dsync.ts
+++ b/front/pages/api/w/[wId]/dsync.ts
@@ -41,10 +41,7 @@ async function handler(
   }
 
   const flags = await getFeatureFlags(workspace);
-  if (
-    !flags.includes("workos_user_provisioning") &&
-    !flags.includes("workos")
-  ) {
+  if (!flags.includes("workos_user_provisioning")) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/dsync.ts
+++ b/front/pages/api/w/[wId]/dsync.ts
@@ -41,7 +41,10 @@ async function handler(
   }
 
   const flags = await getFeatureFlags(workspace);
-  if (!flags.includes("workos_user_provisioning")) {
+  if (
+    !flags.includes("workos_user_provisioning") ||
+    !flags.includes("workos")
+  ) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/enterprise-connection.ts
+++ b/front/pages/api/w/[wId]/enterprise-connection.ts
@@ -55,6 +55,7 @@ export type PostCreateEnterpriseConnectionRequestBodySchemaType =
   | IdpSpecificConnectionTypeDetails
   | SAMLConnectionTypeDetails;
 
+// TODO(workos): Remove this once we have migrated to WorkOS.
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<

--- a/front/pages/api/w/[wId]/sso.ts
+++ b/front/pages/api/w/[wId]/sso.ts
@@ -41,7 +41,7 @@ async function handler(
   }
 
   const flags = await getFeatureFlags(workspace);
-  if (!flags.includes("workos")) {
+  if (!flags.includes("okta_enterprise_connection")) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -47,7 +47,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   perSeatPricing: SubscriptionPerSeatPricing | null;
-  enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails;
   plan: PlanType;
   workspaceHasAvailableSeats: boolean;
   workspaceVerifiedDomains: WorkspaceDomain[];

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -23,14 +23,7 @@ import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
-import type { EnterpriseConnectionStrategyDetails } from "@app/components/workspace/SSOConnection";
 import WorkspaceAccessPanel from "@app/components/workspace/WorkspaceAccessPanel";
-import config from "@app/lib/api/config";
-import {
-  makeAudienceUri,
-  makeEnterpriseConnectionInitiateLoginUrl,
-  makeSamlAcsUrl,
-} from "@app/lib/api/enterprise_connection";
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
 import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -75,18 +68,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const workspaceHasAvailableSeats =
     await checkWorkspaceSeatAvailabilityUsingAuth(auth);
 
-  const enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails =
-    {
-      callbackUrl: config.getAuth0TenantUrl(),
-      initiateLoginUrl: await makeEnterpriseConnectionInitiateLoginUrl(
-        owner.sId,
-        null
-      ),
-      // SAML specific.
-      audienceUri: makeAudienceUri(owner),
-      samlAcsUrl: makeSamlAcsUrl(owner),
-    };
-
   const perSeatPricing = await subscriptionResource.getPerSeatPricing();
   const subscription = subscriptionResource.toJSON();
 
@@ -96,7 +77,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       perSeatPricing,
-      enterpriseConnectionStrategyDetails,
       plan,
       workspaceHasAvailableSeats,
       workspaceVerifiedDomains,
@@ -109,7 +89,6 @@ export default function WorkspaceAdmin({
   owner,
   subscription,
   perSeatPricing,
-  enterpriseConnectionStrategyDetails,
   plan,
   workspaceHasAvailableSeats,
   workspaceVerifiedDomains,
@@ -153,9 +132,6 @@ export default function WorkspaceAdmin({
           description="Verify your domain, manage team members and their permissions."
         />
         <WorkspaceAccessPanel
-          enterpriseConnectionStrategyDetails={
-            enterpriseConnectionStrategyDetails
-          }
           workspaceVerifiedDomains={workspaceVerifiedDomains}
           owner={owner}
           plan={plan}


### PR DESCRIPTION
## Description

This enables the SSO setup flow for all users having the okta_enterprise_connection FF. Users will all see the "Activate SSO" link that will redirect to workos portal,  and can't setup any auth0 sso connection anymore.
Login is still on Auth0, only setup is possible.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk


## Deploy Plan

deploy front
