### PR TITLE
Upg: limit notion tool search to 16 results and cleanup the output to return way less data and get the polished UI

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -302,7 +302,6 @@ export const SearchResultResourceSchema = z.object({
   ref: z.string(),
   chunks: z.array(z.string()),
   source: z.object({
-    name: z.string(),
     provider: z.string().optional(),
   }),
 });

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -29,10 +29,7 @@ import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  getDataSourceNameFromView,
-  getDisplayNameForDocument,
-} from "@app/lib/data_sources";
+import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -674,7 +671,6 @@ const createServer = (
             source: {
               provider:
                 dataSourceView.dataSource.connectorProvider ?? undefined,
-              name: getDataSourceNameFromView(dataSourceView),
             },
             tags: doc.tags,
             ref: refs.shift() as string,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -62,7 +62,7 @@ export async function getInternalMCPServer(
     case "missing_action_catcher":
       return missingActionCatcherServer(auth, agentLoopContext);
     case "notion":
-      return notionServer();
+      return notionServer(auth, agentLoopContext);
     case "include_data":
       return includeDataServer(auth, agentLoopContext);
     case "run_agent":

--- a/front/lib/actions/mcp_internal_actions/servers/search/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search/utils.ts
@@ -17,10 +17,7 @@ import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  getDataSourceNameFromView,
-  getDisplayNameForDocument,
-} from "@app/lib/data_sources";
+import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { TimeFrame } from "@app/types";
@@ -170,7 +167,7 @@ export async function searchFunction({
   const refs = getRefs().slice(refsOffset, refsOffset + topK);
 
   const results: SearchResultResourceType[] = searchResults.value.documents.map(
-    (doc) => {
+    (doc): SearchResultResourceType => {
       const dataSourceView = coreSearchArgs.find(
         (args) =>
           args.dataSourceView.dataSource.dustAPIDataSourceId ===
@@ -187,7 +184,6 @@ export async function searchFunction({
         id: doc.document_id,
         source: {
           provider: dataSourceView.dataSource.connectorProvider ?? undefined,
-          name: getDataSourceNameFromView(dataSourceView),
         },
         tags: doc.tags,
         ref: refs.shift() as string,

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -70,7 +70,7 @@ function makeQueryResource(
 ): SearchQueryResourceType {
   const timeFrameAsString =
     renderRelativeTimeFrameForToolOutput(relativeTimeFrame);
-  let text = `Searching ${timeFrameAsString}`;
+  let text = `Searching Slack ${timeFrameAsString}`;
   if (keywords.length > 0) {
     text += ` with keywords: ${keywords.join(", ")}`;
   }
@@ -284,23 +284,24 @@ const createServer = (
             refsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
           );
 
-          const results: SearchResultResourceType[] = matches.map((match) => {
-            return {
-              mimeType:
-                INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-              uri: match.permalink ?? "",
-              text: `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
+          const results: SearchResultResourceType[] = matches.map(
+            (match): SearchResultResourceType => {
+              return {
+                mimeType:
+                  INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+                uri: match.permalink ?? "",
+                text: `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
 
-              id: match.ts ?? "",
-              source: {
-                provider: "slack",
-                name: "Slack",
-              },
-              tags: [],
-              ref: refs.shift() as string,
-              chunks: [stripNullBytes(match.text ?? "")],
-            };
-          });
+                id: match.ts ?? "",
+                source: {
+                  provider: "slack",
+                },
+                tags: [],
+                ref: refs.shift() as string,
+                chunks: [stripNullBytes(match.text ?? "")],
+              };
+            }
+          );
 
           return {
             isError: false,

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -168,6 +168,14 @@ export function isMCPConfigurationForInternalSlack(
   );
 }
 
+export function isMCPConfigurationForInternalNotion(
+  arg: AgentActionConfigurationType
+): arg is ServerSideMCPServerConfigurationType {
+  return (
+    isServerSideMCPServerConfiguration(arg) &&
+    isInternalMCPServerOfName(arg.internalMCPServerId, "notion")
+  );
+}
 export function isMCPConfigurationForDustAppRun(
   arg: AgentActionConfigurationType
 ): arg is ServerSideMCPServerConfigurationType {
@@ -235,6 +243,15 @@ export function isMCPInternalSlack(
   return (
     isServerSideMCPToolConfiguration(arg) &&
     isInternalMCPServerOfName(arg.internalMCPServerId, "slack")
+  );
+}
+
+export function isMCPInternalNotion(
+  arg: ActionConfigurationType
+): arg is ServerSideMCPToolConfigurationType {
+  return (
+    isServerSideMCPToolConfiguration(arg) &&
+    isInternalMCPServerOfName(arg.internalMCPServerId, "notion")
   );
 }
 

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -20,6 +20,7 @@ import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
 import {
   isMCPInternalDataSourceFileSystem,
   isMCPInternalInclude,
+  isMCPInternalNotion,
   isMCPInternalSearch,
   isMCPInternalSlack,
   isMCPInternalWebsearch,
@@ -34,6 +35,7 @@ import { assertNever } from "@app/types";
 
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
 export const SLACK_SEARCH_ACTION_NUM_RESULTS = 16;
+export const NOTION_SEARCH_ACTION_NUM_RESULTS = 16;
 
 export const ACTION_SPECIFICATIONS: Record<
   AssistantBuilderActionConfiguration["type"],
@@ -254,6 +256,9 @@ export function getCitationsCount({
       }
       if (isMCPInternalSlack(action)) {
         return SLACK_SEARCH_ACTION_NUM_RESULTS;
+      }
+      if (isMCPInternalNotion(action)) {
+        return NOTION_SEARCH_ACTION_NUM_RESULTS;
       }
       return getRetrievalTopK({
         agentConfiguration,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -2,6 +2,7 @@ import moment from "moment-timezone";
 
 import type { ServerToolsAndInstructions } from "@app/lib/actions/mcp_actions";
 import {
+  isMCPConfigurationForInternalNotion,
   isMCPConfigurationForInternalSlack,
   isMCPConfigurationForInternalWebsearch,
   isMCPConfigurationWithDataSource,
@@ -129,7 +130,8 @@ export async function constructPromptMultiActions(
       isWebsearchConfiguration(action) ||
       isMCPConfigurationWithDataSource(action) ||
       isMCPConfigurationForInternalWebsearch(action) ||
-      isMCPConfigurationForInternalSlack(action)
+      isMCPConfigurationForInternalSlack(action) ||
+      isMCPConfigurationForInternalNotion(action)
   );
 
   if (canRetrieveDocuments) {


### PR DESCRIPTION
## Description

I noticed that notion search was using a lot of tokens.
This fixes it by limiting the number of results to 16 (like other searches).
Updated the output to remove a lot of unnecessary information and return the proper types to get the nice UI.
Added a post filter to allow restricting to a timeframe.

## Tests

Local
<img width="882" alt="image" src="https://github.com/user-attachments/assets/1ed37038-2c5f-45fd-9efc-0049580a6bee" />
<img width="744" alt="image" src="https://github.com/user-attachments/assets/d564e13a-1240-4193-89c9-87547b32b938" />
<img width="897" alt="image" src="https://github.com/user-attachments/assets/f8776ca6-0a20-40cb-bfc1-f52f35f5716f" />
<img width="751" alt="image" src="https://github.com/user-attachments/assets/84116b46-3246-4482-8368-f69301d9cd57" />

## Risk

Low

## Deploy Plan

Deploy front