### PR TITLE
[front] enh(FS tools): add nodes to the output of `search`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -606,15 +606,9 @@ const createServer = (
       );
 
       if (coreSearchArgs.length === 0) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "Search action must have at least one data source configured.",
-            },
-          ],
-        };
+        return makeMCPToolTextError(
+          "Search action must have at least one data source configured."
+        );
       }
 
       const searchResults = await coreAPI.searchDataSources(
@@ -643,27 +637,15 @@ const createServer = (
       );
 
       if (searchResults.isErr()) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: searchResults.error.message,
-            },
-          ],
-        };
+        return makeMCPToolTextError(
+          `Failed to search content: ${searchResults.error.message}`
+        );
       }
 
       if (refsOffset + topK > getRefs().length) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "The search exhausted the total number of references available for citations",
-            },
-          ],
-        };
+        return makeMCPToolTextError(
+          "The search exhausted the total number of references available for citations"
+        );
       }
 
       const refs = getRefs().slice(refsOffset, refsOffset + topK);

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -521,7 +521,6 @@ const createServer = (
           "The query to search for. This is a natural language query. It doesn't support any " +
             "specific filter syntax."
         ),
-
       relativeTimeFrame: z
         .string()
         .regex(/^(all|\d+[hdwmy])$/)
@@ -616,24 +615,22 @@ const createServer = (
         topK,
         credentials,
         false,
-        coreSearchArgs.map((args) => {
-          return {
-            projectId: args.projectId,
-            dataSourceId: args.dataSourceId,
-            filter: {
-              ...args.filter,
-              tags: {
-                in: null,
-                not: null,
-              },
-              timestamp: {
-                gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
-                lt: null,
-              },
+        coreSearchArgs.map((args) => ({
+          projectId: args.projectId,
+          dataSourceId: args.dataSourceId,
+          filter: {
+            ...args.filter,
+            tags: {
+              in: null,
+              not: null,
             },
-            view_filter: args.view_filter,
-          };
-        })
+            timestamp: {
+              gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
+              lt: null,
+            },
+          },
+          view_filter: args.view_filter,
+        }))
       );
 
       if (searchResults.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -288,7 +288,7 @@ const createServer = (
 
       const dataSourceNodeId = rootNodeId
         ? extractDataSourceIdFromNodeId(rootNodeId)
-        : undefined;
+        : null;
 
       // If rootNodeId is provided and is a data source node ID, search only in
       // the data source. If rootNodeId is provided and is a regular node ID,
@@ -671,6 +671,24 @@ const createServer = (
           };
         }
       );
+
+      const searchNodeIds = searchResults.value.documents.map(
+        ({ document_id }) => document_id
+      );
+
+      const searchResult = await coreAPI.searchNodes({
+        filter: {
+          node_ids: searchNodeIds,
+          data_source_views: coreSearchArgs.map((args) => ({
+            data_source_id: args.dataSourceId,
+            view_filter: args.filter.parents?.in ?? [],
+          })),
+        },
+      });
+
+      if (searchResult.isErr()) {
+        return makeMCPToolTextError("Failed to search content");
+      }
 
       return {
         isError: false,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -695,6 +695,9 @@ const createServer = (
             view_filter: args.filter.parents?.in ?? [],
           })),
         },
+        options: {
+          limit: searchNodeIds.length,
+        },
       });
 
       if (searchResult.isErr()) {


### PR DESCRIPTION
## Description

- This PR adds the rendered nodes to the output of the `search` tool. The nodes fetched are the ones mapping to the documents that were retrieved.
- This change was motivated by the observation that agents often fail to chain a search with more FS tools, sometimes confusing the node IDs with the citations for instance.

## Tests

- Tested.

## Risk

- Low.

## Deploy Plan

- Deploy front.
