### PR TITLE
Add: slack mcp server

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -242,7 +242,7 @@ export function AgentMessage({
   })();
 
   const references = Object.entries(
-    agentMessageToRender?.citations ?? {}
+    agentMessageToRender.citations ?? {}
   ).reduce<Record<string, MarkdownCitation>>((acc, [key, citation]) => {
     if (citation) {
       const IconComponent = getCitationIcon(citation.provider, isDark);

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -22,6 +22,7 @@ import {
   HubspotLogo,
   NotionLogo,
   SalesforceLogo,
+  SlackLogo,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import type { ComponentProps } from "react";
@@ -54,6 +55,7 @@ export const InternalActionIcons = {
   SalesforceLogo,
   GmailLogo,
   GcalLogo,
+  SlackLogo,
 };
 
 export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -36,6 +36,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "think",
   "web_search_&_browse",
   "google_calendar",
+  "slack",
 ] as const;
 
 // Whether the server is available by default in the global space.
@@ -221,6 +222,23 @@ export const INTERNAL_MCP_SERVERS: Record<
       check_availability: "never_ask",
     },
   },
+  conversation_files: {
+    id: 17,
+    availability: "auto_hidden_builder",
+  },
+  slack: {
+    id: 18,
+    availability: "manual",
+    isRestricted: (plan, featureFlags) => {
+      return featureFlags.includes("slack_tool");
+    },
+    tools_stakes: {
+      search_messages: "never_ask",
+      list_users: "never_ask",
+      list_public_channels: "never_ask",
+      post_message: "low",
+    },
+  },
   search: {
     id: 1006,
     availability: "auto",
@@ -229,10 +247,6 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 1008,
     availability: "auto",
     timeoutMs: 5 * 60 * 1000, // 5 minutes
-  },
-  conversation_files: {
-    id: 17,
-    availability: "auto_hidden_builder",
   },
 
   primitive_types_debugger: {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -20,6 +20,7 @@ import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search/search";
+import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack";
 import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server_v2";
 import { default as thinkServer } from "@app/lib/actions/mcp_internal_actions/servers/think";
@@ -84,6 +85,8 @@ export async function getInternalMCPServer(
       return dataSourcesFileSystemServer(auth, agentLoopContext);
     case "conversation_files":
       return conversationFilesServer(auth, agentLoopContext);
+    case "slack":
+      return slackServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -1,0 +1,410 @@
+import type { SearchResultResourceType } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebClient } from "@slack/web-api";
+import type { Member } from "@slack/web-api/dist/response/UsersListResponse";
+import { z } from "zod";
+
+import { makeQueryResource } from "@app/lib/actions/mcp_internal_actions/servers/search/utils";
+import {
+  makeMCPToolJSONSuccess,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  actionRefsOffset,
+  SLACK_SEARCH_ACTION_NUM_RESULTS,
+} from "@app/lib/actions/utils";
+import { getRefs } from "@app/lib/api/assistant/citations";
+import config from "@app/lib/api/config";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { removeDiacritics } from "@app/lib/utils";
+import { parseTimeFrame, stripNullBytes, timeFrameFromNow } from "@app/types";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "slack",
+  version: "1.0.0",
+  description: "Slack tools for searching and posting messages.",
+  authorization: {
+    provider: "slack" as const,
+    supported_use_cases: ["personal_actions"] as const,
+    // Use a magic prefix to split the scopes into user and bot scopes which is a slack specific thing.
+    scope:
+      "user_scope:chat:write user_scope:search:read user_scope:users:read user_scope:channels:read" as const,
+  },
+  icon: "SlackLogo",
+  documentationUrl: "https://docs.dust.tt/docs/slack-tool-setup",
+};
+
+const getSlackClient = async (accessToken?: string) => {
+  if (!accessToken) {
+    throw new Error("No access token provided");
+  }
+
+  return new WebClient(accessToken, {
+    timeout: 10000,
+    rejectRateLimitedCalls: false,
+    retryConfig: {
+      retries: 1,
+      factor: 1,
+    },
+  });
+};
+
+const createServer = (
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
+  const server = new McpServer(serverInfo);
+
+  server.tool(
+    "search_messages",
+    "Search messages accross all channels and dms for the current user",
+    {
+      query: z
+        .string()
+        .describe(
+          "The string used to retrieve relevant messages using keyword based search" +
+            " based on the user request and conversation context. It can use the query modifiers from the Slack search syntax." +
+            " Shorter queries are generally better."
+        ),
+      channels: z
+        .string()
+        .array()
+        .optional()
+        .describe("Narrow the search to a specific channels names (optional)"),
+      usersFrom: z
+        .string()
+        .array()
+        .optional()
+        .describe(
+          "Narrow the search to messages wrote by specific users ids (optional)"
+        ),
+      usersTo: z
+        .string()
+        .array()
+        .optional()
+        .describe(
+          "Narrow the search to direct messages sent to specific users ids (optional)"
+        ),
+      usersMentioned: z
+        .string()
+        .array()
+        .optional()
+        .describe(
+          "Narrow the search to messages mentioning specific users ids (optional)"
+        ),
+      relativeTimeFrame: z
+        .string()
+        .regex(/^(all|\d+[hdwmy])$/)
+        .describe(
+          "The time frame (relative to LOCAL_TIME) to restrict the search based" +
+            " on the user request and past conversation context." +
+            " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
+            " where {k} is a number. Be strict, do not invent invalid values."
+        ),
+    },
+    async (
+      {
+        query,
+        usersFrom,
+        usersTo,
+        usersMentioned,
+        relativeTimeFrame,
+        channels,
+      },
+      { authInfo }
+    ) => {
+      const accessToken = authInfo?.token;
+      const slackClient = await getSlackClient(accessToken);
+
+      const timeFrame = parseTimeFrame(relativeTimeFrame);
+      const originalQuery = query;
+
+      if (timeFrame) {
+        const timestampInMs = timeFrameFromNow(timeFrame);
+        const date = new Date(timestampInMs);
+        query = `${query} after:${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
+      }
+
+      if (channels && channels.length > 0) {
+        query = `${query} ${channels
+          .map((channel) =>
+            channel.charAt(0) === "#" ? `in:${channel}` : `in:#${channel}`
+          )
+          .join(" ")}`;
+      }
+
+      if (usersFrom && usersFrom.length > 0) {
+        query = `${query} ${usersFrom.map((user) => `from:${user}`).join(" ")}`;
+      }
+
+      if (usersTo && usersTo.length > 0) {
+        query = `${query} ${usersTo.map((user) => `to:${user}`).join(" ")}`;
+      }
+
+      if (usersMentioned && usersMentioned.length > 0) {
+        query = `${query} ${usersMentioned.map((user) => `${user}`).join(" ")}`;
+      }
+
+      if (!agentLoopContext?.runContext) {
+        throw new Error("Unreachable: missing agentLoopRunContext.");
+      }
+
+      const refsOffset = actionRefsOffset({
+        agentConfiguration: agentLoopContext.runContext.agentConfiguration,
+        stepActionIndex: agentLoopContext.runContext.stepActionIndex,
+        stepActions: agentLoopContext.runContext.stepActions,
+        refsOffset: agentLoopContext.runContext.citationsRefsOffset,
+      });
+
+      const messages = await slackClient.search.messages({
+        query,
+        sort: "score",
+        sort_dir: "desc",
+        highlight: false,
+        count: SLACK_SEARCH_ACTION_NUM_RESULTS,
+        page: 1,
+      });
+
+      if (!messages.ok) {
+        return makeMCPToolTextError(
+          `Error searching messages: ${messages.error}`
+        );
+      }
+      const refs = getRefs().slice(
+        refsOffset,
+        refsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+      );
+
+      const results: SearchResultResourceType[] = (
+        messages.messages?.matches ?? []
+      )
+        .filter((match) => !!match.text)
+        .map((match) => {
+          return {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+            uri: match.permalink ?? "",
+            text: `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
+
+            id: match.ts ?? "",
+            source: {
+              provider: "slack",
+              name: "Slack",
+            },
+            tags: [],
+            ref: refs.shift() as string,
+            chunks: [stripNullBytes(match.text ?? "")],
+          };
+        });
+
+      return {
+        isError: false,
+        content: [
+          ...results.map((result) => ({
+            type: "resource" as const,
+            resource: result,
+          })),
+          {
+            type: "resource" as const,
+            resource: makeQueryResource(originalQuery, timeFrame),
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    "post_message",
+    "Post a message to a channel or a direct message",
+    {
+      to: z
+        .string()
+        .describe(
+          "The channel or user to post the message to. Accepted values are the channel name, the channel id or the user id. If you need to find the user id, you can use the `list_users` tool. " +
+            "Messages sent to a user will be sent as a direct message."
+        ),
+      message: z
+        .string()
+        .describe(
+          "The message to post. You can use slack-flavored markdown to format the message. " +
+            "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the id of the user you want to mention. " +
+            "If you want to reference a channel, you must use <#CHANNEL_ID> where CHANNEL_ID is the id of the channel you want to reference. " +
+            "NEVER use the channel name or the user name directly in a message as it will not be parsed correctly and appear as plain text."
+        ),
+      threadTs: z
+        .string()
+        .optional()
+        .describe(
+          "The thread ts of the message to reply to. If you need to find the thread ts, you can use the `search_messages` tool, the thread ts is the id of the message you want to reply to. If you don't provide a thread ts, the message will be posted as a top-level message."
+        ),
+    },
+    async ({ to, message, threadTs }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      const slackClient = await getSlackClient(accessToken);
+
+      const originalMessage = message;
+
+      if (!agentLoopContext?.runContext) {
+        throw new Error("Unreachable: missing agentLoopRunContext.");
+      }
+
+      const agentUrl = `${config.getClientFacingUrl()}/w/${auth.getNonNullableWorkspace().sId}/assistant/new?assistantDetails=${agentLoopContext.runContext.agentConfiguration.sId}`;
+      message = `${originalMessage}\n_Sent via <${agentUrl}|${agentLoopContext.runContext.agentConfiguration.name} Agent> on Dust_`;
+
+      const response = await slackClient.chat.postMessage({
+        channel: to,
+        text: message,
+        mrkdwn: true,
+        thread_ts: threadTs,
+      });
+
+      if (!response.ok) {
+        return makeMCPToolTextError(`Error posting message: ${response.error}`);
+      }
+
+      return makeMCPToolJSONSuccess({
+        message: `Message posted to ${to}`,
+        result: response,
+      });
+    }
+  );
+
+  server.tool(
+    "list_users",
+    "List all users in the workspace",
+    {
+      nameFilter: z
+        .string()
+        .optional()
+        .describe("The name of the user to filter by (optional)"),
+    },
+    async ({ nameFilter }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      const slackClient = await getSlackClient(accessToken);
+
+      const users: Member[] = [];
+
+      let cursor: string | undefined = undefined;
+      do {
+        const response = await slackClient.users.list({
+          cursor,
+          limit: 100,
+        });
+        if (!response.ok) {
+          return makeMCPToolTextError(`Error listing users: ${response.error}`);
+        }
+        users.push(...(response.members ?? []));
+        cursor = response.response_metadata?.next_cursor;
+
+        if (nameFilter) {
+          const normalizedNameFilter = removeDiacritics(
+            nameFilter.toLowerCase()
+          );
+          const filteredUsers = users.filter(
+            (user) =>
+              removeDiacritics(user.name?.toLowerCase() ?? "").includes(
+                normalizedNameFilter
+              ) ||
+              removeDiacritics(user.real_name?.toLowerCase() ?? "").includes(
+                normalizedNameFilter
+              )
+          );
+
+          // Early return if we found a user
+          if (filteredUsers.length > 0) {
+            return makeMCPToolJSONSuccess({
+              message: `The workspace has ${filteredUsers.length} users containing "${nameFilter}"`,
+              result: filteredUsers,
+            });
+          }
+        }
+      } while (cursor);
+
+      if (nameFilter) {
+        return makeMCPToolJSONSuccess({
+          message: `The workspace has ${users.length} users but none containing "${nameFilter}"`,
+          result: users,
+        });
+      }
+
+      return makeMCPToolJSONSuccess({
+        message: `The workspace has ${users.length} users`,
+        result: users,
+      });
+    }
+  );
+
+  server.tool(
+    "list_public_channels",
+    "List all public channels in the workspace",
+    {
+      nameFilter: z
+        .string()
+        .optional()
+        .describe("The name of the channel to filter by (optional)"),
+    },
+    async ({ nameFilter }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      const slackClient = await getSlackClient(accessToken);
+
+      const channels: any[] = [];
+
+      let cursor: string | undefined = undefined;
+      do {
+        const response = await slackClient.conversations.list({
+          cursor,
+          limit: 100,
+          types: "public_channel",
+        });
+        if (!response.ok) {
+          return makeMCPToolTextError(
+            `Error listing channels: ${response.error}`
+          );
+        }
+        channels.push(...(response.channels ?? []));
+        cursor = response.response_metadata?.next_cursor;
+
+        if (nameFilter) {
+          const normalizedNameFilter = removeDiacritics(
+            nameFilter.toLowerCase()
+          );
+          const filteredChannels = channels.filter(
+            (channel) =>
+              removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
+                normalizedNameFilter
+              ) ||
+              removeDiacritics(
+                channel.topic?.value?.toLowerCase() ?? ""
+              ).includes(normalizedNameFilter)
+          );
+
+          // Early return if we found a channel
+          if (filteredChannels.length > 0) {
+            return makeMCPToolJSONSuccess({
+              message: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"`,
+              result: filteredChannels,
+            });
+          }
+        }
+      } while (cursor);
+
+      if (nameFilter) {
+        return makeMCPToolJSONSuccess({
+          message: `The workspace has ${channels.length} channels but none containing "${nameFilter}"`,
+          result: channels,
+        });
+      }
+
+      return makeMCPToolJSONSuccess({
+        message: `The workspace has ${channels.length} channels`,
+        result: channels,
+      });
+    }
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -159,6 +159,15 @@ export function isMCPConfigurationForInternalWebsearch(
   );
 }
 
+export function isMCPConfigurationForInternalSlack(
+  arg: AgentActionConfigurationType
+): arg is ServerSideMCPServerConfigurationType {
+  return (
+    isServerSideMCPServerConfiguration(arg) &&
+    isInternalMCPServerOfName(arg.internalMCPServerId, "slack")
+  );
+}
+
 export function isMCPConfigurationForDustAppRun(
   arg: AgentActionConfigurationType
 ): arg is ServerSideMCPServerConfigurationType {
@@ -217,6 +226,15 @@ export function isMCPInternalWebsearch(
   return (
     isServerSideMCPToolConfiguration(arg) &&
     isInternalMCPServerOfName(arg.internalMCPServerId, "web_search_&_browse")
+  );
+}
+
+export function isMCPInternalSlack(
+  arg: ActionConfigurationType
+): arg is ServerSideMCPToolConfigurationType {
+  return (
+    isServerSideMCPToolConfiguration(arg) &&
+    isInternalMCPServerOfName(arg.internalMCPServerId, "slack")
   );
 }
 

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -16,15 +16,14 @@ import type {
 } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
-import { isInternalMCPServerOfName } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
 import {
   isMCPInternalDataSourceFileSystem,
   isMCPInternalInclude,
   isMCPInternalSearch,
+  isMCPInternalSlack,
   isMCPInternalWebsearch,
   isRetrievalConfiguration,
-  isServerSideMCPToolConfiguration,
   isWebsearchConfiguration,
 } from "@app/lib/actions/types/guards";
 import type { WebsearchConfigurationType } from "@app/lib/actions/websearch";
@@ -34,6 +33,7 @@ import type { AgentConfigurationType, AgentMessageType } from "@app/types";
 import { assertNever } from "@app/types";
 
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
+export const SLACK_SEARCH_ACTION_NUM_RESULTS = 16;
 
 export const ACTION_SPECIFICATIONS: Record<
   AssistantBuilderActionConfiguration["type"],
@@ -247,16 +247,13 @@ export function getCitationsCount({
     case "reasoning_configuration":
       return 0;
     case "mcp_configuration":
-      if (
-        isServerSideMCPToolConfiguration(action) &&
-        isInternalMCPServerOfName(
-          action.internalMCPServerId,
-          "web_search_&_browse"
-        )
-      ) {
+      if (isMCPInternalWebsearch(action)) {
         return getWebsearchNumResults({
           stepActions,
         });
+      }
+      if (isMCPInternalSlack(action)) {
+        return SLACK_SEARCH_ACTION_NUM_RESULTS;
       }
       return getRetrievalTopK({
         agentConfiguration,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -2,6 +2,7 @@ import moment from "moment-timezone";
 
 import type { ServerToolsAndInstructions } from "@app/lib/actions/mcp_actions";
 import {
+  isMCPConfigurationForInternalSlack,
   isMCPConfigurationForInternalWebsearch,
   isMCPConfigurationWithDataSource,
   isWebsearchConfiguration,
@@ -127,7 +128,8 @@ export async function constructPromptMultiActions(
       isRetrievalConfiguration(action) ||
       isWebsearchConfiguration(action) ||
       isMCPConfigurationWithDataSource(action) ||
-      isMCPConfigurationForInternalWebsearch(action)
+      isMCPConfigurationForInternalWebsearch(action) ||
+      isMCPConfigurationForInternalSlack(action)
   );
 
   if (canRetrieveDocuments) {

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -12,11 +12,13 @@ import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
   setupUri({
     connection,
+    extraConfig,
   }: {
     connection: OAuthConnectionType;
     useCase: OAuthUseCase;
+    extraConfig?: ExtraConfigType;
   }) {
-    const scopes = [
+    const default_scopes = [
       "app_mentions:read",
       "channels:history",
       "channels:join",
@@ -34,10 +36,37 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       "mpim:history",
       "files:read",
     ];
+
+    let user_scopes: string[] = [];
+    let bot_scopes: string[] = [...default_scopes];
+
+    if (extraConfig?.scope) {
+      const scopes_raw = extraConfig.scope.split(" ");
+
+      // it's a bit of hack here to split the scopes into user and bot scopes which is a slack specific thing.
+      user_scopes = scopes_raw
+        .filter((scope) => scope.startsWith("user_scope:"))
+        .map((scope) => scope.replace("user_scope:", ""));
+
+      bot_scopes = scopes_raw.filter(
+        (scope) => !scope.startsWith("user_scope")
+      );
+
+      if (user_scopes.length !== 0 && bot_scopes.length !== 0) {
+        // To simplify the implementation, we don't support both user and bot scopes at the same time.
+        throw new Error("User and bot scopes cannot be set at the same time.");
+      }
+    }
+
     return (
       `https://slack.com/oauth/v2/authorize?` +
       `client_id=${config.getOAuthSlackClientId()}` +
-      `&scope=${encodeURIComponent(scopes.join(" "))}` +
+      (bot_scopes.length > 0
+        ? `&scope=${encodeURIComponent(bot_scopes.join(" "))}`
+        : "") +
+      (user_scopes.length > 0
+        ? `&user_scope=${encodeURIComponent(user_scopes.join(" "))}`
+        : "") +
       `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("slack"))}` +
       `&state=${connection.connection_id}`
     );
@@ -51,7 +80,10 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
     return getStringFromQuery(query, "state");
   }
 
-  isExtraConfigValid(extraConfig: ExtraConfigType) {
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions" || useCase === "platform_actions") {
+      return "scope" in extraConfig;
+    }
     return Object.keys(extraConfig).length === 0;
   }
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -25,6 +25,7 @@
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-visually-hidden": "^1.1.2",
         "@sendgrid/mail": "^8.0.0",
+        "@slack/web-api": "^6.13.0",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/forms": "^0.5.3",
         "@tanstack/react-table": "^8.13.0",
@@ -7975,6 +7976,77 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=12.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
+      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.13.0.tgz",
+      "integrity": "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.11.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^1.7.4",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/form-data": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.4.13",
       "hasInstallScript": true,
@@ -9265,6 +9337,15 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
+    "node_modules/@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -9512,6 +9593,12 @@
       "engines": {
         "node": ">= 0.12"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@types/sanitize-html": {
       "version": "2.11.0",
@@ -14661,6 +14748,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -17780,6 +17873,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -21347,6 +21446,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -21391,6 +21499,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {

--- a/front/package.json
+++ b/front/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-visually-hidden": "^1.1.2",
     "@sendgrid/mail": "^8.0.0",
+    "@slack/web-api": "^6.13.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.3",
     "@tanstack/react-table": "^8.13.0",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -34,6 +34,7 @@ export const WHITELISTABLE_FEATURES = [
   "salesforce_tool",
   "search_knowledge_builder",
   "show_debug_tools",
+  "slack_tool",
   "snowflake_connector_feature",
   "usage_data_api",
   "workos_user_provisioning",

--- a/sdks/js/src/mcp_icon_types.ts
+++ b/sdks/js/src/mcp_icon_types.ts
@@ -22,6 +22,7 @@ export const MCPInternalActionIconSchema = z.enum([
   "SalesforceLogo",
   "GmailLogo",
   "GcalLogo",
+  "SlackLogo",
 ]);
 
 export const MCPExternalActionIconSchema = z.enum([

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -838,6 +838,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "search_knowledge_builder"
   | "show_debug_tools"
+  | "slack_tool"
   | "snowflake_connector_feature"
   | "usage_data_api"
   | "workos_user_provisioning"


### PR DESCRIPTION
## Description

Add slack internal mcp server using personal credentials with 4 tools:
- search messages
- list channels
- list users
- post message

I updated the front side oauth provider to handle "user scope" and dynamically setting the scopes.
I updated the oauth service slack provider to handle the user token (if any) otherwise fallback to the normal oauth token.
I added the slack web client to package.json.

## Tests

Locally

<img width="914" alt="image" src="https://github.com/user-attachments/assets/e88c9182-9c4b-4455-b307-68da49116264" />
<img width="881" alt="image" src="https://github.com/user-attachments/assets/51c08516-626d-4057-98a1-b919560ef344" />
<img width="869" alt="image" src="https://github.com/user-attachments/assets/87c7fcf8-1cfd-4feb-adad-f85e7eb22a6d" />
<img width="225" alt="image" src="https://github.com/user-attachments/assets/72c8a2f2-9939-49e0-8ddd-a083db97a6ab" />
<img width="873" alt="image" src="https://github.com/user-attachments/assets/9dc70d29-b398-4374-9872-5cdbce13569d" />
<img width="742" alt="image" src="https://github.com/user-attachments/assets/7a35cf58-a493-4b38-9791-415d3550313c" />


## Risk

Low, behind a FF

## Deploy Plan

Deploy oauth, deploy front
