### PR TITLE
[connectors] fix(Zendesk): strip null bytes from ticket subjects

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -17,7 +17,8 @@ import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
-import { DataSourceConfig, ModelId, stripNullBytes } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
+import { stripNullBytes } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -17,7 +17,7 @@ import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
-import { DataSourceConfig, ModelId, stripNullBytes } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();
@@ -200,9 +200,7 @@ export async function syncTicket({
       })
       .join("\n")}`.trim();
 
-    const ticketContentInMarkdown = turndownService.turndown(
-      stripNullBytes(ticketContent)
-    );
+    const ticketContentInMarkdown = turndownService.turndown(ticketContent);
 
     const renderedMarkdown = await renderMarkdownSection(
       dataSourceConfig,

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -17,7 +17,7 @@ import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
-import type { DataSourceConfig, ModelId } from "@connectors/types";
+import { DataSourceConfig, ModelId, stripNullBytes } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const turndownService = new TurndownService();
@@ -200,7 +200,9 @@ export async function syncTicket({
       })
       .join("\n")}`.trim();
 
-    const ticketContentInMarkdown = turndownService.turndown(ticketContent);
+    const ticketContentInMarkdown = turndownService.turndown(
+      stripNullBytes(ticketContent)
+    );
 
     const renderedMarkdown = await renderMarkdownSection(
       dataSourceConfig,


### PR DESCRIPTION
## Description

- This PR strips null bytes from Zendesk ticket subjects.
- Having null bytes causes the upsert to fail.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
