### PR TITLE
Fix: directly use the model to delete MCPServerConnection

### DIFF
--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -19,7 +19,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import type { ModelId, Result } from "@app/types";
+import type { LightWorkspaceType, ModelId, Result } from "@app/types";
 import {
   Err,
   formatUserFullName,
@@ -219,6 +219,18 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
   }
 
   // Deletion.
+
+  static async deleteAllForWorkspace(
+    workspace: LightWorkspaceType,
+    transaction?: Transaction
+  ) {
+    return this.model.destroy({
+      where: {
+        workspaceId: workspace.id,
+      },
+      transaction,
+    });
+  }
 
   async delete(
     auth: Authenticator,

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -27,7 +27,6 @@ import {
   AgentMCPActionOutputItem,
   AgentMCPServerConfiguration,
 } from "@app/lib/models/assistant/actions/mcp";
-import { MCPServerConnection } from "@app/lib/models/assistant/actions/mcp_server_connection";
 import {
   AgentProcessAction,
   AgentProcessConfiguration,
@@ -576,23 +575,9 @@ export const deleteRemoteMCPServersActivity = async ({
 }) => {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
-  const personalConnections = await MCPServerConnectionResource.listByWorkspace(
-    auth,
-    {
-      connectionType: "personal",
-    }
+  await MCPServerConnectionResource.deleteAllForWorkspace(
+    auth.getNonNullableWorkspace()
   );
-  for (const mcpServerConnection of personalConnections) {
-    await mcpServerConnection.delete(auth);
-  }
-
-  const workspaceConnections =
-    await MCPServerConnectionResource.listByWorkspace(auth, {
-      connectionType: "workspace",
-    });
-  for (const mcpServerConnection of workspaceConnections) {
-    await mcpServerConnection.delete(auth);
-  }
 
   const remoteMCPServers = await RemoteMCPServerResource.listByWorkspace(auth);
   for (const remoteMCPServer of remoteMCPServers) {


### PR DESCRIPTION
## Description

Didn't work because list personal will rely on the specific auth passed in.
Instead, use the model directly.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front