### PR TITLE
Add slack API usage logs and metrics

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -2,7 +2,10 @@ import type { Result } from "@dust-tt/client";
 import { DustAPI, Err, Ok } from "@dust-tt/client";
 
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
-import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
+import {
+  getSlackClient,
+  reportSlackUsage,
+} from "@connectors/connectors/slack/lib/slack_client";
 import {
   getSlackChannelSourceUrl,
   slackChannelInternalIdFromSlackChannelId,
@@ -49,6 +52,12 @@ export async function autoReadChannel(
   const slackClient = await getSlackClient(connectorId, {
     // Do not reject rate limited calls in auto read channel. Mostly calls from webhooks.
     rejectRateLimitedCalls: false,
+  });
+
+  reportSlackUsage({
+    connectorId,
+    method: "conversations.info",
+    channelId: slackChannelId,
   });
   const remoteChannel = await slackClient.conversations.info({
     channel: slackChannelId,

--- a/connectors/src/connectors/slack/lib/thread.ts
+++ b/connectors/src/connectors/slack/lib/thread.ts
@@ -3,16 +3,21 @@ import type { MessageElement } from "@slack/web-api/dist/response/ConversationsH
 import type { ConversationsRepliesResponse } from "@slack/web-api/dist/response/ConversationsRepliesResponse";
 
 import mainLogger from "@connectors/logger/logger";
+import type { ModelId } from "@connectors/types";
+
+import { reportSlackUsage } from "./slack_client";
 
 const logger = mainLogger.child({ provider: "slack" });
 
-// The pagination logic for getting all the messages of a Slack thread
-// is a bit complicated, so we put it in a separate function.
+// The pagination logic for getting all the messages of a Slack thread is a bit complicated, so we
+// put it in a separate function.
 export async function getRepliesFromThread({
+  connectorId,
   slackClient,
   channelId,
   threadTs,
 }: {
+  connectorId: ModelId;
   slackClient: WebClient;
   channelId: string;
   threadTs: string;
@@ -24,6 +29,12 @@ export async function getRepliesFromThread({
   do {
     const now = new Date();
 
+    reportSlackUsage({
+      connectorId,
+      method: "conversations.replies",
+      channelId,
+      limit: 200,
+    });
     const replies: ConversationsRepliesResponse =
       await slackClient.conversations.replies({
         channel: channelId,


### PR DESCRIPTION
## Description

Start tracking slack API usage
Probably lots of logs, will remove them if too big, keeping metrics.

## Tests

N/A

## Risk

Covered by type checking

## Deploy Plan

- deploy `connectors`