### PR TITLE
Fix: relocation script didn't unpause connectors

### DIFF
--- a/connectors/src/api/pause_connector.ts
+++ b/connectors/src/api/pause_connector.ts
@@ -32,7 +32,7 @@ const _pauseConnectorAPIHandler = async (
     const pauseRes = await getConnectorManager({
       connectorProvider: connector.type,
       connectorId: connector.id,
-    }).pause();
+    }).pauseAndStop();
 
     if (pauseRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/api/unpause_connector.ts
+++ b/connectors/src/api/unpause_connector.ts
@@ -40,7 +40,7 @@ const _unpauseConnectorAPIHandler = async (
     const unpauseRes = await getConnectorManager({
       connectorProvider: connector.type,
       connectorId: connector.id,
-    }).unpause();
+    }).unpauseAndResume();
 
     if (unpauseRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/connectors/bigquery/index.ts
+++ b/connectors/src/connectors/bigquery/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { assertNever, Err, Ok } from "@dust-tt/client";
 
 import type { TestConnectionError } from "@connectors/connectors/bigquery/lib/bigquery_api";
@@ -53,6 +53,8 @@ function handleTestConnectionError(
 }
 
 export class BigQueryConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "bigquery";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -358,28 +360,6 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
     memoizationKey?: string;
   }): Promise<Result<string[], Error>> {
     return new Ok([internalId]);
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(
-        new Error(`Connector not found with id ${this.connectorId}`)
-      );
-    }
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(
-        new Error(`Connector not found with id ${this.connectorId}`)
-      );
-    }
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async setConfigurationKey({

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -416,12 +416,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     }
 
     await connector.markAsPaused();
-    const r = await stopConfluenceSyncWorkflow(this.connectorId);
-    if (r.isErr()) {
-      return r;
-    }
-
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -432,12 +427,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     }
 
     await connector.markAsUnpaused();
