### PR TITLE
Add: support to use fixed ip proxy fror specific workspace

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -40,7 +40,7 @@ export async function getInternalMCPServer(
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":
-      return githubServer();
+      return githubServer(auth);
     case "hubspot":
       return hubspotServer();
     case "image_generation":

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -38,12 +38,14 @@ import type {
   MCPToolType,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase, OAuthProvider, Result } from "@app/types";
 import {
   assertNever,
+  EnvironmentConfig,
   Err,
   isOAuthProvider,
   normalizeError,
@@ -122,9 +124,19 @@ export type MCPConnectionParams =
   | ServerSideMCPConnectionParams
   | ClientSideMCPConnectionParams;
 
-function createMCPDispatcher(): ProxyAgent | undefined {
-  const proxyHost = config.getUntrustedEgressProxyHost();
-  const proxyPort = config.getUntrustedEgressProxyPort();
+function createMCPDispatcher(auth: Authenticator): ProxyAgent | undefined {
+  // Default to the generic proxy.
+  let proxyHost = config.getUntrustedEgressProxyHost();
+  let proxyPort = config.getUntrustedEgressProxyPort();
+
+  if (isWorkspaceUsingStaticIP(auth.getNonNullableWorkspace())) {
+    proxyHost = `http://${EnvironmentConfig.getEnvVariable(
+      "PROXY_USER_NAME"
+    )}:${EnvironmentConfig.getEnvVariable(
+      "PROXY_USER_PASSWORD"
+    )}@${EnvironmentConfig.getEnvVariable("PROXY_HOST")}`;
+    proxyPort = EnvironmentConfig.getEnvVariable("PROXY_PORT");
+  }
 
   if (proxyHost && proxyPort) {
     const proxyUrl = `http://${proxyHost}:${proxyPort}`;
@@ -305,7 +317,7 @@ export const connectToMCPServer = async (
             const req = {
               requestInit: {
                 headers: undefined,
-                dispatcher: createMCPDispatcher(),
+                dispatcher: createMCPDispatcher(auth),
               },
               authProvider: new MCPOAuthProvider(auth, token),
             };
@@ -336,7 +348,7 @@ export const connectToMCPServer = async (
       const url = new URL(params.remoteMCPServerUrl);
       const req = {
         requestInit: {
-          dispatcher: createMCPDispatcher(),
+          dispatcher: createMCPDispatcher(auth),
           headers: { ...(params.headers ?? {}) },
         },
         authProvider: new MCPOAuthProvider(auth, undefined),

--- a/front/lib/misc.ts
+++ b/front/lib/misc.ts
@@ -1,0 +1,7 @@
+import type { LightWorkspaceType } from "@dust-tt/client";
+import { hash as blake3 } from "blake3";
+
+// Check this slack thread for more details: https://dust4ai.slack.com/archives/C050SM8NSPK/p1750433286397399.
+export const isWorkspaceUsingStaticIP = (workspace: LightWorkspaceType) =>
+  blake3(workspace.sId).toString("hex") ===
+  "5e6faccb8b7e2be7cab0a46a1376126b75032acbfbd5c723d9b0f0b38a73b334";

--- a/front/lib/misc.ts
+++ b/front/lib/misc.ts
@@ -2,6 +2,7 @@ import type { LightWorkspaceType } from "@dust-tt/client";
 import { hash as blake3 } from "blake3";
 
 // Check this slack thread for more details: https://dust4ai.slack.com/archives/C050SM8NSPK/p1750433286397399.
+// Any change to this function should be reviewed by @spolu.
 export const isWorkspaceUsingStaticIP = (workspace: LightWorkspaceType) =>
   blake3(workspace.sId).toString("hex") ===
   "5e6faccb8b7e2be7cab0a46a1376126b75032acbfbd5c723d9b0f0b38a73b334";


### PR DESCRIPTION
## Description

Add support for going thru our fixed IP proxy in github tool and remote mcp for a specific workspace..

## Tests

Tested locally with tinyproxy

## Risk

Low, code shouldn't change behavior when FF is not on.

## Deploy Plan

Deploy front, add `PROXY_USER_NAME` `PROXY_USER_PASSWORD` `PROXY_HOST` and `PROXY_PORT` to front.