### PR TITLE
[front] login: log when lastLoginAt update fails

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -76,7 +76,18 @@ async function handler(
     externalUser: session.user,
   });
 
-  await user.recordLoginActivity();
+  try {
+    await user.recordLoginActivity();
+  } catch (error) {
+    logger.error(
+      {
+        userId: user.id,
+        workspaceId: targetWorkspaceId,
+        error,
+      },
+      "Failed to record login activity for user."
+    );
+  }
 
   // TODO(workos): Remove after switch to workos. Update user information when user is created with auth0.
   if (userCreated && session.type === "auth0" && session.user.workOSUserId) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

We're seeing a [bunch of errors](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20region%3Aeurope-west1%20-service%3Aconnectors%20%40url%3A%22%2Fapi%2Flogin%22&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40route&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1750073482681&to_ts=1750159882681&live=true) related to the update of users. We believe it's related to the newly added update of lastLoginAt field during the connection.

Adding some logs to be able to further debug the situation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Could not replicate the bug. Adding some logs to see it and have more context.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

No risks.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.