### PR TITLE
[front] feat(provisioning): Handle role assignments by group

### DIFF
--- a/front/components/workspace/DirectorySync.tsx
+++ b/front/components/workspace/DirectorySync.tsx
@@ -245,7 +245,7 @@ export default function UserProvisioning({
 
   return (
     <Page.Vertical gap="lg">
-      <Page.H variant="h4">User provisionning</Page.H>
+      <Page.H variant="h4">User provisioning</Page.H>
       <div className="flex w-full flex-row items-center gap-2">
         <div className="flex-1">
           <DirectorySyncStatus

--- a/front/pages/api/w/[wId]/dsync.ts
+++ b/front/pages/api/w/[wId]/dsync.ts
@@ -49,7 +49,7 @@ async function handler(
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
-        message: "Your workspace is not authorized to perfom this action.",
+        message: "Your workspace is not authorized to perform this action.",
       },
     });
   }

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -32,7 +32,11 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import mainLogger from "@app/logger/logger";
-import type { LightWorkspaceType, Result } from "@app/types";
+import type {
+  LightWorkspaceType,
+  MembershipRoleType,
+  Result,
+} from "@app/types";
 
 const logger = mainLogger.child(
   {},
@@ -40,6 +44,9 @@ const logger = mainLogger.child(
     msgPrefix: "[WorkOS Event] ",
   }
 );
+
+const ADMIN_GROUP_NAME = "dust-admins";
+const BUILDER_GROUP_NAME = "dust-builders";
 
 /**
  * Verify if workspace exist, if it does will call the callback with the found workspace.
@@ -64,6 +71,159 @@ async function verifyWorkOSWorkspace<E extends object, R>(
   }
 
   return handler(workspace, event);
+}
+
+/**
+ * Handle role assignment based on the name of the group.
+ */
+async function handleRoleAssignmentForGroup(
+  workspace: LightWorkspaceType,
+  user: UserResource,
+  group: GroupResource,
+  action: "add" | "remove"
+) {
+  let targetRole: MembershipRoleType | null = null;
+
+  if (group.name === ADMIN_GROUP_NAME) {
+    targetRole = "admin";
+  } else if (group.name === BUILDER_GROUP_NAME) {
+    targetRole = "builder";
+  }
+
+  if (!targetRole) {
+    // Not a special group, no role assignment needed.
+    return;
+  }
+
+  const currentMembership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+
+  if (!currentMembership) {
+    logger.warn(
+      `User ${user.sId} has no active membership in workspace ${workspace.sId}, cannot assign role.`
+    );
+    return;
+  }
+
+  if (action === "add") {
+    // Assign the target role if user doesn't already have it or a higher role
+    const shouldAssignRole =
+      (targetRole === "admin" && currentMembership.role !== "admin") ||
+      (targetRole === "builder" && currentMembership.role === "user");
+
+    if (shouldAssignRole) {
+      const updateResult = await MembershipResource.updateMembershipRole({
+        user,
+        workspace,
+        newRole: targetRole,
+      });
+
+      if (updateResult.isErr()) {
+        logger.error(
+          { error: updateResult.error, userId: user.sId, role: targetRole },
+          `Failed to assign ${targetRole} role to user`
+        );
+        throw new Error(
+          `Failed to assign ${targetRole} role to user ${user.sId}: ${updateResult.error.type}`
+        );
+      }
+
+      logger.info(
+        {
+          userId: user.sId,
+          oldRole: currentMembership.role,
+          newRole: targetRole,
+          groupName: group.name,
+        },
+        `Assigned ${targetRole} role to user based on group membership`
+      );
+
+      void ServerSideTracking.trackUpdateMembershipRole({
+        user: user.toJSON(),
+        workspace,
+        previousRole: currentMembership.role,
+        role: targetRole,
+      });
+    }
+  } else if (action === "remove") {
+    // Check if the user should lose their role when removed from the group.
+    // We need to check if they're still in other groups that grant the same or higher role.
+    const shouldDowngradeRole = await shouldDowngradeUserRole(
+      workspace,
+      user,
+      targetRole
+    );
+
+    if (shouldDowngradeRole) {
+      const newRole = targetRole === "admin" ? "builder" : "user";
+
+      const updateResult = await MembershipResource.updateMembershipRole({
+        user,
+        workspace,
+        newRole,
+      });
+
+      if (updateResult.isErr()) {
+        logger.error(
+          { error: updateResult.error, userId: user.sId, role: newRole },
+          "Failed to downgrade user role."
+        );
+        throw new Error(
+          `Failed to downgrade user role for ${user.sId}: ${updateResult.error.type}`
+        );
+      }
+
+      logger.info(
+        {
+          userId: user.sId,
+          oldRole: currentMembership.role,
+          newRole,
+          groupName: group.name,
+        },
+        "Downgraded user role after group removal"
+      );
+
+      void ServerSideTracking.trackUpdateMembershipRole({
+        user: user.toJSON(),
+        workspace,
+        previousRole: currentMembership.role,
+        role: newRole,
+      });
+    }
+  }
+}
+
+/**
+ * Check if the user should be downgraded when removed from a role-granting group.
+ */
+async function shouldDowngradeUserRole(
+  workspace: LightWorkspaceType,
+  user: UserResource,
+  roleBeingRemoved: MembershipRoleType
+): Promise<boolean> {
+  // Get all groups the user is a member of
+  const userGroups = await GroupResource.listUserGroupsInWorkspace({
+    user,
+    workspace,
+  });
+
+  // Check if user is still in any groups that grant the same or higher role
+  for (const group of userGroups) {
+    if (
+      (group.name === ADMIN_GROUP_NAME &&
+        (roleBeingRemoved === "admin" || roleBeingRemoved === "builder")) ||
+      (group.name === BUILDER_GROUP_NAME && roleBeingRemoved === "builder")
+    ) {
+      // User is still in a group that grants this role or higher
+      return false;
+    }
+  }
+
+  // User is not in any other groups that grant this role
+  return true;
 }
 
 // WorkOS webhooks do not guarantee event ordering. Events can arrive out of sequence.
