### PR TITLE
[front] Add script to reset user passwords

### DIFF
--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -50,8 +50,8 @@ const sendPasswordResetEmail = async (
     childLogger.info({ workOSUserId: user.id }, "Found user in WorkOS");
 
     if (execute) {
-      // Send password reset email via WorkOS
-      await getWorkOS().userManagement.sendPasswordResetEmail({
+      // Send password reset email via WorkOS.
+      await getWorkOS().userManagement.createPasswordReset({
         email: user.email,
       });
 

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -63,7 +63,7 @@ const sendPasswordResetEmail = async (
         to: email,
         from: {
           name: "Dust team",
-          email: "team@dust.tt",
+          email: "support@dust.help",
         },
         subject: "[Dust] Password Reset Required - Important Update",
         body: `<p>We're writing to inform you about an important update to your Dust account authentication.</p>

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -51,6 +51,7 @@ const sendPasswordResetEmail = async (
   if (execute) {
     try {
       // Create a password reset token via WorkOS. The token is included in the URL.
+      // Note that this call also sends an email.
       const { passwordResetUrl, userId, email } =
         await getWorkOS().userManagement.createPasswordReset({
           email: user.email,

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -7,6 +7,7 @@ import { fetchWorkOSUserWithEmail } from "@app/lib/api/workos/user";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
+import { normalizeError } from "@app/types";
 
 interface CsvRecord {
   email: string;
@@ -95,7 +96,7 @@ const sendPasswordResetEmail = async (
     }
   } catch (error) {
     childLogger.error({ error }, "Error processing password reset for user");
-    return { success: false, error: String(error) };
+    return { success: false, error: normalizeError(error).message };
   }
 };
 

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -76,6 +76,16 @@ const sendPasswordResetEmail = async (
         <p>Thank you for your understanding and for being a valued Dust user.</p>`,
       });
 
+      if (emailResult.isErr()) {
+        childLogger.error(
+          { error: emailResult.error },
+          "Failed to send notification email"
+        );
+        // Don't fail the operation if our notification email fails.
+      } else {
+        childLogger.info("Successfully sent notification email");
+      }
+
       return { success: true };
     } catch (error) {
       childLogger.error({ error }, "Error processing password reset for user");

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -1,0 +1,193 @@
+import { parse } from "csv-parse";
+import * as fs from "fs";
+
+import { sendEmailWithTemplate } from "@app/lib/api/email";
+import { getWorkOS } from "@app/lib/api/workos/client";
+import { fetchWorkOSUserWithEmail } from "@app/lib/api/workos/user";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+
+interface CsvRecord {
+  email: string;
+}
+
+const readCsvFile = async (filePath: string): Promise<CsvRecord[]> => {
+  const parser = parse({
+    delimiter: ",",
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+  });
+
+  const records: CsvRecord[] = [];
+  fs.createReadStream(filePath).pipe(parser);
+
+  for await (const record of parser) {
+    records.push(record);
+  }
+
+  return records;
+};
+
+const createPasswordResetAndSendEmail = async (
+  email: string,
+  execute: boolean,
+  logger: Logger
+): Promise<{ success: boolean; error?: string }> => {
+  const childLogger = logger.child({ email });
+
+  try {
+    // First, check if user exists in WorkOS
+    const userResult = await fetchWorkOSUserWithEmail(email);
+    if (userResult.isErr()) {
+      childLogger.warn("User not found in WorkOS");
+      return { success: false, error: "User not found in WorkOS" };
+    }
+
+    const user = userResult.value;
+    childLogger.info({ workOSUserId: user.id }, "Found user in WorkOS");
+
+    if (execute) {
+      const passwordReset =
+        await getWorkOS().userManagement.createPasswordResetChallenge({
+          email: user.email,
+        });
+
+      childLogger.info(
+        { passwordResetId: passwordReset.id },
+        "Created password reset challenge"
+      );
+
+      // Send email to user
+      const emailResult = await sendEmailWithTemplate({
+        to: email,
+        from: {
+          name: "Dust team",
+          email: "team@dust.tt",
+        },
+        subject: "[Dust] Password Reset Required - Important Update",
+        body: `<p>We're writing to inform you about an important update to your Dust account authentication.</p>
+        
+        <p>As part of our ongoing migration to improve security and user experience, we need you to reset your password.</p>
+        
+        <p>Please click the link below to reset your password:</p>
+        <p><a href="${passwordReset.challengeUrl}">Reset Your Password</a></p>
+        
+        <p>This link will expire in 24 hours for security reasons.</p>
+        
+        <p>If you have any questions or need assistance, please don't hesitate to reach out to our support team.</p>
+        
+        <p>Thank you for your understanding and for being a valued Dust user.</p>`,
+      });
+
+      if (emailResult.isErr()) {
+        childLogger.error(
+          { error: emailResult.error },
+          "Failed to send password reset email"
+        );
+        return { success: false, error: "Failed to send email" };
+      }
+
+      childLogger.info("Successfully sent password reset email");
+      return { success: true };
+    } else {
+      childLogger.info("Would create password reset challenge and send email");
+      return { success: true };
+    }
+  } catch (error) {
+    childLogger.error({ error }, "Error processing password reset for user");
+    return { success: false, error: String(error) };
+  }
+};
+
+makeScript(
+  {
+    csvPath: {
+      alias: "csv",
+      describe: "Path to the CSV file containing user emails",
+      type: "string",
+      demandOption: true,
+    },
+    concurrency: {
+      alias: "c",
+      describe: "Number of concurrent operations",
+      type: "number",
+      default: 5,
+    },
+  },
+  async ({ csvPath, concurrency, execute }, logger) => {
+    logger.info({ csvPath, execute }, "Starting password reset email script");
+
+    // Read CSV file
+    let records: CsvRecord[];
+    try {
+      records = await readCsvFile(csvPath);
+      logger.info(`Read ${records.length} records from CSV file`);
+    } catch (error) {
+      logger.error({ error, csvPath }, "Failed to read CSV file");
+      throw error;
+    }
+
+    // Validate CSV structure
+    if (records.length === 0) {
+      throw new Error("CSV file is empty");
+    }
+
+    const firstRecord = records[0];
+    if (!firstRecord || !("email" in firstRecord)) {
+      throw new Error("CSV file must have an 'email' column");
+    }
+
+    // Filter out invalid emails
+    const validRecords = records.filter((record) => {
+      if (!record.email || typeof record.email !== "string") {
+        logger.warn({ record }, "Skipping record with invalid email");
+        return false;
+      }
+      return true;
+    });
+
+    logger.info(`Processing ${validRecords.length} valid email records`);
+
+    // Process users with concurrency control
+    const results = await concurrentExecutor(
+      validRecords,
+      async (record) => {
+        const result = await createPasswordResetAndSendEmail(
+          record.email.trim().toLowerCase(),
+          execute,
+          logger
+        );
+        return { email: record.email, ...result };
+      },
+      { concurrency }
+    );
+
+    // Summary
+    const successful = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+
+    logger.info(
+      {
+        total: results.length,
+        successful,
+        failed,
+        execute,
+      },
+      "Password reset email script completed"
+    );
+
+    // Log failures
+    const failures = results.filter((r) => !r.success);
+    if (failures.length > 0) {
+      logger.warn({ failures }, "Some operations failed");
+    }
+
+    if (execute) {
+      logger.info(`Successfully sent ${successful} password reset emails`);
+    } else {
+      logger.info(`Would send ${successful} password reset emails`);
+    }
+  }
+);

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -51,7 +51,7 @@ const sendPasswordResetEmail = async (
   if (execute) {
     try {
       // Create a password reset token via WorkOS. The token is included in the URL.
-      // Note that this call also sends an email.
+      // /!\ Note that this call also sends an email if the password-reset emails are activated.
       const { passwordResetUrl, userId, email } =
         await getWorkOS().userManagement.createPasswordReset({
           email: user.email,

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -39,7 +39,7 @@ const sendPasswordResetEmail = async (
   const childLogger = logger.child({ email });
 
   try {
-    // First, check if user exists in WorkOS
+    // First, check if the user exists in WorkOS.
     const userResult = await fetchWorkOSUserWithEmail(email);
     if (userResult.isErr()) {
       childLogger.warn("User not found in WorkOS");
@@ -53,12 +53,11 @@ const sendPasswordResetEmail = async (
       // Send password reset email via WorkOS
       await getWorkOS().userManagement.sendPasswordResetEmail({
         email: user.email,
-        passwordResetUrl: `https://dust.tt/reset-password?email=${encodeURIComponent(user.email)}`,
       });
 
       childLogger.info("WorkOS password reset email sent");
 
-      // Also send our custom email with explanation
+      // Also send our custom email with an explanation.
       const emailResult = await sendEmailWithTemplate({
         to: email,
         from: {
@@ -82,7 +81,7 @@ const sendPasswordResetEmail = async (
           { error: emailResult.error },
           "Failed to send notification email"
         );
-        // Don't fail the operation if our notification email fails
+        // Don't fail the operation if our notification email fails.
       } else {
         childLogger.info("Successfully sent notification email");
       }
@@ -118,7 +117,7 @@ makeScript(
   async ({ csvPath, concurrency, execute }, logger) => {
     logger.info({ csvPath, execute }, "Starting password reset email script");
 
-    // Read CSV file
+    // Read the CSV file.
     let records: CsvRecord[];
     try {
       records = await readCsvFile(csvPath);
@@ -128,7 +127,7 @@ makeScript(
       throw error;
     }
 
-    // Validate CSV structure
+    // Validate the structure of the CSV file.
     if (records.length === 0) {
       throw new Error("CSV file is empty");
     }
@@ -138,7 +137,7 @@ makeScript(
       throw new Error("CSV file must have an 'email' column");
     }
 
-    // Filter out invalid emails
+    // Filter out invalid emails.
     const validRecords = records.filter((record) => {
       if (!record.email || typeof record.email !== "string") {
         logger.warn({ record }, "Skipping record with invalid email");
@@ -149,7 +148,6 @@ makeScript(
 
     logger.info(`Processing ${validRecords.length} valid email records`);
 
-    // Process users with concurrency control
     const results = await concurrentExecutor(
       validRecords,
       async (record) => {
@@ -163,7 +161,7 @@ makeScript(
       { concurrency }
     );
 
-    // Summary
+    // Summary.
     const successful = results.filter((r) => r.success).length;
     const failed = results.filter((r) => !r.success).length;
 
@@ -177,7 +175,7 @@ makeScript(
       "Password reset email script completed"
     );
 
-    // Log failures
+    // Log failures.
     const failures = results.filter((r) => !r.success);
     if (failures.length > 0) {
       logger.warn({ failures }, "Some operations failed");

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -50,10 +50,11 @@ const sendPasswordResetEmail = async (
 
   if (execute) {
     try {
-      // Send password reset email via WorkOS.
-      await getWorkOS().userManagement.createPasswordReset({
-        email: user.email,
-      });
+      // Create a password reset token via WorkOS. The token is included in the URL.
+      const { passwordResetUrl, userId, email } =
+        await getWorkOS().userManagement.createPasswordReset({
+          email: user.email,
+        });
 
       childLogger.info("WorkOS password reset email sent");
 
@@ -66,13 +67,52 @@ const sendPasswordResetEmail = async (
         },
         subject: "[Dust] Password Reset Required - Important Update",
         body: `<p>We're writing to inform you about an important update to your Dust account authentication.</p>
-        
         <p>As part of our ongoing migration to improve security and user experience, we need you to reset your password.</p>
-        
-        <p>You should have received a password reset email from WorkOS. Please check your inbox and follow the instructions to reset your password.</p>
-        
-        <p>If you don't see the reset email, please check your spam folder or contact our support team.</p>
-        
+        <p>Please click the button below to reset your password:</p>
+        <div style="text-align: center; margin: 40px 0;">
+          <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 auto;">
+            <tr>
+              <td style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                         border-radius: 8px;
+                         box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+                         transition: all 0.3s ease;">
+                <a href="${passwordResetUrl}"
+                   style="display: inline-block;
+                          padding: 16px 32px;
+                          color: #ffffff;
+                          text-decoration: none;
+                          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+                          font-size: 16px;
+                          font-weight: 600;
+                          letter-spacing: 0.5px;
+                          border-radius: 8px;
+                          text-align: center;
+                          min-width: 200px;">
+                  🔐 Reset Your Password
+                </a>
+              </td>
+            </tr>
+          </table>
+        </div>
+
+        <p style="color: #666; font-size: 14px; margin-top: 30px;">If the button doesn't work, you can also copy and paste this link into your browser:</p>
+        <div style="background-color: #f8f9fa;
+                    border: 1px solid #e9ecef;
+                    border-radius: 6px;
+                    padding: 12px;
+                    margin: 10px 0;
+                    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;">
+          <p style="word-break: break-all;
+                    color: #495057;
+                    font-size: 13px;
+                    margin: 0;
+                    line-height: 1.4;">
+            ${passwordResetUrl}
+          </p>
+        </div>
+
+        <p>If you don't see this email or have any issues, please check your spam folder or contact our support team at support@dust.tt.</p>
+
         <p>Thank you for your understanding and for being a valued Dust user.</p>`,
       });
 
@@ -83,7 +123,10 @@ const sendPasswordResetEmail = async (
         );
         // Don't fail the operation if our notification email fails.
       } else {
-        childLogger.info("Successfully sent notification email");
+        childLogger.info(
+          { userId, email },
+          "Successfully sent notification email"
+        );
       }
 
       return { success: true };


### PR DESCRIPTION
## Description

- This PR adds a script that resets password for selected users + sends an email prompting them to set a new password.
- Important: the password reset emails have to be disabled prior to running the script, otherwise the call to `createPasswordReset` will also send an email.

## Tests

- Tested locally with 1 email address that belongs to me without actually sending the email.

The link in the email redirects to the following page.

<img width="349" alt="1750347747780" src="https://github.com/user-attachments/assets/36e8b0a6-2841-495f-b077-41497f9fbea8" />

- Was able to reset my password and log in.

## Risk

- The script does send emails.

## Deploy Plan

- No deploy.
