### PR TITLE
Re-apply "Continuing as new due when signal received more than 990 times"

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -1,6 +1,7 @@
 import {
   continueAsNew,
   executeChild,
+  log,
   setHandler,
   sleep,
   workflowInfo,
@@ -89,9 +90,9 @@ function getSlackActivities() {
   };
 }
 
-// we have a maximum of 990 debounces before we continue as new
+// we have a maximum of 990 signal received before we continue as new
 // this is to avoid "Failed to signalWithStart Workflow: 3 INVALID_ARGUMENT: exceeded workflow execution limit for signal events"
-const MAX_DEBOUNCE_COUNT = 990;
+const MAX_SIGNAL_RECEIVED_COUNT = 990;
 
 /**
  * This workflow is in charge of synchronizing all the content of the Slack channels selected by the user.
@@ -151,7 +152,10 @@ export async function workspaceFullSync(
   });
 
   await getSlackActivities().saveSuccessSyncActivity(connectorId);
-  console.log(`Workspace sync done for connector ${connectorId}`);
+  log.info(`Workspace sync done for connector ${connectorId}`, {
+    connectorId,
+    fromTs,
+  });
 }
 
 /**
@@ -203,9 +207,31 @@ export async function syncOneThreadDebounced(
 ) {
   let signaled = false;
   let debounceCount = 0;
+  let receivedSignalsCount = 0;
 
-  setHandler(newWebhookSignal, () => {
-    console.log("Got a new webhook ");
+  setHandler(newWebhookSignal, async () => {
+    receivedSignalsCount++;
+    log.info("Got a new webhook signal for syncOneThreadDebounced", {
+      connectorId,
+      channelId,
+      threadTs,
+      debounceCount,
+      receivedSignalsCount,
+    });
+    if (receivedSignalsCount >= MAX_SIGNAL_RECEIVED_COUNT) {
+      log.info(
+        `Continuing as Workflow as new due to too many signals received for syncOneThreadDebounced: ${receivedSignalsCount}`,
+        {
+          connectorId,
+          channelId,
+          threadTs,
+          debounceCount,
+          receivedSignalsCount,
+        }
+      );
+      await continueAsNew(connectorId, channelId, threadTs);
+      return;
+    }
     signaled = true;
   });
 
@@ -214,13 +240,6 @@ export async function syncOneThreadDebounced(
     await sleep(10000);
     if (signaled) {
       debounceCount++;
-      if (debounceCount >= MAX_DEBOUNCE_COUNT) {
-        console.log(
-          `Continuing as new due to too many debounces: ${debounceCount}`
-        );
-        await continueAsNew(connectorId, channelId, threadTs);
-        return;
-      }
       continue;
     }
     const channel = await getSlackActivities().getChannel(
@@ -231,7 +250,12 @@ export async function syncOneThreadDebounced(
       throw new Error(`Could not find channel name for channel ${channelId}`);
     }
 
-    console.log(`Talked to slack after debouncing ${debounceCount} time(s)`);
+    log.info(`Talked to slack after debouncing ${debounceCount} time(s)`, {
+      connectorId,
+      channelId,
+      threadTs,
+      debounceCount,
+    });
     await getSlackActivities().syncChannelMetadata(
       connectorId,
       channelId,
@@ -258,9 +282,31 @@ export async function syncOneMessageDebounced(
 ) {
   let signaled = false;
   let debounceCount = 0;
+  let receivedSignalsCount = 0;
 
-  setHandler(newWebhookSignal, () => {
-    console.log("Got a new webhook ");
+  setHandler(newWebhookSignal, async () => {
+    receivedSignalsCount++;
+    log.info("Got a new webhook signal for syncOneMessageDebounced", {
+      connectorId,
+      channelId,
+      threadTs,
+      debounceCount,
+      receivedSignalsCount,
+    });
+    if (receivedSignalsCount >= MAX_SIGNAL_RECEIVED_COUNT) {
+      log.info(
+        `Continuing as Workflow as new due to too many signals received for syncOneMessageDebounced: ${receivedSignalsCount}`,
+        {
+          connectorId,
+          channelId,
+          threadTs,
+          debounceCount,
+          receivedSignalsCount,
+        }
+      );
+      await continueAsNew(connectorId, channelId, threadTs);
+      return;
+    }
     signaled = true;
   });
 
@@ -269,17 +315,20 @@ export async function syncOneMessageDebounced(
     await sleep(10000);
     if (signaled) {
       debounceCount++;
-      if (debounceCount >= MAX_DEBOUNCE_COUNT) {
-        console.log(
-          `Continuing as new due to too many debounces: ${debounceCount}`
-        );
-        await continueAsNew(connectorId, channelId, threadTs);
-        return;
-      }
-      console.log("Debouncing, sleep 10 secs");
+      log.info("Debouncing, sleep 10 secs", {
+        connectorId,
+        channelId,
+        threadTs,
+        debounceCount,
+      });
       continue;
     }
-    console.log(`Talked to slack after debouncing ${debounceCount} time(s)`);
+    log.info(`Talked to slack after debouncing ${debounceCount} time(s)`, {
+      connectorId,
+      channelId,
+      threadTs,
+      debounceCount,
+    });
 
     const channel = await getSlackActivities().getChannel(
       connectorId,


### PR DESCRIPTION
This reverts commit 9a52e69e6df866b8c98c19a2c58074185f33a71a.

Re-apply https://github.com/dust-tt/dust/pull/13532

Last time it was deployed it generated `Non-Determinism` errors in Temporal.
Actually those errors can be fixed with a manual restart of these workflow (discussed with @Fraggle)

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge deploy and monitor `Non-Determinism` warn logs and for each run Id reset the workflow manually.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
