### PR TITLE
Ignore skipped Slack channel when getting permissions, in temporal activities and in webhooks

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -335,6 +335,18 @@ const _webhookSlackAPIHandler = async (
                   return null;
                 }
 
+                if (slackChannel.skipReason) {
+                  logger.info(
+                    {
+                      connectorId: c.connectorId,
+                      slackChannelId: channel,
+                      skipReason: slackChannel.skipReason,
+                    },
+                    `Ignoring message because channel is skipped: ${slackChannel.skipReason}`
+                  );
+                  return null;
+                }
+
                 if (!["read", "read_write"].includes(slackChannel.permission)) {
                   logger.info(
                     {

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -380,7 +380,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
           SlackChannel.findAll({
             where: {
               connectorId: this.connectorId,
-              // Here we do not filter out channels with skipReason because we need to know the one who are skipped.
+              // Here we do not filter out channels with skipReason because we need to know the ones that are skipped.
             },
           }),
         ]);

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -358,6 +358,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
           where: {
             connectorId: this.connectorId,
             permission: permissionToFilter,
+            skipReason: null, // We hide skipped channels from the UI.
           },
         });
         slackChannels.push(
@@ -379,6 +380,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
           SlackChannel.findAll({
             where: {
               connectorId: this.connectorId,
+              // Here we do not filter out channels with skipReason because we need to know the one who are skipped.
             },
           }),
         ]);
@@ -396,8 +398,15 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             continue;
           }
 
+          const localChannel = localChannelsById[remoteChannel.id];
+
+          // Skip channels with skipReason
+          if (localChannel?.skipReason) {
+            continue;
+          }
+
           const permissions =
-            localChannelsById[remoteChannel.id]?.permission ||
+            localChannel?.permission ||
             (remoteChannel.is_member ? "write" : "none");
 
           if (

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -372,6 +372,7 @@ export async function getChannelsToSync(
         permission: {
           [Op.or]: ["read", "read_write"],
         },
+        skipReason: null,
       },
     }),
   ]);


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/3192

Ignore the skipped Slack channels everywhere: 
- garbage collect them
- stop syncing them
- ignore in webhooks
- do not display them anymore in the UI (get permissions)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connectors. 