### PR TITLE
Fix: search members should work for all users

### DIFF
--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -9,21 +9,22 @@ import { itInTransaction } from "@app/tests/utils/utils";
 import handler from "./search";
 
 describe("GET /api/w/[wId]/members/search", () => {
-  itInTransaction("returns 403 for non-admin users", async () => {
-    const { req, res } = await createPrivateApiMockRequest({
+  // We need search to work for all users as they can be added as editors of an agent by anyone.
+  itInTransaction("allows users to search members", async () => {
+    const { req, res, user } = await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
     });
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "workspace_auth_error",
-        message: "Only workspace admins can search members.",
-      },
-    });
+    expect(res._getStatusCode()).toBe(200);
+
+    const data = res._getJSONData();
+    expect(data.total).toBe(1);
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0].id).toBe(user.id);
+    expect(data.members[0].workspaces[0].role).toBe("user");
   });
 
   itInTransaction("returns 405 for non-GET methods", async () => {

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -44,16 +44,6 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      if (!auth.isAdmin()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "Only workspace admins can search members.",
-          },
-        });
-      }
-
       const queryRes = SearchMembersQueryCodec.decode(req.query);
 
       if (isLeft(queryRes)) {


### PR DESCRIPTION
## Description

Revert part of https://github.com/dust-tt/dust/pull/13515/files as this was actually needed for anyone to be able to add another user as editor.

## Tests

Updated

## Risk

Low

## Deploy Plan

Deploy front