### PR TITLE
[connectors] feat(webcrawler): Remove the old cheerio and basic(firecrawl/scrape) crawler

### DIFF
--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -128,15 +128,15 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       );
     }
 
-    // If it's not firecrawl-api, it's a long running activity
-    if (webConfig.customCrawler !== "firecrawl-api") {
+    // If it's firecrawl-api
+    if (webConfig.crawlId !== null) {
+      // If not, there is not really workflows to stop
+      await getFirecrawl().cancelCrawl(webConfig.crawlId);
+    } else {
       const res = await stopCrawlWebsiteWorkflow(this.connectorId);
       if (res.isErr()) {
         return res;
       }
-    } else if (webConfig.crawlId !== null) {
-      // If not, there is not really workflows to stop
-      await getFirecrawl().cancelCrawl(webConfig.crawlId);
     }
 
     return new Ok(undefined);
@@ -153,7 +153,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     }
 
     // Before launching again, cancel on Firecrawl side and reset the crawlId
-    if (webConfig.customCrawler === "firecrawl-api" && webConfig.crawlId) {
+    if (webConfig.crawlId) {
       await getFirecrawl().cancelCrawl(webConfig.crawlId);
       await webConfig.updateCrawlId(null);
     }

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -131,6 +131,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
   });
 
   if (!crawlerResponse.success) {
+    await syncFailed(connectorId, "webcrawling_error");
     throw new Error(crawlerResponse.error);
   }
 

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,12 +1,8 @@
 import type { FirecrawlDocument } from "@mendable/firecrawl-js";
-import { FirecrawlError } from "@mendable/firecrawl-js";
 import { Context } from "@temporalio/activity";
-import { isCancellation } from "@temporalio/workflow";
-import { BasicCrawler, CheerioCrawler, Configuration, LogLevel } from "crawlee";
 import { randomUUID } from "crypto";
 import path from "path";
 import { Op } from "sequelize";
