### PR TITLE
[front] fix content flickering in tool approval window

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -21,7 +21,7 @@ import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp";
 import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import type { LightWorkspaceType } from "@app/types";
-import { asDisplayName } from "@app/types";
+import { asDisplayName, pluralize } from "@app/types";
 
 type MCPActionValidationRequest = Omit<
   MCPApproveExecutionEvent,
@@ -241,7 +241,7 @@ export function ActionValidationProvider({
               {validationQueue.length > 0 && (
                 <div className="mt-2 text-sm font-medium text-info-900 dark:text-info-900-night">
                   {validationQueue.length} more request
-                  {validationQueue.length > 1 ? "s" : ""} in the queue
+                  {pluralize(validationQueue.length)} in the queue
                 </div>
               )}
 


### PR DESCRIPTION
## Description
This PR is to fix the content flickering in tool approval window. Right now when the dialog is being closed, we update the currentValidation to null before closing animation ends so you see the flickering like this:


https://github.com/user-attachments/assets/c67ff54d-89bb-45a7-b77c-6bae81b7809b

I also took this opportunity to clean up and improve the code a bit, I left a few comments here and there. 


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
- If tool approval works as before (you can approve/decline)
- If the queue system works as before (the queue gets correctly updated) 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
