### PR TITLE
Defer rate limit handling to Slack client in slow-lane

### DIFF
--- a/connectors/src/lib/temporal_queue_routing.ts
+++ b/connectors/src/lib/temporal_queue_routing.ts
@@ -10,6 +10,10 @@ export function makeSlowQueueName(baseQueueName: string): string {
   return baseQueueName.replace(/(-queue-v\d+)$/, `-slow$1`);
 }
 
+export function isSlowLaneQueue(queueName: string): boolean {
+  return /-slow-queue-v\d+$/.test(queueName);
+}
+
 // Workflow-level utilities for dynamic queue routing.
 function shouldUseSlowLane({
   connectorId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See full context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1750248847815999).

This PR ensures that for Slack activities being processed from the slow lane queue, we defer the rate limit handling to the Slack client, to block activity and ensure we only process up to `maxConcurrentActivityTaskExecutions`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
