### PR TITLE
[front] fix(dark mode): update text color on webbrowse errors

### DIFF
--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -43,7 +43,7 @@ export function MCPBrowseActionDetails({
                     </span>
                   </>
                 ) : (
-                  <span className="text-sm text-foreground">
+                  <span className="text-sm text-foreground dark:text-foreground-night">
                     Cannot fetch content for {r.uri}, error code :{" "}
                     {r.responseCode}.{r.errorMessage}
                   </span>

--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -44,8 +44,8 @@ export function MCPBrowseActionDetails({
                   </>
                 ) : (
                   <span className="text-sm text-foreground dark:text-foreground-night">
-                    Cannot fetch content for {r.uri}, error code :{" "}
-                    {r.responseCode}.{r.errorMessage}
+                    Cannot fetch content for {r.uri}, error code:{" "}
+                    {r.responseCode}. {r.errorMessage}
                   </span>
                 )}
               </div>


### PR DESCRIPTION
## Description

- This PR fixes some unreadable text in the action detaills in dark mode.

<img width="549" alt="Screenshot 2025-06-19 at 4 35 59 PM" src="https://github.com/user-attachments/assets/a7ceeef8-cb43-42d4-b086-928bd6e435e9" />

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
