### PR TITLE
[front] fix search members payload

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -38,6 +38,7 @@ import type {
   AgentConfigurationScope,
   AgentConfigurationType,
   UserType,
+  UserTypeWithWorkspace,
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
@@ -175,7 +176,7 @@ function AssistantDetailsEditors({
   const isCurrentUserEditor =
     editors.findIndex((u) => u.sId === user.sId) !== -1;
 
-  const onRemoveMember = async (user: UserTypeWithWorkspaces) => {
+  const onRemoveMember = async (user: UserTypeWithWorkspace) => {
     if (isCurrentUserEditor) {
       await updateEditors({ removeEditorIds: [user.sId], addEditorIds: [] });
     }
@@ -194,7 +195,7 @@ function AssistantDetailsEditors({
         membersData={{
           members: editors.map((user) => ({
             ...user,
-            workspaces: [owner],
+            workspace: owner,
           })),
           isLoading: isEditorsLoading,
           totalMembersCount: editors.length,

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -39,7 +39,6 @@ import type {
   AgentConfigurationType,
   UserType,
   UserTypeWithWorkspace,
-  UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
 import { GLOBAL_AGENTS_SID, isAdmin } from "@app/types";

--- a/front/components/assistant_builder/SettingsScreen.tsx
+++ b/front/components/assistant_builder/SettingsScreen.tsx
@@ -787,8 +787,7 @@ function EditorsMembersList({
   );
 
   const members = useMemo(
-    () =>
-      builderState.editors?.map((m) => ({ ...m, workspaces: [owner] })) ?? [],
+    () => builderState.editors?.map((m) => ({ ...m, workspace: owner })) ?? [],
     [builderState, owner]
   );
 

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -109,19 +109,18 @@ export function InviteEmailModal({
 
     const invitesByCase = {
       activeSameRole: existingMembers.filter(
-        (m) => m && m.workspaces[0].role === invitationRole
+        (m) => m && m.workspaces.role === invitationRole
       ),
       activeDifferentRole: existingMembers.filter(
         (m) =>
           m &&
-          m.workspaces[0].role !== invitationRole &&
-          m.workspaces[0].role !== "none"
+          m.workspaces.role !== invitationRole &&
+          m.workspaces.role !== "none"
       ),
       notInWorkspace: inviteEmailsList.filter(
         (m) =>
           !existingMembers.find((x) => x.email === m) ||
-          existingMembers.find((x) => x.email === m)?.workspaces[0].role ===
-            "none"
+          existingMembers.find((x) => x.email === m)?.workspaces.role === "none"
       ),
     };
 
@@ -140,7 +139,7 @@ export function InviteEmailModal({
               {activeDifferentRole.map((user) => (
                 <div key={user.email}>{`- ${
                   user.fullName
-                } (current role: ${displayRole(user.workspaces[0].role)})`}</div>
+                } (current role: ${displayRole(user.workspace.role)})`}</div>
               ))}
             </div>
           </div>

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -13,7 +13,7 @@ import type { KeyedMutator } from "swr";
 
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
-import type { RoleType, UserType, UserTypeWithWorkspaces } from "@app/types";
+import type { RoleType, UserType, UserTypeWithWorkspace } from "@app/types";
 
 type RowData = {
   icon: string;
@@ -34,9 +34,9 @@ function getTableRows({
   onRemoveMemberClick,
   currentUserId,
 }: {
-  allUsers: UserTypeWithWorkspaces[];
-  onClick: (user: UserTypeWithWorkspaces) => void;
-  onRemoveMemberClick?: (user: UserTypeWithWorkspaces) => void;
+  allUsers: UserTypeWithWorkspace[];
+  onClick: (user: UserTypeWithWorkspace) => void;
+  onRemoveMemberClick?: (user: UserTypeWithWorkspace) => void;
   currentUserId: string;
 }): RowData[] {
   return allUsers.map((user) => ({
@@ -44,7 +44,7 @@ function getTableRows({
     name: user.fullName,
     userId: user.sId,
     email: user.email ?? "",
-    role: user.workspaces[0].role,
+    role: user.workspace.role,
     isCurrentUser: user.sId === currentUserId,
     onClick: () => onClick(user),
     onRemoveMemberClick: () => onRemoveMemberClick?.(user),
@@ -52,7 +52,7 @@ function getTableRows({
 }
 
 type MembersData = {
-  members: UserTypeWithWorkspaces[];
+  members: UserTypeWithWorkspace[];
   totalMembersCount: number;
   isLoading: boolean;
   mutateRegardlessOfQueryParams:
@@ -134,8 +134,8 @@ export function MembersList({
 }: {
   currentUser: UserType | null;
   membersData: MembersData;
-  onRowClick: (user: UserTypeWithWorkspaces) => void;
-  onRemoveMemberClick?: (user: UserTypeWithWorkspaces) => void;
+  onRowClick: (user: UserTypeWithWorkspace) => void;
+  onRemoveMemberClick?: (user: UserTypeWithWorkspace) => void;
   showColumns: ("name" | "email" | "role" | "remove")[];
   pagination?: PaginationState;
   setPagination?: (pagination: PaginationState) => void;
@@ -150,9 +150,7 @@ export function MembersList({
   const columns = memberColumns.filter((c) => showColumns.includes(c.id));
 
   const rows = useMemo(() => {
-    const filteredMembers = members.filter(
-      (m) => m.workspaces[0].role !== "none"
-    );
+    const filteredMembers = members.filter((m) => m.workspace.role !== "none");
     return getTableRows({
       allUsers: filteredMembers,
       onClick: onRowClick,

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -25,7 +25,7 @@ import { ROLES_DATA } from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { handleMembersRoleChange } from "@app/lib/client/members";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
-import type { ActiveRoleType, UserTypeWithWorkspaces } from "@app/types";
+import type { ActiveRoleType, UserTypeWithWorkspace } from "@app/types";
 import { isActiveRoleType } from "@app/types";
 
 export function ChangeMemberModal({
@@ -34,10 +34,10 @@ export function ChangeMemberModal({
   mutateMembers,
 }: {
   onClose: () => void;
-  member: UserTypeWithWorkspaces | null;
+  member: UserTypeWithWorkspace | null;
   mutateMembers: KeyedMutator<SearchMembersResponseBody>;
 }) {
-  const { role = null } = member?.workspaces[0] ?? {};
+  const { role = null } = member?.workspace ?? {};
 
   const sendNotification = useSendNotification();
   const [selectedRole, setSelectedRole] = useState<ActiveRoleType | null>(
@@ -172,8 +172,7 @@ export function ChangeMemberModal({
               rightButtonProps={{
                 label: "Update role",
                 onClick: handleSave,
-                disabled:
-                  selectedRole === member.workspaces[0].role || isSaving,
+                disabled: selectedRole === member.workspace.role || isSaving,
                 loading: isSaving,
               }}
             />

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -26,6 +26,7 @@ import type {
   Result,
   RoleType,
   SubscriptionType,
+  UserTypeWithWorkspace,
   UserTypeWithWorkspaces,
   WorkspaceSegmentationType,
   WorkspaceType,
@@ -202,7 +203,7 @@ export async function searchMembers(
     searchEmails?: string[];
   },
   paginationParams: SearchMembersPaginationParams
-): Promise<{ members: UserTypeWithWorkspaces[]; total: number }> {
+): Promise<{ members: UserTypeWithWorkspace[]; total: number }> {
   const owner = auth.workspace();
   if (!owner) {
     return { members: [], total: 0 };
@@ -234,7 +235,7 @@ export async function searchMembers(
     total = results.total;
   }
 
-  const usersWithWorkspaces = users.map((u) => {
+  const usersWithWorkspace = users.map((u) => {
     const [m] = u.memberships ?? [];
     let role: RoleType = "none";
 
@@ -253,11 +254,11 @@ export async function searchMembers(
 
     return {
       ...u.toJSON(),
-      workspaces: [{ ...owner, role, flags: null }],
+      workspace: { ...owner, role, flags: null },
     };
   });
 
-  return { members: usersWithWorkspaces, total };
+  return { members: usersWithWorkspace, total };
 }
 
 export async function getMembersCount(

--- a/front/lib/client/members.ts
+++ b/front/lib/client/members.ts
@@ -1,11 +1,11 @@
-import type { RoleType, UserTypeWithWorkspaces } from "@app/types";
+import type { RoleType, UserTypeWithWorkspace } from "@app/types";
 
 export async function handleMembersRoleChange({
   members,
   role,
   sendNotification,
 }: {
-  members: UserTypeWithWorkspaces[];
+  members: UserTypeWithWorkspace[];
   role: RoleType;
   sendNotification: any;
 }): Promise<void> {
@@ -13,7 +13,7 @@ export async function handleMembersRoleChange({
     return;
   }
   const promises = members.map((member) =>
-    fetch(`/api/w/${member.workspaces[0].sId}/members/${member.sId}`, {
+    fetch(`/api/w/${member.workspace.sId}/members/${member.sId}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -24,7 +24,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     expect(data.total).toBe(1);
     expect(data.members).toHaveLength(1);
     expect(data.members[0].id).toBe(user.id);
-    expect(data.members[0].workspaces[0].role).toBe("user");
+    expect(data.members[0].workspace.role).toBe("user");
   });
 
   itInTransaction("returns 405 for non-GET methods", async () => {

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -9,7 +9,7 @@ import { searchMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { apiError } from "@app/logger/withlogging";
-import type { UserTypeWithWorkspaces, WithAPIErrorResponse } from "@app/types";
+import type { UserTypeWithWorkspace, WithAPIErrorResponse } from "@app/types";
 
 const DEFAULT_PAGE_LIMIT = 25;
 
@@ -33,7 +33,7 @@ const SearchMembersQueryCodec = t.type({
 });
 
 export type SearchMembersResponseBody = {
-  members: UserTypeWithWorkspaces[];
+  members: UserTypeWithWorkspace[];
   total: number;
 };
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -37,7 +37,7 @@ import type {
   SubscriptionPerSeatPricing,
   SubscriptionType,
   UserType,
-  UserTypeWithWorkspaces,
+  UserTypeWithWorkspace,
   WorkspaceDomain,
   WorkspaceType,
 } from "@app/types";
@@ -255,7 +255,7 @@ function WorkspaceMembersList({
   });
 
   const [selectedMember, setSelectedMember] =
-    useState<UserTypeWithWorkspaces | null>(null);
+    useState<UserTypeWithWorkspace | null>(null);
 
   const membersData = useSearchMembers({
     workspaceId: owner.sId,

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -97,6 +97,10 @@ export type UserType = {
   lastLoginAt: number | null;
 };
 
+export type UserTypeWithWorkspace = UserType & {
+  workspace: WorkspaceType;
+};
+
 export type UserTypeWithWorkspaces = UserType & {
   workspaces: WorkspaceType[];
 };


### PR DESCRIPTION
## Description
This PR is to change the payload structure of `members/search` endpoint. Part of https://github.com/orgs/dust-tt/projects/3/views/1?pane=issue&itemId=114784196&issue=dust-tt%7Ctasks%7C3118 . When you search members from specific workspace, there is only one workspace but we return as an array to match with type `UserTypeWithWorkspaces`. I added a new type UserTypeWithWorkspace, and return workspace as it is. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Safe to rollback but it can break some functionalities (invitation, role change) if I forgot to update somewhere

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
