### PR TITLE
[front] fix(MCP): fix `JSONSchema` comparison

### DIFF
--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -269,6 +269,7 @@ describe("JSON Schema Utilities", () => {
 
       for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
         const result = findMatchingSubSchemas(mainSchema, mimeType);
+        // It should not match any existing type.
         expect(Object.keys(result)).toStrictEqual([]);
       }
     });

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -255,5 +255,22 @@ describe("JSON Schema Utilities", () => {
       );
       expect(Object.keys(r)).toStrictEqual(["optionalTimeFrame"]);
     });
+
+    it("should handle arrays of any", () => {
+      // Schema we get with the zod schema z.object({ query: z.array(z.any()) }).
+      const mainSchema: JSONSchema = {
+        type: "object",
+        properties: {
+          query: {
+            type: "array",
+          },
+        },
+      };
+
+      for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
+        const result = findMatchingSubSchemas(mainSchema, mimeType);
+        expect(Object.keys(result)).toStrictEqual([]);
+      }
+    });
   });
 });

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -40,9 +40,12 @@ export function areSchemasEqual(
   // Checking for arrays with a single schema for all items.
   if (
     schemaA.type === "array" &&
-    isJSONSchemaObject(schemaA.items) &&
-    isJSONSchemaObject(schemaB.items) &&
-    !areSchemasEqual(schemaA.items, schemaB.items)
+    // If one is an object and not the other, then they are not equal.
+    (isJSONSchemaObject(schemaA.items) !== isJSONSchemaObject(schemaB.items) ||
+      // If both are objects, we compare the schemas recursively.
+      (isJSONSchemaObject(schemaA.items) &&
+        isJSONSchemaObject(schemaB.items) &&
+        !areSchemasEqual(schemaA.items, schemaB.items)))
   ) {
     return false;
   }


### PR DESCRIPTION
## Description

- Fix https://github.com/dust-tt/tasks/issues/3189.
- This PR fixes the `JSONSchema` comparison for detecting required configuration, which failed to compare `z.array(z.any())` due to the comparison not checking discrepancies in one array being `{ type: "array" }` with `items` `undefined`, and the other having an `items` field.

## Tests

- Tested locally, checked for regression on other types that rely on an array (`search`, `tables_query`).

## Risk

- Medium blast radius but well tested.

## Deploy Plan

- Deploy front.
