### PR TITLE
Slack: put more in slow lane + increase startToCloseTimeout

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -26,6 +26,9 @@ import { newWebhookSignal, syncChannelSignal } from "./signals";
 // Configuration for slow lane routing.
 const SLOW_LANE_CONNECTOR_IDS: string[] = [
   // Add connector IDs that should be routed to slow lane.
+  "1444",
+  "20542",
+  "20640",
   "23791",
   "24659",
   "23840",
@@ -89,6 +92,7 @@ const SLOW_LANE_CONNECTOR_IDS: string[] = [
   "274877908541",
   "274877908701",
   "274877908661",
+  "274877907284",
 ];
 
 // Dynamic activity creation with fresh routing evaluation (enables retry queue switching).
@@ -130,7 +134,7 @@ function getSlackActivities() {
       slowLaneConnectorIds: SLOW_LANE_CONNECTOR_IDS,
       activityOptions: {
         heartbeatTimeout: "5 minutes",
-        startToCloseTimeout: "10 minutes",
+        startToCloseTimeout: "20 minutes",
       },
     }
   );


### PR DESCRIPTION
## Description

Putting more workspaces in the slow lane (from [DD](https://app.datadoghq.eu/dashboard/eza-jyh-pwy?fromUser=true&refresh_mode=sliding&tpl_var_workflowId%5B0%5D=slack%2A&from_ts=1750495464763&to_ts=1750497264763&live=true))
Also increasing startToCloseTimeout for syncNonThreadedChunk because we get monitors for it. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connectors