### PR TITLE
[JIT Search] Migrate legacy process JIT actions to JIT server

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -39,7 +39,7 @@ import {
   getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
-import { getEmulatedAndJITActions } from "@app/lib/api/assistant/jit_actions";
+import { getEmulatedActionsAndJITServers } from "@app/lib/api/assistant/jit_actions";
 import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
 import config from "@app/lib/api/config";
@@ -404,11 +404,13 @@ async function* runMultiActionsAgent(
     }
   }
 
-  const { emulatedActions, jitServers } = await getEmulatedAndJITActions(auth, {
-    agentActions,
-    agentMessage,
-    conversation,
-  });
+  const { emulatedActions, jitServers } = await getEmulatedActionsAndJITServers(
+    auth,
+    {
+      agentMessage,
+      conversation,
+    }
+  );
 
   // Get client-side MCP server configurations from user message context.
   const clientSideMCPActionConfigurations =

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -404,12 +404,11 @@ async function* runMultiActionsAgent(
     }
   }
 
-  const { emulatedActions, jitActions, jitServers } =
-    await getEmulatedAndJITActions(auth, {
-      agentActions,
-      agentMessage,
-      conversation,
-    });
+  const { emulatedActions, jitServers } = await getEmulatedAndJITActions(auth, {
+    agentActions,
+    agentMessage,
+    conversation,
+  });
 
   // Get client-side MCP server configurations from user message context.
   const clientSideMCPActionConfigurations =
@@ -433,7 +432,6 @@ async function* runMultiActionsAgent(
   );
 
   if (!isLastGenerationIteration) {
-    availableActions.push(...jitActions);
     availableActions.push(...mcpActions.flatMap((s) => s.tools));
   }
 

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -21,7 +21,6 @@ import type {
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
-import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   isMultiSheetSpreadsheetContentType,
@@ -371,15 +370,13 @@ async function getJITServers(
   return jitServers;
 }
 
-export async function getEmulatedAndJITActions(
+export async function getEmulatedActionsAndJITServers(
   auth: Authenticator,
   {
     agentMessage,
-    agentActions, // eslint-disable-line @typescript-eslint/no-unused-vars
     conversation,
   }: {
     agentMessage: AgentMessageType;
-    agentActions: AgentActionConfigurationType[];
     conversation: ConversationType;
   }
 ): Promise<{

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -21,10 +21,7 @@ import type {
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { TableDataSourceConfiguration } from "@app/lib/actions/tables_query";
-import type {
-  ActionConfigurationType,
-  AgentActionConfigurationType,
-} from "@app/lib/actions/types/agent";
+import type { AgentActionConfigurationType } from "@app/lib/actions/types/agent";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   isMultiSheetSpreadsheetContentType,
@@ -387,7 +384,6 @@ export async function getEmulatedAndJITActions(
   }
 ): Promise<{
   emulatedActions: AgentActionType[];
-  jitActions: ActionConfigurationType[];
   jitServers: MCPServerConfigurationType[];
 }> {
   const emulatedActions: AgentActionType[] = [];
@@ -412,7 +408,7 @@ export async function getEmulatedAndJITActions(
     "Emulated actions must have step -1"
   );
 
-  return { emulatedActions, jitActions: [], jitServers };
+  return { emulatedActions, jitServers };
 }
 
 async function getTablesFromMultiSheetSpreadsheet(

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -288,10 +288,7 @@ async function getJITServers(
       tables: null,
       childAgentId: null,
       reasoningModel: null,
-      timeFrame: {
-        duration: 1,
-        unit: "month",
-      },
+      timeFrame: null,
       jsonSchema: null,
       additionalConfiguration: {},
       mcpServerViewId: extractDataView.sId,
@@ -354,10 +351,7 @@ async function getJITServers(
       tables: null,
       childAgentId: null,
       reasoningModel: null,
-      timeFrame: {
-        duration: 1,
-        unit: "month",
-      },
+      timeFrame: null,
       jsonSchema: null,
       additionalConfiguration: {},
       mcpServerViewId: extractDataView.sId,


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/2968

## Description

Migrates legacy process JIT actions to new JIT server, following the pattern established in PR #13443 for retrieval actions. This PR:
- Converts process actions (extract_folder_N) to use JIT servers instead of JIT actions
- Populates `jitServers` for process operations in `jit_actions.ts`
- Completes the migration by renaming `getJITActions` to `getJITServers` 
- Removes `getSupportingActions` as it's no longer needed

## Risks

Blast radius: Process/extract actions in conversations with files
Risk: low

## Tests

- [ ] Verify extract actions work on conversation files
- [ ] Test folder extraction functionality continues to work
- [ ] Confirm JIT server configuration properly handles data source filters

## Deploy Plan

- Deploy front service