### PR TITLE
[connectors] fix(Gong): prevent incorrect early stop

### DIFF
--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -119,7 +119,7 @@ export async function gongSyncTranscriptsActivity({
       { ...loggerArgs, pageCursor },
       "[Gong] No more transcripts found."
     );
-    return { nextPageCursor: null };
+    return { nextPageCursor };
   }
 
   const transcriptsInDb = await GongTranscriptResource.fetchByCallIds(

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -119,7 +119,7 @@ export async function gongSyncTranscriptsActivity({
       { ...loggerArgs, pageCursor },
       "[Gong] No more transcripts found."
     );
-    return { nextPageCursor };
+    return { nextPageCursor: null };
   }
 
   const transcriptsInDb = await GongTranscriptResource.fetchByCallIds(

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -135,6 +135,10 @@ export async function gongSyncTranscriptsActivity({
     );
   }
   if (transcriptsToSync.length === 0) {
+    logger.warn(
+      { ...loggerArgs },
+      "[Gong] All transcripts are already in DB."
+    );
     return { nextPageCursor: null };
   }
 

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -135,7 +135,7 @@ export async function gongSyncTranscriptsActivity({
     );
   }
   if (transcriptsToSync.length === 0) {
-    logger.warn(
+    logger.info(
       { ...loggerArgs },
       "[Gong] All transcripts are already in DB."
     );

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -157,7 +157,7 @@ export async function gongSyncTranscriptsActivity({
           { ...loggerArgs, callId: transcript.callId },
           "[Gong] Transcript metadata not found."
         );
-        return { nextPageCursor: null };
+        return;
       }
 
       const { parties = [] } = transcriptMetadata;

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -135,11 +135,8 @@ export async function gongSyncTranscriptsActivity({
     );
   }
   if (transcriptsToSync.length === 0) {
-    logger.info(
-      { ...loggerArgs },
-      "[Gong] All transcripts are already in DB."
-    );
-    return { nextPageCursor: null };
+    logger.info({ ...loggerArgs }, "[Gong] All transcripts are already in DB.");
+    return { nextPageCursor };
   }
 
   const callsMetadata = await getTranscriptsMetadata({


### PR DESCRIPTION
## Description

- Remediation to https://github.com/dust-tt/tasks/issues/3044.
- This PR fixes a bug on the Gong connector where fetching a page where all connectors are already in db stops the sync (by reporting a null cursor for the next page) instead of skipping the page.
- This PR also adds a log on all transcripts to sync already being found in db to help track those.
- This issue has affected all full syncs that do not force resync.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
