### PR TITLE
Restructure Slack code to avoid Temporal context issue

### DIFF
--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -1,4 +1,5 @@
-import { getChannels } from "@connectors/connectors/slack/temporal/activities";
+import { getChannels } from "@connectors/connectors/slack/lib/channels";
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
@@ -23,7 +24,9 @@ async function main() {
       }
     );
 
-    const channelsInSlack = await getChannels(c.id, true);
+    const slackClient = await getSlackClient(c.id);
+
+    const channelsInSlack = await getChannels(slackClient, c.id, true);
     const channelIdsInSlackSet = new Set(
       channelsInSlack.map((c) => c.id).filter((id) => id)
     );

--- a/connectors/migrations/20250429_autojoin_slack_channels.ts
+++ b/connectors/migrations/20250429_autojoin_slack_channels.ts
@@ -1,8 +1,11 @@
 import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
 import { makeScript } from "scripts/helpers";
 
-import { joinChannel } from "@connectors/connectors/slack/lib/channels";
-import { getChannels } from "@connectors/connectors/slack/temporal/activities";
+import {
+  getChannels,
+  joinChannel,
+} from "@connectors/connectors/slack/lib/channels";
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import type Logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -80,8 +83,13 @@ makeScript(
       );
     }
 
-    // Get all channels from Slack
-    const remoteChannels = await getChannels(parseInt(connectorId, 10), false);
+    // Get all channels from Slack.
+    const slackClient = await getSlackClient(connector.id);
+    const remoteChannels = await getChannels(
+      slackClient,
+      parseInt(connectorId, 10),
+      false
+    );
     const matchingChannels = remoteChannels.filter(
       (c) => c.name && new RegExp(pattern).test(c.name)
     );

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -12,9 +12,11 @@ import {
   BaseConnectorManager,
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
-import { getChannels } from "@connectors/connectors/slack//temporal/activities";
 import { getBotEnabled } from "@connectors/connectors/slack/bot";
-import { joinChannel } from "@connectors/connectors/slack/lib/channels";
+import {
+  getChannels,
+  joinChannel,
+} from "@connectors/connectors/slack/lib/channels";
 import {
   getSlackAccessToken,
   getSlackClient,
@@ -367,8 +369,13 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
           }))
         );
       } else {
+        const slackClient = await getSlackClient(c.id, {
+          // Do not reject rate limited calls in update connector. Called from the API.
+          rejectRateLimitedCalls: false,
+        });
+
         const [remoteChannels, localChannels] = await Promise.all([
-          getChannels(c.id, false),
+          getChannels(slackClient, c.id, false),
           SlackChannel.findAll({
             where: {
               connectorId: this.connectorId,

--- a/connectors/src/connectors/slack/lib/bot_user_helpers.ts
+++ b/connectors/src/connectors/slack/lib/bot_user_helpers.ts
@@ -1,0 +1,30 @@
+import type { WebClient } from "@slack/web-api";
+
+import { reportSlackUsage } from "@connectors/connectors/slack/lib/slack_client";
+import type { ModelId } from "@connectors/types";
+import { cacheWithRedis } from "@connectors/types";
+
+async function getBotUserId(
+  slackClient: WebClient,
+  connectorId: ModelId
+): Promise<string> {
+  reportSlackUsage({
+    connectorId,
+    method: "auth.test",
+  });
+  const authRes = await slackClient.auth.test({});
+  if (authRes.error) {
+    throw new Error(`Failed to fetch auth info: ${authRes.error}`);
+  }
+  if (!authRes.user_id) {
+    throw new Error(`Failed to fetch auth info: user_id is undefined`);
+  }
+
+  return authRes.user_id;
+}
+
+export const getBotUserIdMemoized = cacheWithRedis(
+  getBotUserId,
+  (slackClient, connectorId) => connectorId.toString(),
+  60 * 10 * 1000
+);

--- a/connectors/src/connectors/slack/lib/bot_user_helpers.ts
+++ b/connectors/src/connectors/slack/lib/bot_user_helpers.ts
@@ -1,6 +1,9 @@
 import type { WebClient } from "@slack/web-api";
 
+import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
 import { reportSlackUsage } from "@connectors/connectors/slack/lib/slack_client";
+import { cacheGet, cacheSet } from "@connectors/lib/cache";
+import logger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 import { cacheWithRedis } from "@connectors/types";
 
@@ -28,3 +31,49 @@ export const getBotUserIdMemoized = cacheWithRedis(
   (slackClient, connectorId) => connectorId.toString(),
   60 * 10 * 1000
 );
+
+export async function getUserName(
+  slackUserId: string,
+  connectorId: ModelId,
+  slackClient: WebClient
+): Promise<string | undefined> {
+  const fromCache = await cacheGet(getUserCacheKey(slackUserId, connectorId));
+  if (fromCache) {
+    return fromCache;
+  }
+
+  try {
+    reportSlackUsage({
+      connectorId,
+      method: "users.info",
+    });
+    const info = await slackClient.users.info({ user: slackUserId });
+
+    if (info && info.user) {
+      const displayName = info.user.profile?.display_name;
+      const realName = info.user.profile?.real_name;
+      const userName = displayName || realName || info.user.name;
+
+      if (userName) {
+        await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
+        return info.user.name;
+      }
+    }
+
+    return undefined;
+  } catch (err) {
+    if (isSlackWebAPIPlatformError(err)) {
+      if (err.data.error === "user_not_found") {
+        logger.info({ connectorId, slackUserId }, "Slack user not found.");
+
+        return undefined;
+      }
+    }
+
+    throw err;
+  }
+}
+
+export function getUserCacheKey(userId: string, connectorId: ModelId) {
+  return `slack-userid2name-${connectorId}-${userId}`;
+}

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -382,7 +382,7 @@ export async function getChannelsToSync(
   return remoteChannels.filter((c) => c.id && readAllowedChannels.has(c.id));
 }
 
-export async function getChannel(
+export async function getChannelById(
   slackClient: WebClient,
   connectorId: ModelId,
   channelId: string

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -1,12 +1,13 @@
 import {
+  getChannelById,
   joinChannel,
   updateSlackChannelInConnectorsDb,
 } from "@connectors/connectors/slack/lib/channels";
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import {
   getSlackChannelSourceUrl,
   slackChannelInternalIdFromSlackChannelId,
 } from "@connectors/connectors/slack/lib/utils";
-import { getChannel } from "@connectors/connectors/slack/temporal/activities";
 import {
   launchSlackGarbageCollectWorkflow,
   launchSlackSyncOneThreadWorkflow,
@@ -303,7 +304,13 @@ export const slack = async ({
         throw new Error(`Could not find connector for workspace ${args.wId}`);
       }
 
-      const remoteChannel = await getChannel(connector.id, args.channelId);
+      const slackClient = await getSlackClient(connector.id);
+
+      const remoteChannel = await getChannelById(
+        slackClient,
+        connector.id,
+        args.channelId
+      );
       if (!remoteChannel.name) {
         throw new Error(
           `Could not find channel name for channel ${args.channelId}`
@@ -364,7 +371,13 @@ export const slack = async ({
         throw new Error(`Could not find connector for workspace ${args.wId}`);
       }
 
-      const remoteChannel = await getChannel(connector.id, args.channelId);
+      const slackClient = await getSlackClient(connector.id);
+
+      const remoteChannel = await getChannelById(
+        slackClient,
+        connector.id,
+        args.channelId
+      );
       if (!remoteChannel.name) {
         throw new Error(
           `Could not find channel name for channel ${args.channelId}`
@@ -410,7 +423,13 @@ export const slack = async ({
         throw new Error(`Could not find connector for workspace ${args.wId}`);
       }
 
-      const remoteChannel = await getChannel(connector.id, args.channelId);
+      const slackClient = await getSlackClient(connector.id);
+
+      const remoteChannel = await getChannelById(
+        slackClient,
+        connector.id,
+        args.channelId
+      );
       if (!remoteChannel.name) {
         throw new Error(
           `Could not find channel name for channel ${args.channelId}`

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -1,0 +1,122 @@
+import type { WebClient } from "@slack/web-api";
+import type { MessageElement } from "@slack/web-api/dist/response/ConversationsRepliesResponse";
+
+import { getUserName } from "@connectors/connectors/slack/lib/bot_user_helpers";
+import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
+import { renderDocumentTitleAndContent } from "@connectors/lib/data_sources";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
+import { safeSubstring } from "@connectors/types";
+
+async function processMessageForMentions(
+  message: string,
+  connectorId: ModelId,
+  slackClient: WebClient
+): Promise<string> {
+  const matches = message.match(/<@[A-Z-0-9]+>/g);
+  if (!matches) {
+    return message;
+  }
+  for (const m of matches) {
+    const userId = m.replace(/<|@|>/g, "");
+    const userName = await getUserName(userId, connectorId, slackClient);
+    if (!userName) {
+      continue;
+    }
+
+    message = message.replace(m, `@${userName}`);
+
+    continue;
+  }
+
+  return message;
+}
+
+function formatDateForUpsert(date: Date) {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  const hours = date.getHours().toString().padStart(2, "0");
+  const minutes = date.getMinutes().toString().padStart(2, "0");
+
+  return `${year}${month}${day} ${hours}:${minutes}`;
+}
+
+export async function formatMessagesForUpsert({
+  dataSourceConfig,
+  channelName,
+  messages,
+  isThread,
+  connectorId,
+  slackClient,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  channelName: string;
+  messages: MessageElement[];
+  isThread: boolean;
+  connectorId: ModelId;
+  slackClient: WebClient;
+}): Promise<CoreAPIDataSourceDocumentSection> {
+  const data = await Promise.all(
+    messages.map(async (message) => {
+      const text = await processMessageForMentions(
+        message.text as string,
+        connectorId,
+        slackClient
+      );
+
+      const userName = await getUserName(
+        message.user as string,
+        connectorId,
+        slackClient
+      );
+      const messageDate = new Date(parseInt(message.ts as string, 10) * 1000);
+      const messageDateStr = formatDateForUpsert(messageDate);
+
+      const filesInfo = message.files
+        ? "\n" +
+          message.files
+            .map((file) => {
+              return `Attached file : ${file.name} ( ${file.mimetype} )`;
+            })
+            .join("\n")
+        : "";
+
+      return {
+        messageDate,
+        dateStr: messageDateStr,
+        userName,
+        text: text + filesInfo,
+        content: text + "\n",
+        sections: [],
+      };
+    })
+  );
+
+  const first = data.at(0);
+  const last = data.at(-1);
+  if (!last || !first) {
+    throw new Error("Cannot format empty list of messages");
+  }
+
+  const title = isThread
+    ? `Thread in #${channelName}: ${
+        safeSubstring(first.text.replace(/\s+/g, " ").trim(), 0, 128) + "..."
+      }`
+    : `Messages in #${channelName}`;
+
+  return renderDocumentTitleAndContent({
+    dataSourceConfig,
+    title,
+    createdAt: first.messageDate,
+    updatedAt: last.messageDate,
+    content: {
+      prefix: null,
+      content: null,
+      sections: data.map((d) => ({
+        prefix: `>> @${d.userName} [${d.dateStr}]:\n`,
+        content: d.text + "\n",
+        sections: [],
+      })),
+    },
+  });
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread with context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1750260319335279?thread_ts=1750248847.815999&cid=C050SM8NSPK).

In https://github.com/dust-tt/dust/pull/13562 we changed the Slack rate limit handling within the slow lane and assumed that all activities code was only used in a Temporal context, this is actually not the case for the Slack connectors. This broke the slack bot.

This PR slightly moves code around to ensure that all code in activities file is EXCLUSIVELY used in a Temporal context.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
