### PR TITLE
[front] fix DB query in space permissions workflow

### DIFF
--- a/front/lib/api/assistant/permissions.ts
+++ b/front/lib/api/assistant/permissions.ts
@@ -25,7 +25,7 @@ export async function listAgentConfigurationsForGroups(
   groups: GroupResource[]
 ) {
   return AgentConfiguration.findAll({
-    attributes: ["sId", "groupIds"],
+    attributes: ["sId"],
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       status: "active",


### PR DESCRIPTION
## Description

- This PR fixes the `updateSpacePermissionsWorkflow` workflow, which currently fails on a query on a missing column in db.
- The column is named `groupIds`, it was removed in https://github.com/dust-tt/dust/pull/11772 but the migration does not seem to have been run in production (the issue was observed locally). We do not have the column in the Sequelize model and we do not have it if we run the migrations in order.
- There are no other places where we pass `groupIds` in an attribute field of a Sequelize `findAll` or `findOne`.

## Tests

## Risk

- Low, only one code path affected.

## Deploy Plan

- Deploy front.
