### PR TITLE
[ext] chore(auth): port login to api v1

### DIFF
--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -2,7 +2,6 @@ import {
   DUST_API_AUDIENCE,
   DUST_US_URL,
   FRONT_EXTENSION_URL,
-  getOAuthClientID,
 } from "@app/shared/lib/config";
 import { generatePKCE } from "@app/shared/lib/utils";
 import type { StoredTokens } from "@app/shared/services/auth";
@@ -256,7 +255,6 @@ export class FrontAuthService extends AuthService {
     try {
       const tokenParams: Record<string, string> = {
         grant_type: "refresh_token",
-        client_id: getOAuthClientID("workos"),
         refresh_token: (await this.getStoredTokens())?.refreshToken || "",
       };
 

--- a/extension/shared/lib/config.ts
+++ b/extension/shared/lib/config.ts
@@ -12,33 +12,6 @@ export const WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? "";
 export const WORKOS_DOMAIN =
   process.env.WORKOS_DOMAIN ?? "https://api.workos.com";
 
-export const getOAuthClientID = (auth: string) =>
-  auth === "auth0" ? AUTH0_CLIENT_ID : WORKOS_CLIENT_ID;
-export const getAuthorizeURL = ({
-  auth,
-  queryString,
-}: {
-  auth: string;
-  queryString: string;
-}) =>
-  auth === "auth0"
-    ? `https://${AUTH0_CLIENT_DOMAIN}/authorize?${queryString}`
-    : `https://${WORKOS_DOMAIN}/user_management/authorize?${queryString}`;
-export const getTokenURL = (auth: string) =>
-  auth === "auth0"
-    ? `https://${AUTH0_CLIENT_DOMAIN}/oauth/token`
-    : `https://${WORKOS_DOMAIN}/user_management/authenticate`;
-export const getLogoutURL = ({
-  auth,
-  queryString,
-}: {
-  auth: string;
-  queryString: string;
-}) =>
-  auth === "auth0"
-    ? `https://${AUTH0_CLIENT_DOMAIN}/v2/logout?${queryString}`
-    : `https://${WORKOS_DOMAIN}/user_management/sessions/logout?${queryString}`;
-
 export const DUST_US_URL = process.env.DUST_US_URL ?? "";
 export const DUST_EU_URL = process.env.DUST_EU_URL ?? "";
 export const DEFAULT_DUST_API_DOMAIN =


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Port the use of api/v1 to chrome extension.
This way we standardize auth between the different platforms, and switching from auth0 to workos is really easy for both platforms. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, can log with both.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Break auth in extension, but should be okay.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Release extension.