### PR TITLE
Fix: restrict members endpoints to admins only

### DIFF
--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -65,6 +65,16 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Only workspace admins can access the members list.",
+          },
+        });
+      }
+
       const paginationRes = MembersPaginationCodec.decode(req.query);
       if (isLeft(paginationRes)) {
         return apiError(req, res, {
@@ -78,7 +88,7 @@ async function handler(
 
       const paginationParams = paginationRes.right;
 
-      if (auth.isBuilder() && req.query.role && req.query.role === "admin") {
+      if (req.query.role && req.query.role === "admin") {
         const { members, total, nextPageParams } = await getMembers(
           auth,
           {

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -9,20 +9,21 @@ import { itInTransaction } from "@app/tests/utils/utils";
 import handler from "./search";
 
 describe("GET /api/w/[wId]/members/search", () => {
-  itInTransaction("allows search for non-admin users", async () => {
-    const { req, res, user } = await createPrivateApiMockRequest({
+  itInTransaction("returns 403 for non-admin users", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
     });
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(200);
-    const data = res._getJSONData();
-    expect(data.total).toBe(1);
-    expect(data.members).toHaveLength(1);
-    expect(data.members[0].id).toBe(user.id);
-    expect(data.members[0].workspaces[0].role).toBe("user");
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can search members.",
+      },
+    });
   });
 
   itInTransaction("returns 405 for non-GET methods", async () => {

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -44,6 +44,16 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Only workspace admins can search members.",
+          },
+        });
+      }
+
       const queryRes = SearchMembersQueryCodec.decode(req.query);
 
       if (isLeft(queryRes)) {


### PR DESCRIPTION
## Summary
- Restrict members list endpoint (`/api/w/[wId]/members`) to admin-only access
- Restrict members search endpoint (`/api/w/[wId]/members/search`) to admin-only access
- Update corresponding tests to expect 403 for non-admin users

## Problem
Members list and search endpoints were accessible to all workspace members, allowing enumeration of workspace membership. This poses a security and privacy concern as any workspace member could discover all other members.

This wasn't updated when we "removed" most of the builders concept

## Solution
Added admin authorization checks (`auth.isAdmin()`) at the beginning of both endpoint handlers. Non-admin users now receive a 403 Forbidden response with clear error messages.

## Test plan
- [x] Updated existing tests to expect 403 for non-admin users
- [x] Verified admin users can still access endpoints normally
- [x] All linting and type checking passes
- [x] Run full test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)