### PR TITLE
[front] fix: ensure all auto tools are created in Agent Builder

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -69,7 +69,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  if (await isRestrictedFromAgentCreation(owner)) {
+  const isRestricted = await isRestrictedFromAgentCreation(owner);
+  if (isRestricted) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -31,6 +31,7 @@ import type {
   TemplateAgentConfigurationType,
   WorkspaceType,
 } from "@app/types";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;
@@ -73,6 +74,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       notFound: true,
     };
   }
+
+  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
   const { spaces, dataSourceViews, dustApps, mcpServerViews } =
     await getAccessibleSourcesAndApps(auth);

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -20,6 +20,7 @@ import config from "@app/lib/api/config";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
 import type {
   AgentConfigurationType,
@@ -31,7 +32,6 @@ import type {
   TemplateAgentConfigurationType,
   WorkspaceType,
 } from "@app/types";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;


### PR DESCRIPTION
## Description

- This PR adds an `ensureAllAutoToolsAreCreated` in Agent Builder when creating a new agent.
- Had the issue in development where a newly added tool would not appear (had no reason to visit any of the locations where `ensureAllAutoToolsAreCreated` was called).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
