### PR TITLE
Slack handle rate limit

### DIFF
--- a/connectors/migrations/db/migration_79.sql
+++ b/connectors/migrations/db/migration_79.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 19, 2025
+ALTER TABLE "public"."connectors" ADD COLUMN "metadata" JSONB;

--- a/connectors/scripts/mark_rate_limited_slack_connectors.ts
+++ b/connectors/scripts/mark_rate_limited_slack_connectors.ts
@@ -1,0 +1,185 @@
+import type { Logger } from "pino";
+
+import { getChannels } from "@connectors/connectors/slack/lib/channels";
+import {
+  getSlackClient,
+  withSlackErrorHandling,
+} from "@connectors/connectors/slack/lib/slack_client";
+import { ProviderRateLimitError } from "@connectors/lib/error";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import { concurrentExecutor } from "@connectors/types";
+
+import { makeScript } from "./helpers";
+
+const TEST_CALLS_COUNT = 10;
+
+const SLACK_CONNECTOR_TYPE = "slack";
+
+async function handleRateLimit(
+  connector: ConnectorResource,
+  {
+    context,
+    execute,
+    logger,
+  }: { context: string; execute: boolean; logger: Logger }
+) {
+  logger.error(
+    { connectorId: connector.id },
+    `Rate limit detected ${context} - marking connector as rate limited`
+  );
+
+  if (execute) {
+    await connector.markAsRateLimited();
+    logger.info(
+      { connectorId: connector.id },
+      "Connector marked as rate limited"
+    );
+  } else {
+    logger.info(
+      { connectorId: connector.id },
+      "DRY RUN: Would mark connector as rate limited"
+    );
+  }
+}
+
+makeScript(
+  {
+    connectorId: { type: "number", required: false },
+  },
+  async ({ connectorId, execute }, logger) => {
+    const slackConnectors = connectorId
+      ? await ConnectorResource.fetchByIds(SLACK_CONNECTOR_TYPE, [connectorId])
+      : await ConnectorResource.listByType(SLACK_CONNECTOR_TYPE, {});
+
+    logger.info(
+      `Testing ${slackConnectors.length} Slack connector(s) for rate limits`
+    );
+
+    for (const connector of slackConnectors) {
+      logger.info(
+        { connectorId: connector.id },
+        "Starting rate limit test for connector"
+      );
+
+      try {
+        const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+          connector.id
+        );
+        if (!slackConfig) {
+          logger.warn(
+            { connectorId: connector.id },
+            "No Slack configuration found"
+          );
+          continue;
+        }
+
+        const slackClient = await getSlackClient(connector.id);
+
+        let channels;
+        try {
+          channels = await withSlackErrorHandling(async () =>
+            getChannels(slackClient, connector.id, false)
+          );
+        } catch (error: unknown) {
+          if (error instanceof ProviderRateLimitError) {
+            await handleRateLimit(connector, {
+              context: "while fetching channels",
+              execute,
+              logger,
+            });
+            continue;
+          } else {
+            throw error;
+          }
+        }
+        const [testChannel] = channels;
+        if (!testChannel) {
+          logger.warn(
+            { connectorId: connector.id },
+            "No channels found for connector"
+          );
+          continue;
+        }
+
+        logger.info(
+          {
+            connectorId: connector.id,
+            channelName: testChannel.name,
+            channelId: testChannel.id,
+          },
+          "Testing with channel"
+        );
+
+        const results = await concurrentExecutor(
+          Array.from({ length: TEST_CALLS_COUNT }, (_, i) => i),
+          async (i): Promise<boolean> => {
+            try {
+              logger.info(
+                { connectorId: connector.id, attempt: i + 1 },
+                `Making test API call ${i + 1}/${TEST_CALLS_COUNT}`
+              );
+
+              await withSlackErrorHandling(async () =>
+                slackClient.conversations.history({
+                  channel: testChannel.id!,
+                  limit: 100,
+                })
+              );
+
+              logger.info(
+                { connectorId: connector.id, attempt: i + 1 },
+                "API call successful"
+              );
+
+              return false;
+            } catch (error: unknown) {
+              if (error instanceof ProviderRateLimitError) {
+                logger.error(
+                  { connectorId: connector.id, attempt: i + 1 },
+                  "ProviderRateLimitError detected!"
+                );
+                return true;
+              } else {
+                logger.error(
+                  {
+                    connectorId: connector.id,
+                    attempt: i + 1,
+                    error,
+                  },
+                  "API call failed with non-rate-limit error"
+                );
+                return false;
+              }
+            }
+          },
+          { concurrency: TEST_CALLS_COUNT }
+        );
+
+        const rateLimitDetected = results.some((r) => r);
+        if (rateLimitDetected) {
+          await handleRateLimit(connector, {
+            context: "during API calls",
+            execute,
+            logger,
+          });
+        } else {
+          logger.info(
+            { connectorId: connector.id },
+            "No rate limiting detected - connector appears healthy"
+          );
+        }
+      } catch (error: unknown) {
+        logger.error(
+          {
+            connectorId: connector.id,
+            error,
+          },
+          "Failed to test connector"
+        );
+      }
+    }
+
+    logger.info("Rate limit testing completed");
+  }
+);

--- a/connectors/scripts/mark_rate_limited_slack_connectors.ts
+++ b/connectors/scripts/mark_rate_limited_slack_connectors.ts
@@ -12,6 +12,8 @@ import { concurrentExecutor } from "@connectors/types";
 
 import { makeScript } from "./helpers";
 
+// Stress test for rate limiting. New Slack quotas are 1 call/minute for Tier 3 endpoints,
+// running 10 calls in parallel should be enough to trigger the rate limit.
 const TEST_CALLS_COUNT = 10;
 
 const SLACK_CONNECTOR_TYPE = "slack";

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -223,6 +223,26 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     });
   }
 
+  // Metadata.
+
+  async markAsRateLimited() {
+    return this.update({
+      metadata: {
+        ...this.metadata,
+        rateLimited: { at: new Date() },
+      },
+    });
+  }
+
+  async markAsNotRateLimited() {
+    return this.update({
+      metadata: {
+        ...this.metadata,
+        rateLimited: null,
+      },
+    });
+  }
+
   get isAuthTokenRevoked() {
     return this.errorType === "oauth_token_revoked";
   }

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -9,6 +9,10 @@ import type {
   ConnectorSyncStatus,
 } from "@connectors/types";
 
+export interface ConnectorMetadata {
+  rateLimited?: { at: Date } | null;
+}
+
 export class ConnectorModel extends BaseModel<ConnectorModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -30,6 +34,7 @@ export class ConnectorModel extends BaseModel<ConnectorModel> {
   declare lastGCTime: Date | null;
 
   declare pausedAt?: Date | null;
+  declare metadata: ConnectorMetadata | null;
 }
 
 ConnectorModel.init(
@@ -103,6 +108,10 @@ ConnectorModel.init(
     },
     pausedAt: {
       type: DataTypes.DATE,
+      allowNull: true,
+    },
+    metadata: {
+      type: DataTypes.JSONB,
       allowNull: true,
     },
   },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/3199.

This PR adds a new `metadata` field on the `connectors` table to store rate limited flag. There is no endpoint to get your API quota on Slack, so this PR bundles a script to stress test Tier 3 endpoints `conversations.history` and flag them as rate limited.

Could have leveraged the `pausedAt` and `errorType` but there are too much logic around those two fields. Goal here is to have a silent track to move fast.

Slack rate limits being spread over 1 minute, I'll scale down all connectors-worker to 0 to have a clean window.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] Run migration
- [ ] Deploy connectors
- [ ] Run stress
