### PR TITLE
Implement slow lane queue routing for Slack connectors

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -168,8 +168,8 @@ async function _getTypedChannelsUncached(
 
 export async function getChannelsToSync(connectorId: number) {
   const [remoteChannels, localChannels] = await Promise.all([
-    await getChannels(connectorId, true),
-    await SlackChannel.findAll({
+    getChannels(connectorId, true),
+    SlackChannel.findAll({
       where: {
         connectorId: connectorId,
         permission: {

--- a/connectors/src/connectors/slack/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/slack/temporal/cast_known_errors.ts
@@ -21,7 +21,7 @@ export class SlackCastKnownErrorsInterceptor
       if (err instanceof ProviderRateLimitError) {
         if (err.retryAfter) {
           throw ApplicationFailure.create({
-            message: `${err.message}. Retry after ${err.retryAfter}s`,
+            message: `${err.message}. Retry after ${err.retryAfter / 1000}s`,
             nextRetryDelay: err.retryAfter,
           });
         }

--- a/connectors/src/connectors/slack/temporal/config.ts
+++ b/connectors/src/connectors/slack/temporal/config.ts
@@ -1,4 +1,4 @@
-import { makeSlowQueueName } from "@connectors/lib/temporal_queue_routing";
+import { makeSlowQueueName } from "../../../lib/temporal_queue_routing";
 
 const WORKFLOW_VERSION = 5;
 export const QUEUE_NAME = `slack-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/slack/temporal/config.ts
+++ b/connectors/src/connectors/slack/temporal/config.ts
@@ -1,2 +1,5 @@
+import { makeSlowQueueName } from "@connectors/lib/temporal_queue_routing";
+
 const WORKFLOW_VERSION = 5;
 export const QUEUE_NAME = `slack-queue-v${WORKFLOW_VERSION}`;
+export const SLOW_QUEUE_NAME = makeSlowQueueName(QUEUE_NAME);

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -10,9 +10,17 @@ import {
 import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
-import { QUEUE_NAME } from "./config";
+import { QUEUE_NAME, SLOW_QUEUE_NAME } from "./config";
 
 export async function runSlackWorker() {
+  // Start both normal and slow lane workers in the same deployment
+  // This keeps things simple - both workers run together when "slack" is started
+  const promises = [runSlackNormalWorker(), runSlackSlowWorker()];
+
+  await Promise.all(promises);
+}
+
+async function runSlackNormalWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
@@ -22,6 +30,30 @@ export async function runSlackWorker() {
     reuseV8Context: true,
     namespace,
     maxConcurrentActivityTaskExecutions: 16,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+        () => new SlackCastKnownErrorsInterceptor(),
+      ],
+    },
+  });
+
+  await worker.run();
+}
+
+async function runSlackSlowWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    taskQueue: SLOW_QUEUE_NAME,
+    connection,
+    reuseV8Context: true,
+    namespace,
+    maxConcurrentActivityTaskExecutions: 4, // Lower concurrency for slow lane.
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     interceptors: {
       activityInbound: [

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -27,12 +27,12 @@ const SLOW_LANE_CONNECTOR_IDS: string[] = [
   "5", // Workspace 4d76593070.
 ];
 
-// Dynamic activity creation based on connector ID
+// Dynamic activity creation based on connector ID.
 function getSlackActivities() {
   const connectorId = getConnectorIdFromWorkflow();
 
   return {
-    // Short timeout activities
+    // Short timeout activities.
     shortTimeout: getActivitiesForConnector<typeof activities>({
       baseQueue: QUEUE_NAME,
       connectorId,
@@ -40,18 +40,7 @@ function getSlackActivities() {
       activityOptions: { startToCloseTimeout: "10 minutes" },
     }),
 
-    // Long timeout activities
-    longTimeout: getActivitiesForConnector<typeof activities>({
-      baseQueue: QUEUE_NAME,
-      connectorId,
-      slowLaneConnectorIds: SLOW_LANE_CONNECTOR_IDS,
-      activityOptions: {
-        heartbeatTimeout: "15 minutes",
-        startToCloseTimeout: "90 minutes",
-      },
-    }),
-
-    // Medium timeout activities
+    // Medium timeout activities.
     mediumTimeout: getActivitiesForConnector<typeof activities>({
       baseQueue: QUEUE_NAME,
       connectorId,
@@ -59,6 +48,17 @@ function getSlackActivities() {
       activityOptions: {
         heartbeatTimeout: "5 minutes",
         startToCloseTimeout: "10 minutes",
+      },
+    }),
+
+    // Long timeout activities.
+    longTimeout: getActivitiesForConnector<typeof activities>({
+      baseQueue: QUEUE_NAME,
+      connectorId,
+      slowLaneConnectorIds: SLOW_LANE_CONNECTOR_IDS,
+      activityOptions: {
+        heartbeatTimeout: "15 minutes",
+        startToCloseTimeout: "90 minutes",
       },
     }),
   };

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -24,7 +24,7 @@ import { newWebhookSignal, syncChannelSignal } from "./signals";
 // Configuration for slow lane routing.
 const SLOW_LANE_CONNECTOR_IDS: string[] = [
   // Add connector IDs that should be routed to slow lane.
-  "5", // Workspace 4d76593070.
+  "5",
 ];
 
 // Dynamic activity creation with fresh routing evaluation (enables retry queue switching).

--- a/connectors/src/lib/temporal_queue_routing.ts
+++ b/connectors/src/lib/temporal_queue_routing.ts
@@ -1,0 +1,78 @@
+import type {
+  ActivityInterfaceFor,
+  ActivityOptions,
+} from "@temporalio/workflow";
+import { workflowInfo } from "@temporalio/workflow";
+import { proxyActivities } from "@temporalio/workflow";
+
+// Helper to build slow lane queue name from base queue name.
+export function makeSlowQueueName(baseQueueName: string): string {
+  return baseQueueName.replace(/(-queue-v\d+)$/, `-slow$1`);
+}
+
+// Workflow-level utilities for dynamic queue routing.
+function shouldUseSlowLane({
+  connectorId,
+  slowLaneConnectorIds,
+}: {
+  connectorId: string;
+  slowLaneConnectorIds: string[];
+}): boolean {
+  return slowLaneConnectorIds.includes(connectorId);
+}
+
+// Extract connector ID from workflow's search attributes.
+export function getConnectorIdFromWorkflow(): string | null {
+  const info = workflowInfo();
+  const searchAttributes = info.searchAttributes;
+
+  if (searchAttributes && searchAttributes.connectorId) {
+    const connectorIdArray = searchAttributes.connectorId;
+    if (Array.isArray(connectorIdArray) && connectorIdArray.length > 0) {
+      return String(connectorIdArray[0]);
+    }
+  }
+
+  return null;
+}
+
+// Create activity proxy with dynamic task queue routing (following relocation pattern).
+function getActivitiesForLane<T>({
+  activityOptions,
+  baseQueue,
+  useSlowLane,
+}: {
+  activityOptions: ActivityOptions;
+  baseQueue: string;
+  useSlowLane: boolean;
+}): ActivityInterfaceFor<T> {
+  const taskQueue = useSlowLane ? makeSlowQueueName(baseQueue) : baseQueue;
+
+  return proxyActivities<T>({
+    taskQueue,
+    ...activityOptions,
+  });
+}
+
+// Determine which lane to use for a connector.
+export function getActivitiesForConnector<T>({
+  baseQueue,
+  connectorId,
+  slowLaneConnectorIds,
+  activityOptions,
+}: {
+  baseQueue: string;
+  connectorId: string | null;
+  slowLaneConnectorIds: string[];
+  activityOptions: ActivityOptions;
+}): ActivityInterfaceFor<T> {
+  const useSlowLane = connectorId
+    ? shouldUseSlowLane({ connectorId, slowLaneConnectorIds })
+    : false;
+
+  return getActivitiesForLane<T>({
+    activityOptions,
+    baseQueue,
+    useSlowLane,
+  });
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We've been dealing with a persistent issue where certain Slack workspaces hit rate limits constantly, causing their workflows to get stuck and impacting the performance of other connectors. These problematic connectors end up consuming worker concurrency slots while waiting for rate limit backoffs, effectively starving other healthy connectors of resources.

The current approach of having all connectors share the same worker pool with uniform concurrency (16 for Slack) means problematic workspaces degrade system-wide performance.

This PR introduces a "slow lane" routing system that allows us to isolate rate-limited connectors into a separate queue with intentionally lower concurrency (4 vs 16). This follows the same proven pattern we use for cross-region routing in the relocation worker.

Key features:
- Activity-level routing: Ongoing workflows automatically route activities to slow lane when connector is added to the list
- Dynamic queue selection: Activities are routed at execution time based on connector ID from search attributes
- Generic implementation: Can be easily adopted by any connector provider
- Zero downtime: Both normal and slow workers run together in the same deployment

For now it relies on a hard coded connector ids array, ideally we can leverage a Poke plugin in the future.

This should both improve success rates for rate-limited connectors (by reducing API pressure) and prevent them from degrading overall system performance.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
I don't expect any non determinism error ... but we never know!

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
