### PR TITLE
[connectors] feat(webcrawler): Handle new customCrawler to use firecrawlApi

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -166,7 +166,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
       delay: 3,
       scrapeOptions: {
         onlyMainContent: true,
-        formats: ["markdown", "changeTracking"],
+        formats: ["markdown"],
         headers: customHeaders,
         maxAge: 43_200_000, // Use last 12h of cache
       },

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -61,15 +61,6 @@ import {
 
 import { DustHttpClient } from "../lib/http";
 
-const { DUST_CONNECTORS_WEBHOOKS_SECRET, CONNECTORS_PUBLIC_URL } = process.env;
-
-if (!DUST_CONNECTORS_WEBHOOKS_SECRET) {
-  throw new Error("DUST_CONNECTORS_WEBHOOKS_SECRET is not defined");
-}
-if (!CONNECTORS_PUBLIC_URL) {
-  throw new Error("CONNECTORS_PUBLIC_URL is not defined");
-}
-
 const CONCURRENCY = 1;
 
 export async function markAsCrawled(connectorId: ModelId) {
@@ -171,7 +162,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
         maxAge: 43_200_000, // Use last 12h of cache
       },
       webhook: {
-        url: `${CONNECTORS_PUBLIC_URL}/webhooks/${DUST_CONNECTORS_WEBHOOKS_SECRET}/firecrawl`,
+        url: `${apiConfig.getConnectorsPublicURL()}/webhooks/${apiConfig.getDustConnectorsWebhooksSecret()}/firecrawl`,
         metadata: {
           connectorId: String(connectorId),
         },

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -31,4 +31,10 @@ export const apiConfig = {
       "UNTRUSTED_EGRESS_PROXY_PORT"
     );
   },
+  getDustConnectorsWebhooksSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_CONNECTORS_WEBHOOKS_SECRET");
+  },
+  getConnectorsPublicURL: (): string => {
+    return EnvironmentConfig.getEnvVariable("CONNECTORS_PUBLIC_URL");
+  },
 };

--- a/connectors/src/types/webcrawler.ts
+++ b/connectors/src/types/webcrawler.ts
@@ -24,7 +24,7 @@ export function isDepthOption(value: unknown): value is DepthOption {
   return DepthOptions.includes(value as DepthOption);
 }
 
-export const WebcrawlerCustomCrawler = ["firecrawl"] as const;
+export const WebcrawlerCustomCrawler = ["firecrawl", "firecrawl-api"] as const;
 export type WebcrawlerCustomCrawler = (typeof WebcrawlerCustomCrawler)[number];
 
 export const WebCrawlerConfigurationTypeSchema = t.type({
@@ -46,7 +46,11 @@ export const WebCrawlerConfigurationTypeSchema = t.type({
     t.literal("monthly"),
   ]),
   headers: t.record(t.string, t.string),
-  customCrawler: t.union([t.null, t.literal("firecrawl")]),
+  customCrawler: t.union([
+    t.null,
+    t.literal("firecrawl"),
+    t.literal("firecrawl-api"),
+  ]),
 });
 
 export type WebCrawlerConfiguration = t.TypeOf<


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3170
- if `customCrawler` is set to `firecrawl-api`, use `/crawl` of firecrawl
- Plugged our existing option to the firecrawl equivalent
- Didn't explicitly write events to be sent via webhooks, so it's all.
- Use `maxAge` in the scrape options, this use the firecrawl cache version if younger than 12h, arbitrary, feels an ok time for pages that are crawled multiple time. It's also shared with what our mcp web browse.
- ~~Added the `changeTracking` format, can be useful for later as it gives us if the page has changed since a last crawl, could be interesting to avoid updating documents/page that haven't changed.~~

## Tests
- N/A

## Risk
- Not sure about not returning the `pageCount` at the end as this activity is not the one doing the crawling now.

## Deploy Plan
- Deploy front
