### PR TITLE
[front] - feat(groups): improve UI for members/groups management in a space

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -89,7 +89,7 @@ export function ConfirmDialog({
           }}
           rightButtonProps={{
             label: confirmData?.validateLabel ?? "OK",
-            variant: "warning",
+            variant: confirmData?.validateVariant ?? "warning",
             onClick: async () => {
               resolveConfirm(true);
               closeDialogFn();

--- a/front/components/groups/GroupsList.tsx
+++ b/front/components/groups/GroupsList.tsx
@@ -1,8 +1,8 @@
 import {
   Button,
   DataTable,
-  FolderIcon,
   Spinner,
+  UserGroupIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type { CellContext, PaginationState } from "@tanstack/react-table";
@@ -27,7 +27,7 @@ const groupColumns = [
     accessorKey: "name",
     header: "Directory name",
     cell: (info: GroupInfo) => (
-      <DataTable.CellContent icon={FolderIcon}>
+      <DataTable.CellContent icon={UserGroupIcon}>
         {info.row.original.name}
       </DataTable.CellContent>
     ),

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
   EmptyCTA,
   Input,
+  Label,
   MoreIcon,
   Page,
   ScrollArea,
@@ -38,7 +39,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { GroupsList } from "@app/components/groups/GroupsList";
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { SearchGroupsDropdown } from "@app/components/spaces/SearchGroupsDropdown";
-import { SearchMembersPopover } from "@app/components/spaces/SearchMembersPopover";
+import { SearchMembersDropdown } from "@app/components/spaces/SearchMembersDropdown";
 import { useGroups } from "@app/lib/swr/groups";
 import {
   useCreateSpace,
@@ -468,7 +469,7 @@ export function CreateOrEditSpaceModal({
                 {isManual && selectedMembers.length === 0 && (
                   <EmptyCTA
                     action={
-                      <SearchMembersPopover
+                      <SearchMembersDropdown
                         owner={owner}
                         selectedMembers={selectedMembers}
                         onMembersUpdated={(members) => {
@@ -499,7 +500,8 @@ export function CreateOrEditSpaceModal({
                 {isManual && selectedMembers.length > 0 && (
                   <>
                     <div className="flex flex-row items-center justify-between">
-                      <SearchMembersPopover
+                      <Label className="text-lg">Members</Label>
+                      <SearchMembersDropdown
                         owner={owner}
                         selectedMembers={selectedMembers}
                         onMembersUpdated={(members) => {
@@ -510,7 +512,7 @@ export function CreateOrEditSpaceModal({
                     </div>
                     <SearchInput
                       name="search"
-                      placeholder={"Search (email)"}
+                      placeholder="Search (email)"
                       value={searchSelectedMembers}
                       onChange={(s) => {
                         setSearchSelectedMembers(s);
@@ -531,6 +533,7 @@ export function CreateOrEditSpaceModal({
                 {!isManual && selectedGroups.length > 0 && (
                   <>
                     <div className="flex flex-row items-center justify-between">
+                      <Label className="text-lg">Provisioned groups</Label>
                       <SearchGroupsDropdown
                         owner={owner}
                         selectedGroups={selectedGroups}

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -294,8 +294,8 @@ export function CreateOrEditSpaceModal({
           message:
             "This switches from manual member to group-based access. " +
             "Your current member list will be saved but no longer active.",
-          validateLabel: "Switch to Groups",
-          validateVariant: "warning",
+          validateLabel: "Confirm",
+          validateVariant: "primary",
         });
 
         if (confirmed) {
@@ -314,8 +314,8 @@ export function CreateOrEditSpaceModal({
           message:
             "This switches from group-based access to manual member management. " +
             "Your current group settings will be saved but no longer active.",
-          validateLabel: "Switch to Manual",
-          validateVariant: "warning",
+          validateLabel: "Confirm",
+          validateVariant: "primary",
         });
 
         if (confirmed) {

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -464,6 +464,7 @@ export function CreateOrEditSpaceModal({
                     </TabsList>
                   </Tabs>
                 ) : null}
+
                 {isManual && selectedMembers.length === 0 && (
                   <EmptyCTA
                     action={
@@ -494,7 +495,8 @@ export function CreateOrEditSpaceModal({
                     message="Add groups to the space"
                   />
                 )}
-                {isManual && selectedGroups.length > 0 && (
+
+                {isManual && selectedMembers.length > 0 && (
                   <>
                     <div className="flex flex-row items-center justify-between">
                       <SearchMembersPopover

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -1,9 +1,14 @@
 import {
   Button,
   DataTable,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   EmptyCTA,
   Input,
   Label,
+  MoreIcon,
   Page,
   ScrollArea,
   SearchInput,
@@ -17,6 +22,7 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
+  TrashIcon,
   useSendNotification,
   XMarkIcon,
 } from "@dust-tt/sparkle";
@@ -354,13 +360,42 @@ export function CreateOrEditSpaceModal({
     <Sheet open={isOpen} onOpenChange={handleClose}>
       <SheetContent trapFocusScope={false} size="lg">
         <SheetHeader>
-          <SheetTitle>
-            Space Settings
-          </SheetTitle>
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-0">
+              <SheetTitle>Space Settings</SheetTitle>
+            </div>
+
+            {isAdmin && space && space.kind === "regular" && (
+              <>
+                <ConfirmDeleteSpaceDialog
+                  space={space}
+                  handleDelete={onDelete}
+                  isOpen={showDeleteConfirmDialog}
+                  isDeleting={isDeleting}
+                  onClose={() => setShowDeleteConfirmDialog(false)}
+                />
+                <div className="flex w-full justify-end">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button icon={MoreIcon} size="sm" variant="ghost" />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                      <DropdownMenuItem
+                        label="Delete Space"
+                        onClick={() => setShowDeleteConfirmDialog(true)}
+                        icon={TrashIcon}
+                        variant="warning"
+                      />
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </>
+            )}
+          </div>
         </SheetHeader>
         <SheetContainer>
           <div className="flex w-full flex-col gap-y-4">
-            <div className="mb-4 flex w-full flex-col gap-y-2">
+            <div className="mb-4 flex w-full flex-col gap-y-4">
               <Page.SectionHeader title="Name" />
               {!space ? (
                 <Input
@@ -512,26 +547,6 @@ export function CreateOrEditSpaceModal({
                     </ScrollArea>
                   </>
                 )}
-              </>
-            )}
-
-            {isAdmin && space && space.kind === "regular" && (
-              <>
-                <ConfirmDeleteSpaceDialog
-                  space={space}
-                  handleDelete={onDelete}
-                  isOpen={showDeleteConfirmDialog}
-                  isDeleting={isDeleting}
-                  onClose={() => setShowDeleteConfirmDialog(false)}
-                />
-                <div className="flex w-full justify-end">
-                  <Button
-                    size="sm"
-                    label="Delete Space"
-                    variant="warning"
-                    onClick={() => setShowDeleteConfirmDialog(true)}
-                  />
-                </div>
               </>
             )}
           </div>

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -464,90 +464,97 @@ export function CreateOrEditSpaceModal({
                     </TabsList>
                   </Tabs>
                 ) : null}
-                {(isManual && selectedMembers.length === 0) ||
-                (!isManual && selectedGroups.length === 0) ? (
-                  isManual ? (
-                    <EmptyCTA
-                      action={
-                        <SearchMembersPopover
-                          owner={owner}
-                          selectedMembers={selectedMembers}
-                          onMembersUpdated={(members) => {
-                            setSelectedMembers(members);
-                            setIsDirty(true);
-                          }}
-                        />
-                      }
-                      message="Add members to the space"
-                    />
-                  ) : (
-                    <EmptyCTA
-                      action={
-                        <SearchGroupsDropdown
-                          owner={owner}
-                          selectedGroups={selectedGroups}
-                          onGroupsUpdated={(groups) => {
-                            setSelectedGroups(groups);
-                            setIsDirty(true);
-                          }}
-                        />
-                      }
-                      message="Add groups to the space"
-                    />
-                  )
-                ) : (
+                {isManual && selectedMembers.length === 0 && (
+                  <EmptyCTA
+                    action={
+                      <SearchMembersPopover
+                        owner={owner}
+                        selectedMembers={selectedMembers}
+                        onMembersUpdated={(members) => {
+                          setSelectedMembers(members);
+                          setIsDirty(true);
+                        }}
+                      />
+                    }
+                    message="Add members to the space"
+                  />
+                )}
+                {!isManual && selectedGroups.length === 0 && (
+                  <EmptyCTA
+                    action={
+                      <SearchGroupsDropdown
+                        owner={owner}
+                        selectedGroups={selectedGroups}
+                        onGroupsUpdated={(groups) => {
+                          setSelectedGroups(groups);
+                          setIsDirty(true);
+                        }}
+                      />
+                    }
+                    message="Add groups to the space"
+                  />
+                )}
+                {isManual && selectedGroups.length > 0 && (
                   <>
                     <div className="flex flex-row items-center justify-between">
-                      {isManual ? (
-                        <SearchMembersPopover
-                          owner={owner}
-                          selectedMembers={selectedMembers}
-                          onMembersUpdated={(members) => {
-                            setSelectedMembers(members);
-                            setIsDirty(true);
-                          }}
-                        />
-                      ) : (
-                        <SearchGroupsDropdown
-                          owner={owner}
-                          selectedGroups={selectedGroups}
-                          onGroupsUpdated={(groups) => {
-                            setSelectedGroups(groups);
-                            setIsDirty(true);
-                          }}
-                        />
-                      )}
+                      <SearchMembersPopover
+                        owner={owner}
+                        selectedMembers={selectedMembers}
+                        onMembersUpdated={(members) => {
+                          setSelectedMembers(members);
+                          setIsDirty(true);
+                        }}
+                      />
                     </div>
                     <SearchInput
                       name="search"
-                      placeholder={
-                        isManual ? "Search (email)" : "Search groups"
-                      }
+                      placeholder={"Search (email)"}
                       value={searchSelectedMembers}
                       onChange={(s) => {
                         setSearchSelectedMembers(s);
                       }}
                     />
                     <ScrollArea className="h-full">
-                      {isManual ? (
-                        <MembersTable
-                          onMembersUpdated={(members) => {
-                            setSelectedMembers(members);
-                            setIsDirty(true);
-                          }}
-                          selectedMembers={selectedMembers}
-                          searchSelectedMembers={searchSelectedMembers}
-                        />
-                      ) : (
-                        <GroupsTable
-                          onGroupsUpdated={(groups) => {
-                            setSelectedGroups(groups);
-                            setIsDirty(true);
-                          }}
-                          selectedGroups={selectedGroups}
-                          searchSelectedGroups={searchSelectedMembers}
-                        />
-                      )}
+                      <MembersTable
+                        onMembersUpdated={(members) => {
+                          setSelectedMembers(members);
+                          setIsDirty(true);
+                        }}
+                        selectedMembers={selectedMembers}
+                        searchSelectedMembers={searchSelectedMembers}
+                      />
+                    </ScrollArea>
+                  </>
+                )}
+                {!isManual && selectedGroups.length > 0 && (
+                  <>
+                    <div className="flex flex-row items-center justify-between">
+                      <SearchGroupsDropdown
+                        owner={owner}
+                        selectedGroups={selectedGroups}
+                        onGroupsUpdated={(groups) => {
+                          setSelectedGroups(groups);
+                          setIsDirty(true);
+                        }}
+                      />
+                    </div>
+                    <SearchInput
+                      name="search"
+                      placeholder={"Search groups"}
+                      value={searchSelectedMembers}
+                      onChange={(s) => {
+                        setSearchSelectedMembers(s);
+                      }}
+                    />
+                    <ScrollArea className="h-full">
+                      <GroupsTable
+                        onGroupsUpdated={(groups) => {
+                          setSelectedGroups(groups);
+                          setIsDirty(true);
+                        }}
+                        selectedGroups={selectedGroups}
+                        searchSelectedGroups={searchSelectedMembers}
+                      />
                     </ScrollArea>
                   </>
                 )}

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -7,7 +7,6 @@ import {
   DropdownMenuTrigger,
   EmptyCTA,
   Input,
-  Label,
   MoreIcon,
   Page,
   ScrollArea,
@@ -284,16 +283,17 @@ export function CreateOrEditSpaceModal({
         return;
       }
 
-      // If switching from manual to group mode with manually added members
+      // If switching from manual to group mode with manually added members.
       if (
         managementType === "manual" &&
         value === "group" &&
         selectedMembers.length > 0
       ) {
         const confirmed = await confirm({
-          title: "Switch to Group Management",
+          title: "Switch to groups",
           message:
-            "Switching to group member management will remove all manually added members",
+            "This switches from manual member to group-based access. " +
+            "Your current member list will be saved but no longer active.",
           validateLabel: "Switch to Groups",
           validateVariant: "warning",
         });
@@ -303,16 +303,17 @@ export function CreateOrEditSpaceModal({
           setIsDirty(true);
         }
       }
-      // If switching from group to manual mode with selected groups
+      // If switching from group to manual mode with selected groups.
       else if (
         managementType === "group" &&
         value === "manual" &&
         selectedGroups.length > 0
       ) {
         const confirmed = await confirm({
-          title: "Switch to Manual Management",
+          title: "Switch to members",
           message:
-            "Switching to manual member management will remove all selected groups",
+            "This switches from group-based access to manual member management. " +
+            "Your current group settings will be saved but no longer active.",
           validateLabel: "Switch to Manual",
           validateVariant: "warning",
         });
@@ -322,7 +323,7 @@ export function CreateOrEditSpaceModal({
           setIsDirty(true);
         }
       } else {
-        // For direct switches without selections, clear everything and let user start fresh
+        // For direct switches without selections, clear everything and let the user start fresh.
         setManagementType(value);
         setIsDirty(true);
       }
@@ -434,12 +435,12 @@ export function CreateOrEditSpaceModal({
                 />
               </div>
               {isRestricted ? (
-                <Label>Restricted access is active.</Label>
+                <span>Restricted access is active.</span>
               ) : (
-                <Label>
+                <span>
                   Restricted access is disabled. The space is accessible to
                   everyone in the workspace.
-                </Label>
+                </span>
               )}
             </div>
 
@@ -455,8 +456,11 @@ export function CreateOrEditSpaceModal({
                     }}
                   >
                     <TabsList>
-                      <TabsTrigger value="manual" label="Members management" />
-                      <TabsTrigger value="group" label="Group management" />
+                      <TabsTrigger value="manual" label="Manual access" />
+                      <TabsTrigger
+                        value="group"
+                        label="Provisioned group access"
+                      />
                     </TabsList>
                   </Tabs>
                 ) : null}

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -355,7 +355,7 @@ export function CreateOrEditSpaceModal({
       <SheetContent trapFocusScope={false} size="lg">
         <SheetHeader>
           <SheetTitle>
-            {space ? `Edit ${space.name}` : "Create a Space"}
+            Space Settings
           </SheetTitle>
         </SheetHeader>
         <SheetContainer>

--- a/front/components/spaces/SearchGroupsDropdown.tsx
+++ b/front/components/spaces/SearchGroupsDropdown.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSearchbar,
   DropdownMenuTrigger,
+  PlusIcon,
 } from "@dust-tt/sparkle";
 import { UserGroupIcon } from "@dust-tt/sparkle";
 import React, { useCallback, useMemo, useState } from "react";
@@ -52,7 +53,7 @@ export function SearchGroupsDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button label="Add user groups" icon={UserGroupIcon} size="sm" />
+        <Button label="Add groups" icon={PlusIcon} size="sm" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="w-80"

--- a/front/components/spaces/SearchGroupsDropdown.tsx
+++ b/front/components/spaces/SearchGroupsDropdown.tsx
@@ -72,8 +72,7 @@ export function SearchGroupsDropdown({
             onClick={addGroup(group)}
             icon={UserGroupIcon}
             label={group.name}
-            // TODO: add member count
-            description=""
+            description={`${group.memberCount} members`}
           />
         ))}
         {filteredGroups.length === 0 && !isGroupsLoading && (

--- a/front/components/spaces/SearchMembersDropdown.tsx
+++ b/front/components/spaces/SearchMembersDropdown.tsx
@@ -14,7 +14,7 @@ import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { useSearchMembers } from "@app/lib/swr/memberships";
 import type { LightWorkspaceType, UserType } from "@app/types";
 
-interface SearchMembersPopoverProps {
+interface SearchMembersDropdownProps {
   owner: LightWorkspaceType;
   selectedMembers: UserType[];
   onMembersUpdated: (members: UserType[]) => void;
@@ -22,11 +22,11 @@ interface SearchMembersPopoverProps {
 
 const DefaultPagination = { pageIndex: 0, pageSize: 25 };
 
-export function SearchMembersPopover({
+export function SearchMembersDropdown({
   owner,
   selectedMembers,
   onMembersUpdated,
-}: SearchMembersPopoverProps) {
+}: SearchMembersDropdownProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [pagination, setPagination] = useState(DefaultPagination);
   const [allMembers, setAllMembers] = useState<UserType[]>([]);

--- a/front/components/spaces/SearchMembersPopover.tsx
+++ b/front/components/spaces/SearchMembersPopover.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSearchbar,
   DropdownMenuTrigger,
-  UserIcon,
+  PlusIcon,
 } from "@dust-tt/sparkle";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -56,7 +56,7 @@ export function SearchMembersPopover({
     }
   }, [members, isLoading, pagination.pageIndex]);
 
-  // effect to reset pagination when search term changes
+  // Effect to reset pagination when the search term changes.
   useEffect(() => {
     setPagination(DefaultPagination);
   }, [searchTerm]);
@@ -84,7 +84,7 @@ export function SearchMembersPopover({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button label="Add members" icon={UserIcon} size="sm" />
+        <Button label="Add members" icon={PlusIcon} size="sm" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="w-80"
@@ -107,7 +107,7 @@ export function SearchMembersPopover({
           />
         ))}
         {filteredMembers.length === 0 && !isLoading && (
-          <div className="py-6 text-center text-sm text-muted-foreground">
+          <div className="py-6 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
             {searchTerm ? "No members found" : "No members available"}
           </div>
         )}
@@ -116,7 +116,7 @@ export function SearchMembersPopover({
           hasMore={hasMore}
           showLoader={isLoading}
           loader={
-            <div className="py-2 text-center text-sm text-muted-foreground">
+            <div className="py-2 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
               Loading more members...
             </div>
           }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2940.
- Various changes: copy improvements, labels addition, color changes, other small UI changes.

<img width="253" alt="Screenshot 2025-06-18 at 7 29 46 AM" src="https://github.com/user-attachments/assets/502fb819-9c45-486e-b68a-a82737fb7064" />

<img width="253" alt="Screenshot 2025-06-18 at 7 28 00 AM" src="https://github.com/user-attachments/assets/5be09bdf-57a6-4810-9b9f-a5cb67de1dfe" />

<img width="253" alt="Screenshot 2025-06-18 at 7 28 17 AM" src="https://github.com/user-attachments/assets/3ccfb700-860b-4eb5-b7ab-c174eb9843c4" />

One missing information compared to the Figma: we don't display where the directory is managed (Okta, Entra, ...). This information is not synced as of yet.

## Tests

- Tested locally.

## Risk

- Low, only UI.

## Deploy Plan

- Deploy front.