-import turndown from "turndown";
 
 import {
   getAllFoldersForUrl,
@@ -14,19 +10,8 @@ import {
   getFolderForUrl,
   getParentsForPage,
   isTopFolder,
-  shouldCrawlLink,
   stableIdForUrl,
-  verifyRedirect,
-  WebCrawlerError,
 } from "@connectors/connectors/webcrawler/lib/utils";
-import {
-  FIRECRAWL_REQ_TIMEOUT,
-  MAX_BLOCKED_RATIO,
-  MAX_PAGES_TOO_LARGE_RATIO,
-  MAX_TIME_TO_CRAWL_MINUTES,
-  MIN_EXTRACTED_TEXT_LENGTH,
-  REQUEST_HANDLING_TIMEOUT,
-} from "@connectors/connectors/webcrawler/temporal/workflows";
 import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
@@ -52,7 +37,7 @@ import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
-import type { ModelId, WebcrawlerCustomCrawler } from "@connectors/types";
+import type { ModelId } from "@connectors/types";
 import {
   INTERNAL_MIME_TYPES,
   normalizeError,
@@ -61,10 +46,6 @@ import {
   WEBCRAWLER_MAX_DEPTH,
   WEBCRAWLER_MAX_PAGES,
 } from "@connectors/types";
-
-import { DustHttpClient } from "../lib/http";
-
-const CONCURRENCY = 1;
 
 export async function markAsCrawled(connectorId: ModelId) {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -86,7 +67,6 @@ export async function markAsCrawled(connectorId: ModelId) {
 }
 
 export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
-  const startCrawlingTime = Date.now();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     logger.error({ connectorId }, "Connector not found");
@@ -123,800 +103,57 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
 
   const customHeaders = webCrawlerConfig.getCustomHeaders();
 
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-
-  const pageCount = {
-    valid: 0,
-    tooLarge: 0,
-    blocked: 0,
-    total() {
-      return this.valid + this.tooLarge + this.blocked;
-    },
-  };
-  let totalExtracted = 0;
-  let crawlingError = 0;
-  let upsertingError = 0;
-  const createdFolders = new Set<string>();
-
   const maxRequestsPerCrawl =
     webCrawlerConfig.maxPageToCrawl || WEBCRAWLER_MAX_PAGES;
 
   // temporay solution to have both crawler while we test them
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let crawler: BasicCrawler<any>;
 
   let rootUrl = webCrawlerConfig.url.trim();
   if (!rootUrl.startsWith("http://") && !rootUrl.startsWith("https://")) {
     rootUrl = `http://${rootUrl}`;
   }
 
-  if (
-    webCrawlerConfig.customCrawler ===
-    ("firecrawl-api" satisfies WebcrawlerCustomCrawler)
-  ) {
-    const crawlerResponse = await firecrawlApp.asyncCrawlUrl(rootUrl, {
-      maxDiscoveryDepth: webCrawlerConfig.depth ?? WEBCRAWLER_MAX_DEPTH,
-      limit: maxRequestsPerCrawl,
-      allowBackwardLinks: webCrawlerConfig.crawlMode === "website",
-      delay: 3,
-      scrapeOptions: {
-        onlyMainContent: true,
-        formats: ["markdown"],
-        headers: customHeaders,
-        maxAge: 43_200_000, // Use last 12h of cache
+  const crawlerResponse = await firecrawlApp.asyncCrawlUrl(rootUrl, {
+    maxDiscoveryDepth: webCrawlerConfig.depth ?? WEBCRAWLER_MAX_DEPTH,
+    limit: maxRequestsPerCrawl,
+    allowBackwardLinks: webCrawlerConfig.crawlMode === "website",
+    delay: 3,
+    scrapeOptions: {
+      onlyMainContent: true,
+      formats: ["markdown"],
+      headers: customHeaders,
+      maxAge: 43_200_000, // Use last 12h of cache
+    },
+    webhook: {
+      url: `${apiConfig.getConnectorsPublicURL()}/webhooks/${apiConfig.getDustConnectorsWebhooksSecret()}/firecrawl`,
+      metadata: {
+        connectorId: String(connectorId),
       },
-      webhook: {
-        url: `${apiConfig.getConnectorsPublicURL()}/webhooks/${apiConfig.getDustConnectorsWebhooksSecret()}/firecrawl`,
-        metadata: {
-          connectorId: String(connectorId),
-        },
-      },
-    });
+    },
+  });
 
-    if (!crawlerResponse.success) {
-      throw new Error(crawlerResponse.error);
-    }
+  if (!crawlerResponse.success) {
+    throw new Error(crawlerResponse.error);
+  }
 
-    if (crawlerResponse.id) {
-      await webCrawlerConfig.updateCrawlId(crawlerResponse.id);
-    } else {
-      // Shouldn't happen, but based on the types, let's make sure
-      childLogger.warn(
-        { webCrawlerConfigId: webCrawlerConfig.id, url: rootUrl },
-        "No ID found when creating a Firecrawl crawler"
-      );
-    }
-
-    childLogger.info(
-      { crawlerId: crawlerResponse.id, url: rootUrl },
-      "Firecrawl crawler started"
-    );
-    return {
-      launchGarbageCollect: false,
-      startedAtTs: startedAt.getTime(),
-    };
-  } else if (
-    webCrawlerConfig.customCrawler ===
-    ("firecrawl" satisfies WebcrawlerCustomCrawler)
-  ) {
-    crawler = new BasicCrawler(
-      {
-        maxRequestsPerCrawl,
-        maxConcurrency: CONCURRENCY,
-        maxRequestsPerMinute: 20, // 1 request every 3 seconds average, to avoid overloading the target website
-        requestHandlerTimeoutSecs: REQUEST_HANDLING_TIMEOUT,
-        async requestHandler({ request, enqueueLinks }) {
-          Context.current().heartbeat({
-            type: "http_request",
-            url: request.url,
-          });
-
-          const checkUrl = await verifyRedirect(request.url);
-          if (checkUrl.isErr()) {
-            childLogger.error(
-              {
-                type: checkUrl.error.type,
-                configId: webCrawlerConfig.id,
-                sourceUrl: request.url,
-              },
-              checkUrl.error.message
-            );
-            return;
-          }
-
-          Context.current().heartbeat({
-            type: "verify_redirect",
-            url: checkUrl,
-          });
-
-          const currentRequestDepth = request.userData.depth || 0;
-
-          if (
-            checkUrl.value !== request.url &&
-            !shouldCrawlLink(
-              checkUrl.value.toString(),
-              webCrawlerConfig,
-              currentRequestDepth
-            )
-          ) {
-            childLogger.warn(
-              { sourceUrl: request.url, url: checkUrl.value },
-              "Should not crawl"
-            );
-            return;
-          }
-
-          const crawlerResponse = await firecrawlApp.scrapeUrl(request.url, {
-            onlyMainContent: true,
-            formats: ["markdown", "links"],
-            headers: customHeaders,
-            timeout: FIRECRAWL_REQ_TIMEOUT,
-          });
-
-          if (!crawlerResponse.success) {
-            crawlingError++;
-            childLogger.error(
-              { url: request.url, configId: webCrawlerConfig.id },
-              `Error scraping: ${crawlerResponse.error}`
-            );
-            return;
-          }
-
-          childLogger.debug(
-            {
-              url: request.url,
-              configId: webCrawlerConfig.id,
-              links: crawlerResponse.links,
-            },
-            "Receive response"
-          );
-
-          Context.current().heartbeat({
-            type: "scraping",
-            url: checkUrl,
-          });
-
-          // try-catch allowing activity cancellation by temporal (various timeouts, or signal)
-          try {
-            await Context.current().sleep(1);
-          } catch (e) {
-            if (isCancellation(e)) {
-              childLogger.error(
-                { error: e },
-                "The activity was canceled. Aborting crawl."
-              );
-
-              // raise a panic flag if the activity is aborted because it exceeded the maximum time to crawl
-              const isTooLongToCrawl =
-                Date.now() - startCrawlingTime >
-                1000 * 60 * (MAX_TIME_TO_CRAWL_MINUTES - 1);
-
-              if (isTooLongToCrawl) {
-                childLogger.error(
-                  {
-                    url: rootUrl,
-                    configId: webCrawlerConfig.id,
-                    panic: true,
-                    crawls_per_minute: Math.round(
-                      pageCount.valid / MAX_TIME_TO_CRAWL_MINUTES
-                    ),
-                  },
-                  `Website takes too long to crawl`
-                );
-              }
-
-              // abort crawling
-              await crawler.autoscaledPool?.abort();
-              await crawler.teardown();
-              // leave without rethrowing, to avoid retries by the crawler
-              // (the cancellation already throws at the activity & workflow level)
-              return;
-            }
-            throw e;
-          }
-
-          await enqueueLinks({
-            urls:
-              crawlerResponse.links?.filter((link) =>
-                shouldCrawlLink(link, webCrawlerConfig, currentRequestDepth)
-              ) ?? [],
-            userData: {
-              depth: currentRequestDepth + 1,
-            },
-          });
-
-          const extracted = crawlerResponse.markdown ?? "[NO CONTENT]";
-
-          totalExtracted += extracted.length;
-          const pageTitle = crawlerResponse.metadata?.title ?? randomUUID();
-
-          // note that parentFolderUrls.length === parentFolderIds.length -1
-          // since parentFolderIds includes the page as first element
-          // and parentFolderUrls does not
-          const parentFolderUrls = getAllFoldersForUrl(request.url);
-          const parentFolderIds = getParentsForPage(request.url, false);
-
-          for (const [index, folder] of parentFolderUrls.entries()) {
-            if (createdFolders.has(folder)) {
-              continue;
-            }
-
-            const logicalParent = isTopFolder(request.url)
-              ? null
-              : getFolderForUrl(folder);
-            const [webCrawlerFolder] = await WebCrawlerFolder.upsert({
-              url: folder,
-              parentUrl: logicalParent,
-              connectorId: connector.id,
-              webcrawlerConfigurationId: webCrawlerConfig.id,
-              internalId: stableIdForUrl({
-                url: folder,
-                ressourceType: "folder",
-              }),
-              lastSeenAt: new Date(),
-            });
-
-            // parent folder ids of the page are in hierarchy order from the
-            // page to the root so for the current folder, its parents start at
-            // index+1 (including itself as first parent) and end at the root
-            const parents = parentFolderIds.slice(index + 1);
-            await upsertDataSourceFolder({
-              dataSourceConfig,
-              folderId: webCrawlerFolder.internalId,
-              timestampMs: webCrawlerFolder.updatedAt.getTime(),
-              parents,
-              parentId: parents[1] || null,
-              title: getDisplayNameForFolder(webCrawlerFolder),
-              mimeType: INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
-              sourceUrl: webCrawlerFolder.url,
-            });
-
-            createdFolders.add(folder);
-          }
-          const documentId = stableIdForUrl({
-            url: request.url,
-            ressourceType: "document",
-          });
-
-          await WebCrawlerPage.upsert({
-            url: request.url,
-            parentUrl: isTopFolder(request.url)
-              ? null
-              : getFolderForUrl(request.url),
-            connectorId: connector.id,
-            webcrawlerConfigurationId: webCrawlerConfig.id,
-            documentId: documentId,
-            title: pageTitle,
-            depth: currentRequestDepth,
-            lastSeenAt: new Date(),
-          });
-
-          childLogger.info(
-            {
-              documentId,
-              configId: webCrawlerConfig.id,
-              documentLen: extracted.length,
-              url: request.url,
-            },
-            "Successfully crawled page"
-          );
-
-          statsDClient.increment("connectors_webcrawler_crawls.count", 1);
-          statsDClient.increment(
-            "connectors_webcrawler_crawls_bytes.count",
-            extracted.length
-          );
-
-          Context.current().heartbeat({
-            type: "upserting",
-            url: checkUrl,
-          });
-
-          try {
-            if (extracted.length > MAX_SMALL_DOCUMENT_TXT_LEN) {
-              pageCount.tooLarge++;
-            }
-            if (
-              extracted.length > 0 &&
-              extracted.length <= MAX_SMALL_DOCUMENT_TXT_LEN
-            ) {
-              const validatedUrl = validateUrl(request.url);
-              if (!validatedUrl.valid || !validatedUrl.standardized) {
-                childLogger.info(
-                  {
-                    documentId,
-                    configId: webCrawlerConfig.id,
-                    url: request.url,
-                  },
-                  `Invalid document or URL. Skipping`
-                );
-                return;
-              }
-
-              const formattedDocumentContent = formatDocumentContent({
-                title: pageTitle,
-                content: extracted,
-                url: validatedUrl.standardized,
-              });
-
-              await upsertDataSourceDocument({
-                dataSourceConfig,
-                documentId: documentId,
-                documentContent: formattedDocumentContent,
-                documentUrl: validatedUrl.standardized,
-                timestampMs: new Date().getTime(),
-                tags: [`title:${stripNullBytes(pageTitle)}`],
-                parents: parentFolderIds,
-                parentId: parentFolderIds[1] || null,
-                upsertContext: {
-                  sync_type: "batch",
-                },
-                title: stripNullBytes(pageTitle),
-                mimeType: "text/html",
-                async: true,
-              });
-            } else {
-              childLogger.info(
-                {
-                  documentId,
-                  configId: webCrawlerConfig.id,
-                  documentLen: extracted.length,
-                  title: pageTitle,
-                  url: request.url,
-                },
-                `Document is empty or too big to be upserted. Skipping`
-              );
-              return;
-            }
-          } catch (e) {
-            upsertingError++;
-            childLogger.error(
-              {
-                error: e,
-                configId: webCrawlerConfig.id,
-                url: rootUrl,
-              },
-              "Webcrawler error while upserting document"
-            );
-          }
-
-          pageCount.valid++;
-          await reportInitialSyncProgress(
-            connector.id,
-            `${pageCount.valid} pages`
-          );
-        },
-        errorHandler: () => {
-          // Errors are already logged by the crawler, so we are not re-logging them here.
-          Context.current().heartbeat({
-            type: "error_handler",
-          });
-        },
-      },
-      new Configuration({
-        purgeOnStart: true,
-        persistStorage: false,
-        logLevel: LogLevel.OFF,
-        availableMemoryRatio: 0.1,
-      })
-    );
+  if (crawlerResponse.id) {
+    await webCrawlerConfig.updateCrawlId(crawlerResponse.id);
   } else {
-    crawler = new CheerioCrawler(
-      {
-        httpClient: new DustHttpClient(),
-        navigationTimeoutSecs: 10,
-        preNavigationHooks: [
-          async (crawlingContext) => {
-            Context.current().heartbeat({
-              type: "pre_navigation",
-            });
-
-            if (!crawlingContext.request.headers) {
-              crawlingContext.request.headers = {};
-            }
-            for (const [header, value] of Object.entries(customHeaders)) {
-              crawlingContext.request.headers[header] = value;
-            }
-          },
-        ],
-        maxRequestsPerCrawl,
-        maxConcurrency: CONCURRENCY,
-        maxRequestsPerMinute: 20, // 1 request every 3 seconds average, to avoid overloading the target website
-        requestHandlerTimeoutSecs: REQUEST_HANDLING_TIMEOUT,
-        async requestHandler({ $, request, enqueueLinks }) {
-          if (request.skipNavigation) {
-            childLogger.info({ url: request.url }, "Skipping page");
-            return;
-          }
-
-          Context.current().heartbeat({
-            type: "http_request",
-          });
-          const currentRequestDepth = request.userData.depth || 0;
-
-          // try-catch allowing activity cancellation by temporal (various timeouts, or signal)
-          try {
-            await Context.current().sleep(1);
-          } catch (e) {
-            if (isCancellation(e)) {
-              childLogger.error(
-                { error: e },
-                "The activity was canceled. Aborting crawl."
-              );
-
-              // raise a panic flag if the activity is aborted because it exceeded the maximum time to crawl
-              const isTooLongToCrawl =
-                Date.now() - startCrawlingTime >
-                1000 * 60 * (MAX_TIME_TO_CRAWL_MINUTES - 1);
-
-              if (isTooLongToCrawl) {
-                childLogger.error(
-                  {
-                    url: rootUrl,
-                    configId: webCrawlerConfig.id,
-                    panic: true,
-                    crawls_per_minute: Math.round(
-                      pageCount.valid / MAX_TIME_TO_CRAWL_MINUTES
-                    ),
-                  },
-                  `Website takes too long to crawl`
-                );
-              }
-
-              // abort crawling
-              await crawler.autoscaledPool?.abort();
-              await crawler.teardown();
-              // leave without rethrowing, to avoid retries by the crawler
-              // (the cancellation already throws at the activity & workflow level)
-              return;
-            }
-            throw e;
-          }
-
-          await enqueueLinks({
-            userData: {
-              depth: currentRequestDepth + 1,
-            },
-            transformRequestFunction: (req) => {
-              try {
-                if (
-                  new URL(req.url).protocol !== "http:" &&
-                  new URL(req.url).protocol !== "https:"
-                ) {
-                  return false;
-                }
-              } catch (e) {
-                return false;
-              }
-              if (webCrawlerConfig.crawlMode === "child") {
-                // We only want to crawl children of the original url
-                if (
-                  !new URL(req.url).pathname.startsWith(
-                    new URL(webCrawlerConfig.url).pathname
-                  )
-                ) {
-                  // path is not a child of the original url
-                  return false;
-                }
-              }
-              if (
-                req.userData?.depth >= WEBCRAWLER_MAX_DEPTH ||
-                req.userData?.depth >= webCrawlerConfig.depth
-              ) {
-                return false;
-              }
-              return req;
-            },
-          });
-          const extracted = new turndown()
-            .remove([
-              "style",
-              "script",
-              "iframe",
-              "noscript",
-              "nav",
-              "footer",
-              "header",
-              "form",
-              "meta",
-              "img",
-            ])
-            .turndown($.html());
-
-          totalExtracted += extracted.length;
-          const pageTitle = $("title").text();
-
-          // note that parentFolderUrls.length === parentFolderIds.length -1
-          // since parentFolderIds includes the page as first element
-          // and parentFolderUrls does not
-          const parentFolderUrls = getAllFoldersForUrl(request.url);
-          const parentFolderIds = getParentsForPage(request.url, false);
-
-          for (const [index, folder] of parentFolderUrls.entries()) {
-            if (createdFolders.has(folder)) {
-              continue;
-            }
-
-            const logicalParent = isTopFolder(request.url)
-              ? null
-              : getFolderForUrl(folder);
-            const [webCrawlerFolder] = await WebCrawlerFolder.upsert({
-              url: folder,
-              parentUrl: logicalParent,
-              connectorId: connector.id,
-              webcrawlerConfigurationId: webCrawlerConfig.id,
-              internalId: stableIdForUrl({
-                url: folder,
-                ressourceType: "folder",
-              }),
-              lastSeenAt: new Date(),
-            });
-
-            // parent folder ids of the page are in hierarchy order from the
-            // page to the root so for the current folder, its parents start at
-            // index+1 (including itself as first parent) and end at the root
-            const parents = parentFolderIds.slice(index + 1);
-            await upsertDataSourceFolder({
-              dataSourceConfig,
-              folderId: webCrawlerFolder.internalId,
-              timestampMs: webCrawlerFolder.updatedAt.getTime(),
-              parents,
-              parentId: parents[1] || null,
-              title: getDisplayNameForFolder(webCrawlerFolder),
-              mimeType: INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
-              sourceUrl: webCrawlerFolder.url,
-            });
-
-            createdFolders.add(folder);
-          }
-          const documentId = stableIdForUrl({
-            url: request.url,
-            ressourceType: "document",
-          });
-
-          await WebCrawlerPage.upsert({
-            url: request.url,
-            parentUrl: isTopFolder(request.url)
-              ? null
-              : getFolderForUrl(request.url),
-            connectorId: connector.id,
-            webcrawlerConfigurationId: webCrawlerConfig.id,
-            documentId: documentId,
-            title: pageTitle,
-            depth: currentRequestDepth,
-            lastSeenAt: new Date(),
-          });
-
-          childLogger.info(
-            {
-              documentId,
-              configId: webCrawlerConfig.id,
-              documentLen: extracted.length,
-              url: request.url,
-            },
-            "Successfully crawled page"
-          );
-
-          statsDClient.increment("connectors_webcrawler_crawls.count", 1);
-          statsDClient.increment(
-            "connectors_webcrawler_crawls_bytes.count",
-            extracted.length
-          );
-
-          Context.current().heartbeat({
-            type: "upserting",
-          });
-
-          try {
-            if (extracted.length > MAX_SMALL_DOCUMENT_TXT_LEN) {
-              pageCount.tooLarge++;
-            }
-            if (
-              extracted.length > 0 &&
-              extracted.length <= MAX_SMALL_DOCUMENT_TXT_LEN
-            ) {
-              const validatedUrl = validateUrl(request.url);
-              if (!validatedUrl.valid || !validatedUrl.standardized) {
-                childLogger.info(
-                  {
-                    documentId,
-                    configId: webCrawlerConfig.id,
-                    url: request.url,
-                  },
-                  `Invalid document or URL. Skipping`
-                );
-                return;
-              }
-
-              const formattedDocumentContent = formatDocumentContent({
-                title: pageTitle,
-                content: extracted,
-                url: validatedUrl.standardized,
-              });
-
-              await upsertDataSourceDocument({
-                dataSourceConfig,
-                documentId: documentId,
-                documentContent: formattedDocumentContent,
-                documentUrl: validatedUrl.standardized,
-                timestampMs: new Date().getTime(),
-                tags: [`title:${stripNullBytes(pageTitle)}`],
-                parents: parentFolderIds,
-                parentId: parentFolderIds[1] || null,
-                upsertContext: {
-                  sync_type: "batch",
-                },
-                title: stripNullBytes(pageTitle),
-                mimeType: "text/html",
-                async: true,
-              });
-            } else {
-              childLogger.info(
-                {
-                  documentId,
-                  configId: webCrawlerConfig.id,
-                  documentLen: extracted.length,
-                  title: pageTitle,
-                  url: request.url,
-                },
-                `Document is empty or too big to be upserted. Skipping`
-              );
-              return;
-            }
-          } catch (e) {
-            upsertingError++;
-            childLogger.error(
-              {
-                error: e,
-                configId: webCrawlerConfig.id,
-                url: rootUrl,
-              },
-              "Webcrawler error while upserting document"
-            );
-          }
-
-          pageCount.valid++;
-          await reportInitialSyncProgress(
-            connector.id,
-            `${pageCount.valid} pages`
-          );
-        },
-        failedRequestHandler: async (context, error) => {
-          Context.current().heartbeat({
-            type: "failed_request",
-          });
-
-          if (error instanceof WebCrawlerError) {
-            childLogger.error(
-              { url: context.request.url, type: error.type },
-              error.message
-            );
-            return;
-          }
-
-          childLogger.error(
-            {
-              url: context.request.url,
-              error,
-            },
-            "webcrawler failedRequestHandler"
-          );
-          if (
-            !context.response ||
-            context.response.statusCode === 403 ||
-            context.response.statusCode === 429
-          ) {
-            pageCount.blocked++;
-          }
-          crawlingError++;
-        },
-        errorHandler: () => {
-          // Errors are already logged by the crawler, so we are not re-logging them here.
-          Context.current().heartbeat({
-            type: "error_handler",
-          });
-        },
-      },
-      new Configuration({
-        purgeOnStart: true,
-        persistStorage: false,
-        logLevel: LogLevel.OFF,
-        availableMemoryRatio: 0.1,
-      })
+    // Shouldn't happen, but based on the types, let's make sure
+    childLogger.warn(
+      { webCrawlerConfigId: webCrawlerConfig.id, url: rootUrl },
+      "No ID found when creating a Firecrawl crawler"
     );
   }
 
   childLogger.info(
-    {
-      url: rootUrl,
-      configId: webCrawlerConfig.id,
-    },
-    "Webcrawler activity started"
+    { crawlerId: crawlerResponse.id, url: rootUrl },
+    "Firecrawl crawler started"
   );
-
-  let stats;
-  try {
-    stats = await crawler.run([rootUrl]);
-  } catch (error: unknown) {
-    // Check if this is a URL validation error from the crawler
-    if (
-      error &&
-      typeof error === "object" &&
-      "errors" in error &&
-      Array.isArray((error as { errors: unknown[] }).errors) &&
-      (error as { errors: unknown[] }).errors.some(
-        (e: unknown) =>
-          Array.isArray(e) &&
-          e[1]?.errors?.some(
-            (err: unknown) =>
-              Array.isArray(err) &&
-              err[0] === "url" &&
-              err[1]?.constraint === "s.string.url"
-          )
-      )
-    ) {
-      childLogger.error(
-        {
-          url: rootUrl,
-          configId: webCrawlerConfig.id,
-          error: error,
-        },
-        "Invalid URL format detected"
-      );
-      await syncFailed(connector.id, "webcrawling_error");
-      return;
-    } else if (error instanceof FirecrawlError) {
-      statsDClient.increment("connectors_webcrawler_scrape_error", [
-        `status_code:${error.statusCode}`,
-        `configId:${webCrawlerConfig.id}`,
-      ]);
-    }
-
-    throw error;
-  }
-
-  await crawler.teardown();
-
-  // checks for cancellation and throws if it's the case
-  await Context.current().sleep(1);
-
-  if (pageCount.blocked / pageCount.total() > MAX_BLOCKED_RATIO) {
-    await syncFailed(connector.id, "webcrawling_error_blocked");
-  } else if (
-    pageCount.tooLarge / pageCount.total() >
-    MAX_PAGES_TOO_LARGE_RATIO
-  ) {
-    await syncFailed(connector.id, "webcrawling_error_content_too_large");
-  } else if (totalExtracted < MIN_EXTRACTED_TEXT_LENGTH) {
-    await syncFailed(connector.id, "webcrawling_error_empty_content");
-  } else if (pageCount.valid === 0) {
-    await syncFailed(connector.id, "webcrawling_error");
-  } else if (stats.requestsFinished >= maxRequestsPerCrawl) {
-    await syncFailed(connector.id, "webcrawling_synchronization_limit_reached");
-  } else {
-    await syncSucceeded(connector.id);
-  }
-  if (upsertingError > 0) {
-    throw new Error(
-      `Webcrawler failed while upserting documents to Dust. Error count: ${upsertingError}`
-    );
-  }
-
-  childLogger.info(
-    {
-      url: rootUrl,
-      pageCount: pageCount.valid,
-      crawlingError,
-      configId: webCrawlerConfig.id,
-    },
-    "Webcrawler activity finished"
-  );
-
   return {
-    launchGarbageCollect: true,
+    launchGarbageCollect: false,
     startedAtTs: startedAt.getTime(),
-    pageCount: pageCount.valid,
-    crawlingError,
   };
 }
 

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -106,9 +106,6 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
   const maxRequestsPerCrawl =
     webCrawlerConfig.maxPageToCrawl || WEBCRAWLER_MAX_PAGES;
 
-  // temporay solution to have both crawler while we test them
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-
   let rootUrl = webCrawlerConfig.url.trim();
   if (!rootUrl.startsWith("http://") && !rootUrl.startsWith("https://")) {
     rootUrl = `http://${rootUrl}`;

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -10,8 +10,6 @@ import {
 import type * as activities from "@connectors/connectors/webcrawler/temporal/activities";
 import type { ModelId } from "@connectors/types";
 
-import { WEBCRAWLER_MAX_PAGES } from "../../../types/webcrawler";
-
 // timeout for crawling a single url = timeout for upserting (5 minutes) + 2mn
 // leeway to crawl on slow websites
 export const REQUEST_HANDLING_TIMEOUT = 420;
@@ -19,25 +17,22 @@ export const REQUEST_HANDLING_TIMEOUT = 420;
 // them 20mn to hearbeat.
 export const HEARTBEAT_TIMEOUT = 1200;
 
-export const FIRECRAWL_REQ_TIMEOUT = 30_000; // millisecond
-export const MAX_TIME_TO_CRAWL_MINUTES =
-  (WEBCRAWLER_MAX_PAGES * FIRECRAWL_REQ_TIMEOUT) / 1000 / 60; // X millisecond timeout per page, and we have a hardcoded limit of Y pages
 export const MIN_EXTRACTED_TEXT_LENGTH = 1024;
 export const MAX_BLOCKED_RATIO = 0.9;
 export const MAX_PAGES_TOO_LARGE_RATIO = 0.9;
 
-const { crawlWebsiteByConnectorId, webCrawlerGarbageCollector } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: `${MAX_TIME_TO_CRAWL_MINUTES} minutes`,
-    heartbeatTimeout: `${HEARTBEAT_TIMEOUT} seconds`,
-    cancellationType: ActivityCancellationType.TRY_CANCEL,
-    retry: {
-      initialInterval: `${REQUEST_HANDLING_TIMEOUT * 2} seconds`,
-      maximumInterval: "3600 seconds",
-    },
-  });
+const { webCrawlerGarbageCollector } = proxyActivities<typeof activities>({
+  startToCloseTimeout: `60 minutes`,
+  heartbeatTimeout: `${HEARTBEAT_TIMEOUT} seconds`,
+  cancellationType: ActivityCancellationType.TRY_CANCEL,
+  retry: {
+    initialInterval: `${REQUEST_HANDLING_TIMEOUT * 2} seconds`,
+    maximumInterval: "3600 seconds",
+  },
+});
 
 const {
+  crawlWebsiteByConnectorId,
   getConnectorIdsForWebsitesToCrawl,
   markAsCrawled,
   firecrawlCrawlFailed,


### PR DESCRIPTION
## Description
Completely remove the code that is using Crawlee, make no disctinction between `customCrawler` (will be drop and remove in a second time).
- https://github.com/dust-tt/tasks/issues/3167
- https://github.com/dust-tt/tasks/issues/2924

## Tests
- Locally

## Risk
- Mid, relying to Firecrawl entirely. Firecrawl has been working nicely, some stuck website here and there but at least now it's not stuck in our temporal. But pretty localized, should be ok to revert in case.

## Deploy Plan
- Deploy connectors
