### PR TITLE
[front] Handle login redirection in case of legacy SSO

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -86,7 +86,9 @@ export default function LandingLayout({
               label="Sign in"
               icon={LoginIcon}
               onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                if (e.shiftKey) {
+                if (e.metaKey) {
+                  window.location.href = `/api/workos/login?returnTo=${postLoginReturnToUrl}`;
+                } else if (e.shiftKey) {
                   window.location.href = `/api/auth/login?prompt=login&returnTo=${postLoginReturnToUrl}`;
                 } else {
                   window.location.href = `/api/auth/login?returnTo=${postLoginReturnToUrl}`;

--- a/front/lib/api/enterprise_connection.ts
+++ b/front/lib/api/enterprise_connection.ts
@@ -13,7 +13,7 @@ import type {
 import type { LightWorkspaceType } from "@app/types";
 import { assertNever } from "@app/types";
 
-function makeEnterpriseConnectionName(workspaceId: string) {
+export function makeEnterpriseConnectionName(workspaceId: string) {
   return `workspace-${workspaceId}`;
 }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -977,9 +977,10 @@ export async function getSession(
   req: NextApiRequest | GetServerSidePropsContext["req"],
   res: NextApiResponse | GetServerSidePropsContext["res"]
 ): Promise<SessionWithUser | null> {
+  // Get Auth0 session first - in case of legacy SSO connection, we'll have 2 sessions and Auth0 will contains the SSO session
   return (
-    (await getWorkOSSession(req, res)) ||
     (await getAuth0Session(req, res)) ||
+    (await getWorkOSSession(req, res)) ||
     null
   );
 }

--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -201,6 +201,7 @@ export default handleAuth({
   logout: async (req: NextApiRequest, res: NextApiResponse) => {
     res.setHeader("Set-Cookie", [
       "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+      "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
     ]);
     return handleLogout(req, res, {
       returnTo:

--- a/front/pages/api/v1/auth/[action].ts
+++ b/front/pages/api/v1/auth/[action].ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
+import logger from "@app/logger/logger";
 
 type Provider = {
   authorizeUri: string;
@@ -82,7 +83,7 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
     const data = await response.json();
     res.status(response.status).json(data);
   } catch (error) {
-    console.error("Error in authenticate proxy:", error);
+    logger.error({ error }, "Error in authenticate proxy");
     res.status(500).json({ error: "Internal server error" });
   }
 }
@@ -93,10 +94,6 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
     ...query,
     client_id: getProvider().clientId,
   }).toString();
-  console.log(
-    "Redirecting to logout URL:",
-    `https://${getProvider().logoutUri}?${params}`
-  );
   const authorizeUrl = `https://${getProvider().logoutUri}?${params}`;
   res.redirect(authorizeUrl);
 }

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -1,4 +1,3 @@
-import { reachabilityResponseFromProto } from "@temporalio/client";
 import { sealData } from "iron-session";
 import type { NextApiRequest, NextApiResponse } from "next";
 

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -1,7 +1,9 @@
+import { reachabilityResponseFromProto } from "@temporalio/client";
 import { sealData } from "iron-session";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
+import { makeEnterpriseConnectionName } from "@app/lib/api/enterprise_connection";
 import type { RegionType } from "@app/lib/api/regions/config";
 import {
   config as multiRegionsConfig,
@@ -11,7 +13,9 @@ import { checkUserRegionAffinity } from "@app/lib/api/regions/lookup";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import type { SessionCookie } from "@app/lib/api/workos/user";
 import { setRegionForUser } from "@app/lib/api/workos/user";
-import { getSession } from "@app/lib/auth";
+import { getFeatureFlags, getSession } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models/workspace";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { isString } from "@app/types";
@@ -44,15 +48,53 @@ export default async function handler(
 async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
   try {
     const { organizationId, screenHint, loginHint, returnTo } = req.query;
+
+    let organizationIdToUse;
+
+    if (organizationId && typeof organizationId === "string") {
+      organizationIdToUse = organizationId;
+    }
+
+    // Get the last workspace ID from cookie if available
+    const lastWorkspaceId = req.cookies.lastWorkspaceId;
+
+    if (lastWorkspaceId) {
+      const workspace = await Workspace.findOne({
+        where: {
+          sId: lastWorkspaceId,
+        },
+      });
+      if (workspace) {
+        const lightWorkspace = renderLightWorkspaceType({ workspace });
+        const featureFlags = await getFeatureFlags(lightWorkspace);
+        if (
+          featureFlags.includes("okta_enterprise_connection") &&
+          !featureFlags.includes("workos")
+        ) {
+          // Redirect to legacy enterprise login
+          res.redirect(
+            `/api/auth/login?connection=${makeEnterpriseConnectionName(
+              workspace.sId
+            )}`
+          );
+          return;
+        }
+
+        if (workspace.workOSOrganizationId) {
+          organizationIdToUse = workspace.workOSOrganizationId;
+        }
+      }
+    }
+
     let enterpriseParams: { organizationId?: string; connectionId?: string } =
       {};
-    if (organizationId && typeof organizationId === "string") {
+    if (organizationIdToUse) {
       // TODO(workos): We will want to cache this data
       const connections = await getWorkOS().sso.listConnections({
-        organizationId,
+        organizationId: organizationIdToUse,
       });
       enterpriseParams = {
-        organizationId,
+        organizationId: organizationIdToUse,
         connectionId:
           connections.data.length > 0 ? connections.data[0]?.id : undefined,
       };
@@ -242,6 +284,7 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
 
   res.setHeader("Set-Cookie", [
     "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+    "appSession=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
     "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
   ]);
 

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -79,10 +79,6 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
           );
           return;
         }
-
-        if (workspace.workOSOrganizationId) {
-          organizationIdToUse = workspace.workOSOrganizationId;
-        }
       }
     }
 


### PR DESCRIPTION
## Description

- New login available on meta+click  (for testing)
- Both logout clear both sessions, to avoid session mixup
- On workos login : check the workspaceId cookie. If it's set and workspace matches legacy sso, redictre to sso login.
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
