### PR TITLE
[connectors] chore(crawler): Error handling

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@dust-tt/client": "file:../sdks/js",
         "@google-cloud/bigquery": "^7.9.2",
-        "@mendable/firecrawl-js": "^1.25.5",
+        "@mendable/firecrawl-js": "^1.26.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.40.0",
         "@notionhq/client": "^2.2.15",
@@ -3101,9 +3101,9 @@
       }
     },
     "node_modules/@mendable/firecrawl-js": {
-      "version": "1.25.5",
-      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-1.25.5.tgz",
-      "integrity": "sha512-cozEZipMdtyfAQKX8IFC8DW06cYd7CxL8cxwMaD61sQrWpLkGcpivoMEeSFuyJTKmobAYAT5EB5ZExUJSVJkXw==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-1.26.0.tgz",
+      "integrity": "sha512-g/CaCCQiUeR/4ZIeIqHm+rDU6zHmRAUDgmhQOufoDzp15vYKW50UhlHNqKDr0aigwXugi0yCSsyJoRV3Ksc51Q==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@dust-tt/client": "file:../sdks/js",
     "@google-cloud/bigquery": "^7.9.2",
-    "@mendable/firecrawl-js": "^1.25.5",
+    "@mendable/firecrawl-js": "^1.26.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@microsoft/microsoft-graph-types": "^2.40.0",
     "@notionhq/client": "^2.2.15",

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -116,7 +116,8 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
     crawlerResponse = await firecrawlApp.asyncCrawlUrl(rootUrl, {
       maxDiscoveryDepth: webCrawlerConfig.depth ?? WEBCRAWLER_MAX_DEPTH,
       limit: maxRequestsPerCrawl,
-      allowBackwardLinks: webCrawlerConfig.crawlMode === "website",
+      crawlEntireDomain: webCrawlerConfig.crawlMode === "website",
+      maxConcurrency: 4,
       delay: 3,
       scrapeOptions: {
         onlyMainContent: true,

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,4 +1,5 @@
 import type { FirecrawlDocument } from "@mendable/firecrawl-js";
+import { FirecrawlError } from "@mendable/firecrawl-js";
 import { Context } from "@temporalio/activity";
 import { randomUUID } from "crypto";
 import path from "path";
@@ -111,13 +112,12 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
     rootUrl = `http://${rootUrl}`;
   }
 
-  let crawlerResponse;
   try {
-    crawlerResponse = await firecrawlApp.asyncCrawlUrl(rootUrl, {
+    const crawlerResponse = await firecrawlApp.asyncCrawlUrl(rootUrl, {
       maxDiscoveryDepth: webCrawlerConfig.depth ?? WEBCRAWLER_MAX_DEPTH,
       limit: maxRequestsPerCrawl,
       crawlEntireDomain: webCrawlerConfig.crawlMode === "website",
-      maxConcurrency: 4,
+      maxConcurrency: 2,
       delay: 3,
       scrapeOptions: {
         onlyMainContent: true,
@@ -132,57 +132,70 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
         },
       },
     });
+
+    if (!crawlerResponse.success) {
+      childLogger.error(
+        {
+          url: rootUrl,
+          connectorId,
+          webCrawlerConfigId: webCrawlerConfig.id,
+        },
+        `Firecrawl crawl failed: ${crawlerResponse.error}`
+      );
+      await syncFailed(connectorId, "webcrawling_error");
+    } else {
+      childLogger.info(
+        { crawlerId: crawlerResponse.id, url: rootUrl },
+        "Firecrawl crawler started"
+      );
+
+      if (crawlerResponse.id) {
+        await webCrawlerConfig.updateCrawlId(crawlerResponse.id);
+      } else {
+        // Shouldn't happen, but based on the types, let's make sure
+        childLogger.warn(
+          { webCrawlerConfigId: webCrawlerConfig.id, url: rootUrl },
+          "No ID found when creating a Firecrawl crawler"
+        );
+      }
+    }
   } catch (error) {
     // Handle thrown errors from Firecrawl API
-    const errorMessage = normalizeError(error).message;
-    crawlerResponse = {
-      success: false,
-      error: errorMessage,
-    };
-  }
+    if (error instanceof FirecrawlError) {
+      childLogger.error(
+        {
+          rootUrl,
+          connectorId,
+          webCrawlerConfigId: webCrawlerConfig.id,
+          firecrawlStatusCode: error.statusCode,
+          firecrawlError: {
+            statusCode: error.statusCode,
+            name: error.name,
+          },
+        },
+        `Firecrawl crawler failed: ${error.message}`
+      );
 
-  if (!crawlerResponse.success) {
-    const errorMessage = crawlerResponse.error || "Unknown error";
-    childLogger.error(
-      {
-        error: errorMessage,
-        url: rootUrl,
+      await syncFailed(
         connectorId,
-      },
-      "Firecrawl crawl failed"
-    );
-
-    // Check if it's a 403 error for unsupported websites.
-    if (
-      errorMessage.includes("status code 403") ||
-      errorMessage.includes("no longer supported")
-    ) {
-      await syncFailed(connectorId, "webcrawling_error_blocked");
+        error.statusCode === 403
+          ? "webcrawling_error_blocked"
+          : "webcrawling_error"
+      );
     } else {
       await syncFailed(connectorId, "webcrawling_error");
+      const errorMessage = normalizeError(error).message;
+      childLogger.error(
+        {
+          rootUrl,
+          connectorId,
+          webCrawlerConfigId: webCrawlerConfig.id,
+        },
+        `Unhandled crawler error: ${errorMessage}`
+      );
     }
-
-    // Return gracefully instead of throwing to prevent workflow from getting stuck.
-    return {
-      launchGarbageCollect: false,
-      startedAtTs: startedAt.getTime(),
-    };
   }
 
-  if (crawlerResponse.id) {
-    await webCrawlerConfig.updateCrawlId(crawlerResponse.id);
-  } else {
-    // Shouldn't happen, but based on the types, let's make sure
-    childLogger.warn(
-      { webCrawlerConfigId: webCrawlerConfig.id, url: rootUrl },
-      "No ID found when creating a Firecrawl crawler"
-    );
-  }
-
-  childLogger.info(
-    { crawlerId: crawlerResponse.id, url: rootUrl },
-    "Firecrawl crawler started"
-  );
   return {
     launchGarbageCollect: false,
     startedAtTs: startedAt.getTime(),

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@heroicons/react": "^2.0.11",
         "@hookform/resolvers": "^3.3.4",
         "@hubspot/api-client": "^12.0.1",
-        "@mendable/firecrawl-js": "^1.25.5",
+        "@mendable/firecrawl-js": "^1.26.0",
         "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
         "@notionhq/client": "^2.3.0",
         "@octokit/core": "^6.1.5",
@@ -2946,9 +2946,9 @@
       }
     },
     "node_modules/@mendable/firecrawl-js": {
-      "version": "1.25.5",
-      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-1.25.5.tgz",
-      "integrity": "sha512-cozEZipMdtyfAQKX8IFC8DW06cYd7CxL8cxwMaD61sQrWpLkGcpivoMEeSFuyJTKmobAYAT5EB5ZExUJSVJkXw==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-1.26.0.tgz",
+      "integrity": "sha512-g/CaCCQiUeR/4ZIeIqHm+rDU6zHmRAUDgmhQOufoDzp15vYKW50UhlHNqKDr0aigwXugi0yCSsyJoRV3Ksc51Q==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",

--- a/front/package.json
+++ b/front/package.json
@@ -30,7 +30,7 @@
     "@heroicons/react": "^2.0.11",
     "@hookform/resolvers": "^3.3.4",
     "@hubspot/api-client": "^12.0.1",
-    "@mendable/firecrawl-js": "^1.25.5",
+    "@mendable/firecrawl-js": "^1.26.0",
     "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
     "@notionhq/client": "^2.3.0",
     "@octokit/core": "^6.1.5",


### PR DESCRIPTION
## Description
- Update firecrawl package
- Use new option `maxConcurrency` to limit parallel scrape
- use `FirecrawlError` to have a better handling of error coming from Firecrawl.

## Tests
- Locally

## Risk
- Low, at worst will trigger some monitor, but easy to update/revert

## Deploy Plan
- Deploy connectors