### PR TITLE
Fix Slack Client Proxy for Error Handling

### DIFF
--- a/connectors/src/connectors/slack/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/slack/temporal/cast_known_errors.ts
@@ -1,0 +1,35 @@
+import { ApplicationFailure } from "@temporalio/common";
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  Next,
+} from "@temporalio/worker";
+
+import { ProviderRateLimitError } from "@connectors/lib/error";
+
+export class SlackCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
+  async execute(
+    input: ActivityExecuteInput,
+    next: Next<ActivityInboundCallsInterceptor, "execute">
+  ): Promise<unknown> {
+    try {
+      return await next(input);
+    } catch (err: unknown) {
+      // Ensure rate limit errors with retryAfterMs are honored.
+      if (err instanceof ProviderRateLimitError) {
+        if (err.retryAfter) {
+          throw ApplicationFailure.create({
+            message: `${err.message}. Retry after ${err.retryAfter}s`,
+            nextRetryDelay: err.retryAfter,
+          });
+        }
+
+        throw err;
+      }
+
+      throw err;
+    }
+  }
+}

--- a/connectors/src/connectors/slack/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/slack/temporal/cast_known_errors.ts
@@ -25,8 +25,6 @@ export class SlackCastKnownErrorsInterceptor
             nextRetryDelay: err.retryAfter,
           });
         }
-
-        throw err;
       }
 
       throw err;

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -2,6 +2,7 @@ import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
 import * as activities from "@connectors/connectors/slack/temporal/activities";
+import { SlackCastKnownErrorsInterceptor } from "@connectors/connectors/slack/temporal/cast_known_errors";
 import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
@@ -27,6 +28,7 @@ export async function runSlackWorker() {
         (ctx: Context) => {
           return new ActivityInboundLogInterceptor(ctx, logger);
         },
+        () => new SlackCastKnownErrorsInterceptor(),
       ],
     },
   });

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -52,6 +52,16 @@ export class ProviderWorkflowError extends DustConnectorWorkflowError {
   }
 }
 
+export class ProviderRateLimitError extends ProviderWorkflowError {
+  constructor(
+    message: string,
+    originalError?: Error | APIError,
+    readonly retryAfter?: number
+  ) {
+    super("slack", message, "rate_limit_error", originalError);
+  }
+}
+
 export class HTTPError extends Error {
   readonly statusCode: number;
   constructor(message: string, statusCode: number) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since https://github.com/dust-tt/dust/pull/13469, the SlackClient now rejects on rate limit errors. It used to apply its internal logic that was blocking activities for hours. Now that it throws on rate limit we enter the proxy code that applies some retries (up to 3 times). The issue with this code is that it makes assumptions that it will always be run from a Temporal workflow which isn't correct. This lead to error like `Error: async hook stack has become corrupted (actual: 60201, expected: 4)`.

This PR keeps the proxy (unfortunately!) but only use it to map Slack errors to our custom errors. This is particularly relevant for rate limit errors (very common on Slack those days!).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
