### PR TITLE
[front] enh: hide certain types of content from the model

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -238,9 +238,9 @@ function hideFileContentForModel({
     return content;
   }
   // We want to hide the original file url from the model.
-  const sid = makeSId("file", {
-    workspaceId: workspaceId,
+  const sid = FileResource.modelIdToSId({
     id: fileId,
+    workspaceId: workspaceId,
   });
   let contentType;
   switch (content.type) {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -245,7 +245,7 @@ function hideContentForModel({
   // We want to hide the original file url from the model.
   const sid = FileResource.modelIdToSId({
     id: fileId,
-    workspaceId: workspaceId,
+    workspaceId,
   });
   let contentType;
   switch (content.type) {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -228,7 +228,7 @@ type ActionBaseParams = Omit<
   "id" | "type" | "executionState" | "output" | "isError"
 >;
 
-function hideFileContentForModel({
+function hideContentForModel({
   fileId,
   content,
   workspaceId,
@@ -1056,7 +1056,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         executionState: status,
         id: action.id,
         isError: false,
-        output: outputItems.map(hideFileContentForModel),
+        output: outputItems.map(hideContentForModel),
         type: "tool_action",
       }),
     };
@@ -1136,7 +1136,7 @@ export async function mcpActionTypesFromAgentMessageIds(
     return new MCPActionType({
       id: action.id,
       params: action.params,
-      output: action.outputItems.map(hideFileContentForModel),
+      output: action.outputItems.map(hideContentForModel),
       functionCallId: action.functionCallId,
       functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -106,7 +106,8 @@ const createServer = (
 
   server.tool(
     "cat",
-    "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). The nodeId can be obtained using the 'find', 'list' or 'search' tools.",
+    "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
+      "The nodeId can be obtained using the 'find', 'list' or 'search' tools.",
     {
       dataSources:
         ConfigurableToolInputSchemas[

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -118,7 +118,8 @@ const createServer = (
         .number()
         .optional()
         .describe(
-          "The character position to start reading from (0-based). If not provided, starts from the beginning."
+          "The character position to start reading from (0-based). If not provided, starts from " +
+            "the beginning."
         ),
       limit: z
         .number()
@@ -130,7 +131,8 @@ const createServer = (
         .string()
         .optional()
         .describe(
-          "A regular expression to filter lines. Applied after offset/limit slicing. Only lines matching this pattern will be returned."
+          "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
+            "matching this pattern will be returned."
         ),
     },
     async ({ dataSources, nodeId, offset, limit, grep }) => {
@@ -714,7 +716,8 @@ const createServer = (
     "locate_in_tree",
     "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
       "This is useful for understanding where a specific node is located within the data source structure. " +
-      "The path is returned as a list of nodes, with the first node being the data source root and the last node being the target node.",
+      "The path is returned as a list of nodes, with the first node being the data source root and " +
+      "the last node being the target node.",
     {
       nodeId: z.string().describe("The ID of the node to locate in the tree."),
       dataSources:
@@ -940,7 +943,8 @@ async function getAgentDataSourceConfigurations(
           ) {
             return new Err(
               new Error(
-                `Workspace mismatch: configuration workspace ${configInfo.configuration.workspaceId} does not match authenticated workspace`
+                "Workspace mismatch: configuration workspace " +
+                  `${configInfo.configuration.workspaceId} does not match authenticated workspace.`
               )
             );
           }

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -106,7 +106,7 @@ const createServer = (
 
   server.tool(
     "cat",
-    "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). The nodeId can be obtained using the 'find_by_title', 'find' or 'search' tools.",
+    "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). The nodeId can be obtained using the 'find', 'list' or 'search' tools.",
     {
       dataSources:
         ConfigurableToolInputSchemas[


### PR DESCRIPTION
## Description

- This PR hides the `TOOL_OUTPUT.SEARCH_QUERY` content from the output that is shown to the model.
- This content is only used for display purpose (in `MCPActionDetails`) and are not of any use for the model.
- Next step is to postprocess every output to remove certain fields (like the mime type). This is more LOC and may require taking a step back and defining a standardized approach (proposal incoming).

## Tests

- Tested.

## Risk

- Low, it changes the behavior of the agents but is retrocompatible.

## Deploy Plan

- Deploy front.
