### PR TITLE
[front] fix(WorkOS): create users on WorkOS on sync

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -169,9 +169,9 @@ export async function fetchOrCreateWorkOSUserWithEmail(
     email: workOSUser.email,
   });
 
-  let [createdUser] = workOSUserResponse.data;
-  if (!createdUser) {
-    createdUser = await getWorkOS().userManagement.createUser({
+  const [existingUser] = workOSUserResponse.data;
+  if (!existingUser) {
+    const createdUser = await getWorkOS().userManagement.createUser({
       email: workOSUser.email,
       firstName: workOSUser.firstName ?? undefined,
       lastName: workOSUser.lastName ?? undefined,
@@ -180,15 +180,16 @@ export async function fetchOrCreateWorkOSUserWithEmail(
       },
     });
     logger.info(
-      { workOSUser, createdUser, email: workOSUser.email },
+      { workOSUser, createdUser: existingUser, email: workOSUser.email },
       "Created WorkOS user for webhook event"
     );
-  } else {
-    logger.info(
-      { workOSUser, createdUser, email: workOSUser.email },
-      "Found WorkOS user for webhook event"
-    );
-  }
 
-  return new Ok(createdUser);
+    return new Ok(createdUser);
+  }
+  logger.info(
+    { workOSUser, createdUser: existingUser, email: workOSUser.email },
+    "Found WorkOS user for webhook event"
+  );
+
+  return new Ok(existingUser);
 }

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -2,9 +2,9 @@ import type {
   AuthenticateWithSessionCookieFailedResponse,
   AuthenticateWithSessionCookieSuccessResponse,
   AuthenticationResponse as WorkOSAuthenticationResponse,
+  DirectoryUser as WorkOSDirectoryUser,
   RefreshSessionResponse,
   User as WorkOSUser,
-  DirectoryUser as WorkOSDirectoryUser,
 } from "@workos-inc/node";
 import { sealData, unsealData } from "iron-session";
 import type {

--- a/front/migrations/20250619_reset_emails_workos.ts
+++ b/front/migrations/20250619_reset_emails_workos.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 
 import { sendEmailWithTemplate } from "@app/lib/api/email";
 import { getWorkOS } from "@app/lib/api/workos/client";
-import { fetchWorkOSUserWithEmail } from "@app/lib/api/workos/user";
+import { fetchUserFromWorkOS } from "@app/lib/api/workos/user";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
@@ -39,7 +39,7 @@ const sendPasswordResetEmail = async (
   const childLogger = logger.child({ email });
 
   // First, check if the user exists in WorkOS.
-  const userResult = await fetchWorkOSUserWithEmail(email);
+  const userResult = await fetchUserFromWorkOS(email);
   if (userResult.isErr()) {
     childLogger.warn("User not found in WorkOS");
     return { success: false, error: "User not found in WorkOS" };

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -12,7 +12,7 @@ import assert from "assert";
 import { createAndLogMembership } from "@app/lib/api/signup";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import {
-  fetchWorkOSUserWithEmail,
+  fetchOrCreateWorkOSUserWithEmail,
   getUserNicknameFromEmail,
 } from "@app/lib/api/workos/user";
 import {
@@ -446,7 +446,7 @@ async function handleUserAddedToGroup(
     return;
   }
 
-  const workOSUserRes = await fetchWorkOSUserWithEmail(event.user.email);
+  const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail(event.user);
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
   }
@@ -490,7 +490,7 @@ async function handleUserRemovedFromGroup(
     return;
   }
 
-  const workOSUserRes = await fetchWorkOSUserWithEmail(event.user.email);
+  const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail(event.user);
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
   }
@@ -527,7 +527,7 @@ async function handleCreateOrUpdateWorkOSUser(
   workspace: LightWorkspaceType,
   event: DirectoryUser
 ) {
-  const workOSUserRes = await fetchWorkOSUserWithEmail(event.email);
+  const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail(event);
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
   }
@@ -572,7 +572,7 @@ async function handleDeleteWorkOSUser(
   workspace: LightWorkspaceType,
   event: DirectoryUser
 ) {
-  const workOSUserRes = await fetchWorkOSUserWithEmail(event.email);
+  const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail(event);
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
   }


### PR DESCRIPTION
## Description

- When receiving a webhook such as `dsync.user.created` we actually need to create the user on WorkOS with the data we got from the event.
- We currently have a workflow stuck due to that.
- This PR addresses the issue by systematically creating missing users.

## Tests

## Risk

## Deploy Plan

- Deploy fornt.
