### PR TITLE
[front] enh: polish space provisioning UI

### DIFF
--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -374,7 +374,7 @@ export function CreateOrEditSpaceModal({
         <SheetHeader>
           <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-0">
-              <SheetTitle>`Space Settings - ${spaceName}`</SheetTitle>
+              <SheetTitle>Space Settings - {spaceName}</SheetTitle>
             </div>
 
             {isAdmin && space && space.kind === "regular" && (

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -430,7 +430,7 @@ export function CreateOrEditSpaceModal({
         <SheetContainer>
           <div className="flex w-full flex-col gap-y-4">
             {!space && (
-              <>
+              <div className="mb-4 flex w-full flex-col gap-y-4">
                 <Page.SectionHeader title="Name" />
                 <Input
                   placeholder="Space's name"
@@ -443,7 +443,7 @@ export function CreateOrEditSpaceModal({
                     setIsDirty(true);
                   }}
                 />
-              </>
+              </div>
             )}
 
             <div className="flex w-full items-center justify-between overflow-visible">

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   EmptyCTA,
-  Label,
   MoreIcon,
   Page,
   PencilSquareIcon,
@@ -474,6 +473,26 @@ export function CreateOrEditSpaceModal({
                         />
                       </DropdownMenuContent>
                     </DropdownMenu>
+                    {isManual && selectedMembers.length > 0 && (
+                      <SearchMembersDropdown
+                        owner={owner}
+                        selectedMembers={selectedMembers}
+                        onMembersUpdated={(members) => {
+                          setSelectedMembers(members);
+                          setIsDirty(true);
+                        }}
+                      />
+                    )}
+                    {!isManual && selectedGroups.length > 0 && (
+                      <SearchGroupsDropdown
+                        owner={owner}
+                        selectedGroups={selectedGroups}
+                        onGroupsUpdated={(groups) => {
+                          setSelectedGroups(groups);
+                          setIsDirty(true);
+                        }}
+                      />
+                    )}
                   </div>
                 ) : null}
 
@@ -510,17 +529,6 @@ export function CreateOrEditSpaceModal({
 
                 {isManual && selectedMembers.length > 0 && (
                   <>
-                    <div className="flex flex-row items-center justify-between">
-                      <Label className="text-lg">Members</Label>
-                      <SearchMembersDropdown
-                        owner={owner}
-                        selectedMembers={selectedMembers}
-                        onMembersUpdated={(members) => {
-                          setSelectedMembers(members);
-                          setIsDirty(true);
-                        }}
-                      />
-                    </div>
                     <SearchInput
                       name="search"
                       placeholder="Search (email)"
@@ -543,17 +551,6 @@ export function CreateOrEditSpaceModal({
                 )}
                 {!isManual && selectedGroups.length > 0 && (
                   <>
-                    <div className="flex flex-row items-center justify-between">
-                      <Label className="text-lg">Provisioned groups</Label>
-                      <SearchGroupsDropdown
-                        owner={owner}
-                        selectedGroups={selectedGroups}
-                        onGroupsUpdated={(groups) => {
-                          setSelectedGroups(groups);
-                          setIsDirty(true);
-                        }}
-                      />
-                    </div>
                     <SearchInput
                       name="search"
                       placeholder={"Search groups"}

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -388,7 +388,7 @@ export function CreateOrEditSpaceModal({
                 />
                 <EditSpaceNameDialog
                   space={space}
-                  onEditName={onEditName}
+                  handleEditName={onEditName}
                   isOpen={showEditNameDialog}
                   isSaving={isSaving}
                   onClose={() => setShowEditNameDialog(false)}

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -19,9 +19,6 @@ import {
   SheetHeader,
   SheetTitle,
   SliderToggle,
-  Tabs,
-  TabsList,
-  TabsTrigger,
   TrashIcon,
   useSendNotification,
   XMarkIcon,
@@ -445,22 +442,39 @@ export function CreateOrEditSpaceModal({
             {isRestricted && (
               <>
                 {isWorkOSFeatureEnabled ? (
-                  <Tabs
-                    value={managementType}
-                    onValueChange={(tabId) => {
-                      if (isMembersManagementType(tabId)) {
-                        void handleManagementTypeChange(tabId);
-                      }
-                    }}
-                  >
-                    <TabsList>
-                      <TabsTrigger value="manual" label="Manual access" />
-                      <TabsTrigger
-                        value="group"
-                        label="Provisioned group access"
-                      />
-                    </TabsList>
-                  </Tabs>
+                  <div className="flex flex-row items-center justify-between">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline"
+                          isSelect
+                          label={
+                            managementType === "manual"
+                              ? "Manual access"
+                              : "Provisioned group access"
+                          }
+                        />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        <DropdownMenuItem
+                          label="Manual access"
+                          onClick={() => {
+                            if (isMembersManagementType("manual")) {
+                              void handleManagementTypeChange("manual");
+                            }
+                          }}
+                        />
+                        <DropdownMenuItem
+                          label="Provisioned group access"
+                          onClick={() => {
+                            if (isMembersManagementType("group")) {
+                              void handleManagementTypeChange("group");
+                            }
+                          }}
+                        />
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
                 ) : null}
 
                 {isManual && selectedMembers.length === 0 && (

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   EmptyCTA,
+  Input,
   MoreIcon,
   Page,
   PencilSquareIcon,
@@ -283,8 +284,15 @@ export function CreateOrEditSpaceModal({
       return;
     }
 
+    if (spaceInfo) {
+      await doUpdate(space, {
+        name: newName.trim(),
+        isRestricted: spaceInfo.isRestricted,
+      });
+      await mutateSpaceInfo();
+    }
+
     setSpaceName(newName.trim());
-    setIsDirty(false);
     setShowEditNameDialog(false);
   };
 
@@ -374,7 +382,9 @@ export function CreateOrEditSpaceModal({
         <SheetHeader>
           <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-0">
-              <SheetTitle>Space Settings - {spaceName}</SheetTitle>
+              <SheetTitle>
+                Space Settings{space ? `- ${spaceName}` : ""}
+              </SheetTitle>
             </div>
 
             {isAdmin && space && space.kind === "regular" && (
@@ -419,6 +429,23 @@ export function CreateOrEditSpaceModal({
         </SheetHeader>
         <SheetContainer>
           <div className="flex w-full flex-col gap-y-4">
+            {!space && (
+              <>
+                <Page.SectionHeader title="Name" />
+                <Input
+                  placeholder="Space's name"
+                  value={spaceName}
+                  name="spaceName"
+                  message="Space name must be unique"
+                  messageStatus="info"
+                  onChange={(e) => {
+                    setSpaceName(e.target.value);
+                    setIsDirty(true);
+                  }}
+                />
+              </>
+            )}
+
             <div className="flex w-full items-center justify-between overflow-visible">
               <Page.SectionHeader title="Restricted Access" />
               <SliderToggle

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -374,7 +374,7 @@ export function CreateOrEditSpaceModal({
         <SheetHeader>
           <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-0">
-              <SheetTitle>Space Settings</SheetTitle>
+              <SheetTitle>`Space Settings - ${spaceName}`</SheetTitle>
             </div>
 
             {isAdmin && space && space.kind === "regular" && (

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -397,7 +397,7 @@ export function CreateOrEditSpaceModal({
                   onClose={() => setShowDeleteConfirmDialog(false)}
                 />
                 <EditSpaceNameDialog
-                  space={space}
+                  spaceInfo={spaceInfo}
                   handleEditName={onEditName}
                   isOpen={showEditNameDialog}
                   isSaving={isSaving}

--- a/front/components/spaces/EditSpaceNameDialog.tsx
+++ b/front/components/spaces/EditSpaceNameDialog.tsx
@@ -1,0 +1,90 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import type { SpaceType } from "@app/types";
+
+interface EditSpaceNameDialogProps {
+  space: SpaceType;
+  onEditName: (newName: string) => void;
+  isOpen: boolean;
+  isSaving: boolean;
+  onClose: () => void;
+}
+
+export function EditSpaceNameDialog({
+  space,
+  onEditName,
+  isOpen,
+  isSaving,
+  onClose,
+}: EditSpaceNameDialogProps) {
+  const [editingSpaceName, setEditingSpaceName] = useState<string>(space.name);
+
+  const handleClose = () => {
+    // Reset the space name.
+    setEditingSpaceName(space.name);
+    onClose();
+  };
+
+  const handleSave = () => {
+    if (editingSpaceName.trim()) {
+      onEditName(editingSpaceName.trim());
+    }
+  };
+
+  // Initialize the editing name when dialog opens.
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      setEditingSpaceName(space.name);
+    } else {
+      handleClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rename the space</DialogTitle>
+        </DialogHeader>
+        {isSaving ? (
+          <div className="flex justify-center py-8">
+            <Spinner variant="dark" size="md" />
+          </div>
+        ) : (
+          <>
+            <DialogContainer>
+              <Input
+                placeholder="Space's name"
+                value={editingSpaceName}
+                name="editingSpaceName"
+                onChange={(e) => setEditingSpaceName(e.target.value)}
+              />
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: handleClose,
+              }}
+              rightButtonProps={{
+                label: "Confirm",
+                onClick: handleSave,
+                disabled: !editingSpaceName.trim(),
+              }}
+            />
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/spaces/EditSpaceNameDialog.tsx
+++ b/front/components/spaces/EditSpaceNameDialog.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 import type { SpaceType } from "@app/types";
 
 interface EditSpaceNameDialogProps {
-  space: SpaceType;
+  spaceInfo: SpaceType | null;
   handleEditName: (newName: string) => void;
   isOpen: boolean;
   isSaving: boolean;
@@ -21,17 +21,19 @@ interface EditSpaceNameDialogProps {
 }
 
 export function EditSpaceNameDialog({
-  space,
+  spaceInfo,
   handleEditName,
   isOpen,
   isSaving,
   onClose,
 }: EditSpaceNameDialogProps) {
-  const [editingSpaceName, setEditingSpaceName] = useState<string>(space.name);
+  const [editingSpaceName, setEditingSpaceName] = useState<string>(
+    spaceInfo?.name ?? ""
+  );
 
   const handleClose = () => {
     // Reset the space name.
-    setEditingSpaceName(space.name);
+    setEditingSpaceName(spaceInfo?.name ?? "");
     onClose();
   };
 
@@ -41,10 +43,10 @@ export function EditSpaceNameDialog({
     }
   };
 
-  // Initialize the editing name when dialog opens.
+  // Initialize the editing name when the dialog opens.
   const handleOpenChange = (open: boolean) => {
     if (open) {
-      setEditingSpaceName(space.name);
+      setEditingSpaceName(spaceInfo?.name ?? "");
     } else {
       handleClose();
     }

--- a/front/components/spaces/EditSpaceNameDialog.tsx
+++ b/front/components/spaces/EditSpaceNameDialog.tsx
@@ -14,7 +14,7 @@ import type { SpaceType } from "@app/types";
 
 interface EditSpaceNameDialogProps {
   space: SpaceType;
-  onEditName: (newName: string) => void;
+  handleEditName: (newName: string) => void;
   isOpen: boolean;
   isSaving: boolean;
   onClose: () => void;
@@ -22,7 +22,7 @@ interface EditSpaceNameDialogProps {
 
 export function EditSpaceNameDialog({
   space,
-  onEditName,
+  handleEditName,
   isOpen,
   isSaving,
   onClose,
@@ -37,7 +37,7 @@ export function EditSpaceNameDialog({
 
   const handleSave = () => {
     if (editingSpaceName.trim()) {
-      onEditName(editingSpaceName.trim());
+      handleEditName(editingSpaceName.trim());
     }
   };
 

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -375,18 +375,19 @@ export function useDeleteFolderOrWebsite({
 type DoCreateOrUpdateAllowedParams =
   | {
       name: string | null;
-      isRestricted: false;
+      isRestricted: boolean;
+      managementMode?: never;
     }
   | {
       name: string | null;
       memberIds: string[];
-      groupIds: undefined;
+      groupIds?: never;
       isRestricted: true;
       managementMode: "manual";
     }
   | {
       name: string | null;
-      memberIds: undefined;
+      memberIds?: never;
       groupIds: string[];
       isRestricted: true;
       managementMode: "group";
@@ -404,7 +405,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
   });
 
   const doCreate = async (params: DoCreateOrUpdateAllowedParams) => {
-    const { name, isRestricted } = params;
+    const { name, managementMode, isRestricted } = params;
     if (!name) {
       return null;
     }
@@ -412,8 +413,8 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
     const url = `/api/w/${owner.sId}/spaces`;
     let res;
 
-    if (isRestricted) {
-      const { managementMode, memberIds, groupIds } = params;
+    if (managementMode) {
+      const { memberIds, groupIds } = params;
 
       // Must have either memberIds or groupIds for restricted spaces
       if (
@@ -491,7 +492,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
     space: SpaceType,
     params: DoCreateOrUpdateAllowedParams
   ) => {
-    const { name: newName, isRestricted } = params;
+    const { name: newName, managementMode } = params;
 
     const updatePromises: Promise<Response>[] = [];
 
@@ -513,8 +514,8 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
 
     // Prepare space members update request if provided.
     const spaceMembersUrl = `/api/w/${owner.sId}/spaces/${space.sId}/members`;
-    if (isRestricted) {
-      const { managementMode, memberIds, groupIds } = params;
+    if (managementMode) {
+      const { memberIds, groupIds, isRestricted } = params;
 
       updatePromises.push(
         fetch(spaceMembersUrl, {

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -380,14 +380,16 @@ type DoCreateOrUpdateAllowedParams =
   | {
       name: string | null;
       memberIds: string[];
+      groupIds: undefined;
       isRestricted: true;
-      managementMode?: "manual";
+      managementMode: "manual";
     }
   | {
       name: string | null;
+      memberIds: undefined;
       groupIds: string[];
       isRestricted: true;
-      managementMode?: "group";
+      managementMode: "group";
     };
 
 export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
@@ -407,9 +409,11 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
       return null;
     }
 
+    const url = `/api/w/${owner.sId}/spaces`;
+    let res;
+
     if (isRestricted) {
-      const memberIds = "memberIds" in params ? params.memberIds : undefined;
-      const groupIds = "groupIds" in params ? params.groupIds : undefined;
+      const { managementMode, memberIds, groupIds } = params;
 
       // Must have either memberIds or groupIds for restricted spaces
       if (
@@ -418,24 +422,32 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
       ) {
         return null;
       }
-    }
 
-    const url = `/api/w/${owner.sId}/spaces`;
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name,
-        ...("memberIds" in params && { memberIds: params.memberIds }),
-        ...("groupIds" in params && { groupIds: params.groupIds }),
-        ...("managementMode" in params && {
-          managementMode: params.managementMode,
+      res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name,
+          memberIds,
+          groupIds,
+          managementMode,
+          isRestricted,
         }),
-        isRestricted,
-      }),
-    });
+      });
+    } else {
+      res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name,
+          isRestricted,
+        }),
+      });
+    }
 
     if (!res.ok) {
       const errorData = await getErrorFromResponse(res);
@@ -480,10 +492,6 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
     params: DoCreateOrUpdateAllowedParams
   ) => {
     const { name: newName, isRestricted } = params;
-    const memberIds = "memberIds" in params ? params.memberIds : undefined;
-    const groupIds = "groupIds" in params ? params.groupIds : undefined;
-    const managementMode =
-      "managementMode" in params ? params.managementMode : undefined;
 
     const updatePromises: Promise<Response>[] = [];
 
@@ -505,22 +513,24 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
 
     // Prepare space members update request if provided.
     const spaceMembersUrl = `/api/w/${owner.sId}/spaces/${space.sId}/members`;
-    updatePromises.push(
-      fetch(spaceMembersUrl, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          ...(memberIds !== undefined && { memberIds }),
-          ...(groupIds !== undefined && { groupIds }),
-          ...(managementMode !== undefined && {
+    if (isRestricted) {
+      const { managementMode, memberIds, groupIds } = params;
+
+      updatePromises.push(
+        fetch(spaceMembersUrl, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            memberIds,
+            groupIds,
             managementMode,
+            isRestricted,
           }),
-          isRestricted,
-        }),
-      })
-    );
+        })
+      );
+    }
 
     if (updatePromises.length === 0) {
       return null;


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1750420378188289).
- This PR polishes the UI for groups and members selection in spaces:
  - Move the name edition in the `...`.
  - Turn the tabs to switch between members/groups into a dropdown.

<img width="450" alt="Screenshot 2025-06-23 at 9 24 56 AM" src="https://github.com/user-attachments/assets/eb2a161e-acfd-48c3-a5bc-fcad1088b25f" />

As per IRL, we aim for maximal consistency with actions in Agent Builder. Therefore: the name of the space now also appears in the sheet title.

## Tests

- Tested locally.

## Risk

- Low, only UI changes.

## Deploy Plan

- Deploy front.
