### PR TITLE
[connectors] feat(webcrawler): Update sync status based on crawl status when completed

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { FirecrawlDocument } from "@mendable/firecrawl-js";
-import FirecrawlApp, { FirecrawlError } from "@mendable/firecrawl-js";
+import { FirecrawlError } from "@mendable/firecrawl-js";
 import { Context } from "@temporalio/activity";
 import { isCancellation } from "@temporalio/workflow";
 import { BasicCrawler, CheerioCrawler, Configuration, LogLevel } from "crawlee";
@@ -37,6 +37,7 @@ import {
   upsertDataSourceDocument,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
+import { getFirecrawl } from "@connectors/lib/firecrawl";
 import {
   WebCrawlerFolder,
   WebCrawlerPage,
@@ -104,9 +105,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
     throw new Error(`Webcrawler configuration not found for connector.`);
   }
 
-  const firecrawlApp = new FirecrawlApp({
-    apiKey: apiConfig.getFirecrawlAPIConfig().apiKey,
-  });
+  const firecrawlApp = getFirecrawl();
 
   const childLogger = logger.child({
     connectorId: connector.id,
@@ -1273,7 +1272,20 @@ export async function firecrawlCrawlCompleted(
     return;
   }
 
-  await syncSucceeded(connector.id);
+  const crawlStatus = await getFirecrawl().checkCrawlStatus(crawlId);
+  if (!crawlStatus.success) {
+    localLogger.error(
+      { connectorId, crawlId },
+      `Couldn't fetch crawl status: ${crawlStatus.error}`
+    );
+    return;
+  }
+
+  if (crawlStatus.completed >= crawlStatus.total) {
+    await syncFailed(connectorId, "webcrawling_synchronization_limit_reached");
+  } else {
+    await syncSucceeded(connector.id);
+  }
 
   return {
     lastSyncStartTs: connector.lastSyncStartTime?.getTime() ?? null,

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1272,6 +1272,13 @@ export async function firecrawlCrawlCompleted(
     return;
   }
 
+  const webConfig =
+    await WebCrawlerConfigurationResource.fetchByConnectorId(connectorId);
+  if (webConfig === null) {
+    localLogger.error({ connectorId }, "WebCrawlerConfiguration not found");
+    return;
+  }
+
   const crawlStatus = await getFirecrawl().checkCrawlStatus(crawlId);
   if (!crawlStatus.success) {
     localLogger.error(
@@ -1281,7 +1288,7 @@ export async function firecrawlCrawlCompleted(
     return;
   }
 
-  if (crawlStatus.completed >= crawlStatus.total) {
+  if (crawlStatus.completed >= webConfig.maxPageToCrawl) {
     await syncFailed(connectorId, "webcrawling_synchronization_limit_reached");
   } else {
     await syncSucceeded(connector.id);

--- a/connectors/src/lib/firecrawl.ts
+++ b/connectors/src/lib/firecrawl.ts
@@ -1,0 +1,15 @@
+import FirecrawlApp from "@mendable/firecrawl-js";
+
+import { apiConfig } from "@connectors/lib/api/config";
+
+let firecrawlApp: FirecrawlApp;
+
+export const getFirecrawl = () => {
+  if (!firecrawlApp) {
+    firecrawlApp = new FirecrawlApp({
+      apiKey: apiConfig.getFirecrawlAPIConfig().apiKey,
+    });
+  }
+
+  return firecrawlApp;
+};

--- a/connectors/src/types/webcrawler.ts
+++ b/connectors/src/types/webcrawler.ts
@@ -66,5 +66,5 @@ export const WEBCRAWLER_DEFAULT_CONFIGURATION: WebCrawlerConfigurationType = {
   crawlMode: "website",
   crawlFrequency: "monthly",
   headers: {},
-  customCrawler: "firecrawl",
+  customCrawler: "firecrawl-api",
 };

--- a/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
+++ b/front/lib/api/poke/plugins/data_sources/custom_crawler.ts
@@ -16,6 +16,7 @@ export const customCrawlerPlugin = createPlugin({
         description: "Select a crawler",
         values: [
           { label: "Firecrawl", value: "firecrawl" },
+          { label: "Firecrawl API", value: "firecrawl-api" },
           { label: "Default", value: "default" },
         ],
       },

--- a/front/types/connectors/webcrawler.ts
+++ b/front/types/connectors/webcrawler.ts
@@ -24,7 +24,7 @@ export function isDepthOption(value: unknown): value is DepthOption {
   return DepthOptions.includes(value as DepthOption);
 }
 
-export const WebcrawlerCustomCrawler = ["firecrawl"] as const;
+export const WebcrawlerCustomCrawler = ["firecrawl", "firecrawl-api"] as const;
 export type WebcrawlerCustomCrawler = (typeof WebcrawlerCustomCrawler)[number];
 
 export const WebCrawlerConfigurationTypeSchema = t.type({
@@ -46,7 +46,11 @@ export const WebCrawlerConfigurationTypeSchema = t.type({
     t.literal("monthly"),
   ]),
   headers: t.record(t.string, t.string),
-  customCrawler: t.union([t.null, t.literal("firecrawl")]),
+  customCrawler: t.union([
+    t.null,
+    t.literal("firecrawl"),
+    t.literal("firecrawl-api"),
+  ]),
 });
 
 export type WebCrawlerConfiguration = t.TypeOf<
@@ -61,6 +65,6 @@ export const WEBCRAWLER_DEFAULT_CONFIGURATION: WebCrawlerConfigurationType = {
   maxPageToCrawl: 50,
   crawlMode: "website",
   crawlFrequency: "monthly",
-  customCrawler: "firecrawl",
+  customCrawler: "firecrawl-api",
   headers: {},
 };


### PR DESCRIPTION
## Description
- When getting a completed event from firecrawl, also check the crawl status to know how many pages were crawled compared to how many the max is.
- Make `firecrawl-api` the default for new crawler

## Tests
- Locally

## Risk
- Mid, having broken crawler has the default

## Deploy Plan
- deploy front
- deploy connectors
