### PR TITLE
Upg: make error messages of agents more user friendly

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -30,6 +30,7 @@ import {
 } from "@app/lib/actions/types/guards";
 import { getCitationsCount } from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
+import { getPublicErrorMessage } from "@app/lib/api/assistant/agent_errors";
 import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
@@ -624,11 +625,13 @@ async function* runMultiActionsAgent(
   );
 
   if (res.isErr()) {
+    const publicErrorMessage = getPublicErrorMessage(res.error);
     logger.error(
       {
         workspaceId: conversation.owner.sId,
         conversationId: conversation.sId,
         error: res.error,
+        publicErrorMessage,
       },
       "Error running multi-actions agent."
     );
@@ -639,7 +642,7 @@ async function* runMultiActionsAgent(
       messageId: agentMessage.sId,
       error: {
         code: "multi_actions_error",
-        message: `Error running multi-actions agent action: [${res.error.type}] ${res.error.message}`,
+        message: publicErrorMessage,
         metadata: null,
       },
     } satisfies AgentErrorEvent;

--- a/front/lib/api/assistant/agent_errors.ts
+++ b/front/lib/api/assistant/agent_errors.ts
@@ -30,13 +30,13 @@ export const getPublicErrorMessage = (error: {
         error.message.includes("at least one message is required") ||
         error.message.includes("exceed context limit")
       ) {
-        return "Your conversation content is too big and has exceeded the context window of the model. Try to reduce the amount of data you are sending or start a new conversation.";
+        return "Context window (the amount of data the agent can process) exceeded. This can happen if your first message was very long or if the agent retrieved a lot of data while helping you. Try breaking your request into smaller parts or updating your agent configuration to output less data.";
       } else if (error.message.includes("Internal server error")) {
         return "Anthropic (provider of Claude) encountered an internal server error. Please try again.";
       }
     } else if (error.message.includes("OpenAIError")) {
       if (error.message.includes("maximum context length")) {
-        return "Your conversation content is too big and has exceeded the context window of the model. Try to reduce the amount of data you are sending or start a new conversation.";
+        return "Context window (the amount of data the agent can process) exceeded. This can happen if your first message was very long or if the agent retrieved a lot of data while helping you. Try breaking your request into smaller parts or updating your agent configuration to output less data.";
       } else if (error.message.includes("Invalid schema for response_format")) {
         const contextPart = error.message.split("In context=")[1];
         return `Your agent is configured to return a response in a format that is not supported by the model: ${contextPart}. Please update your agent configuration in Instructions > Advanced Settings > Structured Response Format.`;

--- a/front/lib/api/assistant/agent_errors.ts
+++ b/front/lib/api/assistant/agent_errors.ts
@@ -1,0 +1,49 @@
+/**
+ * Get a user-friendly error message from an API error.
+ * This function handles various error cases from different model providers (Anthropic, OpenAI)
+ * and returns appropriate messages that can be shown to end users.
+ *
+ * For a full list of possible errors and their frequency, see:
+ * https://app.datadoghq.eu/logs?query=%40error.code%3Amulti_actions_error%20message%3A%22Error%20running%20multi-actions%20agent.%22
+ *
+ * Common error cases handled:
+ * - Anthropic overload/503 errors
+ * - Context window exceeded (both providers)
+ * - Internal server errors (both providers)
+ * - Invalid response format configuration
+ * - Streaming errors
+ *
+ * @param error - The error object containing message and type
+ **/
+export const getPublicErrorMessage = (error: {
+  message: string;
+  type: string;
+}): string => {
+  if (error.type == "multi_actions_error") {
+    if (error.message.includes("AnthropicError")) {
+      if (
+        error.message.includes("overloaded_error") ||
+        error.message.includes("503 Service Unavailable")
+      ) {
+        return "Anthropic (provider of Sonnet) is currently overloaded. Please try again later.";
+      } else if (error.message.includes("at least one message is required")) {
+        return "Your conversation content is too big and has exceeded the context window of the model. Try to reduce the amount of data you are sending.";
+      } else if (error.message.includes("Internal server error")) {
+        return "Anthropic (provider of Sonnet) encountered an internal server error. Please try again.";
+      }
+    } else if (error.message.includes("OpenAIError")) {
+      if (error.message.includes("maximum context length")) {
+        return "Your conversation content is too big and has exceeded the context window of the model. Try to reduce the amount of data you are sending.";
+      } else if (error.message.includes("Invalid schema for response_format")) {
+        const contextPart = error.message.split("In context=")[1];
+        return `Your agent is configured to return a response in a format that is not supported by the model: ${contextPart}. Please update your agent configuration.`;
+      } else if (error.message.includes("server_error")) {
+        return "OpenAI (provider of GPT) encountered an internal server error. Please try again.";
+      }
+    } else if (error.message.includes("Error streaming chunks")) {
+      return "There was an error streaming the answer to your query. Please try again.";
+    }
+  }
+  // Original message is used as a fallback.
+  return `Error running agent: [${error.type}] ${error.message}`;
+};

--- a/front/lib/api/assistant/agent_errors.ts
+++ b/front/lib/api/assistant/agent_errors.ts
@@ -25,18 +25,21 @@ export const getPublicErrorMessage = (error: {
         error.message.includes("overloaded_error") ||
         error.message.includes("503 Service Unavailable")
       ) {
-        return "Anthropic (provider of Sonnet) is currently overloaded. Please try again later.";
-      } else if (error.message.includes("at least one message is required")) {
-        return "Your conversation content is too big and has exceeded the context window of the model. Try to reduce the amount of data you are sending.";
+        return "Anthropic (provider of Claude) is currently overloaded. Please try again later.";
+      } else if (
+        error.message.includes("at least one message is required") ||
+        error.message.includes("exceed context limit")
+      ) {
+        return "Your conversation content is too big and has exceeded the context window of the model. Try to reduce the amount of data you are sending or start a new conversation.";
       } else if (error.message.includes("Internal server error")) {
-        return "Anthropic (provider of Sonnet) encountered an internal server error. Please try again.";
+        return "Anthropic (provider of Claude) encountered an internal server error. Please try again.";
       }
     } else if (error.message.includes("OpenAIError")) {
       if (error.message.includes("maximum context length")) {
-        return "Your conversation content is too big and has exceeded the context window of the model. Try to reduce the amount of data you are sending.";
+        return "Your conversation content is too big and has exceeded the context window of the model. Try to reduce the amount of data you are sending or start a new conversation.";
       } else if (error.message.includes("Invalid schema for response_format")) {
         const contextPart = error.message.split("In context=")[1];
-        return `Your agent is configured to return a response in a format that is not supported by the model: ${contextPart}. Please update your agent configuration.`;
+        return `Your agent is configured to return a response in a format that is not supported by the model: ${contextPart}. Please update your agent configuration in Instructions > Advanced Settings > Structured Response Format.`;
       } else if (error.message.includes("server_error")) {
         return "OpenAI (provider of GPT) encountered an internal server error. Please try again.";
       }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1878,16 +1878,6 @@ async function* streamRunAgentEvents(
           errorMessage: event.error.message,
           errorMetadata: event.error.metadata,
         });
-
-        logger.error(
-          {
-            error: event.error,
-            workspaceId: auth.workspace()?.sId,
-            agentMessageId: agentMessage.sId,
-          },
-          "Agent error"
-        );
-
         yield event;
         return;
 


### PR DESCRIPTION
## Description

Return a user-friendly error message for the most common cases of agent errors.
I tried my best but feel free to suggest changes to the messages themselves.

We had 2 entries for each error : so I also removed another error log that was more or less the same thing.

## Risk

Low

## Deploy Plan

Deploy front