### PR TITLE
[front] login: fix lastLoginAt update to be sure user exists

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -76,21 +76,6 @@ async function handler(
     externalUser: session.user,
   });
 
-  try {
-    await user.recordLoginActivity();
-  } catch (error) {
-    logger.error(
-      {
-        session,
-        user,
-        nullableUser,
-        workspaceId: targetWorkspaceId,
-        error,
-      },
-      "Failed to record login activity for user."
-    );
-  }
-
   // TODO(workos): Remove after switch to workos. Update user information when user is created with auth0.
   if (userCreated && session.type === "auth0" && session.user.workOSUserId) {
     await updateUserFromAuth0(
@@ -192,6 +177,19 @@ async function handler(
   if (!u || u.workspaces.length === 0) {
     res.redirect("/no-workspace?flow=revoked");
     return;
+  }
+
+  try {
+    await user.recordLoginActivity();
+  } catch (error) {
+    logger.error(
+      {
+        userId: user.id,
+        worksOSUserId: user.workOSUserId,
+        error,
+      },
+      "Failed to record login activity for user."
+    );
   }
 
   if (targetWorkspace) {

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -18,7 +18,7 @@ import { getSignUpUrl } from "@app/lib/signup";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types";
+import { normalizeError, type WithAPIErrorResponse } from "@app/types";
 
 async function handler(
   req: NextApiRequest,
@@ -186,7 +186,7 @@ async function handler(
       {
         userId: user.id,
         worksOSUserId: user.workOSUserId,
-        error,
+        errorMessage: normalizeError(error).message,
       },
       "Failed to record login activity for user."
     );

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -18,7 +18,8 @@ import { getSignUpUrl } from "@app/lib/signup";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import { normalizeError, type WithAPIErrorResponse } from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types";
+import { normalizeError } from "@app/types";
 
 async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

After investigating this [error](https://app.datadoghq.eu/logs?query=%22Failed%20to%20record%20login%20activity%20for%20user.%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host,service,@workOSUserId,@session.user.workOSUserId&fromUser=true&messageDisplay=inline&storage=hot&stream_sort=host,asc&viz=stream&from_ts=1750170060000&to_ts=1750170090000&live=false) : 
The login flow is kinda convoluted, the solution is to move the update to the lastLoginAt as late as possible.

With this, we _might_ miss some updates, if I forgot a specific flow, but this should be good.
For sure, we will now not be updating lastLoginAt on users that were not upserted in database.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks, missing some really case-specific new logins in db, but that should be safe.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.