-    const r = await launchConfluenceSyncWorkflow(this.connectorId, null);
-    if (r.isErr()) {
-      return r;
-    }
-
-    return new Ok(undefined);
+    return this.resume();
   }
 
   async retrieveContentNodeParents({

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -144,7 +144,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
 
         // If connector was previously paused, unpause it.
         if (connector.isPaused()) {
-          await this.unpause();
+          await this.unpauseAndResume();
         }
       } else {
         logger.info(

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
 import {
@@ -44,6 +44,8 @@ const logger = mainLogger.child({
 });
 
 export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "confluence";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -406,28 +408,6 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     }
 
     return new Ok(undefined);
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error({ connectorId: this.connectorId }, "Connector not found.");
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error({ connectorId: this.connectorId }, "Connector not found.");
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async retrieveContentNodeParents({

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -131,7 +131,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (c.isPaused()) {
-        await this.unpause();
+        await this.unpauseAndResume();
       }
 
       await launchGithubFullSyncWorkflow({

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { assertNever, Err, Ok } from "@dust-tt/client";
 
 import {
@@ -48,6 +48,8 @@ import { INTERNAL_MIME_TYPES, normalizeError } from "@connectors/types";
 const logger = mainLogger.child({ provider: "github" });
 
 export class GithubConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "github";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -580,26 +582,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error({ connectorId: this.connectorId }, "Connector not found");
-      return new Err(new Error("Connector not found"));
-    }
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error({ connectorId: this.connectorId }, "Connector not found");
-      return new Err(new Error("Connector not found"));
-    }
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async setPermissions(): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -589,8 +589,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
     await connector.markAsPaused();
-    await terminateAllWorkflowsForConnectorId(this.connectorId);
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -600,12 +599,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
     await connector.markAsUnpaused();
-    await launchGithubFullSyncWorkflow({
-      connectorId: this.connectorId,
-      syncCodeOnly: false,
-    });
-
-    return new Ok(undefined);
+    return this.resume();
   }
 
   async setPermissions(): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
 import { makeGongTranscriptFolderInternalId } from "@connectors/connectors/gong/lib/internal_ids";
@@ -57,6 +57,8 @@ export function makeGongForceResyncWorkflowId(
 }
 
 export class GongConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "gong";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -267,22 +269,6 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
 
   async setPermissions(): Promise<Result<void, Error>> {
     throw new Error("Method not supported.");
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await fetchGongConnector({
-      connectorId: this.connectorId,
-    });
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await fetchGongConnector({
-      connectorId: this.connectorId,
-    });
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -154,7 +154,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (connector.isPaused()) {
-        await this.unpause();
+        await this.unpauseAndResume();
 
         await triggerSchedule({
           connector,

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -783,8 +783,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       );
     }
     await connector.markAsPaused();
-    await terminateAllWorkflowsForConnectorId(this.connectorId);
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -795,21 +794,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       );
     }
     await connector.markAsUnpaused();
-    const r = await launchGoogleDriveFullSyncWorkflow(
-      this.connectorId,
-      null,
-      []
-    );
-    if (r.isErr()) {
-      return r;
-    }
-    const incrementalSync = await launchGoogleDriveIncrementalSyncWorkflow(
-      this.connectorId
-    );
-    if (incrementalSync.isErr()) {
-      return incrementalSync;
-    }
-    return new Ok(undefined);
+    return this.resume();
   }
 
   async stop(): Promise<Result<undefined, Error>> {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -199,7 +199,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (connector.isPaused()) {
-        await this.unpause();
+        await this.unpauseAndResume();
       }
     }
 

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok, removeNulls } from "@dust-tt/client";
 import type { drive_v3 } from "googleapis";
 import type { GaxiosResponse, OAuth2Client } from "googleapis-common";
@@ -67,6 +67,8 @@ import {
 } from "@connectors/types";
 
 export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "google_drive";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -773,28 +775,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     }
 
     return launchGoogleGarbageCollector(this.connectorId);
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(
-        new Error(`Connector not found with id ${this.connectorId}`)
-      );
-    }
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(
-        new Error(`Connector not found with id ${this.connectorId}`)
-      );
-    }
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async stop(): Promise<Result<undefined, Error>> {

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
 import {
@@ -53,6 +53,8 @@ import type {
 import type { DataSourceConfig } from "@connectors/types";
 
 export class IntercomConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "intercom";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -626,34 +628,6 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "[Intercom] Connector not found."
-      );
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "[Intercom] Connector not found."
-      );
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -161,7 +161,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (connector.isPaused()) {
-        await this.unpause();
+        await this.unpauseAndResume();
       }
 
       await IntercomWorkspaceModel.update(

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -98,7 +98,7 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
 
   abstract garbageCollect(): Promise<Result<string, Error>>;
 
-  async pause(): Promise<Result<undefined, Error>> {
+  async pauseAndStop(): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       throw new Error(
@@ -109,7 +109,7 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
     return this.stop();
   }
 
-  async unpause(): Promise<Result<undefined, Error>> {
+  async unpauseAndResume(): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       throw new Error(

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -590,8 +590,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       );
     }
     await connector.markAsPaused();
-    await terminateAllWorkflowsForConnectorId(this.connectorId);
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -602,26 +601,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       );
     }
     await connector.markAsUnpaused();
-    const r = await launchMicrosoftFullSyncWorkflow(this.connectorId);
-    if (r.isErr()) {
-      return r;
-    }
-
-    const gcRes = await launchMicrosoftGarbageCollectionWorkflow(
-      this.connectorId
-    );
-
-    if (gcRes.isErr()) {
-      return gcRes;
-    }
-
-    const incrementalSync = await launchMicrosoftIncrementalSyncWorkflow(
-      this.connectorId
-    );
-    if (incrementalSync.isErr()) {
-      return incrementalSync;
-    }
-    return new Ok(undefined);
+    return this.resume();
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -165,7 +165,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (connector.isPaused()) {
-        await this.unpause();
+        await this.unpauseAndResume();
       }
     }
 

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { assertNever, Err, Ok } from "@dust-tt/client";
 import { Client } from "@microsoft/microsoft-graph-client";
 
@@ -62,6 +62,8 @@ import type {
 import type { DataSourceConfig } from "@connectors/types";
 
 export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "microsoft";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -580,28 +582,6 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(
-        new Error(`Connector not found with id ${this.connectorId}`)
-      );
-    }
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(
-        new Error(`Connector not found with id ${this.connectorId}`)
-      );
-    }
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -343,12 +343,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     }
 
     await connector.markAsPaused();
-    const stopRes = await this.stop();
-    if (stopRes.isErr()) {
-      return stopRes;
-    }
-
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -366,12 +361,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     }
 
     await connector.markAsUnpaused();
