### PR TITLE
[front] chore: Avoid re-render

### DIFF
--- a/front/components/assistant/WelcomeTourGuideProvider.tsx
+++ b/front/components/assistant/WelcomeTourGuideProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef } from "react";
+import { createContext, useContext, useMemo, useRef } from "react";
 
 type WelcomeTourGuideContextType = {
   startConversationRef: React.RefObject<HTMLDivElement>;
@@ -18,14 +18,16 @@ export function WelcomeTourGuideProvider({
   const spaceMenuButtonRef = useRef<HTMLDivElement>(null);
   const createAgentButtonRef = useRef<HTMLDivElement>(null);
 
+  const value = useMemo(() => {
+    return {
+      startConversationRef,
+      spaceMenuButtonRef,
+      createAgentButtonRef,
+    };
+  }, [startConversationRef, spaceMenuButtonRef, createAgentButtonRef]);
+
   return (
-    <WelcomeTourGuideContext.Provider
-      value={{
-        startConversationRef,
-        spaceMenuButtonRef,
-        createAgentButtonRef,
-      }}
-    >
+    <WelcomeTourGuideContext.Provider value={value}>
       {children}
     </WelcomeTourGuideContext.Provider>
   );

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -12,7 +12,7 @@ import {
 } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import type { SidebarNavigation } from "@app/components/navigation/config";
@@ -51,16 +51,16 @@ export const NavigationSidebar = React.forwardRef<
   ref
 ) {
   const router = useRouter();
-  const [activePath, setActivePath] = useState("");
+  const activePath = useMemo(() => {
+    if (router.isReady && router.route) {
+      return router.route;
+    }
+    return "";
+  }, [router.isReady, router.route]);
 
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
-  useEffect(() => {
-    if (router.isReady && router.route) {
-      setActivePath(router.route);
-    }
-  }, [router.route, router.isReady]);
 
   const { spaceMenuButtonRef } = useWelcomeTourGuide();
 


### PR DESCRIPTION
## Description
Avoid re-render inside the global WelcomeTourGuideContext by wrapping the refs inside a `useMemo`. Even though the refs are not triggering re-rendering, having them inside an object make that object re-render each time its parent is rendered.

Also replace a useless useEffect by a useMemo

## Tests
- Locally

## Risk
- Low

## Deploy Plan
- Deploy front
