### PR TITLE
[front] feat(auth): Use redis cache to store subscription

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -59,7 +59,9 @@ const createServer = (auth: Authenticator): McpServer => {
           return formats;
         },
         () => `get_source_format_to_convert_to_${output_format}`,
-        60 * 60 * 24 * 1000
+        {
+          ttlMs: 60 * 60 * 24 * 1000,
+        }
       )();
 
       return {

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -9,7 +9,7 @@ import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
-import { cacheWithRedis } from "@app/lib/utils/cache";
+import { CACHE_WITH_REDIS_MAX_TTL, cacheWithRedis } from "@app/lib/utils/cache";
 import type { SupportedFileContentType } from "@app/types";
 import { assertNever, normalizeError, validateUrl } from "@app/types";
 
@@ -60,7 +60,7 @@ const createServer = (auth: Authenticator): McpServer => {
         },
         () => `get_source_format_to_convert_to_${output_format}`,
         {
-          ttlMs: 60 * 60 * 24 * 1000,
+          ttlMs: CACHE_WITH_REDIS_MAX_TTL,
         }
       )();
 

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -57,7 +57,9 @@ export const getProviderStatusMemoized = cacheWithRedis(
   },
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.
-  2 * 60 * 1000
+  {
+    ttlMs: 2 * 60 * 1000,
+  }
 );
 
 export const getDustStatusMemoized = cacheWithRedis(
@@ -67,5 +69,7 @@ export const getDustStatusMemoized = cacheWithRedis(
   },
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.
-  2 * 60 * 1000
+  {
+    ttlMs: 2 * 60 * 1000,
+  }
 );

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -184,7 +184,7 @@ export class Authenticator {
             user,
             workspace: renderLightWorkspaceType({ workspace }),
           }),
-          SubscriptionResource.fetchActiveByWorkspace(
+          SubscriptionResource.fetchActiveByWorkspaceCache(
             renderLightWorkspaceType({ workspace })
           ),
         ]);

--- a/front/lib/plans/usage/seats.ts
+++ b/front/lib/plans/usage/seats.ts
@@ -26,5 +26,7 @@ export const countActiveSeatsInWorkspaceCached = cacheWithRedis(
   (workspaceId) => {
     return `count-active-seats-in-workspace:${workspaceId}`;
   },
-  60 * 10 * 1000 // 10 minutes
+  {
+    ttlMs: 60 * 10 * 1000, // 10 minutes
+  }
 );

--- a/front/lib/resources/base_resource.ts
+++ b/front/lib/resources/base_resource.ts
@@ -8,11 +8,6 @@ import type {
 } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
-import {
-  CACHE_WITH_REDIS_KEY,
-  getRedisCacheClient,
-} from "@app/lib/utils/cache";
-import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
 
 interface BaseResourceConstructor<
@@ -93,13 +88,6 @@ export abstract class BaseResource<M extends Model & ResourceWithId> {
 
     // Update the current instance with the new values to avoid stale data.
     Object.assign(this, affectedRows[0].get());
-
-    try {
-      const redisCacheClient = await getRedisCacheClient();
-      await redisCacheClient.del(`${CACHE_WITH_REDIS_KEY}-${this.className()}`);
-    } catch (err) {
-      logger.error(err);
-    }
 
     return [affectedCount];
   }

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -66,7 +66,9 @@ const getCachedMetadata = cacheWithRedis(
     return metadata;
   },
   (_auth: Authenticator, id: string) => `internal-mcp-server-metadata-${id}`,
