### PR TITLE
[front] chore(stripe): Use SubscriptionResource in stripe webhooks

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -24,7 +24,6 @@ import type {
   LightWorkspaceType,
   MembershipOriginType,
   MembershipRoleType,
-  ModelId,
   PublicAPILimitsType,
   Result,
   RoleType,
@@ -344,13 +343,6 @@ export async function unsafeGetWorkspacesByModelId(
       },
     })
   ).map((w) => renderLightWorkspaceType({ workspace: w }));
-}
-
-export async function unsafeGetWorkspaceByModelId(
-  modelId: ModelId
-): Promise<LightWorkspaceType | undefined> {
-  const [workspace] = await unsafeGetWorkspacesByModelId([modelId]);
-  return workspace;
 }
 
 export async function areAllSubscriptionsCanceled(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -346,8 +346,11 @@ export async function unsafeGetWorkspacesByModelId(
   ).map((w) => renderLightWorkspaceType({ workspace: w }));
 }
 
-export async function unsafeGetWorkspaceByModelId(modelId: ModelId) {
-  return WorkspaceModel.findByPk(modelId);
+export async function unsafeGetWorkspaceByModelId(
+  modelId: ModelId
+): Promise<LightWorkspaceType | undefined> {
+  const [workspace] = await unsafeGetWorkspacesByModelId([modelId]);
+  return workspace;
 }
 
 export async function areAllSubscriptionsCanceled(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -24,6 +24,7 @@ import type {
   LightWorkspaceType,
   MembershipOriginType,
   MembershipRoleType,
+  ModelId,
   PublicAPILimitsType,
   Result,
   RoleType,
@@ -343,6 +344,10 @@ export async function unsafeGetWorkspacesByModelId(
       },
     })
   ).map((w) => renderLightWorkspaceType({ workspace: w }));
+}
+
+export async function unsafeGetWorkspaceByModelId(modelId: ModelId) {
+  return WorkspaceModel.findByPk(modelId);
 }
 
 export async function areAllSubscriptionsCanceled(

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -683,6 +683,33 @@ export class Authenticator {
     });
   }
 
+  static async internalAdminForWorkspaceWithSubscription(
+    subscription: SubscriptionResource
+  ) {
+    const workspace = await WorkspaceModel.findOne({
+      where: {
+        id: subscription.workspaceId,
+      },
+    });
+
+    if (!workspace) {
+      throw new Error(
+        `Could not find workspace for subscription ${subscription.sId}`
+      );
+    }
+
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      workspace.id
+    );
+
+    return new Authenticator({
+      workspace,
+      role: "admin",
+      groups: globalGroup ? [globalGroup] : [],
+      subscription,
+    });
+  }
+
   /**
    * Exchanges an Authenticator associated with a system key for one associated with a user.
    *

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -45,7 +45,6 @@ import type {
   PlanType,
   Result,
   SubscriptionPerSeatPricing,
-  SubscriptionStatusType,
   SubscriptionType,
   UserType,
   WorkspaceType,
@@ -642,20 +641,6 @@ export class SubscriptionResource extends BaseResource<Subscription> {
       billingPeriod: recurring.interval === "year" ? "yearly" : "monthly",
       quantity: item.quantity,
     };
-  }
-
-  async updateStatus(
-    status: SubscriptionStatusType,
-    date: Date,
-    transaction?: Transaction
-  ) {
-    return this.update(
-      {
-        status,
-        endDate: date,
-      },
-      transaction
-    );
   }
 
   async setActive(trialing: boolean) {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -226,7 +226,7 @@ async function handler(
               }
 
               if (activeSubscription) {
-                await activeSubscription.updateStatus("ended", now, t);
+                await activeSubscription.setEnded(now, t);
               }
               const stripeSubscription =
                 await stripe.subscriptions.retrieve(stripeSubscriptionId);

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -10,7 +10,10 @@ import {
   sendCancelSubscriptionEmail,
   sendReactivateSubscriptionEmail,
 } from "@app/lib/api/email";
-import { getMembers } from "@app/lib/api/workspace";
+import {
+  getMembers,
+  unsafeGetWorkspaceByModelId,
+} from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { Plan } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
@@ -369,7 +372,7 @@ async function handler(
             await subscription.updatePaymentFailingSince(now);
           }
 
-          const workspace = await WorkspaceModel.findByPk(
+          const workspace = await unsafeGetWorkspaceByModelId(
             subscription.workspaceId
           );
           if (!workspace) {
@@ -522,7 +525,7 @@ async function handler(
               requestCancelAt: endDate ? now : null,
             });
 
-            const workspace = await WorkspaceModel.findByPk(
+            const workspace = await unsafeGetWorkspaceByModelId(
               subscription.workspaceId
             );
             if (!workspace) {
@@ -695,7 +698,7 @@ async function handler(
                 "[Stripe Webhook] Received customer.subscription.deleted event with the subscription status = active. Ending the subscription and deleting some workspace data"
               );
 
-              const workspace = await WorkspaceModel.findByPk(
+              const workspace = await unsafeGetWorkspaceByModelId(
                 matchingSubscription.workspaceId
               );
               if (!workspace) {
@@ -755,7 +758,7 @@ async function handler(
             return res.status(200).json({ success: true });
           }
 
-          const workspace = await WorkspaceModel.findByPk(
+          const workspace = await unsafeGetWorkspaceByModelId(
             trialingSubscription.workspaceId
           );
           if (!workspace) {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -225,7 +225,10 @@ async function handler(
                 });
               }
 
-              if (activeSubscription) {
+              if (
+                activeSubscription &&
+                !activeSubscription.isLegacyFreeNoPlan()
+              ) {
                 await activeSubscription.setEnded(now, t);
               }
               const stripeSubscription =


### PR DESCRIPTION
## Description
- Remove Subscription model direct calls inside stripe webhooks
- **Note**: `fetchActiveByWorkspace` will return a `FREE_NO_PLAN_SUBSCRIPTION_ID` type of subscription (which doesn't exists in DB), so need to use `isLegacyFreeNoPlan` to avoid updating a non existing subscription.
_To avoid mistakenly do that, we either could throw if `id < 0` in the many mutate method of the resource, or do the same directly in the `BaseResource`, open to suggestion_

## Tests
- [x] locally, signup to a new workspace and enter my stripe CC details, got subscribed correctly.
- [x] cancelling a subscription from Stripe move the workspace back to FREE_NO_PLAN

## Risk
- Mid, impact is on new / returning client, but only on their subscription, should have no impact on the daily usage of the product.

## Deploy Plan
- Deploy front
