### PR TITLE
[front] chore: Add react scan

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -2,7 +2,6 @@ const path = require("path");
 
 const showReactScan =
   process.env.NODE_ENV === "development" && process.env.REACT_SCAN === "true";
-console.log(`show react scan: ${showReactScan}`);
 
 const CONTENT_SECURITY_POLICIES = [
   "default-src 'none';",

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -1,8 +1,12 @@
 const path = require("path");
 
+const showReactScan =
+  process.env.NODE_ENV === "development" && process.env.REACT_SCAN === "true";
+console.log(`show react scan: ${showReactScan}`);
+
 const CONTENT_SECURITY_POLICIES = [
   "default-src 'none';",
-  `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.cr-relay.com;`,
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.cr-relay.com ${showReactScan ? "unpkg.com" : ""};`,
   `style-src 'self' 'unsafe-inline';`,
   `img-src 'self' data: https:;`,
   `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com;`,

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -1,10 +1,16 @@
 import Document, { Head, Html, Main, NextScript } from "next/document";
 
+const { NODE_ENV, REACT_SCAN } = process.env;
+
 class MyDocument extends Document {
   render() {
     return (
       <Html>
         <Head>
+          {NODE_ENV === "development" && REACT_SCAN === "true" && (
+            // eslint-disable-next-line @next/next/no-sync-scripts
+            <script src="https://unpkg.com/react-scan/dist/auto.global.js" />
+          )}
           <base href={process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL} />
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link


### PR DESCRIPTION
## Description
- Add optioan [react-scan](https://react-scan.com/) for easy React debug and optimization
- if developer is in development and they can set the `REACT_SCAN` env to `true` to activate it
- No install required, only add the header script and add `unpkg.com` in the CSP if both env are setup.

## Tests
<img width="1505" alt="Capture d’écran 2025-06-20 à 14 15 58" src="https://github.com/user-attachments/assets/8ef42098-17e8-4e03-bf03-ad12c1a5e5b3" />

## Risk
- super low, only in dev with specifics env, super easy to revert if necessary

## Deploy Plan
N/A