-  isDevelopment() ? 1000 : METADATA_CACHE_TTL_MS
+  {
+    ttlMs: isDevelopment() ? 1000 : METADATA_CACHE_TTL_MS,
+  }
 );
 
 export class InternalMCPServerInMemoryResource {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -97,8 +97,8 @@ export class SubscriptionResource extends BaseResource<Subscription> {
       this.fetchActiveByWorkspaces,
       () => workspace.sId,
       {
-        ttlMs: 3_600_000, // 1h
-        prefix: SubscriptionResource.prototype.className(),
+        ttlMs: 120_000, // 2min
+        prefix: `${SubscriptionResource.prototype.className()}:w:${workspace.sId}`,
       }
     )([workspace]);
 

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -30,20 +30,6 @@ type CacheableFunction<T, Args extends unknown[]> = (
 
 type KeyResolver<Args extends unknown[]> = (...args: Args) => string;
 
-export const getRedisCacheClient = async () => {
-  const REDIS_CACHE_URI = process.env.REDIS_CACHE_URI;
-  if (!REDIS_CACHE_URI) {
-    throw new Error("REDIS_CACHE_URI is not set");
-  }
-
-  const redisCli = await redisClient({
-    origin: "cache_with_redis",
-    redisUri: REDIS_CACHE_URI,
-  });
-
-  return redisCli;
-};
-
 export const CACHE_WITH_REDIS_KEY = "cacheWithRedis";
 export const CACHE_WITH_REDIS_MAX_TTL = 60 * 60 * 24 * 1000;
 

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -44,13 +44,14 @@ export const getRedisCacheClient = async () => {
   return redisCli;
 };
 
+export const CACHE_WITH_REDIS_KEY = "cacheWithRedis";
+export const CACHE_WITH_REDIS_MAX_TTL = 60 * 60 * 24 * 1000;
+
 export type CacheWithRedisOptions = {
   ttlMs: number;
   redisUri?: string;
   prefix?: string;
 };
-
-export const CACHE_WITH_REDIS_KEY = "cacheWithRedis";
 
 // Wrapper function to cache the result of a function with Redis.
 // Usage:
@@ -64,7 +65,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
   resolver: KeyResolver<Args>,
   { ttlMs, redisUri, prefix }: CacheWithRedisOptions
 ): (...args: Args) => Promise<T> {
-  if (ttlMs > 60 * 60 * 24 * 1000) {
+  if (ttlMs > CACHE_WITH_REDIS_MAX_TTL) {
     throw new Error("ttlMs should be less than 24 hours");
   }
 

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -30,6 +30,20 @@ type CacheableFunction<T, Args extends unknown[]> = (
 
 type KeyResolver<Args extends unknown[]> = (...args: Args) => string;
 
+export const getRedisCacheClient = async () => {
+  const REDIS_CACHE_URI = process.env.REDIS_CACHE_URI;
+  if (!REDIS_CACHE_URI) {
+    throw new Error("REDIS_CACHE_URI is not set");
+  }
+
+  const redisCli = await redisClient({
+    origin: "cache_with_redis",
+    redisUri: REDIS_CACHE_URI,
+  });
+
+  return redisCli;
+};
+
 // Wrapper function to cache the result of a function with Redis.
 // Usage:
 // const cachedFn = cacheWithRedis(fn, (fnArg1, fnArg2, ...) => `${fnArg1}-${fnArg2}`, 60 * 10 * 1000);

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -114,6 +114,7 @@
         "sqids": "^0.3.0",
         "sqlite3": "^5.1.6",
         "stripe": "^14.2.0",
+        "superjson": "^2.2.2",
         "swr": "^2.2.4",
         "tailwind-merge": "^2.2.1",
         "tailwind-scrollbar-hide": "^1.1.7",
@@ -11799,6 +11800,21 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
@@ -18061,6 +18077,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -25201,6 +25229,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
+      "integrity": "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {

--- a/front/package.json
+++ b/front/package.json
@@ -131,6 +131,7 @@
     "sqids": "^0.3.0",
     "sqlite3": "^5.1.6",
     "stripe": "^14.2.0",
+    "superjson": "^2.2.2",
     "swr": "^2.2.4",
     "tailwind-merge": "^2.2.1",
     "tailwind-scrollbar-hide": "^1.1.7",


### PR DESCRIPTION
## Description
- Add method to SubscriptionResource to get a `fetchActiveByWorkspaceCache`
- Make cache ttls super short to avoid having to control lifecycle for now.
- Use [superjson](https://github.com/flightcontrolhq/superjson) to stringify/parse complex type, like Class.
  - Add `SuperJSON.registerClass(SubscriptionResource)` to let superjson know which class to check.
- [x] Need to move subscription updates method in the webhooks into the Resource: https://github.com/dust-tt/dust/pull/13579

## Tests
- [x] Locally
- [x] Front-edge

## Risk
- Having stale subscription data, but mitigate as the ttls is low.

## Deploy Plan
- Deploy front
