### PR TITLE
Make ENABLE_BOT_CRAWLING use getInitialProps

### DIFF
--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -1,9 +1,25 @@
+import type { DocumentContext, DocumentInitialProps } from "next/document";
 import Document, { Head, Html, Main, NextScript } from "next/document";
 
-const { ENABLE_BOT_CRAWLING } = process.env;
+interface MyDocumentProps extends DocumentInitialProps {
+  enableBotCrawling: boolean;
+}
 
-class MyDocument extends Document {
+class MyDocument extends Document<MyDocumentProps> {
+  static async getInitialProps(ctx: DocumentContext): Promise<MyDocumentProps> {
+    const initialProps = await Document.getInitialProps(ctx);
+
+    const { ENABLE_BOT_CRAWLING } = process.env;
+
+    return {
+      ...initialProps,
+      enableBotCrawling: ENABLE_BOT_CRAWLING === "true",
+    };
+  }
+
   render() {
+    const { enableBotCrawling } = this.props;
+
     return (
       <Html>
         <Head>
@@ -14,9 +30,7 @@ class MyDocument extends Document {
             href="https://fonts.gstatic.com"
             crossOrigin="anonymous"
           />
-          {ENABLE_BOT_CRAWLING !== "true" && (
-            <meta name="robots" content="noindex" />
-          )}
+          {!enableBotCrawling && <meta name="robots" content="noindex" />}
         </Head>
         <body>
           <noscript>


### PR DESCRIPTION
## Description

We've been disabling google on all front facing pages because our implementation of ENABLE_BOT_CRAWLING did not seem to work the way we expected.

All our pages currently have a noindex tag in prod, while ENABLE_BOT_CRAWLING is set to true in the front pod. 

On google, we just have the homepage and the docs. Nothing of the solutions pages or anything else 😱 

<img width="920" alt="Screenshot 2025-06-20 at 14 54 41" src="https://github.com/user-attachments/assets/51c83609-7cd0-4b64-874b-97f9dc137cbd" />

Tested locally, the noindex tag actually gets removed when the env var is there
 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
