### PR TITLE
[sparkle] allow message to be empty in EmptyCTA

### DIFF
--- a/sparkle/src/components/EmptyCTA.tsx
+++ b/sparkle/src/components/EmptyCTA.tsx
@@ -5,7 +5,7 @@ import { cn } from "@sparkle/lib/utils";
 
 interface EmptyCTAProps extends React.HTMLAttributes<HTMLDivElement> {
   action: React.ReactNode;
-  message: string;
+  message?: string;
 }
 
 const EmptyCTA = React.forwardRef<HTMLDivElement, EmptyCTAProps>(
@@ -20,14 +20,16 @@ const EmptyCTA = React.forwardRef<HTMLDivElement, EmptyCTAProps>(
       )}
       {...props}
     >
-      <div
-        className={cn(
-          "s-text-center s-text-sm",
-          "s-text-muted-foreground dark:s-text-muted-foreground-night"
-        )}
-      >
-        {message}
-      </div>
+      {message && (
+        <div
+          className={cn(
+            "s-text-center s-text-sm",
+            "s-text-muted-foreground dark:s-text-muted-foreground-night"
+          )}
+        >
+          {message}
+        </div>
+      )}
       <div>{action}</div>
     </div>
   )

--- a/sparkle/src/stories/EmptyCTA.stories.tsx
+++ b/sparkle/src/stories/EmptyCTA.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 
-import { EmptyCTA, EmptyCTAButton } from "@sparkle/components";
-import { CloudArrowDownIcon } from "@sparkle/icons/app";
+import { Button, EmptyCTA, EmptyCTAButton } from "@sparkle/components";
+import { CloudArrowDownIcon, PlusIcon } from "@sparkle/icons/app";
 
 const meta = {
   title: "Components/EmptyCTA",
@@ -12,7 +12,7 @@ export default meta;
 
 export const Demo = () => {
   return (
-    <div>
+    <div className="s-flex s-flex-col s-gap-4">
       <div className="s-flex s-items-center s-space-x-2">
         <EmptyCTA
           action={
@@ -23,6 +23,9 @@ export const Demo = () => {
           }
           message="You don't have any spaces yet."
         />
+      </div>
+      <div className="s-flex s-items-center s-space-x-2">
+        <EmptyCTA action={<Button icon={PlusIcon} label="Add domain" />} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
Currently you have to pass `message` to EmptyCTA, but this PR is to make it optional so that you can have an empty CTA with just action button: 

![image (2)](https://github.com/user-attachments/assets/855a1cb8-3b49-4d59-a4e7-feb32a202569)


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
