### PR TITLE
Cli command to skip Slack channel

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -552,10 +552,9 @@ export const slack = async ({
       const previousSkipReason = channel.skipReason;
 
       if (!previousSkipReason) {
-        logger.info(
-          `Channel ${args.channelId} (${channel.slackChannelName}) was not skipped, doing nothing.`
+        throw new Error(
+          `Channel ${args.channelId} (${channel.slackChannelName}) is not skipped`
         );
-        return { success: true };
       }
 
       await channel.update({

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -509,6 +509,8 @@ export const SlackCommandSchema = t.type({
     t.literal("sync-channel"),
     t.literal("sync-thread"),
     t.literal("skip-thread"),
+    t.literal("skip-channel"),
+    t.literal("unskip-channel"),
     t.literal("uninstall-for-unknown-team-ids"),
     t.literal("whitelist-domains"),
     t.literal("whitelist-bot"),


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/3192
Adding cli commands to skip or unskip a Slack channel. 
I initially wanted to do a poké plugin but was more complex so this is a good first start. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connectors. 