### PR TITLE
[Slackstorm] Admin: Slack bot integration + reorganize menu structure

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,4 +1,5 @@
 import {
+  BarChartIcon,
   BookOpenIcon,
   BracesIcon,
   ChatBubbleLeftRightIcon,
@@ -48,6 +49,7 @@ export type SubNavigationAdminId =
   | "providers"
   | "api_keys"
   | "dev_secrets"
+  | "analytics"
   | "actions";
 
 export type SubNavigationAppId =
@@ -179,12 +181,12 @@ export const subNavigationAdmin = ({
   if (isAdmin(owner)) {
     nav.push({
       id: "workspace",
-      label: "Workspace Settings",
+      label: "Workspace Management",
       variant: "primary",
       menus: [
         {
           id: "members",
-          label: "Domain & Members",
+          label: "People & Security",
           icon: UserIcon,
           href: `/w/${owner.sId}/members`,
           current: current === "members",
@@ -193,7 +195,7 @@ export const subNavigationAdmin = ({
         },
         {
           id: "workspace",
-          label: "Workspace",
+          label: "Workspace Settings",
           icon: CompanyIcon,
           href: `/w/${owner.sId}/workspace`,
           current: current === "workspace",
@@ -201,20 +203,20 @@ export const subNavigationAdmin = ({
           subMenu: current === "workspace" ? subMenu : undefined,
         },
         {
-          id: "subscription",
-          label: "Subscription",
-          icon: ShapesIcon,
-          href: `/w/${owner.sId}/subscription`,
-          current: current === "subscription",
-          subMenuLabel: current === "subscription" ? subMenuLabel : undefined,
-          subMenu: current === "subscription" ? subMenu : undefined,
+          id: "analytics",
+          label: "Analytics",
+          icon: BarChartIcon,
+          href: `/w/${owner.sId}/analytics`,
+          current: current === "analytics",
+          subMenuLabel: current === "analytics" ? subMenuLabel : undefined,
+          subMenu: current === "analytics" ? subMenu : undefined,
         },
       ],
     });
 
     nav.push({
       id: "developers",
-      label: "Developers",
+      label: "Builder Tools Management",
       variant: "primary",
       menus: [
         {

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -5,10 +5,10 @@ import {
   ChatBubbleLeftRightIcon,
   Cog6ToothIcon,
   CommandLineIcon,
-  CompanyIcon,
   DocumentTextIcon,
   FolderOpenIcon,
   LockIcon,
+  PlanetIcon,
   ShapesIcon,
   UserIcon,
 } from "@dust-tt/sparkle";
@@ -197,7 +197,7 @@ export const subNavigationAdmin = ({
         {
           id: "workspace",
           label: "Workspace Settings",
-          icon: CompanyIcon,
+          icon: PlanetIcon,
           href: `/w/${owner.sId}/workspace`,
           current: current === "workspace",
           subMenuLabel: current === "workspace" ? subMenuLabel : undefined,

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -212,6 +212,15 @@ export const subNavigationAdmin = ({
           subMenuLabel: current === "analytics" ? subMenuLabel : undefined,
           subMenu: current === "analytics" ? subMenu : undefined,
         },
+        {
+          id: "subscription",
+          label: "Subscription",
+          icon: ShapesIcon,
+          href: `/w/${owner.sId}/subscription`,
+          current: current === "subscription",
+          subMenuLabel: current === "subscription" ? subMenuLabel : undefined,
+          subMenu: current === "subscription" ? subMenu : undefined,
+        },
       ],
     });
 

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -149,6 +149,7 @@ export const getTopNavigationTabs = (
           "/w/[wId]/members",
           "/w/[wId]/workspace",
           "/w/[wId]/subscription",
+          "/w/[wId]/analytics",
           "/w/[wId]/actions",
           "/w/[wId]/developers/providers",
           "/w/[wId]/developers/api-keys",

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -96,7 +96,8 @@ export function EditSpaceManagedDataSourcesViews({
         (dsv) =>
           isManaged(dsv.dataSource) &&
           (!dataSourceView ||
-            dsv.dataSource.sId === dataSourceView.dataSource.sId)
+            dsv.dataSource.sId === dataSourceView.dataSource.sId) &&
+          dsv.dataSource.connectorProvider !== "slack_bot"
       ),
     [systemSpaceDataSourceViews, dataSourceView]
   );

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -311,62 +311,67 @@ export const SpaceResourcesList = ({
       return [];
     }
 
-    return spaceDataSourceViews.map((dataSourceView) => {
-      const provider = dataSourceView.dataSource.connectorProvider;
+    return spaceDataSourceViews
+      .filter(
+        (dataSourceView) =>
+          dataSourceView.dataSource.connectorProvider !== "slack_bot"
+      )
+      .map((dataSourceView) => {
+        const provider = dataSourceView.dataSource.connectorProvider;
 
-      const menuItems: MenuItem[] = [];
-      if (isWebsiteOrFolder && canWriteInSpace) {
-        menuItems.push({
-          label: "Edit",
-          kind: "item",
-          icon: PencilSquareIcon,
-          onClick: (e) => {
-            e.stopPropagation();
-            setSelectedDataSourceView(dataSourceView);
-            setShowFolderOrWebsiteModal(true);
-          },
-        });
-        if (isFolder) {
+        const menuItems: MenuItem[] = [];
+        if (isWebsiteOrFolder && canWriteInSpace) {
           menuItems.push({
-            label: "Use from API",
+            label: "Edit",
             kind: "item",
-            icon: CubeIcon,
+            icon: PencilSquareIcon,
             onClick: (e) => {
               e.stopPropagation();
               setSelectedDataSourceView(dataSourceView);
-              setShowViewFolderAPIModal(true);
+              setShowFolderOrWebsiteModal(true);
+            },
+          });
+          if (isFolder) {
+            menuItems.push({
+              label: "Use from API",
+              kind: "item",
+              icon: CubeIcon,
+              onClick: (e) => {
+                e.stopPropagation();
+                setSelectedDataSourceView(dataSourceView);
+                setShowViewFolderAPIModal(true);
+              },
+            });
+          }
+          menuItems.push({
+            label: "Delete",
+            icon: TrashIcon,
+            kind: "item",
+            variant: "warning",
+            onClick: (e) => {
+              e.stopPropagation();
+              setSelectedDataSourceView(dataSourceView);
+              setShowDeleteConfirmDialog(true);
             },
           });
         }
-        menuItems.push({
-          label: "Delete",
-          icon: TrashIcon,
-          kind: "item",
-          variant: "warning",
-          onClick: (e) => {
+
+        return {
+          dataSourceView,
+          label: getDataSourceNameFromView(dataSourceView),
+          icon: getConnectorProviderLogoWithFallback({ provider, isDark }),
+          workspaceId: owner.sId,
+          isAdmin,
+          isLoading: provider ? isLoadingByProvider[provider] : false,
+          menuItems,
+          buttonOnClick: (e) => {
             e.stopPropagation();
             setSelectedDataSourceView(dataSourceView);
-            setShowDeleteConfirmDialog(true);
+            setShowConnectorPermissionsModal(true);
           },
-        });
-      }
-
-      return {
-        dataSourceView,
-        label: getDataSourceNameFromView(dataSourceView),
-        icon: getConnectorProviderLogoWithFallback({ provider, isDark }),
-        workspaceId: owner.sId,
-        isAdmin,
-        isLoading: provider ? isLoadingByProvider[provider] : false,
-        menuItems,
-        buttonOnClick: (e) => {
-          e.stopPropagation();
-          setSelectedDataSourceView(dataSourceView);
-          setShowConnectorPermissionsModal(true);
-        },
-        onClick: () => onSelect(dataSourceView.sId),
-      };
-    });
+          onClick: () => onSelect(dataSourceView.sId),
+        };
+      });
   }, [
     spaceDataSourceViews,
     owner.sId,

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Cog6ToothIcon,
   ContextItem,
   DropdownMenu,
   DropdownMenuContent,
@@ -149,7 +150,7 @@ export function ProviderManagementModal({
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <Button variant="primary" label="Manage Models" className="grow-0" />
+        <Button variant="outline" label="Manage Models" icon={Cog6ToothIcon} />
       </SheetTrigger>
       <SheetContent size="lg">
         <SheetHeader hideButton>

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -149,7 +149,7 @@ export function ProviderManagementModal({
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <Button variant="primary" label="Manage providers" className="grow-0" />
+        <Button variant="primary" label="Manage Models" className="grow-0" />
       </SheetTrigger>
       <SheetContent size="lg">
         <SheetHeader hideButton>

--- a/front/lib/api/oauth/providers/slack_bot.ts
+++ b/front/lib/api/oauth/providers/slack_bot.ts
@@ -33,6 +33,7 @@ export class SlackBotOAuthProvider implements BaseOAuthStrategyProvider {
       "team:read",
       "im:read",
       "users:read",
+      "users:read.email",
     ];
     return (
       `https://slack.com/oauth/v2/authorize?` +

--- a/front/lib/api/oauth/providers/slack_bot.ts
+++ b/front/lib/api/oauth/providers/slack_bot.ts
@@ -32,6 +32,7 @@ export class SlackBotOAuthProvider implements BaseOAuthStrategyProvider {
       "mpim:read",
       "team:read",
       "im:read",
+      "users:read",
     ];
     return (
       `https://slack.com/oauth/v2/authorize?` +

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -90,17 +90,17 @@ export function useConnectorConfig({
   owner,
 }: {
   configKey: string;
-  dataSource: DataSourceType;
+  dataSource: DataSourceType | null;
   disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
   const configFetcher: Fetcher<GetOrPostManagedDataSourceConfigResponseBody> =
     fetcher;
 
-  const url = `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`;
+  const url = `/api/w/${owner.sId}/data_sources/${dataSource?.sId}/managed/config/${configKey}`;
 
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
-    disabled,
+    disabled: disabled || !!dataSource,
   });
 
   return {
@@ -160,7 +160,7 @@ export function useToggleSlackChatBot({
   dataSource,
   owner,
 }: {
-  dataSource: DataSourceType;
+  dataSource: DataSourceType | null;
   owner: LightWorkspaceType;
 }) {
   const sendNotification = useSendNotification();
@@ -171,6 +171,16 @@ export function useToggleSlackChatBot({
     configKey: "botEnabled",
     disabled: true, // Needed just to mutate
   });
+
+  if (!dataSource) {
+    return () => {
+      sendNotification({
+        type: "error",
+        title: "Failed to Enable Slack Bot",
+        description: "Tried to enable Slack Bot, but no data source was found.",
+      });
+    };
+  }
 
   const doToggle = async (botEnabled: boolean) => {
     const res = await fetch(

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -100,7 +100,7 @@ export function useConnectorConfig({
   const url = `/api/w/${owner.sId}/data_sources/${dataSource?.sId}/managed/config/${configKey}`;
 
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
-    disabled: disabled || !!dataSource,
+    disabled: disabled || !dataSource,
   });
 
   return {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -295,7 +295,7 @@ const handleDataSourceWithProvider = async ({
   let dataSourceDescription = getDefaultDataSourceDescription(provider, suffix);
 
   let { configuration } = body;
-  if (provider === "slack") {
+  if (provider === "slack" || provider === "slack_bot") {
     configuration = {
       botEnabled: true,
       whitelistedDomains: undefined,

--- a/front/pages/w/[wId]/analytics/index.tsx
+++ b/front/pages/w/[wId]/analytics/index.tsx
@@ -1,0 +1,169 @@
+import { BarChartIcon, Page } from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import { useState } from "react";
+
+import { subNavigationAdmin } from "@app/components/navigation/config";
+import AppContentLayout from "@app/components/sparkle/AppContentLayout";
+import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { ActivityReport } from "@app/components/workspace/ActivityReport";
+import { QuickInsights } from "@app/components/workspace/Analytics";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
+import type { SubscriptionType, WorkspaceType } from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  const subscription = auth.subscription();
+  if (!owner || !auth.isAdmin() || !subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+      subscription,
+    },
+  };
+});
+
+export default function Analytics({
+  owner,
+  subscription,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [isDownloadingData, setIsDownloadingData] = useState(false);
+
+  const { subscriptions } = useWorkspaceSubscriptions({
+    owner,
+  });
+
+  const handleDownload = async (selectedMonth: string | null) => {
+    if (!selectedMonth) {
+      return;
+    }
+
+    const queryString = `mode=month&start=${selectedMonth}&table=all`;
+
+    setIsDownloadingData(true);
+    try {
+      const response = await fetch(
+        `/api/w/${owner.sId}/workspace-usage?${queryString}`
+      );
+
+      if (!response.ok) {
+        throw new Error(`Error: ${response.status}`);
+      }
+
+      const contentType = response.headers.get("Content-Type");
+      const isZip = contentType === "application/zip";
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+
+      const [year, month] = selectedMonth.split("-");
+
+      const getMonthName = (monthIndex: number) => {
+        const months = [
+          "jan",
+          "feb",
+          "mar",
+          "apr",
+          "may",
+          "jun",
+          "jul",
+          "aug",
+          "sep",
+          "oct",
+          "nov",
+          "dec",
+        ];
+        return months[monthIndex - 1];
+      };
+
+      const monthName = getMonthName(Number(month));
+
+      const fileExtension = isZip ? "zip" : "csv";
+      const filename = `dust_${owner.name}_activity_${year}_${monthName}.${fileExtension}`;
+
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", filename);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (error) {
+      alert("Failed to download activity data.");
+    } finally {
+      setIsDownloadingData(false);
+    }
+  };
+
+  const monthOptions: string[] = [];
+
+  if (subscriptions.length > 0) {
+    const oldestStartDate = subscriptions.reduce(
+      (oldest, current) => {
+        if (!current.startDate) {
+          return oldest;
+        }
+        if (!oldest) {
+          return new Date(current.startDate);
+        }
+        return new Date(current.startDate) < oldest
+          ? new Date(current.startDate)
+          : oldest;
+      },
+      null as Date | null
+    );
+
+    if (oldestStartDate) {
+      const startDateYear = oldestStartDate.getFullYear();
+      const startDateMonth = oldestStartDate.getMonth();
+
+      const currentYear = new Date().getFullYear();
+      const currentMonth = new Date().getMonth();
+
+      for (let year = currentYear; year >= startDateYear; year--) {
+        const startMonth = year === startDateYear ? startDateMonth : 0;
+        const endMonth = year === currentYear ? currentMonth : 11;
+        for (let month = endMonth; month >= startMonth; month--) {
+          monthOptions.push(`${year}-${String(month + 1).padStart(2, "0")}`);
+        }
+      }
+    }
+  }
+
+  return (
+    <>
+      <AppContentLayout
+        subscription={subscription}
+        owner={owner}
+        subNavigation={subNavigationAdmin({ owner, current: "analytics" })}
+      >
+        <Page.Vertical align="stretch" gap="xl">
+          <Page.Header
+            title="Analytics"
+            icon={BarChartIcon}
+            description="Monitor workspace activity and usage"
+          />
+          <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
+            <QuickInsights owner={owner} />
+            <ActivityReport
+              isDownloading={isDownloadingData}
+              monthOptions={monthOptions}
+              handleDownload={handleDownload}
+            />
+          </div>
+        </Page.Vertical>
+      </AppContentLayout>
+    </>
+  );
+}
+
+Analytics.getLayout = (page: React.ReactElement) => {
+  return <AppRootLayout>{page}</AppRootLayout>;
+};

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -203,9 +203,11 @@ export default function WorkspaceAdmin({
     if (slackBotDataSource) {
       await toggleSlackBotOnExistingDataSource(!isSlackBotEnabled);
     } else {
-      const dataSource = await createSlackBotConnectionAndDataSource();
-      if (dataSource) {
-        await toggleSlackBotOnExistingDataSource(true);
+      const createRes = await createSlackBotConnectionAndDataSource();
+      if (createRes) {
+        // No need to toggle since default config already enabled the bot.
+        // await toggleSlackBotOnExistingDataSource(true);
+        // TODO: likely better to still make the call (but tricky since data source is not yet created).
         window.location.reload();
       } else {
         sendNotification({

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -2,8 +2,10 @@ import {
   Avatar,
   Button,
   CompanyIcon,
+  Dialog,
   Input,
   Page,
+  PencilSquareIcon,
   SliderToggle,
 } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
@@ -47,6 +49,7 @@ export default function WorkspaceAdmin({
   const [workspaceNameError, setWorkspaceNameError] = useState<string>("");
 
   const [slackBotEnabled, setSlackBotEnabled] = useState(false);
+  const [showEditWorkspaceNameModal, setShowEditWorkspaceNameModal] = useState(false);
 
   const formValidation = useCallback(() => {
     if (workspaceName === owner.name) {
@@ -96,6 +99,34 @@ export default function WorkspaceAdmin({
 
   return (
     <>
+      <Dialog
+        isOpen={showEditWorkspaceNameModal}
+        onClose={() => {
+          setShowEditWorkspaceNameModal(false);
+          setWorkspaceName(owner.name);
+          setWorkspaceNameError("");
+        }}
+        title="Edit Workspace Name"
+        onValidate={async () => {
+          await handleUpdateWorkspace();
+          setShowEditWorkspaceNameModal(false);
+        }}
+        validateLabel="Save"
+        isValidating={updating}
+        disabled={disable}
+      >
+        <div className="flex flex-col gap-4">
+          <Page.P>Think GitHub repository names, short and memorable.</Page.P>
+          <Input
+            name="name"
+            placeholder="Workspace name"
+            value={workspaceName}
+            onChange={(e) => setWorkspaceName(e.target.value)}
+            message={workspaceNameError}
+            messageStatus="error"
+          />
+        </div>
+      </Dialog>
       <AppContentLayout
         subscription={subscription}
         owner={owner}
@@ -104,34 +135,29 @@ export default function WorkspaceAdmin({
         <Page.Vertical align="stretch" gap="xl">
           <Page.Header title="Workspace Settings" icon={CompanyIcon} />
           <Page.Vertical align="stretch" gap="md">
-            <Page.H variant="h4">Workspace Name</Page.H>
-            <Page.P variant="secondary">{owner.name}</Page.P>
-            <div className="flex flex-row gap-2">
-              <Input
-                name="name"
-                placeholder="Workspace name"
-                value={workspaceName}
-                onChange={(e) => setWorkspaceName(e.target.value)}
-                message={workspaceNameError}
-                messageStatus="error"
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <Page.H variant="h4">Workspace Name</Page.H>
+                <Page.P variant="secondary" className="mt-1">
+                  {owner.name}
+                </Page.P>
+              </div>
+              <Button
+                variant="secondary"
+                label="Edit"
+                icon={PencilSquareIcon}
+                onClick={() => setShowEditWorkspaceNameModal(true)}
               />
-              {!disable && (
-                <Button
-                  variant="primary"
-                  disabled={disable || updating}
-                  onClick={handleUpdateWorkspace}
-                  label={updating ? "Saving..." : "Save"}
-                  className="grow-0"
-                />
-              )}
             </div>
           </Page.Vertical>
           <Page.Vertical align="stretch" gap="md">
-            <Page.H variant="h4">Model Selection</Page.H>
-            <Page.P variant="secondary">
-              Select the models you want available to your workspace.
-            </Page.P>
-            <div>
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <Page.H variant="h4">Model Selection</Page.H>
+                <Page.P variant="secondary" className="mt-1">
+                  Select the models you want available to your workspace.
+                </Page.P>
+              </div>
               <ProviderManagementModal owner={owner} />
             </div>
           </Page.Vertical>
@@ -160,16 +186,16 @@ export default function WorkspaceAdmin({
           </Page.Vertical>
           <Page.Vertical align="stretch" gap="md">
             <Page.H variant="h4">Subscriptions</Page.H>
-            <div className="flex items-center justify-between">
+            <div className="space-y-6">
               <div>
                 <Page.H variant="h6">Your plan</Page.H>
-                <div className="flex items-center gap-2">
-                  <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-900">
+                <div className="mt-2 flex items-center gap-2">
+                  <span className="rounded-md bg-blue-100 px-3 py-1 text-sm font-medium text-blue-900">
                     {subscription.plan.name}
                   </span>
                   <Button
                     variant="tertiary"
-                    label="..."
+                    label="•••"
                     size="xs"
                     onClick={() => {}}
                   />
@@ -177,18 +203,14 @@ export default function WorkspaceAdmin({
               </div>
               <div>
                 <Page.H variant="h6">Payment, invoicing & billing</Page.H>
-                <Page.P variant="secondary">
-                  Estimated monthly billing: $
-                  {subscription.plan.limits.users.maxUsers
-                    ? subscription.plan.limits.users.maxUsers * 29
-                    : 0}{" "}
-                  ({subscription.plan.limits.users.maxUsers || 0} members, $29
-                  per member)
+                <Page.P variant="secondary" className="mt-1">
+                  Estimated monthly billing: ${subscription.plan.limits.users.maxUsers ? subscription.plan.limits.users.maxUsers * 29 : 0} ({subscription.plan.limits.users.maxUsers || 0} members, $29 per member)
                 </Page.P>
                 <Button
                   variant="secondary"
                   label="Dust's dashboard on Stripe"
                   icon={CompanyIcon}
+                  className="mt-3"
                   onClick={() =>
                     window.open(`/w/${owner.sId}/subscription/manage`, "_blank")
                   }

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -14,8 +14,8 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
-  SliderToggle,
   SlackLogo,
+  SliderToggle,
 } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import { useCallback, useEffect, useState } from "react";
@@ -26,7 +26,7 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { ProviderManagementModal } from "@app/components/workspace/ProviderManagementModal";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { useWorkspaceActiveUsers } from "@app/lib/swr/workspaces";
+import { useMembersCount } from "@app/lib/swr/memberships";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
@@ -62,8 +62,7 @@ export default function WorkspaceAdmin({
   const [slackBotEnabled, setSlackBotEnabled] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
-  const { activeUsers } = useWorkspaceActiveUsers({ workspaceId: owner.sId });
-  const workspaceSeats = activeUsers ? activeUsers.length : 0;
+  const workspaceSeats = useMembersCount(owner);
 
   const formValidation = useCallback(() => {
     if (workspaceName === owner.name) {

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -2,6 +2,7 @@ import {
   Avatar,
   Button,
   CompanyIcon,
+  PlanetIcon,
   Dialog,
   Input,
   Page,
@@ -49,7 +50,8 @@ export default function WorkspaceAdmin({
   const [workspaceNameError, setWorkspaceNameError] = useState<string>("");
 
   const [slackBotEnabled, setSlackBotEnabled] = useState(false);
-  const [showEditWorkspaceNameModal, setShowEditWorkspaceNameModal] = useState(false);
+  const [showEditWorkspaceNameModal, setShowEditWorkspaceNameModal] =
+    useState(false);
 
   const formValidation = useCallback(() => {
     if (workspaceName === owner.name) {
@@ -133,14 +135,12 @@ export default function WorkspaceAdmin({
         subNavigation={subNavigationAdmin({ owner, current: "workspace" })}
       >
         <Page.Vertical align="stretch" gap="xl">
-          <Page.Header title="Workspace Settings" icon={CompanyIcon} />
+          <Page.Header title="Workspace Settings" icon={PlanetIcon} />
           <Page.Vertical align="stretch" gap="md">
             <div className="flex items-center justify-between">
               <div className="flex-1">
                 <Page.H variant="h4">Workspace Name</Page.H>
-                <Page.P variant="secondary" className="mt-1">
-                  {owner.name}
-                </Page.P>
+                <Page.P variant="secondary">{owner.name}</Page.P>
               </div>
               <Button
                 variant="secondary"
@@ -154,7 +154,7 @@ export default function WorkspaceAdmin({
             <div className="flex items-center justify-between">
               <div className="flex-1">
                 <Page.H variant="h4">Model Selection</Page.H>
-                <Page.P variant="secondary" className="mt-1">
+                <Page.P variant="secondary">
                   Select the models you want available to your workspace.
                 </Page.P>
               </div>
@@ -203,8 +203,13 @@ export default function WorkspaceAdmin({
               </div>
               <div>
                 <Page.H variant="h6">Payment, invoicing & billing</Page.H>
-                <Page.P variant="secondary" className="mt-1">
-                  Estimated monthly billing: ${subscription.plan.limits.users.maxUsers ? subscription.plan.limits.users.maxUsers * 29 : 0} ({subscription.plan.limits.users.maxUsers || 0} members, $29 per member)
+                <Page.P variant="secondary">
+                  Estimated monthly billing: $
+                  {subscription.plan.limits.users.maxUsers
+                    ? subscription.plan.limits.users.maxUsers * 29
+                    : 0}{" "}
+                  ({subscription.plan.limits.users.maxUsers || 0} members, $29
+                  per member)
                 </Page.P>
                 <Button
                   variant="secondary"

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -129,7 +129,7 @@ export default function WorkspaceAdmin({
               <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
                 <SheetTrigger asChild>
                   <Button
-                    variant="secondary"
+                    variant="outline"
                     label="Edit"
                     icon={PencilSquareIcon}
                   />

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -208,7 +208,6 @@ export default function WorkspaceAdmin({
           </Page.Vertical>
           <Page.Vertical align="stretch" gap="md">
             <Page.H variant="h4">Integrations</Page.H>
-            <div className="h-full border-b border-border dark:border-border-night" />
             <SlackBotToggle
               owner={owner}
               slackBotDataSource={slackBotDataSource}
@@ -306,6 +305,7 @@ function SlackBotToggle({
 
   return (
     <ContextItem.List>
+      <div className="h-full border-b border-border dark:border-border-night" />
       <ContextItem
         title="Slack Bot"
         subElement="Use Dust Agents in Slack with the Dust Slack app"

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -46,7 +46,7 @@ import {
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
-  slackBotDataSource: DataSourceResource | null;
+  slackBotDataSource: DataSourceType | null;
   systemSpace: SpaceType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -67,7 +67,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      slackBotDataSource,
+      slackBotDataSource: slackBotDataSource?.toJSON() ?? null,
       systemSpace: systemSpace.toJSON(),
     },
   };
@@ -88,7 +88,7 @@ export default function WorkspaceAdmin({
   const [isChangingSlackBot, setIsChangingSlackBot] = useState(false);
 
   const toggleSlackBotOnExistingDataSource = useToggleSlackChatBot({
-    dataSource: slackBotDataSource?.toJSON() ?? null,
+    dataSource: slackBotDataSource ?? null,
     owner,
   });
 
@@ -119,7 +119,7 @@ export default function WorkspaceAdmin({
 
   const { configValue } = useConnectorConfig({
     configKey: "botEnabled",
-    dataSource: slackBotDataSource?.toJSON() ?? null,
+    dataSource: slackBotDataSource ?? null,
     owner,
   });
 

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -3,10 +3,16 @@ import {
   Button,
   CompanyIcon,
   PlanetIcon,
-  Dialog,
   Input,
   Page,
   PencilSquareIcon,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
   SliderToggle,
 } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
@@ -50,8 +56,7 @@ export default function WorkspaceAdmin({
   const [workspaceNameError, setWorkspaceNameError] = useState<string>("");
 
   const [slackBotEnabled, setSlackBotEnabled] = useState(false);
-  const [showEditWorkspaceNameModal, setShowEditWorkspaceNameModal] =
-    useState(false);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   const formValidation = useCallback(() => {
     if (workspaceName === owner.name) {
@@ -93,42 +98,21 @@ export default function WorkspaceAdmin({
       window.alert("Failed to update workspace.");
       setUpdating(false);
     } else {
+      setIsSheetOpen(false);
       // We perform a full refresh so that the Workspace name updates and we get a fresh owner
       // object so that the formValidation logic keeps working.
       window.location.reload();
     }
   };
 
+  const handleCancel = () => {
+    setWorkspaceName(owner.name);
+    setWorkspaceNameError("");
+    setIsSheetOpen(false);
+  };
+
   return (
     <>
-      <Dialog
-        isOpen={showEditWorkspaceNameModal}
-        onClose={() => {
-          setShowEditWorkspaceNameModal(false);
-          setWorkspaceName(owner.name);
-          setWorkspaceNameError("");
-        }}
-        title="Edit Workspace Name"
-        onValidate={async () => {
-          await handleUpdateWorkspace();
-          setShowEditWorkspaceNameModal(false);
-        }}
-        validateLabel="Save"
-        isValidating={updating}
-        disabled={disable}
-      >
-        <div className="flex flex-col gap-4">
-          <Page.P>Think GitHub repository names, short and memorable.</Page.P>
-          <Input
-            name="name"
-            placeholder="Workspace name"
-            value={workspaceName}
-            onChange={(e) => setWorkspaceName(e.target.value)}
-            message={workspaceNameError}
-            messageStatus="error"
-          />
-        </div>
-      </Dialog>
       <AppContentLayout
         subscription={subscription}
         owner={owner}
@@ -142,12 +126,48 @@ export default function WorkspaceAdmin({
                 <Page.H variant="h4">Workspace Name</Page.H>
                 <Page.P variant="secondary">{owner.name}</Page.P>
               </div>
-              <Button
-                variant="secondary"
-                label="Edit"
-                icon={PencilSquareIcon}
-                onClick={() => setShowEditWorkspaceNameModal(true)}
-              />
+              <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+                <SheetTrigger asChild>
+                  <Button
+                    variant="secondary"
+                    label="Edit"
+                    icon={PencilSquareIcon}
+                  />
+                </SheetTrigger>
+                <SheetContent>
+                  <SheetHeader>
+                    <SheetTitle>Edit Workspace Name</SheetTitle>
+                  </SheetHeader>
+                  <SheetContainer>
+                    <div className="mt-6 flex flex-col gap-4">
+                      <Page.P>
+                        Think GitHub repository names, short and memorable.
+                      </Page.P>
+                      <Input
+                        name="name"
+                        placeholder="Workspace name"
+                        value={workspaceName}
+                        onChange={(e) => setWorkspaceName(e.target.value)}
+                        message={workspaceNameError}
+                        messageStatus="error"
+                      />
+                    </div>
+                  </SheetContainer>
+                  <SheetFooter>
+                    <Button
+                      variant="tertiary"
+                      label="Cancel"
+                      onClick={handleCancel}
+                    />
+                    <Button
+                      variant="primary"
+                      label={updating ? "Saving..." : "Save"}
+                      disabled={disable || updating}
+                      onClick={handleUpdateWorkspace}
+                    />
+                  </SheetFooter>
+                </SheetContent>
+              </Sheet>
             </div>
           </Page.Vertical>
           <Page.Vertical align="stretch" gap="md">

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -22,26 +22,26 @@ import type { InferGetServerSidePropsType } from "next";
 import { useCallback, useEffect, useState } from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
+import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { ProviderManagementModal } from "@app/components/workspace/ProviderManagementModal";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import {
+  useConnectorConfig,
+  useToggleSlackChatBot,
+} from "@app/lib/swr/connectors";
 import { useMembersCount } from "@app/lib/swr/memberships";
+import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type {
   DataSourceType,
   SpaceType,
   SubscriptionType,
   WorkspaceType,
 } from "@app/types";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
-import { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
-import {
-  useConnectorConfig,
-  useToggleSlackChatBot,
-} from "@app/lib/swr/connectors";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -307,8 +307,7 @@ export default function WorkspaceAdmin({
                     }
                     disabled={isChangingSlackBot}
                     onClick={() => {
-                      toggleSlackBot();
-                      setIsChangingSlackBot(false);
+                      void toggleSlackBot();
                     }}
                   />
                 }


### PR DESCRIPTION
## Description
- Reorganized the admin menu structure as per the new design
- Created a dedicated Analytics page separate from Workspace Settings
- Added Integrations section with Slack Bot toggle in Workspace Settings
- Updated navigation labels and structure

## Risks
Blast radius: Admin menu navigation and workspace settings page, new slack app bot
Risk: low


## Deploy Plan
front