### PR TITLE
feat(snowflake): add support for keypair auth

### DIFF
--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -154,7 +154,20 @@ impl Credential {
 
         let keys_to_check = match provider {
             CredentialProvider::Snowflake => {
-                vec!["account", "warehouse", "username", "password", "role"]
+                // Check if it's key-pair auth or password auth
+                if content.get("auth_type").and_then(|v| v.as_str()) == Some("keypair") {
+                    vec![
+                        "account",
+                        "warehouse",
+                        "username",
+                        "private_key",
+                        "role",
+                        "auth_type",
+                    ]
+                } else {
+                    // Legacy or explicit password auth
+                    vec!["account", "warehouse", "username", "password", "role"]
+                }
             }
             CredentialProvider::Modjo => {
                 vec!["api_key"]

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -6,12 +6,15 @@ import {
   Icon,
   Input,
   Page,
+  RadioGroup,
+  RadioGroupItem,
   Sheet,
   SheetContainer,
   SheetContent,
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  TextArea,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -53,7 +56,9 @@ export function CreateOrUpdateConnectionSnowflakeModal({
   const { isDark } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [authType, setAuthType] = useState<"password" | "keypair">("password");
   const [credentials, setCredentials] = useState<SnowflakeCredentials>({
+    auth_type: "password",
     username: "",
     password: "",
     account: "",
@@ -67,20 +72,58 @@ export function CreateOrUpdateConnectionSnowflakeModal({
   }
 
   const areCredentialsValid = () => {
-    return Object.values(credentials).every((value) => value.length > 0);
+    const baseFieldsValid =
+      credentials.account.length > 0 &&
+      credentials.role.length > 0 &&
+      credentials.warehouse.length > 0 &&
+      credentials.username.length > 0;
+
+    if ("password" in credentials) {
+      return baseFieldsValid && credentials.password.length > 0;
+    } else if ("private_key" in credentials) {
+      return baseFieldsValid && credentials.private_key.length > 0;
+    }
+    return false;
   };
 
   function onSuccess(ds: DataSourceType) {
     setCredentials({
+      auth_type: "password",
       username: "",
       password: "",
       account: "",
       role: "",
       warehouse: "",
     });
+    setAuthType("password");
     _onSuccess(ds);
     onClose();
   }
+
+  const handleAuthTypeChange = (newAuthType: "password" | "keypair") => {
+    setAuthType(newAuthType);
+    if (newAuthType === "password") {
+      setCredentials({
+        auth_type: "password",
+        username: credentials.username,
+        password: "",
+        account: credentials.account,
+        role: credentials.role,
+        warehouse: credentials.warehouse,
+      });
+    } else {
+      setCredentials({
+        auth_type: "keypair",
+        username: credentials.username,
+        private_key: "",
+        private_key_passphrase: undefined,
+        account: credentials.account,
+        role: credentials.role,
+        warehouse: credentials.warehouse,
+      });
+    }
+    setError(null);
+  };
 
   const createSnowflakeConnection = async () => {
     if (!onSuccess || !createDatasource) {
@@ -254,6 +297,27 @@ export function CreateOrUpdateConnectionSnowflakeModal({
             {error && <Chip color="warning" label={error} />}
 
             <div className="w-full space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  Authentication Method
+                </label>
+                <RadioGroup
+                  name="authType"
+                  value={authType}
+                  onValueChange={(value: string) =>
+                    handleAuthTypeChange(value as "password" | "keypair")
+                  }
+                >
+                  <RadioGroupItem
+                    value="password"
+                    label="Username & Password"
+                  />
+                  <RadioGroupItem
+                    value="keypair"
+                    label="Key Pair Authentication"
+                  />
+                </RadioGroup>
+              </div>
               <Input
                 label="Snowflake Account identifier"
                 name="account_identifier"
@@ -294,17 +358,76 @@ export function CreateOrUpdateConnectionSnowflakeModal({
                   setError(null);
                 }}
               />
-              <Input
-                label="Password"
-                name="password"
-                type="password"
-                value={credentials.password}
-                placeholder=""
-                onChange={(e) => {
-                  setCredentials({ ...credentials, password: e.target.value });
-                  setError(null);
-                }}
-              />
+              {authType === "password" ? (
+                <Input
+                  label="Password"
+                  name="password"
+                  type="password"
+                  value={"password" in credentials ? credentials.password : ""}
+                  placeholder=""
+                  onChange={(e) => {
+                    setCredentials({
+                      ...credentials,
+                      auth_type: "password",
+                      password: e.target.value,
+                    } as SnowflakeCredentials);
+                    setError(null);
+                  }}
+                />
+              ) : (
+                <>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">
+                      Private Key (PEM format)
+                    </label>
+                    <TextArea
+                      name="privateKey"
+                      value={
+                        "private_key" in credentials
+                          ? credentials.private_key
+                          : ""
+                      }
+                      placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----"
+                      rows={8}
+                      onChange={(e) => {
+                        setCredentials({
+                          ...credentials,
+                          auth_type: "keypair",
+                          private_key: e.target.value,
+                        } as SnowflakeCredentials);
+                        setError(null);
+                      }}
+                    />
+                  </div>
+                  <Input
+                    label="Private Key Passphrase (optional)"
+                    name="privateKeyPassphrase"
+                    type="password"
+                    value={
+                      "private_key_passphrase" in credentials
+                        ? credentials.private_key_passphrase || ""
+                        : ""
+                    }
+                    placeholder="Leave empty if key is not encrypted"
+                    onChange={(e) => {
+                      setCredentials({
+                        ...credentials,
+                        auth_type: "keypair",
+                        private_key_passphrase: e.target.value || undefined,
+                      } as SnowflakeCredentials);
+                      setError(null);
+                    }}
+                  />
+                  <div className="text-sm text-muted-foreground">
+                    <p className="mb-2">To use key-pair authentication:</p>
+                    <ol className="ml-4 list-decimal space-y-1">
+                      <li>Generate an RSA key pair (minimum 2048 bits)</li>
+                      <li>Register the public key with your Snowflake user</li>
+                      <li>Paste the private key above in PEM format</li>
+                    </ol>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </SheetContainer>

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -1,6 +1,5 @@
 import * as t from "io-ts";
 
-import type { LightWorkspaceType } from "@app/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const OAUTH_USE_CASES = [
@@ -242,13 +241,45 @@ export function isProviderWithDefaultWorkspaceConfiguration(
 
 // Credentials
 
-export const SnowflakeCredentialsSchema = t.type({
+// Base schema with common fields
+const SnowflakeBaseCredentialsSchema = t.type({
   username: t.string,
-  password: t.string,
   account: t.string,
   role: t.string,
   warehouse: t.string,
 });
+
+// Legacy schema for backward compatibility
+export const SnowflakeLegacyCredentialsSchema = t.intersection([
+  SnowflakeBaseCredentialsSchema,
+  t.type({
+    password: t.string,
+  }),
+]);
+
+export const SnowflakePasswordCredentialsSchema = t.intersection([
+  SnowflakeBaseCredentialsSchema,
+  t.type({
+    auth_type: t.literal("password"),
+    password: t.string,
+  }),
+]);
+
+export const SnowflakeKeyPairCredentialsSchema = t.intersection([
+  SnowflakeBaseCredentialsSchema,
+  t.type({
+    auth_type: t.literal("keypair"),
+    private_key: t.string,
+    private_key_passphrase: t.union([t.string, t.undefined]),
+  }),
+]);
+
+export const SnowflakeCredentialsSchema = t.union([
+  SnowflakeLegacyCredentialsSchema,
+  SnowflakePasswordCredentialsSchema,
+  SnowflakeKeyPairCredentialsSchema,
+]);
+
 export type SnowflakeCredentials = t.TypeOf<typeof SnowflakeCredentialsSchema>;
 
 export const CheckBigQueryCredentialsSchema = t.type({
@@ -319,7 +350,18 @@ export type ConnectionCredentials =
 export function isSnowflakeCredentials(
   credentials: ConnectionCredentials
 ): credentials is SnowflakeCredentials {
-  return "username" in credentials && "password" in credentials;
+  return (
+    "username" in credentials &&
+    "account" in credentials &&
+    "role" in credentials &&
+    "warehouse" in credentials &&
+    (("password" in credentials &&
+      (!("auth_type" in credentials) ||
+        credentials.auth_type === "password")) ||
+      ("auth_type" in credentials &&
+        credentials.auth_type === "keypair" &&
+        "private_key" in credentials))
+  );
 }
 
 export function isModjoCredentials(


### PR DESCRIPTION
## Description

Adds "keypair" as an alternative authentication method.

password-based auth is getting deprecated in the near future, and moving to keypair auth is a blocker for some customers.

## Tests

Extensive tests locally.

## Risk

Risk of breaking snowflake connection

## Deploy Plan

Deploy `oauth`, `connectors` and then `front`