### PR TITLE
[front] Add cookie with last accessed workspace

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -138,6 +138,12 @@ export function withSessionAuthenticationForWorkspace<T>(
         });
       }
 
+      // Set permanent cookie with current workspace ID
+      res.setHeader(
+        "Set-Cookie",
+        `lastWorkspaceId=${wId}; Path=/; SameSite=Lax; Max-Age=31536000`
+      );
+
       const auth = await Authenticator.fromSession(session, wId);
       req.addResourceToLog?.(auth.getNonNullableUser());
 


### PR DESCRIPTION
## Description

Just store the current workspace in a permanent cookie.
Will be used to customize sign in link in case of non migrated-sso workspace, to avoid clumsy login flow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy front
