### PR TITLE
[front] chore(MCP): remove/refresh outdated TODOs

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -167,10 +167,12 @@ export function GenericActionDetails({
             contentChildren={
               <CodeBlock wrapLongLines>
                 {action.output
-                  // @ts-expect-error TODO(mcp): fixing typing resulting to unknown type
-                  .filter((o) => o.text || o.resource.text)
-                  // @ts-expect-error TODO(mcp): fixing typing resulting to unknown type
-                  .map((o) => o.text || o.resource.text)
+                  .filter(
+                    (o) => o.text || (o.type === "resource" && o.resource.text)
+                  )
+                  .map(
+                    (o) => o.text || (o.type === "resource" && o.resource.text)
+                  )
                   .join("\n")}
               </CodeBlock>
             }

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -48,7 +48,7 @@ export function ThinkingBlock({ resource }: ThinkingBlockProps) {
     resource.text && (
       <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
         <ContentMessage
-          title="Reasoning" // TODO(mcp): to be challenged by the design team (could be "Thoughts")
+          title="Reasoning"
           variant="primary"
           icon={InformationCircleIcon}
           size="lg"

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1231,11 +1231,6 @@ function AddKnowledgeDropdown({
         collisionPadding={10}
       >
         {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
-          // TODO(mcp): remove this when we are ready to clean up tables query entirely.
-          if (key === "TABLES_QUERY") {
-            return null;
-          }
-
           const spec = ACTION_SPECIFICATIONS[key];
           if (hideAction(key)) {
             return null;

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -1077,7 +1077,6 @@ function renderNode(
     parentTitle: node.parent_title,
     lastUpdatedAt: formatTimestamp(node.timestamp),
     sourceUrl: node.source_url,
-    // TODO(2025-06-02 aubin): see if we want a translation on these.
     mimeType: node.mime_type,
     hasChildren: node.children_count > 0,
     connectorProvider:

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -323,7 +323,6 @@ function createServer(
         },
       });
 
-      // TODO(mcp) probably do the same for the section file
       // Check if we should generate a section JSON file.
       const shouldGenerateSectionFile = results.some((result) =>
         Object.values(result).some(

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -74,8 +74,6 @@ function createServer(
 
       const owner = auth.getNonNullableWorkspace();
 
-      // TODO(mcp): if we stream events, here we want to inform that it has started.
-
       // Render conversation for the action.
       const supportedModel = getSupportedModelConfig(
         agentLoopRunContext.agentConfiguration.model

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -298,7 +298,6 @@ function createServer(
         output: sanitizedOutput,
       });
 
-      // TODO(mcp): return the CSV file itself as a MCP resource and let the other side handle it
       // Generate the CSV file.
       const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {
         title: queryTitle,

--- a/front/lib/api/assistant/permissions.ts
+++ b/front/lib/api/assistant/permissions.ts
@@ -158,8 +158,6 @@ export async function getAgentConfigurationGroupIdsFromActions(
   return Array.from(spacePermissions.values())
     .map((set) => Array.from(set))
     .filter((arr) => arr.length > 0);
-
-  // TODO(mcp): add something here for child agents.
 }
 
 export async function getContentFragmentGroupIds(

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -350,7 +350,8 @@ AgentMCPActionOutputItem.belongsTo(FileModel, {
 
 /**
  * Configuration of a child agent used by an MCP server.
- * TODO(mcp): move this model in a file dedicated to the configuration blocks, add Resources for all of them.
+ * TODO(mcp): move this model in a file dedicated to the configuration blocks, add Resources for
+ *  all of them (should be done after cleaning up all the actions).
  */
 export class AgentChildAgentConfiguration extends WorkspaceAwareModel<AgentChildAgentConfiguration> {
   declare createdAt: CreationOptional<Date>;


### PR DESCRIPTION
## Description

This PR cleans up TODOs left in the code relative to MCP.
Rationale:
- The `tables_query` ones will be handled in the exploded version.
- The part in `ActionsScreen.tsx` was redundant with `hideAction`.
- The child agent permissions are handled in the `run_agent` tool.
- The type error in the text outputs is now directly handled.
- The migration to resource should probably be done after we're done migrating every action.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
