### PR TITLE
Fix slack retry-after logic

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -114,7 +114,8 @@ export async function getSlackClient(
           throw new ProviderRateLimitError(
             `Rate limited: ${e.message} (retry after ${e.retryAfter}s)`,
             e,
-            e.retryAfter
+            // Slack returns retryAfter in seconds, but Temporal expects milliseconds.
+            e.retryAfter * 1000
           );
         }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In https://github.com/dust-tt/dust/pull/13487 oversaw that Slack `retryAfter` was in seconds, whereas Temporal `ApplicationFailure` expects ms.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
