### PR TITLE
[front] Log in with workOSUserId provided by auth0

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -167,18 +167,13 @@ export function UserMenu({
           label="Sign&nbsp;out"
           icon={LogoutIcon}
           onClick={() => {
-            window.location.href = "/api/auth/logout";
+            if (document.cookie.includes("sessionType=workos")) {
+              window.location.href = "/api/workos/logout";
+            } else {
+              window.location.href = "/api/auth/logout";
+            }
           }}
         />
-        {document.cookie.includes("sessionType=workos") && (
-          <DropdownMenuItem
-            onClick={() => {
-              window.location.href = "/api/workos/logout";
-            }}
-            icon={LogoutIcon}
-            label="Sign&nbsp;out from WorkOS"
-          />
-        )}
 
         {showDebugTools(featureFlags) && (
           <>

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -68,13 +68,6 @@ function mapAuth0ProviderToLegacy(auth0Sub: string): LegacyProviderInfo {
 export async function fetchUserFromSession(session: SessionWithUser) {
   const { workOSUserId, auth0Sub } = session.user;
 
-  if (session.type === "workos" && workOSUserId) {
-    const userWithWorkOS = await UserResource.fetchByWorkOSUserId(workOSUserId);
-    if (userWithWorkOS) {
-      return userWithWorkOS;
-    }
-  }
-
   //TODO(workos): Remove auth0 user lookup.
   if (session.type === "auth0" && auth0Sub) {
     const userWithAuth0 = await UserResource.fetchByAuth0Sub(auth0Sub);
@@ -83,7 +76,21 @@ export async function fetchUserFromSession(session: SessionWithUser) {
     }
 
     const legacyProviderInfo = mapAuth0ProviderToLegacy(auth0Sub);
-    return fetchUserWithLegacyProvider(legacyProviderInfo, auth0Sub);
+    const legacyUser = await fetchUserWithLegacyProvider(
+      legacyProviderInfo,
+      auth0Sub
+    );
+
+    if (legacyUser) {
+      return legacyUser;
+    }
+  }
+
+  if (workOSUserId) {
+    const userWithWorkOS = await UserResource.fetchByWorkOSUserId(workOSUserId);
+    if (userWithWorkOS) {
+      return userWithWorkOS;
+    }
   }
 
   return null;

--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -198,13 +198,15 @@ export default handleAuth({
       return res.redirect("/login-error");
     }
   },
-  logout: handleLogout((req) => {
-    return {
+  logout: async (req: NextApiRequest, res: NextApiResponse) => {
+    res.setHeader("Set-Cookie", [
+      "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+    ]);
+    return handleLogout(req, res, {
       returnTo:
         "query" in req
           ? (req.query.returnTo as string)
           : config.getClientFacingUrl(),
-      clearSession: true,
-    };
-  }),
+    });
+  },
 });

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -240,10 +240,10 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
     }
   }
 
-  res.setHeader(
-    "Set-Cookie",
-    "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax"
-  );
+  res.setHeader("Set-Cookie", [
+    "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+    "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+  ]);
 
   res.redirect(returnTo as string);
 }


### PR DESCRIPTION
## Description

Auth0 provides the workosId stored in user metadata. If user was created with workos and not associated with an auth0Sub, we can still fetch the user based on this.

Keep one single logout, based on current session cookie. Clear cookies on logout.

This allows to login with auth0 with a user created only by workos.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
