### PR TITLE
Spolu report first sync

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1245,7 +1245,8 @@ export async function firecrawlCrawlPage(
   }
 
   if (!connector?.firstSuccessfulSyncTime) {
-    // If this is the first sync we report the progress.
+    // If this is the first sync we report the progress. This is a bit racy but that's not a big
+    // problem as this is simple reporting of initial progress.
     const pagesCount = await WebCrawlerPage.count({
       where: {
         connectorId,

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1053,7 +1053,7 @@ export async function firecrawlCrawlPage(
     scrapeId,
   });
 
-  let connector = await ConnectorResource.fetchById(connectorId);
+  const connector = await ConnectorResource.fetchById(connectorId);
   const webCrawlerConfig =
     await WebCrawlerConfigurationResource.fetchByConnectorId(connectorId);
 

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -150,7 +150,9 @@ export async function firecrawlCrawlCompletedWorkflow(
 
   // If we have a lastSyncStartTs, we start the garbage collector workflow.
   if (res?.lastSyncStartTs) {
-    // sleep for 120s
+    // Sleep for 120s to provide a buffer for all firecrawl page scrape webhooks to arrive and be
+    // processed. If some arrive after that means we may have a race on garbage collecting (deleting
+    // and upserting a page) which may lead to dropping a few pages which is not catastrophic.
     await new Promise((resolve) => setTimeout(resolve, 120_000));
 
     await startChild(garbageCollectWebsiteWorkflow, {

--- a/connectors/src/lib/sync_status.ts
+++ b/connectors/src/lib/sync_status.ts
@@ -54,7 +54,6 @@ export async function reportInitialSyncProgress(
 
   await connector.update({
     firstSyncProgress: progress,
-    lastSyncSuccessfulTime: null,
   });
 
   return new Ok(undefined);


### PR DESCRIPTION
## Description

Remove the set to null of `lastSyncSuccessfulTime` in `reportInitialSyncProgress` as it makes no sense (if it was set it means that we believe we finished at some point and a later racy call should not re-update it). Investigated call site and quite convinced this is peaceful.

Report initial sync state for firecrawl api webcrawl

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `connectors`