### PR TITLE
Do remote DB sync only every 6 hours

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/client.ts
+++ b/connectors/src/connectors/snowflake/temporal/client.ts
@@ -29,6 +29,9 @@ export async function launchSnowflakeSyncWorkflow(
   const client = await getTemporalClient();
   const workflowId = makeSnowflakeSyncWorkflowId(connectorId);
 
+  // hourOffset ensures jobs are distributed across the day based on connector ID
+  const hourOffset = connector.id % 6;
+
   try {
     await client.workflow.signalWithStart(snowflakeSyncWorkflow, {
       args: [
@@ -47,8 +50,8 @@ export async function launchSnowflakeSyncWorkflow(
       memo: {
         connectorId,
       },
-      // Every hour.
-      cronSchedule: `${connector.id % 60} * * * *`,
+      // Every 6 hours, with hour offset based on connector ID
+      cronSchedule: `${connector.id % 60} ${hourOffset},${(hourOffset + 6) % 24},${(hourOffset + 12) % 24},${(hourOffset + 18) % 24} * * *`,
     });
   } catch (err) {
     return new Err(normalizeError(err));


### PR DESCRIPTION
## Description

We had some rate limit error because of doing "getTable()" in the sync job.
Do it only every 6 hours instead of every hour.

## Deploy Plan

Deploy connector, restart all bigquery and snowflake workflows