@@ -311,6 +471,9 @@ async function handleUserAddedToGroup(
   if (res.isErr()) {
     throw new Error(res.error.message);
   }
+
+  // Handle role assignment for special groups.
+  await handleRoleAssignmentForGroup(workspace, user, group, "add");
 }
 
 async function handleUserRemovedFromGroup(
@@ -345,6 +508,9 @@ async function handleUserRemovedFromGroup(
   if (res.isErr()) {
     throw new Error(res.error.message);
   }
+
+  // Handle role assignment for special groups.
+  await handleRoleAssignmentForGroup(workspace, user, group, "remove");
 }
 
 async function handleCreateOrUpdateWorkOSUser(

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -76,12 +76,17 @@ async function verifyWorkOSWorkspace<E extends object, R>(
 /**
  * Handle role assignment based on the name of the group.
  */
-async function handleRoleAssignmentForGroup(
-  workspace: LightWorkspaceType,
-  user: UserResource,
-  group: GroupResource,
-  action: "add" | "remove"
-) {
+async function handleRoleAssignmentForGroup({
+  workspace,
+  user,
+  group,
+  action,
+}: {
+  workspace: LightWorkspaceType;
+  user: UserResource;
+  group: GroupResource;
+  action: "add" | "remove";
+}) {
   let targetRole: MembershipRoleType | null = null;
 
   if (group.name === ADMIN_GROUP_NAME) {
@@ -473,7 +478,7 @@ async function handleUserAddedToGroup(
   }
 
   // Handle role assignment for special groups.
-  await handleRoleAssignmentForGroup(workspace, user, group, "add");
+  await handleRoleAssignmentForGroup({ workspace, user, group, action: "add" });
 }
 
 async function handleUserRemovedFromGroup(
@@ -510,7 +515,12 @@ async function handleUserRemovedFromGroup(
   }
 
   // Handle role assignment for special groups.
-  await handleRoleAssignmentForGroup(workspace, user, group, "remove");
+  await handleRoleAssignmentForGroup({
+    workspace,
+    user,
+    group,
+    action: "remove",
+  });
 }
 
 async function handleCreateOrUpdateWorkOSUser(

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -464,17 +464,17 @@ async function handleUserAddedToGroup(
       `Group not found for workOSId "${event.group.id}" in workspace "${workspace.sId}"`
     );
   }
+
   const isMember = await group.isMember(user);
-  if (isMember) {
+  if (!isMember) {
+    const res = await group.addMember(auth, user.toJSON());
+    if (res.isErr()) {
+      throw new Error(res.error.message);
+    }
+  } else {
     logger.info(
       `User "${user.sId}" is already member of group "${group.sId}", skipping`
     );
-    return;
-  }
-
-  const res = await group.addMember(auth, user.toJSON());
-  if (res.isErr()) {
-    throw new Error(res.error.message);
   }
 
   // Handle role assignment for special groups.

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -114,7 +114,7 @@ async function handleRoleAssignmentForGroup({
   }
 
   if (action === "add") {
-    // Assign the target role if user doesn't already have it or a higher role
+    // Assign the target role if user doesn't already have it or a higher role.
     const shouldAssignRole =
       (targetRole === "admin" && currentMembership.role !== "admin") ||
       (targetRole === "builder" && currentMembership.role === "user");
@@ -209,25 +209,25 @@ async function shouldDowngradeUserRole(
   user: UserResource,
   roleBeingRemoved: MembershipRoleType
 ): Promise<boolean> {
-  // Get all groups the user is a member of
+  // Get all groups the user is a member of.
   const userGroups = await GroupResource.listUserGroupsInWorkspace({
     user,
     workspace,
   });
 
-  // Check if user is still in any groups that grant the same or higher role
+  // Check if user is still in any groups that grant the same or higher role.
   for (const group of userGroups) {
     if (
       (group.name === ADMIN_GROUP_NAME &&
         (roleBeingRemoved === "admin" || roleBeingRemoved === "builder")) ||
       (group.name === BUILDER_GROUP_NAME && roleBeingRemoved === "builder")
     ) {
-      // User is still in a group that grants this role or higher
+      // User is still in a group that grants this role or higher.
       return false;
     }
   }
 
-  // User is not in any other groups that grant this role
+  // User is not in any other groups that grant this role.
   return true;
 }
 


### PR DESCRIPTION
## Description

- This PR adds the following feature: when a group has the name `dust-admins` (resp. `dust-builders`), then all its users will be bumped to admin (resp. `builders`) on Dust.
- Closes https://github.com/dust-tt/tasks/issues/3183.
- Note: can't seem to reproduce but had an issue at some point where I added the group in Assigment in the Okta app and then pushed the group, which failed as it tried to create a new group with the same name and workspace ID but a different workOS group ID. Retried end-to-end and was not able to reproduce.

## Tests

- Tested locally with Okta: created 2 groups `dust-admins` and `dust-builders` with some users in common, tested by adding one first, then the other and then removing one.

## Risk

- Low.

## Deploy Plan

- Deploy front.
