### PR TITLE
Fix: account for tools in tokens count

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -1,5 +1,6 @@
-import parseArgs from "minimist";
 import fs from "fs/promises";
+import parseArgs from "minimist";
+import path from "path";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
@@ -13,6 +14,7 @@ import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { getDustProdActionRegistry } from "@app/lib/registry";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -34,8 +36,6 @@ import {
   removeNulls,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
-import path from "path";
-import { KeyResource } from "@app/lib/resources/key_resource";
 
 // `cli` takes an object type and a command as first two arguments and then a list of arguments.
 const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
@@ -333,11 +333,13 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       const MIN_GENERATION_TOKENS = 2048;
       const allowedTokenCount = model.contextSize - MIN_GENERATION_TOKENS;
       const prompt = "";
+      const tools = "";
 
       const convoRes = await renderConversationForModel(auth, {
         conversation,
         model,
         prompt,
+        tools,
         allowedTokenCount,
       });
 
@@ -460,7 +462,7 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
         `Pausing all LabsTranscripts workflows and recording active ones... (activeIdsFile: ${activeIdsFile})`
       );
       const allWorkspaces = await Workspace.findAll();
-      let activeConfigSIds: string[] = [];
+      const activeConfigSIds: string[] = [];
       for (const ws of allWorkspaces) {
         const configs =
           await LabsTranscriptsConfigurationResource.findByWorkspaceId(ws.id);

--- a/front/lib/actions/dust_app_run.ts
+++ b/front/lib/actions/dust_app_run.ts
@@ -458,11 +458,13 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
       const MIN_GENERATION_TOKENS = 2048;
       const allowedTokenCount = model.contextSize - MIN_GENERATION_TOKENS;
       const prompt = "";
+      const tools = "";
 
       const convoRes = await renderConversationForModel(auth, {
         conversation,
         model,
         prompt,
+        tools,
         allowedTokenCount,
         excludeImages: true,
       });

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -252,6 +252,7 @@ async function prepareParamsWithHistory(
         conversation: agentLoopRunContext.conversation,
         model,
         prompt: "",
+        tools: "",
         allowedTokenCount,
         excludeImages: true,
       });

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -94,6 +94,7 @@ function createServer(
         conversation: agentLoopRunContext.conversation,
         model: supportedModel,
         prompt: agentLoopRunContext.agentConfiguration.instructions ?? "",
+        tools: "",
         allowedTokenCount,
         excludeImages: true,
       });

--- a/front/lib/actions/reasoning.ts
+++ b/front/lib/actions/reasoning.ts
@@ -402,6 +402,7 @@ export async function* runReasoning(
     conversation,
     model: supportedModel,
     prompt: agentConfiguration.instructions ?? "",
+    tools: "",
     allowedTokenCount: supportedModel.contextSize - REASONING_GENERATION_TOKENS,
     excludeImages: true,
   });

--- a/front/lib/actions/tables_query.ts
+++ b/front/lib/actions/tables_query.ts
@@ -485,6 +485,7 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
       conversation,
       model: supportedModel,
       prompt: agentConfiguration.instructions ?? "",
+      tools: "",
       allowedTokenCount,
       excludeImages: true,
     });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -375,6 +375,7 @@ export async function generateConversationTitle(
     conversation,
     model,
     prompt: "", // There is no prompt for title generation.
+    tools: "",
     allowedTokenCount: model.contextSize - MIN_GENERATION_TOKENS,
     excludeActions: true,
     excludeImages: true,


### PR DESCRIPTION
## Description

This PR aim to estimate the tokens used by tools definition and take it into account for the allowed context window.
With agents using a lot of tools becoming more and more common, without taking them into account, we are sending too much data to the model.
I approximated by using a string representation of the name, description and input schema + a small adjusting factor as I learnt that internally the model have a more efficient representation.

## Tests

Locally

## Risk

Low as, worse case scenario, compared to today we are going to truncate a bit more the rendered conversation.

## Deploy Plan

Deploy front