-    const r = await this.resume();
-    if (r.isErr()) {
-      return r;
-    }
-
-    return new Ok(undefined);
+    return this.resume();
   }
 
   async sync({

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import _ from "lodash";
 
@@ -78,6 +78,8 @@ export async function workspaceIdFromConnectionId(connectionId: string) {
 }
 
 export class NotionConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "notion";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -326,42 +328,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     }
 
     return new Ok(undefined);
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-
-    if (!connector) {
-      logger.error(
-        {
-          connectorId: this.connectorId,
-        },
-        "Notion connector not found."
-      );
-
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-
-    if (!connector) {
-      logger.error(
-        {
-          connectorId: this.connectorId,
-        },
-        "Notion connector not found."
-      );
-
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async sync({

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -218,7 +218,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (c.isPaused()) {
-        await this.unpause();
+        await this.unpauseAndResume();
       }
 
       const dataSourceConfig = dataSourceConfigFromConnector(c);

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
 import type {
@@ -42,6 +42,8 @@ const logger = mainLogger.child({
 });
 
 export class SalesforceConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "salesforce";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -315,41 +317,6 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
     }
 
     return new Ok(undefined);
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-
-    if (!connector) {
-      logger.error(
-        {
-          connectorId: this.connectorId,
-        },
-        "Notion connector not found."
-      );
-
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-
-    if (!connector) {
-      logger.error(
-        {
-          connectorId: this.connectorId,
-        },
-        "Notion connector not found."
-      );
-
-      return new Err(new Error("Connector not found"));
-    }
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async setConfigurationKey(): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -332,12 +332,7 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
     }
 
     await connector.markAsPaused();
-    const stopRes = await this.stop();
-    if (stopRes.isErr()) {
-      return stopRes;
-    }
-
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -354,12 +349,7 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
     await connector.markAsUnpaused();
-    const r = await this.resume();
-    if (r.isErr()) {
-      return r;
-    }
-
-    return new Ok(undefined);
+    return this.resume();
   }
 
   async setConfigurationKey(): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import { WebClient } from "@slack/web-api";
 import PQueue from "p-queue";
@@ -51,6 +51,8 @@ import {
 const { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } = process.env;
 
 export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurationType> {
+  readonly provider: ConnectorProvider = "slack";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -693,32 +695,6 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(
-        new Error(`Connector not found with id ${this.connectorId}`)
-      );
-    }
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(
-        new Error(`Connector not found with id ${this.connectorId}`)
-      );
-    }
-    await connector.markAsUnpaused();
-    const r = await launchSlackSyncWorkflow(this.connectorId, null);
-    if (r.isErr()) {
-      return r;
-    }
-    return new Ok(undefined);
   }
 
   async stop(): Promise<Result<undefined, Error>> {

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -191,7 +191,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
     // If connector was previously paused, unpause it.
     if (c.isPaused()) {
-      await this.unpause();
+      await this.unpauseAndResume();
     }
 
     return new Ok(c.id.toString());

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -703,8 +703,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       );
     }
     await connector.markAsPaused();
-    await terminateAllWorkflowsForConnectorId(this.connectorId);
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -723,10 +722,15 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    logger.info(
-      { connectorId: this.connectorId },
-      `Stopping Slack connector is a no-op.`
-    );
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+
+    await terminateAllWorkflowsForConnectorId(this.connectorId);
+
     return new Ok(undefined);
   }
 

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -368,12 +368,7 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     }
 
     await connector.markAsPaused();
-    const stopRes = await this.stop();
-    if (stopRes.isErr()) {
-      return stopRes;
-    }
-
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -387,12 +382,7 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     }
 
     await connector.markAsUnpaused();
-    const r = await launchSnowflakeSyncWorkflow(this.connectorId);
-    if (r.isErr()) {
-      return r;
-    }
-
-    return new Ok(undefined);
+    return this.resume();
   }
 
   async setConfigurationKey(): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { assertNever, Err, Ok } from "@dust-tt/client";
 
 import type {
@@ -55,6 +55,8 @@ function handleTestConnectionError(
 }
 
 export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "snowflake";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -355,34 +357,6 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     }
 
     return new Ok(undefined);
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "Snowflake connector not found."
-      );
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "Snowflake connector not found."
-      );
-      return new Err(new Error("Connector not found"));
-    }
-
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async setConfigurationKey(): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
 import type {
@@ -44,6 +44,8 @@ import {
 } from "./temporal/client";
 
 export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerConfigurationType> {
+  readonly provider: ConnectorProvider = "webcrawler";
+
   static async create({
     dataSourceConfig,
     configuration,
@@ -257,24 +259,6 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
   }): Promise<Result<string[], Error>> {
     // This isn't used for webcrawler.
     return new Ok([internalId]);
-  }
-
-  async pause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      throw new Error("Connector not found.");
-    }
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  async unpause(): Promise<Result<undefined, Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      throw new Error("Connector not found.");
-    }
-    await connector.markAsUnpaused();
-    return this.resume();
   }
 
   async configure({

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -265,11 +265,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       throw new Error("Connector not found.");
     }
     await connector.markAsPaused();
-    const stopRes = await stopCrawlWebsiteWorkflow(this.connectorId);
-    if (stopRes.isErr()) {
-      return stopRes;
-    }
-    return new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
@@ -278,13 +274,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       throw new Error("Connector not found.");
     }
     await connector.markAsUnpaused();
