### PR TITLE
Flav/remove slack client proxy

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -57,6 +57,26 @@ function isWebAPIPlatformError(error: unknown): error is WebAPIPlatformError {
   );
 }
 
+/**
+ * Creates a Slack WebClient instance for making API calls.
+ *
+ * IMPORTANT: When using this client in Temporal activities, wrap all API calls
+ * with `withSlackErrorHandling()` to properly convert Slack errors to workflow errors
+ * (rate limits, auth errors, etc.) that can be handled by Temporal interceptors.
+ *
+ * @example
+ * ```typescript
+ * const slackClient = await getSlackClient(connectorId);
+ *
+ * // ✅ Correct usage in Temporal activities:
+ * const result = await withSlackErrorHandling(() =>
+ *   slackClient.conversations.list({ types: "public_channel" })
+ * );
+ *
+ * // ❌ Incorrect usage in Temporal activities (raw Slack errors won't be converted):
+ * const result = await slackClient.conversations.list({ types: "public_channel" });
+ * ```
+ */
 export async function getSlackClient(
   connectorId: ModelId,
   options?: { rejectRateLimitedCalls?: boolean }

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -92,60 +92,50 @@ export async function getSlackClient(
     },
   });
 
-  // Proxy to convert Slack errors to proper workflow errors.
-  const handler: ProxyHandler<WebClient> = {
-    get: function (target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-      if (["function", "object"].indexOf(typeof value) > -1) {
-        return new Proxy(value, handler);
-      }
-      return Reflect.get(target, prop, receiver);
-    },
-    apply: async function (target, thisArg, argumentsList) {
-      try {
-        // @ts-expect-error can't get typescript to be happy with this, but it works.
-        // eslint-disable-next-line @typescript-eslint/return-await
-        return await Reflect.apply(target, thisArg, argumentsList);
-      } catch (e) {
-        // Convert Slack errors to proper workflow errors - NO RETRIES HERE.
+  return slackClient;
+}
 
-        // Rate limit errors.
-        if (isWebAPIRateLimitedError(e)) {
-          throw new ProviderRateLimitError(
-            `Rate limited: ${e.message} (retry after ${e.retryAfter}s)`,
-            e,
-            // Slack returns retryAfter in seconds, but Temporal expects milliseconds.
-            e.retryAfter * 1000
-          );
-        }
+export async function withSlackErrorHandling<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (e) {
+    // Convert Slack errors to proper workflow errors.
 
-        // HTTP 503 errors (Slack is down).
-        if (isWebAPIHTTPError(e) && e.statusCode === 503) {
-          throw new ProviderWorkflowError(
-            "slack",
-            `Slack is down: ${e.statusMessage}`,
-            "transient_upstream_activity_error",
-            e
-          );
-        }
+    // Rate limit errors.
+    if (isWebAPIRateLimitedError(e)) {
+      throw new ProviderRateLimitError(
+        `Rate limited: ${e.message} (retry after ${e.retryAfter}s)`,
+        e,
+        // Slack returns retryAfter in seconds, but Temporal expects milliseconds.
+        e.retryAfter * 1000
+      );
+    }
 
-        // Platform errors (auth issues).
-        if (
-          isWebAPIPlatformError(e) &&
-          ["account_inactive", "invalid_auth", "missing_scope"].includes(
-            e.data.error
-          )
-        ) {
-          throw new ExternalOAuthTokenError();
-        }
+    // HTTP 503 errors (Slack is down).
+    if (isWebAPIHTTPError(e) && e.statusCode === 503) {
+      throw new ProviderWorkflowError(
+        "slack",
+        `Slack is down: ${e.statusMessage}`,
+        "transient_upstream_activity_error",
+        e
+      );
+    }
 
-        // Pass through everything else unchanged.
-        throw e;
-      }
-    },
-  };
+    // Platform errors (auth issues).
+    if (
+      isWebAPIPlatformError(e) &&
+      ["account_inactive", "invalid_auth", "missing_scope"].includes(
+        e.data.error
+      )
+    ) {
+      throw new ExternalOAuthTokenError();
+    }
 
-  return new Proxy(slackClient, handler);
+    // Pass through everything else unchanged.
+    throw e;
+  }
 }
 
 export type SlackUserInfo = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We attempted to fix the async hook error we observe through https://github.com/dust-tt/dust/pull/13487, but this isn't enough. The Slack client's deep recursive proxy is still casually causing async hook corruption in production:
``` 
Error: async hook stack has become corrupted (actual: 330809, expected: 4)
```

This PR  replaced the deep proxy with a simple `withSlackErrorHandling()` wrapper function.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
