### PR TITLE
Fix: hide knowledge and instruction for global agent, show a button / chip to go to the dust agent knowledge management page

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -4,6 +4,7 @@ import {
   BarChartIcon,
   Button,
   Chip,
+  Cog6ToothIcon,
   ContentMessage,
   DustIcon,
   InformationCircleIcon,
@@ -101,27 +102,47 @@ function AssistantDetailsInfo({
       )}
 
       <div className="text-sm text-foreground dark:text-foreground-night">
-        {agentConfiguration?.description}
+        {agentConfiguration.description}
       </div>
       {agentConfiguration && (
         <AssistantEditedSection agentConfiguration={agentConfiguration} />
       )}
+      {agentConfiguration.sId === "dust" && (
+        <div className="text-sm text-foreground dark:text-foreground-night">
+          {isAdmin(owner) ? (
+            <Button
+              label="Manage Dust Agent's Knowledge"
+              icon={Cog6ToothIcon}
+              href={`/w/${owner.sId}/builder/assistants/dust`}
+            />
+          ) : (
+            <Chip
+              color="blue"
+              label="Your admin(s) can manage Dust Agent's Knowledge."
+            />
+          )}
+        </div>
+      )}
       <Page.Separator />
 
-      <AssistantKnowledgeSection
-        agentConfiguration={agentConfiguration}
-        owner={owner}
-      />
+      {agentConfiguration.scope !== "global" && (
+        <>
+          <AssistantKnowledgeSection
+            agentConfiguration={agentConfiguration}
+            owner={owner}
+          />
 
-      {agentConfiguration?.instructions ? (
-        <div className="flex flex-col gap-5">
-          <div className="heading-lg text-foreground dark:text-foreground-night">
-            Instructions
-          </div>
-          <ReadOnlyTextArea content={agentConfiguration.instructions} />
-        </div>
-      ) : (
-        "This agent has no instructions."
+          {agentConfiguration?.instructions ? (
+            <div className="flex flex-col gap-5">
+              <div className="heading-lg text-foreground dark:text-foreground-night">
+                Instructions
+              </div>
+              <ReadOnlyTextArea content={agentConfiguration.instructions} />
+            </div>
+          ) : (
+            "This agent has no instructions."
+          )}
+        </>
       )}
       <AssistantToolsSection
         agentConfiguration={agentConfiguration}


### PR DESCRIPTION
## Description

- Hide knowledge and instructions for global agents
- Show button / chip for @dust knowledge management
- Fix showing remote database as usable with the @dust agent

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front