### PR TITLE
Metaprompt for helpfulness

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -145,7 +145,7 @@ export async function constructPromptMultiActions(
     "\nParentheses cannot be used to enclose mathematical formulas: BAD: \\( \\Delta \\), GOOD: $$ \\Delta $$.\n";
 
   guidelinesSection +=
-    "\n Respond with clarity and helpfulness. When not instructed otherwise, give answers that are structured, visually clear, and reader-friendly—using headings, bullet points, and examples where helpful.";
+    "\n Respond in a helpful, honest, and engaging way. Unless instructed to be brief, present answers with clear structure and formatting to improve readability—use headings, bullet points, and examples when appropriate.";
 
   // INSTRUCTIONS section
   let instructions = "# INSTRUCTIONS\n\n";

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -144,9 +144,6 @@ export async function constructPromptMultiActions(
     "\nEvery latex formula should be inside double dollars $$ blocks." +
     "\nParentheses cannot be used to enclose mathematical formulas: BAD: \\( \\Delta \\), GOOD: $$ \\Delta $$.\n";
 
-  guidelinesSection +=
-    "\n Respond in a helpful, honest, and engaging way. Unless instructed to be brief, present answers with clear structure and formatting to improve readability—use headings, bullet points, and examples when appropriate.";
-
   // INSTRUCTIONS section
   let instructions = "# INSTRUCTIONS\n\n";
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -144,6 +144,9 @@ export async function constructPromptMultiActions(
     "\nEvery latex formula should be inside double dollars $$ blocks." +
     "\nParentheses cannot be used to enclose mathematical formulas: BAD: \\( \\Delta \\), GOOD: $$ \\Delta $$.\n";
 
+  guidelinesSection +=
+    "\n Respond with clarity and helpfulness. When not instructed otherwise, give answers that are structured, visually clear, and reader-friendly—using headings, bullet points, and examples where helpful.";
+
   // INSTRUCTIONS section
   let instructions = "# INSTRUCTIONS\n\n";
 

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -58,6 +58,9 @@ import {
 
 const readFileAsync = promisify(fs.readFile);
 
+const globalAgentGuidelines =
+  "Respond in a helpful, honest, and engaging way. Unless instructed to be brief, present answers with clear structure and formatting to improve readability: use emojis, headings, bullet points, and examples when appropriate.";
+
 // Used when returning an agent with status 'disabled_by_admin'
 const dummyModelConfiguration = {
   providerId: GPT_4_1_MODEL_CONFIG.providerId,
@@ -330,7 +333,7 @@ function _getGPT35TurboGlobalAgent({
     versionAuthorId: null,
     name: "gpt3.5-turbo",
     description: GPT_3_5_TURBO_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/gpt3_avatar_full.png",
     status,
     scope: "global",
@@ -381,7 +384,7 @@ function _getGPT4GlobalAgent({
     versionAuthorId: null,
     name: "gpt4",
     description: GPT_4_1_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png",
     status,
     scope: "global",
@@ -430,7 +433,7 @@ function _getO3MiniGlobalAgent({
     versionAuthorId: null,
     name: "o3-mini",
     description: O3_MINI_HIGH_REASONING_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/o1_avatar_full.png",
     status,
     scope: "global",
@@ -470,7 +473,7 @@ function _getO1GlobalAgent({
     versionAuthorId: null,
     name: "o1",
     description: O1_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/o1_avatar_full.png",
     status,
     scope: "global",
@@ -510,7 +513,7 @@ function _getO1MiniGlobalAgent({
     versionAuthorId: null,
     name: "o1-mini",
     description: O1_MINI_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/o1_avatar_full.png",
     status,
     scope: "global",
@@ -551,7 +554,7 @@ function _getO1HighReasoningGlobalAgent({
     versionAuthorId: null,
     name: "o1-high-reasoning",
     description: O1_HIGH_REASONING_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/o1_avatar_full.png",
     status,
     scope: "global",
@@ -593,7 +596,7 @@ function _getO3GlobalAgent({
     versionAuthorId: null,
     name: "o3",
     description: O3_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/o1_avatar_full.png",
     status,
     scope: "global",
@@ -628,7 +631,7 @@ function _getClaudeInstantGlobalAgent({
     versionAuthorId: null,
     name: "claude-instant",
     description: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
@@ -669,7 +672,7 @@ function _getClaude2GlobalAgent({
     versionAuthorId: null,
     name: "claude-2",
     description: CLAUDE_2_DEFAULT_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
@@ -706,7 +709,7 @@ function _getClaude3HaikuGlobalAgent({
     versionAuthorId: null,
     name: "claude-3-haiku",
     description: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
@@ -747,7 +750,7 @@ function _getClaude3OpusGlobalAgent({
     versionAuthorId: null,
     name: "claude-3-opus",
     description: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
@@ -833,6 +836,7 @@ function _getClaude4SonnetGlobalAgent({
     name: "claude-4-sonnet",
     description: CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG.description,
     instructions:
+      globalAgentGuidelines +
       "Only use visualization if it is strictly necessary to visualize " +
       "data or if it was explicitly requested by the user. " +
       "Do not use visualization if markdown is sufficient.",
@@ -877,6 +881,7 @@ function _getClaude3_7GlobalAgent({
     name: "claude-3.7",
     description: CLAUDE_3_7_SONNET_DEFAULT_MODEL_CONFIG.description,
     instructions:
+      globalAgentGuidelines +
       "Only use visualization if it is strictly necessary to visualize " +
       "data or if it was explicitly requested by the user. " +
       "Do not use visualization if markdown is sufficient.",
@@ -922,7 +927,7 @@ function _getMistralLargeGlobalAgent({
     versionAuthorId: null,
     name: "mistral",
     description: MISTRAL_LARGE_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
     status,
     scope: "global",
@@ -970,7 +975,7 @@ function _getMistralMediumGlobalAgent({
     versionAuthorId: null,
     name: "mistral-medium",
     description: MISTRAL_MEDIUM_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
     status,
     scope: "global",
@@ -1012,7 +1017,7 @@ function _getMistralSmallGlobalAgent({
     versionAuthorId: null,
     name: "mistral-small",
     description: MISTRAL_SMALL_MODEL_CONFIG.description,
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
     status,
     scope: "global",
@@ -1106,7 +1111,7 @@ function _getDeepSeekR1GlobalAgent({
     name: "DeepSeek R1",
     description:
       "DeepSeek's reasoning model. Served from a US inference provider. Cannot use any tools",
-    instructions: null,
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/deepseek_avatar_full.png",
     status,
     scope: "global",

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -58,8 +58,14 @@ import {
 
 const readFileAsync = promisify(fs.readFile);
 
-const globalAgentGuidelines =
-  "Respond in a helpful, honest, and engaging way. Unless instructed to be brief, present answers with clear structure and formatting to improve readability: use emojis, headings, bullet points, and examples when appropriate.";
+const globalAgentGuidelines = `
+  Respond in a helpful, honest, and engaging way. 
+  Unless instructed to be brief, present answers with clear structure and formatting to improve readability: use emojis, headings, bullet points, and examples when appropriate.
+  The agent always respects the mardown format and generates spaces to nest content.
+
+  Only use visualization if it is strictly necessary to visualize data or if it was explicitly requested by the user.
+  Do not use visualization if markdown is sufficient.
+  `;
 
 // Used when returning an agent with status 'disabled_by_admin'
 const dummyModelConfiguration = {
@@ -300,7 +306,7 @@ function _getHelperGlobalAgent({
     versionAuthorId: null,
     name: "help",
     description: "Help on how to use Dust",
-    instructions: prompt,
+    instructions: prompt + globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/helper_avatar_full.png",
     status: status,
     userFavorite: false,
@@ -791,10 +797,7 @@ function _getClaude3GlobalAgent({
     versionAuthorId: null,
     name: "claude-3.5",
     description: CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG.description,
-    instructions:
-      "Only use visualization if it is strictly necessary to visualize " +
-      "data or if it was explicitly requested by the user. " +
-      "Do not use visualization if markdown is sufficient.",
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
@@ -835,11 +838,7 @@ function _getClaude4SonnetGlobalAgent({
     versionAuthorId: null,
     name: "claude-4-sonnet",
     description: CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG.description,
-    instructions:
-      globalAgentGuidelines +
-      "Only use visualization if it is strictly necessary to visualize " +
-      "data or if it was explicitly requested by the user. " +
-      "Do not use visualization if markdown is sufficient.",
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
@@ -880,11 +879,7 @@ function _getClaude3_7GlobalAgent({
     versionAuthorId: null,
     name: "claude-3.7",
     description: CLAUDE_3_7_SONNET_DEFAULT_MODEL_CONFIG.description,
-    instructions:
-      globalAgentGuidelines +
-      "Only use visualization if it is strictly necessary to visualize " +
-      "data or if it was explicitly requested by the user. " +
-      "Do not use visualization if markdown is sufficient.",
+    instructions: globalAgentGuidelines,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
@@ -1433,9 +1428,8 @@ function _getDustGlobalAgent(
       }
     : dummyModelConfiguration;
 
-  const instructions = `The agent answers with precision and brevity. It produces short and straight to the point answers.
+  const instructions = `${globalAgentGuidelines}
 The agent should not provide additional information or content that the user did not ask for.
-When possible, the agent should answer using a single sentence.
 
 # When the user asks a questions to the agent, the agent should analyze the situation as follows:
 
@@ -1457,9 +1451,7 @@ When possible, the agent should answer using a single sentence.
    and the public internet before answering the user's question.
 
 4. If the user's query require neither internal company data or recent public knowledge,
-   the agent is allowed to answer without using any tool.
-
-The agent always respects the mardown format and generates spaces to nest content.`;
+   the agent is allowed to answer without using any tool.`;
 
   const dustAgent = {
     id: -1,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -61,7 +61,7 @@ const readFileAsync = promisify(fs.readFile);
 const globalAgentGuidelines = `
   Respond in a helpful, honest, and engaging way. 
   Unless instructed to be brief, present answers with clear structure and formatting to improve readability: use emojis, headings, bullet points, and examples when appropriate.
-  The agent always respects the mardown format and generates spaces to nest content.
+  The agent always respects the markdown format and generates spaces to nest content.
 
   Only use visualization if it is strictly necessary to visualize data or if it was explicitly requested by the user.
   Do not use visualization if markdown is sufficient.


### PR DESCRIPTION
## Description

We have users telling us our answers are not as appealing as the ones from ChatGPT - so adding a metaprompt to get a better experience in answers when no styling is precised in the agent instructions.

The goal is to get closer to the new styling of what ChatGPT offers:

![Screenshot 2025-06-18 at 11 06 21](https://github.com/user-attachments/assets/25d6d449-2b85-4f45-bd70-a18cca1ae4ae)


## CLAUDE4
<img width="964" alt="Screenshot 2025-06-18 at 18 06 33" src="https://github.com/user-attachments/assets/f432e1d5-8710-4a18-8d0b-eadc788bda87" />
<img width="1031" alt="Screenshot 2025-06-18 at 18 06 17" src="https://github.com/user-attachments/assets/3b31bd68-d405-4d50-8742-03574e35b714" />

## GPT4
<img width="871" alt="Screenshot 2025-06-18 at 18 04 10" src="https://github.com/user-attachments/assets/4f72fe44-7a7e-494a-aee2-369ee7c52772" />
<img width="856" alt="Screenshot 2025-06-18 at 18 04 36" src="https://github.com/user-attachments/assets/fa8a0003-19fa-4c9b-be9f-f29ac2c0f512" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
