### PR TITLE
fix: properly display individual docs selected in folders

### DIFF
--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -337,7 +337,7 @@ async function renderDataSourcesConfigurations(
 
       const serializedDataSourceView = dataSourceView.toJSON();
 
-      if (!dataSourceView.dataSource.connectorId || !sr.resources) {
+      if (!sr.resources) {
         return {
           dataSourceView: serializedDataSourceView,
           selectedResources: [],


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/3185

We can select individual files in folder in the builder, but coming back to edit the agent actually drops the selection due to a wrong condition.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
