### PR TITLE
Increase default token count adjustment from 1 to 1.15

### DIFF
--- a/front/lib/tokenization.ts
+++ b/front/lib/tokenization.ts
@@ -2,7 +2,13 @@ import _ from "lodash";
 
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { CoreAPI, Err, Ok, safeSubstring } from "@app/types";
+import {
+  CoreAPI,
+  DEFAULT_TOKEN_COUNT_ADJUSTMENT,
+  Err,
+  Ok,
+  safeSubstring,
+} from "@app/types";
 
 import config from "./api/config";
 
@@ -33,7 +39,10 @@ export async function tokenCountForTexts(
       }
       for (const tokens of res.value.tokens) {
         counts.push(
-          Math.round(tokens.length * (model.tokenCountAdjustment ?? 1))
+          Math.round(
+            tokens.length *
+              (model.tokenCountAdjustment ?? DEFAULT_TOKEN_COUNT_ADJUSTMENT)
+          )
         );
       }
     }

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -573,7 +573,8 @@ export const O4_MINI_HIGH_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   reasoningEffort: "high",
 };
 
-const ANTHROPIC_TOKEN_COUNT_ADJUSTMENT = 1.25;
+export const DEFAULT_TOKEN_COUNT_ADJUSTMENT = 1.15;
+const ANTHROPIC_TOKEN_COUNT_ADJUSTMENT = 1.3;
 
 export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",


### PR DESCRIPTION
## Description

In addition to [account for tools](https://github.com/dust-tt/dust/pull/13637), also increase default and anthropic token count adjustment factor as we are slightly over the window from time to time.
See [logs](https://app.datadoghq.eu/logs?query=%40error.code%3Amulti_actions_error%20context&agg_m=count&agg_m_source=base&agg_q=%23extracted_error&agg_q_source=base&agg_t=count&clustering_pattern_field_path=source&fromUser=true&refresh_mode=sliding&saved-view-id=171043&storage=hot&top_n=1000&top_o=top&viz=stream&x_missing=true&from_ts=1750167039753&to_ts=1750426239753&live=true)

## Tests

Local

## Risk

Low but we will be even more aggressive to truncate content.

## Deploy Plan

Deploy front