### PR TITLE
[front] feat(crawler): Hide daily crawl frequency option if it's not already here

### DIFF
--- a/front/components/spaces/websites/SpaceWebsiteForm.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteForm.tsx
@@ -138,11 +138,15 @@ export function SpaceWebsiteForm({
             </DropdownMenuTrigger>
             <DropdownMenuContent>
               <DropdownMenuRadioGroup>
-                {CrawlingFrequencies.map((frequency) => (
+                {CrawlingFrequencies.filter(
+                  (freq) =>
+                    state.crawlFrequency === "daily" ? true : freq !== "daily" // Only display the 'daily' option if the crawler has it
+                ).map((frequency) => (
                   <DropdownMenuRadioItem
                     key={frequency}
                     value={frequency}
                     label={FREQUENCY_DISPLAY_TEXT[frequency]}
+                    disabled={frequency === "daily"}
                     onClick={() =>
                       dispatch({
                         type: "SET_FIELD",


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3165
- This way helps supporting removing the option and not breaking UI for current crawler, or when we activate it manually for users.

## Tests
<img width="375" alt="Capture d’écran 2025-06-17 à 12 12 14" src="https://github.com/user-attachments/assets/95fda73b-f66f-46a5-b2d5-87e7b6a916da" />
<img width="391" alt="Capture d’écran 2025-06-17 à 12 12 28" src="https://github.com/user-attachments/assets/5a7c12ed-d6a3-4f52-8bbe-08a0a171f19e" />

- left: Crawler config that has 'daily' set manually in database
- right: Crawler config that isn't set with daily

## Risk
- Low technically, UI only, but users will start asking questions

## Deploy Plan
- Deploy front
- Prob communicate with users
