### PR TITLE
[front] use only a tag for editing/creating agent 

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@dust-tt/client": "^1.0.54",
-        "@dust-tt/sparkle": "^0.2.527",
+        "@dust-tt/sparkle": "^0.2.529",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.527",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.527.tgz",
-      "integrity": "sha512-XbWliOIpVEs3yHzcIHpGwqafuYVsZsSa+b2H8uCPp4o2ccSIIS56ctSONUtkRF6fllgPLkaA2Vt2C05JZ0CFLg==",
+      "version": "0.2.529",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.529.tgz",
+      "integrity": "sha512-Tk0gxemDGr93qE0PPArO8Am8f62dlnFBoOgxzpiwXR0Ju4fI6F1SSgwChbIkrEPLaPnc1h7X5MbSjReyRZ8wTw==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@dust-tt/client": "^1.0.54",
-    "@dust-tt/sparkle": "^0.2.527",
+    "@dust-tt/sparkle": "^0.2.529",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -172,11 +172,14 @@ export function AssistantDetailsButtonBar({
         !isRestrictedFromAgentCreation && (
           <Button
             size="sm"
+            href={
+              canEditAssistant
+                ? `/w/${owner.sId}/builder/assistants/${agentConfiguration.sId}?flow=workspace_assistants`
+                : undefined
+            }
             disabled={!canEditAssistant}
-            href={`/w/${owner.sId}/builder/assistants/${agentConfiguration.sId}?flow=workspace_assistants`}
             variant="outline"
             icon={PencilSquareIcon}
-            className={!canEditAssistant ? "pointer-events-none" : ""}
           />
         )}
 

--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -170,19 +170,14 @@ export function AssistantDetailsButtonBar({
 
       {agentConfiguration.scope !== "global" &&
         !isRestrictedFromAgentCreation && (
-          <Link
-            onClick={(e) => !canEditAssistant && e.preventDefault()}
-            href={`/w/${owner.sId}/builder/assistants/${
-              agentConfiguration.sId
-            }?flow=workspace_assistants`}
-          >
-            <Button
-              size="sm"
-              disabled={!canEditAssistant}
-              variant="outline"
-              icon={PencilSquareIcon}
-            />
-          </Link>
+          <Button
+            size="sm"
+            disabled={!canEditAssistant}
+            href={`/w/${owner.sId}/builder/assistants/${agentConfiguration.sId}?flow=workspace_assistants`}
+            variant="outline"
+            icon={PencilSquareIcon}
+            className={!canEditAssistant ? "pointer-events-none" : ""}
+          />
         )}
 
       {agentConfiguration.scope !== "global" && (

--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -158,15 +158,12 @@ export function AssistantDetailsButtonBar({
         />
       </div>
 
-      <Link
+      <Button
+        icon={ChatBubbleBottomCenterTextIcon}
+        size="sm"
+        variant="outline"
         href={`/w/${owner.sId}/assistant/new?assistant=${agentConfiguration.sId}`}
-      >
-        <Button
-          icon={ChatBubbleBottomCenterTextIcon}
-          size="sm"
-          variant="outline"
-        />
-      </Link>
+      />
 
       {agentConfiguration.scope !== "global" &&
         !isRestrictedFromAgentCreation && (

--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -13,7 +13,6 @@ import {
   StarStrokeIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.527",
+        "@dust-tt/sparkle": "^0.2.529-rc-7",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1103,10 +1103,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.527",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.527.tgz",
-      "integrity": "sha512-XbWliOIpVEs3yHzcIHpGwqafuYVsZsSa+b2H8uCPp4o2ccSIIS56ctSONUtkRF6fllgPLkaA2Vt2C05JZ0CFLg==",
-      "license": "ISC",
+      "version": "0.2.529-rc-7",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.529-rc-7.tgz",
+      "integrity": "sha512-5AZO3qolHh/L8ELLp+r3JmQNT76ipMXoBd5pcQLVG2ROuwRtKCKXpfMyTt1sBYfimrkrMMbaxppulUfW3oZ4cQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.529-rc-7",
+        "@dust-tt/sparkle": "^0.2.529",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1103,9 +1103,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.529-rc-7",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.529-rc-7.tgz",
-      "integrity": "sha512-5AZO3qolHh/L8ELLp+r3JmQNT76ipMXoBd5pcQLVG2ROuwRtKCKXpfMyTt1sBYfimrkrMMbaxppulUfW3oZ4cQ==",
+      "version": "0.2.529",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.529.tgz",
+      "integrity": "sha512-Tk0gxemDGr93qE0PPArO8Am8f62dlnFBoOgxzpiwXR0Ju4fI6F1SSgwChbIkrEPLaPnc1h7X5MbSjReyRZ8wTw==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.527",
+    "@dust-tt/sparkle": "^0.2.529-rc-7",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.529-rc-7",
+    "@dust-tt/sparkle": "^0.2.529",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -342,17 +342,14 @@ export default function WorkspaceAssistants({
                     owner={owner}
                   />
                   {!isRestrictedFromAgentCreation && (
-                    <Link
+                    <Button
+                      variant="primary"
+                      icon={PlusIcon}
                       href={`/w/${owner.sId}/builder/assistants/create?flow=workspace_assistants`}
-                    >
-                      <Button
-                        variant="primary"
-                        icon={PlusIcon}
-                        label="Create an agent"
-                        data-gtm-label="assistantCreationButton"
-                        data-gtm-location="assistantsWorkspace"
-                      />
-                    </Link>
+                      label="Create an agent"
+                      data-gtm-label="assistantCreationButton"
+                      data-gtm-location="assistantsWorkspace"
+                    />
                   )}
                 </div>
               )}

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -17,7 +17,6 @@ import {
   useHashParam,
 } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
-import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AgentEditBar } from "@app/components/assistant/AgentEditBar";


### PR DESCRIPTION
## Description
This PR is to attempt fix the route navigation not happening when you click agent's Edit button or Create button. We do pretty weird stuff for making a link to look like a button. What I noticed is 

- When navigation doesn't happen, no request is fired (event is probably not triggered?) 
- We wrap < button > tag with < a > tag, which is invalid HTML

I temporary fixed Button tag in Sparkle to not wrap button with a tag, here I remove Link tag and use Button component only (since it will wrap with Next Link when there is href, the behaviour should be the same?)

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
