### PR TITLE
[Slackstorm] Handle new rate-limited bot interactions (message)

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -71,7 +71,7 @@ import { ProviderRateLimitError } from "@connectors/lib/error";
 const SLACK_RATE_LIMIT_ERROR_MESSAGE =
   "Slack has blocked the agent from continuing the conversation, due to new restrictive" +
   " rate limits. You can retry the conversation later. You can learn more about slack's new " +
-  "rate limits [here](https://docs.dust.tt/docs/slack#rate-limits)";
+  "rate limits [here](https://www.notion.so/dust-tt/Slack-API-Changes-Impact-and-Response-Plan-21728599d94180f3b2b4e892e6d20af6)";
 
 const MAX_FILE_SIZE_TO_UPLOAD = 10 * 1024 * 1024; // 10 MB
 
@@ -1033,7 +1033,7 @@ async function makeContentFragments(
         blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MESSAGE),
         thread_ts: threadTs,
       });
-      return new Ok(null);
+      return new Err(new Error(SLACK_RATE_LIMIT_ERROR_MESSAGE));
     }
     throw e;
   }

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1033,7 +1033,9 @@ async function makeContentFragments(
         blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MESSAGE),
         thread_ts: threadTs,
       });
+      return new Ok(null);
     }
+    throw e;
   }
   let shouldTake = false;
   for (const reply of replies) {

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -70,8 +70,7 @@ import {
 
 const SLACK_RATE_LIMIT_ERROR_MESSAGE =
   "Slack has blocked the agent from continuing the conversation, due to new restrictive" +
-  " rate limits. You can retry the conversation later. You can learn more about slack's new " +
-  "rate limits [here](https://www.notion.so/dust-tt/Slack-API-Changes-Impact-and-Response-Plan-21728599d94180f3b2b4e892e6d20af6)";
+  " rate limits. You can retry the conversation later.";
 
 const MAX_FILE_SIZE_TO_UPLOAD = 10 * 1024 * 1024; // 10 MB
 

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -53,6 +53,7 @@ import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import { sectionFullText } from "@connectors/lib/data_sources";
+import { ProviderRateLimitError } from "@connectors/lib/error";
 import {
   SlackChannel,
   SlackChatBotMessage,
@@ -66,7 +67,6 @@ import {
   getHeaderFromGroupIds,
   getHeaderFromUserEmail,
 } from "@connectors/types";
-import { ProviderRateLimitError } from "@connectors/lib/error";
 
 const SLACK_RATE_LIMIT_ERROR_MESSAGE =
   "Slack has blocked the agent from continuing the conversation, due to new restrictive" +

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -22,6 +22,7 @@ import jaroWinkler from "talisman/metrics/jaro-winkler";
 
 import {
   makeErrorBlock,
+  makeMarkdownBlock,
   makeMessageUpdateBlocksAndText,
 } from "@connectors/connectors/slack/chat/blocks";
 import { streamConversationToSlack } from "@connectors/connectors/slack/chat/stream_conversation_handler";
@@ -70,7 +71,7 @@ import { ProviderRateLimitError } from "@connectors/lib/error";
 const SLACK_RATE_LIMIT_ERROR_MESSAGE =
   "Slack has blocked the agent from continuing the conversation, due to new restrictive" +
   " rate limits. You can retry the conversation later. You can learn more about slack's new " +
-  "rate limits here: TODO";
+  "rate limits [here](https://docs.dust.tt/docs/slack#rate-limits)";
 
 const MAX_FILE_SIZE_TO_UPLOAD = 10 * 1024 * 1024; // 10 MB
 
@@ -1029,7 +1030,7 @@ async function makeContentFragments(
     if (e instanceof ProviderRateLimitError) {
       slackClient.chat.postMessage({
         channel: channelId,
-        text: SLACK_RATE_LIMIT_ERROR_MESSAGE,
+        blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MESSAGE),
         thread_ts: threadTs,
       });
     }

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -28,7 +28,7 @@ function makeDividerBlock() {
   };
 }
 
-function makeMarkdownBlock(text?: string) {
+export function makeMarkdownBlock(text?: string) {
   return text
     ? [
         {


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/3207

`conversation.history` and `conversation.replies` are now Tier-1 limited.

The bot uses conversation.replies once per call. We want to show an appropriate message here for rate limits on this call.

Risks
---
low

Deploy
---
connectors
