### PR TITLE
[connectors] chore: add support for firecrawl-api type of crawler in migration script

### DIFF
--- a/connectors/migrations/20250604_migrate_crawler_to_default.ts
+++ b/connectors/migrations/20250604_migrate_crawler_to_default.ts
@@ -56,9 +56,13 @@ makeScript(
       return;
     }
 
-    if (crawler !== null && crawler !== "firecrawl") {
+    if (
+      crawler !== null &&
+      crawler !== "firecrawl" &&
+      crawler !== "firecrawl-api"
+    ) {
       logger.error(
-        `"${crawler}" is not a valid crawler option, only null or "firecrawl" are allowed`
+        `"${crawler}" is not a valid crawler option, only null, "firecrawl" or "firecrawl-api" are allowed`
       );
       return;
     }
@@ -83,12 +87,11 @@ makeScript(
       forcedWorkspaces = res.value;
     }
 
-    // If the new crawler is null, it means the previous was firecrawl
-    const currentCrawler = crawler === null ? "firecrawl" : null;
-
     const webcrawlerConfigs = await WebCrawlerConfigurationModel.findAll({
       where: {
-        customCrawler: currentCrawler,
+        customCrawler: {
+          [Op.not]: crawler,
+        },
       },
       include: [
         {


### PR DESCRIPTION
## Description
- Add `firecrawl-api` option in the script to migrate crawler.
- Change findAll pattern to find the not in the new crawler.

## Tests
- Locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Deploy connectors
