### PR TITLE
Fix tool output hiding mechanism

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -229,7 +229,7 @@ type ActionBaseParams = Omit<
   "id" | "type" | "executionState" | "output" | "isError"
 >;
 
-function hideFileResourceForModel({
+function hideFileFromActionOutput({
   fileId,
   content,
   workspaceId,
@@ -1064,7 +1064,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
         executionState: status,
         id: action.id,
         isError: false,
-        output: removeNulls(outputItems.map(hideFileResourceForModel)),
+        output: removeNulls(outputItems.map(hideFileFromActionOutput)),
         type: "tool_action",
       }),
     };
@@ -1145,7 +1145,7 @@ export async function mcpActionTypesFromAgentMessageIds(
       id: action.id,
       params: action.params,
       output: removeNulls(
-        action.outputItems.map(hideFileResourceForModel)
+        action.outputItems.map(hideFileFromActionOutput)
       ).filter(shouldHideContentForModel),
       functionCallId: action.functionCallId,
       functionCallName: action.functionCallName,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -364,7 +364,9 @@ export class MCPActionType extends BaseAction {
       name: this.functionCallName,
       function_call_id: this.functionCallId,
       content: this.output
-        ? JSON.stringify(this.output)
+        ? JSON.stringify(
+            this.output.filter((o) => !shouldHideContentForModel(o))
+          )
         : "Successfully executed action, no output.",
     };
   }
@@ -1144,9 +1146,7 @@ export async function mcpActionTypesFromAgentMessageIds(
     return new MCPActionType({
       id: action.id,
       params: action.params,
-      output: removeNulls(
-        action.outputItems.map(hideFileFromActionOutput)
-      ).filter(shouldHideContentForModel),
+      output: removeNulls(action.outputItems.map(hideFileFromActionOutput)),
       functionCallId: action.functionCallId,
       functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,


### PR DESCRIPTION
## Description

- A mechanism to hide certain types of tool output was introduced in #13492.
- The approach only worked in a streaming context and caused the output to be hidden in the UI when going to an existing conversation.
- As a result we would have `No query provided` in the action details instead of the nicely formatted query `Searching for xxx across ...`.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
