### PR TITLE
[front] fix safari layout bug in agent selector by mounting portal 

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -34,7 +34,6 @@ export function AssistantPicker({
   showFooterButtons = true,
   size = "md",
   isLoading = false,
-  mountPortal = true,
 }: AssistantPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -68,7 +67,6 @@ export function AssistantPicker({
       <DropdownMenuContent
         className="h-96 w-96"
         align="end"
-        mountPortal={mountPortal}
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar

--- a/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ChildAgentConfigurationSection.tsx
@@ -122,7 +122,6 @@ export function ChildAgentConfigurationSection({
                   />
                 }
                 showFooterButtons={false}
-                mountPortal={false}
               />
             </div>
           </div>
@@ -146,7 +145,6 @@ export function ChildAgentConfigurationSection({
                 />
               }
               showFooterButtons={false}
-              mountPortal={false}
             />
           </div>
         </Card>


### PR DESCRIPTION
## Description
We stopped using portal for run_agent assistant picker in https://github.com/dust-tt/dust/pull/12093 but this breaks the layout in Safari:

![Capture d’écran 2025-06-19 à 11 09 22](https://github.com/user-attachments/assets/d5c20eb6-844d-4717-958c-38dc43c74ab5)

Safari has own weird logic for stacking contexts + position sticky doesn't work when a parent element has certain css (like `transform`). The only solution I could think of is mounting on top of the DOM to get out from the current stacking context. As far as I can tell the scroll seems to be working fine, but do I miss something? 🤔


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
