### PR TITLE
Connectors: slack_bot provider

### DIFF
--- a/connectors/src/api/configuration.ts
+++ b/connectors/src/api/configuration.ts
@@ -71,6 +71,7 @@ const _patchConnectorConfiguration = async (
     case "bigquery":
     case "zendesk":
     case "gong":
+    case "slack_bot":
     case "slack": {
       throw new Error(
         `Connector type ${connector.type} does not support configuration patching`

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -105,7 +105,8 @@ const _createConnectorAPIHandler = async (
         break;
       }
 
-      case "slack": {
+      case "slack":
+      case "slack_bot": {
         const configurationRes = ioTsParsePayload(
           configuration,
           SlackConfigurationTypeSchema
@@ -120,7 +121,7 @@ const _createConnectorAPIHandler = async (
           });
         }
         connectorRes = await createConnector({
-          connectorProvider: "slack",
+          connectorProvider: req.params.connector_provider,
           params: {
             configuration: configurationRes.value,
             dataSourceConfig: {

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -15,6 +15,7 @@ import { MicrosoftConnectorManager } from "@connectors/connectors/microsoft";
 import { NotionConnectorManager } from "@connectors/connectors/notion";
 import { SalesforceConnectorManager } from "@connectors/connectors/salesforce";
 import { SlackConnectorManager } from "@connectors/connectors/slack";
+import { SlackBotConnectorManager } from "@connectors/connectors/slack_bot";
 import { SnowflakeConnectorManager } from "@connectors/connectors/snowflake";
 import { WebcrawlerConnectorManager } from "@connectors/connectors/webcrawler";
 import { ZendeskConnectorManager } from "@connectors/connectors/zendesk";
@@ -58,6 +59,8 @@ export function getConnectorManager({
       return new NotionConnectorManager(connectorId);
     case "slack":
       return new SlackConnectorManager(connectorId);
+    case "slack_bot":
+      return new SlackBotConnectorManager(connectorId);
     case "webcrawler":
       return new WebcrawlerConnectorManager(connectorId);
     case "snowflake":
@@ -80,7 +83,10 @@ export function createConnector({
   params,
 }:
   | {
-      connectorProvider: Exclude<ConnectorProvider, "webcrawler" | "slack">;
+      connectorProvider: Exclude<
+        ConnectorProvider,
+        "webcrawler" | "slack" | "slack_bot"
+      >;
       params: {
         dataSourceConfig: DataSourceConfig;
         connectionId: string;
@@ -96,7 +102,7 @@ export function createConnector({
       };
     }
   | {
-      connectorProvider: "slack";
+      connectorProvider: "slack" | "slack_bot";
       params: {
         dataSourceConfig: DataSourceConfig;
         connectionId: string;
@@ -120,6 +126,8 @@ export function createConnector({
       return NotionConnectorManager.create(params);
     case "slack":
       return SlackConnectorManager.create(params);
+    case "slack_bot":
+      return SlackBotConnectorManager.create(params);
     case "webcrawler":
       return WebcrawlerConnectorManager.create(params);
     case "snowflake":

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -159,7 +159,11 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             },
             `Attempting Slack app deactivation [updateSlackConnector/team_id_mismatch]`
           );
-          const uninstallRes = await uninstallSlack(connectionId);
+          const uninstallRes = await uninstallSlack(
+            connectionId,
+            SLACK_CLIENT_ID,
+            SLACK_CLIENT_SECRET
+          );
 
           if (uninstallRes.isErr()) {
             throw new Error("Failed to deactivate the mismatching Slack app");
@@ -242,7 +246,11 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       );
 
       try {
-        const uninstallRes = await uninstallSlack(connector.connectionId);
+        const uninstallRes = await uninstallSlack(
+          connector.connectionId,
+          SLACK_CLIENT_ID,
+          SLACK_CLIENT_SECRET
+        );
 
         if (uninstallRes.isErr() && !force) {
           return uninstallRes;
@@ -733,11 +741,15 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
   }
 }
 
-export async function uninstallSlack(connectionId: string) {
-  if (!SLACK_CLIENT_ID) {
+export async function uninstallSlack(
+  connectionId: string,
+  slackClientId: string | undefined,
+  slackClientSecret: string | undefined
+) {
+  if (!slackClientId) {
     throw new Error("SLACK_CLIENT_ID is not defined");
   }
-  if (!SLACK_CLIENT_SECRET) {
+  if (!slackClientSecret) {
     throw new Error("SLACK_CLIENT_SECRET is not defined");
   }
 
@@ -757,8 +769,8 @@ export async function uninstallSlack(connectionId: string) {
       method: "apps.uninstall",
     });
     const deleteRes = await slackClient.apps.uninstall({
-      client_id: SLACK_CLIENT_ID,
-      client_secret: SLACK_CLIENT_SECRET,
+      client_id: slackClientId,
+      client_secret: slackClientSecret,
     });
     if (deleteRes && !deleteRes.ok) {
       return new Err(

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -1,6 +1,5 @@
 import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
-import { WebClient } from "@slack/web-api";
 
 import type {
   CreateConnectorErrorCode,

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -1,0 +1,426 @@
+import type { ConnectorProvider, Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import { WebClient } from "@slack/web-api";
+
+import type {
+  CreateConnectorErrorCode,
+  RetrievePermissionsErrorCode,
+  UpdateConnectorErrorCode,
+} from "@connectors/connectors/interface";
+import {
+  BaseConnectorManager,
+  ConnectorManagerError,
+} from "@connectors/connectors/interface";
+import { getBotEnabled } from "@connectors/connectors/slack/bot";
+import {
+  getSlackAccessToken,
+  getSlackClient,
+  reportSlackUsage,
+} from "@connectors/connectors/slack/lib/slack_client";
+import logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import type { ContentNode, SlackConfigurationType } from "@connectors/types";
+import type { DataSourceConfig } from "@connectors/types";
+import { isSlackAutoReadPatterns, safeParseJSON } from "@connectors/types";
+
+import {
+  getAutoReadChannelPatterns,
+  getRestrictedSpaceAgentsEnabled,
+  uninstallSlack,
+} from "../slack";
+
+const { SLACK_BOT_CLIENT_ID, SLACK_BOT_CLIENT_SECRET } = process.env;
+
+export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigurationType> {
+  readonly provider: ConnectorProvider = "slack_bot";
+
+  static async create({
+    dataSourceConfig,
+    connectionId,
+    configuration,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+    connectionId: string;
+    configuration: SlackConfigurationType;
+  }): Promise<Result<string, ConnectorManagerError<CreateConnectorErrorCode>>> {
+    const slackAccessToken = await getSlackAccessToken(connectionId);
+    const client = new WebClient(slackAccessToken);
+
+    const teamInfo = await client.team.info();
+    if (teamInfo.ok !== true) {
+      throw new Error(
+        `Could not get slack team info. Error message: ${
+          teamInfo.error || "unknown"
+        }`
+      );
+    }
+    if (!teamInfo.team?.id) {
+      throw new Error(
+        `Could not get slack team id. Error message: ${
+          teamInfo.error || "unknown"
+        }`
+      );
+    }
+    const connector = await ConnectorResource.makeNew(
+      "slack_bot",
+      {
+        connectionId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceId: dataSourceConfig.dataSourceId,
+      },
+      {
+        autoReadChannelPatterns: configuration.autoReadChannelPatterns,
+        botEnabled: true,
+        slackTeamId: teamInfo.team.id,
+        whitelistedDomains: configuration.whitelistedDomains,
+        restrictedSpaceAgentsEnabled:
+          configuration.restrictedSpaceAgentsEnabled ?? true,
+      }
+    );
+
+    return new Ok(connector.id.toString());
+  }
+
+  async update({
+    connectionId,
+  }: {
+    connectionId?: string | null;
+  }): Promise<Result<string, ConnectorManagerError<UpdateConnectorErrorCode>>> {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      throw new Error(`Connector ${this.connectorId} not found`);
+    }
+
+    const currentSlackConfig =
+      await SlackConfigurationResource.fetchByConnectorId(this.connectorId);
+    if (!currentSlackConfig) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Slack configuration not found"
+      );
+      throw new Error(
+        `Slack configuration not found for connector ${this.connectorId}`
+      );
+    }
+
+    const updateParams: Parameters<typeof c.update>[0] = {};
+
+    if (connectionId) {
+      const accessToken = await getSlackAccessToken(connectionId);
+      const slackClient = await getSlackClient(accessToken, {
+        // Do not reject rate limited calls in update connector. Called from the API.
+        rejectRateLimitedCalls: false,
+      });
+
+      reportSlackUsage({
+        connectorId: c.id,
+        method: "team.info",
+      });
+      const teamInfoRes = await slackClient.team.info();
+      if (!teamInfoRes.ok || !teamInfoRes.team?.id) {
+        throw new Error("Can't get the Slack team information.");
+      }
+
+      const newTeamId = teamInfoRes.team.id;
+      if (newTeamId !== currentSlackConfig.slackTeamId) {
+        const configurations =
+          await SlackConfigurationResource.listForTeamId(newTeamId);
+
+        // Revoke the token if no other slack connector is active on the same slackTeamId.
+        if (configurations.length == 0) {
+          logger.info(
+            {
+              connectorId: c.id,
+              slackTeamId: newTeamId,
+              connectionId: connectionId,
+            },
+            `Attempting Slack app deactivation [updateSlackConnector/team_id_mismatch]`
+          );
+          const uninstallRes = await uninstallSlack(
+            connectionId,
+            SLACK_BOT_CLIENT_ID,
+            SLACK_BOT_CLIENT_SECRET
+          );
+
+          if (uninstallRes.isErr()) {
+            throw new Error("Failed to deactivate the mismatching Slack app");
+          }
+          logger.info(
+            {
+              connectorId: c.id,
+              slackTeamId: newTeamId,
+              connectionId: connectionId,
+            },
+            `Deactivated Slack app [updateSlackConnector/team_id_mismatch]`
+          );
+        } else {
+          logger.info(
+            {
+              slackTeamId: newTeamId,
+              activeConfigurations: configurations.length,
+            },
+            `Skipping deactivation of the Slack app [updateSlackConnector/team_id_mismatch]`
+          );
+        }
+
+        return new Err(
+          new ConnectorManagerError(
+            "CONNECTOR_OAUTH_TARGET_MISMATCH",
+            "Cannot change the Slack Team of a Data Source"
+          )
+        );
+      }
+
+      updateParams.connectionId = connectionId;
+    }
+
+    await c.update(updateParams);
+
+    // If connector was previously paused, unpause it.
+    if (c.isPaused()) {
+      await this.unpauseAndResume();
+    }
+
+    return new Ok(c.id.toString());
+  }
+
+  async clean({
+    force,
+  }: {
+    force: boolean;
+  }): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Could not find connector with id ${this.connectorId}`)
+      );
+    }
+
+    const configuration = await SlackConfigurationResource.fetchByConnectorId(
+      this.connectorId
+    );
+    if (!configuration) {
+      return new Err(
+        new Error(
+          `Could not find configuration for connector id ${this.connectorId}`
+        )
+      );
+    }
+
+    const configurations = await SlackConfigurationResource.listForTeamId(
+      configuration.slackTeamId
+    );
+
+    // We deactivate our connections only if we are the only live slack connection for this team.
+    if (configurations.length == 1) {
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackTeamId: configuration.slackTeamId,
+          connectionId: connector.connectionId,
+        },
+        `Attempting Slack app deactivation [cleanupSlackConnector]`
+      );
+
+      try {
+        const uninstallRes = await uninstallSlack(
+          connector.connectionId,
+          SLACK_BOT_CLIENT_ID,
+          SLACK_BOT_CLIENT_SECRET
+        );
+
+        if (uninstallRes.isErr() && !force) {
+          return uninstallRes;
+        }
+      } catch (e) {
+        if (!force) {
+          throw e;
+        }
+      }
+
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackTeamId: configuration.slackTeamId,
+        },
+        `Deactivated Slack app [cleanupSlackConnector]`
+      );
+    } else {
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackTeamId: configuration.slackTeamId,
+          activeConfigurations: configurations.length - 1,
+        },
+        `Skipping deactivation of the Slack app [cleanupSlackConnector]`
+      );
+    }
+
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Slack connector."
+      );
+      return res;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async sync(): Promise<Result<string, Error>> {
+    return new Ok("slack-bot-no-sync");
+  }
+
+  async retrievePermissions(): Promise<
+    Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+  > {
+    return new Ok([]);
+  }
+
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    return new Ok([internalId]);
+  }
+
+  async setPermissions(): Promise<Result<void, Error>> {
+    return new Ok(undefined);
+  }
+
+  async setConfigurationKey({
+    configKey,
+    configValue,
+  }: {
+    configKey: string;
+    configValue: string;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+
+    const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+      this.connectorId
+    );
+    if (!slackConfig) {
+      return new Err(
+        new Error(
+          `Slack configuration not found for connector ${this.connectorId}`
+        )
+      );
+    }
+
+    switch (configKey) {
+      case "botEnabled": {
+        if (configValue === "true") {
+          return slackConfig.enableBot();
+        } else {
+          return new Err(
+            new Error("SlackBot configuration assumes slack bot is enabled")
+          );
+        }
+      }
+
+      case "autoReadChannelPatterns": {
+        const parsedConfig = safeParseJSON(configValue);
+        if (parsedConfig.isErr()) {
+          return new Err(parsedConfig.error);
+        }
+
+        const autoReadChannelPatterns = parsedConfig.value;
+        if (!Array.isArray(autoReadChannelPatterns)) {
+          return new Err(
+            new Error("autoReadChannelPatterns must be an array of objects")
+          );
+        }
+
+        if (!isSlackAutoReadPatterns(autoReadChannelPatterns)) {
+          return new Err(
+            new Error(
+              "autoReadChannelPatterns must be an array of objects with pattern and spaceId"
+            )
+          );
+        }
+
+        return slackConfig.setAutoReadChannelPatterns(autoReadChannelPatterns);
+      }
+
+      case "restrictedSpaceAgentsEnabled": {
+        const enabled = configValue === "true";
+        await slackConfig.model.update(
+          { restrictedSpaceAgentsEnabled: enabled },
+          { where: { id: slackConfig.id } }
+        );
+        return new Ok(undefined);
+      }
+
+      default: {
+        return new Err(new Error(`Invalid config key ${configKey}`));
+      }
+    }
+  }
+
+  async getConfigurationKey({
+    configKey,
+  }: {
+    configKey: string;
+  }): Promise<Result<string | null, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+
+    switch (configKey) {
+      case "botEnabled": {
+        const botEnabledRes = await getBotEnabled(this.connectorId);
+        if (botEnabledRes.isErr()) {
+          return botEnabledRes;
+        }
+        return new Ok(botEnabledRes.value.toString());
+      }
+
+      case "autoReadChannelPatterns": {
+        const autoReadChannelPatterns = await getAutoReadChannelPatterns(
+          this.connectorId
+        );
+
+        return autoReadChannelPatterns;
+      }
+
+      case "restrictedSpaceAgentsEnabled": {
+        const restrictedSpaceAgentsEnabled =
+          await getRestrictedSpaceAgentsEnabled(this.connectorId);
+        return restrictedSpaceAgentsEnabled;
+      }
+
+      default:
+        return new Err(new Error(`Invalid config key ${configKey}`));
+    }
+  }
+
+  async stop(): Promise<Result<undefined, Error>> {
+    return new Ok(undefined);
+  }
+
+  async resume(): Promise<Result<undefined, Error>> {
+    return new Ok(undefined);
+  }
+
+  async garbageCollect(): Promise<Result<string, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -50,6 +50,7 @@ export interface ConnectorProviderModelM {
   microsoft: MicrosoftConfigurationModel;
   notion: NotionConnectorState;
   slack: SlackConfigurationModel;
+  slack_bot: SlackConfigurationModel;
   webcrawler: WebCrawlerConfigurationModel;
   snowflake: SnowflakeConfigurationModel;
   zendesk: ZendeskConfigurationModel;
@@ -88,6 +89,7 @@ export interface ConnectorProviderConfigurationTypeM {
   notion: null;
   snowflake: null;
   slack: SlackConfigurationType;
+  slack_bot: SlackConfigurationType;
   webcrawler: WebCrawlerConfigurationType;
   zendesk: null;
   bigquery: null;
@@ -146,6 +148,9 @@ export function getConnectorProviderStrategy(
       return new NotionConnectorStrategy();
 
     case "slack":
+      return new SlackConnectorStrategy();
+
+    case "slack_bot":
       return new SlackConnectorStrategy();
 
     case "webcrawler":

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -25,7 +25,9 @@ import logger from "./logger/logger";
 
 setupGlobalErrorHandler(logger);
 
-type WorkerType = ConnectorProvider | "notion_garbage_collector";
+type WorkerType =
+  | Exclude<ConnectorProvider, "slack_bot">
+  | "notion_garbage_collector";
 
 const workerFunctions: Record<WorkerType, () => Promise<void>> = {
   confluence: runConfluenceWorker,

--- a/connectors/src/types/configuration.ts
+++ b/connectors/src/types/configuration.ts
@@ -2,7 +2,6 @@ import * as t from "io-ts";
 
 import type { SlackConfigurationType } from "./slack";
 import { SlackConfigurationTypeSchema } from "./slack";
-import type { SlackBotConfigurationType } from "./slack_bot";
 import type { WebCrawlerConfigurationType } from "./webcrawler";
 import { WebCrawlerConfigurationTypeSchema } from "./webcrawler";
 
@@ -23,7 +22,6 @@ export type UpdateConnectorConfigurationType = t.TypeOf<
 export type ConnectorConfiguration =
   | WebCrawlerConfigurationType
   | SlackConfigurationType
-  | SlackBotConfigurationType
   | null;
 
 export function isWebCrawlerConfiguration(
@@ -45,7 +43,7 @@ export type ConnectorConfigurations = {
   webcrawler: WebCrawlerConfigurationType;
   notion: null;
   slack: SlackConfigurationType;
-  slack_bot: SlackBotConfigurationType;
+  slack_bot: SlackConfigurationType;
   google_drive: null;
   github: null;
   confluence: null;

--- a/connectors/src/types/configuration.ts
+++ b/connectors/src/types/configuration.ts
@@ -2,6 +2,7 @@ import * as t from "io-ts";
 
 import type { SlackConfigurationType } from "./slack";
 import { SlackConfigurationTypeSchema } from "./slack";
+import type { SlackBotConfigurationType } from "./slack_bot";
 import type { WebCrawlerConfigurationType } from "./webcrawler";
 import { WebCrawlerConfigurationTypeSchema } from "./webcrawler";
 
@@ -22,6 +23,7 @@ export type UpdateConnectorConfigurationType = t.TypeOf<
 export type ConnectorConfiguration =
   | WebCrawlerConfigurationType
   | SlackConfigurationType
+  | SlackBotConfigurationType
   | null;
 
 export function isWebCrawlerConfiguration(
@@ -43,6 +45,7 @@ export type ConnectorConfigurations = {
   webcrawler: WebCrawlerConfigurationType;
   notion: null;
   slack: SlackConfigurationType;
+  slack_bot: SlackBotConfigurationType;
   google_drive: null;
   github: null;
   confluence: null;

--- a/connectors/src/types/slack.ts
+++ b/connectors/src/types/slack.ts
@@ -6,7 +6,7 @@ const SlackAutoReadPatternSchema = t.type({
   pattern: t.string,
   spaceId: t.string,
 });
-const SlackAutoReadPatternsSchema = t.array(SlackAutoReadPatternSchema);
+export const SlackAutoReadPatternsSchema = t.array(SlackAutoReadPatternSchema);
 
 export type SlackAutoReadPattern = t.TypeOf<typeof SlackAutoReadPatternSchema>;
 

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -155,6 +155,10 @@ export function contentFragmentToAttachmentCitation(
 
   if (contentFragment.contentNodeData) {
     const { provider, nodeType } = contentFragment.contentNodeData;
+    if (provider === "slack_bot") {
+      // TODO(spolu): clean-up once slack_bot is added to providers
+      throw new Error("`slack_bot` provider not yet supported");
+    }
     const logo = getConnectorProviderLogoWithFallback({ provider });
 
     const visual =

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -316,6 +316,7 @@ const ConnectorProvidersSchema = FlexibleEnumSchema<
   | "intercom"
   | "notion"
   | "slack"
+  | "slack_bot"
   | "microsoft"
   | "webcrawler"
   | "snowflake"


### PR DESCRIPTION
## Description

- Introduce a new connector provider `slack_bot`
- Reuse SlackConfiguration (botEnabled assumed true)

Fixes: https://github.com/dust-tt/tasks/issues/3215

## Tests

Type checking

## Risk

N/A (not used)

## Deploy Plan

- deploy `connectors`