-
-    const r = await this.resume();
-    if (r.isErr()) {
-      return r;
-    }
-
-    return new Ok(undefined);
+    return this.resume();
   }
 
   async configure({

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { assertNever, Err, Ok } from "@dust-tt/client";
 
 import type {
@@ -60,6 +60,8 @@ const SYNC_UNRESOLVED_TICKETS_CONFIG_KEY =
 const HIDE_CUSTOMER_DETAILS_CONFIG_KEY = "zendeskHideCustomerDetails";
 
 export class ZendeskConnectorManager extends BaseConnectorManager<null> {
+  readonly provider: ConnectorProvider = "zendesk";
+
   static async create({
     dataSourceConfig,
     connectionId,
@@ -606,36 +608,6 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
-  }
-
-  /**
-   * Marks the connector as paused in db and stops all workflows.
-   */
-  async pause(): Promise<Result<undefined, Error>> {
-    const { connectorId } = this;
-    const connector = await ConnectorResource.fetchById(connectorId);
-    if (!connector) {
-      logger.error({ connectorId }, "[Zendesk] Connector not found.");
-      throw new Error("[Zendesk] Connector not found.");
-    }
-    await connector.markAsPaused();
-    return this.stop();
-  }
-
-  /**
-   * Marks the connector as unpaused in db and restarts the workflows.
-   * Does not trigger full syncs, only restart the incremental and gc workflows.
-   */
-  async unpause(): Promise<Result<undefined, Error>> {
-    const { connectorId } = this;
-    const connector = await ConnectorResource.fetchById(connectorId);
-    if (!connector) {
-      logger.error({ connectorId }, "[Zendesk] Connector not found.");
-      throw new Error("[Zendesk] Connector not found.");
-    }
-    await connector.markAsUnpaused();
-    // launch a gc and an incremental workflow (sync workflow without signals).
-    return this.resume();
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -181,7 +181,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
 
       // if the connector was previously paused, unpause it.
       if (connector.isPaused()) {
-        await this.unpause();
+        await this.unpauseAndResume();
       }
     }
     return new Ok(connector.id.toString());

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -147,11 +147,11 @@ export const connectors = async ({
       return { success: true };
     }
     case "pause": {
-      await throwOnError(manager.pause());
+      await throwOnError(manager.pauseAndStop());
       return { success: true };
     }
     case "unpause": {
-      await throwOnError(manager.unpause());
+      await throwOnError(manager.unpauseAndResume());
       return { success: true };
     }
     case "resume": {

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -144,7 +144,7 @@ export class ActivityInboundLogInterceptor
           });
 
           if (connectorManager) {
-            await connectorManager.pause();
+            await connectorManager.pauseAndStop();
           } else {
             this.logger.error(
               {

--- a/front/scripts/relocation/relocate_workspace.ts
+++ b/front/scripts/relocation/relocate_workspace.ts
@@ -1,7 +1,7 @@
 import { updateAllWorkspaceUsersRegionMetadata } from "@app/admin/relocate_users";
 import {
   pauseAllManagedDataSources,
-  resumeAllManagedDataSources,
+  unpauseAllManagedDataSources,
 } from "@app/lib/api/data_sources";
 import { pauseAllLabsWorkflows } from "@app/lib/api/labs";
 import type { RegionType } from "@app/lib/api/regions/config";
@@ -188,14 +188,14 @@ makeScript(
             return;
           }
 
-          // 2) Resume all webcrawler connectors in the destination region.
-          const resumeDestConnectorsRes = await resumeAllManagedDataSources(
+          // 2) Unpause all webcrawler connectors in the destination region.
+          const unpauseDestConnectorsRes = await unpauseAllManagedDataSources(
             auth,
             ["webcrawler"]
           );
-          if (resumeDestConnectorsRes.isErr()) {
+          if (unpauseDestConnectorsRes.isErr()) {
             logger.error(
-              `Failed to resume connectors: ${resumeDestConnectorsRes.error.message}`
+              `Failed to unpause connectors: ${unpauseDestConnectorsRes.error.message}`
             );
             return;
           }
@@ -215,12 +215,12 @@ makeScript(
             return;
           }
 
-          // 2) Resume all connectors in the source region.
-          const resumeSrcConnectorsRes =
-            await resumeAllManagedDataSources(auth);
-          if (resumeSrcConnectorsRes.isErr()) {
+          // 2) Unpause all connectors in the source region.
+          const unpauseSrcConnectorsRes =
+            await unpauseAllManagedDataSources(auth);
+          if (unpauseSrcConnectorsRes.isErr()) {
             logger.error(
-              `Failed to resume connectors: ${resumeSrcConnectorsRes.error.message}`
+              `Failed to unpause connectors: ${unpauseSrcConnectorsRes.error.message}`
             );
             return;
           }


### PR DESCRIPTION
## Description

We used to "pause" in the relocation step but "resume" in the resume-in-destination step, I believe we actually need to unpause.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front