### PR TITLE
[ext] provisioning(workos): rework auth on front plugin

### DIFF
--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -22,7 +22,7 @@ const POPUP_CONFIG = {
   CHECK_INTERVAL_MS: 100,
 } as const;
 
-const DEFAULT_TOKEN_EXPIRY = 5 * 6; // 5 minutes in seconds
+const DEFAULT_TOKEN_EXPIRY = 5 * 60; // 5 minutes in seconds
 
 interface PopupResult<T = void> {
   data?: T;

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -1,9 +1,10 @@
 import {
   DUST_API_AUDIENCE,
+  DUST_US_URL,
   FRONT_EXTENSION_URL,
   getOAuthClientID,
-  DUST_US_URL,
 } from "@app/shared/lib/config";
+import { generatePKCE, normalizeError } from "@app/shared/lib/utils";
 import type { StoredTokens } from "@app/shared/services/auth";
 import {
   AuthError,
@@ -14,7 +15,6 @@ import type { StorageService } from "@app/shared/services/storage";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import { jwtDecode } from "jwt-decode";
-import { generatePKCE } from "@app/shared/lib/utils";
 
 export class FrontAuthService extends AuthService {
   private popupWindow: Window | null = null;
@@ -99,7 +99,7 @@ export class FrontAuthService extends AuthService {
               }
             }
           } catch (e) {
-            // Ignore cross-origin errors
+            reject(normalizeError(e));
           }
         }, 100);
       });
@@ -228,12 +228,12 @@ export class FrontAuthService extends AuthService {
             resolve();
           }
         } catch (e) {
-          // Ignore cross-origin errors
+          reject(normalizeError(e));
         }
       }, 100);
     });
 
-    this.storage.clear();
+    await this.storage.clear();
     return true;
   }
 

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -4,7 +4,7 @@ import {
   FRONT_EXTENSION_URL,
   getOAuthClientID,
 } from "@app/shared/lib/config";
-import { generatePKCE, normalizeError } from "@app/shared/lib/utils";
+import { generatePKCE } from "@app/shared/lib/utils";
 import type { StoredTokens } from "@app/shared/services/auth";
 import {
   AuthError,
@@ -98,8 +98,9 @@ export class FrontAuthService extends AuthService {
                 resolve({ code });
               }
             }
-          } catch (e) {
-            reject(normalizeError(e));
+          } finally {
+            // Ignore errors accessing popup location (cross-origin)
+            // This is expected if the popup has navigated to a different domain
           }
         }, 100);
       });
@@ -212,7 +213,7 @@ export class FrontAuthService extends AuthService {
     }
 
     // Wait for the popup to complete logout
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve) => {
       const checkPopup = setInterval(() => {
         if (popup.closed) {
           clearInterval(checkPopup);
@@ -227,8 +228,9 @@ export class FrontAuthService extends AuthService {
             popup.close();
             resolve();
           }
-        } catch (e) {
-          reject(normalizeError(e));
+        } finally {
+          // Ignore errors accessing popup location (cross-origin)
+          // This is expected if the popup has navigated to a different domain
         }
       }, 100);
     });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

To be able to login with workos on the front extension, we need to rework the login flow.
We implement the use of the newly created api/v1/auth/[action] endpoint.

WorkOS authentication:
![gif](https://github.com/user-attachments/assets/f78586db-5d81-4f46-9b63-bdde42571c66)

Next step : port this logic to chrome extension, and drop api/v1/auth endpoint.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Logged in with WorkOS and Auth0 successfully. Sent messages successfully. Logged out successfully.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks, only front extension.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Merge https://github.com/dust-tt/dust/pull/13446
Deploy front ext.