### PR TITLE
[ext] auth: honor expires_in in front

### DIFF
--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -81,7 +81,7 @@ export class FrontAuthService extends AuthService {
 
     const result = await openAndWaitForPopup<{ code: string }>(
       authUrl,
-      "WorkOS Auth",
+      "Authentication",
       (popup) => {
         const popupUrl = popup.location.href;
         if (popupUrl?.includes("code=")) {
@@ -174,7 +174,7 @@ export class FrontAuthService extends AuthService {
       const tokens = await this.saveTokens({
         accessToken: data.access_token,
         refreshToken: data.refresh_token || "",
-        expiresIn: DEFAULT_TOKEN_EXPIRY,
+        expiresIn: data.expires_in || DEFAULT_TOKEN_EXPIRY,
       });
 
       const claims = jwtDecode<Record<string, string>>(data.access_token);
@@ -291,7 +291,7 @@ export class FrontAuthService extends AuthService {
       const storedTokens = await this.saveTokens({
         accessToken: data.access_token,
         refreshToken: data.refresh_token || "",
-        expiresIn: DEFAULT_TOKEN_EXPIRY,
+        expiresIn: data.expires_in || DEFAULT_TOKEN_EXPIRY,
       });
       return new Ok(storedTokens);
     } catch (error) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

During the implementation of the bi-login in Front with Auth0 and Workos, I set the token expiry to a hard defined constant. We should honor the token expiry if it exists.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand. The user is not de-logged and refreshed every 5 minutes when expires_in exists in token.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front extension.